### PR TITLE
[LF] fix encoder for ELocation

### DIFF
--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -525,8 +525,10 @@ private[daml] class EncodeV1(minor: LV.Minor) {
       binder -> body
     })
 
-    private def encodeExprBuilder(expr0: Expr): PLF.Expr.Builder = {
-      val builder = PLF.Expr.newBuilder()
+    private def encodeExprBuilder(
+        expr0: Expr,
+        builder: PLF.Expr.Builder = PLF.Expr.newBuilder(),
+    ): PLF.Expr.Builder = {
 
       // EAbss breaks the exhaustiveness checker.
       (expr0: @unchecked) match {
@@ -630,7 +632,7 @@ private[daml] class EncodeV1(minor: LV.Minor) {
         case ESome(typ, x) =>
           builder.setOptionalSome(PLF.Expr.OptionalSome.newBuilder().setType(typ).setBody(x))
         case ELocation(loc, expr) =>
-          encodeExprBuilder(expr).setLocation(loc)
+          encodeExprBuilder(expr, builder).setLocation(loc)
         case EUpdate(u) =>
           builder.setUpdate(u)
         case EScenario(s) =>

--- a/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1Spec.scala
+++ b/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1Spec.scala
@@ -270,7 +270,7 @@ object EncodeV1Spec {
       case EAbs(binder, body, Some(_)) =>
         EAbs(normalizer.apply(binder), normalizer.apply(body), None)
       case ELocation(loc, expr) if loc.packageId == hashCode =>
-        ELocation(loc = loc.copy(packageId = pkgId), expr)
+        ELocation(loc = loc.copy(packageId = pkgId), normalizer.apply(expr))
     }
     lazy val normalizer = new AstRewriter(exprRule = exprRule, identifierRule = identifierRule)
 

--- a/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1Spec.scala
+++ b/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1Spec.scala
@@ -89,10 +89,10 @@ class EncodeV1Spec extends AnyWordSpec with Matchers with TableDrivenPropertyChe
            record Tree.Node (a: *) = { value: a, left : Mod:Tree a, right : Mod:Tree a };
            enum Color = Red | Green | Blue;
 
+           val unit: Unit = loc(Mod, unit, 92, 12, 92, 61) ();
            val aVar: forall (a:*). a -> a = /\ (a: *). \ (x: a) -> x;
            val aValue: forall (a:*). a -> a = Mod:aVar;
            val aBuiltin : Int64 -> Int64 -> Int64 = ADD_INT64;
-           val unit: Unit = ();
            val myFalse: Bool = False;
            val myTrue: Bool = True;
            val aInt: Int64 = 14;
@@ -263,13 +263,16 @@ object EncodeV1Spec {
 
   private def normalize(pkg: Package, hashCode: PackageId, selfPackageId: PackageId): Package = {
 
-    val replacePkId: PartialFunction[Identifier, Identifier] = {
+    val identifierRule: PartialFunction[Identifier, Identifier] = {
       case Identifier(`hashCode`, name) => Identifier(selfPackageId, name)
     }
-    lazy val dropEAbsRef: PartialFunction[Expr, Expr] = { case EAbs(binder, body, Some(_)) =>
-      EAbs(normalizer.apply(binder), normalizer.apply(body), None)
+    lazy val exprRule: PartialFunction[Expr, Expr] = {
+      case EAbs(binder, body, Some(_)) =>
+        EAbs(normalizer.apply(binder), normalizer.apply(body), None)
+      case ELocation(loc, expr) if loc.packageId == hashCode =>
+        ELocation(loc = loc.copy(packageId = pkgId), expr)
     }
-    lazy val normalizer = new AstRewriter(exprRule = dropEAbsRef, identifierRule = replacePkId)
+    lazy val normalizer = new AstRewriter(exprRule = exprRule, identifierRule = identifierRule)
 
     normalizer.apply(pkg)
   }


### PR DESCRIPTION
Without this fix the ELocation expression were simply drop when converted to protobuf.

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
