### PR TITLE
Bisected daml.execution.cache.register_update [DPP-1248].

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/ExecutionMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/ExecutionMetrics.scala
@@ -122,16 +122,31 @@ class ExecutionMetrics(override val prefix: MetricName, override val registry: M
     override val prefix: MetricName = ExecutionMetrics.this.prefix :+ "cache"
     override val registry = ExecutionMetrics.this.registry
 
-    val keyState: CacheMetrics = new CacheMetrics(prefix :+ "key_state", registry)
-    val contractState: CacheMetrics = new CacheMetrics(prefix :+ "contract_state", registry)
+    object keyState {
+      val stateCache: CacheMetrics = new CacheMetrics(prefix :+ "key_state", registry)
 
-    @MetricDoc.Tag(
-      summary = "The time spent to update the cache.",
-      description = """The total time spent in sequential update steps of the contract state caches
-                      |updating logic. This metric is created with debugging purposes in mind.""",
-      qualification = Debug,
-    )
-    val registerCacheUpdate: Timer = timer(prefix :+ "register_update")
+      @MetricDoc.Tag(
+        summary = "The time spent to update the cache.",
+        description =
+          """The total time spent in sequential update steps of the contract state caches
+                        |updating logic. This metric is created with debugging purposes in mind.""",
+        qualification = Debug,
+      )
+      val registerCacheUpdate: Timer = timer(prefix :+ "key_state" :+ "register_update")
+    }
+
+    object contractState {
+      val stateCache: CacheMetrics = new CacheMetrics(prefix :+ "contract_state", registry)
+
+      @MetricDoc.Tag(
+        summary = "The time spent to update the cache.",
+        description =
+          """The total time spent in sequential update steps of the contract state caches
+                        |updating logic. This metric is created with debugging purposes in mind.""",
+        qualification = Debug,
+      )
+      val registerCacheUpdate: Timer = timer(prefix :+ "contract_state" :+ "register_update")
+    }
 
     @MetricDoc.Tag(
       summary =

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/ContractKeyStateCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/ContractKeyStateCache.scala
@@ -18,9 +18,9 @@ object ContractKeyStateCache {
       initialCacheIndex = initialCacheIndex,
       cache = SizedCache.from[GlobalKey, ContractKeyStateValue](
         SizedCache.Configuration(cacheSize),
-        metrics.daml.execution.cache.keyState,
+        metrics.daml.execution.cache.keyState.stateCache,
       ),
-      registerUpdateTimer = metrics.daml.execution.cache.registerCacheUpdate,
+      registerUpdateTimer = metrics.daml.execution.cache.keyState.registerCacheUpdate,
     )
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/ContractsStateCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/ContractsStateCache.scala
@@ -18,9 +18,9 @@ object ContractsStateCache {
       initialCacheIndex = initialCacheIndex,
       cache = SizedCache.from[ContractId, ContractStateValue](
         SizedCache.Configuration(cacheSize),
-        metrics.daml.execution.cache.contractState,
+        metrics.daml.execution.cache.contractState.stateCache,
       ),
-      registerUpdateTimer = metrics.daml.execution.cache.registerCacheUpdate,
+      registerUpdateTimer = metrics.daml.execution.cache.contractState.registerCacheUpdate,
     )
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/StateCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/StateCache.scala
@@ -148,7 +148,7 @@ private[platform] case class StateCache[K, V](
                   s"Pending updates tracker for $key not registered. This could be due to a transient error causing a restart in the index service."
                 )
             }
-          }
+          },
         )
       }
       .recover {

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/StateCacheSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/StateCacheSpec.scala
@@ -29,9 +29,7 @@ class StateCacheSpec extends AsyncFlatSpec with Matchers with MockitoSugar with 
   override implicit def executionContext: ExecutionContext =
     scala.concurrent.ExecutionContext.global
 
-  private val cacheUpdateTimer = new Metrics(
-    new MetricRegistry
-  ).daml.execution.cache.registerCacheUpdate
+  private val cacheUpdateTimer = Metrics.ForTesting.timer(MetricName("cache-update"))
 
   behavior of s"$className.putAsync"
 


### PR DESCRIPTION
CHANGELOG_BEGIN
* Removed daml_execution_cache_register_update metric
* Added:
  - daml_execution_cache_contract_state_register_update
  - daml_execution_cache_key_state_register_update CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
