### PR TITLE
Proper error handling on input validation of disclosed contracts

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
@@ -127,6 +127,13 @@ object Error {
 
     final case class BadDisclosedContract(message: String) extends Error
 
+    final case class DuplicateDisclosedContractId(
+        contractId: Value.ContractId,
+        templateId: Ref.Identifier,
+    ) extends Error {
+      override def message: String =
+        s"Preprocessor encountered a duplicate disclosed contract ID $contractId for template $templateId"
+    }
   }
 
   // Error happening during interpretation


### PR DESCRIPTION
* Fixes #14200

- [x] Add in unit test and validate that the preprocessor does not currently detect duplicate disclosed contract IDs
- [x] Modify `preprocessDisclosedContracts` to detect and reject (with a `Error.Preprocessing.DuplicateDisclosedContractId`) duplicate contract IDs
- [x] Ensure unit tests now pass

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
