### PR TITLE
Fix DD test case 'Cross Daml-LF version with double data-dependency'

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -343,7 +343,7 @@ tests tools = testGroup "Data Dependencies" $
                 , " - " <> show oldProjDar
                 , " - " <> show (proja </> "proja.dar")
                 ]
-            callProcessSilent (damlcForTarget tools depLfVer)
+            callProcessSilent damlc
                 ["build"
                 , "--project-root", projb
                 , "--target", LF.renderVersion targetLfVer


### PR DESCRIPTION
The problem is that `damlcForTarget tools depLfVer` could return an older damlc than needed for `targetLfVer`.

The reason this didn't fail before is that the legacy damlc supports up to LF=1.14, and `lfVersionTestPairs` never had `depLfVer < 1.14 && targetLfVer > 1.14`

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
