### PR TITLE
Clean `dlint` flags

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -1048,8 +1048,8 @@ vrNoteSetNotification vr note = do
 -- callback of any errors. NOTE: results may contain errors for any
 -- dependent module.
 -- TODO (MK): We should have a non-Daml version of this rule
-ofInterestRule :: Options -> Rules ()
-ofInterestRule opts = do
+ofInterestRule :: Rules ()
+ofInterestRule = do
     -- go through a rule (not just an action), so it shows up in the profile
     action $ useNoFile OfInterest
     defineNoFile $ \OfInterest -> do
@@ -1377,7 +1377,7 @@ damlRule opts = do
     getOpenVirtualResourcesRule
     getDlintSettingsRule (optDlintUsage opts)
     damlGhcSessionRule opts
-    when (optEnableOfInterestRule opts) (ofInterestRule opts)
+    when (optEnableOfInterestRule opts) ofInterestRule
 
 mainRule :: Options -> Rules ()
 mainRule options = do

--- a/compiler/damlc/daml-ide-core/test/Development/IDE/Core/API/Testing.hs
+++ b/compiler/damlc/daml-ide-core/test/Development/IDE/Core/API/Testing.hs
@@ -54,7 +54,6 @@ import Development.IDE.Core.Shake (ShakeLspEnv(..), NotificationHandler(..))
 import qualified Development.IDE.Core.Rules.Daml  as API
 import qualified Development.IDE.Types.Diagnostics as D
 import qualified Development.IDE.Types.Location as D
-import DA.Bazel.Runfiles
 import DA.Daml.LF.ScenarioServiceClient as SS
 import Development.IDE.Core.API.Testing.Visualize
 import Development.IDE.Core.Rules.Daml
@@ -152,9 +151,8 @@ runShakeTest = runShakeTestOpts id
 -- | Run shake test on freshly initialised shake service, with custom options.
 runShakeTestOpts :: (Daml.Options -> Daml.Options) -> Maybe SS.Handle -> ShakeTest () -> IO (Either ShakeTestError ShakeTestResults)
 runShakeTestOpts fOpts mbScenarioService (ShakeTest m) = do
-    dlintDataDir <-locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
     let options = fOpts (defaultOptions Nothing)
-            { optDlintUsage = DlintEnabled dlintDataDir False
+            { optDlintUsage = DlintEnabled defaultDlintOptions
             , optEnableOfInterestRule = True
             , optEnableScenarios = EnableScenarios True
             }

--- a/compiler/damlc/daml-ide-core/test/Development/IDE/Core/API/Testing.hs
+++ b/compiler/damlc/daml-ide-core/test/Development/IDE/Core/API/Testing.hs
@@ -154,7 +154,7 @@ runShakeTestOpts fOpts mbScenarioService (ShakeTest m) = do
     let options = fOpts (defaultOptions Nothing)
             { optDlintUsage = DlintEnabled DlintOptions
                 { dlintRulesFile = DefaultDlintRulesFile
-                , dlintHintFiles = ExplicitDlintHintFiles []
+                , dlintHintFiles = NoDlintHintFiles
                 }
             , optEnableOfInterestRule = True
             , optEnableScenarios = EnableScenarios True

--- a/compiler/damlc/daml-ide-core/test/Development/IDE/Core/API/Testing.hs
+++ b/compiler/damlc/daml-ide-core/test/Development/IDE/Core/API/Testing.hs
@@ -152,7 +152,10 @@ runShakeTest = runShakeTestOpts id
 runShakeTestOpts :: (Daml.Options -> Daml.Options) -> Maybe SS.Handle -> ShakeTest () -> IO (Either ShakeTestError ShakeTestResults)
 runShakeTestOpts fOpts mbScenarioService (ShakeTest m) = do
     let options = fOpts (defaultOptions Nothing)
-            { optDlintUsage = DlintEnabled defaultDlintOptions
+            { optDlintUsage = DlintEnabled DlintOptions
+                { dlintRulesFile = DefaultDlintRulesFile
+                , dlintHintFiles = ExplicitDlintHintFiles []
+                }
             , optEnableOfInterestRule = True
             , optEnableScenarios = EnableScenarios True
             }

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module DA.Daml.Options.Types
     ( Options(..)
@@ -10,7 +11,7 @@ module DA.Daml.Options.Types
     , AllowLargeTuples(..)
     , SkipScenarioValidation(..)
     , DlintRulesFile(..)
-    , DlintHintFiles(..)
+    , DlintHintFiles(.., NoDlintHintFiles)
     , DlintOptions(..)
     , DlintUsage(..)
     , Haddock(..)
@@ -154,6 +155,9 @@ data DlintHintFiles
     --    * "~/.dlint.yaml"
   | ExplicitDlintHintFiles [FilePath]
   deriving Show
+
+pattern NoDlintHintFiles :: DlintHintFiles
+pattern NoDlintHintFiles = ExplicitDlintHintFiles []
 
 data DlintOptions = DlintOptions
   { dlintRulesFile :: DlintRulesFile

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -9,6 +9,9 @@ module DA.Daml.Options.Types
     , EnableScenarios(..)
     , AllowLargeTuples(..)
     , SkipScenarioValidation(..)
+    , DlintRulesFile(..)
+    , DlintHintFiles(..)
+    , DlintOptions(..)
     , DlintUsage(..)
     , Haddock(..)
     , IncrementalBuild(..)
@@ -17,6 +20,7 @@ module DA.Daml.Options.Types
     , ModRenaming(..)
     , PackageArg(..)
     , defaultOptions
+    , defaultDlintOptions
     , getBaseDir
     , damlArtifactDir
     , projectPackageDatabase
@@ -90,7 +94,7 @@ data Options = Options
     -- ^ Controls whether the scenario service server run package validations.
     -- This is mostly used to run additional checks on CI while keeping the IDE fast.
   , optDlintUsage :: DlintUsage
-  -- ^ Information about dlint usage.
+    -- ^ dlint configuration.
   , optIsGenerated :: Bool
     -- ^ Whether we're compiling generated code. Then we allow internal imports.
   , optDflagCheck :: Bool
@@ -129,8 +133,43 @@ newtype IgnorePackageMetadata = IgnorePackageMetadata { getIgnorePackageMetadata
 newtype Haddock = Haddock Bool
   deriving Show
 
+-- | The dlint rules file is a dlint yaml file that's used as the base for
+-- the rules used during linting. Really there is no difference between the
+-- rules file and the other hint files, but it is useful to specify them
+-- separately since this one can act as the base, allowing the other hint files
+-- to selectively ignore individual rules.
+data DlintRulesFile
+  = DefaultDlintRulesFile
+    -- ^ "WORKSPACE/compiler/damlc/daml-ide-core/dlint.yaml"
+  | ExplicitDlintRulesFile FilePath
+    -- ^ User-provided rules file
+  deriving Show
+
+data DlintHintFiles
+  = ImplicitDlintHintFile
+    -- ^ First existing file of
+    --    *       ".dlint.yaml"
+    --    *    "../.dlint.yaml"
+    --    * "../../.dlint.yaml"
+    --    * ...
+    --    * "~/.dlint.yaml"
+  | ExplicitDlintHintFiles [FilePath]
+  deriving Show
+
+data DlintOptions = DlintOptions
+  { dlintRulesFile :: DlintRulesFile
+  , dlintHintFiles :: DlintHintFiles
+  }
+  deriving Show
+
+defaultDlintOptions :: DlintOptions
+defaultDlintOptions = DlintOptions
+  { dlintRulesFile = DefaultDlintRulesFile
+  , dlintHintFiles = ExplicitDlintHintFiles []
+  }
+
 data DlintUsage
-  = DlintEnabled { dlintUseDataDir :: FilePath, dlintAllowOverrides :: Bool }
+  = DlintEnabled DlintOptions
   | DlintDisabled
   deriving Show
 

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -20,7 +20,6 @@ module DA.Daml.Options.Types
     , ModRenaming(..)
     , PackageArg(..)
     , defaultOptions
-    , defaultDlintOptions
     , getBaseDir
     , damlArtifactDir
     , projectPackageDatabase
@@ -161,12 +160,6 @@ data DlintOptions = DlintOptions
   , dlintHintFiles :: DlintHintFiles
   }
   deriving Show
-
-defaultDlintOptions :: DlintOptions
-defaultDlintOptions = DlintOptions
-  { dlintRulesFile = DefaultDlintRulesFile
-  , dlintHintFiles = ExplicitDlintHintFiles []
-  }
 
 data DlintUsage
   = DlintEnabled DlintOptions

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -139,7 +139,11 @@ cmdIde numProcessors =
         <$> telemetryOpt
         <*> debugOpt
         <*> enableScenarioServiceOpt
-        <*> optionsParser numProcessors (EnableScenarioService True) (pure Nothing)
+        <*> optionsParser
+              numProcessors
+              (EnableScenarioService True)
+              (pure Nothing)
+              (optionalDlintUsageParser True)
 
 cmdLicense :: Mod CommandFields Command
 cmdLicense =
@@ -157,7 +161,11 @@ cmdCompile numProcessors =
     cmd = execCompile
         <$> inputFileOpt
         <*> outputFileOpt
-        <*> optionsParser numProcessors (EnableScenarioService False) optPackageName
+        <*> optionsParser
+              numProcessors
+              (EnableScenarioService False)
+              optPackageName
+              disabledDlintUsageParser
         <*> optWriteIface
         <*> optional (strOptionOnce $ long "iface-dir" <> metavar "IFACE_DIR" <> help "Directory for interface files")
 
@@ -176,7 +184,11 @@ cmdDesugar numProcessors =
     cmd = execDesugar
       <$> inputFileOpt
       <*> outputFileOpt
-      <*> optionsParser numProcessors (EnableScenarioService False) optPackageName
+      <*> optionsParser
+            numProcessors
+            (EnableScenarioService False)
+            optPackageName
+            disabledDlintUsageParser
 
 cmdDebugIdeSpanInfo :: Int -> Mod CommandFields Command
 cmdDebugIdeSpanInfo numProcessors =
@@ -187,7 +199,11 @@ cmdDebugIdeSpanInfo numProcessors =
     cmd = execDebugIdeSpanInfo
       <$> inputFileOpt
       <*> outputFileOpt
-      <*> optionsParser numProcessors (EnableScenarioService False) optPackageName
+      <*> optionsParser
+            numProcessors
+            (EnableScenarioService False)
+            optPackageName
+            disabledDlintUsageParser
 
 cmdLint :: Int -> Mod CommandFields Command
 cmdLint numProcessors =
@@ -197,7 +213,11 @@ cmdLint numProcessors =
   where
     cmd = execLint
         <$> many inputFileOpt
-        <*> optionsParser numProcessors (EnableScenarioService False) optPackageName
+        <*> optionsParser
+              numProcessors
+              (EnableScenarioService False)
+              optPackageName
+              enabledDlintUsageParser
 
 cmdTest :: Int -> Mod CommandFields Command
 cmdTest numProcessors =
@@ -216,7 +236,11 @@ cmdTest numProcessors =
       <*> fmap ShowCoverage showCoverageOpt
       <*> fmap UseColor colorOutput
       <*> junitOutput
-      <*> optionsParser numProcessors (EnableScenarioService True) optPackageName
+      <*> optionsParser
+            numProcessors
+            (EnableScenarioService True)
+            optPackageName
+            disabledDlintUsageParser
       <*> initPkgDbOpt
     filesOpt = optional (flag' () (long "files" <> help filesDoc) *> many inputFileOpt)
     filesDoc = "Only run test declarations in the specified files."
@@ -288,7 +312,11 @@ cmdBuild numProcessors =
     cmd =
         execBuild
             <$> projectOpts "daml build"
-            <*> optionsParser numProcessors (EnableScenarioService False) (pure Nothing)
+            <*> optionsParser
+                  numProcessors
+                  (EnableScenarioService False)
+                  (pure Nothing)
+                  disabledDlintUsageParser
             <*> optionalOutputFileOpt
             <*> incrementalBuildOpt
             <*> initPkgDbOpt
@@ -323,7 +351,11 @@ cmdRepl numProcessors =
                     )
             <*> timeModeFlag
             <*> projectOpts "daml repl"
-            <*> optionsParser numProcessors (EnableScenarioService False) (pure Nothing)
+            <*> optionsParser
+                  numProcessors
+                  (EnableScenarioService False)
+                  (pure Nothing)
+                  disabledDlintUsageParser
             <*> strOptionOnce (long "script-lib" <> value "daml-script" <> internal)
             -- This is useful for tests and `bazel run`.
 
@@ -400,7 +432,13 @@ cmdInit numProcessors =
     command "init" $
     info (helper <*> cmd) $ progDesc "Initialize a Daml project" <> fullDesc
   where
-    cmd = execInit <$> optionsParser numProcessors (EnableScenarioService False) (pure Nothing) <*> projectOpts "daml damlc init"
+    cmd = execInit
+            <$> optionsParser
+                  numProcessors
+                  (EnableScenarioService False)
+                  (pure Nothing)
+                  disabledDlintUsageParser
+            <*> projectOpts "daml damlc init"
 
 cmdPackage :: Int -> Mod CommandFields Command
 cmdPackage numProcessors =
@@ -411,7 +449,11 @@ cmdPackage numProcessors =
     cmd = execPackage
         <$> projectOpts "daml damlc package"
         <*> inputFileOpt
-        <*> optionsParser numProcessors (EnableScenarioService False) (Just <$> packageNameOpt)
+        <*> optionsParser
+              numProcessors
+              (EnableScenarioService False)
+              (Just <$> packageNameOpt)
+              disabledDlintUsageParser
         <*> optionalOutputFileOpt
         <*> optFromDalf
 
@@ -455,7 +497,11 @@ cmdDocTest numProcessors =
     progDesc "Early Access (Labs). doc tests" <> fullDesc
   where
     cmd = execDocTest
-        <$> optionsParser numProcessors (EnableScenarioService True) optPackageName
+        <$> optionsParser
+              numProcessors
+              (EnableScenarioService True)
+              optPackageName
+              disabledDlintUsageParser
         <*> many inputFileOpt
 
 --------------------------------------------------------------------------------
@@ -511,16 +557,14 @@ execIde telemetry (Debug debug) enableScenarioService options =
                       whenJust gcpStateM $ \gcpState -> Logger.GCP.logIgnored gcpState
                       f loggerH
                   TelemetryDisabled -> f loggerH
-          dlintDataDir <- locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
           options <- pure options
               { optScenarioService = enableScenarioService
               , optEnableOfInterestRule = True
               , optSkipScenarioValidation = SkipScenarioValidation True
               -- TODO(MH): The `optionsParser` does not provide a way to skip
               -- individual options. As a stopgap we ignore the argument to
-              -- --jobs and the dlint config.
+              -- --jobs.
               , optThreads = 0
-              , optDlintUsage = DlintEnabled dlintDataDir True
               }
           installDepsAndInitPackageDb options (InitPkgDb True)
           scenarioServiceConfig <- readScenarioServiceConfig
@@ -612,7 +656,6 @@ execLint inputFiles opts =
        withProjectRoot' projectOpts $ \relativize ->
        do
          loggerH <- getLogger opts "lint"
-         opts <- setDlintDataDir opts
          withDamlIdeState opts loggerH diagnosticsLogger $ \ide -> do
              inputFiles <- getInputFiles relativize inputFiles
              setFilesOfInterest ide (HashSet.fromList inputFiles)
@@ -628,13 +671,6 @@ execLint inputFiles opts =
            withPackageConfig defaultProjectPath $ \PackageConfigFields {pSrc} -> do
            getDamlRootFiles pSrc
        fs -> forM fs $ fmap toNormalizedFilePath' . relativize
-     setDlintDataDir :: Options -> IO Options
-     setDlintDataDir opts = do
-       defaultDir <-locateRunfiles $
-         mainWorkspace </> "compiler/damlc/daml-ide-core"
-       return $ case optDlintUsage opts of
-         DlintEnabled _ _ -> opts
-         DlintDisabled  -> opts{optDlintUsage=DlintEnabled defaultDir True}
 
 defaultProjectPath :: ProjectPath
 defaultProjectPath = ProjectPath "."
@@ -726,8 +762,7 @@ execRepl dars importPkgs mbLedgerConfig mbAuthToken mbAppId mbSslConf mbMaxInbou
             -- We change directory so make this absolute
             dars <- mapM makeAbsolute dars
             opts <- pure opts
-                { optDlintUsage = DlintDisabled
-                , optScenarioService = EnableScenarioService False
+                { optScenarioService = EnableScenarioService False
                 , optPackageImports = optPackageImports opts ++ pkgFlags
                 }
             logger <- getLogger opts "repl"

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -27,7 +27,11 @@ cmd numProcessors f = command "docs" $
 
 documentation :: Int -> Parser CmdArgs
 documentation numProcessors = Damldoc
-    <$> optionsParser numProcessors (EnableScenarioService False) optPackageName
+    <$> optionsParser
+          numProcessors
+          (EnableScenarioService False)
+          optPackageName
+          disabledDlintUsageParser
     <*> optInputFormat
     <*> optOutputPath
     <*> optOutputFormat

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -272,7 +272,7 @@ dlintHintFilesParser =
                     \'.dlint.yaml' files will be ignored."
           )
     clearDlintHintFiles =
-      flag' (ExplicitDlintHintFiles [])
+      flag' NoDlintHintFiles
         ( long "lint-no-hint-files"
           <> internal
           <> help "Use no hint files for linting. This also ignores any \

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -9,7 +9,6 @@ import Data.List.Extra     (lower, splitOn, trim)
 import Options.Applicative hiding (option, strOption)
 import qualified Options.Applicative (option, strOption)
 import Options.Applicative.Extended
-import Safe (lastMay)
 import Data.List
 import Data.Maybe
 import qualified DA.Pretty           as Pretty
@@ -231,34 +230,104 @@ allowLargeTuplesOpt = AllowLargeTuples <$>
     where
         desc = "Do not warn when tuples of size > 5 are used."
 
--- The implementation of dlintUsageOpt allows multiple uses of dlintEnabledOpt
--- and dlintDisabledOpt, with only the last one winning. As a result,
--- dlintEnabledOpt uses strOption instead of strOptionOnce
-dlintEnabledOpt :: Parser DlintUsage
-dlintEnabledOpt = DlintEnabled
-  <$> Options.Applicative.strOption
-  ( long "with-dlint"
-    <> metavar "DIR"
-    <> internal
-    <> help "Enable linting with 'dlint.yaml' directory"
-  )
-  <*> switch
-  ( long "allow-overrides"
-    <> internal
-    <> help "Allow '.dlint.yaml' configuration overrides"
-  )
+dlintRulesFileParser :: Parser DlintRulesFile
+dlintRulesFileParser =
+  lastOr DefaultDlintRulesFile $
+    defaultDlintRulesFile <|> explicitDlintRulesFile
+  where
+    defaultDlintRulesFile =
+      flag' DefaultDlintRulesFile
+        ( long "lint-default-rules"
+          <> internal
+          <> help "Use the default rules file for linting"
+        )
+    explicitDlintRulesFile =
+      ExplicitDlintRulesFile <$> strOptionOnce
+        ( long "lint-rules-file"
+          <> metavar "FILE"
+          <> internal
+          <> help "Use FILE as the rules file for linting"
+        )
 
-dlintDisabledOpt :: Parser DlintUsage
-dlintDisabledOpt = flag' DlintDisabled
-  ( long "without-dlint"
-    <> internal
-    <> help "Disable dlint"
-  )
+dlintHintFilesParser :: Parser DlintHintFiles
+dlintHintFilesParser =
+  lastOr ImplicitDlintHintFile $
+    implicitDlintHintFile <|> explicitDlintHintFiles <|> clearDlintHintFiles
+  where
+    implicitDlintHintFile =
+      flag' ImplicitDlintHintFile
+        ( long "lint-implicit-hint-file"
+          <> internal
+          <> help "Use the first '.dlint.yaml' file found in the \
+                  \project directory or any parent thereof, or, failing that, \
+                  \in the home directory of the current user."
+        )
+    explicitDlintHintFiles =
+      fmap ExplicitDlintHintFiles $
+        some $ Options.Applicative.strOption
+          ( long "lint-hint-file"
+            <> metavar "FILE"
+            <> internal
+            <> help "Add FILE as a hint file for linting. Any implicit \
+                    \'.dlint.yaml' files will be ignored."
+          )
+    clearDlintHintFiles =
+      flag' (ExplicitDlintHintFiles [])
+        ( long "lint-no-hint-files"
+          <> internal
+          <> help "Use no hint files for linting. This also ignores any \
+                  \implicit '.dlint.yaml' files"
+        )
 
-dlintUsageOpt :: Parser DlintUsage
-dlintUsageOpt = fmap (fromMaybe DlintDisabled . lastMay) $
-  many (dlintEnabledOpt <|> dlintDisabledOpt)
+dlintOptionsParser :: Parser DlintOptions
+dlintOptionsParser = DlintOptions
+  <$> dlintRulesFileParser
+  <*> dlintHintFilesParser
 
+-- | Use @'disabledDlintUsageParser'@ as the @Parser DlintUsage@ argument of
+-- @optionsParser@ for commands that never perform any linting.
+--
+-- No lint related options will appear for the user.
+disabledDlintUsageParser :: Parser DlintUsage
+disabledDlintUsageParser = pure DlintDisabled
+
+-- | Use @'enabledDlintUsageParser'@ as the @Parser DlintUsage@ argument of
+-- @optionsParser@ for commands that always perform linting.
+--
+-- The options that modify linting settings will be available, but not the ones
+-- for enabling/disabling linting itself.
+enabledDlintUsageParser :: Parser DlintUsage
+enabledDlintUsageParser = DlintEnabled <$> dlintOptionsParser
+
+-- | Use @'optionalDlintUsageParser' enabled@ as the @Parser DlintUsage@
+-- argument of @optionsParser@ for commands where the user can decide whether
+-- or not to perform linting.
+--
+-- @enabled@ sets the default behavior if the user doesn't explicitly enable or
+-- disable linting.
+--
+-- The options that modify linting settings will be available, as well as
+-- two options for enabling/disabling linting.
+optionalDlintUsageParser :: Bool -> Parser DlintUsage
+optionalDlintUsageParser def =
+  fromParsed
+    <$> lastOr def (enableDlint <|> disableDlint)
+    <*> dlintOptionsParser
+  where
+    fromParsed enabled options
+      | enabled = DlintEnabled options
+      | otherwise = DlintDisabled
+
+    enableDlint = flag' True
+      ( long "with-dlint"
+        <> internal
+        <> help "Enable dlint"
+      )
+    disableDlint = flag' False
+      ( long "without-dlint"
+        <> internal
+        <> help "Disable dlint"
+      )
 
 cliOptLogLevel :: Parser Logger.Priority
 cliOptLogLevel =
@@ -283,8 +352,8 @@ optPackageName = optional $ fmap GHC.stringToUnitId $ strOptionOnce $
 
 -- | Parametrized by the type of pkgname parser since we want that to be different for
 -- "package".
-optionsParser :: Int -> EnableScenarioService -> Parser (Maybe GHC.UnitId) -> Parser Options
-optionsParser numProcessors enableScenarioService parsePkgName = do
+optionsParser :: Int -> EnableScenarioService -> Parser (Maybe GHC.UnitId) -> Parser DlintUsage -> Parser Options
+optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage = do
     let parseUnitId Nothing = (Nothing, Nothing)
         parseUnitId (Just unitId) = case splitUnitId unitId of
             (name, mbVersion) -> (Just name, mbVersion)
@@ -304,7 +373,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = do
     optGhcCustomOpts <- optGhcCustomOptions
     let optScenarioService = enableScenarioService
     let optSkipScenarioValidation = SkipScenarioValidation False
-    optDlintUsage <- dlintUsageOpt
+    optDlintUsage <- parseDlintUsage
     optIsGenerated <- optIsGenerated
     optDflagCheck <- optNoDflagCheck
     let optCoreLinting = False

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -206,7 +206,7 @@ getIntegrationTests registerTODO scenarioService = do
                 , optCoreLinting = True
                 , optDlintUsage = DlintEnabled DlintOptions
                     { dlintRulesFile = DefaultDlintRulesFile
-                    , dlintHintFiles = ExplicitDlintHintFiles []
+                    , dlintHintFiles = NoDlintHintFiles
                     }
                 , optSkipScenarioValidation = SkipScenarioValidation skipValidation
                 }

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -196,8 +196,6 @@ getIntegrationTests registerTODO scenarioService = do
     let outdir = "compiler/damlc/output"
     createDirectoryIfMissing True outdir
 
-    dlintDataDir <- locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
-
     -- initialise the compiler service
     vfs <- makeVFSHandle
     -- We use a separate service for generated files so that we can test files containing internal imports.
@@ -206,7 +204,7 @@ getIntegrationTests registerTODO scenarioService = do
           let opts = (defaultOptions (Just version))
                 { optThreads = 0
                 , optCoreLinting = True
-                , optDlintUsage = DlintEnabled dlintDataDir False
+                , optDlintUsage = DlintEnabled defaultDlintOptions
                 , optSkipScenarioValidation = SkipScenarioValidation skipValidation
                 }
               mkIde options = do

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -204,7 +204,10 @@ getIntegrationTests registerTODO scenarioService = do
           let opts = (defaultOptions (Just version))
                 { optThreads = 0
                 , optCoreLinting = True
-                , optDlintUsage = DlintEnabled defaultDlintOptions
+                , optDlintUsage = DlintEnabled DlintOptions
+                    { dlintRulesFile = DefaultDlintRulesFile
+                    , dlintHintFiles = ExplicitDlintHintFiles []
+                    }
                 , optSkipScenarioValidation = SkipScenarioValidation skipValidation
                 }
               mkIde options = do

--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -1206,10 +1206,7 @@ expectScriptFailure xs vr pred = case find ((vr ==) . fst) xs of
       assertFailure $ "Predicate for " <> show vr <> " failed on " <> show err
 
 options :: Options
-options =
-  (defaultOptions (Just lfVersion))
-    { optDlintUsage = DlintDisabled
-    }
+options = defaultOptions (Just lfVersion)
 
 runScripts :: SS.Handle -> [T.Text] -> IO [(VirtualResource, Either T.Text T.Text)]
 runScripts service fileContent = bracket getIdeState shutdown $ \ideState -> do

--- a/compiler/damlc/tests/src/DA/Test/ScriptService_1_15.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService_1_15.hs
@@ -148,10 +148,8 @@ expectScriptSuccess xs vr pred = case find ((vr ==) . fst) xs of
       assertFailure $ "Predicate for " <> show vr <> " failed on " <> show r
 
 options :: Options
-options =
-  (defaultOptions (Just lfVersion))
-    { optDlintUsage = DlintDisabled
-    }
+options = defaultOptions (Just lfVersion)
+
 
 runScripts :: SS.Handle -> [T.Text] -> IO [(VirtualResource, Either T.Text T.Text)]
 runScripts service fileContent = bracket getIdeState shutdown $ \ideState -> do

--- a/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
+++ b/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
@@ -10,10 +10,13 @@ module Options.Applicative.Extended
     , optionOnce
     , optionOnce'
     , strOptionOnce
+    , lastOr
     ) where
 
-import Options.Applicative
 import GHC.Exts (IsString (..))
+import Options.Applicative
+
+import qualified Data.List.NonEmpty as NE
 
 -- | A morally boolean value with a default third option (called Auto) to be determined later.
 data YesNoAuto
@@ -76,3 +79,15 @@ optionOnce' errMsg reader options = const <$> actualParser <*> errorIfTwiceParse
 
 strOptionOnce :: IsString a => Mod OptionFields a -> Parser a
 strOptionOnce = optionOnce str
+
+-- | @'lastOr' def one@ returns the value of the last succesful @one@, if any,
+-- otherwise returns @def@.
+--
+-- /Note/: if @one@ always succeeds, @lastOr def one@ will loop forever.
+--
+-- /Note/: @lastOr def one@ will never fail, so it cannot be used with @some@
+-- or @many@ (or @lastOr@ itself)
+lastOr :: Alternative f => b -> f b -> f b
+lastOr def one =
+      NE.last <$> NE.some1 one
+  <|> pure def


### PR DESCRIPTION
This cleans up a few issues I found when looking at the lint-related options. The main ones are:
1. `damlc` commands that don't care about lint options no longer accept any lint options.
4. It is now possible to specify the "base" rules file by its full path (rather than the path of its containing directory with the file being forced to have the name `dlint.yaml`).
2.  It is now possible to specify multiple concrete hints files ("overrides") rather than just having the option of the implicit `.dlint.yaml` from the closest ancestor or the user's home directory.
5. `damlc lint` no longer accepts options to enable/disable linting.
6. Parsed values of `optDlintUsage` are no longer overridden by the compiler anywhere.