### PR TITLE
[engine] drop deprecated LenientExercise Command

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/ReplayCommand.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/ReplayCommand.scala
@@ -20,16 +20,6 @@ object ReplayCommand {
       argument: Value,
   ) extends ReplayCommand
 
-  // TODO: https://github.com/digital-asset/daml/issues/12051
-  //  Drop this, once Canton support ambiguous choices properly
-  @deprecated("use Exercise")
-  final case class LenientExercise(
-      templateId: TypeConName,
-      contractId: Value.ContractId,
-      choiceId: ChoiceName,
-      argument: Value,
-  ) extends ReplayCommand
-
   /** Exercise a template choice, by template Id or interface Id. */
   final case class Exercise(
       templateId: TypeConName,


### PR DESCRIPTION
CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
