### PR TITLE
[DPP-1278] User/party management: do not assert on detailed error mes…

### DIFF
--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/FutureAssertions.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/FutureAssertions.scala
@@ -13,10 +13,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 
-case class ExpectedErrorDescription(
-    errorCode: ErrorCode,
-    exceptionMessageSubstring: Option[String],
-)
 final class FutureAssertions[T](future: Future[T]) {
 
   /** Checks that the future failed, and returns the throwable.
@@ -35,21 +31,10 @@ final class FutureAssertions[T](future: Future[T]) {
   )(implicit executionContext: ExecutionContext): Future[Throwable] =
     handle(predicate, context)
 
-  // TODO um-for-hub: Delete me
-  def mustFailWith(
-      context: String,
-      expected: ExpectedErrorDescription,
-  )(implicit executionContext: ExecutionContext): Future[Unit] =
-    mustFailWith(
-      context = context,
-      errorCode = expected.errorCode,
-      exceptionMessageSubstring = expected.exceptionMessageSubstring,
-    )
-
   def mustFailWith(
       context: String,
       errorCode: ErrorCode,
-      exceptionMessageSubstring: Option[String],
+      exceptionMessageSubstring: Option[String] = None,
   )(implicit executionContext: ExecutionContext): Future[Unit] = {
     for {
       error <- mustFail(context)

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/PartyManagementServiceIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/PartyManagementServiceIT.scala
@@ -136,9 +136,6 @@ final class PartyManagementServiceIT extends PartyManagementITBase {
         .mustFailWith(
           "allocating a party",
           LedgerApiErrors.RequestValidation.InvalidArgument,
-          Some(
-            "INVALID_ARGUMENT: INVALID_ARGUMENT(8,0): The submitted command has invalid arguments: The value of an annotation is empty for key: 'key2'"
-          ),
         )
     } yield ()
   })

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/PartyManagementServiceUpdateRpcIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/PartyManagementServiceUpdateRpcIT.scala
@@ -103,9 +103,6 @@ class PartyManagementServiceUpdateRpcIT extends PartyManagementITBase {
           .mustFailWith(
             "bad annotations key syntax on a user update",
             errorCode = LedgerApiErrors.Admin.PartyManagement.InvalidUpdatePartyDetailsRequest,
-            exceptionMessageSubstring = Some(
-              s"INVALID_ARGUMENT: INVALID_PARTY_DETAILS_UPDATE_REQUEST(8,0): Update operation for party '${partyDetails.party}' failed due to: Update request attempted to modify not-modifiable 'is_local' attribute"
-            ),
           )
   )
 
@@ -129,9 +126,6 @@ class PartyManagementServiceUpdateRpcIT extends PartyManagementITBase {
           .mustFailWith(
             "bad annotations key syntax on a user update",
             errorCode = LedgerApiErrors.Admin.PartyManagement.InvalidUpdatePartyDetailsRequest,
-            exceptionMessageSubstring = Some(
-              s"INVALID_ARGUMENT: INVALID_PARTY_DETAILS_UPDATE_REQUEST(8,0): Update operation for party '${partyDetails.party}' failed due to: Update request attempted to modify not-modifiable 'display_name' attribute"
-            ),
           )
   )
 
@@ -207,9 +201,6 @@ class PartyManagementServiceUpdateRpcIT extends PartyManagementITBase {
       .mustFailWith(
         "update with an unknown update path",
         errorCode = LedgerApiErrors.RequestValidation.MissingField,
-        exceptionMessageSubstring = Some(
-          s"INVALID_ARGUMENT: MISSING_FIELD(8,0): The submitted command is missing a mandatory field: party_details"
-        ),
       )
   })
 
@@ -232,9 +223,6 @@ class PartyManagementServiceUpdateRpcIT extends PartyManagementITBase {
         .mustFailWith(
           "updating a non-existent party",
           errorCode = LedgerApiErrors.Admin.PartyManagement.PartyNotFound,
-          exceptionMessageSubstring = Some(
-            s"NOT_FOUND: PARTY_NOT_FOUND(11,0): Party: '$party' was not found when updating a party record"
-          ),
         )
     } yield ()
   })

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/UserManagementServiceIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/UserManagementServiceIT.scala
@@ -420,9 +420,7 @@ final class UserManagementServiceIT extends UserManagementServiceITBase {
       assertGrpcError(
         res,
         LedgerApiErrors.RequestValidation.InvalidArgument,
-        exceptionMessageSubstring = Some(
-          "The submitted command has invalid arguments: field user.metadata.resource_version must be not set"
-        ),
+        exceptionMessageSubstring = Some("user.metadata.resource_version"),
       )
     }
   })

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/UserManagementServiceUpdateRpcIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/UserManagementServiceUpdateRpcIT.scala
@@ -101,9 +101,7 @@ class UserManagementServiceUpdateRpcIT extends UserManagementServiceITBase {
           .mustFailWith(
             "update with an unknown update path",
             errorCode = LedgerApiErrors.RequestValidation.MissingField,
-            exceptionMessageSubstring = Some(
-              s"INVALID_ARGUMENT: MISSING_FIELD(8,0): The submitted command is missing a mandatory field: user"
-            ),
+            exceptionMessageSubstring = Some("missing a mandatory field: user"),
           )
   )
 
@@ -125,9 +123,6 @@ class UserManagementServiceUpdateRpcIT extends UserManagementServiceITBase {
         .mustFailWith(
           "updating non-existent party",
           errorCode = LedgerApiErrors.Admin.UserManagement.UserNotFound,
-          exceptionMessageSubstring = Some(
-            s"NOT_FOUND: USER_NOT_FOUND(11,0): updating user failed for unknown user \"$userId1\""
-          ),
         )
     } yield ()
   })
@@ -149,9 +144,6 @@ class UserManagementServiceUpdateRpcIT extends UserManagementServiceITBase {
           .mustFailWith(
             "update with an unknown update path",
             errorCode = LedgerApiErrors.RequestValidation.InvalidField,
-            exceptionMessageSubstring = Some(
-              s"INVALID_ARGUMENT: INVALID_FIELD(8,0): The submitted command has a field with invalid value: Invalid field user.id: User ID \"%%!!!\" does not match regex \"[a-z0-9@^$$.!`\\-#+'~_|:]{1,128}\""
-            ),
           )
   )
 

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/objectmeta/ObjectMetaTests.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/objectmeta/ObjectMetaTests.scala
@@ -97,9 +97,7 @@ trait ObjectMetaTests extends ObjectMetaTestsBase {
             updatePaths = Seq(annotationsUpdatePath),
           ).mustFailWith(
             "updating a resource using an outdated resource version",
-            concurrentUserUpdateDetectedErrorDescription(
-              id = getId(resource)
-            ),
+            concurrentUserUpdateDetectedErrorCode,
           )
           // Updating a resource with the concurrent change detection enabled and prlviding the up-to-date resource version
           _ <- update(
@@ -178,10 +176,7 @@ trait ObjectMetaTests extends ObjectMetaTestsBase {
           updatePaths = Seq(annotationsUpdatePath, annotationsUpdatePath),
         ).mustFailWith(
           "updating a resource",
-          invalidUpdateRequestErrorDescription(
-            id = getId(resource),
-            errorMessageSuffix = s"The update path: '$annotationsUpdatePath' is duplicated.",
-          ),
+          invalidUpdateRequestErrorCode,
         )
   )
 
@@ -198,10 +193,7 @@ trait ObjectMetaTests extends ObjectMetaTestsBase {
         )
           .mustFailWith(
             "updating a resource",
-            invalidUpdateRequestErrorDescription(
-              id = getId(resource),
-              errorMessageSuffix = "The update mask contains no entries",
-            ),
+            invalidUpdateRequestErrorCode,
           )
   )
 
@@ -218,10 +210,7 @@ trait ObjectMetaTests extends ObjectMetaTestsBase {
             updatePaths = Seq("unknown_field"),
           ).mustFailWith(
             "fail 1",
-            invalidUpdateRequestErrorDescription(
-              id = getId(resource),
-              errorMessageSuffix = "The update path: 'unknown_field' points to an unknown field.",
-            ),
+            invalidUpdateRequestErrorCode,
           )
           _ <- update(
             id = getId(resource),
@@ -229,10 +218,7 @@ trait ObjectMetaTests extends ObjectMetaTestsBase {
             updatePaths = Seq("aaa!bbb"),
           ).mustFailWith(
             "fail 2",
-            invalidUpdateRequestErrorDescription(
-              id = getId(resource),
-              errorMessageSuffix = "The update path: 'aaa!bbb' points to an unknown field.",
-            ),
+            invalidUpdateRequestErrorCode,
           )
           _ <- update(
             id = getId(resource),
@@ -240,10 +226,7 @@ trait ObjectMetaTests extends ObjectMetaTestsBase {
             updatePaths = Seq(""),
           ).mustFailWith(
             "fail 3",
-            invalidUpdateRequestErrorDescription(
-              id = getId(resource),
-              errorMessageSuffix = "The update path: '' points to an unknown field.",
-            ),
+            invalidUpdateRequestErrorCode,
           )
         } yield ()
   )

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/objectmeta/ObjectMetaTestsBase.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/objectmeta/ObjectMetaTestsBase.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites.v1_8.objectmeta
 
-import com.daml.ledger.api.testtool.infrastructure.ExpectedErrorDescription
+import com.daml.error.ErrorCode
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
 import com.daml.ledger.api.v1.admin.object_meta.ObjectMeta
 
@@ -69,13 +69,8 @@ trait ObjectMetaTestsBase {
     assert(v.nonEmpty, s"resource version (from $sourceMsg) must be non empty")
   }
 
-  private[objectmeta] def concurrentUserUpdateDetectedErrorDescription(
-      id: ResourceId
-  ): ExpectedErrorDescription
+  private[objectmeta] def concurrentUserUpdateDetectedErrorCode: ErrorCode
 
-  private[objectmeta] def invalidUpdateRequestErrorDescription(
-      id: ResourceId,
-      errorMessageSuffix: String,
-  ): ExpectedErrorDescription
+  private[objectmeta] def invalidUpdateRequestErrorCode: ErrorCode
 
 }

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/objectmeta/PartyManagementServiceObjectMetaIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/objectmeta/PartyManagementServiceObjectMetaIT.scala
@@ -3,8 +3,8 @@
 
 package com.daml.ledger.api.testtool.suites.v1_8.objectmeta
 
+import com.daml.error.ErrorCode
 import com.daml.error.definitions.LedgerApiErrors
-import com.daml.ledger.api.testtool.infrastructure.ExpectedErrorDescription
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
 import com.daml.ledger.api.testtool.suites.v1_8.PartyManagementITBase
 import com.daml.ledger.api.v1.admin.object_meta.ObjectMeta
@@ -104,23 +104,9 @@ class PartyManagementServiceObjectMetaIT extends PartyManagementITBase with Obje
       .map(_.getPartyDetails.getLocalMetadata)
   }
 
-  override private[objectmeta] def concurrentUserUpdateDetectedErrorDescription(
-      id: ResourceId
-  ): ExpectedErrorDescription = ExpectedErrorDescription(
-    errorCode = LedgerApiErrors.Admin.PartyManagement.ConcurrentPartyDetailsUpdateDetected,
-    exceptionMessageSubstring = Some(
-      s"ABORTED: CONCURRENT_PARTY_DETAILS_UPDATE_DETECTED(2,0): Update operation for party '${id}' failed due to a concurrent update to the same party"
-    ),
-  )
+  override private[objectmeta] def concurrentUserUpdateDetectedErrorCode: ErrorCode =
+    LedgerApiErrors.Admin.PartyManagement.ConcurrentPartyDetailsUpdateDetected
 
-  override private[objectmeta] def invalidUpdateRequestErrorDescription(
-      id: ResourceId,
-      errorMessageSuffix: String,
-  ): ExpectedErrorDescription = ExpectedErrorDescription(
-    errorCode = LedgerApiErrors.Admin.PartyManagement.InvalidUpdatePartyDetailsRequest,
-    exceptionMessageSubstring = Some(
-      s"INVALID_ARGUMENT: INVALID_PARTY_DETAILS_UPDATE_REQUEST(8,0): Update operation for party '${id}' failed due to: $errorMessageSuffix"
-    ),
-  )
-
+  override private[objectmeta] def invalidUpdateRequestErrorCode: ErrorCode =
+    LedgerApiErrors.Admin.PartyManagement.InvalidUpdatePartyDetailsRequest
 }

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/objectmeta/UserManagementServiceObjectMetaIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/objectmeta/UserManagementServiceObjectMetaIT.scala
@@ -6,8 +6,8 @@
 
 package com.daml.ledger.api.testtool.suites.v1_8.objectmeta
 
+import com.daml.error.ErrorCode
 import com.daml.error.definitions.LedgerApiErrors
-import com.daml.ledger.api.testtool.infrastructure.ExpectedErrorDescription
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
 import com.daml.ledger.api.testtool.suites.v1_8.UserManagementServiceITBase
 import com.daml.ledger.api.v1.admin.object_meta.ObjectMeta
@@ -122,23 +122,8 @@ class UserManagementServiceObjectMetaIT extends UserManagementServiceITBase with
       .map(_.getUser.getMetadata)
   }
 
-  override private[objectmeta] def concurrentUserUpdateDetectedErrorDescription(
-      id: ResourceId
-  ): ExpectedErrorDescription = ExpectedErrorDescription(
-    errorCode = LedgerApiErrors.Admin.UserManagement.ConcurrentUserUpdateDetected,
-    exceptionMessageSubstring = Some(
-      s"ABORTED: CONCURRENT_USER_UPDATE_DETECTED(2,0): Update operation for user '${id}' failed due to a concurrent update to the same user"
-    ),
-  )
-
-  override private[objectmeta] def invalidUpdateRequestErrorDescription(
-      id: ResourceId,
-      errorMessageSuffix: String,
-  ): ExpectedErrorDescription = ExpectedErrorDescription(
-    errorCode = LedgerApiErrors.Admin.UserManagement.InvalidUpdateUserRequest,
-    exceptionMessageSubstring = Some(
-      s"INVALID_ARGUMENT: INVALID_USER_UPDATE_REQUEST(8,0): Update operation for user id '${id}' failed due to: $errorMessageSuffix"
-    ),
-  )
-
+  override private[objectmeta] def concurrentUserUpdateDetectedErrorCode: ErrorCode =
+    LedgerApiErrors.Admin.UserManagement.ConcurrentUserUpdateDetected
+  override private[objectmeta] def invalidUpdateRequestErrorCode: ErrorCode =
+    LedgerApiErrors.Admin.UserManagement.InvalidUpdateUserRequest
 }


### PR DESCRIPTION
…sages in conformance tests as they should not be subject to compatibility checking.

By doing this change we are loosing some detailed test coverage, but preventing future spurious compatibility tests failures.

(Another idea would be to have a "is_compatiblity_testing" boolean available and use it to disable those detailed assertions when actually running the compat suite)



changelog_begin
changelog_end
