### PR TITLE
no linting suggestions in intro code samlpes

### DIFF
--- a/docs/source/daml/intro/daml/daml-intro-10/.dlint.yaml
+++ b/docs/source/daml/intro/daml/daml-intro-10/.dlint.yaml
@@ -1,3 +1,2 @@
-- ignore: {name: Use if}
 - ignore: {name: Use when}
 - ignore: {name: Use sum}

--- a/docs/source/daml/intro/daml/daml-intro-10/.dlint.yaml
+++ b/docs/source/daml/intro/daml/daml-intro-10/.dlint.yaml
@@ -1,0 +1,3 @@
+- ignore: {name: Use if}
+- ignore: {name: Use when}
+- ignore: {name: Use sum}

--- a/docs/source/daml/intro/daml/daml-intro-10/.dlint.yaml
+++ b/docs/source/daml/intro/daml/daml-intro-10/.dlint.yaml
@@ -1,2 +1,5 @@
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 - ignore: {name: Use when}
 - ignore: {name: Use sum}

--- a/docs/source/daml/intro/daml/daml-intro-3/.dlint.yaml
+++ b/docs/source/daml/intro/daml/daml-intro-3/.dlint.yaml
@@ -1,0 +1,2 @@
+- ignore: {name: Use === for better error messages}
+- ignore: {name: Use isNone}

--- a/docs/source/daml/intro/daml/daml-intro-3/.dlint.yaml
+++ b/docs/source/daml/intro/daml/daml-intro-3/.dlint.yaml
@@ -1,2 +1,5 @@
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 - ignore: {name: Use === for better error messages}
 - ignore: {name: Use isNone}

--- a/docs/source/daml/intro/daml/daml-intro-4/.dlint.yaml
+++ b/docs/source/daml/intro/daml/daml-intro-4/.dlint.yaml
@@ -1,0 +1,1 @@
+- ignore: {name: Use === for better error messages}

--- a/docs/source/daml/intro/daml/daml-intro-4/.dlint.yaml
+++ b/docs/source/daml/intro/daml/daml-intro-4/.dlint.yaml
@@ -1,1 +1,4 @@
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 - ignore: {name: Use === for better error messages}

--- a/docs/source/daml/intro/daml/daml-intro-5/.dlint.yaml
+++ b/docs/source/daml/intro/daml/daml-intro-5/.dlint.yaml
@@ -1,0 +1,1 @@
+- ignore: {name: Use === for better error messages}

--- a/docs/source/daml/intro/daml/daml-intro-5/.dlint.yaml
+++ b/docs/source/daml/intro/daml/daml-intro-5/.dlint.yaml
@@ -1,1 +1,4 @@
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 - ignore: {name: Use === for better error messages}

--- a/docs/source/daml/intro/daml/daml-intro-6/.dlint.yaml
+++ b/docs/source/daml/intro/daml/daml-intro-6/.dlint.yaml
@@ -1,0 +1,1 @@
+- ignore: {name: Use === for better error messages}

--- a/docs/source/daml/intro/daml/daml-intro-6/.dlint.yaml
+++ b/docs/source/daml/intro/daml/daml-intro-6/.dlint.yaml
@@ -1,1 +1,4 @@
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 - ignore: {name: Use === for better error messages}

--- a/docs/source/daml/intro/daml/daml-intro-7/.dlint.yaml
+++ b/docs/source/daml/intro/daml/daml-intro-7/.dlint.yaml
@@ -1,0 +1,1 @@
+- ignore: {name: Use === for better error messages}

--- a/docs/source/daml/intro/daml/daml-intro-7/.dlint.yaml
+++ b/docs/source/daml/intro/daml/daml-intro-7/.dlint.yaml
@@ -1,1 +1,4 @@
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 - ignore: {name: Use === for better error messages}

--- a/docs/source/daml/intro/daml/daml-intro-9/.dlint.yaml
+++ b/docs/source/daml/intro/daml/daml-intro-9/.dlint.yaml
@@ -1,0 +1,1 @@
+- ignore: {name: Use === for better error messages}

--- a/docs/source/daml/intro/daml/daml-intro-9/.dlint.yaml
+++ b/docs/source/daml/intro/daml/daml-intro-9/.dlint.yaml
@@ -1,1 +1,4 @@
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 - ignore: {name: Use === for better error messages}


### PR DESCRIPTION
Ideally, we should not have default warnings triggered by our introductory examples. There may be a broader discussion needed around what exactly the default linting options should be (and I'll take this opportunity to re-plug my idea of having all the possible options in the default `.dlint.yaml`), but in the meantime I think it's distracting for our users if our intro templates seem to have issues in the IDE.

CHANGELOG_BEGIN
CHANGELOG_END