### PR TITLE
Restrict degree to which Speedy.Machine exposes its mutable state

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -368,7 +368,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
       time: Time.Timestamp,
   ): Result[(SubmittedTransaction, Tx.Metadata)] = machine.withOnLedger("Daml Engine") { onLedger =>
     def detailMsg = Some(
-      s"Last location: ${Pretty.prettyLoc(machine.lastLocation).render(80)}, partial transaction: ${onLedger.nodesToString}"
+      s"Last location: ${Pretty.prettyLoc(machine.getLastLocation).render(80)}, partial transaction: ${onLedger.nodesToString}"
     )
     def versionDisclosedContract(d: speedy.DisclosedContract): Versioned[DisclosedContract] = {
       val version = machine.tmplId2TxVersion(d.templateId)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
@@ -4,18 +4,19 @@
 package com.daml.lf
 package speedy
 
-import com.daml.lf.speedy.Speedy.{Machine, Control}
-import scala.collection.mutable.Map
+import com.daml.lf.speedy.Speedy.{Control, Machine}
+
+import scala.collection.mutable
 
 private[speedy] object Classify { // classify the machine state w.r.t what step occurs next
 
   final class Counts(
       var ctrlExpr: Int = 0,
       var ctrlValue: Int = 0,
-      var exprs: Map[String, Int] = Map.empty,
-      var konts: Map[String, Int] = Map.empty,
+      var exprs: mutable.Map[String, Int] = mutable.Map.empty,
+      var konts: mutable.Map[String, Int] = mutable.Map.empty,
   ) {
-    def steps = ctrlExpr + ctrlValue
+    def steps: Int = ctrlExpr + ctrlValue
     def pp: String = {
       val lines =
         (("CtrlExpr:", ctrlExpr) :: exprs.toList.map { case (expr, n) => ("- " + expr, n) }) ++
@@ -25,16 +26,16 @@ private[speedy] object Classify { // classify the machine state w.r.t what step 
   }
 
   def classifyMachine(machine: Machine, counts: Counts): Unit = {
-    machine.control match {
+    machine.currentControl match {
       case Control.Value(_) =>
         // classify a value by the continution it is about to return to
         counts.ctrlValue += 1
-        val kont = machine.kontStack.get(machine.kontStack.size - 1).getClass.getSimpleName
-        val _ = counts.konts += kont -> (counts.konts.get(kont).getOrElse(0) + 1)
+        val kont = machine.peekKontStackEnd().getClass.getSimpleName
+        val _ = counts.konts += kont -> (counts.konts.getOrElse(kont, 0) + 1)
       case Control.Expression(exp) =>
         counts.ctrlExpr += 1
         val expr = exp.getClass.getSimpleName
-        val _ = counts.exprs += expr -> (counts.exprs.get(expr).getOrElse(0) + 1)
+        val _ = counts.exprs += expr -> (counts.exprs.getOrElse(expr, 0) + 1)
       case _ => ()
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -4,7 +4,6 @@
 package com.daml.lf
 package speedy
 
-import java.util
 import scala.jdk.CollectionConverters._
 
 import com.daml.lf.speedy.Speedy._
@@ -14,7 +13,7 @@ import com.daml.lf.speedy.SValue._
 private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK machine states
 
   def ppMachine(m: Machine): String = {
-    s"[${m.envBase}] ${ppEnv(m.env)} -- ${ppCtrl(m.control)} -- ${ppKontStack(m.kontStack)}"
+    s"[${m.currentEnvBase}] ${ppEnv(m.currentEnv)} -- ${ppCtrl(m.currentControl)} -- ${ppKontStack(m)}"
   }
 
   def ppCtrl(control: Control): String =
@@ -31,8 +30,8 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
     s"#${env.size()}={${commas(env.asScala.map(pp))}}"
   }
 
-  def ppKontStack(ks: util.ArrayList[Kont]): String = {
-    s"[${ppKont(ks.get(ks.size - 1))}... #${ks.size()}]" // head kont & size
+  def ppKontStack(m: Machine): String = {
+    s"[${ppKont(m.peekKontStackEnd())}... #${m.kontDepth()}]" // head kont & size
   }
 
   def ppKont(k: Kont): String = k.getClass.getSimpleName

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -963,7 +963,7 @@ private[lf] object SBuiltin {
               templateId = cached.templateId,
               arg = createArgValue,
               agreementText = agreement,
-              optLocation = machine.lastLocation,
+              optLocation = machine.getLastLocation,
               signatories = cached.signatories,
               stakeholders = cached.stakeholders,
               key = cached.key,
@@ -1029,7 +1029,7 @@ private[lf] object SBuiltin {
           templateId = templateId,
           interfaceId = interfaceId,
           choiceId = choiceId,
-          optLocation = machine.lastLocation,
+          optLocation = machine.getLastLocation,
           consuming = consuming,
           actingParties = ctrls,
           signatories = sigs,
@@ -1454,7 +1454,7 @@ private[lf] object SBuiltin {
       onLedger.ptx.insertFetch(
         coid = coid,
         templateId = templateId,
-        optLocation = machine.lastLocation,
+        optLocation = machine.getLastLocation,
         signatories = signatories,
         observers = observers,
         key = key,
@@ -1498,7 +1498,7 @@ private[lf] object SBuiltin {
       }
       onLedger.ptx.insertLookup(
         templateId = templateId,
-        optLocation = machine.lastLocation,
+        optLocation = machine.getLastLocation,
         key = Node.KeyWithMaintainers(
           key = keyWithMaintainers.key,
           maintainers = keyWithMaintainers.maintainers,
@@ -1769,7 +1769,7 @@ private[lf] object SBuiltin {
         machine: Machine,
     ): Control = {
       val message = getSText(args, 0)
-      machine.traceLog.add(message, machine.lastLocation)(machine.loggingContext)
+      machine.traceLog.add(message, machine.getLastLocation)(machine.loggingContext)
       Control.Value(args.get(1))
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -234,7 +234,7 @@ object SExpr {
   /** A let-expression with a single RHS */
   final case class SELet1General(rhs: SExpr, body: SExpr) extends SExpr with SomeArrayEquals {
     def execute(machine: Machine): Control = {
-      machine.pushKont(KPushTo(machine, machine.env, body))
+      machine.pushKont(KPushTo(machine, machine.currentEnv, body))
       Control.Expression(rhs)
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -326,7 +326,7 @@ private[lf] object Speedy {
     /* Actuals: to access values for a function application's arguments. */
     private[this] var actuals: Actuals = null
     /* [env] is a stack of temporary values for: let-bindings and pattern-matches. */
-    private[speedy] var env: Env = emptyEnv // TODO: restrict this - TailCallTest!!
+    private[speedy] var env: Env = emptyEnv
     /* [envBase] is the depth of the temporaries-stack when the current code-context was
      * begun. We revert to this depth when entering a closure, or returning to the top
      * continuation on the kontStack.
@@ -336,7 +336,7 @@ private[lf] object Speedy {
      * once the control has been evaluated.
      */
     private[speedy] var kontStack: util.ArrayList[Kont] =
-      initialKontStack() // TODO: restrict this - TailCallTest!!
+      initialKontStack()
     /* The last encountered location */
     private[this] var lastLocation: Option[Location] = None
     /* Used when enableLightweightStepTracing is true */
@@ -347,17 +347,17 @@ private[lf] object Speedy {
     private[speedy] def currentControl: Control = control
 
     private[speedy] def currentFrame: Frame =
-      frame // FIXME: this should be a immutable return value
+      frame
 
     private[speedy] def currentActuals: Actuals =
-      actuals // FIXME: this should be a immutable return value
+      actuals
 
-    private[speedy] def currentEnv: Env = env // FIXME: this should be a immutable return value
+    private[speedy] def currentEnv: Env = env
 
     private[speedy] def currentEnvBase: Int = envBase
 
     private[speedy] def currentKontStack: util.ArrayList[Kont] =
-      kontStack // FIXME: this should be a immutable return value
+      kontStack
 
     private[lf] def getLastLocation: Option[Location] = lastLocation
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -335,8 +335,7 @@ private[lf] object Speedy {
     /* Kont, or continuation specifies what should be done next
      * once the control has been evaluated.
      */
-    private[speedy] var kontStack: util.ArrayList[Kont] =
-      initialKontStack()
+    private[speedy] var kontStack: util.ArrayList[Kont] = initialKontStack()
     /* The last encountered location */
     private[this] var lastLocation: Option[Location] = None
     /* Used when enableLightweightStepTracing is true */
@@ -346,18 +345,15 @@ private[lf] object Speedy {
 
     private[speedy] def currentControl: Control = control
 
-    private[speedy] def currentFrame: Frame =
-      frame
+    private[speedy] def currentFrame: Frame = frame
 
-    private[speedy] def currentActuals: Actuals =
-      actuals
+    private[speedy] def currentActuals: Actuals = actuals
 
     private[speedy] def currentEnv: Env = env
 
     private[speedy] def currentEnvBase: Int = envBase
 
-    private[speedy] def currentKontStack: util.ArrayList[Kont] =
-      kontStack
+    private[speedy] def currentKontStack: util.ArrayList[Kont] = kontStack
 
     private[lf] def getLastLocation: Option[Location] = lastLocation
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala
@@ -111,7 +111,7 @@ class TailCallTest extends AnyWordSpec with Matchers with TableDrivenPropertyChe
     envBound match {
       case None => ()
       case Some(bound) =>
-        machine.env = new BoundedArrayList[SValue](bound) // FIXME: not good!!
+        machine.env = new BoundedArrayList[SValue](bound)
     }
     // maybe replace the kont-stack with a bounded version
     kontBound match {
@@ -123,7 +123,7 @@ class TailCallTest extends AnyWordSpec with Matchers with TableDrivenPropertyChe
           } else {
             machine.peekKontStackTop()
           }
-        machine.kontStack = new BoundedArrayList[Speedy.Kont](bound) // FIXME: not good!!
+        machine.kontStack = new BoundedArrayList[Speedy.Kont](bound)
         machine.pushKont(onlyKont)
     }
     // run the machine

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala
@@ -111,20 +111,20 @@ class TailCallTest extends AnyWordSpec with Matchers with TableDrivenPropertyChe
     envBound match {
       case None => ()
       case Some(bound) =>
-        machine.env = new BoundedArrayList[SValue](bound)
+        machine.env = new BoundedArrayList[SValue](bound) // FIXME: not good!!
     }
     // maybe replace the kont-stack with a bounded version
     kontBound match {
       case None => ()
       case Some(bound) =>
         val onlyKont: Speedy.Kont =
-          if (machine.kontStack.size != 1) {
-            crash(s"setBoundedKontStack, unexpected size of kont-stack: ${machine.kontStack.size}")
+          if (machine.kontDepth() != 1) {
+            crash(s"setBoundedKontStack, unexpected size of kont-stack: ${machine.kontDepth()}")
           } else {
-            machine.kontStack.get(0)
+            machine.peekKontStackTop()
           }
-        machine.kontStack = new BoundedArrayList[Speedy.Kont](bound)
-        machine.kontStack.add(onlyKont)
+        machine.kontStack = new BoundedArrayList[Speedy.Kont](bound) // FIXME: not good!!
+        machine.pushKont(onlyKont)
     }
     // run the machine
     machine.run() match {

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -558,7 +558,7 @@ object Repl {
         case error: ScenarioRunner.ScenarioError =>
           println(
             "failed at " +
-              prettyLoc(machine.lastLocation).render(128) +
+              prettyLoc(machine.getLastLocation).render(128) +
               ": " + PrettyScenario.prettyError(error.error).render(128)
           )
           failures += 1

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -61,7 +61,7 @@ class CollectAuthorityState {
       compiledPackages,
       expr,
     )
-    the_sexpr = machine.control match {
+    the_sexpr = machine.currentControl match {
       case Control.Expression(exp) => exp
       case x => crash(s"expected Control.Expression, got: $x")
     }


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->

Goal of this PR is to perform a minimal set of (simple minded) refactors to `Speedy.Machine` to reduce the degree to which it spills its internal mutable state. Its the first step of many in the direction of this goal!

CHANGELOG_BEGIN
CHANGELOG_END
