### PR TITLE
Make damlc options fail if used more than once

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -78,6 +78,7 @@ import "ghc-lib-parser" Module (unitIdString, stringToUnitId)
 import qualified Network.Socket as NS
 import Options.Applicative.Extended
 import Options.Applicative hiding (option, strOption)
+import qualified Options.Applicative (option)
 import qualified Proto3.Suite as PS
 import qualified Proto3.Suite.JSONPB as Proto.JSONPB
 import System.Directory.Extra
@@ -326,7 +327,7 @@ cmdRepl numProcessors =
             <*> strOptionOnce (long "script-lib" <> value "daml-script" <> internal)
             -- This is useful for tests and `bazel run`.
 
-    packageImport = optionOnce readPackage $
+    packageImport = Options.Applicative.option readPackage $
         long "import"
         <> short 'i'
         <> help "Import modules of these packages into the REPL"

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -77,6 +77,7 @@ import GHC.Conc
 import "ghc-lib-parser" Module (unitIdString, stringToUnitId)
 import qualified Network.Socket as NS
 import Options.Applicative.Extended
+import Options.Applicative hiding (option, strOption)
 import qualified Proto3.Suite as PS
 import qualified Proto3.Suite.JSONPB as Proto.JSONPB
 import System.Directory.Extra
@@ -157,7 +158,7 @@ cmdCompile numProcessors =
         <*> outputFileOpt
         <*> optionsParser numProcessors (EnableScenarioService False) optPackageName
         <*> optWriteIface
-        <*> optional (strOption $ long "iface-dir" <> metavar "IFACE_DIR" <> help "Directory for interface files")
+        <*> optional (strOptionOnce $ long "iface-dir" <> metavar "IFACE_DIR" <> help "Directory for interface files")
 
     optWriteIface =
         fmap WriteInterface $
@@ -218,7 +219,7 @@ cmdTest numProcessors =
       <*> initPkgDbOpt
     filesOpt = optional (flag' () (long "files" <> help filesDoc) *> many inputFileOpt)
     filesDoc = "Only run test declarations in the specified files."
-    junitOutput = optional $ strOption $ long "junit" <> metavar "FILENAME" <> help "Filename of JUnit output file"
+    junitOutput = optional $ strOptionOnce $ long "junit" <> metavar "FILENAME" <> help "Filename of JUnit output file"
     colorOutput = switch $ long "color" <> help "Colored test results"
     showCoverageOpt = switch $ long "show-coverage" <> help "Show detailed test coverage"
     runAllTests = switch $ long "all" <> help "Run tests in current project as well as dependencies"
@@ -260,7 +261,7 @@ cmdInspect =
     jsonOpt = switch $ long "json" <> help "Output the raw Protocol Buffer structures as JSON"
     detailOpt =
         fmap (maybe DA.Pretty.prettyNormal DA.Pretty.PrettyLevel) $
-            optional $ option auto $ long "detail" <> metavar "LEVEL" <> help "Detail level of the pretty printed output (default: 0)"
+            optional $ optionOnce auto $ long "detail" <> metavar "LEVEL" <> help "Detail level of the pretty printed output (default: 0)"
     cmd = execInspect <$> inputFileOptWithExt ".dalf or .dar" <*> outputFileOpt <*> jsonOpt <*> detailOpt
 
 cmdVisual :: Mod CommandFields Command
@@ -302,30 +303,30 @@ cmdRepl numProcessors =
             <$> many (strArgument (help "DAR to load in the repl" <> metavar "DAR"))
             <*> many packageImport
             <*> optional
-                  ((,) <$> strOption (long "ledger-host" <> help "Host of the ledger API")
-                       <*> strOption (long "ledger-port" <> help "Port of the ledger API")
+                  ((,) <$> strOptionOnce (long "ledger-host" <> help "Host of the ledger API")
+                       <*> strOptionOnce (long "ledger-port" <> help "Port of the ledger API")
                   )
             <*> accessTokenFileFlag
             <*> optional
                   (ReplClient.ApplicationId <$>
-                     strOption
+                     strOptionOnce
                        (long "application-id" <>
                         help "Application ID used for command submissions"
                        )
                   )
             <*> sslConfig
             <*> optional
-                    (option auto $
+                    (optionOnce auto $
                         long "max-inbound-message-size" <>
                         help "Optional max inbound message size in bytes."
                     )
             <*> timeModeFlag
             <*> projectOpts "daml repl"
             <*> optionsParser numProcessors (EnableScenarioService False) (pure Nothing)
-            <*> strOption (long "script-lib" <> value "daml-script" <> internal)
+            <*> strOptionOnce (long "script-lib" <> value "daml-script" <> internal)
             -- This is useful for tests and `bazel run`.
 
-    packageImport = option readPackage $
+    packageImport = optionOnce readPackage $
         long "import"
         <> short 'i'
         <> help "Import modules of these packages into the REPL"
@@ -337,7 +338,7 @@ cmdRepl numProcessors =
             unless (looksLikePackageName strName) $
                 Left $ "Illegal package name: " ++ strName
             pure pkg
-    accessTokenFileFlag = optional . option str $
+    accessTokenFileFlag = optional . optionOnce str $
         long "access-token-file"
         <> metavar "TOKEN_PATH"
         <> help "Path to the token-file for ledger authorization"
@@ -348,17 +349,17 @@ cmdRepl numProcessors =
             [ long "tls"
             , help "Enable TLS for the connection to the ledger. This is implied if --cacrt, --pem or --crt are passed"
             ]
-        mbCACert <- optional $ strOption $ mconcat
+        mbCACert <- optional $ strOptionOnce $ mconcat
             [ long "cacrt"
             , help "The crt file to be used as the trusted root CA."
             ]
         mbClientKeyCertPair <- optional $ liftA2 ReplClient.ClientSSLKeyCertPair
-            (strOption $ mconcat
+            (strOptionOnce $ mconcat
                  [ long "pem"
                  , help "The pem file to be used as the private key in mutual authentication."
                  ]
             )
-            (strOption $ mconcat
+            (strOptionOnce $ mconcat
                  [ long "crt"
                  , help "The crt file to be used as the cert chain in mutual authentication."
                  ]

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -225,6 +225,9 @@ enableScenariosOpt = EnableScenarios <$>
             "Enable/disable support for scenarios as a language feature. \
             \If disabled, defining top-level scenarios is a compile-time error"
 
+-- The implementation of dlintUsageOpt allows multiple uses of dlintEnabledOpt
+-- and dlintDisabledOpt, with only the last one winning. As a result,
+-- dlintEnabledOpt uses strOption instead of strOptionOnce
 dlintEnabledOpt :: Parser DlintUsage
 dlintEnabledOpt = DlintEnabled
   <$> Options.Applicative.strOption

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -7,6 +7,7 @@ module DA.Cli.Options
 
 import Data.List.Extra     (lower, splitOn, trim)
 import Options.Applicative hiding (option, strOption)
+import qualified Options.Applicative (option, strOption)
 import Options.Applicative.Extended
 import Safe (lastMay)
 import Data.List
@@ -226,7 +227,7 @@ enableScenariosOpt = EnableScenarios <$>
 
 dlintEnabledOpt :: Parser DlintUsage
 dlintEnabledOpt = DlintEnabled
-  <$> strOptionOnce
+  <$> Options.Applicative.strOption
   ( long "with-dlint"
     <> metavar "DIR"
     <> internal
@@ -317,19 +318,19 @@ optionsParser numProcessors enableScenarioService parsePkgName = do
     optImportPath :: Parser [FilePath]
     optImportPath =
         many $
-        strOptionOnce $
+        Options.Applicative.strOption $
         metavar "INCLUDE-PATH" <>
         help "Path to an additional source directory to be included" <>
         long "include"
 
     optPackageDir :: Parser [FilePath]
-    optPackageDir = many $ strOptionOnce $ metavar "LOC-OF-PACKAGE-DB"
+    optPackageDir = many $ Options.Applicative.strOption $ metavar "LOC-OF-PACKAGE-DB"
                       <> help "use package database in the given location"
                       <> long "package-db"
 
     optPackageImport :: Parser PackageFlag
     optPackageImport =
-      optionOnce readPackageImport $
+      Options.Applicative.option readPackageImport $
       metavar "PACKAGE" <>
       help "explicit import of a package with optional renaming of modules" <>
       long "package" <>
@@ -434,7 +435,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = do
 optGhcCustomOptions :: Parser [String]
 optGhcCustomOptions =
     fmap concat $ many $
-    optionOnce (stringsSepBy ' ') $
+    Options.Applicative.option (stringsSepBy ' ') $
     long "ghc-option" <>
     metavar "OPTION" <>
     help "Options to pass to the underlying GHC"

--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -73,6 +73,7 @@ da_haskell_binary(
         "typed-process",
         "time",
         "text",
+        "optparse-applicative",
     ],
     main_function = "DA.Daml.Helper.Main.main",
     src_strip_prefix = "src",

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -10,6 +10,7 @@ import Data.Foldable
 import Data.List.Extra
 import Numeric.Natural
 import Options.Applicative.Extended
+import Options.Applicative
 import System.Environment
 import System.Exit
 import System.IO.Extra

--- a/daml-assistant/src/DA/Daml/Assistant/Command.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Command.hs
@@ -19,6 +19,7 @@ import Data.List
 import Data.Maybe
 import Data.Foldable
 import Options.Applicative.Types
+import Options.Applicative
 import Options.Applicative.Extended
 import System.Environment
 import System.FilePath

--- a/libs-haskell/da-hs-base/BUILD.bazel
+++ b/libs-haskell/da-hs-base/BUILD.bazel
@@ -64,8 +64,26 @@ da_haskell_library(
 )
 
 da_haskell_test(
-    name = "da-hs-base-tests",
-    srcs = glob(["tests/**/*.hs"]),
+    name = "da-hs-base-options-tests",
+    srcs = glob(["tests/Options.hs"]),
+    hackage_deps = [
+        "base",
+        "tasty",
+        "tasty-hunit",
+        "optparse-applicative",
+    ],
+    main_function = "Options.main",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":da-hs-base",
+        "//daml-assistant:daml-project-config",
+        "//libs-haskell/test-utils",
+    ],
+)
+
+da_haskell_test(
+    name = "da-hs-base-telemetry-tests",
+    srcs = glob(["tests/Telemetry.hs"]),
     hackage_deps = [
         "aeson",
         "extra",

--- a/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
+++ b/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
@@ -60,12 +60,11 @@ flagYesNoAuto flagName defaultValue helpText mods =
 -- | optparse-applicative does not provide useful error messages when a valid
 -- option is passed more than once https://github.com/pcapriotti/optparse-applicative/issues/395
 --
--- This provides better error messages by constructing and running two parsers
--- for the same option, where the second parser throws an error if it is
--- invoked.
+-- This provides better error messages by constructing two parsers for the same
+-- option, where the second parser automatically throws an infomative error.
 --
--- If the option is specified a second time, the parser is invoked and triggers
--- an error.
+-- If the option is specified a second time, the second parser is invoked and
+-- triggers an error.
 optionOnce :: ReadM a -> Mod OptionFields a -> Parser a
 optionOnce = optionOnce' "Option specified more than once."
 

--- a/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
+++ b/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
@@ -2,15 +2,18 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 module Options.Applicative.Extended
-    ( module Options.Applicative
-    , YesNoAuto (..)
+    ( YesNoAuto (..)
     , flagYesNoAuto
     , flagYesNoAuto'
     , determineAuto
     , determineAutoM
+    , optionOnce
+    , optionOnce'
+    , strOptionOnce
     ) where
 
 import Options.Applicative
+import GHC.Exts (IsString (..))
 
 -- | A morally boolean value with a default third option (called Auto) to be determined later.
 data YesNoAuto
@@ -37,7 +40,7 @@ determineAutoM m = \case
 -- This maps yes to "Just true", no to "Just False" and auto to "Nothing"
 flagYesNoAuto' :: String -> String -> Mod OptionFields YesNoAuto -> Parser YesNoAuto
 flagYesNoAuto' flagName helpText mods =
-    option reader (long flagName <> value Auto <> help helpText <> completeWith ["true", "false", "yes", "no", "auto"] <> mods)
+    optionOnce reader (long flagName <> value Auto <> help helpText <> completeWith ["true", "false", "yes", "no", "auto"] <> mods)
   where reader = eitherReader $ \case
             "yes" -> Right Yes
             "true" -> Right Yes
@@ -53,3 +56,24 @@ flagYesNoAuto flagName defaultValue helpText mods =
     determineAuto defaultValue <$> flagYesNoAuto' flagName (helpText <> commonHelp) mods
     where
         commonHelp = " Can be set to \"yes\", \"no\" or \"auto\" to select the default (" <> show defaultValue <> ")"
+
+-- | optparse-applicative does not provide useful error messages when a valid
+-- option is passed more than once https://github.com/pcapriotti/optparse-applicative/issues/395
+--
+-- This provides better error messages by constructing and running two parsers
+-- for the same option, where the second parser throws an error if it is
+-- invoked.
+--
+-- If the option is specified a second time, the parser is invoked and triggers
+-- an error.
+optionOnce :: ReadM a -> Mod OptionFields a -> Parser a
+optionOnce = optionOnce' "Option specified more than once."
+
+optionOnce' :: String -> ReadM a -> Mod OptionFields a -> Parser a
+optionOnce' errMsg reader options = const <$> actualParser <*> errorIfTwiceParser
+    where
+    actualParser = option reader options
+    errorIfTwiceParser = option (readerError errMsg) (options <> hidden <> value (error "optionOnce: should not happen"))
+
+strOptionOnce :: IsString a => Mod OptionFields a -> Parser a
+strOptionOnce = optionOnce str

--- a/libs-haskell/da-hs-base/tests/Options.hs
+++ b/libs-haskell/da-hs-base/tests/Options.hs
@@ -1,3 +1,6 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module Options(main) where
 
 import Test.Tasty
@@ -71,4 +74,5 @@ someAndManyParse =
         assertParseFailure $
           execParserPure defaultPrefs parserSome ["--opt", "value", "-ovalue", "-o", "value"]
     ]
+
 

--- a/libs-haskell/da-hs-base/tests/Options.hs
+++ b/libs-haskell/da-hs-base/tests/Options.hs
@@ -1,0 +1,74 @@
+module Options(main) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Options.Applicative.Extended
+import Options.Applicative
+
+main :: IO ()
+main = defaultMain $ testGroup "Extended CLI options" [singleFlagParse, multiFlagParse, someAndManyParse]
+
+parser :: ParserInfo String
+parser = info (optionOnce str (long "opt" <> short 'o')) mempty
+
+parserMany :: ParserInfo [String]
+parserMany = info (many $ optionOnce str (long "opt" <> short 'o')) mempty
+
+parserSome :: ParserInfo [String]
+parserSome = info (some $ optionOnce str (long "opt" <> short 'o')) mempty
+
+assertParseSuccess :: (Eq b, Show b) => b -> ParserResult b -> Assertion
+assertParseSuccess expected (Success actual) = assertEqual "" expected actual
+assertParseSuccess expected (Failure err) = assertFailure $ "Expected " <> show expected <> ", got: " <> show err
+assertParseSuccess expected (CompletionInvoked _) = assertFailure $ "Expected " <> show expected <> ", completion invoked instead."
+
+assertParseFailure :: Show b => ParserResult b -> Assertion
+assertParseFailure (Success actual) = assertFailure $ "Expected flag parse failure, got successful flag parse of value " <> show actual <> " instead."
+assertParseFailure (Failure _) = pure ()
+assertParseFailure (CompletionInvoked _) = assertFailure "Expected flag parse failure, completion invoked instead."
+
+singleFlagParse :: TestTree
+singleFlagParse =
+  testGroup "single flag parse is valid"
+    [ testCase "long flag with argument separate word succeeds" $
+        assertParseSuccess "value" $
+          execParserPure defaultPrefs parser ["--opt", "value"]
+    , testCase "long flag with argument same word succeeds" $
+        assertParseSuccess "value" $
+          execParserPure defaultPrefs parser ["--opt=value"]
+    , testCase "short flag with argument separate word succeeds" $
+        assertParseSuccess "value" $
+          execParserPure defaultPrefs parser ["-o", "value"]
+    , testCase "short flag with argument same word succeeds" $
+        assertParseSuccess "value" $
+          execParserPure defaultPrefs parser ["-ovalue"]
+    ]
+
+multiFlagParse :: TestTree
+multiFlagParse =
+  testGroup "double flag parse is invalid"
+    [ testCase "two long-style occurrences of flag fails" $
+        assertParseFailure $
+          execParserPure defaultPrefs parser ["--opt", "value", "--opt", "value"]
+    , testCase "two short-style occurrences of flag fails" $
+        assertParseFailure $
+          execParserPure defaultPrefs parser ["-ovalue", "--opt value"]
+    , testCase "three long-style occurrences of flag fails" $
+        assertParseFailure $
+          execParserPure defaultPrefs parser ["--opt", "value", "--opt", "value", "--opt", "value"]
+    ]
+
+someAndManyParse :: TestTree
+someAndManyParse =
+  testGroup "single flag parse is valid"
+    [ testCase "many succeeds with no arguments" $
+        assertParseSuccess [] $
+          execParserPure defaultPrefs parserMany []
+    , testCase "many fails when flag is passed twice" $
+        assertParseFailure $
+          execParserPure defaultPrefs parserMany ["--opt", "value", "-ovalue", "-o", "value"]
+    , testCase "some modifier fails when flag is passed twice" $
+        assertParseFailure $
+          execParserPure defaultPrefs parserSome ["--opt", "value", "-ovalue", "-o", "value"]
+    ]
+


### PR DESCRIPTION
Currently, if the user specifies the same CLI option more than once where `many` is not used, we get a cryptic `Invalid option` error.

This is a long-term issue with optparse-applicative, https://github.com/pcapriotti/optparse-applicative/issues/395

As a workaround, I have taken options that should be specified at most once and modified them. My comment in Options.Applicative.Extended elaborates a bit more on the implementation:

```
-- | optparse-applicative does not provide useful error messages when a valid
-- option is passed more than once https://github.com/pcapriotti/optparse-applicative/issues/395
--
-- This provides better error messages by constructing two parsers for the same
-- option, where the second parser automatically throws an infomative error.
--
-- If the option is specified a second time, the second parser is invoked and
-- triggers an error.
```