### PR TITLE
run query-store-independent tests less often

### DIFF
--- a/ledger-service/http-json-oracle/src/itlib/scala/http/HttpServiceWithOracleIntTest.scala
+++ b/ledger-service/http-json-oracle/src/itlib/scala/http/HttpServiceWithOracleIntTest.scala
@@ -4,7 +4,7 @@
 package com.daml.http
 
 abstract class HttpServiceWithOracleIntTest(override val disableContractPayloadIndexing: Boolean)
-    extends AbstractHttpServiceIntegrationTestTokenIndependent
+    extends QueryStoreAndAuthDependentIntegrationTest
     with HttpServiceOracleInt {
 
   override final def testLargeQueries = disableContractPayloadIndexing

--- a/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
@@ -24,7 +24,7 @@ import spray.json.JsValue
 import scala.concurrent.Future
 
 abstract class HttpServiceIntegrationTest
-    extends AbstractHttpServiceIntegrationTestTokenIndependent
+    extends AbstractHttpServiceIntegrationTestQueryStoreIndependent
     with BeforeAndAfterAll {
   import HttpServiceIntegrationTest._
   import AbstractHttpServiceIntegrationTestFuns.ciouDar

--- a/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
@@ -8,7 +8,11 @@ import java.nio.file.Files
 
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{HttpMethods, HttpRequest, StatusCodes, Uri}
-import com.daml.http.dbbackend.JdbcConfig
+import AbstractHttpServiceIntegrationTestFuns.HttpServiceTestFixtureData
+import dbbackend.JdbcConfig
+import json.JsonError
+import util.Logging.instanceUUIDLogCtx
+import com.daml.ledger.api.refinements.{ApiTypes => lar}
 import com.daml.ledger.api.v1.{value => v}
 import com.daml.lf.data.Ref
 import com.daml.lf.value.test.TypedValueGenerators.{ValueAddend => VA}
@@ -17,16 +21,24 @@ import json.SprayJson.{decode => jdecode}
 import com.daml.http.util.TestUtil.writeToFile
 import org.scalacheck.Gen
 import org.scalatest.{Assertion, BeforeAndAfterAll}
-import scalaz.\/-
+import scalaz.{\/-, \/, EitherT}
+import scalaz.std.scalaFuture._
+import scalaz.syntax.apply._
+import scalaz.syntax.bifunctor._
+import scalaz.syntax.show._
 import shapeless.record.{Record => ShRecord}
 import spray.json.JsValue
 
 import scala.concurrent.Future
 
+/** Tests that are exercising features independently of both user authentication
+  * and the query store.
+  */
 abstract class HttpServiceIntegrationTest
     extends AbstractHttpServiceIntegrationTestQueryStoreIndependent
     with BeforeAndAfterAll {
   import HttpServiceIntegrationTest._
+  import json.JsonProtocol._
   import AbstractHttpServiceIntegrationTestFuns.ciouDar
 
   private val staticContent: String = "static"
@@ -58,6 +70,53 @@ abstract class HttpServiceIntegrationTest
     super.afterAll()
   }
 
+  "query with invalid JSON query should return error" in withHttpService { fixture =>
+    fixture
+      .postJsonStringRequest(Uri.Path("/v1/query"), "{NOT A VALID JSON OBJECT")
+      .parseResponse[JsValue]
+      .map(inside(_) { case domain.ErrorResponse(_, _, StatusCodes.BadRequest, _) =>
+        succeed
+      }): Future[Assertion]
+  }
+
+  "should be able to serialize and deserialize domain commands" in withHttpService { fixture =>
+    (testCreateCommandEncodingDecoding(fixture) *>
+      testExerciseCommandEncodingDecoding(fixture)): Future[Assertion]
+  }
+
+  private def testCreateCommandEncodingDecoding(
+      fixture: HttpServiceTestFixtureData
+  ): Future[Assertion] = instanceUUIDLogCtx { implicit lc =>
+    import fixture.{uri, encoder, decoder}
+    import util.ErrorOps._
+    import com.daml.jwt.domain.Jwt
+
+    val command0: domain.CreateCommand[v.Record, domain.ContractTypeId.OptionalPkg] =
+      iouCreateCommand(domain.Party("Alice"))
+
+    type F[A] = EitherT[Future, JsonError, A]
+    val x: F[Assertion] = for {
+      jsVal <- EitherT.either(
+        encoder.encodeCreateCommand(command0).liftErr(JsonError)
+      ): F[JsValue]
+      command1 <- (EitherT.rightT(jwt(uri)): F[Jwt])
+        .flatMap(decoder.decodeCreateCommand(jsVal, _, fixture.ledgerId))
+    } yield command1.bimap(removeRecordId, removePackageId) should ===(command0)
+
+    (x.run: Future[JsonError \/ Assertion]).map(_.fold(e => fail(e.shows), identity))
+  }
+
+  private def testExerciseCommandEncodingDecoding(
+      fixture: HttpServiceTestFixtureData
+  ): Future[Assertion] = {
+    import fixture.{uri, encoder, decoder}
+    val command0 = iouExerciseTransferCommand(lar.ContractId("#a-contract-ID"), domain.Party("Bob"))
+    val jsVal: JsValue = encodeExercise(encoder)(command0)
+    val command1 =
+      jwt(uri).flatMap(decodeExercise(decoder, _, fixture.ledgerId)(jsVal))
+    command1.map(_.bimap(removeRecordId, identity) should ===(command0))
+  }
+
   "should serve static content from configured directory" in withHttpService {
     (uri: Uri, _, _, _) =>
       Http()
@@ -77,7 +136,6 @@ abstract class HttpServiceIntegrationTest
   }
 
   "exercise interface choices" - {
-    import json.JsonProtocol._
     import AbstractHttpServiceIntegrationTestFuns.{UriFixture, EncoderFixture}
 
     def createIouAndExerciseTransfer(

--- a/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTestUserManagement.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTestUserManagement.scala
@@ -29,7 +29,7 @@ import scalaz.syntax.tag._
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class HttpServiceIntegrationTestUserManagementNoAuth
-    extends AbstractHttpServiceIntegrationTestTokenIndependent
+    extends AbstractHttpServiceIntegrationTestQueryStoreIndependent
     with AbstractHttpServiceIntegrationTestFuns
     with HttpServiceUserFixture.UserToken
     with SandboxRequiringAuthorizationFuns

--- a/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresIntTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresIntTest.scala
@@ -11,7 +11,7 @@ import scala.concurrent.Future
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 abstract class HttpServiceWithPostgresIntTest
-    extends AbstractHttpServiceIntegrationTestTokenIndependent
+    extends QueryStoreAndAuthDependentIntegrationTest
     with PostgresAroundAll
     with HttpServicePostgresInt {
 

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -136,6 +136,11 @@ trait AbstractHttpServiceIntegrationTestFunsCustomToken
 
 }
 
+/** Tests that may behave differently depending on
+  *
+  * 1. whether custom or user tokens are used
+  * 2. the query store configuration
+  */
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 abstract class AbstractHttpServiceIntegrationTestTokenIndependent
     extends AsyncFreeSpec
@@ -1673,3 +1678,10 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
   }
 
 }
+
+/** Tests that don't exercise the query store at all, but exercise different
+  * paths due to authentication method.
+  */
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+abstract class AbstractHttpServiceIntegrationTestQueryStoreIndependent
+    extends AbstractHttpServiceIntegrationTestTokenIndependent {}

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -119,7 +119,7 @@ trait AbstractHttpServiceIntegrationTestFunsCustomToken
   * 2. the query store configuration
   */
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
-abstract class AbstractHttpServiceIntegrationTestTokenIndependent
+abstract class QueryStoreAndAuthDependentIntegrationTest
     extends AsyncFreeSpec
     with Matchers
     with Inside
@@ -1135,7 +1135,7 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
   */
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 abstract class AbstractHttpServiceIntegrationTestQueryStoreIndependent
-    extends AbstractHttpServiceIntegrationTestTokenIndependent {
+    extends QueryStoreAndAuthDependentIntegrationTest {
   import HttpServiceTestFixture.accountCreateCommand
   import json.JsonProtocol._
 

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -1624,17 +1624,20 @@ abstract class AbstractHttpServiceIntegrationTestQueryStoreIndependent
       to = None,
       application = None,
     )
-    fixture
-      .postJsonRequestWithMinimumAuth[Struct](
-        Uri.Path("/v1/metering-report"),
-        request.toJson,
-      )
-      .map(inside(_) { case domain.OkResponse(meteringReport, _, StatusCodes.OK) =>
-        meteringReport
-          .fields("request")
-          .getStructValue
-          .fields("from")
-          .getStringValue shouldBe s"${isoDate}T00:00:00Z"
-      })
+    for {
+      reportStruct <- fixture
+        .postJsonRequest(
+          Uri.Path("/v1/metering-report"),
+          request.toJson,
+          headersWithAdminAuth,
+        )
+        .parseResponse[Struct]
+    } yield inside(reportStruct) { case domain.OkResponse(meteringReport, _, StatusCodes.OK) =>
+      meteringReport
+        .fields("request")
+        .getStructValue
+        .fields("from")
+        .getStringValue shouldBe s"${isoDate}T00:00:00Z"
+    }
   }
 }

--- a/security-evidence.md
+++ b/security-evidence.md
@@ -5,7 +5,7 @@
 - Updating the package service succeeds with sufficient authorization: [AuthorizationTest.scala](ledger-service/http-json/src/it/scala/http/AuthorizationTest.scala#L85)
 - accept user tokens: [TestMiddleware.scala](triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala#L152)
 - badly-authorized create is rejected: [AuthorizationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthorizationSpec.scala#L60)
-- badly-authorized create is rejected: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1218)
+- badly-authorized create is rejected: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1510)
 - badly-authorized exercise is rejected: [AuthorizationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthorizationSpec.scala#L158)
 - badly-authorized exercise/create (create is unauthorized) is rejected: [AuthPropagationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthPropagationSpec.scala#L273)
 - badly-authorized exercise/create (exercise is unauthorized) is rejected: [AuthPropagationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthPropagationSpec.scala#L241)
@@ -18,7 +18,7 @@
 - create with no signatories is rejected: [AuthorizationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthorizationSpec.scala#L50)
 - create with non-signatory maintainers is rejected: [AuthorizationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthorizationSpec.scala#L72)
 - exercise with no controllers is rejected: [AuthorizationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthorizationSpec.scala#L148)
-- fetch fails when readAs not authed, even if prior fetch succeeded: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1286)
+- fetch fails when readAs not authed, even if prior fetch succeeded: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L831)
 - forbid a non-authorized party to check the status of a trigger: [TriggerServiceTest.scala](triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala#L681)
 - forbid a non-authorized party to list triggers: [TriggerServiceTest.scala](triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala#L671)
 - forbid a non-authorized party to start a trigger: [TriggerServiceTest.scala](triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala#L660)
@@ -26,7 +26,7 @@
 - forbid a non-authorized user to upload a DAR: [TriggerServiceTest.scala](triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala#L713)
 - multiple websocket requests over the same WebSocket connection are NOT allowed: [AbstractWebsocketServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala#L132)
 - refresh a token after expiry on the server side: [TriggerServiceTest.scala](triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala#L738)
-- reject requests with missing auth header: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L648)
+- reject requests with missing auth header: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1206)
 - request a fresh token after expiry on user request: [TriggerServiceTest.scala](triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala#L723)
 - return the token from a cookie: [TestMiddleware.scala](triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala#L96)
 - return unauthorized on an expired token: [TestMiddleware.scala](triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala#L139)
@@ -208,7 +208,7 @@
 
 ## Performance:
 - Tail call optimization: Tail recursion does not blow the scala JVM stack.: [TailCallTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala#L16)
-- archiving a large number of contracts should succeed: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1492)
+- archiving a large number of contracts should succeed: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L949)
 - creating and listing 20K users should be possible: [HttpServiceIntegrationTestUserManagement.scala](ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTestUserManagement.scala#L558)
 
 ## Input Validation:


### PR DESCRIPTION
Fixes #15047. This only moves tests, except the metering-report test, which was adapted to work with user authentication in dd2dcd3f456db000addc5621f1d234d1692c1263.