### PR TITLE
[engine] fix bug in pretty-print for empty continuation stack

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -33,7 +33,12 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
   }
 
   def ppKontStack(m: Machine): String = {
-    s"[${ppKont(m.peekKontStackEnd())}... #${m.kontDepth()}]" // head kont & size
+    val depth = m.kontDepth()
+    if (depth == 0) {
+      s"[#0]"
+    } else {
+      s"[${ppKont(m.peekKontStackEnd())}... #${depth}]" // head kont & size
+    }
   }
 
   def ppKont(k: Kont): String = k.getClass.getSimpleName


### PR DESCRIPTION
Fix crash while debugging speedy with `enableLightweightStepTracing` switched on; when `kontStack` is empty.
