### PR TITLE
[engine] prefer lastLocation to stackTrace

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -1142,7 +1142,7 @@ scenarioTests mbScenarioService = Tasty.testGroup "Scenario tests"
           let vr = VRScenario foo "test"
           setFilesOfInterest [foo]
           setOpenVirtualResources [vr]
-          expectVirtualResourceRegex vr "Stack trace:.*- boom.*Foo:2:1.*- test.*Foo:4:1"
+          expectVirtualResourceRegex vr "Stack trace:.*- boom.*Foo:2:1"
     , testCase' "HasCallStack constraint" $ do
           let fooContent = T.unlines
                 [ "module Foo where"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -487,7 +487,6 @@ private[lf] object Pretty {
       case SELocF(i) => char('F') + str(i)
     }
 
-    @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppGeneral")
     @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppOnlyFunIsAtomic")
     def prettySExpr(index: Int)(e: SExpr): Doc =
       e match {
@@ -532,10 +531,6 @@ private[lf] object Pretty {
             case SBGetTime => text("$getTime")
             case _ => str(x)
           }
-        case SEAppGeneral(fun, args) =>
-          val prefix = prettySExpr(index)(fun) + text("@E(")
-          intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
-            .tightBracketBy(prefix, char(')'))
         case SEAppOnlyFunIsAtomic(fun, args) =>
           val prefix = prettySExpr(index)(fun) + text("@N(")
           intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -48,12 +48,10 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
     s"${x.ref.qualifiedName.name}"
   }
 
-  @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppGeneral")
   @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppOnlyFunIsAtomic")
   def pp(e: SExpr): String = e match {
     case SEValue(v) => s"(VALUE)${pp(v)}"
     case loc: SELoc => pp(loc)
-    case SEAppGeneral(func, args) => s"@E(${pp(func)},${commas(args.map(pp))})"
     case SEAppOnlyFunIsAtomic(func, args) => s"@N(${pp(func)},${commas(args.map(pp))})"
     case SEAppAtomicGeneral(func, args) => s"@A(${pp(func)},${commas(args.map(pp))})"
     case SEAppAtomicSaturatedBuiltin(b, args) => s"@B(${pp(SEBuiltin(b))},${commas(args.map(pp))})"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SDefinition.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SDefinition.scala
@@ -3,7 +3,6 @@
 
 package com.daml.lf.speedy
 
-import com.daml.lf.data.Ref.Location
 import com.daml.lf.speedy.SExpr.SExpr
 
 /** Top-level speedy definition.
@@ -16,8 +15,7 @@ import com.daml.lf.speedy.SExpr.SExpr
 final case class SDefinition(
     body: SExpr
 ) {
-  private var _cached: Option[(SValue, List[Location])] = None
-  private[speedy] def cached: Option[(SValue, List[Location])] = _cached
-  private[speedy] def setCached(sValue: SValue, stack_trace: List[Location]): Unit =
-    _cached = Some((sValue, stack_trace))
+  private var _cached: Option[SValue] = None
+  private[speedy] def cached: Option[SValue] = _cached
+  private[speedy] def setCached(sValue: SValue): Unit = _cached = Some(sValue)
 }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -54,9 +54,7 @@ object SExpr {
   /** Reference to a value. On first lookup the evaluated expression is
     * stored in 'cached'.
     */
-  final case class SEVal(
-      ref: SDefinitionRef
-  ) extends SExpr {
+  final case class SEVal(ref: SDefinitionRef) extends SExpr {
 
     // The variable `_cached` is used to cache the evaluation of the
     // LF value defined by `ref` once it has been computed.  Hence we
@@ -68,12 +66,11 @@ object SExpr {
     // `setCached`) is done atomically.
     // This is similar how hashcode evaluation is cached in String
     // http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/tip/src/share/classes/java/lang/String.java
-    private var _cached: Option[(SValue, List[Location])] = None
+    private var _cached: Option[SValue] = None
 
-    def cached: Option[(SValue, List[Location])] = _cached
+    def cached: Option[SValue] = _cached
 
-    def setCached(sValue: SValue, stack_trace: List[Location]): Unit =
-      _cached = Some((sValue, stack_trace))
+    def setCached(sValue: SValue): Unit = _cached = Some(sValue)
 
     def execute(machine: Machine): Control = {
       machine.lookupVal(this)
@@ -101,18 +98,6 @@ object SExpr {
   }
 
   object SEValue extends SValueContainer[SEValue] // used by Compiler
-
-  /** Function application with general function/arguments (deprecated)
-    * This case is used only by: fromUpdateSExpr and fromScenarioSExpr.
-    * The use required because of our current stack-trace support, which peeks under KArg.
-    */
-  @deprecated("Prefer SEAppAtomic or SEApp helper instead.")
-  final case class SEAppGeneral(fun: SExpr, args: Array[SExpr]) extends SExpr with SomeArrayEquals {
-    def execute(machine: Machine): Control = {
-      machine.pushKont(KArg(machine, args))
-      Control.Expression(fun)
-    }
-  }
 
   /** Function application with general arguments (deprecated)
     * Although 'fun' is atomic, 'args' are still any kind of expression.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -26,7 +26,6 @@ import com.daml.nameof.NameOf
 import com.daml.scalautil.Statement.discard
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 
-import scala.annotation.nowarn
 import scala.annotation.tailrec
 import scala.collection.mutable
 
@@ -443,6 +442,7 @@ private[lf] object Speedy {
       */
     def pushLocation(loc: Location): Unit = {
       lastLocation = Some(loc)
+      /* NICK....
       val last_index = kontStack.size() - 1
       val last_kont = if (last_index >= 0) Some(kontStack.get(last_index)) else None
       last_kont match {
@@ -470,6 +470,7 @@ private[lf] object Speedy {
           discard(kontStack.set(last_index, KCacheVal(machine, v, defn, loc :: stack_trace)))
         case _ => pushKont(KLocation(this, loc))
       }
+       */
     }
 
     /** Push an entire stack trace to the continuation stack. The first
@@ -483,9 +484,9 @@ private[lf] object Speedy {
       */
     def stackTrace(): ImmArray[Location] = {
       val s = ImmArray.newBuilder[Location]
-      kontStack.forEach {
-        case KLocation(_, location) => discard(s += location)
-        case _ => ()
+      lastLocation match {
+        case None => ()
+        case Some(location) => discard(s += location)
       }
       s.result()
     }
@@ -971,7 +972,6 @@ private[lf] object Speedy {
     @throws[PackageNotFound]
     @throws[CompilationError]
     // Construct a machine for running an update expression (testing -- avoiding scenarios)
-    @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppGeneral")
     def fromUpdateSExpr(
         compiledPackages: CompiledPackages,
         transactionSeed: crypto.Hash,
@@ -985,8 +985,7 @@ private[lf] object Speedy {
         compiledPackages = compiledPackages,
         submissionTime = Time.Timestamp.MinValue,
         initialSeeding = InitialSeeding.TransactionSeed(transactionSeed),
-        expr = SEAppGeneral(updateSE, Array(SEValue.Token)),
-        // expr = SEApp(updateSE, Array(SValue.SToken)), // TODO: when stack-trace hackery is resolved
+        expr = SEApp(updateSE, Array(SValue.SToken)),
         committers = committers,
         readAs = Set.empty,
         limits = limits,
@@ -998,15 +997,14 @@ private[lf] object Speedy {
     @throws[PackageNotFound]
     @throws[CompilationError]
     // Construct an off-ledger machine for running scenario.
-    @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppGeneral")
     def fromScenarioSExpr(
         compiledPackages: CompiledPackages,
         scenario: SExpr,
-    )(implicit loggingContext: LoggingContext): Machine = Machine.fromPureSExpr(
-      compiledPackages = compiledPackages,
-      expr = SEAppGeneral(scenario, Array(SEValue.Token)),
-      // expr = SEApp(scenario, Array(SValue.SToken)), // TODO: when stack-trace hackery is resolved
-    )
+    )(implicit loggingContext: LoggingContext): Machine =
+      Machine.fromPureSExpr(
+        compiledPackages = compiledPackages,
+        expr = SEApp(scenario, Array(SValue.SToken)),
+      )
 
     @throws[PackageNotFound]
     @throws[CompilationError]

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
@@ -10,13 +10,11 @@ import scala.jdk.CollectionConverters._
 
 // Iterates only over immediate children similar to Haskell’s
 // uniplate.
-@nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppGeneral")
 @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppOnlyFunIsAtomic")
 private[speedy] object SExprIterable {
   that =>
   private[iterable] def iterator(e: SExpr): Iterator[SExpr] = e match {
     case SExpr.SEVal(_) => Iterator.empty
-    case SExpr.SEAppGeneral(fun, args) => Iterator(fun) ++ args.iterator
     case SExpr.SEAppOnlyFunIsAtomic(fun, args) => Iterator(fun) ++ args.iterator
     case SExpr.SEAppAtomicGeneral(fun, args) => Iterator(fun) ++ args.iterator
     case SExpr.SEAppAtomicSaturatedBuiltin(_, args) => args.iterator

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -134,12 +134,17 @@ object ScenarioRunner {
     val runner = new ScenarioRunner(machine, initialSeed)
     handleUnsafe(runner.runUnsafe) match {
       case Left(err) =>
+        val stackTrace =
+          machine.getLastLocation match {
+            case None => ImmArray()
+            case Some(location) => ImmArray(location)
+          }
         ScenarioError(
           runner.ledger,
           machine.traceLog,
           machine.warningLog,
           runner.currentSubmission,
-          machine.stackTrace(),
+          stackTrace,
           err,
         )
       case Right(t) => t


### PR DESCRIPTION
TLDR: Remove broken code which constructs `stackTrace()`.
Happy never to have to read those `NOTE(MH)` comments in the `pushLocation` code again! :smile: 

(1) This code was fundamentally broken for various reasons:
- It doesn't make sense to track location info on the continuation stack. The continuation stack is a record of the evaluation still to come; not a context for the current evaluation.
- Stack traces can't sensibly be provided in a language such as Daml which promises that tail-recursion is evaluated in constant stack-space.
- Attempting to keep location info on the continuation stack does not play well when exceptions are thrown and the stack is unwound.

(2) The stack-trace management code was also very hacky:
- The `pushLocation` code contained special cases when the continuation stack was headed by a `KArg`/`SToken` continuation. This is an internal implementation detail. The `KArg` doesn't even exist when we stop using the deprecated `SEAppGeneral` expression constructor.
- The `pushLocation` code also contained special support for copying stack-traces into  `SEVal` and `SDefinition` caches, and then later back on to the continuation stack. Yuck!

(3) The `stackTrace()` code was barely used:
- Some time ago an alternative/simpler location tracking system (`lastLocation`) was implemented.
- Only `ScenarioRunner` makes use of the `stackTrace()`
- Only a single test changes behaviour when we drop use of `stackTrace()` in favour of `getLastLocation`
