### PR TITLE
Fix flaky test

### DIFF
--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/BridgeConfig.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/BridgeConfig.scala
@@ -16,6 +16,7 @@ case class BridgeConfig(
     conflictCheckingEnabled: Boolean = true,
     submissionBufferSize: Int = 500,
     maxDeduplicationDuration: Duration = DefaultMaximumDeduplicationDuration,
+    stageBufferSize: Int = 128,
 )
 
 object BridgeConfig {
@@ -46,6 +47,12 @@ object BridgeConfig {
         .text(
           "Deprecated parameter -- Implicit party creation isn't supported anymore."
         ),
+      builder
+        .opt[Int]("bridge-stage-buffer-size")
+        .text(
+          "Stage buffer size. This buffer is present between each conflict checking processing stage. Defaults to 128."
+        )
+        .action((p, c) => c.copy(extra = c.extra.copy(submissionBufferSize = p))),
       builder.checkConfig(c =>
         Either.cond(
           c.maxDeduplicationDuration.forall(_.compareTo(Duration.ofHours(1L)) <= 0),

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
@@ -100,6 +100,7 @@ object SandboxOnXRunner {
         servicesThreadPoolSize = servicesThreadPoolSize,
         servicesExecutionContext = servicesExecutionContext,
         timeServiceBackendO = timeServiceBackendO,
+        stageBufferSize = bridgeConfig.stageBufferSize,
       )
       apiServer <- new LedgerApiServer(
         ledgerFeatures = LedgerFeatures(
@@ -200,6 +201,7 @@ object SandboxOnXRunner {
       servicesThreadPoolSize: Int,
       servicesExecutionContext: ExecutionContextExecutorService,
       timeServiceBackendO: Option[TimeServiceBackend],
+      stageBufferSize: Int,
   ): IndexService => ResourceOwner[WriteService] = { indexService =>
     val bridgeMetrics = new BridgeMetrics(metrics)
     for {
@@ -210,6 +212,7 @@ object SandboxOnXRunner {
         bridgeMetrics,
         servicesThreadPoolSize,
         timeServiceBackendO.getOrElse(TimeProvider.UTC),
+        stageBufferSize,
       )(loggingContext, servicesExecutionContext)
       writeService <- ResourceOwner.forCloseable(() =>
         new BridgeWriteService(

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/bridge/LedgerBridge.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/bridge/LedgerBridge.scala
@@ -34,6 +34,7 @@ object LedgerBridge {
       bridgeMetrics: BridgeMetrics,
       servicesThreadPoolSize: Int,
       timeProvider: TimeProvider,
+      stageBufferSize: Int,
   )(implicit
       loggingContext: LoggingContext,
       servicesExecutionContext: ExecutionContext,
@@ -45,6 +46,7 @@ object LedgerBridge {
         bridgeMetrics,
         servicesThreadPoolSize,
         timeProvider,
+        stageBufferSize,
       )
     else
       ResourceOwner.forValue(() => new PassThroughLedgerBridge(participantId, timeProvider))
@@ -55,6 +57,7 @@ object LedgerBridge {
       bridgeMetrics: BridgeMetrics,
       servicesThreadPoolSize: Int,
       timeProvider: TimeProvider,
+      stageBufferSize: Int,
   )(implicit
       loggingContext: LoggingContext,
       servicesExecutionContext: ExecutionContext,
@@ -80,6 +83,7 @@ object LedgerBridge {
       maxDeduplicationDuration = initialLedgerConfiguration
         .map(_.maxDeduplicationDuration)
         .getOrElse(BridgeConfig.DefaultMaximumDeduplicationDuration),
+      stageBufferSize = stageBufferSize,
     )
 
   private[bridge] def packageUploadSuccess(

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/bridge/validate/ConflictCheckingLedgerBridge.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/bridge/validate/ConflictCheckingLedgerBridge.scala
@@ -19,7 +19,6 @@ import com.daml.lf.transaction.{GlobalKey => LfGlobalKey, Transaction => LfTrans
 import com.daml.lf.value.Value.ContractId
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.InstrumentedGraph._
-
 import java.time.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -30,18 +29,18 @@ private[validate] class ConflictCheckingLedgerBridge(
     conflictCheckWithCommitted: ConflictCheckWithCommitted,
     sequence: Sequence,
     servicesThreadPoolSize: Int,
+    stageBufferSize: Int,
 ) extends LedgerBridge {
-  private val StageBufferSize = 128
 
   def flow: Flow[Submission, (Offset, Update), NotUsed] =
     Flow[Submission]
-      .buffered(bridgeMetrics.Stages.PrepareSubmission.bufferBefore, StageBufferSize)
+      .buffered(bridgeMetrics.Stages.PrepareSubmission.bufferBefore, stageBufferSize)
       .mapAsyncUnordered(servicesThreadPoolSize)(prepareSubmission)
-      .buffered(bridgeMetrics.Stages.TagWithLedgerEnd.bufferBefore, StageBufferSize)
+      .buffered(bridgeMetrics.Stages.TagWithLedgerEnd.bufferBefore, stageBufferSize)
       .mapAsync(parallelism = 1)(tagWithLedgerEnd)
-      .buffered(bridgeMetrics.Stages.ConflictCheckWithCommitted.bufferBefore, StageBufferSize)
+      .buffered(bridgeMetrics.Stages.ConflictCheckWithCommitted.bufferBefore, stageBufferSize)
       .mapAsync(servicesThreadPoolSize)(conflictCheckWithCommitted)
-      .buffered(bridgeMetrics.Stages.Sequence.bufferBefore, StageBufferSize)
+      .buffered(bridgeMetrics.Stages.Sequence.bufferBefore, stageBufferSize)
       .statefulMapConcat(sequence)
 }
 
@@ -70,6 +69,7 @@ private[bridge] object ConflictCheckingLedgerBridge {
       bridgeMetrics: BridgeMetrics,
       servicesThreadPoolSize: Int,
       maxDeduplicationDuration: Duration,
+      stageBufferSize: Int,
   )(implicit
       servicesExecutionContext: ExecutionContext
   ): ConflictCheckingLedgerBridge =
@@ -88,6 +88,7 @@ private[bridge] object ConflictCheckingLedgerBridge {
         maxDeduplicationDuration = maxDeduplicationDuration,
       ),
       servicesThreadPoolSize = servicesThreadPoolSize,
+      stageBufferSize = stageBufferSize,
     )
 
   private[validate] def withErrorLogger[T](submissionId: Option[String])(

--- a/ledger/sandbox-on-x/src/test/it/scala/com/daml/ledger/platform/sandbox/services/command/CommandServiceBackPressureIT.scala
+++ b/ledger/sandbox-on-x/src/test/it/scala/com/daml/ledger/platform/sandbox/services/command/CommandServiceBackPressureIT.scala
@@ -40,7 +40,7 @@ sealed trait CommandServiceBackPressureITBase
     with TestCommands
     with SuiteResourceManagementAroundAll {
 
-  private val commands = 50
+  private val commands = 100
 
   private def command(party: String) =
     CreateCommand(
@@ -111,7 +111,11 @@ sealed trait CommandServiceBackPressureITBase
     }
   }
 
-  override def bridgeConfig: BridgeConfig = BridgeConfig.Default.copy(submissionBufferSize = 2)
+  override def bridgeConfig: BridgeConfig =
+    BridgeConfig.Default.copy(
+      submissionBufferSize = 1,
+      stageBufferSize = 1,
+    )
 
   override def config = super.config.copy(
     participants = singleParticipant(


### PR DESCRIPTION
* Fix CommandServiceBackpressureIT by increasing load
* Make stage buffer size configurable (allows to limit the drain effect of the heavily buffered pipeline)

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
