### PR TITLE
[lf kvlib] - Handle rollback nodes when traversing transaction [KVL-1566]

### DIFF
--- a/daml-lf/kv-support/src/test/scala/com/daml/lf/kv/transactions/TransactionTraversalSpec.scala
+++ b/daml-lf/kv-support/src/test/scala/com/daml/lf/kv/transactions/TransactionTraversalSpec.scala
@@ -4,7 +4,13 @@
 package com.daml.lf.kv.transactions
 
 import com.daml.lf.kv.ConversionError
-import com.daml.lf.transaction.TransactionOuterClass.{Node, NodeRollback, Transaction}
+import com.daml.lf.transaction.TransactionOuterClass.{
+  KeyWithMaintainers,
+  Node,
+  NodeLookupByKey,
+  NodeRollback,
+  Transaction,
+}
 import com.daml.lf.transaction.TransactionVersion
 import com.daml.lf.value.{ValueCoder, ValueOuterClass}
 import com.google.protobuf.ByteString
@@ -15,70 +21,23 @@ import scala.jdk.CollectionConverters._
 
 class TransactionTraversalSpec extends AnyFunSuite with Matchers {
 
-  private val builder = TransactionBuilder()
-
-  // Creation of a contract with Alice as signatory, and Bob is controller of one of the choices.
-  private val createNid = builder.addNode(
-    createNode(List("Alice"), List("Alice", "Bob"))
-  )
-
-  // Exercise of a contract where Alice as signatory, Charlie has a choice or is an observer.
-  private val exeNid = builder.addNode(
-    exerciseNode(
-      signatories = List("Alice"),
-      stakeholders = List("Alice", "Charlie"),
-      consuming = true,
-      createNid,
-    )
-  )
-
-  // Non-consuming exercise of a contract where Alice as signatory, Charlie has a choice or is an observer.
-  private val nonConsumingExeNid = builder.addNode(
-    exerciseNode(
-      signatories = List("Alice"),
-      stakeholders = List("Alice", "Charlie"),
-      consuming = false,
-    )
-  )
-
-  // A fetch of some contract created by Bob.
-  private val fetchNid = builder.addNode(
-    fetchNode(
-      signatories = List("Bob"),
-      stakeholders = List("Bob"),
-    )
-  )
-
-  // Root node exercising a contract only known to Alice.
-  private val rootNid = builder.addRoot(
-    exerciseNode(
-      signatories = List("Alice"),
-      stakeholders = List("Alice"),
-      consuming = true,
-      fetchNid,
-      nonConsumingExeNid,
-      exeNid,
-    )
-  )
-  private val rawTx = RawTransaction(builder.build.toByteString)
-
   test("traverseTransactionWithWitnesses - consuming nested exercises") {
-
-    TransactionTraversal.traverseTransactionWithWitnesses(rawTx) {
-      case (RawTransaction.NodeId(`createNid`), _, witnesses) =>
+    val testTransaction = RawTransactionForTest()
+    TransactionTraversal.traverseTransactionWithWitnesses(testTransaction.rawTx) {
+      case (RawTransaction.NodeId(testTransaction.`createNid`), _, witnesses) =>
         witnesses should contain.only("Alice", "Bob", "Charlie")
         ()
-      case (RawTransaction.NodeId(`exeNid`), _, witnesses) =>
+      case (RawTransaction.NodeId(testTransaction.`exeNid`), _, witnesses) =>
         witnesses should contain.only("Alice", "Charlie")
         ()
-      case (RawTransaction.NodeId(`nonConsumingExeNid`), _, witnesses) =>
+      case (RawTransaction.NodeId(testTransaction.`nonConsumingExeNid`), _, witnesses) =>
         // Non-consuming exercises are only witnessed by signatories.
         witnesses should contain only "Alice"
         ()
-      case (RawTransaction.NodeId(`rootNid`), _, witnesses) =>
+      case (RawTransaction.NodeId(testTransaction.`rootNid`), _, witnesses) =>
         witnesses should contain only "Alice"
         ()
-      case (RawTransaction.NodeId(`fetchNid`), _, witnesses) =>
+      case (RawTransaction.NodeId(testTransaction.`fetchNid`), _, witnesses) =>
         // This is of course ill-authorized, but we check that parent witnesses are included.
         witnesses should contain.only("Alice", "Bob")
         ()
@@ -88,7 +47,8 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
   }
 
   test("extractPerPackageWitnesses - extract package witness mapping as expected") {
-    val result = TransactionTraversal.extractPerPackageWitnesses(rawTx)
+    val testTransaction = RawTransactionForTest()
+    val result = TransactionTraversal.extractPerPackageWitnesses(testTransaction.rawTx)
     result shouldBe
       Right(
         Map(
@@ -96,6 +56,39 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
           "interface_exercise" -> Set("Alice", "Charlie"),
           "template_create" -> Set("Alice", "Charlie", "Bob"),
           "template_fetch" -> Set("Alice", "Bob"),
+        )
+      )
+  }
+
+  test(
+    "extractPerPackageWitnesses - extract package witness mapping as expected including rollback node"
+  ) {
+    val testTransaction = RawTransactionForTest()
+    val lookupByKeyNode = withNodeBuilder { builder =>
+      builder.setLookupByKey(
+        NodeLookupByKey.newBuilder
+          .setTemplateId(identifierForTemplateId("template_lookup_by_key"))
+          .setKeyWithMaintainers(
+            KeyWithMaintainers.newBuilder().addMaintainers("New maintainer")
+          )
+      )
+    }
+    testTransaction.builder.addRoot(withNodeBuilder { builder =>
+      builder.setRollback(
+        NodeRollback.newBuilder.addChildren(
+          testTransaction.builder.addNode(lookupByKeyNode)
+        )
+      )
+    })
+    val result = TransactionTraversal.extractPerPackageWitnesses(testTransaction.rawTx)
+    result shouldBe
+      Right(
+        Map(
+          "template_exercise" -> Set("Alice", "Charlie"),
+          "interface_exercise" -> Set("Alice", "Charlie"),
+          "template_create" -> Set("Alice", "Charlie", "Bob"),
+          "template_fetch" -> Set("Alice", "Bob"),
+          "template_lookup_by_key" -> Set("New maintainer"),
         )
       )
   }
@@ -116,7 +109,7 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
     actual shouldBe Left(ConversionError.ParseError("Unsupported transaction version 'wrong'"))
   }
 
-  test("traversal - node decoding error") {
+  test("traversal - decode error on rollback nodes") {
     val rootNodeId = "1"
     val rawTx = RawTransaction(
       Transaction
@@ -136,17 +129,58 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
         )
       )
     )
-    TransactionTraversal.extractPerPackageWitnesses(rawTx) shouldBe Left(
-      ConversionError.DecodeError(
-        ValueCoder.DecodeError(
-          "protoActionNodeInfo only supports action nodes but was applied to a rollback node"
-        )
-      )
-    )
   }
 
   // --------------------------------------------------------
   // Helpers for constructing transactions.
+  case class RawTransactionForTest() {
+    val builder: TransactionBuilder = TransactionBuilder()
+
+    // Creation of a contract with Alice as signatory, and Bob is controller of one of the choices.
+    val createNid: String = builder.addNode(
+      createNode(List("Alice"), List("Alice", "Bob"))
+    )
+
+    // Exercise of a contract where Alice as signatory, Charlie has a choice or is an observer.
+    val exeNid: String = builder.addNode(
+      exerciseNode(
+        signatories = List("Alice"),
+        stakeholders = List("Alice", "Charlie"),
+        consuming = true,
+        createNid,
+      )
+    )
+
+    // Non-consuming exercise of a contract where Alice as signatory, Charlie has a choice or is an observer.
+    val nonConsumingExeNid: String = builder.addNode(
+      exerciseNode(
+        signatories = List("Alice"),
+        stakeholders = List("Alice", "Charlie"),
+        consuming = false,
+      )
+    )
+
+    // A fetch of some contract created by Bob.
+    val fetchNid: String = builder.addNode(
+      fetchNode(
+        signatories = List("Bob"),
+        stakeholders = List("Bob"),
+      )
+    )
+
+    // Root node exercising a contract only known to Alice.
+    val rootNid: String = builder.addRoot(
+      exerciseNode(
+        signatories = List("Alice"),
+        stakeholders = List("Alice"),
+        consuming = true,
+        fetchNid,
+        nonConsumingExeNid,
+        exeNid,
+      )
+    )
+    def rawTx: RawTransaction = RawTransaction(builder.build.toByteString)
+  }
 
   case class TransactionBuilder() {
     private var roots = List.empty[String]
@@ -191,7 +225,7 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
   private def createNode(signatories: Iterable[String], stakeholders: Iterable[String]) =
     withNodeBuilder {
       _.getCreateBuilder
-        .setTemplateId(ValueOuterClass.Identifier.newBuilder().setPackageId("template_create"))
+        .setTemplateId(identifierForTemplateId("template_create"))
         .addAllSignatories(signatories.asJava)
         .addAllStakeholders(stakeholders.asJava)
     }
@@ -202,7 +236,7 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
   private def fetchNode(signatories: Iterable[String], stakeholders: Iterable[String]) =
     withNodeBuilder {
       _.getFetchBuilder
-        .setTemplateId(ValueOuterClass.Identifier.newBuilder().setPackageId("template_fetch"))
+        .setTemplateId(identifierForTemplateId("template_fetch"))
         .addAllSignatories(signatories.asJava)
         .addAllStakeholders(stakeholders.asJava)
     }
@@ -219,12 +253,15 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
     withNodeBuilder {
       _.getExerciseBuilder
         .setConsuming(consuming)
-        .setTemplateId(ValueOuterClass.Identifier.newBuilder().setPackageId("template_exercise"))
-        .setInterfaceId(ValueOuterClass.Identifier.newBuilder().setPackageId("interface_exercise"))
+        .setTemplateId(identifierForTemplateId("template_exercise"))
+        .setInterfaceId(identifierForTemplateId("interface_exercise"))
         .addAllSignatories(signatories.asJava)
         .addAllStakeholders(stakeholders.asJava)
         /* NOTE(JM): Actors are no longer included in exercises by the compiler, hence we don't set them */
         .addAllChildren(children.asJava)
     }
 
+  private def identifierForTemplateId = {
+    ValueOuterClass.Identifier.newBuilder().setPackageId _
+  }
 }


### PR DESCRIPTION
- We need to extract all the package party mappings found in a transaction, including the nodes that are under a rollback node
- Rollback nodes have no informees of their own but we extract the children as expected 

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
