### PR TITLE
Minor fixes in intro docs

### DIFF
--- a/docs/source/daml/intro/2_DamlScript.rst
+++ b/docs/source/daml/intro/2_DamlScript.rst
@@ -87,7 +87,7 @@ What this display means:
 
 - The remaining columns, labelled vertically, show which parties know about which contracts. In this simple script, the sole party "Alice" knows about the contract she created.
 
-To run the same test from the command line, save your module in a file ``Token_Test.daml`` and run ``daml damlc -- test --files Token_Test.daml``. If your file contains more than one script, all of them will be run.
+To run the same test from the command line, save your module in a file ``Token_Test.daml`` and run ``daml test --files Token_Test.daml``. If your file contains more than one script, all of them will be run.
 
 .. _intro_2_failure:
 

--- a/docs/source/daml/intro/4_Transformations.rst
+++ b/docs/source/daml/intro/4_Transformations.rst
@@ -103,7 +103,7 @@ Choices In the Ledger Model
 
 In :doc:`1_Token` you learned about the high-level structure of a Daml ledger. With choices and the `exercise` function, you have the next important ingredient to understand the structure of the ledger and transactions.
 
-A *transaction* is a list of *actions*, and there are just four kinds of action: ``create``, ``exercise``, ``fetch`` and ``key assertion``.
+A *transaction* is a list of *actions*, and there are just four kinds of action: ``create``, ``fetch``, ``exercise`` and ``key assertion``.
 
 - A ``create`` action creates a new contract with the given arguments and sets its status to *active*.
 - A ``fetch`` action checks the existence and activeness of a contract.

--- a/docs/source/daml/intro/8_Exceptions.rst
+++ b/docs/source/daml/intro/8_Exceptions.rst
@@ -99,7 +99,7 @@ trusted users looks as follows:
   :end-before: -- ORDER_TRUSTED_END
 
 Let's walk through this code. First, as mentioned, the shop owner is
-the trusting kind, so he wants to start by creating the ``Order``
+the trusting kind, so he wants to start by creating the ``Order`` no
 matter what. Next, we try to charge the customer for the order. We
 could, at this point, check their balance against the cost of the
 order, but that would amount to duplicating the logic already present


### PR DESCRIPTION
Just 3 smaller issues I stumbled upon while reading the extremely helpful docs.

The change in `docs/source/daml/intro/4_Transformations.rst` is so that the in-text listing matches the ordering of the bullets that follow. The other two changes should be self-explanatory.