### PR TITLE
turn on -Xlint -Werror for Java bindings

### DIFF
--- a/language-support/java/bindings-rxjava/BUILD.bazel
+++ b/language-support/java/bindings-rxjava/BUILD.bazel
@@ -13,6 +13,7 @@ load(
     "//rules_daml:daml.bzl",
     "daml_compile",
 )
+load("//language-support/java:javaopts.bzl", "da_java_bindings_javacopts")
 load(
     "//language-support/java/codegen:codegen.bzl",
     "dar_to_java",
@@ -24,6 +25,7 @@ load(
 
 da_java_library(
     name = "bindings-rxjava",
+    javacopts = da_java_bindings_javacopts,
     srcs = glob(["src/main/java/**/*.java"]),
     tags = [
         "javadoc_root_packages=com.daml.ledger.rxjava",

--- a/language-support/java/bindings-rxjava/BUILD.bazel
+++ b/language-support/java/bindings-rxjava/BUILD.bazel
@@ -25,8 +25,8 @@ load(
 
 da_java_library(
     name = "bindings-rxjava",
-    javacopts = da_java_bindings_javacopts,
     srcs = glob(["src/main/java/**/*.java"]),
+    javacopts = da_java_bindings_javacopts,
     tags = [
         "javadoc_root_packages=com.daml.ledger.rxjava",
         "maven_coordinates=com.daml:bindings-rxjava:__VERSION__",

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/DamlLedgerClient.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/DamlLedgerClient.java
@@ -116,7 +116,7 @@ public final class DamlLedgerClient implements LedgerClient {
   private CommandCompletionClient commandCompletionClient;
   private CommandClient commandClient;
   private CommandSubmissionClient commandSubmissionClient;
-  private LedgerIdentityClient ledgerIdentityClient;
+  @Deprecated private LedgerIdentityClient ledgerIdentityClient;
   private PackageClient packageClient;
   private LedgerConfigurationClient ledgerConfigurationClient;
   private TimeClient timeClient;
@@ -139,7 +139,9 @@ public final class DamlLedgerClient implements LedgerClient {
 
   /** Connects this instance of the {@link DamlLedgerClient} to the Ledger. */
   public void connect() {
-    ledgerIdentityClient = new LedgerIdentityClientImpl(channel, this.accessToken, this.timeout);
+    @SuppressWarnings("deprecation")
+    var lic = new LedgerIdentityClientImpl(channel, this.accessToken, this.timeout);
+    ledgerIdentityClient = lic;
 
     String reportedLedgerId = ledgerIdentityClient.getLedgerIdentity().blockingGet();
 
@@ -198,6 +200,7 @@ public final class DamlLedgerClient implements LedgerClient {
     return commandSubmissionClient;
   }
 
+  @Deprecated
   @Override
   public LedgerIdentityClient getLedgerIdentityClient() {
     return ledgerIdentityClient;

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/LedgerClient.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/LedgerClient.java
@@ -19,6 +19,7 @@ public interface LedgerClient {
 
   CommandSubmissionClient getCommandSubmissionClient();
 
+  @Deprecated
   LedgerIdentityClient getLedgerIdentityClient();
 
   PackageClient getPackageClient();

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/LedgerIdentityClient.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/LedgerIdentityClient.java
@@ -5,7 +5,12 @@ package com.daml.ledger.rxjava;
 
 import io.reactivex.Single;
 
-/** An RxJava version of {@link com.daml.ledger.api.v1.LedgerIdentityServiceGrpc} */
+/**
+ * An RxJava version of {@link com.daml.ledger.api.v1.LedgerIdentityServiceGrpc}
+ *
+ * @deprecated Ledger identity string is now optional for all ledger API requests
+ */
+@Deprecated
 public interface LedgerIdentityClient {
 
   Single<String> getLedgerIdentity();

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/LedgerIdentityClient.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/LedgerIdentityClient.java
@@ -8,7 +8,7 @@ import io.reactivex.Single;
 /**
  * An RxJava version of {@link com.daml.ledger.api.v1.LedgerIdentityServiceGrpc}
  *
- * @deprecated Ledger identity string is now optional for all ledger API requests
+ * @deprecated Ledger identity string is optional for all ledger API requests, since Daml 2.0.0
  */
 @Deprecated
 public interface LedgerIdentityClient {

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/grpc/LedgerIdentityClientImpl.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/grpc/LedgerIdentityClientImpl.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+/** @deprecated ledger identity string is optional for all Ledger API requests since Daml 2.0.0 */
 @Deprecated
 public class LedgerIdentityClientImpl implements LedgerIdentityClient {
 

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/grpc/LedgerIdentityClientImpl.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/grpc/LedgerIdentityClientImpl.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+@Deprecated
 public class LedgerIdentityClientImpl implements LedgerIdentityClient {
 
   private LedgerIdentityServiceGrpc.LedgerIdentityServiceFutureStub serviceStub;

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/LedgerIdentityClientTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/LedgerIdentityClientTest.scala
@@ -16,6 +16,7 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.Future
 
+@deprecated("Ledger identity string is optional for all ledger API requests", since = "2.0.0")
 final class LedgerIdentityClientTest extends AnyFlatSpec with Matchers with AuthMatchers {
 
   import LedgerIdentityClientTest._

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/LedgerServices.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/LedgerServices.scala
@@ -215,6 +215,7 @@ final class LedgerServices(val ledgerId: String) {
     }
   }
 
+  @deprecated("ledger identity service", since = "2.0.0")
   def withLedgerIdentityClient(
       getResponse: () => Future[String],
       authService: AuthService = AuthServiceWildcard,

--- a/language-support/java/bindings/BUILD.bazel
+++ b/language-support/java/bindings/BUILD.bazel
@@ -8,6 +8,7 @@ load(
 )
 load("//bazel_tools:proto.bzl", "proto_gen")
 load("//bazel_tools:java.bzl", "da_java_library")
+load("//language-support/java:javaopts.bzl", "da_java_bindings_javacopts")
 
 proto_gen(
     name = "ledger-api-java",
@@ -57,6 +58,7 @@ da_java_library(
         ":ledger-api-java",
         ":ledger-api-java-grpc",
     ],
+    javacopts = da_java_bindings_javacopts,
     tags = [
         "javadoc_root_packages=com.daml.ledger.javaapi.data",
         "maven_coordinates=com.daml:bindings-java:__VERSION__",

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlGenMap.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlGenMap.java
@@ -23,8 +23,6 @@ public final class DamlGenMap extends Value {
     return new DamlGenMap(Collections.unmodifiableMap(map));
   }
 
-  private static @NonNull DamlGenMap EMPTY = fromPrivateMap(Collections.EMPTY_MAP);
-
   public static DamlGenMap of(@NonNull Map<@NonNull Value, @NonNull Value> map) {
     return fromPrivateMap(new LinkedHashMap<>(map));
   }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlList.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlList.java
@@ -27,7 +27,6 @@ public final class DamlList extends Value {
     return fromPrivateList(new ArrayList<>(values));
   }
 
-  @SafeVarargs
   public static DamlList of(@NonNull Value... values) {
     return fromPrivateList(Arrays.asList(values));
   }
@@ -38,7 +37,6 @@ public final class DamlList extends Value {
   }
 
   @Deprecated // use DamlMap:of
-  @SafeVarargs
   public DamlList(@NonNull Value... values) {
     this(Arrays.asList(values));
   }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlList.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlList.java
@@ -23,8 +23,6 @@ public final class DamlList extends Value {
     return damlList;
   }
 
-  private static DamlList EMPTY = fromPrivateList(Collections.EMPTY_LIST);
-
   public static DamlList of(@NonNull List<@NonNull Value> values) {
     return fromPrivateList(new ArrayList<>(values));
   }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlRecord.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlRecord.java
@@ -23,24 +23,25 @@ public class DamlRecord extends Value {
     this(Arrays.asList(fields));
   }
 
-  public DamlRecord(@NonNull Identifier recordId, @NonNull List<@NonNull Field> fields) {
+  public DamlRecord(@NonNull Identifier recordId, @NonNull List<@NonNull ? extends Field> fields) {
     this(Optional.of(recordId), fields, fieldsListToHashMap(fields));
   }
 
-  public DamlRecord(@NonNull List<@NonNull Field> fields) {
+  public DamlRecord(@NonNull List<@NonNull ? extends Field> fields) {
     this(Optional.empty(), fields, fieldsListToHashMap(fields));
   }
 
   public DamlRecord(
       @NonNull Optional<Identifier> recordId,
-      @NonNull List<@NonNull Field> fields,
+      @NonNull List<@NonNull ? extends Field> fields,
       Map<String, Value> fieldsMap) {
     this.recordId = recordId;
-    this.fields = fields;
+    this.fields = Collections.unmodifiableList(fields);
     this.fieldsMap = fieldsMap;
   }
 
-  private static Map<String, Value> fieldsListToHashMap(@NonNull List<@NonNull Field> fields) {
+  private static Map<String, Value> fieldsListToHashMap(
+      @NonNull List<@NonNull ? extends Field> fields) {
     if (fields.isEmpty() || !fields.get(0).getLabel().isPresent()) {
       return Collections.emptyMap();
     } else {

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlRecord.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlRecord.java
@@ -23,25 +23,24 @@ public class DamlRecord extends Value {
     this(Arrays.asList(fields));
   }
 
-  public DamlRecord(@NonNull Identifier recordId, @NonNull List<@NonNull ? extends Field> fields) {
+  public DamlRecord(@NonNull Identifier recordId, @NonNull List<@NonNull Field> fields) {
     this(Optional.of(recordId), fields, fieldsListToHashMap(fields));
   }
 
-  public DamlRecord(@NonNull List<@NonNull ? extends Field> fields) {
+  public DamlRecord(@NonNull List<@NonNull Field> fields) {
     this(Optional.empty(), fields, fieldsListToHashMap(fields));
   }
 
   public DamlRecord(
       @NonNull Optional<Identifier> recordId,
-      @NonNull List<@NonNull ? extends Field> fields,
+      @NonNull List<@NonNull Field> fields,
       Map<String, Value> fieldsMap) {
     this.recordId = recordId;
-    this.fields = Collections.unmodifiableList(fields);
+    this.fields = fields;
     this.fieldsMap = fieldsMap;
   }
 
-  private static Map<String, Value> fieldsListToHashMap(
-      @NonNull List<@NonNull ? extends Field> fields) {
+  private static Map<String, Value> fieldsListToHashMap(@NonNull List<@NonNull Field> fields) {
     if (fields.isEmpty() || !fields.get(0).getLabel().isPresent()) {
       return Collections.emptyMap();
     } else {

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Record.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Record.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import static java.util.Collections.unmodifiableList;
 
 // FIXME When removing this after the deprecation period is over, make DamlRecord final
 /** @deprecated Use {@link DamlRecord} instead. */
@@ -26,11 +27,11 @@ public final class Record extends DamlRecord {
   }
 
   public Record(@NonNull Identifier recordId, @NonNull List<@NonNull Field> fields) {
-    super(recordId, (List) fields); // safe-ish cast due to java.util.List being invariant in E
+    super(recordId, unmodifiableList(fields));
   }
 
   public Record(@NonNull List<@NonNull Field> fields) {
-    super((List) fields); // safe-ish cast due to java.util.List being invariant in E
+    super(unmodifiableList(fields));
   }
 
   public Record(
@@ -39,8 +40,8 @@ public final class Record extends DamlRecord {
       Map<String, Value> fieldsMap) {
     super(
         recordId,
-        (List) fields,
-        fieldsMap); // safe-ish cast due to java.util.List being invariant in E
+        unmodifiableList(fields),
+        fieldsMap);
   }
 
   /** @deprecated Use {@link DamlRecord#fromProto(ValueOuterClass.Record)} instead */

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Record.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Record.java
@@ -3,6 +3,8 @@
 
 package com.daml.ledger.javaapi.data;
 
+import static java.util.Collections.unmodifiableList;
+
 import com.daml.ledger.api.v1.ValueOuterClass;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import static java.util.Collections.unmodifiableList;
 
 // FIXME When removing this after the deprecation period is over, make DamlRecord final
 /** @deprecated Use {@link DamlRecord} instead. */
@@ -38,10 +39,7 @@ public final class Record extends DamlRecord {
       @NonNull Optional<Identifier> recordId,
       @NonNull List<@NonNull Field> fields,
       Map<String, Value> fieldsMap) {
-    super(
-        recordId,
-        unmodifiableList(fields),
-        fieldsMap);
+    super(recordId, unmodifiableList(fields), fieldsMap);
   }
 
   /** @deprecated Use {@link DamlRecord#fromProto(ValueOuterClass.Record)} instead */

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Record.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Record.java
@@ -25,22 +25,19 @@ public final class Record extends DamlRecord {
     super(Arrays.asList(fields));
   }
 
-  public Record(@NonNull Identifier recordId, @NonNull List<@NonNull Field> fields) {
-    super(recordId, (List) fields); // safe-ish cast due to java.util.List being invariant in E
+  public Record(@NonNull Identifier recordId, @NonNull List<@NonNull ? extends Field> fields) {
+    super(recordId, fields);
   }
 
-  public Record(@NonNull List<@NonNull Field> fields) {
-    super((List) fields); // safe-ish cast due to java.util.List being invariant in E
+  public Record(@NonNull List<@NonNull ? extends Field> fields) {
+    super(fields);
   }
 
   public Record(
       @NonNull Optional<Identifier> recordId,
-      @NonNull List<@NonNull Field> fields,
+      @NonNull List<@NonNull ? extends Field> fields,
       Map<String, Value> fieldsMap) {
-    super(
-        recordId,
-        (List) fields,
-        fieldsMap); // safe-ish cast due to java.util.List being invariant in E
+    super(recordId, fields, fieldsMap);
   }
 
   /** @deprecated Use {@link DamlRecord#fromProto(ValueOuterClass.Record)} instead */

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Record.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Record.java
@@ -25,19 +25,22 @@ public final class Record extends DamlRecord {
     super(Arrays.asList(fields));
   }
 
-  public Record(@NonNull Identifier recordId, @NonNull List<@NonNull ? extends Field> fields) {
-    super(recordId, fields);
+  public Record(@NonNull Identifier recordId, @NonNull List<@NonNull Field> fields) {
+    super(recordId, (List) fields); // safe-ish cast due to java.util.List being invariant in E
   }
 
-  public Record(@NonNull List<@NonNull ? extends Field> fields) {
-    super(fields);
+  public Record(@NonNull List<@NonNull Field> fields) {
+    super((List) fields); // safe-ish cast due to java.util.List being invariant in E
   }
 
   public Record(
       @NonNull Optional<Identifier> recordId,
-      @NonNull List<@NonNull ? extends Field> fields,
+      @NonNull List<@NonNull Field> fields,
       Map<String, Value> fieldsMap) {
-    super(recordId, fields, fieldsMap);
+    super(
+        recordId,
+        (List) fields,
+        fieldsMap); // safe-ish cast due to java.util.List being invariant in E
   }
 
   /** @deprecated Use {@link DamlRecord#fromProto(ValueOuterClass.Record)} instead */

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/SubmitCommandsRequest.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/SubmitCommandsRequest.java
@@ -180,6 +180,7 @@ public class SubmitCommandsRequest {
         deduplicationPeriod = Optional.of(Duration.ofSeconds(d.getSeconds(), d.getNanos()));
         break;
       case DEDUPLICATION_TIME:
+        @SuppressWarnings("deprecation")
         com.google.protobuf.Duration t = commands.getDeduplicationTime();
         deduplicationPeriod = Optional.of(Duration.ofSeconds(t.getSeconds(), t.getNanos()));
         break;
@@ -248,11 +249,14 @@ public class SubmitCommandsRequest {
                     .setSeconds(rel.getSeconds())
                     .setNanos(rel.getNano())));
     deduplicationTime.ifPresent(
-        dedup ->
-            builder.setDeduplicationTime(
-                com.google.protobuf.Duration.newBuilder()
-                    .setSeconds(dedup.getSeconds())
-                    .setNanos(dedup.getNano())));
+        dedup -> {
+          @SuppressWarnings("deprecation")
+          var unused =
+              builder.setDeduplicationTime(
+                  com.google.protobuf.Duration.newBuilder()
+                      .setSeconds(dedup.getSeconds())
+                      .setNanos(dedup.getNano()));
+        });
     submissionId.ifPresent(builder::setSubmissionId);
     return builder.build();
   }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ByKey.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ByKey.java
@@ -21,7 +21,7 @@ public abstract class ByKey implements Exercises<ExerciseByKeyCommand> {
   }
 
   /** The origin of the choice, not the template relevant to contractKey. */
-  protected abstract ContractTypeCompanion getCompanion();
+  protected abstract ContractTypeCompanion<?, ?> getCompanion();
 
   /**
    * Parent of all generated {@code ByKey} classes within interfaces. These need to pass both the

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/CreateAnd.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/CreateAnd.java
@@ -22,7 +22,7 @@ public abstract class CreateAnd implements Exercises<CreateAndExerciseCommand> {
   }
 
   /** The origin of the choice, not the createArguments. */
-  protected abstract ContractTypeCompanion getCompanion();
+  protected abstract ContractTypeCompanion<?, ?> getCompanion();
 
   /**
    * Parent of all generated {@code CreateAnd} classes within interfaces. These need to pass both

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/DamlRecord.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/DamlRecord.java
@@ -3,6 +3,22 @@
 
 package com.daml.ledger.javaapi.data.codegen;
 
+/**
+ * Base class of all decoded-to-codegen Daml records <em>with no type parameters</em>.
+ *
+ * <p>This category includes
+ *
+ * <ol>
+ *   <li>all {@link com.daml.ledger.javaapi.data.Template} payloads,
+ *   <li>all interface views, and
+ *   <li>[by convention albeit not by rule] all choice arguments.
+ * </ol>
+ *
+ * <p>Its encoded counterpart is {@link com.daml.ledger.javaapi.data.DamlRecord}, which can be
+ * produced with {@link #toValue}.
+ *
+ * @param <T>
+ */
 public abstract class DamlRecord<T> implements DefinedDataType<T> {
   public abstract com.daml.ledger.javaapi.data.DamlRecord toValue();
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/DamlRecord.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/DamlRecord.java
@@ -17,7 +17,7 @@ package com.daml.ledger.javaapi.data.codegen;
  * <p>Its encoded counterpart is {@link com.daml.ledger.javaapi.data.DamlRecord}, which can be
  * produced with {@link #toValue}.
  *
- * @param <T>
+ * @param <T> A "self type", some subclass of this interface that {@code T} implements.
  */
 public abstract class DamlRecord<T> implements DefinedDataType<T> {
   public abstract com.daml.ledger.javaapi.data.DamlRecord toValue();

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/DefinedDataType.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/DefinedDataType.java
@@ -6,13 +6,16 @@ package com.daml.ledger.javaapi.data.codegen;
 import com.daml.ledger.javaapi.data.Value;
 
 /**
- * Either one of these:
+ * The codegen-decoded form of any of these:
  *
  * <ol>
  *   <li>what {@link DamlRecord} describes,
- *   <li>a variant without type parameters, or
- *   <li>any Daml enum.
+ *   <li>a {@link Variant} without type parameters, or
+ *   <li>any {@link DamlEnum}.
  * </ol>
+ *
+ * <p>Its encoded counterpart is {@link com.daml.ledger.javaapi.data.Value}, which can be produced
+ * with {@link #toValue}.
  *
  * @param <T> A "self type", some subclass of this interface that {@code T} implements.
  */

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/DefinedDataType.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/DefinedDataType.java
@@ -5,6 +5,18 @@ package com.daml.ledger.javaapi.data.codegen;
 
 import com.daml.ledger.javaapi.data.Value;
 
+/**
+ * Either one of these:
+ *
+ * <ol>
+ *   <li>what {@link DamlRecord} describes,
+ *   <li>a variant without type parameters, or
+ *   <li>any Daml enum.
+ * </ol>
+ *
+ * @param <T> A "self type", some subclass of this interface that {@code T} implements.
+ */
 public interface DefinedDataType<T> {
+  /** Produce the encoded form. */
   Value toValue();
 }

--- a/language-support/java/codegen/codegen.bzl
+++ b/language-support/java/codegen/codegen.bzl
@@ -1,6 +1,8 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//language-support/java:javaopts.bzl", "da_java_bindings_javacopts")
+
 def mangle(name):
     return ".".join(name.rsplit("-", 1))
 
@@ -35,6 +37,7 @@ def dar_to_java(**kwargs):
 
     native.java_library(
         name = lib,
+        javacopts = da_java_bindings_javacopts,
         srcs = [
             ":%s" % src_jar,
         ],

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
@@ -202,9 +202,13 @@ object ContractIdClass {
       exerciseChoiceBuilder.build()
     }
 
-    def generateGetCompanion(kind: For) =
+    def generateGetCompanion(markerName: ClassName, kind: For) =
       ClassGenUtils.generateGetCompanion(
-        ClassName get classOf[javaapi.data.codegen.ContractTypeCompanion[_, _]],
+        ParameterizedTypeName.get(
+          ClassName get classOf[javaapi.data.codegen.ContractTypeCompanion[_, _]],
+          markerName,
+          WildcardTypeName subtypeOf classOf[Object],
+        ),
         kind match {
           case For.Interface => InterfaceClass.companionName
           case For.Template => ClassGenUtils.companionFieldName
@@ -271,7 +275,7 @@ object ContractIdClass {
           .build()
       idClassBuilder
         .addMethod(constructor)
-        .addMethod(generateGetCompanion(kind))
+        .addMethod(generateGetCompanion(templateClassName, kind))
       Builder(templateClassName, contractIdClassName, idClassBuilder, choices, packagePrefixes)
     }
   }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/EnumClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/EnumClass.scala
@@ -130,7 +130,7 @@ private[inner] object EnumClass extends StrictLogging {
         classOf[IllegalArgumentException],
         s"Expected a DamlEnum with ${className.simpleName()} constructor, found ",
       )
-      .addStatement("return ($T) $T.__enums$$.get(constructor$$)", className, className)
+      .addStatement("return $T.__enums$$.get(constructor$$)", className)
 
     MethodSpec
       .methodBuilder("valueDecoder")

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
@@ -49,9 +49,11 @@ object InterfaceClass extends StrictLogging {
           )
         )
         .addType(
-          TemplateClass.generateCreateAndClass(-\/(ContractIdClass.For.Interface))
+          TemplateClass.generateCreateAndClass(interfaceName, -\/(ContractIdClass.For.Interface))
         )
-        .addType(TemplateClass.generateByKeyClass(-\/(ContractIdClass.For.Interface)))
+        .addType(
+          TemplateClass.generateByKeyClass(interfaceName, -\/(ContractIdClass.For.Interface))
+        )
         .addType(
           generateInterfaceCompanionClass(
             interfaceName = interfaceName,

--- a/language-support/java/javaopts.bzl
+++ b/language-support/java/javaopts.bzl
@@ -1,0 +1,4 @@
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+da_java_bindings_javacopts = ["-Werror", "-deprecation", "-Xlint"]

--- a/language-support/java/javaopts.bzl
+++ b/language-support/java/javaopts.bzl
@@ -1,4 +1,4 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-da_java_bindings_javacopts = ["-Werror", "-deprecation", "-Xlint"]
+da_java_bindings_javacopts = ["-Werror", "-deprecation", "-Xlint", "-Xlint:-serial"]


### PR DESCRIPTION
We are running with no javac warnings enabled. Let's turn some on.

* all lints on except `serial` because `Serializable` is silly
* deprecate ledger identity service downstream of #12694; should have happened then, probably, but we didn't have an error pointing this out
* a couple Javadocs

```rst
CHANGELOG_BEGIN
- [Java codegen] Now outputs code that should pass ``-Xlint:rawtypes``
  as well as other ``-Xlint`` warnings.
CHANGELOG_END
```