### PR TITLE
rename ChoiceMetadata to Choice

### DIFF
--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -182,8 +182,8 @@ A file is generated that defines five Java classes and an interface:
 
     public static final Identifier TEMPLATE_ID = new Identifier("some-package-id", "Com.Acme.Templates", "Bar");
 
-    public static final ChoiceMetadata<Bar, Archive, Unit> CHOICE_Archive =
-      ChoiceMetadata.create(/* ... */);
+    public static final Choice<Bar, Archive, Unit> CHOICE_Archive =
+      Choice.create(/* ... */);
 
     public static final ContractCompanion.WithKey<Contract, ContractId, Bar, BarKey> COMPANION = 
         new ContractCompanion.WithKey<>("com.acme.templates.Bar",
@@ -518,11 +518,11 @@ Effectively it is a class that contains only the inner type ContractId because o
   public final class TIf {
     public static final Identifier TEMPLATE_ID = new Identifier("94fb4fa48cef1ec7d474ff3d6883a00b2f337666c302ec5e2b87e986da5c27a3", "Interfaces", "TIf");
 
-    public static final ChoiceMetadata<TIf, Transfer, ContractId> CHOICE_Transfer =
-      ChoiceMetadata.create(/* ... */);
+    public static final Choice<TIf, Transfer, ContractId> CHOICE_Transfer =
+      Choice.create(/* ... */);
 
-    public static final ChoiceMetadata<TIf, Archive, Unit> CHOICE_Archive =
-      ChoiceMetadata.create(/* ... */);
+    public static final Choice<TIf, Archive, Unit> CHOICE_Archive =
+      Choice.create(/* ... */);
 
     public static final INTERFACE INTERFACE = new INTERFACE();
 

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/Choice.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/Choice.java
@@ -14,14 +14,14 @@ import java.util.function.Function;
  * @param <ArgType> The choice's argument type
  * @param <ResType> The result from exercising the choice
  */
-public final class ChoiceMetadata<Tpl, ArgType, ResType> {
+public final class Choice<Tpl, ArgType, ResType> {
 
   /** The choice name * */
   public final String name;
 
   private final Function<ArgType, Value> encodeArg;
 
-  private ChoiceMetadata(final String name, final Function<ArgType, Value> encodeArg) {
+  private Choice(final String name, final Function<ArgType, Value> encodeArg) {
     this.name = name;
     this.encodeArg = encodeArg;
   }
@@ -32,8 +32,8 @@ public final class ChoiceMetadata<Tpl, ArgType, ResType> {
    * and <em>should not be referenced directly</em>. Applications should refer to the generated
    * {@code CHOICE_*} fields on templates or interfaces.
    */
-  public static <Tpl, ArgType, ResType> ChoiceMetadata<Tpl, ArgType, ResType> create(
+  public static <Tpl, ArgType, ResType> Choice<Tpl, ArgType, ResType> create(
       final String name, final Function<ArgType, Value> encodeArg) {
-    return new ChoiceMetadata<>(name, encodeArg);
+    return new Choice<>(name, encodeArg);
   }
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractCompanion.java
@@ -81,7 +81,7 @@ public abstract class ContractCompanion<Ct, Id, Data> extends ContractTypeCompan
       Identifier templateId,
       Function<String, Id> newContractId,
       Function<DamlRecord, Data> fromValue,
-      List<ChoiceMetadata<Data, ?, ?>> choices) {
+      List<Choice<Data, ?, ?>> choices) {
     super(templateId, templateClassName, choices);
     this.newContractId = newContractId;
     this.fromValue = fromValue;
@@ -103,7 +103,7 @@ public abstract class ContractCompanion<Ct, Id, Data> extends ContractTypeCompan
         Function<String, Id> newContractId,
         Function<DamlRecord, Data> fromValue,
         NewContract<Ct, Id, Data> newContract,
-        List<ChoiceMetadata<Data, ?, ?>> choices) {
+        List<Choice<Data, ?, ?>> choices) {
       super(templateClassName, templateId, newContractId, fromValue, choices);
       this.newContract = newContract;
     }
@@ -158,7 +158,7 @@ public abstract class ContractCompanion<Ct, Id, Data> extends ContractTypeCompan
         Function<String, Id> newContractId,
         Function<DamlRecord, Data> fromValue,
         NewContract<Ct, Id, Data, Key> newContract,
-        List<ChoiceMetadata<Data, ?, ?>> choices,
+        List<Choice<Data, ?, ?>> choices,
         Function<Value, Key> keyFromValue) {
       super(templateClassName, templateId, newContractId, fromValue, choices);
       this.newContract = newContract;

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractTypeCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractTypeCompanion.java
@@ -33,7 +33,7 @@ public abstract class ContractTypeCompanion<ContractType, Data> {
    * var c2 = Bar.CHOICE_Transfer;
    * </pre>
    */
-  public final Map<String, ChoiceMetadata<ContractType, ?, ?>> choices;
+  public final Map<String, Choice<ContractType, ?, ?>> choices;
 
   /**
    * <strong>INTERNAL API</strong>: this is meant for use by {@link ContractCompanion} and {@link
@@ -42,9 +42,7 @@ public abstract class ContractTypeCompanion<ContractType, Data> {
    * interface in question instead.
    */
   protected ContractTypeCompanion(
-      Identifier templateId,
-      String templateClassName,
-      List<ChoiceMetadata<ContractType, ?, ?>> choices) {
+      Identifier templateId, String templateClassName, List<Choice<ContractType, ?, ?>> choices) {
     TEMPLATE_ID = templateId;
     TEMPLATE_CLASS_NAME = templateClassName;
     this.choices =

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/InterfaceCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/InterfaceCompanion.java
@@ -37,7 +37,7 @@ public abstract class InterfaceCompanion<I, Id, View> extends ContractTypeCompan
       Identifier templateId,
       Function<String, Id> newContractId,
       ValueDecoder<View> valueDecoder,
-      List<ChoiceMetadata<I, ?, ?>> choices) {
+      List<Choice<I, ?, ?>> choices) {
     super(templateId, templateClassName, choices);
     this.newContractId = newContractId;
     this.valueDecoder = valueDecoder;

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -8,7 +8,7 @@ import ClassGenUtils.{companionFieldName, templateIdFieldName}
 import com.daml.lf.codegen.TypeWithContext
 import com.daml.lf.data.Ref
 import Ref.{ChoiceName, PackageId, QualifiedName}
-import com.daml.ledger.javaapi.data.codegen.ChoiceMetadata
+import com.daml.ledger.javaapi.data.codegen.Choice
 import com.daml.lf.codegen.backend.java.inner.ToValueGenerator.generateToValueConverter
 import com.daml.lf.typesig
 import typesig._
@@ -462,7 +462,7 @@ private[inner] object TemplateClass extends StrictLogging {
       templateChoices: Map[ChoiceName, TemplateChoice.FWT],
   ): Seq[FieldSpec] = {
     templateChoices.map { case (choiceName, choice) =>
-      val fieldClass = classOf[ChoiceMetadata[_, _, _]]
+      val fieldClass = classOf[Choice[_, _, _]]
       FieldSpec
         .builder(
           ParameterizedTypeName.get(

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/ChoiceMetadataFieldsSpec.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/ChoiceMetadataFieldsSpec.scala
@@ -4,7 +4,7 @@
 package com.daml.lf.codegen.backend.java
 
 import com.daml.ledger.javaapi.data.Unit
-import com.daml.ledger.javaapi.data.codegen.ChoiceMetadata
+import com.daml.ledger.javaapi.data.codegen.Choice
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import ut.retro.InterfaceRetro
@@ -16,7 +16,7 @@ import scala.jdk.CollectionConverters._
 final class ChoiceMetadataFieldsSpec extends AnyWordSpec with Matchers {
   "Template" should {
     "have choice fields" in {
-      val choice: ChoiceMetadata[Bar, Archive, Unit] = Bar.CHOICE_Archive
+      val choice: Choice[Bar, Archive, Unit] = Bar.CHOICE_Archive
       choice.name shouldBe "Archive"
     }
 


### PR DESCRIPTION
Fixes #15264.

```rst
CHANGELOG_BEGIN
- [Java codegen] The (new since 2.4) ``ChoiceMetadata`` class has been
  renamed to ``Choice``.
CHANGELOG_END
```