### PR TITLE
review daml-intro-10

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -718,15 +718,25 @@ daml_test(
 )
 
 daml_test(
-    name = "daml-intro-daml-test",
+    name = "daml-intro-daml-test-excl-8-9-10",
     srcs = glob(
         ["source/daml/intro/daml/**/*.daml"],
         exclude = [
             "source/daml/intro/daml/daml-intro-8/**",
             "source/daml/intro/daml/daml-intro-9/**",
+            "source/daml/intro/daml/daml-intro-10/**",
         ],
     ),
     deps = ["//daml-script/daml:daml-script.dar"],
+)
+
+daml_test(
+    name = "daml-intro-daml-10-test",
+    srcs = glob(
+        ["source/daml/intro/daml/daml-intro-10/**/*.daml"],
+    ),
+    deps = ["//daml-script/daml:daml-script.dar"],
+    additional_compiler_flags = ["--ghc-option=-Wwarn=incomplete-patterns"],
 )
 
 daml_test(

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -735,8 +735,8 @@ daml_test(
     srcs = glob(
         ["source/daml/intro/daml/daml-intro-10/**/*.daml"],
     ),
-    deps = ["//daml-script/daml:daml-script.dar"],
     additional_compiler_flags = ["--ghc-option=-Wwarn=incomplete-patterns"],
+    deps = ["//daml-script/daml:daml-script.dar"],
 )
 
 daml_test(

--- a/docs/source/daml/intro/10_Functional101.rst
+++ b/docs/source/daml/intro/10_Functional101.rst
@@ -31,7 +31,7 @@ The previous chapters of this introduction to Daml have mostly covered the struc
 When comparing Daml to Haskell it's worth noting:
 
 -   Haskell is a lazy language, which allows you to write things like ``head [1..]``, meaning "take the first element of an infinite list". Daml by contrast is strict. Expressions are fully evaluated, which means it is not possible to work with infinite data structures.
-- Daml has a ``with`` syntax for records, and dot syntax for record field access, neither of which is present in Haskell. But Daml supports Haskell's curly brace record notation.
+- Daml has a ``with`` syntax for records and dot syntax for record field access, neither of which is present in Haskell. However, Daml supports Haskell's curly brace record notation.
 - Daml has a number of Haskell compiler extensions active by default.
 - Daml doesn't support all features of Haskell's type system. For example, there are no existential types or GADTs.
 - Actions are called Monads in Haskell.

--- a/docs/source/daml/intro/10_Functional101.rst
+++ b/docs/source/daml/intro/10_Functional101.rst
@@ -77,7 +77,7 @@ There are two interesting things going on here:
 Function Application
 ....................
 
-Let's start by looking at the right hand part ``a -> a -> a``. The ``->`` is right associative, meaning ``a -> a -> a`` is equivalent to ``a -> (a -> a)``. Using the "maps to" way of reading ``->`` we get "``a`` maps to a function that maps ``a`` to ``a``".
+Let's start by looking at the right hand part ``a -> a -> a``. The ``->`` is right associative, meaning ``a -> a -> a`` is equivalent to ``a -> (a -> a)``. Using the "maps to" way of reading ``->``, we get "``a`` maps to a function that maps ``a`` to ``a``".
 
 And this is indeed what happens. We can define a different version of ``increment`` by *partially applying* ``add``:
 

--- a/docs/source/daml/intro/10_Functional101.rst
+++ b/docs/source/daml/intro/10_Functional101.rst
@@ -135,7 +135,7 @@ Let's turn this into prose: Given that ``t`` is the type of a template, and that
 
 That's quite a mouthful, and does require one to know what *meaning* the typeclass ``Choice`` gives to parameters ``t`` ``c`` and ``r``, but in many cases, that's obvious from the context or names of typeclasses and variables.
 
-Note that using single letters, while common, is not mandatory. The above may be made a little bit clearer by expanding the type parameter names, at the cost of making the code a bit longer:
+Using single letters, while common, is not mandatory. The above may be made a little bit clearer by expanding the type parameter names, at the cost of making the code a bit longer:
 
 .. code-block:: daml
 
@@ -203,7 +203,7 @@ You have probably already guessed it: Anywhere you can put a value in Daml you c
   :start-after: -- FUNCTION_IN_DATA_BEGIN
   :end-before: -- FUNCTION_IN_DATA_END
 
-More commonly, it makes sense to define functions locally, inside a ``let`` clause or similar. A good example of this are the ``validate`` and ``transfer`` functions defined locally in the ``Trade_Settle`` choice of the  model from chapter 9:
+More often it makes sense to define functions locally, inside a ``let`` clause or similar. Good examples of this are the ``validate`` and ``transfer`` functions defined locally in the ``Trade_Settle`` choice of the  model from chapter 9:
 
 .. literalinclude:: daml/daml-intro-9/daml/Intro/Asset/MultiTrade.daml
   :language: daml
@@ -220,7 +220,7 @@ You can see that the function signature is inferred from the context here. If yo
 
     Bear in mind that functions are not serializable, so you can't use them inside template arguments, as choice inputs, or as choice outputs. They also don't have instances of the ``Eq`` or ``Show`` typeclasses which one would commonly want on data types.
 
-The ``mapA`` and ``mapA_`` functions loop through the lists of assets and approvals, and apply the functions ``validate`` and ``transfer`` to each element of those lists, performing the resulting ``Update`` action in the process. We'll look at that more closely under :ref:`looping` below.
+The ``mapA`` and ``mapA_`` functions loop through the lists of assets and approvals and apply the functions ``validate`` and ``transfer`` to each element of those lists, performing the resulting ``Update`` action in the process. We'll look at that more closely under :ref:`looping` below.
 
 Lambdas
 .......
@@ -459,7 +459,7 @@ In effect, the lambda passed to ``foldl`` only "wants" to act on a single elemen
   :start-after: -- SUM_ARR3_BEGIN
   :end-before: -- SUM_ARR3_END
 
-As a rule of thumb, use ``map`` if the result has the same shape as the input and you don't need to carry state from one iteration to the next. Use folds if you need to accumulate state in any way.
+As a rule, use ``map`` if the result has the same shape as the input and you don't need to carry state from one iteration to the next. Use folds if you need to accumulate state in any way.
 
 Recursion
 ~~~~~~~~~
@@ -476,7 +476,7 @@ You may be tempted to make ``reverseWorker`` a local definition inside ``reverse
 Folds and Maps in Action Contexts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The folds and ``map`` function above are pure in the sense introduced in :doc:`5_Restrictions`: The functions used to map or process items have no side-effects. If you have looked at the chapter 9 models, you'll have noticed ``mapA``, ``mapA_``, and ``forA``, that seem to serve a similar role but within ``Action``\ s . A good example is the ``mapA`` call in the ``testMultiTrade`` script:
+The folds and ``map`` function above are pure in the sense introduced in :doc:`5_Restrictions`: The functions used to map or process items have no side effects. If you have looked at the chapter 9 models, you'll have noticed ``mapA``, ``mapA_``, and ``forA``, which seem to serve a similar role but within ``Action``\ s . A good example is the ``mapA`` call in the ``testMultiTrade`` script:
 
 .. literalinclude:: daml/daml-intro-9/daml/Test/Intro/Asset/MultiTrade.daml
   :language: daml
@@ -494,7 +494,7 @@ Intuitively, it's clear how to fix this: we want the compound action consisting 
 
 The ``A`` in ``mapA`` stands for "Action", and you'll find that many functions that have something to do with "looping" have an ``A`` equivalent. The most fundamental of all of these is ``foldlA : Action m => (b -> a -> m b) -> b -> [a] -> m b``, a left fold with side effects. Here the inner function has a side-effect indicated by the ``m`` so the end result ``m b`` also has a side effect: the sum of all the side effects of the inner function.
 
-To improve your familiarity with these concepts, you could try implementing ``foldlA`` in terms of ``foldl``, as well as ``sequence`` and ``mapA`` in terms of ``foldlA``. Here is one set of possible implementations:
+To improve your familiarity with these concepts, try implementing ``foldlA`` in terms of ``foldl``, as well as ``sequence`` and ``mapA`` in terms of ``foldlA``. Here is one set of possible implementations:
 
 .. literalinclude:: daml/daml-intro-10/daml/Main.daml
   :language: daml

--- a/docs/source/daml/intro/10_Functional101.rst
+++ b/docs/source/daml/intro/10_Functional101.rst
@@ -9,7 +9,7 @@ In this chapter, you will learn more about expressing complex logic in a functio
 - Function signatures and functions
 - Advanced control flow (``if...else``, folds, recursion, ``when``)
 
-If you no longer have your chapter 7 and 8 projects set up, and want to look back at the code, please follow the setup instructions in :doc:`9_Dependencies` to get hold of the code for this chapter.
+If you no longer have your chapter 7 and 9 projects set up, and want to look back at the code, please follow the setup instructions in :doc:`9_Dependencies` to get hold of the code for this chapter.
 
 .. note::
 
@@ -31,7 +31,7 @@ The previous chapters of this introduction to Daml have mostly covered the struc
 When comparing Daml to Haskell it's worth noting:
 
 -   Haskell is a lazy language, which allows you to write things like ``head [1..]``, meaning "take the first element of an infinite list". Daml by contrast is strict. Expressions are fully evaluated, which means it is not possible to work with infinite data structures.
-- Daml has a ``with`` syntax for records, and dot syntax for record field access, neither of which present in Haskell. But Daml supports Haskell's curly brace record notation.
+- Daml has a ``with`` syntax for records, and dot syntax for record field access, neither of which is present in Haskell. But Daml supports Haskell's curly brace record notation.
 - Daml has a number of Haskell compiler extensions active by default.
 - Daml doesn't support all features of Haskell's type system. For example, there are no existential types or GADTs.
 - Actions are called Monads in Haskell.
@@ -77,7 +77,7 @@ There are two interesting things going on here:
 Function Application
 ....................
 
-Let's start by looking at the right hand part ``a -> a -> a``. The ``->`` is right associative, meaning ``a -> a -> a`` is equivalent to ``a -> (a -> a)``. Using the "maps to" way of reading ``->`` we get "a maps to a function that maps a to a".
+Let's start by looking at the right hand part ``a -> a -> a``. The ``->`` is right associative, meaning ``a -> a -> a`` is equivalent to ``a -> (a -> a)``. Using the "maps to" way of reading ``->`` we get "``a`` maps to a function that maps ``a`` to ``a``".
 
 And this is indeed what happens. We can define a different version of ``increment`` by *partially applying* ``add``:
 
@@ -88,7 +88,7 @@ And this is indeed what happens. We can define a different version of ``incremen
 
 If you try this out in your IDE, you'll see that the compiler infers type ``Int -> Int`` again. It can do so because of the literal ``1 : Int``.
 
-So if we have a function ``f : a -> b -> c -> d`` and a value ``valA : a``, we get ``f valA : b -> c -> d``, ie we can apply the function argument by argument. If we also had ``valB : b``, we would have ``f valA valB : c -> d``. What this tells you is that function *application* is left associative: ``f valA valB == (f valA) valB``.
+So if we have a function ``f : a -> b -> c -> d`` and a value ``valA : a``, we get ``f valA : b -> c -> d``, i.e. we can apply the function argument by argument. If we also had ``valB : b``, we would have ``f valA valB : c -> d``. What this tells you is that function *application* is left associative: ``f valA valB == (f valA) valB``.
 
 Infix Functions
 ...............
@@ -116,14 +116,14 @@ If we want to partially apply an infix operation we can also do that as follows:
 
 .. note::
 
-  While function application is left associative by default, infix operators can be declared left or right associative and given a precedence. Good examples are the boolean operations ``&&`` and ``||``, which are declared right associative with precedences 3, and 2, respectively. This allows you to write ``True || True && False`` and get value ``True``. See section 4.4.2 of `the Haskell 98 report <https://www.haskell.org/onlinereport/decls.html>`_ for more on fixities. 
+  While function application is left associative by default, infix operators can be declared left or right associative and given a precedence. Good examples are the boolean operations ``&&`` and ``||``, which are declared right associative with precedences 3 and 2, respectively. This allows you to write ``True || True && False`` and get value ``True``. See section 4.4.2 of `the Haskell 98 report <https://www.haskell.org/onlinereport/decls.html>`_ for more on fixities.
 
 Type Constraints
 ................
 
-The ``Additive a =>`` part of the signature of ``add`` is a type constraint on the type parameter ``a``. ``Additive`` here is a typeclass. You already met typeclasses like ``Eq`` and ``Show`` in :doc:`3_Data`. The ``Additive`` typeclass says that you can add a thing. Ie there is a function ``(+) : a -> a -> a``. Now the way to read the full signature of ``add`` is "Given that a has an instance for the Additive typeclass, a maps to a function which maps a to a".
+The ``Additive a =>`` part of the signature of ``add`` is a type constraint on the type parameter ``a``. ``Additive`` here is a typeclass. You already met typeclasses like ``Eq`` and ``Show`` in :doc:`3_Data`. The ``Additive`` typeclass says that you can add a thing, i.e. there is a function ``(+) : a -> a -> a``. Now the way to read the full signature of ``add`` is "Given that ``a`` has an instance for the ``Additive`` typeclass, ``a`` maps to a function which maps ``a`` to ``a``".
 
-Typeclasses in Daml are a bit like interfaces in other languages. To be able to add two things using the ``+`` function, those things need to expose the ``+`` interface.
+Typeclasses in Daml are a bit like interfaces in other languages. To be able to add two things using the ``+`` function, those things need to "expose" (have an instance for) the ``Additive`` interface (typeclass).
 
 Unlike interfaces, typeclasses can have multiple type parameters. A good example, which also demonstrates the use of multiple constraints at the same time, is the signature of the ``exercise`` function:
 
@@ -131,14 +131,21 @@ Unlike interfaces, typeclasses can have multiple type parameters. A good example
 
   exercise : (Template t, Choice t c r) => ContractId t -> c -> Update r
 
-Let's turn this into prose: Given that ``t`` is the type of a template, and that ``t`` has a choice ``c`` with return type ``r``, map a ``ContractId`` for a contract of type ``t`` to a function that takes the choice arguments of type ``c`` and returns an ``Update`` resulting in type ``r``.
+Let's turn this into prose: Given that ``t`` is the type of a template, and that ``t`` has a choice ``c`` with return type ``r``, the ``exercise`` function maps a ``ContractId`` for a contract of type ``t`` to a function that takes the choice arguments of type ``c`` and returns an ``Update`` resulting in type ``r``.
 
 That's quite a mouthful, and does require one to know what *meaning* the typeclass ``Choice`` gives to parameters ``t`` ``c`` and ``r``, but in many cases, that's obvious from the context or names of typeclasses and variables.
+
+Note that using single letters, while common, is not mandatory. The above may be made a little bit clearer by expanding the type parameter names, at the cost of making the code a bit longer:
+
+.. code-block:: daml
+
+  exercise : (Template template, Choice template choice result) =>
+               ContractId template -> choice -> Update result
 
 Pattern Matching in Arguments
 .............................
 
-You met pattern matching in :doc:`3_Data`, using ``case`` statements which is one way of pattern matching. However, it can also be convenient to do the pattern matching at the level of function arguments. Think about implementing the function ``uncurry``:
+You met pattern matching in :doc:`3_Data`, using ``case`` expressions which is one way of pattern matching. However, it can also be convenient to do the pattern matching at the level of function arguments. Think about implementing the function ``uncurry``:
 
 .. literalinclude:: daml/daml-intro-10/daml/Main.daml
   :language: daml
@@ -152,24 +159,24 @@ You met pattern matching in :doc:`3_Data`, using ``case`` statements which is on
   :start-after: -- UNCURRY_BEGIN
   :end-before: -- UNCURRY_END
 
-Using function pattern matching is clearly the most elegant here. We never need the tuple as a whole, just its members. Any pattern matching you can do in ``case`` you can also do at the function level, and the compiler helpfully warns you if you did not cover all cases, which is called "non-exhaustive".
+Any pattern matching you can do in ``case`` you can also do at the function level, and the compiler helpfully warns you if you did not cover all cases, which is called "non-exhaustive".
 
 .. literalinclude:: daml/daml-intro-10/daml/Main.daml
   :language: daml
   :start-after: -- FROM_SOME_BEGIN
   :end-before: -- FROM_SOME_END
 
-The above will give you a warning: 
+The above will give you a warning:
 
-  .. code-block:: none
-  
-    warning:
-      Pattern match(es) are non-exhaustive
-      In an equation for ‘fromSome’: Patterns not matched: None
+.. code-block:: none
 
-This means ``fromSome`` is a partial function. ``fromSome None`` will cause a runtime error.
+  warning:
+    Pattern match(es) are non-exhaustive
+    In an equation for ‘fromSome’: Patterns not matched: None
 
-We can use function level pattern matching together with a feature called *Record Wildcards* to write the function ``issueAsset`` in chapter 8:
+A function that does not cover all its cases, like ``fromSome`` here, is called a *partial* function. ``fromSome None`` will cause a runtime error.
+
+We can use function level pattern matching together with a feature called *Record Wildcards* to write the function ``issueAsset`` in chapter 9:
 
 .. literalinclude:: daml/daml-intro-9/daml/Test/Intro/Asset/MultiTrade.daml
   :language: daml
@@ -178,7 +185,13 @@ We can use function level pattern matching together with a feature called *Recor
 
 The ``..`` in the pattern match here means bind all fields from the given record to local variables, so we have local variables ``issuer``, ``owner``, etc.
 
-The ``..`` in the second to last line means fill all fields of the new record using local variables of the matching name. So the function succinctly transfers all fields except for ``owner``, which is set explicitly, from the V1 Asset to the V2 Asset.
+The ``..`` in the second to last line means fill all fields of the new record using local variables of the matching names, in this case (per the definition of ``Issue_Asset``), ``symbol`` and ``quantity``, taken from the ``asset`` argument to the function. In other words, this is equivalent to:
+
+.. code-block:: daml
+
+   exerciseCmd ahCid Issue_Asset with symbol = asset.symbol, quantity = asset.quantity
+
+because the notation ``asset@(Asset with ..)`` binds ``asset`` to the entire record, while also binding all of the fields of ``asset`` to local variables.
 
 Functions Everywhere
 ....................
@@ -190,14 +203,14 @@ You have probably already guessed it: Anywhere you can put a value in Daml you c
   :start-after: -- FUNCTION_IN_DATA_BEGIN
   :end-before: -- FUNCTION_IN_DATA_END
 
-More commonly, it makes sense to define functions locally, inside a ``let`` clause or similar. A good example of this are the ``validate`` and ``transfer`` functions defined locally in the ``Trade_Settle`` choice of the  model from chapter 8:
+More commonly, it makes sense to define functions locally, inside a ``let`` clause or similar. A good example of this are the ``validate`` and ``transfer`` functions defined locally in the ``Trade_Settle`` choice of the  model from chapter 9:
 
 .. literalinclude:: daml/daml-intro-9/daml/Intro/Asset/MultiTrade.daml
   :language: daml
   :start-after: -- LOCAL_FUNCTIONS_BEGIN
   :end-before: -- LOCAL_FUNCTIONS_END
 
-You can see that the function signature is inferred from the context here. If you look closely (or hover over the function in the IDE), you'll see that it has signature 
+You can see that the function signature is inferred from the context here. If you look closely (or hover over the function in the IDE), you'll see that it has signature
 
 .. code-block:: shell
 
@@ -205,14 +218,14 @@ You can see that the function signature is inferred from the context here. If yo
 
 .. note::
 
-    Bear in mind that functions are not serializable, so you can't use them inside template arguments, or as choice in- or outputs. They also don't have instances of the ``Eq`` or ``Show`` typeclasses which one would commonly want on data types.
+    Bear in mind that functions are not serializable, so you can't use them inside template arguments, as choice inputs, or as choice outputs. They also don't have instances of the ``Eq`` or ``Show`` typeclasses which one would commonly want on data types.
 
-You can probably guess what the ``mapA`` and ``mapA_``\ s in the above choice do. They somehow loop through the lists of assets, and approvals, and the functions ``validate`` and ``transfer`` to each, performing the resulting ``Update`` action in the process. We'll look at that more closely under :ref:`looping` below.
+The ``mapA`` and ``mapA_`` functions loop through the lists of assets and approvals, and apply the functions ``validate`` and ``transfer`` to each element of those lists, performing the resulting ``Update`` action in the process. We'll look at that more closely under :ref:`looping` below.
 
 Lambdas
 .......
 
-Like in most modern languages, Daml also supports inline functions called lambdas. They are defined using ``(\x y z -> ...)`` syntax. For example, a lambda version of ``increment`` would be ``(\n -> n + 1)``.
+Daml supports inline functions, called "lambda"s. They are defined using the ``(\x y z -> ...)`` syntax. For example, a lambda version of ``increment`` would be ``(\n -> n + 1)``.
 
 Control Flow
 ------------
@@ -222,12 +235,12 @@ In this section, we will cover branching and looping, and look at a few common p
 Branching
 .........
 
-Until Chapter 7 the only real kind of control flow introduced has been ``case``, which is a powerful tool for branching. 
+Until Chapter 7 the only real kind of control flow introduced has been ``case``, which is a powerful tool for branching.
 
-If..Else
-~~~~~~~~
+If ... Else
+~~~~~~~~~~~
 
-Chapter 5 also showed a seemingly self-explanatory ``if..else`` statement, but didn't explain it further. And they are actually the same thing. Let's implement the function ``boolToInt : Bool -> Int`` which in typical fashion maps ``True`` to ``1`` and ``False`` to ``0``. Here is an implementation using ``case``:
+Chapter 5 also showed a seemingly self-explanatory ``if ... else`` expression, but didn't explain it further. Let's implement the function ``boolToInt : Bool -> Int`` which in typical fashion maps ``True`` to ``1`` and ``False`` to ``0``. Here is an implementation using ``case``:
 
 .. literalinclude:: daml/daml-intro-10/daml/Main.daml
   :language: daml
@@ -253,21 +266,21 @@ The linter knows the equivalence and suggests a better implementation:
   :start-after: -- BOOL_TO_INT2_BEGIN
   :end-before: -- BOOL_TO_INT2_END
 
-In short: ``if..else`` statements are equivalent to a ``case`` statement, but are easier to read.
+In short: ``if ... else`` expressions are equivalent to ``case`` expressions, but can be easier to read.
 
 Control Flow as Expressions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``case`` statements and ``if..else`` really are control flow in the sense that they short circuit:
+``case`` and ``if ... else`` expressions really are control flow in the sense that they short-circuit:
 
 .. literalinclude:: daml/daml-intro-10/daml/Main.daml
   :language: daml
   :start-after: -- TEXT_TO_BOOL_BEGIN
   :end-before: -- TEXT_TO_BOOL_END
 
-This function behaves as you expect. The error only gets evaluated if an invalid text is passed in.
+This function behaves as you would expect: the error only gets evaluated if an invalid text is passed in.
 
-This is different to functions, where all arguments are evaluated immediately:
+This is different from functions, where all arguments are evaluated immediately:
 
 .. literalinclude:: daml/daml-intro-10/daml/Main.daml
   :language: daml
@@ -276,7 +289,7 @@ This is different to functions, where all arguments are evaluated immediately:
 
 In the above, ``boom`` is an error.
 
-But while being proper control flow, ``case`` and ``if..else`` statements are also expressions in the sense that they result in a value when evaluated. You can actually see that in the function definitions above. Since each of the functions is defined just as a ``case`` or ``if`` statement, the value of the evaluated function is just the value of the ``case``/``if`` statement. Things that have a value have a type. The ``if..else`` expression in ``boolToInt2`` has type ``Int`` as that's what the function returns, the ``case`` expression in ``doError`` has type ``Bool``. To be able to give such expressions an unambiguous type, each branch needs to have the same type. The below function does not compile as one branch tries to return an ``Int`` and the other a ``Text``:
+While providing proper control flow, ``case`` and ``if ... else`` expressions do result in a value when evaluated. You can actually see that in the function definitions above. Since each of the functions is defined just as a ``case`` or ``if ... else`` expression, the value of the evaluated function is just the value of the ``case`` or ``if ... else`` expression. Values have a type: the ``if ... else`` expression in ``boolToInt2`` has type ``Int`` as that is what the function returns; similarly, the ``case`` expression in ``doError`` has type ``Bool``. To be able to give such expressions an unambiguous type, each branch needs to have the same type. The below function does not compile as one branch tries to return an ``Int`` and the other a ``Text``:
 
 .. literalinclude:: daml/daml-intro-10/daml/Main.daml
   :language: daml
@@ -290,6 +303,8 @@ If we need functions that can return two (or more) types of things we need to en
   :start-after: -- INT_OR_TEXT_BEGIN
   :end-before: -- INT_OR_TEXT_END
 
+When you have more than two possible types (and sometimes even just for two types), it can be clearer to define your own variant type to wrap all possibilities.
+
 Branching in Actions
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -300,7 +315,7 @@ The most common case where this becomes important is inside ``do`` blocks. Say w
   :start-after: -- S_T_BEGIN
   :end-before: -- S_T_END
 
-It would be tempting to write a simple ``if..else``, but it won't typecheck:
+It would be tempting to write a simple ``if ... else``, but it won't typecheck if each branch returns a different type:
 
 .. literalinclude:: daml/daml-intro-10/daml/Main.daml
   :language: daml
@@ -331,21 +346,21 @@ The latter is so common that there is a utility function in ``DA.Action`` to get
   :start-after: -- CUSTOM_WHEN_BEGIN
   :end-before: -- CUSTOM_WHEN_END
 
-Note that we still need the ``else`` clause of the same type ``()``. This pattern is so common, it's encapsulated in the standard library function ``DA.Action.when : (Applicative f) => Bool -> f () -> f ()``. 
+Note that we still need the ``else`` clause of the same type ``()``. This pattern is so common, it's encapsulated in the standard library function ``DA.Action.when : (Applicative f) => Bool -> f () -> f ()``.
 
 .. literalinclude:: daml/daml-intro-10/daml/Main.daml
   :language: daml
   :start-after: -- WHEN_BEGIN
   :end-before: -- WHEN_END
 
-Despite ``when`` looking like a simple function, the compiler does some magic so that is short circuits evaluation just like ``if..else``. ``noop`` is a no-op, not an error as one might otherwise expect:
+Despite ``when`` looking like a simple function, the compiler does some magic so that it short-circuits evaluation just like ``if ... else`` and ``case``. The following ``noop`` function is a no-op (i.e. "does nothing"), not an error as one might otherwise expect:
 
 .. literalinclude:: daml/daml-intro-10/daml/Main.daml
   :language: daml
   :start-after: -- MAGIC_WHEN_BEGIN
   :end-before: -- MAGIC_WHEN_END
 
-With ``case``, ``if..else``, ``void`` and ``when``, you can express all branching. However, one additional feature you may want to learn is guards. They are not covered here, but can help avoid deeply nested ``if..else`` blocks. Here's just one example. The Haskell sources at the beginning of the chapter cover this topic in more depth.
+With ``case``, ``if ... else``, ``void`` and ``when``, you can express all branching. However, one additional feature you may want to learn is guards. They are not covered here, but can help avoid deeply nested ``if ... else`` blocks. Here's just one example. The Haskell sources at the beginning of the chapter cover this topic in more depth.
 
 .. literalinclude:: daml/daml-intro-10/daml/Main.daml
   :language: daml
@@ -357,13 +372,13 @@ With ``case``, ``if..else``, ``void`` and ``when``, you can express all branchin
 Looping
 .......
 
-Other than branching, the most common form of control flow is looping. Looping is usually used to iteratively modify some state. We'll use JavaScript in this section to illustrate the procedural way of doing things. 
+Other than branching, the most common form of control flow is looping. Looping is usually used to iteratively modify some state. We'll use JavaScript in this section to illustrate the procedural way of doing things.
 
 .. code-block:: JavaScript
 
   function sum(intArr) {
     var result = 0;
-    intarr.forEach (i => {
+    intArr.forEach (i => {
       result += i;
     });
     return result;
@@ -373,15 +388,13 @@ A more general loop looks like this:
 
 .. code-block:: JavaScript
 
-  function whileFunction(arr) {
-    var rev = initialize(input);
-    while (doContinue (state)) {
-      state = process (state);
+  function whileF(init, cont, step, finalize) {
+    var state = init();
+    while (cont(state)) {
+      state = step(state);
     }
     return finalize(state);
   }
-
-The only real difference is that the iterator is explicit in the former, and implicit in the latter.
 
 In both cases, state is being mutated: ``result`` in the former, ``state`` in the latter. Values in Daml are immutable, so it needs to work differently. In Daml we will do this with folds and recursion.
 
@@ -418,7 +431,7 @@ Almost all loops with explicit iterators can be translated to folds, though we h
     return result;
   }
 
-Translating the ``for`` into a ``forEach`` is easy if you can get your hands on an array containing values ``[0..(l-1)]``. And that's literally how you do it in Daml, using *ranges*. ``[0..(l-1)]`` is shorthand for ``enumFromTo 0 (l-1)``, which returns the list you'd expect.
+Translating the ``for`` into a ``forEach`` is easy if you can get your hands on an array containing values ``[0..(l-1)]``. And that's how you do it in Daml, using *ranges*. ``[0..(l-1)]`` is shorthand for ``enumFromTo 0 (l-1)``, which returns the list you'd expect.
 
 Daml also has an operator ``(!!) : [a] -> Int -> a`` which returns an element in a list. You may now be tempted to write ``sumArrs`` like this:
 
@@ -427,26 +440,26 @@ Daml also has an operator ``(!!) : [a] -> Int -> a`` which returns an element in
   :start-after: -- SUM_ARR_BEGIN
   :end-before: -- SUM_ARR_END
 
-But you should immediately forget again that you just learnt about ``(!!)``. Lists in Daml are linked lists, which makes access using ``(!!)`` slow and idiosyncratic. The way to do this in Daml is to get rid of the ``i`` altogether and instead merge the lists first, and then iterate over the "zipped" up lists:
+Unfortunately, that's not a very good approach. Lists in Daml are linked lists, which makes access using ``(!!)`` too slow for this kind of iteration. A better approach in Daml is to get rid of the ``i`` altogether and instead merge the lists first using the ``zip`` function, and then iterate over the "zipped" up lists:
 
 .. literalinclude:: daml/daml-intro-10/daml/Main.daml
   :language: daml
   :start-after: -- SUM_ARR2_BEGIN
   :end-before: -- SUM_ARR2_END
 
-``zip : [a] -> [b] -> [(a, b)]`` takes two lists, and merges them into a single list where the first element is the 2-tuple containing the first elements to the two input lists, and so on. It drops any left-over elements of the longer list, thus making the ``min`` logic unnecessary.
+``zip : [a] -> [b] -> [(a, b)]`` takes two lists, and merges them into a single list where the first element is the 2-tuple containing the first element of the two input lists, and so on. It drops any left-over elements of the longer list, thus making the ``min`` logic unnecessary.
 
 Maps
 ~~~~
 
-You've probably noticed that what we've done in this second version of ``sumArr`` is pretty standard, we have taken a list ``zip arr1 arr2`` applied a function ``\(x, y) -> x + y``  to each element, and returned the list of results. This operation is called ``map : (a -> b) -> [a] -> [b]``. We can now write ``sumArr`` even more nicely:
+In effect, the lambda passed to ``foldl`` only "wants" to act on a single element of the (zipped-up) input list, but still has to manage the concatenation of the whole state. Acting on each element separately is a common-enough pattern that there is a specialized function for it: ``map : (a -> b) -> [a] -> [b]``. Using it, we can rewrite ``sumArr`` to:
 
 .. literalinclude:: daml/daml-intro-10/daml/Main.daml
   :language: daml
   :start-after: -- SUM_ARR3_BEGIN
   :end-before: -- SUM_ARR3_END
 
-As a rule of thumb: Use ``map`` if the result has the same shape as the input and you don't need to carry state from one iteration to the next. Use folds if you need to accumulate state in any way.
+As a rule of thumb, use ``map`` if the result has the same shape as the input and you don't need to carry state from one iteration to the next. Use folds if you need to accumulate state in any way.
 
 Recursion
 ~~~~~~~~~
@@ -463,25 +476,25 @@ You may be tempted to make ``reverseWorker`` a local definition inside ``reverse
 Folds and Maps in Action Contexts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The folds and ``map`` function above are pure in the sense introduced in :doc:`5_Restrictions`: The functions used to map or process items have no side-effects. In day-to-day Daml that's the exception rather than the rule. If you have looked at the chapter 8 models, you'll have noticed ``mapA``, ``mapA_``, and ``forA`` all over the place. A good example are the ``mapA`` in the ``testMultiTrade`` script:
+The folds and ``map`` function above are pure in the sense introduced in :doc:`5_Restrictions`: The functions used to map or process items have no side-effects. If you have looked at the chapter 9 models, you'll have noticed ``mapA``, ``mapA_``, and ``forA``, that seem to serve a similar role but within ``Action``\ s . A good example is the ``mapA`` call in the ``testMultiTrade`` script:
 
 .. literalinclude:: daml/daml-intro-9/daml/Test/Intro/Asset/MultiTrade.daml
   :language: daml
   :start-after: -- MAPA_BEGIN
   :end-before: -- MAPA_END
 
-Here we have a list of relationships (type ``[Relationship]`` and a function ``setupRelationship : Relationship -> Script (ContractId AssetHolder)``. We want the ``AssetHolder`` contracts for those relationships, ie something of type ``[ContractId AssetHolder]``. Using the map function almost gets us there. ``map setupRelationship rels : [Update (ContractId AssetHolder)]``. This is a list of ``Update`` actions, each resulting in a ``ContractId AssetHolder``. What we need is an ``Update`` action resulting in a ``[ContractId AssetHolder]``. The list and ``Update`` are the wrong way around for our purposes.
+Here we have a list of relationships (type ``[Relationship]``) and a function ``setupRelationship : Relationship -> Script (ContractId AssetHolder)``. We want the ``AssetHolder`` contracts for those relationships, i.e. something of type ``[ContractId AssetHolder]``. Using the map function almost gets us there, but ``map setupRelationship rels`` would have type ``[Update (ContractId AssetHolder)]``. This is a list of ``Update`` actions, each resulting in a ``ContractId AssetHolder``. What we need is an ``Update`` action resulting in a ``[ContractId AssetHolder]``. The list and ``Update`` are nested the wrong way around for our purposes.
 
-Intuitively, it's clear how to fix this: we want the compound action consisting of performing each of the actions in the list in turn. There's a function for that, of course. ``sequence : : Applicative m => [m a] -> m [a]`` implements that intuition and allows us to take the ``Update`` out of the list. So we could write ``sequence (map setupRelationship rels)``. This is so common that it's encapsulated in the ``mapA`` function, a possible implementation of which is
+Intuitively, it's clear how to fix this: we want the compound action consisting of performing each of the actions in the list in turn. There's a function for that: ``sequence : : Applicative m => [m a] -> m [a]``. It implements that intuition and allows us to "take the ``Update`` out of the list", so to speak. So we could write ``sequence (map setupRelationship rels)``. This is so common that it's encapsulated in the ``mapA`` function, a possible implementation of which is
 
 .. literalinclude:: daml/daml-intro-10/daml/Main.daml
   :language: daml
   :start-after: -- MAPA_BEGIN
   :end-before: -- MAPA_END
 
-The ``A`` in ``mapA`` stands for "Action" of course, and you'll find that many functions that have something to do with "looping" have an ``A`` equivalent. The most fundamental of all of these is ``foldlA : Action m => (b -> a -> m b) -> b -> [a] -> m b``, a left fold with side effects. Here the inner function has a side-effect indicated by the ``m`` so the end result ``m b`` also has a side effect: the sum of all the side effects of the inner function.
+The ``A`` in ``mapA`` stands for "Action", and you'll find that many functions that have something to do with "looping" have an ``A`` equivalent. The most fundamental of all of these is ``foldlA : Action m => (b -> a -> m b) -> b -> [a] -> m b``, a left fold with side effects. Here the inner function has a side-effect indicated by the ``m`` so the end result ``m b`` also has a side effect: the sum of all the side effects of the inner function.
 
-Have a go at implementing ``foldlA`` in terms of ``foldl`` and ``sequence`` and ``mapA`` in terms of ``foldA``. Here are some possible implementations:
+To improve your familiarity with these concepts, you could try implementing ``foldlA`` in terms of ``foldl``, as well as ``sequence`` and ``mapA`` in terms of ``foldlA``. Here is one set of possible implementations:
 
 .. literalinclude:: daml/daml-intro-10/daml/Main.daml
   :language: daml
@@ -495,9 +508,9 @@ Have a go at implementing ``foldlA`` in terms of ``foldl`` and ``sequence`` and 
   :start-after: -- FORA_EXAMPLE_BEGIN
   :end-before: -- FORA_EXAMPLE_END
 
-Lastly, you'll have noticed that in some cases we used ``mapA_``, not ``mapA``. The underscore indicates that the result is not used. ``mapA_ fn xs fn = void (mapA fn xs)``. The Daml Linter will alert you if you could use ``mapA_`` instead of ``mapA``, and similarly for ``forA_``.
+Lastly, you'll have noticed that in some cases we used ``mapA_``, not ``mapA``. The underscore indicates that the result is not used, so ``mapA_ fn xs fn == void (mapA fn xs)``. The Daml Linter will alert you if you could use ``mapA_`` instead of ``mapA``, and similarly for ``forA_``.
 
 Next Up
 -------
 
-You now know the basics of functions and control flow, both in pure and Action contexts. The Chapter 8 example shows just how much can be done with just the tools you have encountered here, but there are many more tools at your disposal in the Daml Standard Library. It provides functions and typeclasses for many common circumstances and in :doc:`11_StdLib`, you'll get an overview of the library and learn how to search and browse it.
+You now know the basics of functions and control flow, both in pure and Action contexts. The Chapter 9 example shows just how much can be done with just the tools you have encountered here, but there are many more tools at your disposal in the Daml Standard Library. It provides functions and typeclasses for many common circumstances and in :doc:`11_StdLib`, you'll get an overview of the library and learn how to search and browse it.

--- a/docs/source/daml/intro/daml/daml-intro-10/daml/Main.daml
+++ b/docs/source/daml/intro/daml/daml-intro-10/daml/Main.daml
@@ -1,6 +1,5 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# OPTIONS -Wwarn=incomplete-patterns #-}
 module Main where
 
 import DA.Action
@@ -35,7 +34,7 @@ increment2 = add 1
 
 -- INFIX2_BEGIN
 increment3 = (1 +)
-decrement = (- 1)
+double = (* 2)
 -- INFIX2_END
 
 -- UNCURRY_SIG_BEGIN
@@ -104,13 +103,13 @@ intOrText b = if b
 template T
   with
     p : Party
-  where 
+  where
     signatory p
 
 template S
   with
     p : Party
-  where 
+  where
     signatory p
 -- S_T_END
 
@@ -205,7 +204,7 @@ mapA f xs = sequence (map f xs)
 
 -- IMPLEMENTATIONS_BEGIN
 foldlA2 fn init xs =
-  let 
+  let
     work accA x = do
       acc <- accA
       fn acc x

--- a/rules_daml/daml.bzl
+++ b/rules_daml/daml.bzl
@@ -376,6 +376,7 @@ def daml_test(
         deps = [],
         data_deps = [],
         damlc = "//compiler/damlc:damlc",
+        additional_compiler_flags = [],
         target = None,
         **kwargs):
     sh_inline_test(
@@ -410,7 +411,7 @@ $$DAMLC test {damlc_opts} --files {files}
             sdk_version = sdk_version,
             deps = " ".join(["$(rootpaths %s)" % dep for dep in deps]),
             data_deps = " ".join(["$(rootpaths %s)" % dep for dep in data_deps]),
-            damlc_opts = " ".join(default_damlc_opts),
+            damlc_opts = " ".join(default_damlc_opts + additional_compiler_flags),
             cp_srcs = "\n".join([
                 "mkdir -p $$(dirname {dest}); cp -f {src} {dest}".format(
                     src = "$$(canonicalize_rlocation $(rootpath {}))".format(src),


### PR DESCRIPTION
I started with wanting to remove the warning on incomplete pattern match, thinking example code should be "good". Then I decided I should skim the corresponding docs to check if that warning, or the pragma, were actually mentioned in the text.

It turns out the warning should be there, but the pragma is not explained and not necessary to get the warning. So the pargma can go.

But in the process I noticed a couple things that I belive can be improved in the wording of the document, so I went agead and made a few changes.

CHANGELOG_BEGIN
CHANGELOG_END