### PR TITLE
do not use the external definition of "serializable"

### DIFF
--- a/docs/source/app-dev/daml-lf-translation.rst
+++ b/docs/source/app-dev/daml-lf-translation.rst
@@ -13,7 +13,7 @@ Primitive Types
 
 :ref:`Built-in data types <daml-ref-built-in-types>` in Daml have straightforward mappings to Daml-LF.
 
-This section only covers the serializable types, as these are what client applications can interact with via the generated Daml-LF. (Serializable types are ones whose values can be written in a text or binary format. So not function types, ``Update`` and ``Scenario`` types, as well as any types built up from those.)
+This section only covers the serializable types, as these are what client applications can interact with via the generated Daml-LF. (Serializable types are ones whose values can exist on the ledger. So not function types, ``Update`` and ``Scenario`` types, any types built up from those, and several other restrictions.)
 
 Most built-in types have the same name in Daml-LF as in Daml. These are the exact mappings:
 

--- a/docs/source/app-dev/daml-lf-translation.rst
+++ b/docs/source/app-dev/daml-lf-translation.rst
@@ -13,7 +13,7 @@ Primitive Types
 
 :ref:`Built-in data types <daml-ref-built-in-types>` in Daml have straightforward mappings to Daml-LF.
 
-This section only covers the serializable types, as these are what client applications can interact with via the generated Daml-LF. (Serializable types are ones whose values can exist on the ledger. So not function types, ``Update`` and ``Scenario`` types, any types built up from those, and several other restrictions.)
+This section only covers the serializable types, as these are what client applications can interact with via the generated Daml-LF. (Serializable types are ones whose values can exist on the ledger. Function types, ``Update`` and ``Scenario`` types and any types built up from these are excluded, and there are several other restrictions.)
 
 Most built-in types have the same name in Daml-LF as in Daml. These are the exact mappings:
 


### PR DESCRIPTION
"ones whose values can be written in a text or binary format" is a misleading definition to give for "serializable types" in the context of Daml.

When we say "serializable" in Daml, we *always* mean [the formal Daml-LF definition](https://github.com/digital-asset/daml/blob/e3dcaf8aaf7543186be23244f227d6bfb1d28a08/daml-lf/spec/daml-lf-1.rst#serializable-types), i.e. ⊢ₛ τ, or "τ derives from the rules S".  That is also what we mean here.

There are many examples of types "whose values can be written in a text or binary format", that are nevertheless *not* derivable from S.

As it says in daml-lf-1.rst, "serializable types are the types whose values can be persisted on the ledger".  So we copy over something like that language.