### PR TITLE
Define price in 'Intro: Exceptions' using template parameter instead of local let

### DIFF
--- a/docs/source/daml/intro/8_Exceptions.rst
+++ b/docs/source/daml/intro/8_Exceptions.rst
@@ -55,13 +55,17 @@ amount is always positive so ``Transfer`` cannot transfer more money
 than is available.
 
 The shop is represented as a template signed by the owner. It has a
-field to represent the bank accepted by the owner as well as a list of
-observers that can order items:
+field to represent the bank accepted by the owner, a list of
+observers that can order items, and a fixed price for the items that can be
+ordered:
 
 .. literalinclude:: daml/daml-intro-8/daml/Intro/Exceptions.daml
   :language: daml
   :start-after: -- SHOP_BEGIN
   :end-before: -- SHOP_END
+
+.. note:: In a real setting the price of each item for sale might be
+  defined in a separate contract.
 
 The ordering process is then represented by a non-consuming choice on
 this template which calls ``Transfer`` and creates an ``Order``

--- a/docs/source/daml/intro/daml/daml-intro-8/daml/Intro/Exceptions.daml
+++ b/docs/source/daml/intro/daml/daml-intro-8/daml/Intro/Exceptions.daml
@@ -59,10 +59,10 @@ template Shop
     owner : Party
     bank : Party
     observers : [Party]
+    price : Decimal
   where
     signatory owner
     observer observers
-    let price: Decimal = 100.0
 -- SHOP_END
 
 -- ORDER_BEGIN
@@ -146,6 +146,7 @@ test = script do
     owner = shopOwner
     bank = bank
     observers = [alice]
+    price = 100.0
 
   submit alice $ exerciseCmd shop (OrderItemTrusted alice)
   submit alice $ exerciseCmd shop (OrderItemTrusted alice)


### PR DESCRIPTION
This fixes #15256

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
