### PR TITLE
Ensure interface generation uses package prefixes

### DIFF
--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
@@ -45,7 +45,11 @@ object ClassForType extends StrictLogging {
   ): List[JavaFile] =
     for {
       (interfaceName, interface) <- typeWithContext.interface.interfaces.toList
-      className = ClassName.bestGuess(fullyQualifiedName(interfaceName))
+      classNameString = fullyQualifiedName(
+        Identifier(typeWithContext.interface.packageId, interfaceName),
+        packagePrefixes,
+      )
+      className = ClassName.bestGuess(classNameString)
       interfaceViewTypeName = ClassName.bestGuess(
         fullyQualifiedName(
           interface.viewType.getOrElse(

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
@@ -72,7 +72,7 @@ object ClassForType extends StrictLogging {
             typeWithContext.interface.packageId,
             interfaceName,
           )
-    } yield javaFile(packageName, interfaceClass)
+    } yield javaFile(s"blah.$packageName", interfaceClass)
 
   private def generateSerializableTypes(
       typeWithContext: TypeWithContext,

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
@@ -72,7 +72,7 @@ object ClassForType extends StrictLogging {
             typeWithContext.interface.packageId,
             interfaceName,
           )
-    } yield javaFile(s"blah.$packageName", interfaceClass)
+    } yield javaFile(packageName, interfaceClass)
 
   private def generateSerializableTypes(
       typeWithContext: TypeWithContext,

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
@@ -47,14 +47,20 @@ object ContractIdClass {
     def build(): TypeSpec = idClassBuilder.build()
 
     def addConversionForImplementedInterfaces(
-        implementedInterfaces: Seq[Ref.TypeConName]
+        implementedInterfaces: Seq[Ref.TypeConName],
+        packagePrefixes: Map[PackageId, String],
     ): Builder = {
       idClassBuilder.addMethods(
-        generateToInterfaceMethods("ContractId", "this.contractId", implementedInterfaces).asJava
+        generateToInterfaceMethods(
+          "ContractId",
+          "this.contractId",
+          implementedInterfaces,
+          packagePrefixes,
+        ).asJava
       )
       implementedInterfaces.foreach { interfaceName =>
-        // XXX why doesn't this use packagePrefixes? -SC
-        val name = ClassName.bestGuess(fullyQualifiedName(interfaceName.qualifiedName))
+        val name =
+          ClassName.bestGuess(fullyQualifiedName(interfaceName, packagePrefixes))
         val interfaceContractIdName = name nestedClass "ContractId"
         val tplContractIdClassName = templateClassName.nestedClass("ContractId")
         idClassBuilder.addMethod(
@@ -131,10 +137,10 @@ object ContractIdClass {
       nestedReturn: String,
       selfArgs: String,
       implementedInterfaces: Seq[Ref.TypeConName],
+      packagePrefixes: Map[PackageId, String],
   ) =
     implementedInterfaces.map { interfaceName =>
-      // XXX why doesn't this use packagePrefixes? -SC
-      val name = ClassName.bestGuess(fullyQualifiedName(interfaceName.qualifiedName))
+      val name = ClassName.bestGuess(fullyQualifiedName(interfaceName, packagePrefixes))
       val interfaceContractIdName = name nestedClass nestedReturn
       MethodSpec
         .methodBuilder("toInterface")

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
@@ -38,7 +38,6 @@ object InterfaceClass extends StrictLogging {
               interfaceName,
               packagePrefixes,
               interface.choices,
-              withPrefixes = false, // TODO: remove in #15154
             )
             .asJava
         )
@@ -62,10 +61,15 @@ object InterfaceClass extends StrictLogging {
           )
         )
         .addType(
-          TemplateClass.generateCreateAndClass(interfaceName, -\/(ContractIdClass.For.Interface))
+          TemplateClass.generateCreateAndClass(
+            interfaceName,
+            -\/(ContractIdClass.For.Interface),
+            packagePrefixes,
+          )
         )
         .addType(
-          TemplateClass.generateByKeyClass(interfaceName, -\/(ContractIdClass.For.Interface))
+          TemplateClass
+            .generateByKeyClass(interfaceName, -\/(ContractIdClass.For.Interface), packagePrefixes)
         )
         .addType(
           generateInterfaceCompanionClass(

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/ChoiceMetadataFieldsSpec.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/ChoiceMetadataFieldsSpec.scala
@@ -7,7 +7,7 @@ import com.daml.ledger.javaapi.data.Unit
 import com.daml.ledger.javaapi.data.codegen.ChoiceMetadata
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import retro.InterfaceRetro
+import ut.retro.InterfaceRetro
 import ut.bar.Bar
 import ut.da.internal.template.Archive
 

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/InterfaceRetroImplementsSpec.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/InterfaceRetroImplementsSpec.scala
@@ -5,7 +5,7 @@ package com.daml.lf.codegen.backend.java
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import retro.InterfaceRetro
+import ut.retro.InterfaceRetro
 import ut.retro.TemplateRetro
 
 final class InterfaceRetroImplementsSpec extends AnyWordSpec with Matchers {


### PR DESCRIPTION
Fixes #15154 

CHANGELOG_BEGIN
- [BUGFIX] Interface generation now respects package prefixes argument. This means generated interfaces will now be placed in the right subpackages. 

CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
