### PR TITLE
Backport added logging for time elapsed of ledger client call (#14711)

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -74,7 +74,7 @@ class CommandService(
       val command = createCommand(input)
       val request = submitAndWaitRequest(jwtPayload, input.meta, command, "create")
       val et: ET[ActiveContract[lav1.value.Value]] = for {
-        response <- logResult(Symbol("create"), submitAndWaitForTransaction(jwt, request))
+        response <- logResult(Symbol("create"), submitAndWaitForTransaction(jwt, request)(lc))
         contract <- either(exactlyOneActiveContract(response))
       } yield contract
       et.run
@@ -99,7 +99,7 @@ class CommandService(
 
           val et: ET[ExerciseResponse[lav1.value.Value]] = for {
             response <-
-              logResult(Symbol("exercise"), submitAndWaitForTransactionTree(jwt, request))
+              logResult(Symbol("exercise"), submitAndWaitForTransactionTree(jwt, request)(lc))
             exerciseResult <- either(exerciseResult(response))
             contracts <- either(contracts(response))
           } yield ExerciseResponse(exerciseResult, contracts)
@@ -122,7 +122,7 @@ class CommandService(
       val et: ET[ExerciseResponse[lav1.value.Value]] = for {
         response <- logResult(
           Symbol("createAndExercise"),
-          submitAndWaitForTransactionTree(jwt, request),
+          submitAndWaitForTransactionTree(jwt, request)(lc),
         )
         exerciseResult <- either(exerciseResult(response))
         contracts <- either(contracts(response))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
@@ -111,7 +111,7 @@ private class ContractsFetch(
 
     // we assume that if the ledger termination is LedgerBegin, then
     // `within` will not yield concurrency-relevant results
-    connectionIOFuture(getTermination(jwt, ledgerId)) flatMap {
+    connectionIOFuture(getTermination(jwt, ledgerId)(lc)) flatMap {
       _.cata(go(initTries, templateIds, _), within(LedgerBegin))
     }
   }
@@ -126,7 +126,7 @@ private class ContractsFetch(
       mat: Materializer,
       lc: LoggingContextOf[InstanceUUID],
   ): ConnectionIO[BeginBookmark[Terminates.AtAbsolute]] =
-    connectionIOFuture(getTermination(jwt, ledgerId)) flatMap {
+    connectionIOFuture(getTermination(jwt, ledgerId)(lc)) flatMap {
       _.cata(
         fetchToAbsEnd(FetchContext(jwt, ledgerId, parties), templateIds, _),
         fconn.pure(LedgerBegin),
@@ -304,7 +304,7 @@ private class ContractsFetch(
           transactionFilter(parties, List(templateId)),
           _: lav1.ledger_offset.LedgerOffset,
           absEnd,
-        )
+        )(lc)
 
         // include ACS iff starting at LedgerBegin
         val (idses, lastOff) = (startOffset, disableAcs) match {
@@ -315,7 +315,7 @@ private class ContractsFetch(
               ledgerId,
               transactionFilter(parties, List(templateId)),
               true,
-            )
+            )(lc)
             (stepsAndOffset.out0, stepsAndOffset.out1)
 
           case (AbsoluteBookmark(_), _) | (LedgerBegin, true) =>

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/CommandServiceTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/CommandServiceTest.scala
@@ -100,27 +100,29 @@ object CommandServiceTest {
     (
       new CommandService(
         submitAndWaitForTransaction = (_, req) =>
-          Future {
-            txns.add(req)
-            import lav1.event.{CreatedEvent, Event}, Event.Event.Created
-            val creation = Event(
-              Created(
-                CreatedEvent(
-                  templateId = Some(
-                    lav1.value
-                      .Identifier(tplId.packageId, tplId.moduleName, tplId.entityName)
-                  ),
-                  createArguments = Some(lav1.value.Record()),
+          _ =>
+            Future {
+              txns.add(req)
+              import lav1.event.{CreatedEvent, Event}, Event.Event.Created
+              val creation = Event(
+                Created(
+                  CreatedEvent(
+                    templateId = Some(
+                      lav1.value
+                        .Identifier(tplId.packageId, tplId.moduleName, tplId.entityName)
+                    ),
+                    createArguments = Some(lav1.value.Record()),
+                  )
                 )
               )
-            )
-            \/-(SubmitAndWaitForTransactionResponse(Some(Transaction(events = Seq(creation)))))
-          },
+              \/-(SubmitAndWaitForTransactionResponse(Some(Transaction(events = Seq(creation)))))
+            },
         submitAndWaitForTransactionTree = (_, req) =>
-          Future {
-            trees.add(req)
-            \/-(SubmitAndWaitForTransactionTreeResponse(Some(TransactionTree())))
-          },
+          _ =>
+            Future {
+              trees.add(req)
+              \/-(SubmitAndWaitForTransactionTreeResponse(Some(TransactionTree())))
+            },
       ),
       txns.asScala,
       trees.asScala,

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LeveledLogger.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LeveledLogger.scala
@@ -8,7 +8,7 @@ import org.slf4j.{Logger, Marker}
 private[logging] object LeveledLogger {
 
   final class Trace(logger: Logger) extends LeveledLogger {
-    override protected def isEnabled: Boolean =
+    override def isEnabled: Boolean =
       logger.isTraceEnabled()
     override protected def log(msg: String): Unit =
       logger.trace(msg)
@@ -23,7 +23,7 @@ private[logging] object LeveledLogger {
   }
 
   final class Debug(logger: Logger) extends LeveledLogger {
-    override protected def isEnabled: Boolean =
+    override def isEnabled: Boolean =
       logger.isDebugEnabled()
     override protected def log(msg: String): Unit =
       logger.debug(msg)
@@ -38,7 +38,7 @@ private[logging] object LeveledLogger {
   }
 
   final class Info(logger: Logger) extends LeveledLogger {
-    override protected def isEnabled: Boolean =
+    override def isEnabled: Boolean =
       logger.isInfoEnabled()
     override protected def log(msg: String): Unit =
       logger.info(msg)
@@ -53,7 +53,7 @@ private[logging] object LeveledLogger {
   }
 
   final class Warn(logger: Logger) extends LeveledLogger {
-    override protected def isEnabled: Boolean =
+    override def isEnabled: Boolean =
       logger.isWarnEnabled()
     override protected def log(msg: String): Unit =
       logger.warn(msg)
@@ -68,7 +68,7 @@ private[logging] object LeveledLogger {
   }
 
   final class Error(logger: Logger) extends LeveledLogger {
-    override protected def isEnabled: Boolean =
+    override def isEnabled: Boolean =
       logger.isErrorEnabled()
     override protected def log(msg: String): Unit =
       logger.error(msg)
@@ -86,7 +86,7 @@ private[logging] object LeveledLogger {
 
 private[logging] sealed abstract class LeveledLogger {
 
-  protected def isEnabled: Boolean
+  def isEnabled: Boolean
 
   protected def log(msg: String): Unit
   protected def log(msg: String, t: Throwable): Unit


### PR DESCRIPTION
Backport of #14711.

* Added logging for time elapsed of ledger client call

CHANGELOG_BEGIN
CHANGELOG_END

fixes #14673

* rename logging def

* ADDED TODO

* ADDED TODO

* pass in boolean for determining if it should log based on the log level

* address Ray's comment. Wrong name Ledge -? Ledger

* make isEnable public and use it to determin whether it is debug level

* refactoring. put everything in a inner object LedgerClientRequestTimeLogger

* remove useless line

* address Ray's comment

* address Ray's comment

* log the time used for source as well

* address Stephen's address # Conflicts:
#	ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala #	ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
