### PR TITLE
Duplicate metadata on responseObserver.close [DPP-1241]

### DIFF
--- a/ledger/participant-integration-api/BUILD.bazel
+++ b/ledger/participant-integration-api/BUILD.bazel
@@ -61,6 +61,7 @@ compile_deps = [
     "//libs-scala/build-info",
     "//libs-scala/contextualized-logging",
     "//libs-scala/concurrent",
+    "//libs-scala/grpc-utils",
     "//libs-scala/logging-entries",
     "//libs-scala/ports",
     "//libs-scala/resources",

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/error/ErrorInterceptor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/error/ErrorInterceptor.scala
@@ -18,47 +18,49 @@ import io.grpc.{
   StatusRuntimeException,
 }
 
+import scala.util.control.NonFatal
+
 final class ErrorInterceptor extends ServerInterceptor {
 
   private val logger = ContextualizedLogger.get(getClass)
   private val emptyLoggingContext = LoggingContext.newLoggingContext(identity)
 
   override def interceptCall[ReqT, RespT](
-      call: ServerCall[ReqT, RespT],
-      headers: Metadata,
-      next: ServerCallHandler[ReqT, RespT],
-  ): ServerCall.Listener[ReqT] = {
+                                           call: ServerCall[ReqT, RespT],
+                                           headers: Metadata,
+                                           next: ServerCallHandler[ReqT, RespT],
+                                         ): ServerCall.Listener[ReqT] = {
 
     val forwardingCall = new SimpleForwardingServerCall[ReqT, RespT](call) {
 
       /** Here we are trying to detect status/trailers pairs that:
-        * - originated from the server implementation (i.e. Participant services as opposed to internal to gRPC implementation) AND
-        * - did not originate from self-service errors infrastructure.
-        * NOTE: We are not attempting to detect if a status/trailers pair originates from exceptional conditions within gRPC implementation itself.
-        *
-        * We are handling unary endpoints that returned failed Futures,
-        * We are NOT handling here exceptions thrown outside of Futures or Akka streams. These are handled separately in
-        * [[com.daml.platform.apiserver.error.ErrorListener]].
-        * We are NOT handling here exceptions thrown inside Akka streaming. These are handled in
-        * [[com.daml.grpc.adapter.server.akka.ServerAdapter.toSink]]
-        *
-        * Details:
-        * The gRPC services that we generate via scalapb are using [[scalapb.grpc.Grpc.completeObserver]]
-        * when bridging from Future[T] and into io.grpc.stub.StreamObserver[T].
-        * [[scalapb.grpc.Grpc.completeObserver]] does the following:
-        * a) propagates instances of StatusException and StatusRuntimeException without changes,
-        * b) translates other throwables into a StatusException with Status.INTERNAL.
-        * We assume that we don't need to deal with a) but need to detect and deal with b).
-        * Knowing that Status.INTERNAL is used only by [[com.daml.error.ErrorCategory.SystemInternalAssumptionViolated]],
-        * which is marked a security sensitive, we have the following heuristic: check whether gRPC status is Status.INTERNAL
-        * and gRPC status description is not security sanitized.
-        */
+       * - originated from the server implementation (i.e. Participant services as opposed to internal to gRPC implementation) AND
+       * - did not originate from self-service errors infrastructure.
+       * NOTE: We are not attempting to detect if a status/trailers pair originates from exceptional conditions within gRPC implementation itself.
+       *
+       * We are handling unary endpoints that returned failed Futures,
+       * We are NOT handling here exceptions thrown outside of Futures or Akka streams. These are handled separately in
+       * [[com.daml.platform.apiserver.error.ErrorListener]].
+       * We are NOT handling here exceptions thrown inside Akka streaming. These are handled in
+       * [[com.daml.grpc.adapter.server.akka.ServerAdapter.toSink]]
+       *
+       * Details:
+       * The gRPC services that we generate via scalapb are using [[scalapb.grpc.Grpc.completeObserver]]
+       * when bridging from Future[T] and into io.grpc.stub.StreamObserver[T].
+       * [[scalapb.grpc.Grpc.completeObserver]] does the following:
+       * a) propagates instances of StatusException and StatusRuntimeException without changes,
+       * b) translates other throwables into a StatusException with Status.INTERNAL.
+       * We assume that we don't need to deal with a) but need to detect and deal with b).
+       * Knowing that Status.INTERNAL is used only by [[com.daml.error.ErrorCategory.SystemInternalAssumptionViolated]],
+       * which is marked a security sensitive, we have the following heuristic: check whether gRPC status is Status.INTERNAL
+       * and gRPC status description is not security sanitized.
+       */
       override def close(status: Status, trailers: Metadata): Unit = {
         if (
           status.getCode == Status.Code.INTERNAL &&
-          (status.getDescription == null || !BaseError.isSanitizedSecuritySensitiveMessage(
-            status.getDescription
-          ))
+            (status.getDescription == null || !BaseError.isSanitizedSecuritySensitiveMessage(
+              status.getDescription
+            ))
         ) {
           val recreatedException = status.asRuntimeException(trailers)
           val selfServiceException = LedgerApiErrors.InternalError
@@ -70,13 +72,23 @@ final class ErrorInterceptor extends ServerInterceptor {
           val newMetadata =
             Option(Status.trailersFromThrowable(selfServiceException)).getOrElse(new Metadata())
           val newStatus = Status.fromThrowable(selfServiceException)
-          super.close(newStatus, newMetadata)
+          LogOnUnhandledFailureInClose(superClose(newStatus, newMetadata))
         } else {
-          super.close(status, trailers)
+          LogOnUnhandledFailureInClose(superClose(status, trailers))
         }
       }
 
+      /** This method serves as an accessor to the super.close() which facilitates its access from the outside of this class.
+       * This is needed in order to allow the call to be captured in the closure passed to the [[LogOnUnhandledFailureInClose]]
+       * error handler.
+       *
+       * TODO As of Scala 2.13.8, not using this redirection results in a runtime IllegalAccessError.
+       *      Remove this redirection once the runtime exception can be avoided.
+       */
+      private def superClose(status: Status, trailers: Metadata): Unit =
+        super.close(status, trailers)
     }
+
     val listener = next.startCall(forwardingCall, headers)
     new ErrorListener(
       delegate = listener,
@@ -87,16 +99,16 @@ final class ErrorInterceptor extends ServerInterceptor {
 }
 
 class ErrorListener[ReqT, RespT](delegate: ServerCall.Listener[ReqT], call: ServerCall[ReqT, RespT])
-    extends ForwardingServerCallListener.SimpleForwardingServerCallListener[ReqT](delegate) {
+  extends ForwardingServerCallListener.SimpleForwardingServerCallListener[ReqT](delegate) {
 
   private val logger = ContextualizedLogger.get(getClass)
   private val emptyLoggingContext = LoggingContext.newLoggingContext(identity)
 
   /** Handles errors arising outside Futures or Akka streaming.
-    *
-    * NOTE: We don't override other listener methods: onCancel, onComplete, onReady and onMessage;
-    * as it seems overriding only onHalfClose is sufficient.
-    */
+   *
+   * NOTE: We don't override other listener methods: onCancel, onComplete, onReady and onMessage;
+   * as it seems overriding only onHalfClose is sufficient.
+   */
   override def onHalfClose(): Unit = {
     try {
       super.onHalfClose()
@@ -107,18 +119,40 @@ class ErrorListener[ReqT, RespT](delegate: ServerCall.Listener[ReqT], call: Serv
       // 2. We need to catch it and call `call.close` as otherwise gRPC will close the stream with a Status.UNKNOWN
       //    (see io.grpc.internal.ServerImpl.JumpToApplicationThreadServerStreamListener.internalClose)
       case t: StatusException =>
-        call.close(t.getStatus, t.getTrailers)
+        LogOnUnhandledFailureInClose(call.close(t.getStatus, t.getTrailers))
       case t: StatusRuntimeException =>
-        call.close(t.getStatus, t.getTrailers)
+        LogOnUnhandledFailureInClose(call.close(t.getStatus, t.getTrailers))
       case t: Throwable =>
         val e = LedgerApiErrors.InternalError
           .UnexpectedOrUnknownException(t = t)(
             new DamlContextualizedErrorLogger(logger, emptyLoggingContext, None)
           )
           .asGrpcError
-        call.close(e.getStatus, e.getTrailers)
+        LogOnUnhandledFailureInClose(call.close(e.getStatus, e.getTrailers))
     }
-
   }
+}
 
+private[error] object LogOnUnhandledFailureInClose {
+  private val logger = ContextualizedLogger.get(getClass)
+
+  def apply[T](close: => T): T = {
+    // If close throws, we can't call ServerCall.close a second time
+    // since it might have already been marked internally as closed.
+    // In this situation, we can't do much about it except for notifying the participant operator.
+    try close
+    catch {
+      case NonFatal(e) =>
+        // Instantiate the self-service error code as it logs the error on creation.
+        // This error is considered security-sensitive and can't be propagated to the client.
+        LedgerApiErrors.InternalError
+          .Generic(
+            s"Unhandled error in ${classOf[ServerCall[_, _]].getSimpleName}.close(). " +
+              s"The gRPC client might have not been notified about the call/stream termination. " +
+              s"Either notify clients to retry pending unary/streaming calls or restart the participant server.",
+            Some(e),
+          )(new DamlContextualizedErrorLogger(logger, LoggingContext.empty, None))
+        throw e
+    }
+  }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/error/ErrorInterceptor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/error/ErrorInterceptor.scala
@@ -3,20 +3,11 @@
 
 package com.daml.platform.apiserver.error
 
-import com.daml.error.{BaseError, DamlContextualizedErrorLogger}
 import com.daml.error.definitions.LedgerApiErrors
+import com.daml.error.{BaseError, DamlContextualizedErrorLogger}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import io.grpc.ForwardingServerCall.SimpleForwardingServerCall
-import io.grpc.{
-  ForwardingServerCallListener,
-  Metadata,
-  ServerCall,
-  ServerCallHandler,
-  ServerInterceptor,
-  Status,
-  StatusException,
-  StatusRuntimeException,
-}
+import io.grpc._
 
 import scala.util.control.NonFatal
 
@@ -26,41 +17,41 @@ final class ErrorInterceptor extends ServerInterceptor {
   private val emptyLoggingContext = LoggingContext.newLoggingContext(identity)
 
   override def interceptCall[ReqT, RespT](
-                                           call: ServerCall[ReqT, RespT],
-                                           headers: Metadata,
-                                           next: ServerCallHandler[ReqT, RespT],
-                                         ): ServerCall.Listener[ReqT] = {
+      call: ServerCall[ReqT, RespT],
+      headers: Metadata,
+      next: ServerCallHandler[ReqT, RespT],
+  ): ServerCall.Listener[ReqT] = {
 
     val forwardingCall = new SimpleForwardingServerCall[ReqT, RespT](call) {
 
       /** Here we are trying to detect status/trailers pairs that:
-       * - originated from the server implementation (i.e. Participant services as opposed to internal to gRPC implementation) AND
-       * - did not originate from self-service errors infrastructure.
-       * NOTE: We are not attempting to detect if a status/trailers pair originates from exceptional conditions within gRPC implementation itself.
-       *
-       * We are handling unary endpoints that returned failed Futures,
-       * We are NOT handling here exceptions thrown outside of Futures or Akka streams. These are handled separately in
-       * [[com.daml.platform.apiserver.error.ErrorListener]].
-       * We are NOT handling here exceptions thrown inside Akka streaming. These are handled in
-       * [[com.daml.grpc.adapter.server.akka.ServerAdapter.toSink]]
-       *
-       * Details:
-       * The gRPC services that we generate via scalapb are using [[scalapb.grpc.Grpc.completeObserver]]
-       * when bridging from Future[T] and into io.grpc.stub.StreamObserver[T].
-       * [[scalapb.grpc.Grpc.completeObserver]] does the following:
-       * a) propagates instances of StatusException and StatusRuntimeException without changes,
-       * b) translates other throwables into a StatusException with Status.INTERNAL.
-       * We assume that we don't need to deal with a) but need to detect and deal with b).
-       * Knowing that Status.INTERNAL is used only by [[com.daml.error.ErrorCategory.SystemInternalAssumptionViolated]],
-       * which is marked a security sensitive, we have the following heuristic: check whether gRPC status is Status.INTERNAL
-       * and gRPC status description is not security sanitized.
-       */
+        * - originated from the server implementation (i.e. Participant services as opposed to internal to gRPC implementation) AND
+        * - did not originate from self-service errors infrastructure.
+        * NOTE: We are not attempting to detect if a status/trailers pair originates from exceptional conditions within gRPC implementation itself.
+        *
+        * We are handling unary endpoints that returned failed Futures,
+        * We are NOT handling here exceptions thrown outside of Futures or Akka streams. These are handled separately in
+        * [[com.daml.platform.apiserver.error.ErrorListener]].
+        * We are NOT handling here exceptions thrown inside Akka streaming. These are handled in
+        * [[com.daml.grpc.adapter.server.akka.ServerAdapter.toSink]]
+        *
+        * Details:
+        * The gRPC services that we generate via scalapb are using [[scalapb.grpc.Grpc.completeObserver]]
+        * when bridging from Future[T] and into io.grpc.stub.StreamObserver[T].
+        * [[scalapb.grpc.Grpc.completeObserver]] does the following:
+        * a) propagates instances of StatusException and StatusRuntimeException without changes,
+        * b) translates other throwables into a StatusException with Status.INTERNAL.
+        * We assume that we don't need to deal with a) but need to detect and deal with b).
+        * Knowing that Status.INTERNAL is used only by [[com.daml.error.ErrorCategory.SystemInternalAssumptionViolated]],
+        * which is marked a security sensitive, we have the following heuristic: check whether gRPC status is Status.INTERNAL
+        * and gRPC status description is not security sanitized.
+        */
       override def close(status: Status, trailers: Metadata): Unit = {
         if (
           status.getCode == Status.Code.INTERNAL &&
-            (status.getDescription == null || !BaseError.isSanitizedSecuritySensitiveMessage(
-              status.getDescription
-            ))
+          (status.getDescription == null || !BaseError.isSanitizedSecuritySensitiveMessage(
+            status.getDescription
+          ))
         ) {
           val recreatedException = status.asRuntimeException(trailers)
           val selfServiceException = LedgerApiErrors.InternalError
@@ -72,43 +63,45 @@ final class ErrorInterceptor extends ServerInterceptor {
           val newMetadata =
             Option(Status.trailersFromThrowable(selfServiceException)).getOrElse(new Metadata())
           val newStatus = Status.fromThrowable(selfServiceException)
-          LogOnUnhandledFailureInClose(superClose(newStatus, newMetadata))
+          LogOnUnhandledFailureInClose(closeWithCopiedMetadata(newStatus, newMetadata))
         } else {
-          LogOnUnhandledFailureInClose(superClose(status, trailers))
+          LogOnUnhandledFailureInClose(closeWithCopiedMetadata(status, trailers))
         }
       }
 
       /** This method serves as an accessor to the super.close() which facilitates its access from the outside of this class.
-       * This is needed in order to allow the call to be captured in the closure passed to the [[LogOnUnhandledFailureInClose]]
-       * error handler.
-       *
-       * TODO As of Scala 2.13.8, not using this redirection results in a runtime IllegalAccessError.
-       *      Remove this redirection once the runtime exception can be avoided.
-       */
-      private def superClose(status: Status, trailers: Metadata): Unit =
-        super.close(status, trailers)
+        * This is needed in order to allow the call to be captured in the closure passed to the [[LogOnUnhandledFailureInClose]]
+        * error handler.
+        *
+        * TODO As of Scala 2.13.8, not using this redirection results in a runtime IllegalAccessError.
+        *      Remove this redirection once the runtime exception can be avoided.
+        */
+      private def closeWithCopiedMetadata(status: Status, trailers: Metadata): Unit = {
+        val copiedMetadata = MetadataUtils.copy(trailers)
+        super.close(status, copiedMetadata)
+      }
     }
 
     val listener = next.startCall(forwardingCall, headers)
+
     new ErrorListener(
       delegate = listener,
-      call = call,
+      call = forwardingCall,
     )
   }
-
 }
 
 class ErrorListener[ReqT, RespT](delegate: ServerCall.Listener[ReqT], call: ServerCall[ReqT, RespT])
-  extends ForwardingServerCallListener.SimpleForwardingServerCallListener[ReqT](delegate) {
+    extends ForwardingServerCallListener.SimpleForwardingServerCallListener[ReqT](delegate) {
 
   private val logger = ContextualizedLogger.get(getClass)
   private val emptyLoggingContext = LoggingContext.newLoggingContext(identity)
 
   /** Handles errors arising outside Futures or Akka streaming.
-   *
-   * NOTE: We don't override other listener methods: onCancel, onComplete, onReady and onMessage;
-   * as it seems overriding only onHalfClose is sufficient.
-   */
+    *
+    * NOTE: We don't override other listener methods: onCancel, onComplete, onReady and onMessage;
+    * as it seems overriding only onHalfClose is sufficient.
+    */
   override def onHalfClose(): Unit = {
     try {
       super.onHalfClose()

--- a/ledger/participant-integration-api/src/test/resources/logback-test.xml
+++ b/ledger/participant-integration-api/src/test/resources/logback-test.xml
@@ -43,6 +43,14 @@
         <test>com.daml.platform.indexer.ha.IndexerStabilitySpec</test>
     </appender>
 
+    <appender name="LogOnUnhandledFailureInCloseCapture" class="com.daml.platform.testing.LogCollector">
+        <test>com.daml.platform.apiserver.error.ErrorInterceptorSpec</test>
+    </appender>
+
+    <logger name="com.daml.platform.apiserver.error.LogOnUnhandledFailureInClose" level="INFO">
+        <appender-ref ref="LogOnUnhandledFailureInCloseCapture"/>
+    </logger>
+
     <logger name="com.daml.platform.store.dao.HikariConnection" level="INFO">
         <appender-ref ref="JdbcIndexerSpecAppender"/>
         <appender-ref ref="IndexerStabilitySpecAppender"/>

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/error/ErrorInterceptorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/error/ErrorInterceptorSpec.scala
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 
 final class ErrorInterceptorSpec
-  extends AsyncFreeSpec
+    extends AsyncFreeSpec
     with BeforeAndAfter
     with AkkaBeforeAndAfterAll
     with Matchers
@@ -174,7 +174,7 @@ final class ErrorInterceptorSpec
       assert(LogOnUnhandledFailureInClose(call()) === 2)
     }
 
-    "logs and re-throws the exception of a " in {
+    "logs and re-throws the exception" in {
       val failure = new RuntimeException("some failure")
       val failingCall = () => throw failure
 
@@ -204,8 +204,8 @@ final class ErrorInterceptorSpec
   }
 
   private def exerciseUnaryFutureEndpoint(
-                                           helloService: BindableService
-                                         ): Future[StatusRuntimeException] = {
+      helloService: BindableService
+  ): Future[StatusRuntimeException] = {
     val response: Future[HelloResponse] = server(
       tested = new ErrorInterceptor(),
       service = helloService,
@@ -218,8 +218,8 @@ final class ErrorInterceptorSpec
   }
 
   private def exerciseStreamingAkkaEndpoint(
-                                             helloService: BindableService
-                                           ): Future[StatusRuntimeException] = {
+      helloService: BindableService
+  ): Future[StatusRuntimeException] = {
     val response: Future[Vector[HelloResponse]] = server(
       tested = new ErrorInterceptor(),
       service = helloService,
@@ -247,9 +247,9 @@ final class ErrorInterceptorSpec
   }
 
   private def assertFooMissingError(
-                                     actual: StatusRuntimeException,
-                                     expectedMsg: String,
-                                   ): Assertion = {
+      actual: StatusRuntimeException,
+      expectedMsg: String,
+  ): Assertion = {
     assertError(
       actual,
       expectedStatusCode = FooMissingErrorCode.category.grpcCode.get,
@@ -273,9 +273,9 @@ object ErrorInterceptorSpec {
   }
 
   private def serverOwner(
-                           interceptor: ServerInterceptor,
-                           service: BindableService,
-                         ): ResourceOwner[Server] =
+      interceptor: ServerInterceptor,
+      service: BindableService,
+  ): ResourceOwner[Server] =
     new ResourceOwner[Server] {
       def acquire()(implicit context: ResourceContext): Resource[Server] =
         Resource(Future {
@@ -292,16 +292,16 @@ object ErrorInterceptorSpec {
     }
 
   object FooMissingErrorCode
-    extends ErrorCode(
-      id = "FOO_MISSING_ERROR_CODE",
-      ErrorCategory.InvalidGivenCurrentSystemStateResourceMissing,
-    )(ErrorClass.root()) {
+      extends ErrorCode(
+        id = "FOO_MISSING_ERROR_CODE",
+        ErrorCategory.InvalidGivenCurrentSystemStateResourceMissing,
+      )(ErrorClass.root()) {
 
     case class Error(msg: String)(implicit
-                                  val loggingContext: ContextualizedErrorLogger
+        val loggingContext: ContextualizedErrorLogger
     ) extends DamlError(
-      cause = s"Foo is missing: ${msg}"
-    )
+          cause = s"Foo is missing: ${msg}"
+        )
 
   }
 
@@ -318,18 +318,18 @@ object ErrorInterceptorSpec {
   }
 
   /** @param useSelfService - whether to use self service error codes or "rogue" exceptions
-   * @param errorInsideFutureOrStream - whether to signal the exception inside a Future or a Stream, or outside to them
-   */
+    * @param errorInsideFutureOrStream - whether to signal the exception inside a Future or a Stream, or outside to them
+    */
   class HelloServiceFailing(useSelfService: Boolean, errorInsideFutureOrStream: Boolean)(implicit
-                                                                                         protected val esf: ExecutionSequencerFactory,
-                                                                                         protected val mat: Materializer,
+      protected val esf: ExecutionSequencerFactory,
+      protected val mat: Materializer,
   ) extends HelloServiceAkkaGrpc
-    with HelloServiceResponding
-    with HelloServiceBase {
+      with HelloServiceResponding
+      with HelloServiceBase {
 
     override protected def serverStreamingSource(
-                                                  request: HelloRequest
-                                                ): Source[HelloResponse, NotUsed] = {
+        request: HelloRequest
+    ): Source[HelloResponse, NotUsed] = {
       val where = if (errorInsideFutureOrStream) "inside" else "outside"
       val t: Throwable = if (useSelfService) {
         FooMissingErrorCode

--- a/ledger/test-common/src/main/scala/com/digitalasset/platform/testing/LogCollector.scala
+++ b/ledger/test-common/src/main/scala/com/digitalasset/platform/testing/LogCollector.scala
@@ -51,8 +51,8 @@ object LogCollector {
       logger: ClassTag[Logger],
   ): Seq[Entry] =
     log
-      .get(test.runtimeClass.getName)
-      .flatMap(_.get(logger.runtimeClass.getName))
+      .get(test.runtimeClass.getName.stripSuffix("$"))
+      .flatMap(_.get(logger.runtimeClass.getName.stripSuffix("$")))
       .fold(IndexedSeq.empty[Entry])(_.result())
 
   def clear[Test](implicit test: ClassTag[Test]): Unit = {

--- a/libs-scala/grpc-utils/src/main/scala/io/grpc/MetadataUtils.scala
+++ b/libs-scala/grpc-utils/src/main/scala/io/grpc/MetadataUtils.scala
@@ -1,0 +1,8 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package io.grpc
+
+object MetadataUtils {
+  def copy(original: Metadata): Metadata = new Metadata(original.serialize(): _*)
+}


### PR DESCRIPTION
Implementation-only PR (as an alternative to https://github.com/digital-asset/daml/pull/15084) that proposes the solution of copying the `io.grpc.Metadata` before dispatching errors to `responseObserver.close` (as a mitigation to https://github.com/DACH-NY/canton/issues/10394). 

**NOTE:** Tests are missing for this PR. I will implement them if we reach consensus on the desired solution.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
