### PR TITLE
Add the metrics context to the metric creation API [PLEN-5]

### DIFF
--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/ExposedMetrics.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/ExposedMetrics.scala
@@ -98,7 +98,7 @@ object ExposedMetrics {
           registry
             .register(
               Prefix :+ "latest_record_time" :+ streamName,
-              new Gauges.VarGauge[Long](0L)(MetricsContext.Empty),
+              new Gauges.VarGauge[Long](0L),
             ),
         ),
         recordTimeFunction = f,

--- a/ledger/metrics/src/main/scala/com/daml/metrics/CacheMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/CacheMetrics.scala
@@ -9,7 +9,7 @@ import com.daml.metrics.api.MetricHandle.Counter
 import com.daml.metrics.api.dropwizard.DropwizardFactory
 import com.daml.metrics.api.{MetricDoc, MetricName, MetricsContext}
 
-final class CacheMetrics(override val prefix: MetricName, override val registry: MetricRegistry)
+final class CacheMetrics(val prefix: MetricName, override val registry: MetricRegistry)
     extends DropwizardFactory {
 
   @MetricDoc.Tag(

--- a/ledger/metrics/src/main/scala/com/daml/metrics/CommandMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/CommandMetrics.scala
@@ -9,7 +9,7 @@ import com.daml.metrics.api.MetricHandle.{Counter, Meter, Timer}
 import com.daml.metrics.api.dropwizard.DropwizardFactory
 import com.daml.metrics.api.{MetricDoc, MetricName}
 
-class CommandMetrics(override val prefix: MetricName, override val registry: MetricRegistry)
+class CommandMetrics(val prefix: MetricName, override val registry: MetricRegistry)
     extends DropwizardFactory {
 
   @MetricDoc.Tag(

--- a/ledger/metrics/src/main/scala/com/daml/metrics/DatabaseMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/DatabaseMetrics.scala
@@ -10,7 +10,7 @@ import com.daml.metrics.api.dropwizard.DropwizardFactory
 import com.daml.metrics.api.{MetricDoc, MetricName}
 
 class DatabaseMetrics private[metrics] (
-    override val prefix: MetricName,
+    val prefix: MetricName,
     val name: String,
     override val registry: MetricRegistry,
 ) extends DropwizardFactory {

--- a/ledger/metrics/src/main/scala/com/daml/metrics/ExecutionMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/ExecutionMetrics.scala
@@ -9,7 +9,7 @@ import com.daml.metrics.api.MetricHandle.{Counter, Histogram, Meter, Timer}
 import com.daml.metrics.api.dropwizard.DropwizardFactory
 import com.daml.metrics.api.{MetricDoc, MetricName}
 
-class ExecutionMetrics(override val prefix: MetricName, override val registry: MetricRegistry)
+class ExecutionMetrics(val prefix: MetricName, override val registry: MetricRegistry)
     extends DropwizardFactory {
 
   @MetricDoc.Tag(
@@ -132,7 +132,7 @@ class ExecutionMetrics(override val prefix: MetricName, override val registry: M
     representative = "daml.execution.cache.<state_cache>.evicted_weight"
   )
   object cache extends DropwizardFactory {
-    override val prefix: MetricName = ExecutionMetrics.this.prefix :+ "cache"
+    val prefix: MetricName = ExecutionMetrics.this.prefix :+ "cache"
     override val registry = ExecutionMetrics.this.registry
 
     object keyState {

--- a/ledger/metrics/src/main/scala/com/daml/metrics/HttpJsonApiMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/HttpJsonApiMetrics.scala
@@ -8,11 +8,11 @@ import com.daml.metrics.api.MetricHandle.{Counter, Meter, Timer}
 import com.daml.metrics.api.MetricName
 import com.daml.metrics.api.dropwizard.DropwizardFactory
 
-class HttpJsonApiMetrics(override val prefix: MetricName, override val registry: MetricRegistry)
+class HttpJsonApiMetrics(val prefix: MetricName, override val registry: MetricRegistry)
     extends DropwizardFactory {
 
   object Db extends DropwizardFactory {
-    override val prefix: MetricName = HttpJsonApiMetrics.this.prefix :+ "db"
+    val prefix: MetricName = HttpJsonApiMetrics.this.prefix :+ "db"
     override val registry: MetricRegistry = HttpJsonApiMetrics.this.registry
 
     val fetchByIdFetch: Timer = timer(prefix :+ "fetch_by_id_fetch")

--- a/ledger/metrics/src/main/scala/com/daml/metrics/IndexMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IndexMetrics.scala
@@ -9,7 +9,7 @@ import com.daml.metrics.api.MetricHandle.{Counter, Gauge, Timer}
 import com.daml.metrics.api.dropwizard.DropwizardFactory
 import com.daml.metrics.api.{MetricDoc, MetricName}
 
-class IndexMetrics(override val prefix: MetricName, override val registry: MetricRegistry)
+class IndexMetrics(val prefix: MetricName, override val registry: MetricRegistry)
     extends DropwizardFactory {
 
   @MetricDoc.Tag(

--- a/ledger/metrics/src/main/scala/com/daml/metrics/IndexerMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IndexerMetrics.scala
@@ -11,7 +11,7 @@ import com.daml.metrics.api.MetricHandle.Gauge
 import com.daml.metrics.api.dropwizard.{DropwizardFactory, DropwizardGauge}
 import com.daml.metrics.api.{MetricDoc, MetricName, MetricsContext}
 
-class IndexerMetrics(override val prefix: MetricName, override val registry: MetricRegistry)
+class IndexerMetrics(val prefix: MetricName, override val registry: MetricRegistry)
     extends DropwizardFactory {
 
   @MetricDoc.Tag(

--- a/ledger/metrics/src/main/scala/com/daml/metrics/LAPIMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/LAPIMetrics.scala
@@ -9,7 +9,7 @@ import com.daml.metrics.api.MetricHandle.{Counter, Timer}
 import com.daml.metrics.api.dropwizard.{DropwizardCounter, DropwizardFactory, DropwizardTimer}
 import com.daml.metrics.api.{MetricDoc, MetricName}
 
-class LAPIMetrics(override val prefix: MetricName, override val registry: MetricRegistry)
+class LAPIMetrics(val prefix: MetricName, override val registry: MetricRegistry)
     extends DropwizardFactory {
 
   @MetricDoc.Tag(

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -15,7 +15,6 @@ object Metrics {
 
 final class Metrics(override val registry: MetricRegistry, val meter: OtelMeter)
     extends DropwizardFactory {
-  override val prefix = MetricName("")
 
   object test {
     private val prefix: MetricName = MetricName("test")
@@ -24,7 +23,7 @@ final class Metrics(override val registry: MetricRegistry, val meter: OtelMeter)
   }
 
   object daml extends DropwizardFactory {
-    override val prefix: MetricName = MetricName.Daml
+    val prefix: MetricName = MetricName.Daml
     override val registry = Metrics.this.registry
 
     object commands extends CommandMetrics(prefix :+ "commands", registry)

--- a/ledger/metrics/src/main/scala/com/daml/metrics/ParallelIndexerMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/ParallelIndexerMetrics.scala
@@ -42,7 +42,7 @@ import com.daml.metrics.api.{MetricDoc, MetricName}
 @MetricDoc.GroupTag(
   representative = "daml.parallel_indexer.<stage>.executor.duration"
 )
-class ParallelIndexerMetrics(override val prefix: MetricName, override val registry: MetricRegistry)
+class ParallelIndexerMetrics(val prefix: MetricName, override val registry: MetricRegistry)
     extends DropwizardFactory {
   val initialization = new DatabaseMetrics(prefix, "initialization", registry)
 

--- a/ledger/metrics/src/main/scala/com/daml/metrics/ServicesMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/ServicesMetrics.scala
@@ -9,11 +9,11 @@ import com.daml.metrics.api.MetricHandle.{Counter, Histogram, Meter, Timer}
 import com.daml.metrics.api.dropwizard.{DropwizardFactory, DropwizardTimer}
 import com.daml.metrics.api.{MetricDoc, MetricName}
 
-class ServicesMetrics(override val prefix: MetricName, override val registry: MetricRegistry)
+class ServicesMetrics(val prefix: MetricName, override val registry: MetricRegistry)
     extends DropwizardFactory {
 
   object index extends DropwizardFactory {
-    override val prefix: MetricName = ServicesMetrics.this.prefix :+ "index"
+    val prefix: MetricName = ServicesMetrics.this.prefix :+ "index"
     override val registry: MetricRegistry = ServicesMetrics.this.registry
 
     @MetricDoc.Tag(
@@ -54,7 +54,7 @@ class ServicesMetrics(override val prefix: MetricName, override val registry: Me
     val getTransactionMetering: Timer = timer(prefix :+ "get_transaction_metering")
 
     object InMemoryFanoutBuffer extends DropwizardFactory {
-      override val prefix: MetricName = index.prefix :+ "in_memory_fan_out_buffer"
+      val prefix: MetricName = index.prefix :+ "in_memory_fan_out_buffer"
       override val registry: MetricRegistry = index.registry
 
       @MetricDoc.Tag(
@@ -88,7 +88,7 @@ class ServicesMetrics(override val prefix: MetricName, override val registry: Me
     }
 
     case class BufferedReader(streamName: String) extends DropwizardFactory {
-      override val prefix: MetricName = index.prefix :+ s"${streamName}_buffer_reader"
+      val prefix: MetricName = index.prefix :+ s"${streamName}_buffer_reader"
       override val registry: MetricRegistry = index.registry
 
       @MetricDoc.Tag(
@@ -150,7 +150,7 @@ class ServicesMetrics(override val prefix: MetricName, override val registry: Me
   }
 
   object read extends DropwizardFactory {
-    override val prefix: MetricName = ServicesMetrics.this.prefix :+ "read"
+    val prefix: MetricName = ServicesMetrics.this.prefix :+ "read"
     override val registry: MetricRegistry = index.registry
 
     @MetricDoc.Tag(
@@ -167,7 +167,7 @@ class ServicesMetrics(override val prefix: MetricName, override val registry: Me
   }
 
   object write extends DropwizardFactory {
-    override val prefix: MetricName = ServicesMetrics.this.prefix :+ "write"
+    val prefix: MetricName = ServicesMetrics.this.prefix :+ "write"
     override val registry: MetricRegistry = index.registry
 
     @MetricDoc.Tag(

--- a/ledger/metrics/src/main/scala/com/daml/metrics/api/Gauges.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/api/Gauges.scala
@@ -11,25 +11,18 @@ object Gauges {
 
   trait GaugeWithUpdate[T] extends Gauge[T] {
 
-    def updateValue(x: T)(implicit
-        context: MetricsContext
-    ): Unit
+    def updateValue(x: T): Unit
   }
 
-  case class VarGauge[T](initial: T)(implicit context: MetricsContext) extends GaugeWithUpdate[T] {
-    private val ref = new AtomicReference[(T, MetricsContext)](initial -> context)
-    def updateValue(x: T)(implicit
-        context: MetricsContext
-    ): Unit = ref.set(x -> context)
-    def updateValue(up: T => T)(implicit
-        context: MetricsContext
-    ): Unit = {
-      val _ = ref.updateAndGet { case (value, _) =>
-        up(value) -> context
+  case class VarGauge[T](initial: T) extends GaugeWithUpdate[T] {
+    private val ref = new AtomicReference[T](initial)
+    def updateValue(x: T): Unit = ref.set(x)
+    def updateValue(up: T => T): Unit = {
+      val _ = ref.updateAndGet { value =>
+        up(value)
       }
     }
-    override def getValue: T = ref.get()._1
+    override def getValue: T = ref.get()
 
-    def getValueAndContext: (T, MetricsContext) = ref.get()
   }
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/api/MetricHandle.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/api/MetricHandle.scala
@@ -19,9 +19,9 @@ object MetricHandle {
 
   trait Factory {
 
-    def prefix: MetricName
-
-    def timer(name: MetricName): Timer
+    def timer(name: MetricName)(implicit
+        context: MetricsContext = MetricsContext.Empty
+    ): Timer
 
     def gauge[T](name: MetricName, initial: T)(implicit
         context: MetricsContext
@@ -29,14 +29,22 @@ object MetricHandle {
 
     def gaugeWithSupplier[T](
         name: MetricName,
-        gaugeSupplier: () => () => (T, MetricsContext),
+        gaugeSupplier: () => T,
+    )(implicit
+        context: MetricsContext = MetricsContext.Empty
     ): Unit
 
-    def meter(name: MetricName): Meter
+    def meter(name: MetricName)(implicit
+        context: MetricsContext = MetricsContext.Empty
+    ): Meter
 
-    def counter(name: MetricName): Counter
+    def counter(name: MetricName)(implicit
+        context: MetricsContext = MetricsContext.Empty
+    ): Counter
 
-    def histogram(name: MetricName): Histogram
+    def histogram(name: MetricName)(implicit
+        context: MetricsContext = MetricsContext.Empty
+    ): Histogram
 
   }
 
@@ -81,13 +89,9 @@ object MetricHandle {
   trait Gauge[T] extends MetricHandle {
     def metricType: String = "Gauge"
 
-    def updateValue(newValue: T)(implicit
-        context: MetricsContext = MetricsContext.Empty
-    ): Unit
+    def updateValue(newValue: T): Unit
 
-    def updateValue(f: T => T)(implicit
-        context: MetricsContext
-    ): Unit = updateValue(f(getValue))
+    def updateValue(f: T => T): Unit = updateValue(f(getValue))
 
     def getValue: T
   }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/api/dropwizard/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/api/dropwizard/Metrics.scala
@@ -61,9 +61,7 @@ sealed case class DropwizardCounter(name: String, metric: codahale.Counter) exte
 }
 
 sealed case class DropwizardGauge[T](name: String, metric: Gauges.VarGauge[T]) extends Gauge[T] {
-  def updateValue(newValue: T)(implicit
-      context: MetricsContext = MetricsContext.Empty
-  ): Unit = metric.updateValue(newValue)
+  def updateValue(newValue: T): Unit = metric.updateValue(newValue)
   override def getValue: T = metric.getValue
 }
 

--- a/ledger/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryFactory.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryFactory.scala
@@ -209,7 +209,11 @@ case class OpentelemetryHistogram(
 
 private object AttributesHelper {
 
-  def multiContextAsAttributes(context: MetricsContext*): Attributes = {
+  /** Merges multiple [[MetricsContext]] into a single [[Attributes]] object.
+    * The labels from all the contexts are added as attributes.
+    * If the same label key is defined in multiple contexts, the value from the last metric context will be used.
+    */
+  private[opentelemetry] def multiContextAsAttributes(context: MetricsContext*): Attributes = {
     context
       .foldLeft(Attributes.builder()) { (builder, context) =>
         context.labels.foreachEntry { (key, value) =>

--- a/ledger/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryFactory.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryFactory.scala
@@ -211,8 +211,8 @@ private object AttributesHelper {
 
   def multiContextAsAttributes(context: MetricsContext*): Attributes = {
     context
-      .foldLeft(Attributes.builder()) { case (builder, context) =>
-        context.labels.foreach { case (key, value) =>
+      .foldLeft(Attributes.builder()) { (builder, context) =>
+        context.labels.foreachEntry { (key, value) =>
           builder.put(key, value)
         }
         builder

--- a/ledger/metrics/src/test/suite/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryFactorySpec.scala
+++ b/ledger/metrics/src/test/suite/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryFactorySpec.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.daml.metrics.api.opentelemetry
 
 import com.daml.metrics.api.MetricsContext

--- a/ledger/metrics/src/test/suite/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryFactorySpec.scala
+++ b/ledger/metrics/src/test/suite/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryFactorySpec.scala
@@ -1,0 +1,55 @@
+package com.daml.metrics.api.opentelemetry
+
+import com.daml.metrics.api.MetricsContext
+import io.opentelemetry.api.common.AttributeKey
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.jdk.CollectionConverters.MapHasAsScala
+
+class OpenTelemetryFactorySpec extends AnyWordSpec with Matchers {
+
+  "merging metrics contexts" should {
+
+    "add all labels as attributes" in {
+      val mergedAttributes = AttributesHelper.multiContextAsAttributes(
+        MetricsContext(
+          Map(
+            "key1" -> "value"
+          )
+        ),
+        MetricsContext(
+          Map(
+            "key2" -> "value"
+          )
+        ),
+      )
+      mergedAttributes.asMap().asScala should contain theSameElementsAs Map(
+        AttributeKey.stringKey("key1") -> "value",
+        AttributeKey.stringKey("key2") -> "value",
+      )
+    }
+
+    "merge contexts with duplicate label keys" in {
+      val mergedAttributes = AttributesHelper.multiContextAsAttributes(
+        MetricsContext(
+          Map(
+            "key1" -> "value1"
+          )
+        ),
+        MetricsContext(
+          Map(
+            "key1" -> "value2",
+            "key2" -> "value",
+          )
+        ),
+      )
+      mergedAttributes.asMap().asScala should contain theSameElementsAs Map(
+        AttributeKey.stringKey("key1") -> "value2",
+        AttributeKey.stringKey("key2") -> "value",
+      )
+    }
+
+  }
+
+}

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/bridge/BridgeMetrics.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/bridge/BridgeMetrics.scala
@@ -13,7 +13,7 @@ class BridgeMetrics(metrics: Metrics) extends DropwizardFactory {
 
   override val registry: MetricRegistry = metrics.registry
 
-  override val prefix: MetricName = MetricName.Daml :+ "sandbox_ledger_bridge"
+  val prefix: MetricName = MetricName.Daml :+ "sandbox_ledger_bridge"
 
   val threadpool: MetricName = prefix :+ "threadpool"
 


### PR DESCRIPTION
The labels provided during metric creation are merged with the labels provided during metric recording

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
