### PR TITLE
[daml-script] support query by interface-id

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -931,6 +931,48 @@ da_haskell_test(
 )
 
 da_haskell_test(
+    name = "script-service-interfaces",  # TODO: dedup with script-service test setup
+    srcs = ["src/DA/Test/ScriptService_1_15.hs"],
+    data = [
+        "//compiler/damlc/pkg-db",
+        "//compiler/damlc/stable-packages",
+        "//compiler/scenario-service/server:scenario_service_jar",
+        "//daml-script/daml:daml-script-1.15.dar",
+        ghc_pkg,
+    ],
+    hackage_deps = [
+        "base",
+        "containers",
+        "directory",
+        "data-default",
+        "extra",
+        "filepath",
+        "ghcide",
+        "lsp-types",
+        "unordered-containers",
+        "regex-tdfa",
+        "tasty",
+        "tasty-hunit",
+        "text",
+        "vector",
+    ],
+    main_function = "DA.Test.ScriptService.main",
+    deps = [
+        "//:sdk-version-hs-lib",
+        "//compiler/daml-lf-ast",
+        "//compiler/damlc:damlc-lib",
+        "//compiler/damlc/daml-ide-core",
+        "//compiler/damlc/daml-opts:daml-opts-types",
+        "//compiler/damlc/daml-package-config",
+        "//compiler/damlc/daml-rule-types",
+        "//compiler/scenario-service/client",
+        "//daml-assistant:daml-project-config",
+        "//libs-haskell/bazel-runfiles",
+        "//libs-haskell/da-hs-base",
+    ],
+)
+
+da_haskell_test(
     name = "package-manager",
     size = "large",
     srcs = ["src/DamlcPkgManager.hs"],

--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -42,7 +42,7 @@ import Test.Tasty.HUnit
 import Text.Regex.TDFA
 
 lfVersion :: LF.Version
-lfVersion = max (LF.featureMinVersion LF.featureExceptions) LF.versionDefault
+lfVersion = LF.versionDefault
 
 main :: IO ()
 main =

--- a/compiler/damlc/tests/src/DA/Test/ScriptService_1_15.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService_1_15.hs
@@ -1,0 +1,185 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DA.Test.ScriptService (main) where
+
+import Control.Exception
+import Control.Monad
+import DA.Bazel.Runfiles
+import DA.Cli.Damlc.Packaging
+import DA.Cli.Damlc.DependencyDb
+import qualified DA.Daml.LF.Ast.Version as LF
+import DA.Daml.LF.PrettyScenario (prettyScenarioError, prettyScenarioResult)
+import qualified DA.Daml.LF.ScenarioServiceClient as SS
+import DA.Daml.Options.Types
+import DA.Daml.Package.Config
+import DA.Daml.Project.Types
+import DA.Pretty
+import qualified DA.Service.Logger as Logger
+import qualified DA.Service.Logger.Impl.IO as Logger
+import qualified Data.HashSet as HashSet
+import Data.List
+import qualified Data.Set as S
+import qualified Data.Text as T
+import qualified Data.Vector as V
+import Development.IDE.Core.Debouncer (noopDebouncer)
+import Development.IDE.Core.FileStore (makeVFSHandle, setBufferModified)
+import Development.IDE.Core.IdeState.Daml (getDamlIdeState)
+import Development.IDE.Core.OfInterest (setFilesOfInterest)
+import Development.IDE.Core.RuleTypes.Daml (RunScripts (..), VirtualResource (..))
+import Development.IDE.Core.Rules.Daml (worldForFile)
+import Development.IDE.Core.Service (getDiagnostics, runActionSync, shutdown)
+import Development.IDE.Core.Shake (ShakeLspEnv(..), NotificationHandler(..), use)
+import Development.IDE.Types.Diagnostics (showDiagnostics)
+import Development.IDE.Types.Location (toNormalizedFilePath')
+import SdkVersion
+import System.Directory.Extra
+import System.Environment.Blank
+import System.FilePath
+import System.IO.Extra
+import Test.Tasty
+import Test.Tasty.HUnit
+import Text.Regex.TDFA
+
+lfVersion :: LF.Version
+lfVersion = LF.version1_15
+
+main :: IO ()
+main =
+  withTempDir $ \dir -> do
+    withCurrentDirectory dir $ do
+      setEnv "TASTY_NUM_THREADS" "1" True
+
+      -- Package DB setup, we only need to do this once so we do it at the beginning.
+      scriptDar <- locateRunfiles $ mainWorkspace </> "daml-script/daml/daml-script-1.15.dar"
+      writeFileUTF8 "daml.yaml" $
+        unlines
+          [ "sdk-version: " <> sdkVersion,
+            "name: script-service",
+            "version: 0.0.1",
+            "source: .",
+            "dependencies:",
+            "- daml-prim",
+            "- daml-stdlib",
+            "- " <> show scriptDar
+          ]
+      withPackageConfig (ProjectPath ".") $ \PackageConfigFields {..} -> do
+        let projDir = toNormalizedFilePath' dir
+        installDependencies
+            projDir
+            options
+            pSdkVersion
+            pDependencies
+            pDataDependencies
+        createProjectPackageDb
+          projDir
+          options
+          pModulePrefixes
+
+      logger <- Logger.newStderrLogger Logger.Debug "script-service"
+
+      -- Spinning up the scenario service is expensive so we do it once at the beginning.
+      SS.withScenarioService lfVersion logger scenarioConfig $ \scriptService ->
+        defaultMain $
+          testGroup
+            "Script Service 1.15"
+            [
+              testCase "query by interface" $ do
+                rs <-
+                  runScripts
+                    scriptService
+                    [ "module Test where"
+                    , "import DA.Assert"
+                    , "import Daml.Script"
+
+                    , "interface MyInterface where"
+                    , "  viewtype MyView"
+                    , "data MyView = MyView { info : Int }"
+                    , "template MyTemplate"
+                    , "  with"
+                    , "    p : Party"
+                    , "    v : Int"
+                    , "  where"
+                    , "    signatory p"
+                    , "    interface instance MyInterface for MyTemplate where"
+                    , "      view = MyView { info = 100 + v }"
+                    , "test : Script ()"
+                    , "test = do"
+                    , "  p <- allocateParty \"p\""
+                    , "  cid <- submit p do createCmd (MyTemplate p 42)"
+                    , "  optR <- queryContractId p cid"
+                    , "  let (Some r) = optR"
+                    , "  r === MyTemplate p 42"
+                    , "  let iid : ContractId MyInterface = toInterfaceContractId @MyInterface cid"
+                    , "  Some v <- queryViewContractId p iid"
+                    , "  v.info === 142"
+                    , "  pure ()"
+                    ]
+
+                expectScriptSuccess rs (vr "test") $ \r ->
+                  matchRegex r "Active contracts:"
+
+            ]
+  where
+    scenarioConfig = SS.defaultScenarioServiceConfig {SS.cnfJvmOptions = ["-Xmx200M"]}
+    vr n = VRScenario (toNormalizedFilePath' "Test.daml") n
+
+matchRegex :: T.Text -> T.Text -> Bool
+matchRegex s regex = matchTest (makeRegex regex :: Regex) s
+
+expectScriptSuccess :: HasCallStack =>
+  -- | The list of script results.
+  [(VirtualResource, Either T.Text T.Text)] ->
+  -- | VR of the script
+  VirtualResource ->
+  -- | Predicate on the result
+  (T.Text -> Bool) ->
+  -- | Succeeds if there is a successful result for the given
+  -- VR and the predicate holds.
+  Assertion
+expectScriptSuccess xs vr pred = case find ((vr ==) . fst) xs of
+  Nothing -> assertFailure $ "No result for " <> show vr
+  Just (_, Left err) ->
+    assertFailure $
+      "Expected success for " <> show vr <> " but got "
+        <> show err
+  Just (_, Right r) ->
+    unless (pred r) $
+      assertFailure $ "Predicate for " <> show vr <> " failed on " <> show r
+
+options :: Options
+options =
+  (defaultOptions (Just lfVersion))
+    { optDlintUsage = DlintDisabled
+    }
+
+runScripts :: SS.Handle -> [T.Text] -> IO [(VirtualResource, Either T.Text T.Text)]
+runScripts service fileContent = bracket getIdeState shutdown $ \ideState -> do
+  setBufferModified ideState file $ Just $ T.unlines fileContent
+  setFilesOfInterest ideState (HashSet.singleton file)
+  mbResult <- runActionSync ideState $ use RunScripts file
+  case mbResult of
+    Nothing -> do
+      diags <- getDiagnostics ideState
+      fail (T.unpack $ showDiagnostics diags)
+    Just xs -> do
+      world <- runActionSync ideState (worldForFile file)
+      let render (vr, r) = (vr,) <$> prettyResult world r
+      mapM render xs
+  where
+    prettyResult world (Left err) = case err of
+      SS.BackendError err -> assertFailure $ "Unexpected result " <> show err
+      SS.ExceptionError err -> assertFailure $ "Unexpected result " <> show err
+      SS.ScenarioError err -> pure $ Left $ renderPlain (prettyScenarioError world err)
+    prettyResult world (Right r) = pure $ Right $ renderPlain (prettyScenarioResult world (S.fromList (V.toList (SS.scenarioResultActiveContracts r))) r)
+    file = toNormalizedFilePath' "Test.daml"
+    getIdeState = do
+      vfs <- makeVFSHandle
+      logger <- Logger.newStderrLogger Logger.Error "script-service"
+      getDamlIdeState
+        options
+        (Just service)
+        logger
+        noopDebouncer
+        (DummyLspEnv $ NotificationHandler $ \_ _ -> pure ())
+        vfs

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -13,6 +13,7 @@ module Daml.Script
   , submitTreeMulti
   , query
   , queryContractId
+  , queryViewContractId
   , queryContractKey
   , queryFilter
   , PartyIdHint (..)
@@ -127,6 +128,7 @@ data ScriptF a
   | SubmitTree (SubmitTreePayload a)
   | Query (QueryACS a)
   | QueryContractId (QueryContractIdPayload a)
+  | QueryViewContractId (QueryViewContractIdPayload a)
   | QueryContractKey (QueryContractKeyPayload a)
   | AllocParty (AllocateParty a)
   | ListKnownParties (ListKnownPartiesPayload a)
@@ -214,6 +216,22 @@ queryContractId p c = lift $ Free $ QueryContractId QueryContractIdPayload with
   tplId = templateTypeRep @t
   cid = coerceContractId c
   continue = pure . fmap (fromSome . fromAnyTemplate)
+  locations = getCallStack callStack
+
+data QueryViewContractIdPayload a = QueryViewContractIdPayload
+  { parties : [Party]
+  , interfaceId : TemplateTypeRep
+  , cid : ContractId ()
+  , continue : Optional LedgerValue -> a
+  , locations : [(Text, SrcLoc)]
+  } deriving Functor
+
+queryViewContractId : forall i v p. (TemplateOrInterface i, HasInterfaceView i v, IsParties p) => HasCallStack => p -> ContractId i -> Script (Optional v)
+queryViewContractId p c = lift $ Free $ QueryViewContractId QueryViewContractIdPayload with
+  parties = toParties p
+  interfaceId = templateTypeRep @i
+  cid = coerceContractId c
+  continue = pure . fmap (fromLedgerValue @ v)
   locations = getCallStack callStack
 
 data QueryContractKeyPayload a = QueryContractKeyPayload

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -692,6 +692,19 @@ object Converter {
       contract: ScriptLedgerClient.ActiveContract,
   ): Either[String, SValue] = fromAnyTemplate(translator, contract.templateId, contract.argument)
 
+  def fromInterfaceView(
+      translator: preprocessing.ValueTranslator,
+      viewType: Type,
+      value: Value,
+  ): Either[String, SValue] = {
+    for {
+      translated <- translator
+        .translateValue(viewType, value)
+        .left
+        .map(err => s"Failed to translate value of interface view: $err")
+    } yield translated
+  }
+
   // Convert a Created event to a pair of (ContractId (), AnyTemplate)
   def fromCreated(
       translator: preprocessing.ValueTranslator,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
@@ -86,6 +86,12 @@ object ScriptF {
         case Left(err) => Left(err.pretty)
       }
 
+    def lookupInterfaceViewTy(id: Identifier): Either[String, Ast.Type] =
+      compiledPackages.pkgInterface.lookupInterface(id) match {
+        case Right(key) => Right(key.view)
+        case Left(err) => Left(err.pretty)
+      }
+
     def translateValue(ty: Ast.Type, value: Value): Either[String, SValue] =
       valueTranslator.translateValue(ty, value).left.map(_.toString)
 
@@ -249,11 +255,35 @@ object ScriptF {
       for {
         client <- Converter.toFuture(env.clients.getPartyParticipant(parties.head))
         optR <- client.queryContractId(parties, tplId, cid)
-        optR <- Converter.toFuture(
-          optR.traverse(Converter.fromContract(env.valueTranslator, _))
-        )
+        optR <- Converter.toFuture(optR.traverse(Converter.fromContract(env.valueTranslator, _)))
       } yield SEAppAtomic(SEValue(continue), Array(SEValue(SOptional(optR))))
   }
+
+  final case class QueryViewContractId(
+      parties: OneAnd[Set, Party],
+      interfaceId: Identifier,
+      cid: ContractId,
+      stackTrace: StackTrace,
+      continue: SValue,
+  ) extends Cmd {
+    override def description = "queryViewContractId"
+
+    override def execute(env: Env)(implicit
+        ec: ExecutionContext,
+        mat: Materializer,
+        esf: ExecutionSequencerFactory,
+    ): Future[SExpr] = {
+      for {
+        viewType <- Converter.toFuture(env.lookupInterfaceViewTy(interfaceId))
+        client <- Converter.toFuture(env.clients.getPartyParticipant(parties.head))
+        optR <- client.queryViewContractId(parties, interfaceId, cid)
+        optR <- Converter.toFuture(
+          optR.traverse(Converter.fromInterfaceView(env.valueTranslator, viewType, _))
+        )
+      } yield SEAppAtomic(SEValue(continue), Array(SEValue(SOptional(optR))))
+    }
+  }
+
   final case class QueryContractKey(
       parties: OneAnd[Set, Party],
       tplId: Identifier,
@@ -696,6 +726,30 @@ object ScriptF {
     }
   }
 
+  private def parseQueryViewContractId(
+      ctx: Ctx,
+      v: SValue,
+  ): Either[String, QueryViewContractId] = {
+    def convert(
+        actAs: SValue,
+        interfaceId: SValue,
+        cid: SValue,
+        stackTrace: Option[SValue],
+        continue: SValue,
+    ) =
+      for {
+        actAs <- Converter.toParties(actAs)
+        interfaceId <- Converter.typeRepToIdentifier(interfaceId)
+        cid <- toContractId(cid)
+        stackTrace <- toStackTrace(ctx, stackTrace)
+      } yield QueryViewContractId(actAs, interfaceId, cid, stackTrace, continue)
+    v match {
+      case SRecord(_, _, ArrayList(actAs, interfaceId, cid, continue, stackTrace)) =>
+        convert(actAs, interfaceId, cid, Some(stackTrace), continue)
+      case _ => Left(s"Expected QueryViewContractId payload but got $v")
+    }
+  }
+
   private def parseQueryContractKey(ctx: Ctx, v: SValue): Either[String, QueryContractKey] = {
     def convert(
         actAs: SValue,
@@ -934,6 +988,7 @@ object ScriptF {
       case "SubmitTree" => parseSubmit(ctx, v).map(SubmitTree(_))
       case "Query" => parseQuery(ctx, v)
       case "QueryContractId" => parseQueryContractId(ctx, v)
+      case "QueryViewContractId" => parseQueryViewContractId(ctx, v)
       case "QueryContractKey" => parseQueryContractKey(ctx, v)
       case "AllocParty" => parseAllocParty(ctx, v)
       case "ListKnownParties" => parseListKnownParties(ctx, v)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/GrpcLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/GrpcLedgerClient.scala
@@ -116,6 +116,17 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
     }
   }
 
+  override def queryViewContractId(
+      parties: OneAnd[Set, Ref.Party],
+      interfaceId: Identifier,
+      cid: ContractId,
+  )(implicit
+      ec: ExecutionContext,
+      mat: Materializer,
+  ): Future[Option[Value]] = {
+    sys.error("not implemented") // TODO https://github.com/digital-asset/daml/issues/14830
+  }
+
   // TODO (MK) https://github.com/digital-asset/daml/issues/11737
   private val catchableStatusCodes =
     Set(

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
@@ -209,6 +209,13 @@ class JsonLedgerClient(
       })
     }
   }
+  override def queryViewContractId(
+      parties: OneAnd[Set, Ref.Party],
+      interfaceId: Identifier,
+      cid: ContractId,
+  )(implicit ec: ExecutionContext, mat: Materializer): Future[Option[Value]] = {
+    sys.error("not implemented") // TODO https://github.com/digital-asset/daml/issues/14830
+  }
   override def queryContractKey(
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/ScriptLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/ScriptLedgerClient.scala
@@ -84,6 +84,15 @@ trait ScriptLedgerClient {
       mat: Materializer,
   ): Future[Option[ScriptLedgerClient.ActiveContract]]
 
+  def queryViewContractId(
+      parties: OneAnd[Set, Ref.Party],
+      interfaceId: Identifier,
+      cid: ContractId,
+  )(implicit
+      ec: ExecutionContext,
+      mat: Materializer,
+  ): Future[Option[Value]]
+
   def queryContractKey(
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,


### PR DESCRIPTION
Extend `daml-script` to support query by interface-id: 
- New user function: `queryViewContractId`
- implement for  `IdeLedgeClient`; testing with `ScriptService_1_15.hs`

Advances issue #14830