### PR TITLE
[engine] mark SEAppGeneral and SEAppOnlyFunIsAtomic as @deprecated

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -34,6 +34,7 @@ import com.daml.lf.speedy.{SExpr1 => source}
 import com.daml.lf.speedy.{SExpr => target}
 import com.daml.lf.speedy.Compiler.CompilationError
 
+import scala.annotation.nowarn
 import scala.annotation.tailrec
 
 import scalaz.{@@, Tag}
@@ -450,6 +451,7 @@ private[lf] object Anf {
    translated application is *not* in proper ANF form.
    */
 
+  @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppOnlyFunIsAtomic")
   private[this] def transformMultiAppSafely(
       depth: DepthA,
       env: Env,
@@ -463,7 +465,7 @@ private[lf] object Anf {
       // we dont atomize the args here
       flattenExpList(depth, env, args) { args =>
         // we build a non-atomic application here (only the function is atomic)
-        transform(depth, target.SEAppOnlyFunIsAtomic_DEPRECATED(func1, args.toArray))(k)
+        transform(depth, target.SEAppOnlyFunIsAtomic(func1, args.toArray))(k)
       }
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -18,6 +18,8 @@ import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SBuiltin._
 
+import scala.annotation.nowarn
+
 //
 // Pretty-printer for the interpreter errors and the scenario ledger
 //
@@ -485,6 +487,8 @@ private[lf] object Pretty {
       case SELocF(i) => char('F') + str(i)
     }
 
+    @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppGeneral")
+    @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppOnlyFunIsAtomic")
     def prettySExpr(index: Int)(e: SExpr): Doc =
       e match {
         case SEVal(defId) =>
@@ -528,11 +532,11 @@ private[lf] object Pretty {
             case SBGetTime => text("$getTime")
             case _ => str(x)
           }
-        case SEAppGeneral_DEPRECATED(fun, args) =>
+        case SEAppGeneral(fun, args) =>
           val prefix = prettySExpr(index)(fun) + text("@E(")
           intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
             .tightBracketBy(prefix, char(')'))
-        case SEAppOnlyFunIsAtomic_DEPRECATED(fun, args) =>
+        case SEAppOnlyFunIsAtomic(fun, args) =>
           val prefix = prettySExpr(index)(fun) + text("@N(")
           intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
             .tightBracketBy(prefix, char(')'))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -10,6 +10,8 @@ import com.daml.lf.speedy.Speedy._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
 
+import scala.annotation.nowarn
+
 private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK machine states
 
   def ppMachine(m: Machine): String = {
@@ -46,11 +48,13 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
     s"${x.ref.qualifiedName.name}"
   }
 
+  @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppGeneral")
+  @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppOnlyFunIsAtomic")
   def pp(e: SExpr): String = e match {
     case SEValue(v) => s"(VALUE)${pp(v)}"
     case loc: SELoc => pp(loc)
-    case SEAppGeneral_DEPRECATED(func, args) => s"@E(${pp(func)},${commas(args.map(pp))})"
-    case SEAppOnlyFunIsAtomic_DEPRECATED(func, args) => s"@N(${pp(func)},${commas(args.map(pp))})"
+    case SEAppGeneral(func, args) => s"@E(${pp(func)},${commas(args.map(pp))})"
+    case SEAppOnlyFunIsAtomic(func, args) => s"@N(${pp(func)},${commas(args.map(pp))})"
     case SEAppAtomicGeneral(func, args) => s"@A(${pp(func)},${commas(args.map(pp))})"
     case SEAppAtomicSaturatedBuiltin(b, args) => s"@B(${pp(SEBuiltin(b))},${commas(args.map(pp))})"
     case SEMakeClo(fvs, arity, body) => s"[${commas(fvs.map(pp))}]\\$arity.${pp(body)}"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -106,9 +106,8 @@ object SExpr {
     * This case is used only by: fromUpdateSExpr and fromScenarioSExpr.
     * The use required because of our current stack-trace support, which peeks under KArg.
     */
-  final case class SEAppGeneral_DEPRECATED(fun: SExpr, args: Array[SExpr])
-      extends SExpr
-      with SomeArrayEquals {
+  @deprecated("Prefer SEAppAtomic or SEApp helper instead.")
+  final case class SEAppGeneral(fun: SExpr, args: Array[SExpr]) extends SExpr with SomeArrayEquals {
     def execute(machine: Machine): Control = {
       machine.pushKont(KArg(machine, args))
       Control.Expression(fun)
@@ -121,7 +120,8 @@ object SExpr {
     * Because this case exists we must retain the complicated/slow path in the
     * speedy-machine: executeApplication
     */
-  final case class SEAppOnlyFunIsAtomic_DEPRECATED(fun: SExprAtomic, args: Array[SExpr])
+  @deprecated("Prefer SEAppAtomic or SEApp helper instead.")
+  final case class SEAppOnlyFunIsAtomic(fun: SExprAtomic, args: Array[SExpr])
       extends SExpr
       with SomeArrayEquals {
     def execute(machine: Machine): Control = {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
@@ -38,7 +38,7 @@ package speedy
   * - In SExpr{1,}: SELocA, SELocF, SELocS, SEMakeClo, SELet1General,
   *
   * - In SExpr: SEAppAtomicGeneral, SEAppAtomicSaturatedBuiltin, SECaseAtomic,
-  *   SELet1Builtin, SELet1BuiltinArithmetic, SEAppOnlyFunIsAtomic_DEPRECATED,
+  *   SELet1Builtin, SELet1BuiltinArithmetic, SEAppOnlyFunIsAtomic
   *
   * - In SExpr (runtime only, i.e. rejected by validate): SEDamlException, SEImportValue
   */

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -26,6 +26,7 @@ import com.daml.nameof.NameOf
 import com.daml.scalautil.Statement.discard
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 
+import scala.annotation.nowarn
 import scala.annotation.tailrec
 import scala.collection.mutable
 
@@ -451,7 +452,7 @@ private[lf] object Speedy {
 
         // TODO: Understand how the current approach to stack-trace actually works.
         // Peeking under KArg on the kontStack seems so unprincipled, and relies on our
-        // continued use of SEAppGeneral_DEPRECATED, which we want to remove.
+        // continued use of SEAppGeneral, which we want to remove.
 
         case Some(KArg(_, Array(SEValue.Token))) => {
           // Can't call pushKont here, because we don't push at the top of the stack.
@@ -970,6 +971,7 @@ private[lf] object Speedy {
     @throws[PackageNotFound]
     @throws[CompilationError]
     // Construct a machine for running an update expression (testing -- avoiding scenarios)
+    @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppGeneral")
     def fromUpdateSExpr(
         compiledPackages: CompiledPackages,
         transactionSeed: crypto.Hash,
@@ -983,7 +985,7 @@ private[lf] object Speedy {
         compiledPackages = compiledPackages,
         submissionTime = Time.Timestamp.MinValue,
         initialSeeding = InitialSeeding.TransactionSeed(transactionSeed),
-        expr = SEAppGeneral_DEPRECATED(updateSE, Array(SEValue.Token)),
+        expr = SEAppGeneral(updateSE, Array(SEValue.Token)),
         // expr = SEApp(updateSE, Array(SValue.SToken)), // TODO: when stack-trace hackery is resolved
         committers = committers,
         readAs = Set.empty,
@@ -996,12 +998,13 @@ private[lf] object Speedy {
     @throws[PackageNotFound]
     @throws[CompilationError]
     // Construct an off-ledger machine for running scenario.
+    @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppGeneral")
     def fromScenarioSExpr(
         compiledPackages: CompiledPackages,
         scenario: SExpr,
     )(implicit loggingContext: LoggingContext): Machine = Machine.fromPureSExpr(
       compiledPackages = compiledPackages,
-      expr = SEAppGeneral_DEPRECATED(scenario, Array(SEValue.Token)),
+      expr = SEAppGeneral(scenario, Array(SEValue.Token)),
       // expr = SEApp(scenario, Array(SValue.SToken)), // TODO: when stack-trace hackery is resolved
     )
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
@@ -5,16 +5,19 @@ package com.daml.lf.speedy.iterable
 
 import com.daml.lf.speedy.{SExpr, SValue}
 import com.daml.lf.speedy.SExpr.SExpr
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
 // Iterates only over immediate children similar to Haskell’s
 // uniplate.
+@nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppGeneral")
+@nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppOnlyFunIsAtomic")
 private[speedy] object SExprIterable {
   that =>
   private[iterable] def iterator(e: SExpr): Iterator[SExpr] = e match {
     case SExpr.SEVal(_) => Iterator.empty
-    case SExpr.SEAppGeneral_DEPRECATED(fun, args) => Iterator(fun) ++ args.iterator
-    case SExpr.SEAppOnlyFunIsAtomic_DEPRECATED(fun, args) => Iterator(fun) ++ args.iterator
+    case SExpr.SEAppGeneral(fun, args) => Iterator(fun) ++ args.iterator
+    case SExpr.SEAppOnlyFunIsAtomic(fun, args) => Iterator(fun) ++ args.iterator
     case SExpr.SEAppAtomicGeneral(fun, args) => Iterator(fun) ++ args.iterator
     case SExpr.SEAppAtomicSaturatedBuiltin(_, args) => args.iterator
     case SExpr.SEMakeClo(_, _, body) => Iterator(body)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
@@ -15,6 +15,9 @@ import com.daml.lf.speedy.Anf.flattenToAnf
 import com.daml.lf.speedy.Pretty.SExpr._
 import com.daml.lf.data.Ref._
 
+import scala.annotation.nowarn
+
+@nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppOnlyFunIsAtomic")
 class AnfTest extends AnyWordSpec with Matchers {
 
   "identity: [\\x. x]" should {
@@ -140,7 +143,7 @@ class AnfTest extends AnyWordSpec with Matchers {
       val original = slam(2, source.SEApp(source.SEBuiltin(SBUserError), List(sarg0, sarg1)))
       val expected = lam(
         2,
-        target.SEAppOnlyFunIsAtomic_DEPRECATED(target.SEBuiltin(SBUserError), Array(arg0, arg1)),
+        target.SEAppOnlyFunIsAtomic(target.SEBuiltin(SBUserError), Array(arg0, arg1)),
       )
       testTransform(original, expected)
     }
@@ -201,12 +204,13 @@ class AnfTest extends AnyWordSpec with Matchers {
   private def clo1(fv: target.SELoc, n: Int, body: target.SExpr): target.SExpr =
     target.SEMakeClo(Array(fv), n, body)
 
+  @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppOnlyFunIsAtomic")
   private def app2n(
       func: target.SExprAtomic,
       arg1: target.SExpr,
       arg2: target.SExpr,
   ): target.SExpr =
-    target.SEAppOnlyFunIsAtomic_DEPRECATED(func, Array(arg1, arg2))
+    target.SEAppOnlyFunIsAtomic(func, Array(arg1, arg2))
 
   // anf builders
   private def let1(rhs: target.SExpr, body: target.SExpr): target.SExpr =


### PR DESCRIPTION
prefer @deprecated/@warn for SEAppGeneral and SEAppOnlyFunIsAtomic
over renaming functions with _DEPRECATED suffix

addresses comment here:
https://github.com/digital-asset/daml/pull/15079#discussion_r979802306
