### PR TITLE
Adds support for comparison operators in typescript

### DIFF
--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -303,13 +303,19 @@ export function assert(b: boolean, m: string): void {
   }
 }
 
+export enum ComparisonOperators {
+  "%lt" = "%lt",
+  "%lte" = "%lte",
+  "%gt" = "%gt",
+  "%gte" = "%gte",
+}
+
 /**
  * `Query<T>` is the type of queries for searching for contracts of template
  * or interface type `T`.
  *
- * `Query<T>` is an object consisting of a subset of the fields of `T`.
- *
- * Comparison queries are not yet supported.
+ * `Query<T>` is an object consisting of a subset of the fields of `T`. An
+ * object with comparisons are also accepted.
  *
  * NB: This type is heavily related to the `DeepPartial` type that can be found
  * in the TypeScript community.
@@ -317,8 +323,11 @@ export function assert(b: boolean, m: string): void {
  * @typeparam T The contract template type.
  *
  */
-export type Query<T> = T extends object ? { [K in keyof T]?: Query<T[K]> } : T;
-// TODO(MH): Support comparison queries.
+export type Query<T> = T extends object
+  ? {
+      [K in keyof T]?: Query<T[K]>;
+    }
+  : T | { [key in ComparisonOperators]: T };
 
 /** @internal
  *


### PR DESCRIPTION
Hello,

I noticed that the `Query` type for the Typescript libraries did not yet support comparison operators. This PR adds support for this. I don't believe any other changes are necessary as this is already supported by the JSON API.

CHANGELOG_BEGIN

- [JavaScript Client Libraries] Adds support for comparison operators in typescript

CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
