### PR TITLE
[engine] avoid construction of unrestricted speedy expression applications

### DIFF
--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/speedy/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/speedy/ReplServiceMain.scala
@@ -256,7 +256,7 @@ class ReplService(
       )
     )
     if (!results.isEmpty) {
-      scriptExpr = SEApp(scriptExpr, results.map(SEValue(_)).toArray)
+      scriptExpr = SEApp(scriptExpr, results.toArray)
     }
 
     val signatures = this.signatures.updated(homePackageId, AstUtil.toSignature(pkg))

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -9,7 +9,7 @@ import com.daml.lf.data._
 import com.daml.lf.data.Ref.{Identifier, PackageId, ParticipantId, Party}
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.{InitialSeeding, PartialTransaction, Pretty, SError, SValue}
-import com.daml.lf.speedy.SExpr.{SEApp, SEValue, SExpr}
+import com.daml.lf.speedy.SExpr.{SEApp, SExpr}
 import com.daml.lf.speedy.Speedy.Machine
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.transaction.{
@@ -321,7 +321,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
       compiledPackages = compiledPackages,
       submissionTime = submissionTime,
       initialSeeding = seeding,
-      expr = SEApp(sexpr, Array(SEValue.Token)),
+      expr = SEApp(sexpr, Array(SValue.SToken)),
       committers = submitters,
       readAs = readAs,
       validating = validating,

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
@@ -94,7 +94,7 @@ object PlaySpeedy {
             QualifiedName.assertFromString(s"${base}:${config.funcName}"),
           )
         val func = SEVal(LfDefRef(ref))
-        val arg = SEValue(SInt64(config.argValue))
+        val arg = SInt64(config.argValue)
         SEApp(func, Array(arg))
       }
       Machine.fromPureSExpr(compiledPackages, expr)

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
@@ -36,7 +36,7 @@ object LoadDarFunction extends App {
         val ref: DefinitionRef =
           Identifier(packages.main._1, QualifiedName.assertFromString(s"${base}:${funcName}"))
         val func = SEVal(LfDefRef(ref))
-        val arg = SEValue(SInt64(argValue))
+        val arg = SInt64(argValue)
         SEApp(func, Array(arg))
       }
       val machine = Machine.fromPureSExpr(compiledPackages, expr)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -19,7 +19,7 @@ package com.daml.lf.speedy
   *
   *  The speedy machine now expects that it will never have to execute a non-ANF expression,
   *  crashing at runtime if one is encountered. In particular we must ensure that the
-  *  expression forms: SEAppGeneral and SECase are removed, and replaced by the simpler
+  *  expression forms: SEApp(General) and SECase are removed, and replaced by the simpler
   *  SEAppAtomic and SECaseAtomic (plus SELet as required).
   *
   *  This compilation phase transforms from SExpr1 to SExpr.
@@ -463,7 +463,7 @@ private[lf] object Anf {
       // we dont atomize the args here
       flattenExpList(depth, env, args) { args =>
         // we build a non-atomic application here (only the function is atomic)
-        transform(depth, target.SEAppAtomicFun(func1, args.toArray))(k)
+        transform(depth, target.SEAppOnlyFunIsAtomic_DEPRECATED(func1, args.toArray))(k)
       }
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ClosureConversion.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ClosureConversion.scala
@@ -95,7 +95,7 @@ private[speedy] object ClosureConversion {
       *   two corresponding continuation forms: (Cont.TryCatch1, Cont.TryCatch2).
       *
       *   For the more complex expression forms containing a list of recursive instances
-      *   (i.e. SEAppGeneral), the corresponding continuation forms are also more complex,
+      *   (i.e. SEApp), the corresponding continuation forms are also more complex,
       *   but will generally have two cases (i.e. Cont.App1, Cont.App2), corresponding to
       *   the Nil/Cons cases of the list of recursive instances.
       *

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -165,9 +165,11 @@ private[lf] final class Compiler(
   @throws[PackageNotFound]
   @throws[CompilationError]
   def unsafeCompileInterfaceView(view: InterfaceView): t.SExpr = {
-    SBViewInterface(view.interfaceId)(
-      SBToAnyContract(view.templateId)(t.SEValue(view.argument))
+    val e0 = s.SEApp(
+      s.SEBuiltin(SBViewInterface(view.interfaceId)),
+      List(s.SEApp(s.SEBuiltin(SBToAnyContract(view.templateId)), List(s.SEValue(view.argument)))),
     )
+    pipeline(e0)
   }
 
   private[this] val stablePackageIds = StablePackage.ids(config.allowedLanguageVersions)
@@ -340,9 +342,8 @@ private[lf] final class Compiler(
     val disclosureLambda = pipeline(
       translateContractDisclosureLambda(Env.Empty, disclosures)
     )
-
     t.SELet1(
-      t.SEApp(disclosureLambda, Array(t.SEValue(SValue.Unit))),
+      t.SEApp(disclosureLambda, Array(SValue.Unit)),
       sexpr,
     )
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -532,7 +532,7 @@ private[lf] object Pretty {
           val prefix = prettySExpr(index)(fun) + text("@E(")
           intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
             .tightBracketBy(prefix, char(')'))
-        case SEAppAtomicFun(fun, args) =>
+        case SEAppOnlyFunIsAtomic_DEPRECATED(fun, args) =>
           val prefix = prettySExpr(index)(fun) + text("@N(")
           intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
             .tightBracketBy(prefix, char(')'))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -528,7 +528,7 @@ private[lf] object Pretty {
             case SBGetTime => text("$getTime")
             case _ => str(x)
           }
-        case SEAppGeneral(fun, args) =>
+        case SEAppGeneral_DEPRECATED(fun, args) =>
           val prefix = prettySExpr(index)(fun) + text("@E(")
           intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
             .tightBracketBy(prefix, char(')'))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -49,7 +49,7 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
   def pp(e: SExpr): String = e match {
     case SEValue(v) => s"(VALUE)${pp(v)}"
     case loc: SELoc => pp(loc)
-    case SEAppGeneral(func, args) => s"@E(${pp(func)},${commas(args.map(pp))})"
+    case SEAppGeneral_DEPRECATED(func, args) => s"@E(${pp(func)},${commas(args.map(pp))})"
     case SEAppOnlyFunIsAtomic_DEPRECATED(func, args) => s"@N(${pp(func)},${commas(args.map(pp))})"
     case SEAppAtomicGeneral(func, args) => s"@A(${pp(func)},${commas(args.map(pp))})"
     case SEAppAtomicSaturatedBuiltin(b, args) => s"@B(${pp(SEBuiltin(b))},${commas(args.map(pp))})"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -50,7 +50,7 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
     case SEValue(v) => s"(VALUE)${pp(v)}"
     case loc: SELoc => pp(loc)
     case SEAppGeneral(func, args) => s"@E(${pp(func)},${commas(args.map(pp))})"
-    case SEAppAtomicFun(func, args) => s"@N(${pp(func)},${commas(args.map(pp))})"
+    case SEAppOnlyFunIsAtomic_DEPRECATED(func, args) => s"@N(${pp(func)},${commas(args.map(pp))})"
     case SEAppAtomicGeneral(func, args) => s"@A(${pp(func)},${commas(args.map(pp))})"
     case SEAppAtomicSaturatedBuiltin(b, args) => s"@B(${pp(SEBuiltin(b))},${commas(args.map(pp))})"
     case SEMakeClo(fvs, arity, body) => s"[${commas(fvs.map(pp))}]\\$arity.${pp(body)}"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -100,13 +100,8 @@ object SExpr {
     }
   }
 
-  object SEValue extends SValueContainer[SEValue]
+  object SEValue extends SValueContainer[SEValue] // used by Compiler
 
-  /** Function application:
-    *    General case: 'fun' and 'args' are any kind of expression
-    *    This case *ought* not to exist post-ANF.
-    *    Sadly, we have many code paths where this case is constructed.
-    */
   final case class SEAppGeneral(fun: SExpr, args: Array[SExpr]) extends SExpr with SomeArrayEquals {
     def execute(machine: Machine): Control = {
       machine.pushKont(KArg(machine, args))
@@ -114,10 +109,13 @@ object SExpr {
     }
   }
 
-  /** Function application:
-    *    Special case: 'fun' is an atomic expression.
+  /** Function application with general arguments (deprecated)
+    * Although 'fun' is atomic, 'args' are still any kind of expression.
+    * This case would not exist if we performed a full/standard ANF pass.
+    * Because this case exists we must retain the complicated/slow path in the
+    * speedy-machine: executeApplication
     */
-  final case class SEAppAtomicFun(fun: SExprAtomic, args: Array[SExpr])
+  final case class SEAppOnlyFunIsAtomic_DEPRECATED(fun: SExprAtomic, args: Array[SExpr])
       extends SExpr
       with SomeArrayEquals {
     def execute(machine: Machine): Control = {
@@ -127,6 +125,13 @@ object SExpr {
   }
 
   object SEApp {
+    // Helper: build an application of an unrestricted expression, to value-arguments.
+    def apply(fun: SExpr, args: Array[SValue]): SExpr = {
+      SELet1(fun, SEAppAtomic(SELocS(1), args.map(SEValue(_))))
+    }
+  }
+
+  object SEAppG {
     def apply(fun: SExpr, args: Array[SExpr]): SExpr = {
       SEAppGeneral(fun, args)
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -102,7 +102,13 @@ object SExpr {
 
   object SEValue extends SValueContainer[SEValue] // used by Compiler
 
-  final case class SEAppGeneral(fun: SExpr, args: Array[SExpr]) extends SExpr with SomeArrayEquals {
+  /** Function application with general function/arguments (deprecated)
+    * This case exists purely for use by:
+    * and that us in turn is to support the current stack-trace support, which peeks under KArg.
+    */
+  final case class SEAppGeneral_DEPRECATED(fun: SExpr, args: Array[SExpr])
+      extends SExpr
+      with SomeArrayEquals {
     def execute(machine: Machine): Control = {
       machine.pushKont(KArg(machine, args))
       Control.Expression(fun)
@@ -128,12 +134,6 @@ object SExpr {
     // Helper: build an application of an unrestricted expression, to value-arguments.
     def apply(fun: SExpr, args: Array[SValue]): SExpr = {
       SELet1(fun, SEAppAtomic(SELocS(1), args.map(SEValue(_))))
-    }
-  }
-
-  object SEAppG {
-    def apply(fun: SExpr, args: Array[SExpr]): SExpr = {
-      SEAppGeneral(fun, args)
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -103,8 +103,8 @@ object SExpr {
   object SEValue extends SValueContainer[SEValue] // used by Compiler
 
   /** Function application with general function/arguments (deprecated)
-    * This case exists purely for use by:
-    * and that us in turn is to support the current stack-trace support, which peeks under KArg.
+    * This case is used only by: fromUpdateSExpr and fromScenarioSExpr.
+    * The use required because of our current stack-trace support, which peeks under KArg.
     */
   final case class SEAppGeneral_DEPRECATED(fun: SExpr, args: Array[SExpr])
       extends SExpr

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
@@ -28,7 +28,7 @@ package speedy
   *
   * Summary of which constructors are contained by: SExp0, SExpr1 and SExpr:
   *
-  * - In SExpr{0,1,} (everywhere): SEAppGeneral, SEBuiltin, SELabelClosure,
+  * - In SExpr{0,1,} (everywhere): SEApp(General), SEBuiltin, SELabelClosure,
   *   SELocation, SEScopeExercise, SETryCatch, SEVal, SEValue,
   *
   * - In SExpr0: SEAbs, SEVar
@@ -37,8 +37,8 @@ package speedy
   *
   * - In SExpr{1,}: SELocA, SELocF, SELocS, SEMakeClo, SELet1General,
   *
-  * - In SExpr: SEAppAtomicFun, SEAppAtomicGeneral, SEAppAtomicSaturatedBuiltin,
-  *   SECaseAtomic, SELet1Builtin, SELet1BuiltinArithmetic
+  * - In SExpr: SEAppAtomicGeneral, SEAppAtomicSaturatedBuiltin, SECaseAtomic,
+  *   SELet1Builtin, SELet1BuiltinArithmetic, SEAppOnlyFunIsAtomic_DEPRECATED,
   *
   * - In SExpr (runtime only, i.e. rejected by validate): SEDamlException, SEImportValue
   */
@@ -71,7 +71,7 @@ private[speedy] object SExpr0 {
 
   object SEValue extends SValueContainer[SEValue]
 
-  /** Function application */
+  /** Function application (Function and Args are unrestricted expressions) */
   final case class SEApp(fun: SExpr, args: List[SExpr]) extends SExpr
 
   /** Lambda abstraction. Transformed to SEMakeClo during closure conversion */

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -448,6 +448,11 @@ private[lf] object Speedy {
         // NOTE(MH): If the top of the continuation stack is the monadic token,
         // we push location information under it to account for the implicit
         // lambda binding the token.
+
+        // TODO: Understand how the current approach to stack-trace actually works.
+        // Peeking under KArg on the kontStack seems so unprincipled, and relies on our
+        // continued use of SEAppGeneral_DEPRECATED, which we want to remove.
+
         case Some(KArg(_, Array(SEValue.Token))) => {
           // Can't call pushKont here, because we don't push at the top of the stack.
           kontStack.add(last_index, KLocation(this, loc))
@@ -978,8 +983,8 @@ private[lf] object Speedy {
         compiledPackages = compiledPackages,
         submissionTime = Time.Timestamp.MinValue,
         initialSeeding = InitialSeeding.TransactionSeed(transactionSeed),
-        // expr = SEApp(updateSE, Array(SValue.SToken)),
-        expr = SEAppG(updateSE, Array(SEValue.Token)),
+        expr = SEAppGeneral_DEPRECATED(updateSE, Array(SEValue.Token)),
+        // expr = SEApp(updateSE, Array(SValue.SToken)), // TODO: when stack-trace hackery is resolved
         committers = committers,
         readAs = Set.empty,
         limits = limits,
@@ -996,8 +1001,8 @@ private[lf] object Speedy {
         scenario: SExpr,
     )(implicit loggingContext: LoggingContext): Machine = Machine.fromPureSExpr(
       compiledPackages = compiledPackages,
-      // expr = SEApp(scenario, Array(SValue.SToken)),
-      expr = SEAppG(scenario, Array(SEValue.Token)),
+      expr = SEAppGeneral_DEPRECATED(scenario, Array(SEValue.Token)),
+      // expr = SEApp(scenario, Array(SValue.SToken)), // TODO: when stack-trace hackery is resolved
     )
 
     @throws[PackageNotFound]

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -978,7 +978,8 @@ private[lf] object Speedy {
         compiledPackages = compiledPackages,
         submissionTime = Time.Timestamp.MinValue,
         initialSeeding = InitialSeeding.TransactionSeed(transactionSeed),
-        expr = SEApp(updateSE, Array(SEValue.Token)),
+        // expr = SEApp(updateSE, Array(SValue.SToken)),
+        expr = SEAppG(updateSE, Array(SEValue.Token)),
         committers = committers,
         readAs = Set.empty,
         limits = limits,
@@ -995,7 +996,8 @@ private[lf] object Speedy {
         scenario: SExpr,
     )(implicit loggingContext: LoggingContext): Machine = Machine.fromPureSExpr(
       compiledPackages = compiledPackages,
-      expr = SEApp(scenario, Array(SEValue.Token)),
+      // expr = SEApp(scenario, Array(SValue.SToken)),
+      expr = SEAppG(scenario, Array(SEValue.Token)),
     )
 
     @throws[PackageNotFound]

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
@@ -13,7 +13,7 @@ private[speedy] object SExprIterable {
   that =>
   private[iterable] def iterator(e: SExpr): Iterator[SExpr] = e match {
     case SExpr.SEVal(_) => Iterator.empty
-    case SExpr.SEAppGeneral(fun, args) => Iterator(fun) ++ args.iterator
+    case SExpr.SEAppGeneral_DEPRECATED(fun, args) => Iterator(fun) ++ args.iterator
     case SExpr.SEAppOnlyFunIsAtomic_DEPRECATED(fun, args) => Iterator(fun) ++ args.iterator
     case SExpr.SEAppAtomicGeneral(fun, args) => Iterator(fun) ++ args.iterator
     case SExpr.SEAppAtomicSaturatedBuiltin(_, args) => args.iterator

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
@@ -14,7 +14,7 @@ private[speedy] object SExprIterable {
   private[iterable] def iterator(e: SExpr): Iterator[SExpr] = e match {
     case SExpr.SEVal(_) => Iterator.empty
     case SExpr.SEAppGeneral(fun, args) => Iterator(fun) ++ args.iterator
-    case SExpr.SEAppAtomicFun(fun, args) => Iterator(fun) ++ args.iterator
+    case SExpr.SEAppOnlyFunIsAtomic_DEPRECATED(fun, args) => Iterator(fun) ++ args.iterator
     case SExpr.SEAppAtomicGeneral(fun, args) => Iterator(fun) ++ args.iterator
     case SExpr.SEAppAtomicSaturatedBuiltin(_, args) => args.iterator
     case SExpr.SEMakeClo(_, _, body) => Iterator(body)

--- a/daml-lf/interpreter/src/test/scala/com/daml/SBuiltinInterfaceTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/daml/SBuiltinInterfaceTest.scala
@@ -333,7 +333,7 @@ object SBuiltinInterfaceTest {
       getKey: PartialFunction[GlobalKeyWithMaintainers, Value.ContractId] = PartialFunction.empty,
   ): Try[Either[SError, SValue]] =
     evalSExpr(
-      SEApp(compiledBasePkgs.compiler.unsafeCompile(e), args.map(SEValue(_))),
+      SEApp(compiledBasePkgs.compiler.unsafeCompile(e), args),
       onLedger,
       getPkg,
       getContract,
@@ -352,7 +352,7 @@ object SBuiltinInterfaceTest {
         Speedy.Machine.fromUpdateSExpr(
           compiledBasePkgs,
           transactionSeed = crypto.Hash.hashPrivateKey("SBuiltinTest"),
-          updateSE = SEApp(SEMakeClo(Array(), 2, SELocA(0)), Array(e)),
+          updateSE = SELet1(e, SEMakeClo(Array(SELocS(1)), 1, SELocF(0))),
           committers = Set(alice),
         )
       else

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
@@ -138,7 +138,10 @@ class AnfTest extends AnyWordSpec with Matchers {
   "error (over) applied to 2 arg" should {
     "be transformed to ANF as expected" in {
       val original = slam(2, source.SEApp(source.SEBuiltin(SBUserError), List(sarg0, sarg1)))
-      val expected = lam(2, target.SEAppAtomicFun(target.SEBuiltin(SBUserError), Array(arg0, arg1)))
+      val expected = lam(
+        2,
+        target.SEAppOnlyFunIsAtomic_DEPRECATED(target.SEBuiltin(SBUserError), Array(arg0, arg1)),
+      )
       testTransform(original, expected)
     }
   }
@@ -203,7 +206,7 @@ class AnfTest extends AnyWordSpec with Matchers {
       arg1: target.SExpr,
       arg2: target.SExpr,
   ): target.SExpr =
-    target.SEAppAtomicFun(func, Array(arg1, arg2))
+    target.SEAppOnlyFunIsAtomic_DEPRECATED(func, Array(arg1, arg2))
 
   // anf builders
   private def let1(rhs: target.SExpr, body: target.SExpr): target.SExpr =

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ComparisonSBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ComparisonSBuiltinTest.scala
@@ -644,14 +644,14 @@ class ComparisonSBuiltinTest extends AnyWordSpec with Matchers with TableDrivenP
       ContractId.V1.assertFromString("00" * 32 + "0000"),
       ContractId.V1.assertFromString("00" * 32 + "0001"),
       ContractId.V1.assertFromString("00" + "ff" * 32),
-    ).map(cid => SEValue(SValue.SContractId(cid)): SExpr)
+    ).map(cid => SValue.SContractId(cid): SValue)
 
   private[this] val parties =
     Seq(
       Ref.Party.assertFromString("alice"),
       Ref.Party.assertFromString("bob"),
       Ref.Party.assertFromString("carol"),
-    ).map(p => SEValue(SValue.SParty(p)): SExpr)
+    ).map(p => SValue.SParty(p): SValue)
 
   private[this] def eval(bi: Ast.BuiltinFunction, t: Ast.Type, x: Ast.Expr, y: Ast.Expr) = {
     final case class Goodbye(e: SError) extends RuntimeException("", null, false, false)
@@ -683,7 +683,10 @@ class ComparisonSBuiltinTest extends AnyWordSpec with Matchers with TableDrivenP
       )
     )
     val machine =
-      Speedy.Machine.fromPureSExpr(compiledPackages, SEApp(sexpr, (parties ++ contractIds).toArray))
+      Speedy.Machine.fromPureSExpr(
+        compiledPackages,
+        SEApp(sexpr, (parties ++ contractIds).toArray),
+      )
     SpeedyTestLib.run(machine)
   }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/CompilerTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/CompilerTest.scala
@@ -561,7 +561,7 @@ object CompilerTest {
   )
 
   def tokenApp(sexpr: SExpr): SExpr =
-    SExpr.SEApp(sexpr, Array(SExpr.SEValue.Token))
+    SExpr.SEApp(sexpr, Array(SValue.SToken))
 
   def evalSExpr(
       sexpr: SExpr,

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala
@@ -432,7 +432,7 @@ class EvaluationOrderTest extends AnyFreeSpec with Matchers with Inside {
           .fromUpdateSExpr(
             pkgs,
             seed,
-            if (args.isEmpty) se else SEApp(se, args.map(SEValue(_))),
+            if (args.isEmpty) se else SEApp(se, args),
             parties,
             disclosedContracts = disclosedContracts.map(_.unversioned),
             traceLog = traceLog,

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
@@ -30,7 +30,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
 
   private def applyToParty(pkgs: CompiledPackages, e: Expr, p: Party): SExpr = {
     val se = pkgs.compiler.unsafeCompile(e)
-    SEApp(se, Array(SEValue(SParty(p))))
+    SEApp(se, Array(SParty(p)))
   }
 
   "unhandled throw" should {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureLib.scala
@@ -9,8 +9,8 @@ import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Ref.{IdString, Party}
 import com.daml.lf.data.{FrontStack, ImmArray, Ref, Struct, Time}
 import com.daml.lf.language.Ast
-import com.daml.lf.speedy.SExpr.{SEMakeClo, SEValue}
-import com.daml.lf.speedy.SValue.SContractId
+import com.daml.lf.speedy.SExpr.{SEMakeClo}
+import com.daml.lf.speedy.SValue.{SContractId, SToken}
 import com.daml.lf.transaction.{GlobalKey, GlobalKeyWithMaintainers, TransactionVersion, Versioned}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInstance}
@@ -246,7 +246,7 @@ object ExplicitDisclosureLib {
         transactionSeed = crypto.Hash.hashPrivateKey("ExplicitDisclosureTest"),
         updateSE =
           if (setupArgs.isEmpty) contextSExpr
-          else SExpr.SEApp(contextSExpr, setupArgs.map(SEValue(_))),
+          else SExpr.SEApp(contextSExpr, setupArgs),
         committers = committers,
         disclosedContracts = disclosedContracts,
       )
@@ -258,7 +258,7 @@ object ExplicitDisclosureLib {
 
     assert(setupResult.isRight)
 
-    machine.setExpressionToEvaluate(SExpr.SEApp(runUpdateSExpr(sexpr), Array(SEValue.Token)))
+    machine.setExpressionToEvaluate(SExpr.SEApp(runUpdateSExpr(sexpr), Array(SToken)))
 
     val result = SpeedyTestLib.run(
       machine = machine,

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/LimitsSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/LimitsSpec.scala
@@ -392,8 +392,7 @@ class LimitsSpec extends AnyWordSpec with Matchers with Inside with TableDrivenP
       machine = Speedy.Machine.fromUpdateSExpr(
         compiledPackages = pkgs,
         transactionSeed = txSeed,
-        updateSE =
-          SExpr.SEApp(pkgs.compiler.unsafeCompile(e), agrs.view.map(SExpr.SEValue(_)).toArray),
+        updateSE = SExpr.SEApp(pkgs.compiler.unsafeCompile(e), agrs.view.toArray),
         committers = committers,
         limits = limits,
       ),

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ProfilerTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ProfilerTest.scala
@@ -68,7 +68,7 @@ class ProfilerTest extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
     val transactionSeed: crypto.Hash = crypto.Hash.hashPrivateKey("foobar")
     val party = Ref.Party.assertFromString("Alice")
     val se = compiledPackages.compiler.unsafeCompile(e)
-    val example: SExpr = SEApp(se, Array(SEValue(SParty(party))))
+    val example: SExpr = SEApp(se, Array(SParty(party)))
     val machine =
       Speedy.Machine.fromUpdateSExpr(compiledPackages, transactionSeed, example, Set(party))
     val res = machine.run()

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
@@ -30,7 +30,7 @@ class RollbackTest extends AnyWordSpec with Matchers with TableDrivenPropertyChe
       pkgs1: PureCompiledPackages
   )(e: Expr, party: Party): SubmittedTransaction = {
     val se = pkgs1.compiler.unsafeCompile(e)
-    val example = SEApp(se, Array(SEValue(SParty(party))))
+    val example = SEApp(se, Array(SParty(party)))
     val machine = Speedy.Machine.fromUpdateSExpr(pkgs1, transactionSeed, example, Set(party))
     SpeedyTestLib
       .buildTransaction(machine)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinBigNumericTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinBigNumericTest.scala
@@ -386,7 +386,7 @@ object SBuiltinBigNumericTest {
       if (onLedger)
         Speedy.Machine.fromScenarioSExpr(
           compiledPackages,
-          scenario = SEApp(SEMakeClo(Array(), 2, SELocA(0)), Array(e)),
+          scenario = SELet1(e, SEMakeClo(Array(SELocS(1)), 1, SELocF(0))),
         )
       else
         Speedy.Machine.fromPureSExpr(compiledPackages, e)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -1544,7 +1544,7 @@ class SBuiltinTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
   "SBCrash" - {
     "throws an exception" in {
       val result = evalSExpr(
-        SEApp(SEBuiltin(SBCrash("test message")), Array(SEValue(SUnit))),
+        SEApp(SEBuiltin(SBCrash("test message")), Array(SUnit)),
         onLedger = false,
       )
 
@@ -1629,7 +1629,7 @@ class SBuiltinTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
       val templateId = Ref.Identifier.assertFromString("-pkgId-:Mod:Iou")
 
       evalSExpr(
-        SEApp(SEBuiltin(SBCheckTemplate(templateId)), Array(SEValue(SUnit))),
+        SEApp(SEBuiltin(SBCheckTemplate(templateId)), Array(SUnit)),
         onLedger = false,
       ) shouldBe Right(SBool(true))
     }
@@ -1638,7 +1638,7 @@ class SBuiltinTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
       val templateId = Ref.Identifier.assertFromString("-pkgId-:Mod:NonExistent")
 
       evalSExpr(
-        SEApp(SEBuiltin(SBCheckTemplate(templateId)), Array(SEValue(SUnit))),
+        SEApp(SEBuiltin(SBCheckTemplate(templateId)), Array(SUnit)),
         onLedger = false,
       ) shouldBe Right(SBool(false))
     }
@@ -1649,7 +1649,7 @@ class SBuiltinTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
       val templateId = Ref.Identifier.assertFromString("-pkgId-:Mod:IouWithKey")
 
       evalSExpr(
-        SEApp(SEBuiltin(SBCheckTemplateKey(templateId)), Array(SEValue(SUnit))),
+        SEApp(SEBuiltin(SBCheckTemplateKey(templateId)), Array(SUnit)),
         onLedger = false,
       ) shouldBe Right(SBool(true))
     }
@@ -1658,7 +1658,7 @@ class SBuiltinTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
       val templateId = Ref.Identifier.assertFromString("-pkgId-:Mod:Iou")
 
       evalSExpr(
-        SEApp(SEBuiltin(SBCheckTemplateKey(templateId)), Array(SEValue(SUnit))),
+        SEApp(SEBuiltin(SBCheckTemplateKey(templateId)), Array(SUnit)),
         onLedger = false,
       ) shouldBe Right(SBool(false))
     }
@@ -1690,9 +1690,9 @@ class SBuiltinTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
 
         inside(
           evalSExpr(
-            SEApp(
-              SEBuiltin(SBCacheDisclosedContract(contractId)),
-              Array(cachedContractSExpr),
+            SELet1(
+              cachedContractSExpr,
+              SEAppAtomic(SEBuiltin(SBCacheDisclosedContract(contractId)), Array(SELocS(1))),
             ),
             getContract = Map(
               contractId -> VersionedContractInstance(
@@ -1734,9 +1734,9 @@ class SBuiltinTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
 
         inside(
           evalSExpr(
-            SEApp(
-              SEBuiltin(SBCacheDisclosedContract(contractId)),
-              Array(cachedContractSExpr),
+            SELet1(
+              cachedContractSExpr,
+              SEAppAtomic(SEBuiltin(SBCacheDisclosedContract(contractId)), Array(SELocS(1))),
             ),
             getContract = Map(
               contractId -> VersionedContractInstance(
@@ -1845,7 +1845,7 @@ object SBuiltinTest {
       args: Array[SValue],
       onLedger: Boolean = true,
   ): Either[SError, SValue] =
-    evalSExpr(SEApp(compiledPackages.compiler.unsafeCompile(e), args.map(SEValue(_))), onLedger)
+    evalSExpr(SEApp(compiledPackages.compiler.unsafeCompile(e), args), onLedger)
 
   val alice: Party = Ref.Party.assertFromString("Alice")
   val committers: Set[Party] = Set(alice)
@@ -1867,7 +1867,7 @@ object SBuiltinTest {
         Speedy.Machine.fromUpdateSExpr(
           compiledPackages,
           transactionSeed = crypto.Hash.hashPrivateKey("SBuiltinTest"),
-          updateSE = SEApp(SEMakeClo(Array(), 2, SELocA(0)), Array(sexpr)),
+          updateSE = SELet1(sexpr, SEMakeClo(Array(SELocS(1)), 1, SELocF(0))),
           committers = committers,
         )
       } else {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -519,7 +519,7 @@ object SpeedyTest {
       packages: PureCompiledPackages,
   ): Either[SError, SValue] = {
     val se = packages.compiler.unsafeCompile(e)
-    evalSExpr(SEApp(se, args.map(SEValue(_))), packages)
+    evalSExpr(SEApp(se, args), packages)
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala
@@ -97,10 +97,10 @@ class TailCallTest extends AnyWordSpec with Matchers with TableDrivenPropertyChe
     runExpr(exp, envBound = small, kontBound = small) shouldBe expected
   }
 
-  "fold-right (KFoldr1Map/Reduce case) requires an unbounded env-stack, but a small kont-stack" in {
+  "fold-right (KFoldr1Map/Reduce case) executes with a small env-stack, and a small kont-stack" in {
     val exp = e"F:triangle_viaFoldRight2 100"
     val expected = SValue.SInt64(5050)
-    runExpr(exp, envBound = unbounded, kontBound = small) shouldBe expected
+    runExpr(exp, envBound = small, kontBound = small) shouldBe expected
   }
 
   // Evaluate an expression with optionally bounded env and kont stacks

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala
@@ -97,10 +97,10 @@ class TailCallTest extends AnyWordSpec with Matchers with TableDrivenPropertyChe
     runExpr(exp, envBound = small, kontBound = small) shouldBe expected
   }
 
-  "fold-right (KFoldr1Map/Reduce case) executes with a small env-stack, and a small kont-stack" in {
+  "fold-right (KFoldr1Map/Reduce case) requires an unbounded env-stack, but a small kont-stack" in {
     val exp = e"F:triangle_viaFoldRight2 100"
     val expected = SValue.SInt64(5050)
-    runExpr(exp, envBound = small, kontBound = small) shouldBe expected
+    runExpr(exp, envBound = unbounded, kontBound = small) shouldBe expected
   }
 
   // Evaluate an expression with optionally bounded env and kont stacks

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -8,7 +8,7 @@ import com.daml.lf.crypto
 import com.daml.lf.data.{Bytes, FrontStack, Ref}
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
-import com.daml.lf.speedy.SExpr.{SEApp, SEImportValue, SELocA, SEMakeClo}
+import com.daml.lf.speedy.SExpr.{SELet1, SEImportValue, SELocS, SELocF, SEMakeClo}
 import com.daml.lf.value.Value
 import com.daml.lf.value.test.TypedValueGenerators.genAddend
 import com.daml.lf.value.test.ValueGenerators.{comparableCoidsGen, suffixedV1CidGen}
@@ -189,7 +189,8 @@ class OrderingSpec
     val machine = Speedy.Machine.fromUpdateSExpr(
       PureCompiledPackages.Empty,
       transactionSeed = txSeed,
-      updateSE = SEApp(SEMakeClo(Array(), 2, SELocA(0)), Array(SEImportValue(toAstType(typ), v))),
+      updateSE =
+        SELet1(SEImportValue(toAstType(typ), v), SEMakeClo(Array(SELocS(1)), 1, SELocF(0))),
       committers = committers,
     )
 

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -388,7 +388,7 @@ object ScenarioRunner {
       compiledPackages = compiledPackages,
       submissionTime = Time.Timestamp.MinValue,
       initialSeeding = InitialSeeding.TransactionSeed(seed),
-      expr = SEApp(commands, Array(SEValue(SValue.SToken))),
+      expr = SEApp(commands, Array(SValue.SToken)),
       committers = committers,
       readAs = readAs,
       traceLog = traceLog,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -332,7 +332,7 @@ object Converter {
   private[this] val extractToTuple = SEMakeClo(
     Array(),
     2,
-    SEApp(SEBuiltin(SBStructCon(tupleFieldInputOrder)), Array(SELocA(0), SELocA(1))),
+    SEAppAtomic(SEBuiltin(SBStructCon(tupleFieldInputOrder)), Array(SELocA(0), SELocA(1))),
   )
 
   // Extract the two fields out of the RankN encoding used in the Ap constructor.
@@ -340,8 +340,9 @@ object Converter {
       compiledPackages: CompiledPackages,
       fun: SValue,
   ): Either[String, (SValue, SValue)] = {
+    val e = SELet1(extractToTuple, SEAppAtomic(SEValue(fun), Array(SELocS(1))))
     val machine =
-      Speedy.Machine.fromPureSExpr(compiledPackages, SEApp(SEValue(fun), Array(extractToTuple)))(
+      Speedy.Machine.fromPureSExpr(compiledPackages, e)(
         Script.DummyLoggingContext
       )
     machine.run() match {
@@ -509,21 +510,21 @@ object Converter {
               case ScriptLedgerClient.ExerciseResult(_, _, _, _) =>
                 Left("Expected CreateResult but got ExerciseResult")
             }
-          } yield (SEApp(SEValue(continue), Array(SEValue(contractId))), eventResults.tail)
+          } yield (SEAppAtomic(SEValue(continue), Array(SEValue(contractId))), eventResults.tail)
         }
         case SVariant(_, "Exercise", _, v) => {
           val continue = v.asInstanceOf[SRecord].values.get(3)
           val exercised = eventResults.head.asInstanceOf[ScriptLedgerClient.ExerciseResult]
           for {
             translated <- translateExerciseResult(lookupChoice, translator, exercised)
-          } yield (SEApp(SEValue(continue), Array(SEValue(translated))), eventResults.tail)
+          } yield (SEAppAtomic(SEValue(continue), Array(SEValue(translated))), eventResults.tail)
         }
         case SVariant(_, "ExerciseByKey", _, v) => {
           val continue = v.asInstanceOf[SRecord].values.get(3)
           val exercised = eventResults.head.asInstanceOf[ScriptLedgerClient.ExerciseResult]
           for {
             translated <- translateExerciseResult(lookupChoice, translator, exercised)
-          } yield (SEApp(SEValue(continue), Array(SEValue(translated))), eventResults.tail)
+          } yield (SEAppAtomic(SEValue(continue), Array(SEValue(translated))), eventResults.tail)
         }
         case SVariant(_, "CreateAndExercise", _, v) => {
           val continue = v.asInstanceOf[SRecord].values.get(2)
@@ -531,7 +532,7 @@ object Converter {
           val exercised = eventResults(1).asInstanceOf[ScriptLedgerClient.ExerciseResult]
           for {
             translated <- translateExerciseResult(lookupChoice, translator, exercised)
-          } yield (SEApp(SEValue(continue), Array(SEValue(translated))), eventResults.drop(2))
+          } yield (SEAppAtomic(SEValue(continue), Array(SEValue(translated))), eventResults.drop(2))
         }
         case _ => Left(s"Expected Create, Exercise or ExerciseByKey but got $v")
       }
@@ -545,7 +546,15 @@ object Converter {
     ): Either[String, SExpr] =
       freeAp match {
         case SVariant(_, "PureA", _, v) =>
-          Right(acc.foldLeft[SExpr](SEValue(v))({ case (acc, v) => SEApp(acc, Array(v)) }))
+          Right(acc match {
+            case Nil => SEValue(v)
+            case _ :: _ =>
+              val locs: Array[SExprAtomic] = (1 to acc.length).toArray.reverse.map(SELocS(_))
+              acc.foldRight[SExpr](SEAppAtomic(SEValue(v), locs))({ case (e, acc) =>
+                SELet1(e, acc)
+              })
+          })
+
         case SVariant(_, "Ap", _, v) => {
           val r = for {
             apFields <- toApFields(compiledPackages, v)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -187,7 +187,7 @@ object Script {
 
   final case class Action(expr: SExpr, scriptIds: ScriptIds) extends Script
   final case class Function(expr: SExpr, param: Type, scriptIds: ScriptIds) extends Script {
-    def apply(arg: SExpr): Script.Action = Script.Action(SEApp(expr, Array(arg)), scriptIds)
+    def apply(arg: SValue): Script.Action = Script.Action(SEApp(expr, Array(arg)), scriptIds)
   }
 
   def fromIdentifier(
@@ -368,7 +368,7 @@ object Runner {
           case Some(f) =>
             f(inputJson, script.param) match {
               case Left(msg) => throw new ConverterException(msg)
-              case Right(arg) => script.apply(SEValue(arg))
+              case Right(arg) => script.apply(arg)
             }
           case None =>
             throw new RuntimeException(
@@ -470,16 +470,22 @@ private[lf] class Runner(
               .flatMap { scriptF =>
                 scriptF match {
                   case ScriptF.Catch(act, handle) =>
-                    run(SEApp(SEValue(act), Array(SEValue(SUnit)))).transformWith {
+                    run(SEAppAtomic(SEValue(act), Array(SEValue(SUnit)))).transformWith {
                       case Success(v) => Future.successful(SEValue(v))
                       case Failure(
                             exce @ Runner.InterpretationError(
                               SError.SErrorDamlException(IE.UnhandledException(typ, value))
                             )
                           ) =>
-                        machine.setExpressionToEvaluate(
-                          SEApp(SEValue(handle), Array(SBToAny(typ)(SEImportValue(typ, value))))
-                        )
+                        val e =
+                          SELet1(
+                            SEImportValue(typ, value),
+                            SELet1(
+                              SEAppAtomic(SEBuiltin(SBToAny(typ)), Array(SELocS(1))),
+                              SEAppAtomic(SEValue(handle), Array(SELocS(1))),
+                            ),
+                          )
+                        machine.setExpressionToEvaluate(e)
                         stepToValue()
                           .fold(Future.failed, Future.successful)
                           .flatMap {
@@ -530,7 +536,7 @@ private[lf] class Runner(
         case SRecord(_, _, vals) if vals.size == 1 || vals.size == 2 => {
           vals.get(0) match {
             case SPAP(_, _, _) =>
-              Future(SEApp(SEValue(vals.get(0)), Array(SEValue(SUnit))))
+              Future(SEAppAtomic(SEValue(vals.get(0)), Array(SEValue(SUnit))))
             case _ =>
               Future.failed(
                 new ConverterException(

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -590,7 +590,7 @@ class Runner(
     }
 
   def makeApp(func: SExpr, values: Array[SValue]): SExpr = {
-    SEApp(func, values.map(SEValue(_)))
+    SEApp(func, values)
   }
 
   private[this] def makeAppD(func: SValue, values: SValue*) = makeApp(SEValue(func), values.toArray)


### PR DESCRIPTION
Avoid construction of unrestricted speedy expression applications.`SEApp` (alias for `SEAppGeneral`)
- Replace occurrences of `SEApp(General)` to use `SEAppAtomic`, with `SELet1` as required
- Add new helper `SEApp` for many cases where arguments are simple values.
- Rename the most general unrestricted constructor as `SEAppGeneral_DEPRECATED`. The only remaining use is by `fromUpdateSExpr` and  `fromScenarioSExpr`, due to our unprincipled approach to stack-trace. See `TODO` in `pushLocation`. I hope to fix this in a future PR.
- Rename the slightly less unrestricted constructor as `SEAppOnlyFunIsAtomic_DEPRECATED`. The only call site being in `Anf.scala` (for the case when ANF is not performed). Maybe one day we can perform ANF in all cases, and hence remove this one remaining usage.