### PR TITLE
[lf kvlib] - Handle rollback nodes when traversing transaction [KVL-1566]

### DIFF
--- a/daml-lf/kv-support/src/main/scala/com/daml/lf/kv/transactions/TransactionTraversal.scala
+++ b/daml-lf/kv-support/src/main/scala/com/daml/lf/kv/transactions/TransactionTraversal.scala
@@ -8,13 +8,14 @@ import com.daml.lf.data.{FrontStack, FrontStackCons, ImmArray, Ref}
 import com.daml.lf.kv.ConversionError
 import com.daml.lf.transaction.TransactionOuterClass.Node
 import com.daml.lf.transaction.{TransactionCoder, TransactionOuterClass, TransactionVersion}
-import com.daml.lf.value.{ValueCoder, ValueOuterClass}
+import com.daml.lf.value.ValueOuterClass
 
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 import scalaz._
 import Scalaz._
+import com.daml.lf.value.ValueCoder.DecodeError
 
 object TransactionTraversal {
 
@@ -63,22 +64,22 @@ object TransactionTraversal {
       toVisit: FrontStack[(RawTransaction.NodeId, Set[Ref.Party])],
       packagesToParties: Map[String, Set[Ref.Party]] = Map.empty,
   ): Either[ConversionError, Map[String, Set[Ref.Party]]] = {
+    def addPackage(templateId: ValueOuterClass.Identifier, witnesses: Set[Party]) = {
+      val currentNodePackagesWithWitnesses = Map(
+        templateId.getPackageId -> witnesses
+      )
+      packagesToParties |+| currentNodePackagesWithWitnesses
+    }
     toVisit match {
       case FrontStack() => Right(packagesToParties)
       case FrontStackCons((nodeId, parentWitnesses), toVisit) =>
         val node = nodes(nodeId.value)
-        informeesOfNode(txVersion, node) match {
-          case Left(error) => Left(ConversionError.DecodeError(error))
-          case Right(nodeWitnesses) =>
-            val witnesses = parentWitnesses union nodeWitnesses
-            def addPackage(templateId: ValueOuterClass.Identifier) = {
-              val currentNodePackagesWithWitnesses = Map(
-                templateId.getPackageId -> witnesses
-              )
-              packagesToParties |+| currentNodePackagesWithWitnesses
-            }
-            node.getNodeTypeCase match {
-              case Node.NodeTypeCase.EXERCISE =>
+        lazy val witnesses = informeesOfNode(txVersion, node).map(_ union parentWitnesses)
+        node.getNodeTypeCase match {
+          case Node.NodeTypeCase.EXERCISE =>
+            witnesses match {
+              case Left(value) => Left(value)
+              case Right(witnesses) =>
                 val exercise = node.getExercise
                 // Recurse into children (if any).
                 val next = exercise.getChildrenList.asScala.view
@@ -98,30 +99,58 @@ object TransactionTraversal {
                   next ++: toVisit,
                   packagesToParties |+| currentNodePackagesWithWitnesses,
                 )
-              case Node.NodeTypeCase.FETCH =>
-                traverseWitnessesWithPackages(
-                  txVersion,
-                  nodes,
-                  toVisit,
-                  addPackage(node.getFetch.getTemplateId),
-                )
-              case Node.NodeTypeCase.CREATE =>
-                traverseWitnessesWithPackages(
-                  txVersion,
-                  nodes,
-                  toVisit,
-                  addPackage(node.getCreate.getTemplateId),
-                )
-              case Node.NodeTypeCase.LOOKUP_BY_KEY =>
-                traverseWitnessesWithPackages(
-                  txVersion,
-                  nodes,
-                  toVisit,
-                  addPackage(node.getLookupByKey.getTemplateId),
-                )
-              case Node.NodeTypeCase.NODETYPE_NOT_SET | Node.NodeTypeCase.ROLLBACK =>
-                traverseWitnessesWithPackages(txVersion, nodes, toVisit, packagesToParties)
             }
+          case Node.NodeTypeCase.FETCH =>
+            val templateId = node.getFetch.getTemplateId
+            witnesses match {
+              case Left(error) => Left(error)
+              case Right(witnesses) =>
+                traverseWitnessesWithPackages(
+                  txVersion,
+                  nodes,
+                  toVisit,
+                  addPackage(templateId, witnesses),
+                )
+            }
+          case Node.NodeTypeCase.CREATE =>
+            val templateId = node.getCreate.getTemplateId
+            witnesses match {
+              case Left(error) => Left(error)
+              case Right(witnesses) =>
+                traverseWitnessesWithPackages(
+                  txVersion,
+                  nodes,
+                  toVisit,
+                  addPackage(templateId, witnesses),
+                )
+            }
+          case Node.NodeTypeCase.LOOKUP_BY_KEY =>
+            val templateId = node.getLookupByKey.getTemplateId
+            witnesses match {
+              case Left(error) => Left(error)
+              case Right(witnesses) =>
+                traverseWitnessesWithPackages(
+                  txVersion,
+                  nodes,
+                  toVisit,
+                  addPackage(templateId, witnesses),
+                )
+            }
+          case Node.NodeTypeCase.ROLLBACK =>
+            // Rollback nodes have only the parent witnesses.
+            val rollback = node.getRollback
+            // Recurse into children (if any).
+            val next = rollback.getChildrenList.asScala.view
+              .map(RawTransaction.NodeId(_) -> parentWitnesses)
+              .to(ImmArray)
+            traverseWitnessesWithPackages(
+              txVersion,
+              nodes,
+              next ++: toVisit,
+              packagesToParties,
+            )
+          case Node.NodeTypeCase.NODETYPE_NOT_SET =>
+            Left(ConversionError.DecodeError(DecodeError("NodeType not set.")))
         }
     }
   }
@@ -138,7 +167,7 @@ object TransactionTraversal {
       case FrontStackCons((nodeId, parentWitnesses), toVisit) =>
         val node = nodes(nodeId.value)
         informeesOfNode(txVersion, node) match {
-          case Left(error) => Left(ConversionError.DecodeError(error))
+          case Left(error) => Left(error)
           case Right(nodeWitnesses) =>
             val witnesses = parentWitnesses union nodeWitnesses
             // Here node.toByteString is safe.
@@ -164,9 +193,10 @@ object TransactionTraversal {
   private[this] def informeesOfNode(
       txVersion: TransactionVersion,
       node: TransactionOuterClass.Node,
-  ): Either[ValueCoder.DecodeError, Set[Ref.Party]] =
+  ) =
     TransactionCoder
       .protoActionNodeInfo(txVersion, node)
       .map(_.informeesOfNode)
+      .leftMap(ConversionError.DecodeError)
 
 }

--- a/daml-lf/kv-support/src/test/scala/com/daml/lf/kv/transactions/TransactionTraversalSpec.scala
+++ b/daml-lf/kv-support/src/test/scala/com/daml/lf/kv/transactions/TransactionTraversalSpec.scala
@@ -4,7 +4,13 @@
 package com.daml.lf.kv.transactions
 
 import com.daml.lf.kv.ConversionError
-import com.daml.lf.transaction.TransactionOuterClass.{Node, NodeRollback, Transaction}
+import com.daml.lf.transaction.TransactionOuterClass.{
+  KeyWithMaintainers,
+  Node,
+  NodeLookupByKey,
+  NodeRollback,
+  Transaction,
+}
 import com.daml.lf.transaction.TransactionVersion
 import com.daml.lf.value.{ValueCoder, ValueOuterClass}
 import com.google.protobuf.ByteString
@@ -15,70 +21,23 @@ import scala.jdk.CollectionConverters._
 
 class TransactionTraversalSpec extends AnyFunSuite with Matchers {
 
-  private val builder = TransactionBuilder()
-
-  // Creation of a contract with Alice as signatory, and Bob is controller of one of the choices.
-  private val createNid = builder.addNode(
-    createNode(List("Alice"), List("Alice", "Bob"))
-  )
-
-  // Exercise of a contract where Alice as signatory, Charlie has a choice or is an observer.
-  private val exeNid = builder.addNode(
-    exerciseNode(
-      signatories = List("Alice"),
-      stakeholders = List("Alice", "Charlie"),
-      consuming = true,
-      createNid,
-    )
-  )
-
-  // Non-consuming exercise of a contract where Alice as signatory, Charlie has a choice or is an observer.
-  private val nonConsumingExeNid = builder.addNode(
-    exerciseNode(
-      signatories = List("Alice"),
-      stakeholders = List("Alice", "Charlie"),
-      consuming = false,
-    )
-  )
-
-  // A fetch of some contract created by Bob.
-  private val fetchNid = builder.addNode(
-    fetchNode(
-      signatories = List("Bob"),
-      stakeholders = List("Bob"),
-    )
-  )
-
-  // Root node exercising a contract only known to Alice.
-  private val rootNid = builder.addRoot(
-    exerciseNode(
-      signatories = List("Alice"),
-      stakeholders = List("Alice"),
-      consuming = true,
-      fetchNid,
-      nonConsumingExeNid,
-      exeNid,
-    )
-  )
-  private val rawTx = RawTransaction(builder.build.toByteString)
-
   test("traverseTransactionWithWitnesses - consuming nested exercises") {
-
-    TransactionTraversal.traverseTransactionWithWitnesses(rawTx) {
-      case (RawTransaction.NodeId(`createNid`), _, witnesses) =>
+    val testTransaction = RawTransactionForTest()
+    TransactionTraversal.traverseTransactionWithWitnesses(testTransaction.rawTx) {
+      case (RawTransaction.NodeId(testTransaction.`createNid`), _, witnesses) =>
         witnesses should contain.only("Alice", "Bob", "Charlie")
         ()
-      case (RawTransaction.NodeId(`exeNid`), _, witnesses) =>
+      case (RawTransaction.NodeId(testTransaction.`exeNid`), _, witnesses) =>
         witnesses should contain.only("Alice", "Charlie")
         ()
-      case (RawTransaction.NodeId(`nonConsumingExeNid`), _, witnesses) =>
+      case (RawTransaction.NodeId(testTransaction.`nonConsumingExeNid`), _, witnesses) =>
         // Non-consuming exercises are only witnessed by signatories.
         witnesses should contain only "Alice"
         ()
-      case (RawTransaction.NodeId(`rootNid`), _, witnesses) =>
+      case (RawTransaction.NodeId(testTransaction.`rootNid`), _, witnesses) =>
         witnesses should contain only "Alice"
         ()
-      case (RawTransaction.NodeId(`fetchNid`), _, witnesses) =>
+      case (RawTransaction.NodeId(testTransaction.`fetchNid`), _, witnesses) =>
         // This is of course ill-authorized, but we check that parent witnesses are included.
         witnesses should contain.only("Alice", "Bob")
         ()
@@ -88,7 +47,8 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
   }
 
   test("extractPerPackageWitnesses - extract package witness mapping as expected") {
-    val result = TransactionTraversal.extractPerPackageWitnesses(rawTx)
+    val testTransaction = RawTransactionForTest()
+    val result = TransactionTraversal.extractPerPackageWitnesses(testTransaction.rawTx)
     result shouldBe
       Right(
         Map(
@@ -100,6 +60,62 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
       )
   }
 
+  test(
+    "extractPerPackageWitnesses - extract package witness mapping as expected including rollback node"
+  ) {
+    val testTransaction = RawTransactionForTest()
+    def lookupByKeyNode(index: Int) = withNodeBuilder { builder =>
+      builder.setLookupByKey(
+        NodeLookupByKey.newBuilder
+          .setTemplateId(identifierForTemplateId(s"template_lookup_by_key$index"))
+          .setKeyWithMaintainers(
+            KeyWithMaintainers.newBuilder().addMaintainers(s"LookupByKey$index Party")
+          )
+      )
+    }
+    val transactionBuilder = testTransaction.builder
+    transactionBuilder.addRoot(
+      exerciseNode(
+        signatories = Seq("Exercise with Rollback Node Party"),
+        stakeholders = Seq.empty,
+        consuming = false,
+        children = transactionBuilder.addNode(
+          buildRollbackNodeWithChild(
+            transactionBuilder.addNode(lookupByKeyNode(0)),
+            transactionBuilder.addNode(
+              buildRollbackNodeWithChild(transactionBuilder.addNode(lookupByKeyNode(1)))
+            ),
+          )
+        ),
+      )
+    )
+    val result = TransactionTraversal.extractPerPackageWitnesses(testTransaction.rawTx)
+    result shouldBe
+      Right(
+        Map(
+          "template_exercise" -> Set("Alice", "Charlie", "Exercise with Rollback Node Party"),
+          "interface_exercise" -> Set("Alice", "Charlie", "Exercise with Rollback Node Party"),
+          "template_create" -> Set("Alice", "Charlie", "Bob"),
+          "template_fetch" -> Set("Alice", "Bob"),
+          "template_lookup_by_key0" -> Set(
+            "LookupByKey0 Party",
+            "Exercise with Rollback Node Party",
+          ),
+          "template_lookup_by_key1" -> Set(
+            "LookupByKey1 Party",
+            "Exercise with Rollback Node Party",
+          ),
+        )
+      )
+  }
+
+  private def buildRollbackNodeWithChild(children: String*) = {
+    withNodeBuilder { builder =>
+      builder.setRollback(
+        NodeRollback.newBuilder.addAllChildren(children.asJava)
+      )
+    }
+  }
   test("traversal - transaction parsing error") {
     val rawTx = RawTransaction(ByteString.copyFromUtf8("wrong"))
     TransactionTraversal.traverseTransactionWithWitnesses(rawTx)((_, _, _) => ()) shouldBe Left(
@@ -116,7 +132,7 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
     actual shouldBe Left(ConversionError.ParseError("Unsupported transaction version 'wrong'"))
   }
 
-  test("traversal - node decoding error") {
+  test("traversal - decode error on rollback nodes") {
     val rootNodeId = "1"
     val rawTx = RawTransaction(
       Transaction
@@ -136,17 +152,59 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
         )
       )
     )
-    TransactionTraversal.extractPerPackageWitnesses(rawTx) shouldBe Left(
-      ConversionError.DecodeError(
-        ValueCoder.DecodeError(
-          "protoActionNodeInfo only supports action nodes but was applied to a rollback node"
-        )
-      )
-    )
   }
 
   // --------------------------------------------------------
   // Helpers for constructing transactions.
+  case class RawTransactionForTest() {
+    val builder: TransactionBuilder = TransactionBuilder()
+
+    // Creation of a contract with Alice as signatory, and Bob is controller of one of the choices.
+    val createNid: String = builder.addNode(
+      createNode(List("Alice"), List("Alice", "Bob"))
+    )
+
+    // Exercise of a contract where Alice as signatory, Charlie has a choice or is an observer.
+    val exeNid: String = builder.addNode(
+      exerciseNode(
+        signatories = List("Alice"),
+        stakeholders = List("Alice", "Charlie"),
+        consuming = true,
+        createNid,
+      )
+    )
+
+    // Non-consuming exercise of a contract where Alice as signatory, Charlie has a choice or is an observer.
+    val nonConsumingExeNid: String = builder.addNode(
+      exerciseNode(
+        signatories = List("Alice"),
+        stakeholders = List("Alice", "Charlie"),
+        consuming = false,
+      )
+    )
+
+    // A fetch of some contract created by Bob.
+    val fetchNid: String = builder.addNode(
+      fetchNode(
+        signatories = List("Bob"),
+        stakeholders = List("Bob"),
+      )
+    )
+
+    // Root node exercising a contract only known to Alice.
+    val rootNid: String = builder.addRoot(
+      exerciseNode(
+        signatories = List("Alice"),
+        stakeholders = List("Alice"),
+        consuming = true,
+        fetchNid,
+        nonConsumingExeNid,
+        exeNid,
+      )
+    )
+
+    def rawTx: RawTransaction = RawTransaction(builder.build.toByteString)
+  }
 
   case class TransactionBuilder() {
     private var roots = List.empty[String]
@@ -191,7 +249,7 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
   private def createNode(signatories: Iterable[String], stakeholders: Iterable[String]) =
     withNodeBuilder {
       _.getCreateBuilder
-        .setTemplateId(ValueOuterClass.Identifier.newBuilder().setPackageId("template_create"))
+        .setTemplateId(identifierForTemplateId("template_create"))
         .addAllSignatories(signatories.asJava)
         .addAllStakeholders(stakeholders.asJava)
     }
@@ -202,7 +260,7 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
   private def fetchNode(signatories: Iterable[String], stakeholders: Iterable[String]) =
     withNodeBuilder {
       _.getFetchBuilder
-        .setTemplateId(ValueOuterClass.Identifier.newBuilder().setPackageId("template_fetch"))
+        .setTemplateId(identifierForTemplateId("template_fetch"))
         .addAllSignatories(signatories.asJava)
         .addAllStakeholders(stakeholders.asJava)
     }
@@ -211,20 +269,21 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
     * on.
     */
   private def exerciseNode(
-      signatories: Iterable[String],
-      stakeholders: Iterable[String],
+      signatories: Seq[String],
+      stakeholders: Seq[String],
       consuming: Boolean,
       children: String*
   ) =
     withNodeBuilder {
       _.getExerciseBuilder
         .setConsuming(consuming)
-        .setTemplateId(ValueOuterClass.Identifier.newBuilder().setPackageId("template_exercise"))
-        .setInterfaceId(ValueOuterClass.Identifier.newBuilder().setPackageId("interface_exercise"))
+        .setTemplateId(identifierForTemplateId("template_exercise"))
+        .setInterfaceId(identifierForTemplateId("interface_exercise"))
         .addAllSignatories(signatories.asJava)
         .addAllStakeholders(stakeholders.asJava)
         /* NOTE(JM): Actors are no longer included in exercises by the compiler, hence we don't set them */
         .addAllChildren(children.asJava)
     }
 
+  private def identifierForTemplateId = ValueOuterClass.Identifier.newBuilder().setPackageId _
 }


### PR DESCRIPTION
Cherrypick (#15020)


We need to extract all the package party mappings found in a transaction, including the nodes that are under a rollback node Rollback nodes have no informees of their own but we extract the children as expected

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
