### PR TITLE
Proposal to add widening functions for covariant functors for interface-based subtyping relationships.

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Bifunctor.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Bifunctor.daml
@@ -110,6 +110,13 @@ class Bifunctor p where
     second : (b -> c) -> p a b -> p a c
     second = bimap identity
 
+-- | Widen the first argument if `t` interfaces `i`
+fwiden : forall i t x f. (Bifunctor f, HasToInterface t i) => f t x -> f i x
+fwiden = first toInterface
+
+-- | Widen the second argument if `t` interfaces `i`
+swiden : forall i t x f. (Bifunctor f, HasToInterface t i) => f x t -> f x i
+swiden = second toInterface
 
 
 instance Bifunctor (,) where

--- a/compiler/damlc/daml-stdlib-src/DA/Functor.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Functor.daml
@@ -21,3 +21,7 @@ as <&> f = f <$> as
 -- | Replace all the locations in the input with `()`.
 void : Functor f => f a -> f ()
 void x = () <$ x
+
+-- | Widen `f t` to `f i` if `t` interfaces `i` and `f` is a covariant functor
+widen : forall i t f. (Functor f, HasToInterface t i) => f t -> f i
+widen = fmap toInterface


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->

This is stolen from [Cats](https://github.com/typelevel/cats/blob/main/core/src/main/scala/cats/Functor.scala).

Scala has declaration-site variance but the design choice of Cats is to keep subtyping variance out of most of their datatypes and functions and lift them explicitly with widening or narrowing methods.

Subsequently we could also add widening and narrowing(contramap) functions for typeclasses like `Contravariant`, `Profunctor`, etc in [daml-ctl](https://github.com/digital-asset/daml-ctl).

Please also advise if something like `fmap toInterface` should be replace with some sort of coercion for efficiency.