### PR TITLE
[DPP-1278] Shuffle party related domain classes

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -8,7 +8,7 @@ package ledgerinteraction
 
 import akka.stream.Materializer
 import com.daml.grpc.adapter.ExecutionSequencerFactory
-import com.daml.ledger.api.domain.{PartyDetails, User, UserRight}
+import com.daml.ledger.api.domain.{ObjectMeta, PartyDetails, User, UserRight}
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{ImmArray, Ref, Time}
 import com.daml.lf.engine.preprocessing.ValueTranslator
@@ -379,6 +379,7 @@ class IdeLedgerClient(
         party = Ref.Party.assertFromString(name),
         displayName = Some(displayName),
         isLocal = true,
+        metadata = ObjectMeta.empty,
       )
       _ = allocatedParties += (name -> partyDetails)
     } yield partyDetails.party)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
@@ -23,7 +23,7 @@ import com.daml.ledger.api.auth.{
   CustomDamlJWTPayload,
   StandardJWTPayload,
 }
-import com.daml.ledger.api.domain.{PartyDetails, User, UserRight}
+import com.daml.ledger.api.domain.{ObjectMeta, PartyDetails, User, UserRight}
 import com.daml.lf.command
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{Ref, Time}
@@ -837,6 +837,7 @@ object JsonLedgerClient {
             id.convertTo[Party],
             optName.map(_.convertTo[String]),
             isLocal.convertTo[Boolean],
+            ObjectMeta.empty,
           )
         case _ => deserializationError(s"Expected PartyDetails but got $v")
       }

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/admin/PartyManagementClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/admin/PartyManagementClient.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.client.services.admin
 
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.Party
-import com.daml.ledger.api.domain.{ParticipantId, PartyDetails}
+import com.daml.ledger.api.domain.{ParticipantId, PartyDetails, ObjectMeta}
 import com.daml.ledger.api.v1.admin.party_management_service.PartyManagementServiceGrpc.PartyManagementServiceStub
 import com.daml.ledger.api.v1.admin.party_management_service.{
   AllocatePartyRequest,
@@ -26,6 +26,7 @@ object PartyManagementClient {
       Party.assertFromString(d.party),
       if (d.displayName.isEmpty) None else Some(d.displayName),
       d.isLocal,
+      ObjectMeta.empty,
     )
 
   private val getParticipantIdRequest = GetParticipantIdRequest()

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/admin/UserManagementClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/admin/UserManagementClient.scala
@@ -116,7 +116,7 @@ object UserManagementClient {
       metadata: com.daml.ledger.api.v1.admin.object_meta.ObjectMeta
   ): domain.ObjectMeta = {
     domain.ObjectMeta(
-      // TODO um-for-hub: Ledger-api-client shouldn't need to know how to parse resourceVersion. (ledger-api-domain probably shouldn't be used here)
+      // It's unfortunate that a client is using the server-side domain ObjectMeta and has to know how to parse the resource version
       resourceVersionO =
         Option.when(metadata.resourceVersion.nonEmpty)(metadata.resourceVersion).map(_.toLong),
       annotations = metadata.annotations,
@@ -133,7 +133,7 @@ object UserManagementClient {
 
   private def toProtoObjectMeta(meta: ObjectMeta): admin_proto.object_meta.ObjectMeta =
     admin_proto.object_meta.ObjectMeta(
-      // TODO um-for-hub: Ledger-api-client shouldn't need to know how to serialize resourceVersion. (ledger-api-domain probably shouldn't be used here)
+      // It's unfortunate that a client is using the server-side domain ObjectMeta and has to know how to parse the resource version
       resourceVersion = meta.resourceVersionO.map(_.toString).getOrElse(""),
       annotations = meta.annotations,
     )

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -342,28 +342,6 @@ object domain {
     }
   }
 
-  /** Represents a party with additional known information.
-    *
-    * @param party       The stable unique identifier of a Daml party.
-    * @param displayName Human readable name associated with the party. Might not be unique. If defined must be a non-empty string.
-    * @param isLocal     True if party is hosted by the backing participant.
-    */
-  case class PartyDetails(party: Ref.Party, displayName: Option[String], isLocal: Boolean)
-
-  sealed abstract class PartyEntry() extends Product with Serializable
-
-  object PartyEntry {
-    final case class AllocationAccepted(
-        submissionId: Option[String],
-        partyDetails: PartyDetails,
-    ) extends PartyEntry
-
-    final case class AllocationRejected(
-        submissionId: String,
-        reason: String,
-    ) extends PartyEntry
-  }
-
   /** Configuration entry describes a change to the current configuration. */
   sealed abstract class ConfigurationEntry extends Product with Serializable
 
@@ -419,15 +397,10 @@ object domain {
       metadata: ObjectMeta = ObjectMeta.empty,
   )
 
-  case class ParticipantPartyDetails(
+  case class PartyDetails(
       party: Ref.Party,
       displayName: Option[String],
       isLocal: Boolean,
-      metadata: ObjectMeta,
-  )
-
-  final case class PartyRecord(
-      party: Ref.Party,
       metadata: ObjectMeta,
   )
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
@@ -21,7 +21,13 @@ import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.index.v2
 import com.daml.ledger.participant.state.index.v2.MeteringStore.ReportData
-import com.daml.ledger.participant.state.index.v2.{ContractState, IndexService, MaximumLedgerTime}
+import com.daml.ledger.participant.state.index.v2.{
+  ContractState,
+  IndexService,
+  IndexerPartyDetails,
+  MaximumLedgerTime,
+  PartyEntry,
+}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.{ApplicationId, Party}
 import com.daml.lf.data.Time.Timestamp
@@ -162,17 +168,17 @@ private[daml] final class TimedIndexService(delegate: IndexService, metrics: Met
 
   override def getParties(parties: Seq[Ref.Party])(implicit
       loggingContext: LoggingContext
-  ): Future[List[domain.PartyDetails]] =
+  ): Future[List[IndexerPartyDetails]] =
     Timed.future(metrics.daml.services.index.getParties, delegate.getParties(parties))
 
   override def listKnownParties()(implicit
       loggingContext: LoggingContext
-  ): Future[List[domain.PartyDetails]] =
+  ): Future[List[IndexerPartyDetails]] =
     Timed.future(metrics.daml.services.index.listKnownParties, delegate.listKnownParties())
 
   override def partyEntries(
       startExclusive: Option[LedgerOffset.Absolute]
-  )(implicit loggingContext: LoggingContext): Source[domain.PartyEntry, NotUsed] =
+  )(implicit loggingContext: LoggingContext): Source[PartyEntry, NotUsed] =
     Timed.source(metrics.daml.services.index.partyEntries, delegate.partyEntries(startExclusive))
 
   override def lookupConfiguration()(implicit

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
@@ -25,7 +25,8 @@ import com.daml.ledger.api.v1.admin.party_management_service.{
   UpdatePartyDetailsRequest,
   UpdatePartyDetailsResponse,
 }
-import com.daml.ledger.api.v1.{admin => proto_admin}
+import com.daml.ledger.api.v1.admin.party_management_service.{PartyDetails => ProtoPartyDetails}
+import com.daml.ledger.api.v1.admin.object_meta.{ObjectMeta => ProtoObjectMeta}
 import com.daml.ledger.api.validation.ValidationErrors
 import com.daml.ledger.participant.state.index.v2.{
   IndexPartyManagementService,
@@ -163,9 +164,7 @@ private[apiserver] final class ApiPartyManagementService private (
           partyIdHintO <- FieldValidations.optionalString(
             request.partyIdHint
           )(FieldValidations.requireParty)
-          metadata = request.localMetadata.getOrElse(
-            com.daml.ledger.api.v1.admin.object_meta.ObjectMeta()
-          )
+          metadata = request.localMetadata.getOrElse(ProtoObjectMeta())
           _ <- requireEmptyString(
             metadata.resourceVersion,
             "party_details.local_metadata.resource_version",
@@ -219,7 +218,7 @@ private[apiserver] final class ApiPartyManagementService private (
             "party_details",
           )
           party <- requireParty(partyDetails.party)
-          metadata = partyDetails.localMetadata.getOrElse(proto_admin.object_meta.ObjectMeta())
+          metadata = partyDetails.localMetadata.getOrElse(ProtoObjectMeta())
           resourceVersionNumberO <- optionalString(metadata.resourceVersion)(
             FieldValidations.requireResourceVersion(
               _,
@@ -408,8 +407,8 @@ private[apiserver] object ApiPartyManagementService {
   private def toProtoPartyDetails(
       partyDetails: IndexerPartyDetails,
       metadataO: Option[ObjectMeta],
-  ): proto_admin.party_management_service.PartyDetails =
-    proto_admin.party_management_service.PartyDetails(
+  ): ProtoPartyDetails =
+    ProtoPartyDetails(
       party = partyDetails.party,
       displayName = partyDetails.displayName.getOrElse(""),
       isLocal = partyDetails.isLocal,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/update/PartyRecordUpdateMapper.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/update/PartyRecordUpdateMapper.scala
@@ -3,20 +3,20 @@
 
 package com.daml.platform.apiserver.update
 
-import com.daml.ledger.api.domain.ParticipantPartyDetails
+import com.daml.ledger.api.domain.PartyDetails
 import com.daml.platform.localstore.api.{ObjectMetaUpdate, PartyDetailsUpdate}
 
 object PartyRecordUpdateMapper extends UpdateMapperBase {
 
   import UpdateRequestsPaths.PartyDetailsPaths
 
-  type Resource = ParticipantPartyDetails
+  type Resource = PartyDetails
   type Update = PartyDetailsUpdate
 
   override val fullResourceTrie: UpdatePathsTrie = PartyDetailsPaths.fullUpdateTrie
 
   override def makeUpdateObject(
-      partyRecord: ParticipantPartyDetails,
+      partyRecord: PartyDetails,
       updateTrie: UpdatePathsTrie,
   ): Result[PartyDetailsUpdate] = {
     for {

--- a/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
@@ -15,7 +15,6 @@ import com.daml.ledger.api.domain.{
   LedgerId,
   LedgerOffset,
   PackageEntry,
-  PartyEntry,
   TransactionFilter,
   TransactionId,
 }
@@ -287,12 +286,12 @@ private[index] class IndexServiceImpl(
 
   override def getParties(parties: Seq[Ref.Party])(implicit
       loggingContext: LoggingContext
-  ): Future[List[domain.PartyDetails]] =
+  ): Future[List[IndexerPartyDetails]] =
     ledgerDao.getParties(parties)
 
   override def listKnownParties()(implicit
       loggingContext: LoggingContext
-  ): Future[List[domain.PartyDetails]] =
+  ): Future[List[IndexerPartyDetails]] =
     ledgerDao.listKnownParties()
 
   override def partyEntries(

--- a/ledger/participant-integration-api/src/main/scala/platform/localstore/PersistentPartyRecordStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/localstore/PersistentPartyRecordStore.scala
@@ -7,7 +7,6 @@ import java.sql.Connection
 
 import com.daml.api.util.TimeProvider
 import com.daml.ledger.api.domain
-import com.daml.ledger.api.domain.PartyRecord
 import com.daml.platform.localstore.api.PartyRecordStore.{
   ConcurrentPartyUpdate,
   MaxAnnotationsSizeExceeded,
@@ -21,7 +20,12 @@ import com.daml.platform.localstore.PersistentPartyRecordStore.{
   ConcurrentPartyRecordUpdateDetectedRuntimeException,
   MaxAnnotationsSizeExceededException,
 }
-import com.daml.platform.localstore.api.{LedgerPartyExists, PartyRecordStore, PartyRecordUpdate}
+import com.daml.platform.localstore.api.{
+  LedgerPartyExists,
+  PartyRecord,
+  PartyRecordStore,
+  PartyRecordUpdate,
+}
 import com.daml.platform.localstore.utils.LocalAnnotationsUtils
 import com.daml.platform.server.api.validation.ResourceAnnotationValidation
 import com.daml.platform.store.DbSupport

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/StorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/StorageBackend.scala
@@ -3,12 +3,12 @@
 
 package com.daml.platform.store.backend
 
-import com.daml.ledger.api.domain.{LedgerId, ParticipantId, PartyDetails}
+import com.daml.ledger.api.domain.{LedgerId, ParticipantId}
 import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.index.v2.MeteringStore.{ParticipantMetering, ReportData}
-import com.daml.ledger.participant.state.index.v2.PackageDetails
+import com.daml.ledger.participant.state.index.v2.{IndexerPartyDetails, PackageDetails}
 import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.ledger.EventId
@@ -180,8 +180,8 @@ trait PartyStorageBackend {
       pageSize: Int,
       queryOffset: Long,
   )(connection: Connection): Vector[(Offset, PartyLedgerEntry)]
-  def parties(parties: Seq[Party])(connection: Connection): List[PartyDetails]
-  def knownParties(connection: Connection): List[PartyDetails]
+  def parties(parties: Seq[Party])(connection: Connection): List[IndexerPartyDetails]
+  def knownParties(connection: Connection): List[IndexerPartyDetails]
 }
 
 trait PackageStorageBackend {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/PartyStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/PartyStorageBackendTemplate.scala
@@ -7,8 +7,8 @@ import java.sql.Connection
 
 import anorm.{RowParser, ~}
 import anorm.SqlParser.{bool, flatten, str}
-import com.daml.ledger.api.domain.PartyDetails
 import com.daml.ledger.offset.Offset
+import com.daml.ledger.participant.state.index.v2.IndexerPartyDetails
 import com.daml.platform.Party
 import com.daml.platform.store.backend.Conversions.{
   ledgerString,
@@ -54,7 +54,7 @@ class PartyStorageBackendTemplate(
             PartyLedgerEntry.AllocationAccepted(
               submissionIdOpt,
               recordTime,
-              PartyDetails(party, displayNameOpt, isLocal),
+              IndexerPartyDetails(party, displayNameOpt, isLocal),
             )
         case (
               offset,
@@ -95,12 +95,12 @@ class PartyStorageBackendTemplate(
       .asVectorOf(partyEntryParser)(connection)
   }
 
-  private val partyDetailsParser: RowParser[PartyDetails] = {
+  private val partyDetailsParser: RowParser[IndexerPartyDetails] = {
     import com.daml.platform.store.backend.Conversions.bigDecimalColumnToBoolean
     str("party") ~
       str("display_name").? ~
       bool("is_local") map { case party ~ displayName ~ isLocal =>
-        PartyDetails(
+        IndexerPartyDetails(
           party = Party.assertFromString(party),
           displayName = displayName.filter(_.nonEmpty),
           isLocal = isLocal,
@@ -111,7 +111,7 @@ class PartyStorageBackendTemplate(
   private def queryParties(
       parties: Option[Set[String]],
       connection: Connection,
-  ): Vector[PartyDetails] = {
+  ): Vector[IndexerPartyDetails] = {
     import com.daml.platform.store.backend.Conversions.OffsetToStatement
     val partyFilter = parties match {
       case Some(requestedParties) => cSQL"party_entries.party in ($requestedParties) AND"
@@ -141,10 +141,10 @@ class PartyStorageBackendTemplate(
        """.asVectorOf(partyDetailsParser)(connection)
   }
 
-  override def parties(parties: Seq[Party])(connection: Connection): List[PartyDetails] =
+  override def parties(parties: Seq[Party])(connection: Connection): List[IndexerPartyDetails] =
     queryParties(Some(parties.view.map(_.toString).toSet), connection).toList
 
-  override def knownParties(connection: Connection): List[PartyDetails] =
+  override def knownParties(connection: Connection): List[IndexerPartyDetails] =
     queryParties(None, connection).toList
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -7,12 +7,12 @@ import akka.stream.scaladsl.Source
 import com.daml.daml_lf_dev.DamlLf.Archive
 import com.daml.error.DamlContextualizedErrorLogger
 import com.daml.error.definitions.LedgerApiErrors
-import com.daml.ledger.api.domain.{LedgerId, ParticipantId, PartyDetails}
+import com.daml.ledger.api.domain.{LedgerId, ParticipantId}
 import com.daml.ledger.api.health.{HealthStatus, ReportsHealth}
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.index.v2.MeteringStore.ReportData
-import com.daml.ledger.participant.state.index.v2.PackageDetails
+import com.daml.ledger.participant.state.index.v2.{IndexerPartyDetails, PackageDetails}
 import com.daml.ledger.participant.state.{v2 => state}
 import com.daml.lf.archive.ArchiveParser
 import com.daml.lf.data.Ref
@@ -240,7 +240,7 @@ private class JdbcLedgerDao(
 
   override def getParties(
       parties: Seq[Party]
-  )(implicit loggingContext: LoggingContext): Future[List[PartyDetails]] =
+  )(implicit loggingContext: LoggingContext): Future[List[IndexerPartyDetails]] =
     if (parties.isEmpty)
       Future.successful(List.empty)
     else
@@ -251,7 +251,7 @@ private class JdbcLedgerDao(
 
   override def listKnownParties()(implicit
       loggingContext: LoggingContext
-  ): Future[List[PartyDetails]] =
+  ): Future[List[IndexerPartyDetails]] =
     dbDispatcher
       .executeSql(metrics.daml.index.db.loadAllParties)(
         readStorageBackend.partyStorageBackend.knownParties

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -6,7 +6,7 @@ package com.daml.platform.store.dao
 import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.daml.daml_lf_dev.DamlLf.Archive
-import com.daml.ledger.api.domain.{LedgerId, ParticipantId, PartyDetails}
+import com.daml.ledger.api.domain.{LedgerId, ParticipantId}
 import com.daml.ledger.api.health.ReportsHealth
 import com.daml.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
 import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
@@ -19,7 +19,7 @@ import com.daml.ledger.api.v1.transaction_service.{
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.index.v2.MeteringStore.ReportData
-import com.daml.ledger.participant.state.index.v2.PackageDetails
+import com.daml.ledger.participant.state.index.v2.{IndexerPartyDetails, PackageDetails}
 import com.daml.ledger.participant.state.{v2 => state}
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.transaction.{BlindingInfo, CommittedTransaction}
@@ -106,10 +106,10 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
   /** Returns a list of party details for the parties specified. */
   def getParties(parties: Seq[Party])(implicit
       loggingContext: LoggingContext
-  ): Future[List[PartyDetails]]
+  ): Future[List[IndexerPartyDetails]]
 
   /** Returns a list of all known parties. */
-  def listKnownParties()(implicit loggingContext: LoggingContext): Future[List[PartyDetails]]
+  def listKnownParties()(implicit loggingContext: LoggingContext): Future[List[IndexerPartyDetails]]
 
   def getPartyEntries(
       startExclusive: Offset,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/entries/PartyLedgerEntry.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/entries/PartyLedgerEntry.scala
@@ -3,7 +3,7 @@
 
 package com.daml.platform.store.entries
 
-import com.daml.ledger.api.domain.PartyDetails
+import com.daml.ledger.participant.state.index.v2.IndexerPartyDetails
 import com.daml.lf.data.Time.Timestamp
 import com.daml.platform.SubmissionId
 
@@ -17,7 +17,7 @@ private[platform] object PartyLedgerEntry {
   final case class AllocationAccepted(
       submissionIdOpt: Option[SubmissionId],
       recordTime: Timestamp,
-      partyDetails: PartyDetails,
+      partyDetails: IndexerPartyDetails,
   ) extends PartyLedgerEntry
 
   final case class AllocationRejected(

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoPartiesSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoPartiesSpec.scala
@@ -5,8 +5,8 @@ package com.daml.platform.store.dao
 
 import java.util.UUID
 import akka.stream.scaladsl.Sink
-import com.daml.ledger.api.domain.PartyDetails
 import com.daml.ledger.offset.Offset
+import com.daml.ledger.participant.state.index.v2.IndexerPartyDetails
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
 import com.daml.platform.store.dao.PersistenceResponse
@@ -23,12 +23,12 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
   behavior of "JdbcLedgerDao (parties)"
 
   it should "store and retrieve all parties" in {
-    val alice = PartyDetails(
+    val alice = IndexerPartyDetails(
       party = Ref.Party.assertFromString(s"Alice-${UUID.randomUUID()}"),
       displayName = Some("Alice Arkwright"),
       isLocal = true,
     )
-    val bob = PartyDetails(
+    val bob = IndexerPartyDetails(
       party = Ref.Party.assertFromString(s"Bob-${UUID.randomUUID()}"),
       displayName = Some("Bob Bobertson"),
       isLocal = true,
@@ -48,7 +48,7 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
     val acceptedParty = Ref.Party.assertFromString(s"Accepted-${UUID.randomUUID()}")
     val nonExistentParty = UUID.randomUUID().toString
     val rejectionReason = s"$nonExistentParty is rejected"
-    val accepted = PartyDetails(
+    val accepted = IndexerPartyDetails(
       party = acceptedParty,
       displayName = Some("Accepted Ackbar"),
       isLocal = true,
@@ -101,7 +101,7 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
   it should "retrieve a single party, if they exist" in {
     val party = Ref.Party.assertFromString(s"Carol-${UUID.randomUUID()}")
     val nonExistentParty = UUID.randomUUID().toString
-    val carol = PartyDetails(
+    val carol = IndexerPartyDetails(
       party = party,
       displayName = Some("Carol Carlisle"),
       isLocal = true,
@@ -121,12 +121,12 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
     val danParty = Ref.Party.assertFromString(s"Dan-${UUID.randomUUID()}")
     val eveParty = Ref.Party.assertFromString(s"Eve-${UUID.randomUUID()}")
     val nonExistentParty = UUID.randomUUID().toString
-    val dan = PartyDetails(
+    val dan = IndexerPartyDetails(
       party = danParty,
       displayName = Some("Dangerous Dan"),
       isLocal = true,
     )
-    val eve = PartyDetails(
+    val eve = IndexerPartyDetails(
       party = eveParty,
       displayName = Some("Dangerous Dan"),
       isLocal = true,
@@ -144,7 +144,7 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
 
   it should "be able to store multiple parties with the same identifier, which was local once, and the last update will be visible as query-ing, except is_local: that stays true" in {
     val danParty = Ref.Party.assertFromString(s"Dan-${UUID.randomUUID()}")
-    val dan = PartyDetails(
+    val dan = IndexerPartyDetails(
       party = danParty,
       displayName = Some("Dangerous Dan"),
       isLocal = true,
@@ -192,7 +192,7 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
 
   it should "be able to store multiple parties with the same identifier, which was never local once, and the last update will be visible as query-ing, also is_local: false" in {
     val danParty = Ref.Party.assertFromString(s"Dan-${UUID.randomUUID()}")
-    val dan = PartyDetails(
+    val dan = IndexerPartyDetails(
       party = danParty,
       displayName = Some("Dangerous Dan"),
       isLocal = false,
@@ -236,7 +236,7 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
   }
 
   private def storePartyEntry(
-      partyDetails: PartyDetails,
+      partyDetails: IndexerPartyDetails,
       offset: Offset,
       submissionIdOpt: Option[Ref.SubmissionId] = Some(UUID.randomUUID().toString),
       recordTime: Timestamp = Timestamp.now(),

--- a/ledger/participant-integration-api/src/test/suite/scala/db/migration/translation/apiserver/services/admin/ApiPartyManagementServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/db/migration/translation/apiserver/services/admin/ApiPartyManagementServiceSpec.scala
@@ -7,19 +7,20 @@ import java.util.concurrent.{CompletableFuture, CompletionStage}
 
 import akka.stream.scaladsl.Source
 import com.daml.ledger.api.domain.LedgerOffset.Absolute
-import com.daml.ledger.api.domain.PartyRecord
-import com.daml.ledger.api.domain.{ObjectMeta, PartyDetails, PartyEntry}
+import com.daml.ledger.api.domain.ObjectMeta
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.api.v1.admin.party_management_service.AllocatePartyRequest
 import com.daml.ledger.participant.state.index.v2.{
   IndexPartyManagementService,
   IndexTransactionsService,
+  IndexerPartyDetails,
+  PartyEntry,
 }
 import com.daml.ledger.participant.state.{v2 => state}
 import com.daml.lf.data.Ref
 import com.daml.logging.LoggingContext
 import com.daml.platform.apiserver.services.admin.ApiPartyManagementServiceSpec._
-import com.daml.platform.localstore.api.PartyRecordStore
+import com.daml.platform.localstore.api.{PartyRecord, PartyRecordStore}
 import com.daml.telemetry.TelemetrySpecBase._
 import com.daml.telemetry.{TelemetryContext, TelemetrySpecBase}
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
@@ -54,7 +55,7 @@ class ApiPartyManagementServiceSpec
           Source.single(
             PartyEntry.AllocationAccepted(
               Some("aSubmission"),
-              PartyDetails(party, None, isLocal = true),
+              IndexerPartyDetails(party, None, isLocal = true),
             )
           )
         )

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/update/PartyRecordUpdateMapperSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/update/PartyRecordUpdateMapperSpec.scala
@@ -3,7 +3,7 @@
 
 package com.daml.platform.apiserver.update
 
-import com.daml.ledger.api.domain.{ObjectMeta, ParticipantPartyDetails}
+import com.daml.ledger.api.domain.{ObjectMeta, PartyDetails}
 import com.daml.lf.data.Ref
 import com.daml.platform.localstore.api.{ObjectMetaUpdate, PartyDetailsUpdate}
 import com.google.protobuf.field_mask.FieldMask
@@ -20,7 +20,7 @@ class PartyRecordUpdateMapperSpec extends AnyFreeSpec with Matchers with EitherV
       isLocal: Boolean = false,
       displayNameO: Option[String] = None,
       annotations: Map[String, String] = Map.empty,
-  ): ParticipantPartyDetails = ParticipantPartyDetails(
+  ): PartyDetails = PartyDetails(
     party = party,
     displayName = displayNameO,
     isLocal = isLocal,

--- a/ledger/participant-local-store/src/main/scala/com/daml/platform/localstore/InMemoryPartyRecordStore.scala
+++ b/ledger/participant-local-store/src/main/scala/com/daml/platform/localstore/InMemoryPartyRecordStore.scala
@@ -4,7 +4,7 @@
 package com.daml.platform.localstore
 
 import com.daml.ledger.api.domain
-import com.daml.ledger.api.domain.{ObjectMeta, PartyRecord}
+import com.daml.ledger.api.domain.ObjectMeta
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.Party
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
@@ -13,7 +13,12 @@ import com.daml.platform.localstore.api.PartyRecordStore.{
   PartyRecordExistsFatal,
   Result,
 }
-import com.daml.platform.localstore.api.{LedgerPartyExists, PartyRecordStore, PartyRecordUpdate}
+import com.daml.platform.localstore.api.{
+  LedgerPartyExists,
+  PartyRecord,
+  PartyRecordStore,
+  PartyRecordUpdate,
+}
 import com.daml.platform.localstore.utils.LocalAnnotationsUtils
 import com.daml.platform.server.api.validation.ResourceAnnotationValidation
 

--- a/ledger/participant-local-store/src/main/scala/com/daml/platform/localstore/api/PartyRecord.scala
+++ b/ledger/participant-local-store/src/main/scala/com/daml/platform/localstore/api/PartyRecord.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.localstore.api
+
+import com.daml.ledger.api.domain.ObjectMeta
+import com.daml.lf.data.Ref
+
+final case class PartyRecord(
+    party: Ref.Party,
+    metadata: ObjectMeta,
+)

--- a/ledger/participant-local-store/src/main/scala/com/daml/platform/localstore/api/PartyRecordStore.scala
+++ b/ledger/participant-local-store/src/main/scala/com/daml/platform/localstore/api/PartyRecordStore.scala
@@ -3,7 +3,6 @@
 
 package com.daml.platform.localstore.api
 
-import com.daml.ledger.api.domain.PartyRecord
 import com.daml.lf.data.Ref
 import com.daml.logging.LoggingContext
 import com.daml.platform.server.api.validation.ResourceAnnotationValidation

--- a/ledger/participant-local-store/src/test/lib/com/daml/platform/localstore/PartyRecordStoreTests.scala
+++ b/ledger/participant-local-store/src/test/lib/com/daml/platform/localstore/PartyRecordStoreTests.scala
@@ -3,12 +3,17 @@
 
 package com.daml.platform.localstore
 
-import com.daml.ledger.api.domain.{ObjectMeta, PartyRecord}
+import com.daml.ledger.api.domain.ObjectMeta
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.Party
 import com.daml.logging.LoggingContext
 import com.daml.platform.localstore.api.PartyRecordStore.PartyRecordExistsFatal
-import com.daml.platform.localstore.api.{ObjectMetaUpdate, PartyRecordStore, PartyRecordUpdate}
+import com.daml.platform.localstore.api.{
+  ObjectMetaUpdate,
+  PartyRecord,
+  PartyRecordStore,
+  PartyRecordUpdate,
+}
 import org.scalatest.freespec.AsyncFreeSpec
 
 import scala.concurrent.Future

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPartyManagementService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPartyManagementService.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.participant.state.index.v2
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import com.daml.ledger.api.domain.{LedgerOffset, PartyDetails, PartyEntry}
+import com.daml.ledger.api.domain.LedgerOffset
 import com.daml.lf.data.Ref.{ParticipantId, Party}
 import com.daml.logging.LoggingContext
 
@@ -19,9 +19,9 @@ trait IndexPartyManagementService {
 
   def getParties(
       parties: Seq[Party]
-  )(implicit loggingContext: LoggingContext): Future[List[PartyDetails]]
+  )(implicit loggingContext: LoggingContext): Future[List[IndexerPartyDetails]]
 
-  def listKnownParties()(implicit loggingContext: LoggingContext): Future[List[PartyDetails]]
+  def listKnownParties()(implicit loggingContext: LoggingContext): Future[List[IndexerPartyDetails]]
 
   def partyEntries(
       startExclusive: Option[LedgerOffset.Absolute]

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexerPartyDetails.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexerPartyDetails.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.index.v2
+
+import com.daml.lf.data.Ref
+
+/** Represents a party with additional known information.
+  *
+  * @param party       The stable unique identifier of a Daml party.
+  * @param displayName Human readable name associated with the party. Might not be unique. If defined must be a non-empty string.
+  * @param isLocal     True if party is hosted by the backing participant.
+  */
+case class IndexerPartyDetails(party: Ref.Party, displayName: Option[String], isLocal: Boolean)

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/PartyEntry.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/PartyEntry.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.index.v2
+
+sealed abstract class PartyEntry() extends Product with Serializable
+
+object PartyEntry {
+  final case class AllocationAccepted(
+      submissionId: Option[String],
+      partyDetails: IndexerPartyDetails,
+  ) extends PartyEntry
+
+  final case class AllocationRejected(
+      submissionId: String,
+      reason: String,
+  ) extends PartyEntry
+}

--- a/ledger/recovering-indexer-integration-tests/BUILD.bazel
+++ b/ledger/recovering-indexer-integration-tests/BUILD.bazel
@@ -47,6 +47,7 @@ da_scala_test_suite(
         "//ledger/metrics",
         "//ledger/participant-integration-api",
         "//ledger/participant-state",
+        "//ledger/participant-state-index",
         "//ledger/test-common",
         "//libs-scala/contextualized-logging",
         "//libs-scala/resources",


### PR DESCRIPTION
changelog_begin
changelog_end

Status quo:
ledger-api-domain's domain object contained three classes related to parties:
 1. `PartyDetails`, the oldest, which didn't contain the metadata field and was used both in client and indexer code,
 2. `ParticipantPartyDetails`, added recently during the participant-local metadata extensions, similar to the `PartyDetails` above but additionally contains the metadata field,
 3. `PartyRecord` which held participant-local metadata extensions for a party.

Changes:
 1) `PartyDetails` gets renamed to `IndexerPartyDetails` and together with `PartyEntry` gets moved to participant-state-index Bazel package and is removed from client code,
 2) `ParticipantPartyDetails` gets renamed to `PartyDetails` and is now used in the client code instead.
 3) `PartyRecord` gets moved to participant-local-store Bazel package
