### PR TITLE
check whether bad code in quickstart-java fails the build

### DIFF
--- a/docs/source/app-dev/bindings-java/quickstart/template-root/src/main/java/com/daml/quickstart/iou/IouMain.java
+++ b/docs/source/app-dev/bindings-java/quickstart/template-root/src/main/java/com/daml/quickstart/iou/IouMain.java
@@ -27,7 +27,7 @@ public class IouMain {
   private static final Logger logger = LoggerFactory.getLogger(IouMain.class);
 
   // application id used for sending commands
-  public static final String APP_ID = "IouApp";
+  public static final int APP_ID = "IouApp";
 
   public static void main(String[] args) {
     // Extract host and port from arguments


### PR DESCRIPTION
It's built with `//docs:quickstart-java-lib`.

```
ERROR: /home/vsts/agent/_work/2/s/docs/BUILD.bazel:631:12: Building docs/quickstart-java-lib.jar (1 source file, 1 source jar) failed: (Exit 1): java failed: error executing command 
~~snip~~
docs/source/app-dev/bindings-java/quickstart/template-root/src/main/java/com/daml/quickstart/iou/IouMain.java:30: error: incompatible types: String cannot be converted to int
  public static final int APP_ID = "IouApp";
                                   ^
```