### PR TITLE
replace `x -> d.decode(x)` with `d` in Java codegen output

### DIFF
--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromValueGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromValueGenerator.scala
@@ -294,7 +294,7 @@ private[inner] object FromValueGenerator extends StrictLogging {
     def oneTypeArgPrim(primFun: String, param: Type): Extractor =
       Decoder(
         CodeBlock.of(
-          "$T.$L($L)",
+          "$T.$L($>$Z$L$<)",
           classOf[PrimitiveValueDecoders],
           primFun,
           go(param),
@@ -338,7 +338,7 @@ private[inner] object FromValueGenerator extends StrictLogging {
       case TypePrim(PrimTypeGenMap, ImmArraySeq(keyType, valueType)) =>
         Decoder(
           CodeBlock.of(
-            "$T.fromGenMap($L,$W$L)",
+            "$T.fromGenMap($>$Z$L,$W$L$<)",
             classOf[PrimitiveValueDecoders],
             go(keyType),
             go(valueType),


### PR DESCRIPTION
While the lambda is _almost_ equivalent, it loses any custom `fromContractId` that might have been defined in `d`. By tracking "real" `ValueDecoder` expressions, we can avoid needless _eta_-expansion that removes that evidence.

```java
// We used to generate
Map<Optional<Long>, String> field = PrimitiveValueDecoders.fromGenMap(v$0 ->
      PrimitiveValueDecoders.fromOptional(v$1 -> PrimitiveValueDecoders.fromInt64.decode(v$1))
      .decode(v$0), v$0 -> PrimitiveValueDecoders.fromText.decode(v$0))
    .decode(fields$.get(0).getValue());

// now we generate
Map<Optional<Long>, String> field = PrimitiveValueDecoders.fromGenMap(
      PrimitiveValueDecoders.fromOptional(PrimitiveValueDecoders.fromInt64),
      PrimitiveValueDecoders.fromText).decode(fields$.get(0).getValue());
```

