### PR TITLE
Check package name of preprocessor-excepted modules

### DIFF
--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -66,7 +66,7 @@ import SdkVersion (damlStdlib)
 toCompileOpts :: Options -> Ghcide.IdeOptions
 toCompileOpts Options{..} =
     Ghcide.IdeOptions
-      { optPreprocessor = if optIsGenerated then generatedPreprocessor else damlPreprocessor dataDependableExtensions
+      { optPreprocessor
       , optGhcSession = getDamlGhcSession
       , optPkgLocationOpts = Ghcide.IdePkgLocationOptions
           { optLocateHieFile = locateInPkgDb "hie"
@@ -82,6 +82,11 @@ toCompileOpts Options{..} =
       , optDefer = Ghcide.IdeDefer False
       }
   where
+    optPreprocessor =
+      if optIsGenerated
+        then generatedPreprocessor
+        else damlPreprocessor dataDependableExtensions optMbPackageName
+
     locateInPkgDb :: String -> PackageConfig -> GHC.Module -> IO (Maybe FilePath)
     locateInPkgDb ext pkgConfig mod
       | (importDir : _) <- importDirs pkgConfig = do

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -9,6 +9,7 @@ module DA.Daml.Preprocessor
   , isInternal
   ) where
 
+import qualified DA.Daml.LF.Ast as LF (PackageName (..))
 import           DA.Daml.Preprocessor.Records
 import           DA.Daml.Preprocessor.EnumType
 import           DA.Daml.StablePackages (stablePackageByModuleName)
@@ -87,16 +88,18 @@ isExperimental (GHC.moduleNameString -> x)
   -- Experimental modules need to import internal modules.
   = "DA.Experimental." `isPrefixOf` x
 
-shouldSkipPreprocessor :: GHC.ModuleName -> Bool
-shouldSkipPreprocessor name =
-    isInternal name
-    || Set.member name preprocessorExceptions
-    || isExperimental name
+shouldSkipPreprocessor :: (LF.PackageName, GHC.ModuleName) -> Bool
+shouldSkipPreprocessor (pkgName, modName) =
+    pkgName `elem` fmap LF.PackageName ["daml-prim", "daml-stdlib"]
+      &&
+        (isInternal modName
+        || Set.member modName preprocessorExceptions
+        || isExperimental modName)
 
 -- | Apply all necessary preprocessors
-damlPreprocessor :: ES.EnumSet GHC.Extension -> GHC.DynFlags -> GHC.ParsedSource -> IdePreprocessedSource
-damlPreprocessor dataDependableExtensions dflags x
-    | maybe False shouldSkipPreprocessor name = noPreprocessor dflags x
+damlPreprocessor :: ES.EnumSet GHC.Extension -> Maybe LF.PackageName -> GHC.DynFlags -> GHC.ParsedSource -> IdePreprocessedSource
+damlPreprocessor dataDependableExtensions mPkgName dflags x
+    | maybe False shouldSkipPreprocessor mod = noPreprocessor dflags x
     | otherwise = IdePreprocessedSource
         { preprocWarnings = concat
             [ checkDamlHeader x
@@ -118,7 +121,10 @@ damlPreprocessor dataDependableExtensions dflags x
             $ enumTypePreprocessor "GHC.Types" x
         }
     where
-      name = fmap GHC.unLoc $ GHC.hsmodName $ GHC.unLoc x
+      mod =
+        (,)
+          <$> mPkgName
+          <*> fmap GHC.unLoc (GHC.hsmodName $ GHC.unLoc x)
 
 -- | Preprocessor for generated code.
 generatedPreprocessor :: GHC.DynFlags -> GHC.ParsedSource -> IdePreprocessedSource

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -205,6 +205,7 @@ da_haskell_library(
         ],
         data = [
             ":bond-trading",
+            ":cant-skip-preprocessor",
             ":daml-test-files",
             ":query-lf-lib",
             "//compiler/damlc/pkg-db",
@@ -793,6 +794,15 @@ filegroup(
 filegroup(
     name = "bond-trading",
     srcs = glob(["bond-trading/**"]),
+    visibility = [
+        "__pkg__",
+        "//daml-foundations/integration-tests:__pkg__",
+    ],
+)
+
+filegroup(
+    name = "cant-skip-preprocessor",
+    srcs = glob(["cant-skip-preprocessor/**"]),
     visibility = [
         "__pkg__",
         "//daml-foundations/integration-tests:__pkg__",

--- a/compiler/damlc/tests/cant-skip-preprocessor/DA/Internal/Hack.daml
+++ b/compiler/damlc/tests/cant-skip-preprocessor/DA/Internal/Hack.daml
@@ -1,0 +1,16 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Tests that the daml preprocessor can't be skipped even if the module name
+-- appears in DA.Daml.Preprocessor.shouldSkipPreprocessor
+
+module DA.Internal.Hack where
+
+-- @ERROR range=10:1-10:28; Import of internal module DA.Internal.LF is not allowed
+import DA.Internal.LF (Any)
+
+-- @ERROR range=13:1-13:28; Newtype MyAny has constructor MkMyAny with different name
+newtype MyAny = MkMyAny Any
+
+-- @ERROR range=16:18-16:36; Constructors with multiple fields must give explicit field names
+data MyProduct = MyProduct Int Bool

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -171,15 +171,24 @@ getBondTradingTestFiles = do
     anns <- readFileAnns file
     pure [("bond-trading/Test.daml", file, anns)]
 
+getCantSkipPreprocessorTestFiles :: IO [(String, FilePath, [Ann])]
+getCantSkipPreprocessorTestFiles = do
+    cantSkipPreprocessorLocation <- locateRunfiles $ mainWorkspace </> "compiler/damlc/tests/cant-skip-preprocessor"
+    let file = cantSkipPreprocessorLocation </> "DA" </> "Internal" </> "Hack.daml"
+    anns <- readFileAnns file
+    pure [("cant-skip-preprocessor/DA/Internal/Hack.daml", file, anns)]
+
 getIntegrationTests :: (TODO -> IO ()) -> SS.Handle -> IO TestTree
 getIntegrationTests registerTODO scenarioService = do
     putStrLn $ "rtsSupportsBoundThreads: " ++ show rtsSupportsBoundThreads
     do n <- getNumCapabilities; putStrLn $ "getNumCapabilities: " ++ show n
 
     damlTests <-
-        (<>)
-            <$> getDamlTestFiles "compiler/damlc/tests/daml-test-files"
-            <*> getBondTradingTestFiles
+        mconcat @(IO [(String, FilePath, [Ann])])
+            [ getDamlTestFiles "compiler/damlc/tests/daml-test-files"
+            , getBondTradingTestFiles
+            , getCantSkipPreprocessorTestFiles
+            ]
 
     let (scenariosEnabledTests, plainTests) =
             partition (\(_, _, anns) -> any isEnableScenariosYes anns) damlTests


### PR DESCRIPTION
While looking into [a question on #15142](https://github.com/digital-asset/daml/issues/15142#issuecomment-1267995201) I noticed `preprocessorExceptions` [only looks at the module name](https://github.com/digital-asset/daml/blob/main/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs#L57-L58), so if a user calls their module e.g. `Prelude` **they would be able to skip the preprocessor** steps and thus (among other things) (try to) use non-data-dependable language extensions, **define expectation-breaking data types** (e.g. unlabelled constructors with multiple arguments, records where the data constructor doesn’t match the type constructor), and **import internal modules**.

On @cocreature's suggestion, this PR checks that the name of the package being built is either `daml-prim` or `daml-stdlib` before skipping the preprocessor, in addition to checking that the module's name passes the existing checks.