### PR TITLE
Prevent ledger-api-test-tool's Reporter from throwing misleading NPEs [KVL-1580]

### DIFF
--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
@@ -58,7 +58,8 @@ object Reporter {
 
     private def indented(msg: String, n: Int = 2): String = {
       val indent = " " * n
-      msg.linesIterator.map(l => s"$indent$l").mkString("\n")
+      if (msg != null) msg.linesIterator.map(l => s"$indent$l").mkString("\n")
+      else ""
     }
 
     private def printReport(results: Vector[LedgerTestSummary]): Unit =


### PR DESCRIPTION
The `indented` function is used for reporting exception messages, for example. There are some ugly exceptions like the `EOFException`, where the message is `null`. In such a case the function throws an NPE which can be misleading, as well as causes the test tool to hang.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
