### PR TITLE
Fix potential embarrassing spelling

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -407,7 +407,7 @@ data GetTimePayload a = GetTimePayload
 -- This is primarily useful in tests
 -- where you repeatedly call `query` until a certain state is reached.
 --
--- Note that this will sleep for the same duration in both wallcock and static time mode.
+-- Note that this will sleep for the same duration in both wall clock and static time mode.
 sleep : HasCallStack => RelTime -> Script ()
 sleep duration = lift $ Free $Sleep SleepRec with
   duration = duration


### PR DESCRIPTION
CHANGELOG_BEGIN
  [daml-script] Fix documentation spelling
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
