### PR TITLE
Add Semigroup, Foldable, and Traversable instances for Validation

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Validation.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Validation.daml
@@ -70,6 +70,8 @@ instance Applicative (Validation err) where
     Errors e1 *> Success _ = Errors e1
     Errors e1 *> Errors e2 = Errors (e1 <> e2)
 
+-- | Unlike the Haskell version (see https://hackage.haskell.org/package/either-5.0.2/docs/Data-Either-Validation.html#t:Validation), 
+-- this only results in a `Success` (the last one) if there are no `Errors`.
 instance Semigroup (Validation err a) where
     Errors e1 <> Errors e2 = Errors (e1 <> e2)
     Success _ <> x = x

--- a/compiler/damlc/daml-stdlib-src/DA/Validation.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Validation.daml
@@ -14,7 +14,9 @@ module DA.Validation
   , (<?>)
   ) where
 
+import DA.Foldable
 import DA.NonEmpty as NE
+import DA.Traversable
 import DA.Validation.Types
 
 deriving instance (Eq err, Eq a) => Eq (Validation err a)
@@ -76,6 +78,14 @@ instance Semigroup (Validation err a) where
     Errors e1 <> Errors e2 = Errors (e1 <> e2)
     Success _ <> x = x
     x <> Success _ = x
+
+instance Foldable (Validation err) where
+    foldr _ z (Errors _) = z
+    foldr f z (Success x) = f x z
+
+instance Traversable (Validation err) where
+    mapA _ (Errors x) = pure $ Errors x
+    mapA f (Success x) = Success <$> f x
 
 -- | Convert an `Optional t` into a `Validation Text t`, or
 -- more generally into an `m t` for any `ActionFail` type `m`.

--- a/compiler/damlc/daml-stdlib-src/DA/Validation.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Validation.daml
@@ -70,6 +70,11 @@ instance Applicative (Validation err) where
     Errors e1 *> Success _ = Errors e1
     Errors e1 *> Errors e2 = Errors (e1 <> e2)
 
+instance Semigroup (Validation err a) where
+    Errors e1 <> Errors e2 = Errors (e1 <> e2)
+    Success _ <> x = x
+    x <> Success _ = x
+
 -- | Convert an `Optional t` into a `Validation Text t`, or
 -- more generally into an `m t` for any `ActionFail` type `m`.
 (<?>) : Optional b -> Text -> Validation Text b

--- a/compiler/damlc/tests/daml-test-files/Validation.daml
+++ b/compiler/damlc/tests/daml-test-files/Validation.daml
@@ -52,7 +52,7 @@ semigroup_second_error_test = scenario do
   expected === (v1 <> v2)
 
 foldable_returns_seed_when_input_is_error_test = scenario do
-  let (v: Validation Text Int) = error "fail"
+  let (v: Validation Text Int) = invalid "fail"
       expected = ""
 
   expected === F.foldr (\x z -> show x <> z) "" v
@@ -64,8 +64,8 @@ foldable_returns_expected_value_when_input_is_ok_test = scenario do
   expected === F.foldr (\x z -> show x <> z) "" v
 
 traversable_returns_expected_list_when_input_is_validation_of_list_errors_test = scenario do
-  let (v: Validation Text [Int]) = error "fail"
-      expected = [ error "fail" ]
+  let (v: Validation Text [Int]) = invalid "fail"
+      expected = [ invalid "fail" ]
 
   expected === T.sequence v
 

--- a/compiler/damlc/tests/daml-test-files/Validation.daml
+++ b/compiler/damlc/tests/daml-test-files/Validation.daml
@@ -21,4 +21,32 @@ main = scenario do
   v === Left (NonEmpty with hd = "fail"; tl = ["fail"])
   pure ()
 
+semigroup_two_errors_test = scenario do
+  let (v1: Validation Text Int) = invalid "fail1"
+      v2 = invalid "fail2"
+      expected = Errors $ NonEmpty with hd = "fail1", tl = [ "fail2" ]
+
+  expected === (v1 <> v2)
+
+semigroup_both_success_test = scenario do
+  let (v1: Validation Text Int) = ok 1
+      v2 = ok 2
+      expected = Success 2
+
+  expected === (v1 <> v2)
+
+semigroup_first_error_test = scenario do
+  let (v1: Validation Text Int) = invalid "fail"
+      v2 = ok 1
+      expected = Errors $ NonEmpty with hd = "fail", tl = []
+
+  expected === (v1 <> v2)
+
+semigroup_second_error_test = scenario do
+  let (v1: Validation Text Int) = ok 1
+      v2 = invalid "fail"
+      expected = Errors $ NonEmpty with hd = "fail", tl = []
+
+  expected === (v1 <> v2)
+
 -- @ENABLE-SCENARIOS

--- a/compiler/damlc/tests/daml-test-files/Validation.daml
+++ b/compiler/damlc/tests/daml-test-files/Validation.daml
@@ -5,8 +5,10 @@
 
 module Validation where
 
+import DA.Foldable qualified as F
 import DA.NonEmpty
 import DA.Validation
+import DA.Traversable qualified as T
 import DA.List.Total
 import DA.Assert
 
@@ -48,5 +50,29 @@ semigroup_second_error_test = scenario do
       expected = Errors $ NonEmpty with hd = "fail", tl = []
 
   expected === (v1 <> v2)
+
+foldable_returns_seed_when_input_is_error_test = scenario do
+  let (v: Validation Text Int) = error "fail"
+      expected = ""
+
+  expected === F.foldr (\x z -> show x <> z) "" v
+
+foldable_returns_expected_value_when_input_is_ok_test = scenario do
+  let (v: Validation Text Int) = ok 42
+      expected = "42"
+
+  expected === F.foldr (\x z -> show x <> z) "" v
+
+traversable_returns_expected_list_when_input_is_validation_of_list_errors_test = scenario do
+  let (v: Validation Text [Int]) = error "fail"
+      expected = [ error "fail" ]
+
+  expected === T.sequence v
+
+traversable_returns_expected_list_when_input_is_validation_of_list_success_test = scenario do
+  let (v: Validation Text [Int]) = ok [42]
+      expected = [ ok 42 ]
+
+  expected === T.sequence v
 
 -- @ENABLE-SCENARIOS


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
Adding `Semigroup`, `Foldable`, and `Traversable` instances for `Validation` would be very helpful for folding a list of `Validation` into a single `Validation` value. Also, it is already in the [Haskell version of `Validation`](https://hackage.haskell.org/package/either-5.0.2/docs/src/Data.Either.Validation.html#line-101) so this should not raise too many eyebrows I hope.
