### PR TITLE
Handle sums-of-products correctly in `daml ledger export`

### DIFF
--- a/daml-script/export/integration-tests/golden/export-values/Export.daml
+++ b/daml-script/export/integration-tests/golden/export-values/Export.daml
@@ -88,10 +88,17 @@ export Args{parties, contracts} = do
         intOpts = [None, (Some 77), None, (Some 78)], intListOpts = [None,
           (Some []), (Some [79]), (Some [80, 81, 82])],
         variants = [(Values.VarInt 83), (Values.VarText "84"),
-          (Values.VarRec (Values.Record {int = 85, text = "86", bool = True}))],
+          (Values.VarRec (Values.Record {int = 85, text = "86", bool = True})),
+          (Values.VarFields {rec = (Values.Record {int = 87, text = "88",
+                  bool = True}), int = 89, text = "90"})],
         hkVariants = [(Values.HkVarInt 91), (Values.HkVarText "92"),
           (Values.HkVarAye Values.Cee), (Values.HkVarBee 93),
           (Values.HkVarCee ()), (Values.HkVarRec (Values.HkRecord {int = 94,
                 text = "95", bool = True, aye = Values.Bee, bee = 96,
-                ayeBees = [(Values.Aye, 97), (Values.Cee, 98)]}))]})
+                ayeBees = [(Values.Aye, 97), (Values.Cee, 98)]})),
+          (Values.HkVarFields {hkRec = (Values.HkRecord {int = 99, text = "100",
+                  bool = True, aye = Values.Dee, bee = 101,
+                  ayeBees = [(Values.Bee, 102), (Values.Cee, 103)]}), int = 104,
+              text = "105", ayeBeeCees = [(Values.Dee, 106, ()), (Values.Aye,
+                  107, ())]})]})
   pure ()

--- a/daml-script/export/integration-tests/golden/export-values/Values.daml
+++ b/daml-script/export/integration-tests/golden/export-values/Values.daml
@@ -78,6 +78,12 @@ data Variant
   -}
   | VarInt Int
   | VarText Text
+  {-  The compiler fails with error
+        > Constructors with multiple fields must give explicit field names,
+        > e.g. Foo with bar : Int; baz : Int
+      so we don't test this case.
+  | VarIntText Int Text
+  -}
   | VarRec Record
   | VarFields with
       rec : Record
@@ -87,11 +93,24 @@ data Variant
 
 data HkVariant a b c
   = HkVarUnit
+  {-  The compiler warns
+        > Variant type HkVariant constructor HkVarExplicitUnit has a single argument
+        > of type (). The argument will not be preserved when importing this
+        > package via data-dependencies.
+      so we don't test this case.
+  | HkVarExplicitUnit ()
+  -}
   | HkVarInt Int
   | HkVarText Text
   | HkVarAye a
   | HkVarBee b
   | HkVarCee c
+  {-  The compiler fails with error
+        > Constructors with multiple fields must give explicit field names,
+        > e.g. Foo with bar : Int; baz : Int
+      so we don't test this case.
+  | VarIntTextAyeBee Int Text a b
+  -}
   | HkVarRec (HkRecord a b)
   | HkVarFields with
       hkRec : HkRecord a b

--- a/daml-script/export/integration-tests/golden/export-values/Values.daml
+++ b/daml-script/export/integration-tests/golden/export-values/Values.daml
@@ -166,27 +166,13 @@ initializeWith LedgerParties {bank} = do
             int = 85
             text = "86"
             bool = True)
-          {-
-        , (VarFields with -- TODO: Handle sums of products properly
-                          -- Currently exported with a spurious record
-                          -- constructor `Values.Variant.VarFields` as
-                          -- ```
-                          -- (Values.VarFields (Values.Variant.VarFields
-                          --     { rec = (Values.Record
-                          --         { int = 87
-                          --         , text = "88"
-                          --         , bool = True })
-                          --     , int = 89
-                          --     , text = "90" }))
-                          -- ```
-                          -- https://github.com/digital-asset/daml/issues/14723
+        , (VarFields with
             rec = Record with
               int = 87
               text = "88"
               bool = True
             int = 89
             text = "90")
-          -}
         ]
       hkVariants =
         [ {-
@@ -209,24 +195,7 @@ initializeWith LedgerParties {bank} = do
             aye = Bee
             bee = 96
             ayeBees = [(Aye, 97), (Cee, 98)])
-          {-
-        , (HkVarFields with -- TODO: Handle sums of products properly
-                            -- Currently exported with a spurious record
-                            -- constructor `Values.HkVariant.HkVarFields` as
-                            -- ```
-                            -- (Values.HkVarFields (Values.HkVariant.HkVarFields
-                            --     { hkRec = (Values.HkRecord
-                            --         { int = 99
-                            --         , text = "100"
-                            --         , bool = True
-                            --         , aye = Values.Dee
-                            --         , bee = 101
-                            --         , ayeBees = [(Values.Bee, 102), (Values.Cee, 103)]})
-                            --     , int = 104
-                            --     , text = "105"
-                            --     , ayeBeeCees = [(Values.Dee, 106, ()), (Values.Aye, 107, ())]}))
-                            -- ```
-                            -- https://github.com/digital-asset/daml/issues/14723
+        , (HkVarFields with
             hkRec = HkRecord with
               int = 99
               text = "100"
@@ -237,7 +206,6 @@ initializeWith LedgerParties {bank} = do
             int = 104
             text = "105"
             ayeBeeCees = [(Dee, 106, ()), (Aye, 107, ())])
-          -}
         ]
   pure ()
 

--- a/daml-script/export/integration-tests/golden/export-values/Values.daml
+++ b/daml-script/export/integration-tests/golden/export-values/Values.daml
@@ -153,12 +153,12 @@ initializeWith LedgerParties {bank} = do
       intListOpts = [None, Some [], Some [79], Some [80, 81, 82]]
       variants =
         [ {-
-          VarUnit -- TODO: Handle sums of products properly
+          VarUnit -- TODO: Handle variant without arguments properly
                   -- Currently exported with a spurious argument as
                   -- ```
                   -- Values.VarUnit ()`
                   -- ```
-                  -- https://github.com/digital-asset/daml/issues/14723
+                  -- https://github.com/digital-asset/daml/issues/15153
         , -}
           VarInt 83
         , VarText "84"
@@ -176,12 +176,12 @@ initializeWith LedgerParties {bank} = do
         ]
       hkVariants =
         [ {-
-          HkVarUnit -- TODO: Handle sums of products properly
+          HkVarUnit -- TODO: Handle variant without arguments properly
                     -- Currently exported with a spurious argument as
                     -- ```
                     -- Values.HkVarUnit ()`
                     -- ```
-                    -- https://github.com/digital-asset/daml/issues/14723
+                    -- https://github.com/digital-asset/daml/issues/15153
         , -}
           HkVarInt 91
         , HkVarText "92"

--- a/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
@@ -362,8 +362,6 @@ private[export] object Encode {
       variant.getVariantId.entityName + "." + variant.constructor
     )
 
-  // TODO Handle sums of products properly
-  // https://github.com/digital-asset/daml/issues/14723
   private def encodeVariant(
       partyMap: Map[Party, String],
       cidMap: Map[ContractId, String],

--- a/daml-script/export/src/test/scala/com/daml/script/export/EncodeValueSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/EncodeValueSpec.scala
@@ -88,6 +88,22 @@ class EncodeValueSpec extends AnyFreeSpec with Matchers {
       val variant =
         v.Value().withVariant(v.Variant(Some(id), "Constr", Some(v.Value().withInt64(1))))
       encodeValue(Map.empty, Map.empty, variant.sum).render(80) shouldBe "(M.Constr 1)"
+
+      // Tests a variant constructor declared with record syntax
+      val fields = record.withRecordId(id.withEntityName("V.ConstrFields"))
+      val variantFields =
+        v.Value()
+          .withVariant(v.Variant(Some(id), "ConstrFields", Some(v.Value().withRecord(fields))))
+      encodeValue(Map.empty, Map.empty, variantFields.sum).render(
+        80
+      ) shouldBe "(M.ConstrFields {a = 1, b = (M.R2 {c = 42}), c = M.R3})"
+
+      // Tests a variant constructor declared with an argument of a record type.
+      val variantRec =
+        v.Value().withVariant(v.Variant(Some(id), "ConstrRec", Some(v.Value().withRecord(record))))
+      encodeValue(Map.empty, Map.empty, variantRec.sum).render(
+        80
+      ) shouldBe "(M.ConstrRec (M.R1 {a = 1, b = (M.R2 {c = 42}), c = M.R3}))"
     }
     "contract id" in {
       val cid = v.Value().withContractId("my-contract-id")


### PR DESCRIPTION
This PR changes the encoding logic for values such that Variants with fields are encoded as valid Daml.

This works by adding a special case for the encoding of a `Variant` `v` whose `value` is a `Record` `r`, where `r` and `v`'s package id and module name match and where `r`'s entity name is equal to `v`'s plus `.` and a suffix. 

Closes #14723

---

Spun off as https://github.com/digital-asset/daml/issues/15153:

Note that there's still a problematic case: 

```
Variant(variantId = V, constructor = C, value = Unit)
```

This could represent a value of variant type `V` with constructor `C`, where `C` takes no arguments, e.g.

```haskell
data V = A Int | B Text | C

var : V
var = C
```

or a value of variant type `V a` with constructor `C a`, where `a ~ ()`, e.g.

```haskell
data V a = A Int | B Text | C a

var : V ()
var = C ()
```

There is no way to tell these apart without the type information at hand. We _could_ make the `value` field of `Variant` optional, leaving `value` unset for the former case and set as `Unit` for the latter, but it's currently commented as Required in https://github.com/digital-asset/daml/blob/main/ledger-api/grpc-definitions/com/daml/ledger/api/v1/value.proto#L146-L148