### PR TITLE
Fix `instance Show Text` to produce escaped Text

### DIFF
--- a/compiler/damlc/daml-prim-src/GHC/Show.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Show.daml
@@ -21,6 +21,7 @@ import GHC.CString (fromString)
 import GHC.Tuple ()  -- We're using tuples but they are builtin syntax.
 import GHC.Types
 import GHC.Classes ()
+import GHC.Show.Text (showsPrecText)
 import DA.Types
 
 -- | `showS` should represent some text, and applying it to some argument
@@ -133,7 +134,7 @@ instance Show RoundingMode where
 #endif
 
 instance Show Text where
-  show x = "\"" ++ x ++ "\""
+  showsPrec = showsPrecText
 
 instance Show a => Show [a]  where
   showsPrec _ = showList

--- a/compiler/damlc/daml-prim-src/GHC/Show.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Show.daml
@@ -134,7 +134,7 @@ instance Show RoundingMode where
 #endif
 
 instance Show Text where
-  showsPrec = showsPrecText
+  showsPrec = showsPrecText -- see Note [instance Show Text]
 
 instance Show a => Show [a]  where
   showsPrec _ = showList

--- a/compiler/damlc/daml-prim-src/GHC/Show/Text.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Show/Text.daml
@@ -181,4 +181,5 @@ ctrlChrText c = case c of
   CH("\CAN") -> "CAN"; CH("\EM")  -> "EM";  CH("\SUB") -> "SUB"; CH("\ESC") -> "ESC";
   CH("\FS")  -> "FS";  CH("\GS")  -> "GS";  CH("\RS")  -> "RS";  CH("\US")  -> "US";
 
-  _ -> ""
+  CH(t) -> error $
+    "impossible: GHC.Show.Text.ctrlChrText applied to non-control-character argument, \"" ++ t ++ "\""

--- a/compiler/damlc/daml-prim-src/GHC/Show/Text.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Show/Text.daml
@@ -61,8 +61,11 @@ explode = primExplode
 
 #endif
 
-isDec : Chr -> Bool
-isDec c = CH("0") <= c && c <= CH("9")
+startsWithDigit : Text -> Bool
+startsWithDigit t = "0" <= t && t < ":" -- ':' immediately follows '9' in ASCII
+
+startsWithUppercaseH : Text -> Bool
+startsWithUppercaseH t = "H" <= t && t < "I"
 
 ord : Chr -> Int
 ord CH(t) = case primTextToCodePoints t of
@@ -86,7 +89,7 @@ showLitChrs (CH("\"") :: cs) s = showString "\\\"" (showLitChrs cs s)
 showLitChrs (c        :: cs) s = showLitChr c (showLitChrs cs s)
 
 showLitChr : Chr -> ShowS
-showLitChr c s | c > CH("\DEL")       = showString "\\" (protectEsc isDec (showInt (ord c)) s)
+showLitChr c s | c > CH("\DEL")       = showString "\\" (protectEsc startsWithDigit (showInt (ord c)) s)
 showLitChr CH("\DEL")               s = showString "\\DEL" s
 showLitChr CH("\\")                 s = showString "\\\\" s
 showLitChr c@(CH(t)) s | c >= CH(" ") = showString t s
@@ -97,13 +100,13 @@ showLitChr CH("\n")                 s = showString "\\n" s
 showLitChr CH("\r")                 s = showString "\\r" s
 showLitChr CH("\t")                 s = showString "\\t" s
 showLitChr CH("\v")                 s = showString "\\v" s
-showLitChr CH("\SO")                s = protectEsc (== CH("H")) (showString "\\SO") s
+showLitChr CH("\SO")                s = protectEsc startsWithUppercaseH (showString "\\SO") s
 showLitChr c                        s = showString ("\\" ++ ascii c) s
 
-protectEsc : (Chr -> Bool) -> ShowS -> ShowS
+protectEsc : (Text -> Bool) -> ShowS -> ShowS
 protectEsc p f = f . cont
-               where cont s@(explode -> c::_) | p c = showString "\\&" s
-                     cont s                         = s
+               where cont s | p s = showString "\\&" s
+                     cont s       = s
 
 ascii : Chr -> Text
 ascii c = case c of

--- a/compiler/damlc/daml-prim-src/GHC/Show/Text.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Show/Text.daml
@@ -4,14 +4,27 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
--- #define SHOW_TEXT_CHR_NEWTYPE
+{-
+Note [newtype Chr debugging]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The macro `__DEBUG__SHOW_TEXT_CHR_NEWTYPE` can be `#define`d to switch to an
+implementation where `Chr` is a newtype'd `Text`. This ensures that an
+arbitrary-length `Text` can't be used as a `Chr` without going through a
+conversion function, which can be useful during development.
+
+Since Daml newtypes impose a performance penalty (unlike Haskell newtypes), the
+implementation we actually use in `daml-prim` uses a type synonym instead
+(corresponding to the case where the macro is not defined).
+-}
+-- #define __DEBUG__SHOW_TEXT_CHR_NEWTYPE
 
 module GHC.Show.Text
   ( showsPrecText
   ) where
 
 import GHC.Base (
-#ifdef SHOW_TEXT_CHR_NEWTYPE
+#ifdef __DEBUG__SHOW_TEXT_CHR_NEWTYPE
     map,
 #endif
     (.), (++), ($)
@@ -44,7 +57,8 @@ primIntToText = primitive @"BEToText"
 
 explode : Text -> [Chr]
 
-#ifdef SHOW_TEXT_CHR_NEWTYPE
+-- See Note [newtype Chr debugging]
+#ifdef __DEBUG__SHOW_TEXT_CHR_NEWTYPE
 
 newtype Chr = MkChr Text
   deriving (Eq, Ord)

--- a/compiler/damlc/daml-prim-src/GHC/Show/Text.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Show/Text.daml
@@ -137,20 +137,14 @@ showLitChrs (c        :: cs) = showLitChr c . showLitChrs cs
 
 -- Compared with GHC's `showLitChar`, this is point-free on `ShowS`'s
 -- argument - see Note [Point-free ShowS]
+-- Also, the cases for "\a\b\f\n\r\t\v" are handled by `ctrlChrText`.
 showLitChr : Chr -> ShowS
 showLitChr c | c > CH("\DEL")       = showString "\\" . showInt (ord c) . protectEsc startsWithDigit
 showLitChr CH("\DEL")               = showString "\\DEL"
 showLitChr CH("\\")                 = showString "\\\\"
 showLitChr c@(CH(t)) | c >= CH(" ") = showString t
-showLitChr CH("\a")                 = showString "\\a"
-showLitChr CH("\b")                 = showString "\\b"
-showLitChr CH("\f")                 = showString "\\f"
-showLitChr CH("\n")                 = showString "\\n"
-showLitChr CH("\r")                 = showString "\\r"
-showLitChr CH("\t")                 = showString "\\t"
-showLitChr CH("\v")                 = showString "\\v"
 showLitChr CH("\SO")                = showString "\\SO" . protectEsc startsWithUppercaseH
-showLitChr c                        = showString "\\" . showString (ascii c)
+showLitChr c                        = showString "\\" . showString (ctrlChrText c)
 
 -- Compared with GHC's `protectEsc`, the predicate is applied to the entire
 -- suffix (instead of only its first `Char`), in order to avoid using `explode`.
@@ -164,22 +158,27 @@ protectEsc p = cont
          where cont s | p s = showString "\\&" s
                cont s       = s
 
--- Unlike GHC's `asciiTab`, this is defined as a function instead of a list,
--- since we don't have `(!!)` available for indexing.
-ascii : Chr -> Text
-ascii c = case c of
+-- Unlike GHC's `asciiTab`, on which this is based,
+--   * This is defined as a function instead of a list, since we don't have
+--     `(!!)` available for indexing.
+--   * This drops the case for `'\SP'` (the space character), since it's
+--     already covered by `showLitChr c@(CH(t)) | c >= CH(" ")`.
+--   * This drops the case for `'\SO'`, since it's  already covered by
+--     `showLitChr CH("\SO")`.
+--   * The values for "\BEL\BS\HT\LF\VT\FF\CR" are mapped directly to
+--     "\a\b\t\n\v\f\r" respectively.
+ctrlChrText : Chr -> Text
+ctrlChrText c = case c of
   CH("\NUL") -> "NUL"; CH("\SOH") -> "SOH"; CH("\STX") -> "STX"; CH("\ETX") -> "ETX";
-  CH("\EOT") -> "EOT"; CH("\ENQ") -> "ENQ"; CH("\ACK") -> "ACK"; CH("\BEL") -> "BEL";
+  CH("\EOT") -> "EOT"; CH("\ENQ") -> "ENQ"; CH("\ACK") -> "ACK"; CH("\BEL") -> "a";
 
-  CH("\BS")  -> "BS";  CH("\HT")  -> "HT";  CH("\LF")  -> "LF";  CH("\VT")  -> "VT";
-  CH("\FF")  -> "FF";  CH("\CR")  -> "CR";  CH("\SO")  -> "SO";  CH("\SI")  -> "SI";
+  CH("\BS")  -> "b";   CH("\HT")  -> "t";   CH("\LF")  -> "n";   CH("\VT")  -> "v";
+  CH("\FF")  -> "f";   CH("\CR")  -> "r"; {-CH("\SO")  -> "SO";-}CH("\SI")  -> "SI";
 
   CH("\DLE") -> "DLE"; CH("\DC1") -> "DC1"; CH("\DC2") -> "DC2"; CH("\DC3") -> "DC3";
   CH("\DC4") -> "DC4"; CH("\NAK") -> "NAK"; CH("\SYN") -> "SYN"; CH("\ETB") -> "ETB";
 
   CH("\CAN") -> "CAN"; CH("\EM")  -> "EM";  CH("\SUB") -> "SUB"; CH("\ESC") -> "ESC";
   CH("\FS")  -> "FS";  CH("\GS")  -> "GS";  CH("\RS")  -> "RS";  CH("\US")  -> "US";
-
-  CH("\SP")  -> "SP";
 
   _ -> ""

--- a/compiler/damlc/daml-prim-src/GHC/Show/Text.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Show/Text.daml
@@ -10,10 +10,12 @@ module GHC.Show.Text
   ( showsPrecText
   ) where
 
+import GHC.Base (
 #ifdef SHOW_TEXT_CHR_NEWTYPE
-import GHC.Base (map)
+    map,
 #endif
-import GHC.Base ((.), (++), ($))
+    (.), (++), ($)
+  )
 import GHC.Classes (Eq (..), Ord (..), (&&))
 import GHC.CString (fromString)
 import GHC.Err (error)

--- a/compiler/damlc/daml-prim-src/GHC/Show/Text.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Show/Text.daml
@@ -1,0 +1,124 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- #define SHOW_TEXT_CHR_NEWTYPE
+
+module GHC.Show.Text
+  ( showsPrecText
+  ) where
+
+#ifdef SHOW_TEXT_CHR_NEWTYPE
+import GHC.Base (map)
+#endif
+import GHC.Base ((.), (++), ($))
+import GHC.Classes (Eq (..), Ord (..), (&&))
+import GHC.CString (fromString)
+import GHC.Err (error)
+import GHC.Types (Bool, Int, Text, primitive)
+
+-- # Exported
+
+showsPrecText : Int -> Text -> ShowS
+showsPrecText _ x =
+    showString "\""
+  . showLitText x
+  . showString "\""
+
+-- # Primitives
+
+primExplode : Text -> [Text]
+primExplode = primitive @"BEExplodeText"
+
+primTextToCodePoints : Text -> [Int]
+primTextToCodePoints = primitive @"BETextToCodePoints"
+
+primIntToText : Int -> Text
+primIntToText = primitive @"BEToText"
+
+-- # Internal
+
+explode : Text -> [Chr]
+
+#ifdef SHOW_TEXT_CHR_NEWTYPE
+
+newtype Chr = MkChr Text
+  deriving (Eq, Ord)
+
+#define CH(t) (MkChr t)
+
+explode = map MkChr . primExplode
+
+#else
+
+type Chr = Text
+
+#define CH(t) t
+
+explode = primExplode
+
+#endif
+
+isDec : Chr -> Bool
+isDec c = CH("0") <= c && c <= CH("9")
+
+ord : Chr -> Int
+ord CH(t) = case primTextToCodePoints t of
+  [p] -> p
+  _ -> error $ "impossible: GHC.Show.Text.ord applied to argument with length /= 1, \"" ++ t ++ "\""
+
+type ShowS = Text -> Text
+
+showString : Text -> ShowS
+showString = (++)
+
+showInt : Int -> ShowS
+showInt = showString . primIntToText
+
+showLitText : Text -> ShowS
+showLitText = showLitChrs . explode
+
+showLitChrs : [Chr] -> ShowS
+showLitChrs []               s = s
+showLitChrs (CH("\"") :: cs) s = showString "\\\"" (showLitChrs cs s)
+showLitChrs (c        :: cs) s = showLitChr c (showLitChrs cs s)
+
+showLitChr : Chr -> ShowS
+showLitChr c s | c > CH("\DEL")       = showString "\\" (protectEsc isDec (showInt (ord c)) s)
+showLitChr CH("\DEL")               s = showString "\\DEL" s
+showLitChr CH("\\")                 s = showString "\\\\" s
+showLitChr c@(CH(t)) s | c >= CH(" ") = showString t s
+showLitChr CH("\a")                 s = showString "\\a" s
+showLitChr CH("\b")                 s = showString "\\b" s
+showLitChr CH("\f")                 s = showString "\\f" s
+showLitChr CH("\n")                 s = showString "\\n" s
+showLitChr CH("\r")                 s = showString "\\r" s
+showLitChr CH("\t")                 s = showString "\\t" s
+showLitChr CH("\v")                 s = showString "\\v" s
+showLitChr CH("\SO")                s = protectEsc (== CH("H")) (showString "\\SO") s
+showLitChr c                        s = showString ("\\" ++ ascii c) s
+
+protectEsc : (Chr -> Bool) -> ShowS -> ShowS
+protectEsc p f = f . cont
+               where cont s@(explode -> c::_) | p c = showString "\\&" s
+                     cont s                         = s
+
+ascii : Chr -> Text
+ascii c = case c of
+  CH("\NUL") -> "NUL"; CH("\SOH") -> "SOH"; CH("\STX") -> "STX"; CH("\ETX") -> "ETX";
+  CH("\EOT") -> "EOT"; CH("\ENQ") -> "ENQ"; CH("\ACK") -> "ACK"; CH("\BEL") -> "BEL";
+
+  CH("\BS")  -> "BS";  CH("\HT")  -> "HT";  CH("\LF")  -> "LF";  CH("\VT")  -> "VT";
+  CH("\FF")  -> "FF";  CH("\CR")  -> "CR";  CH("\SO")  -> "SO";  CH("\SI")  -> "SI";
+
+  CH("\DLE") -> "DLE"; CH("\DC1") -> "DC1"; CH("\DC2") -> "DC2"; CH("\DC3") -> "DC3";
+  CH("\DC4") -> "DC4"; CH("\NAK") -> "NAK"; CH("\SYN") -> "SYN"; CH("\ETB") -> "ETB";
+
+  CH("\CAN") -> "CAN"; CH("\EM")  -> "EM";  CH("\SUB") -> "SUB"; CH("\ESC") -> "ESC";
+  CH("\FS")  -> "FS";  CH("\GS")  -> "GS";  CH("\RS")  -> "RS";  CH("\US")  -> "US";
+
+  CH("\SP")  -> "SP";
+
+  _ -> ""

--- a/compiler/damlc/daml-prim-src/GHC/Show/Text.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Show/Text.daml
@@ -5,6 +5,35 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 {-
+Note [instance Show Text]
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The code here has been adapted from GHC's module
+[`GHC.Show`](https://github.com/digital-asset/ghc/blob/da-master-8.8.1/libraries/base/GHC/Show.hs).
+
+Most changes were related to the lack of a native `Char` type in Daml and
+consequently the fact that Daml's `Text` is not a list of `Char`, unlike
+Haskell's `String`. Thus, we introduce `Chr` as a type synonym for `Text` where
+we know the length is exactly 1 (see Note [newtype Chr debugging]). Then,
+`showLitText` is defined in terms of `showLitChrs` (very close to Haskell's
+`showLitString`) but first `explode`s the `Text` argument to produce the list of
+`Chr` that `showLitChrs` expects.
+
+Note [Point-free ShowS]
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Unlike GHC's `showLitChar` and `showLitString`, we do _not_ make `ShowS`'s
+argument explicit.
+
+Empirically, making it explicit in the functions with a `ShowS` return type
+worsened the performance of
+> bazel test //compiler/damlc/tests:integration-v1dev --test_arg -p --test_arg "ShowText.daml"
+Taking 30.0s vs. 13.6 for the point-free version (with `longStringSize = 100000`)
+
+This makes sense considering that `showString` (defined as `(++)`) will only
+do the concatenation once all arguments are available, so the point-free version
+is "lazier" than the literal translation of GHC's.
+
 Note [newtype Chr debugging]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -99,11 +128,15 @@ showInt = showString . primIntToText
 showLitText : Text -> ShowS
 showLitText = showLitChrs . explode
 
+-- Compared with GHC's `showLitString`, this is point-free on `ShowS`'s
+-- argument - see Note [Point-free ShowS]
 showLitChrs : [Chr] -> ShowS
 showLitChrs []               = \s -> s
 showLitChrs (CH("\"") :: cs) = showString "\\\"" . showLitChrs cs
 showLitChrs (c        :: cs) = showLitChr c . showLitChrs cs
 
+-- Compared with GHC's `showLitChar`, this is point-free on `ShowS`'s
+-- argument - see Note [Point-free ShowS]
 showLitChr : Chr -> ShowS
 showLitChr c | c > CH("\DEL")       = showString "\\" . showInt (ord c) . protectEsc startsWithDigit
 showLitChr CH("\DEL")               = showString "\\DEL"
@@ -119,11 +152,20 @@ showLitChr CH("\v")                 = showString "\\v"
 showLitChr CH("\SO")                = showString "\\SO" . protectEsc startsWithUppercaseH
 showLitChr c                        = showString "\\" . showString (ascii c)
 
+-- Compared with GHC's `protectEsc`, the predicate is applied to the entire
+-- suffix (instead of only its first `Char`), in order to avoid using `explode`.
+-- This is okay since the only predicates used (`startsWithDigit` and
+-- `startsWithUppercaseH`) are implemented in terms of comparisons with
+-- single-character `Text`s, so they should be O(1).
+-- Also, unlike GHC's `protectEsc`, this doesn't take a `ShowS` argument for the
+-- prefix; instead the caller adds the prefix before the call to this function.
 protectEsc : (Text -> Bool) -> ShowS
 protectEsc p = cont
          where cont s | p s = showString "\\&" s
                cont s       = s
 
+-- Unlike GHC's `asciiTab`, this is defined as a function instead of a list,
+-- since we don't have `(!!)` available for indexing.
 ascii : Chr -> Text
 ascii c = case c of
   CH("\NUL") -> "NUL"; CH("\SOH") -> "SOH"; CH("\STX") -> "STX"; CH("\ETX") -> "ETX";

--- a/compiler/damlc/daml-prim-src/GHC/Show/Text.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Show/Text.daml
@@ -84,29 +84,29 @@ showLitText : Text -> ShowS
 showLitText = showLitChrs . explode
 
 showLitChrs : [Chr] -> ShowS
-showLitChrs []               s = s
-showLitChrs (CH("\"") :: cs) s = showString "\\\"" (showLitChrs cs s)
-showLitChrs (c        :: cs) s = showLitChr c (showLitChrs cs s)
+showLitChrs []               = \s -> s
+showLitChrs (CH("\"") :: cs) = showString "\\\"" . showLitChrs cs
+showLitChrs (c        :: cs) = showLitChr c . showLitChrs cs
 
 showLitChr : Chr -> ShowS
-showLitChr c s | c > CH("\DEL")       = showString "\\" (protectEsc startsWithDigit (showInt (ord c)) s)
-showLitChr CH("\DEL")               s = showString "\\DEL" s
-showLitChr CH("\\")                 s = showString "\\\\" s
-showLitChr c@(CH(t)) s | c >= CH(" ") = showString t s
-showLitChr CH("\a")                 s = showString "\\a" s
-showLitChr CH("\b")                 s = showString "\\b" s
-showLitChr CH("\f")                 s = showString "\\f" s
-showLitChr CH("\n")                 s = showString "\\n" s
-showLitChr CH("\r")                 s = showString "\\r" s
-showLitChr CH("\t")                 s = showString "\\t" s
-showLitChr CH("\v")                 s = showString "\\v" s
-showLitChr CH("\SO")                s = protectEsc startsWithUppercaseH (showString "\\SO") s
-showLitChr c                        s = showString ("\\" ++ ascii c) s
+showLitChr c | c > CH("\DEL")       = showString "\\" . showInt (ord c) . protectEsc startsWithDigit
+showLitChr CH("\DEL")               = showString "\\DEL"
+showLitChr CH("\\")                 = showString "\\\\"
+showLitChr c@(CH(t)) | c >= CH(" ") = showString t
+showLitChr CH("\a")                 = showString "\\a"
+showLitChr CH("\b")                 = showString "\\b"
+showLitChr CH("\f")                 = showString "\\f"
+showLitChr CH("\n")                 = showString "\\n"
+showLitChr CH("\r")                 = showString "\\r"
+showLitChr CH("\t")                 = showString "\\t"
+showLitChr CH("\v")                 = showString "\\v"
+showLitChr CH("\SO")                = showString "\\SO" . protectEsc startsWithUppercaseH
+showLitChr c                        = showString "\\" . showString (ascii c)
 
-protectEsc : (Text -> Bool) -> ShowS -> ShowS
-protectEsc p f = f . cont
-               where cont s | p s = showString "\\&" s
-                     cont s       = s
+protectEsc : (Text -> Bool) -> ShowS
+protectEsc p = cont
+         where cont s | p s = showString "\\&" s
+               cont s       = s
 
 ascii : Chr -> Text
 ascii c = case c of

--- a/compiler/damlc/tests/daml-test-files/ShowText.daml
+++ b/compiler/damlc/tests/daml-test-files/ShowText.daml
@@ -6,7 +6,7 @@
 module ShowText where
 
 import DA.Foldable (forA_)
-import DA.Text (explode, implode, toCodePoints, unlines)
+import DA.Text (explode, fromCodePoints, implode, toCodePoints, unlines)
 
 -- # Setup
 
@@ -192,3 +192,8 @@ control_RS =
 
 control_US =
   "\US" ==> "\"\\US\""
+
+exhaustive = scenario do
+  forA_ [0..255] \i -> do
+    debugRaw ("exhaustive [" <> show i <> "/255]")
+    debugRaw (show (fromCodePoints [i]))

--- a/compiler/damlc/tests/daml-test-files/ShowText.daml
+++ b/compiler/damlc/tests/daml-test-files/ShowText.daml
@@ -1,0 +1,191 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @ENABLE-SCENARIOS
+
+module ShowText where
+
+import DA.Foldable (forA_)
+import DA.Text (explode, implode, toCodePoints, unlines)
+
+-- # Setup
+
+testCase : Text -> Text -> Scenario ()
+testCase input expectedOutput = do
+  let actualOutput = show input
+  if expectedOutput == actualOutput
+    then pure ()
+    else assertFail $ unlines
+      [ "ShowText.testCase failed:"
+      , "|              input          = " <> show input
+      , "| toCodePoints input          = " <> show (toCodePoints input)
+      , "|              expectedOutput = " <> show expectedOutput
+      , "| toCodePoints expectedOutput = " <> show (toCodePoints expectedOutput)
+      , "|              actualOutput   = " <> show actualOutput
+      , "| toCodePoints actualOutput   = " <> show (toCodePoints actualOutput)
+      ]
+
+infix 2 ==>
+(==>) : Text -> Text -> Scenario ()
+(==>) = testCase
+
+longStringOf : Text -> Text
+longStringOf = implode . replicate 10000
+
+-- # Test cases
+
+empty_string =
+  "" ==> "\"\""
+
+double_quote =
+  "\"" ==> "\"\\\"\""
+
+beyond_ascii = do
+  "é" ==> "\"\\233\""
+  "éx" ==> "\"\\233x\""
+  "é" <> "x" ==> "\"\\233x\""
+  "é0" ==> "\"\\233\\&0\""
+  "é" <> "0" ==> "\"\\233\\&0\""
+  "\233" ==> "\"\\233\""
+  "\233x" ==> "\"\\233x\""
+  "\233" <> "x" ==> "\"\\233x\""
+  "\2330" ==> "\"\\2330\""
+  "\233\&0" ==> "\"\\233\\&0\""
+  "\233" <> "0" ==> "\"\\233\\&0\""
+  "é" <> exes ==> "\"\\233" <> exes <> "\""
+  "\233" <> exes ==> "\"\\233" <> exes <> "\""
+  "é" <> zeros ==> "\"\\233\\&" <> zeros <> "\""
+  "\233" <> zeros ==> "\"\\233\\&" <> zeros <> "\""
+  where
+    exes = longStringOf "x"
+    zeros = longStringOf "0"
+
+backslash =
+  "\\" ==> "\"\\\\\""
+
+printables =
+  forA_ (explode printableChars) \c ->
+    c ==> "\"" <> c <> "\""
+  where
+    printableChars =
+      " !#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+
+control_NUL =
+  "\NUL" ==> "\"\\NUL\""
+
+control_SOH =
+  "\SOH" ==> "\"\\SOH\""
+
+control_STX =
+  "\STX" ==> "\"\\STX\""
+
+control_ETX =
+  "\ETX" ==> "\"\\ETX\""
+
+control_EOT =
+  "\EOT" ==> "\"\\EOT\""
+
+control_ENQ =
+  "\ENQ" ==> "\"\\ENQ\""
+
+control_ACK =
+  "\ACK" ==> "\"\\ACK\""
+
+control_BEL = do
+  -- Note portable representation!
+  "\a" ==> "\"\\a\""
+  "\BEL" ==> "\"\\a\""
+
+control_BS = do
+  -- Note portable representation!
+  "\b" ==> "\"\\b\""
+  "\BS" ==> "\"\\b\""
+
+control_HT = do
+  -- Note portable representation!
+  "\t" ==> "\"\\t\""
+  "\HT" ==> "\"\\t\""
+
+control_LF = do
+  -- Note portable representation!
+  "\n" ==> "\"\\n\""
+  "\LF" ==> "\"\\n\""
+
+control_VT = do
+  -- Note portable representation!
+  "\v" ==> "\"\\v\""
+  "\VT" ==> "\"\\v\""
+
+control_FF = do
+  -- Note portable representation!
+  "\f" ==> "\"\\f\""
+  "\FF" ==> "\"\\f\""
+
+control_CR = do
+  -- Note portable representation!
+  "\r" ==> "\"\\r\""
+  "\CR" ==> "\"\\r\""
+
+control_SO = do
+  "\SO" ==> "\"\\SO\""
+  "\SOh" ==> "\"\\SOh\""
+  "\SO\&h" ==> "\"\\SOh\""
+  "\SO" <> "h" ==> "\"\\SOh\""
+  "\SO\&H" ==> "\"\\SO\\&H\""
+  "\SO" <> "H" ==> "\"\\SO\\&H\""
+  "\SO" <> lowercaseHs ==> "\"\\SO" <> lowercaseHs <> "\""
+  "\SO" <> uppercaseHs ==> "\"\\SO\\&" <> uppercaseHs <> "\""
+  where
+    lowercaseHs = longStringOf "h"
+    uppercaseHs = longStringOf "H"
+
+control_SI =
+  "\SI" ==> "\"\\SI\""
+
+control_DLE =
+  "\DLE" ==> "\"\\DLE\""
+
+control_DC1 =
+  "\DC1" ==> "\"\\DC1\""
+
+control_DC2 =
+  "\DC2" ==> "\"\\DC2\""
+
+control_DC3 =
+  "\DC3" ==> "\"\\DC3\""
+
+control_DC4 =
+  "\DC4" ==> "\"\\DC4\""
+
+control_NAK =
+  "\NAK" ==> "\"\\NAK\""
+
+control_SYN =
+  "\SYN" ==> "\"\\SYN\""
+
+control_ETB =
+  "\ETB" ==> "\"\\ETB\""
+
+control_CAN =
+  "\CAN" ==> "\"\\CAN\""
+
+control_EM =
+  "\EM" ==> "\"\\EM\""
+
+control_SUB =
+  "\SUB" ==> "\"\\SUB\""
+
+control_ESC =
+  "\ESC" ==> "\"\\ESC\""
+
+control_FS =
+  "\FS" ==> "\"\\FS\""
+
+control_GS =
+  "\GS" ==> "\"\\GS\""
+
+control_RS =
+  "\RS" ==> "\"\\RS\""
+
+control_US =
+  "\US" ==> "\"\\US\""

--- a/compiler/damlc/tests/daml-test-files/ShowText.daml
+++ b/compiler/damlc/tests/daml-test-files/ShowText.daml
@@ -29,8 +29,11 @@ infix 2 ==>
 (==>) : Text -> Text -> Scenario ()
 (==>) = testCase
 
+longStringSize : Int
+longStringSize = 10000
+
 longStringOf : Text -> Text
-longStringOf = implode . replicate 10000
+longStringOf = implode . replicate longStringSize
 
 -- # Test cases
 

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DarReaderTest.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DarReaderTest.scala
@@ -77,6 +77,7 @@ class DarReaderTest
       archiveModuleNames shouldBe Set(
         "GHC.Enum",
         "GHC.Show",
+        "GHC.Show.Text",
         "GHC.Num",
         "GHC.Stack.Types",
         "GHC.Classes",


### PR DESCRIPTION
Closes https://github.com/digital-asset/daml/issues/15177

While checking the effects on Daml Studio, I found at least five other places that display strings not quite correctly:
* [compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs:903](https://github.com/digital-asset/daml/blob/main/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs#L903)
* [daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala:431](https://github.com/digital-asset/daml/blob/main/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala#L431)
* [daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala:498](https://github.com/digital-asset/daml/blob/main/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala#L498)
* [daml-script/export/src/main/scala/com/daml/script/export/Encode.scala:199-201](https://github.com/digital-asset/daml/blob/main/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala#L199-L201)
* [language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/ShowEncoding.scala:140-150](https://github.com/digital-asset/daml/blob/main/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/ShowEncoding.scala#L140-L150)

For the first one, since it's in Haskell, the fix would be to simply use the `Show` instance of `Text` (which matches that for `String`). For the rest, in Scala, we would need to re-implement the encoding in a common place and reuse it.