### PR TITLE
Only report coverage for package-local choices/templates

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -203,9 +203,9 @@ printTestCoverage ::
 printTestCoverage ShowCoverage {getShowCoverage} allPackages results
   | any (isLeft . snd) $ concatMap snd results = pure ()
   | otherwise = do
-      printReport $ report "templates/choices defined in module" isLocal
-      printReport $ report "templates/choices defined outside module" (not . isLocal)
-      printReport $ report "all templates/choices available" (const True)
+      printReport $ report "defined in local module" isLocal
+      printReport $ report "defined in external modules" (not . isLocal)
+      printReport $ report "defined anywhere" (const True)
   where
     report :: String -> (LocalOrExternal -> Bool) -> Report
     report groupName pred =
@@ -249,7 +249,7 @@ printTestCoverage ShowCoverage {getShowCoverage} allPackages results
             frac msg a b = msg ++ ": " ++ show a ++ " / " ++ show b
             pct msg a b = frac msg a b ++ " (" ++ percentage a b ++ ")"
             indent = ("  " ++)
-            header = "group: " ++ groupName
+            header = groupName ++ ":"
             body1 =
                 [ pct "choices" (S.size internalExercisedAnywhere) (S.size definedChoicesInside)
                 , pct "templates" (S.size internalCreatedAnywhere) (S.size definedTemplatesInside)

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -203,8 +203,8 @@ printTestCoverage ::
 printTestCoverage ShowCoverage {getShowCoverage} allPackages results
   | any (isLeft . snd) $ concatMap snd results = pure ()
   | otherwise = do
-      printReport $ report "defined in local module" isLocal
-      printReport $ report "defined in external modules" (not . isLocal)
+      printReport $ report "defined in local package" isLocal
+      printReport $ report "defined in external packages" (not . isLocal)
       printReport $ report "defined anywhere" (const True)
   where
     report :: String -> (LocalOrExternal -> Bool) -> Report

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -203,7 +203,9 @@ printTestCoverage ::
 printTestCoverage ShowCoverage {getShowCoverage} allPackages results
   | any (isLeft . snd) $ concatMap snd results = pure ()
   | otherwise = do
-      printReport $ report "local" isLocal
+      printReport $ report "templates/choices defined in module" isLocal
+      printReport $ report "templates/choices defined outside module" (not . isLocal)
+      printReport $ report "all templates/choices available" (const True)
   where
     report :: String -> (LocalOrExternal -> Bool) -> Report
     report groupName pred =

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -203,8 +203,8 @@ printTestCoverage ::
 printTestCoverage ShowCoverage {getShowCoverage} allPackages results
   | any (isLeft . snd) $ concatMap snd results = pure ()
   | otherwise = do
-      printReport $ report "defined in local package" isLocal
-      printReport $ report "defined in external packages" (not . isLocal)
+      printReport $ report "defined in local modules" isLocal
+      printReport $ report "defined in external modules" (not . isLocal)
       printReport $ report "defined anywhere" (const True)
   where
     report :: String -> (LocalOrExternal -> Bool) -> Report

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -289,7 +289,7 @@ printTestCoverage ShowCoverage {getShowCoverage} allPackages results
         in
         TemplateIdentifier { package, qualifiedTemplate }
 
-    templatesDefinedIn :: [LocalOrExternal] -> M.Map TemplateIdentifier LF.Qualified LF.Template
+    templatesDefinedIn :: [LocalOrExternal] -> M.Map TemplateIdentifier (LF.Qualified LF.Template)
     templatesDefinedIn localOrExternals = M.fromList
         [ (lfTemplateIdentifier templateInfo, templateInfo)
         | localOrExternal <- localOrExternals

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -209,12 +209,12 @@ printTestCoverage ShowCoverage {getShowCoverage} allPackages results
   where
     report :: String -> (LocalOrExternal -> Bool) -> Report
     report groupName pred =
-        let filteredResults :: [(LocalOrExternal, [(VirtualResource, Either SSC.Error SS.ScenarioResult)])]
-            filteredResults = filter (pred . fst) results
-            definedTemplatesInside = M.keysSet $ templatesDefinedIn $ map fst filteredResults
-            definedChoicesInside = M.keysSet $ choicesDefinedIn $ map fst filteredResults
-            exercisedInside = foldMap (exercisedChoices . snd) filteredResults
-            createdInside = foldMap (createdTemplates . snd) filteredResults
+        let allMatchingPackages = filter pred allPackages
+            allMatchingResults = map snd $ filter (pred . fst) results
+            definedTemplatesInside = M.keysSet $ templatesDefinedIn allMatchingPackages
+            definedChoicesInside = M.keysSet $ choicesDefinedIn allMatchingPackages
+            exercisedInside = foldMap exercisedChoices allMatchingResults
+            createdInside = foldMap createdTemplates allMatchingResults
             internalExercisedAnywhere = allExercisedChoices `S.intersection` definedChoicesInside
             internalExercisedInternal = exercisedInside `S.intersection` definedChoicesInside
             externalExercisedInternal = exercisedInside `S.difference` definedChoicesInside

--- a/compiler/damlc/tests/src/DamlcTest.hs
+++ b/compiler/damlc/tests/src/DamlcTest.hs
@@ -317,7 +317,7 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
             exitCode @?= ExitSuccess
             let out = lines stdout
             assertBool ("test coverage is reported correctly: " <> stdout)
-                       ("defined in local module:\n  choices: 1 / 3 (33%)\n  templates: 1 / 2 (50%)" `isInfixOf` stdout)
+                       ("defined in local modules:\n  choices: 1 / 3 (33%)\n  templates: 1 / 2 (50%)" `isInfixOf` stdout)
             assertBool ("test summary is reported correctly: " <> out!!1)
                        ("Test Summary" `isPrefixOf` (out!!1))
             assertBool ("test summary is reported correctly: " <> out!!3)
@@ -577,7 +577,7 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
             (unlines
               ["B.daml:needleHaystack: ok, 0 active contracts, 0 transactions."
               , "a:test_needleHaystack: ok, 0 active contracts, 0 transactions."
-              , "defined in local module:"
+              , "defined in local modules:"
               , "  choices: 0 / 0 (100%)"
               , "  templates: 0 / 0 (100%)"
               ] `isInfixOf` stdout)
@@ -647,7 +647,7 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
           assertBool ("Test coverage is reported correctly: " <> stdout)
             (unlines
                  [ "B.daml:x: ok, 0 active contracts, 2 transactions."
-                 , "defined in local module:"
+                 , "defined in local modules:"
                  , "  choices: 1 / 3 (33%)"
                  , "  templates: 1 / 2 (50%)"
                  , "  templates never created:"

--- a/compiler/damlc/tests/src/DamlcTest.hs
+++ b/compiler/damlc/tests/src/DamlcTest.hs
@@ -4,7 +4,7 @@ module DamlcTest
    ( main
    ) where
 
-import Data.List.Extra (isInfixOf, isSuffixOf, isPrefixOf)
+import Data.List.Extra (isInfixOf, isPrefixOf)
 import System.Directory
 import System.Environment.Blank
 import System.Exit
@@ -358,12 +358,12 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
             assertBool
                 ("test coverage is reported correctly: " <> stdout)
                 (unlines
-                     [ "templates never created:"
-                     , "Foo:S"
-                     , "choices never executed:"
-                     , "Foo:S:Archive"
-                     , "Foo:T:Archive\n"
-                     ] `isSuffixOf`
+                     [ "  templates never created:"
+                     , "    Foo:S"
+                     , "  choices never executed:"
+                     , "    Foo:S:Archive"
+                     , "    Foo:T:Archive\n"
+                     ] `isInfixOf`
                  stdout)
 -- TODO: https://github.com/digital-asset/daml/issues/13044
 -- reactive the test
@@ -507,14 +507,20 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
             (unlines
                  [ "B.daml:x: ok, 0 active contracts, 2 transactions."
                  , "a:testA: ok, 0 active contracts, 2 transactions."
-                 , "test coverage: templates 67%, choices 40%"
-                 , "templates never created:"
-                 , "B:S"
-                 , "choices never executed:"
-                 , "B:S:Archive"
-                 , "B:T:Archive"
-                 , "a:A:U:Archive\n"
-                 ] `isSuffixOf`
+                 ] `isInfixOf`
+             stdout)
+          assertBool ("Test coverage is reported correctly: " <> stdout)
+            (unlines
+                 [ "defined anywhere:"
+                 , "  choices: 2 / 5 (40%)"
+                 , "  templates: 2 / 3 (67%)"
+                 , "  templates never created:"
+                 , "    B:S"
+                 , "  choices never executed:"
+                 , "    B:S:Archive"
+                 , "    B:T:Archive"
+                 , "    a:A:U:Archive"
+                 ] `isInfixOf`
              stdout)
           exitCode @?= ExitSuccess
     , testCase "Filter tests with --test-pattern" $ withTempDir $ \projDir -> do
@@ -571,8 +577,10 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
             (unlines
               ["B.daml:needleHaystack: ok, 0 active contracts, 0 transactions."
               , "a:test_needleHaystack: ok, 0 active contracts, 0 transactions."
-              , "test coverage: templates 100%, choices 100%"
-              ] `isSuffixOf` stdout)
+              , "defined in local module:"
+              , "  choices: 0 / 0 (100%)"
+              , "  templates: 0 / 0 (100%)"
+              ] `isInfixOf` stdout)
           exitCode @?= ExitSuccess
     , testCase "Full test coverage report without --all set (but imports)" $ withTempDir $ \projDir -> do
           createDirectoryIfMissing True (projDir </> "a")
@@ -639,13 +647,15 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
           assertBool ("Test coverage is reported correctly: " <> stdout)
             (unlines
                  [ "B.daml:x: ok, 0 active contracts, 2 transactions."
-                 , "test coverage: templates 50%, choices 33%"
-                 , "templates never created:"
-                 , "B:S"
-                 , "choices never executed:"
-                 , "B:S:Archive"
-                 , "B:T:Archive\n"
-                 ] `isSuffixOf`
+                 , "defined in local module:"
+                 , "  choices: 1 / 3 (33%)"
+                 , "  templates: 1 / 2 (50%)"
+                 , "  templates never created:"
+                 , "    B:S"
+                 , "  choices never executed:"
+                 , "    B:S:Archive"
+                 , "    B:T:Archive\n"
+                 ] `isInfixOf`
              stdout)
           exitCode @?= ExitSuccess
     , testCase "File with failing script" $ do

--- a/compiler/damlc/tests/src/DamlcTest.hs
+++ b/compiler/damlc/tests/src/DamlcTest.hs
@@ -316,8 +316,8 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
                 ""
             exitCode @?= ExitSuccess
             let out = lines stdout
-            assertBool ("test coverage is reported correctly: " <> out!!4)
-                       ("test coverage: templates 50%, choices 33%" == (out!!4))
+            assertBool ("test coverage is reported correctly: " <> stdout)
+                       ("defined in local module:\n  choices: 1 / 3 (33%)\n  templates: 1 / 2 (50%)" `isInfixOf` stdout)
             assertBool ("test summary is reported correctly: " <> out!!1)
                        ("Test Summary" `isPrefixOf` (out!!1))
             assertBool ("test summary is reported correctly: " <> out!!3)


### PR DESCRIPTION
https://github.com/digital-asset/daml/issues/14309

This splits the coverage report into three parts:
- coverage of templates/choices defined in this package
- coverage of templates/choices defined in external imported packages
- coverage of all templates/choices defined