### PR TITLE
[LF] improve AstRewriter

### DIFF
--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -528,7 +528,7 @@ private[daml] class EncodeV1(minor: LV.Minor) {
     private def encodeExprBuilder(
         expr0: Expr,
         builder: PLF.Expr.Builder = PLF.Expr.newBuilder(),
-    ): PLF.Expr.Builder = {
+    ): builder.type = {
 
       // EAbss breaks the exhaustiveness checker.
       (expr0: @unchecked) match {


### PR DESCRIPTION
Allows easy renaming of `packageId` in a Ast  

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
