### PR TITLE
Generalize the <?> operator to support a generic error type

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Validation.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Validation.daml
@@ -87,8 +87,8 @@ instance Traversable (Validation err) where
     mapA _ (Errors x) = pure $ Errors x
     mapA f (Success x) = Success <$> f x
 
--- | Convert an `Optional t` into a `Validation Text t`, or
+-- | Convert an `Optional t` into a `Validation err t`, or
 -- more generally into an `m t` for any `ActionFail` type `m`.
-(<?>) : Optional b -> Text -> Validation Text b
+(<?>) : Optional b -> err -> Validation err b
 None <?> s = invalid s
 Some v <?> _ = pure v


### PR DESCRIPTION
The original implementation forces the caller to always use `Text` as the error type. This seems unnecessarily restrictive as the types can be polymorphic on the caller's side.

CHANGELOG_BEGIN
* [Stdlib] Generalize the <?> operator to support a generic type for Validation
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
