### PR TITLE
mark internal Java bindings functions in Javadoc

### DIFF
--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/Exercises.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/Exercises.java
@@ -11,5 +11,10 @@ import com.daml.ledger.javaapi.data.Value;
  * @param <Cmd> The returned type of ledger command.
  */
 public interface Exercises<Cmd> {
+  /**
+   * <strong>Internal</strong>: this is meant for use by <a
+   * href="https://docs.daml.com/app-dev/bindings-java/codegen.html">the Java code generator</a>,
+   * and <em>should not be referenced directly by applications</em>.
+   */
   Cmd makeExerciseCmd(String choice, Value choiceArgument);
 }


### PR DESCRIPTION
The note formats as follows:

> **Internal**: this is meant for use by [the Java code generator](https://docs.daml.com/app-dev/bindings-java/codegen.html), and _should not be referenced directly by applications_.