### PR TITLE
Log Runner stream runtime exceptions at ERROR and with a stack trace

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
@@ -133,7 +133,7 @@ object TriggerRunnerImpl {
               case cause: Throwable =>
                 // Report the failure to the server.
                 config.server ! Server.TriggerInitializationFailure(triggerInstance, cause.toString)
-                logger.info(s"Trigger $name failed during initialization: $cause")
+                logger.error(s"Trigger $name failed during initialization", cause)
                 // Tell our monitor there's been a failure. The
                 // monitor's supervisor strategy will respond to
                 // this by writing the exception to the log and
@@ -156,7 +156,7 @@ object TriggerRunnerImpl {
             case Failed(cause) =>
               // Report the failure to the server.
               config.server ! Server.TriggerRuntimeFailure(triggerInstance, cause.toString)
-              logger.info(s"Trigger $name failed: $cause")
+              logger.error(s"Trigger $name failed", cause)
               // Tell our monitor there's been a failure. The
               // monitor's supervisor strategy will respond to this by
               // writing the exception to the log and attempting to


### PR DESCRIPTION
- [x] log stream failures in `Runner` at ERROR with stack trace

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
