### PR TITLE
[daml-script] use all parties for queryView

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -81,7 +81,7 @@ case class Participants[+T](
     participants: Map[Participant, T],
     party_participants: Map[Party, Participant],
 ) {
-  def getPartyParticipant(party: Party): Either[String, T] =
+  private def getPartyParticipant(party: Party): Either[String, T] =
     party_participants.get(party) match {
       case None =>
         default_participant.toRight(s"No participant for party $party and no default participant")

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
@@ -253,7 +253,7 @@ object ScriptF {
         esf: ExecutionSequencerFactory,
     ): Future[SExpr] =
       for {
-        client <- Converter.toFuture(env.clients.getPartyParticipant(parties.head))
+        client <- Converter.toFuture(env.clients.getPartiesParticipant(parties))
         optR <- client.queryContractId(parties, tplId, cid)
         optR <- Converter.toFuture(optR.traverse(Converter.fromContract(env.valueTranslator, _)))
       } yield SEAppAtomic(SEValue(continue), Array(SEValue(SOptional(optR))))
@@ -281,7 +281,7 @@ object ScriptF {
 
       for {
         viewType <- Converter.toFuture(env.lookupInterfaceViewTy(interfaceId))
-        client <- Converter.toFuture(env.clients.getPartyParticipant(parties.head))
+        client <- Converter.toFuture(env.clients.getPartiesParticipant(parties))
         list <- client.queryView(parties, interfaceId)
         list <- Converter.toFuture(
           list
@@ -318,7 +318,7 @@ object ScriptF {
     ): Future[SExpr] = {
       for {
         viewType <- Converter.toFuture(env.lookupInterfaceViewTy(interfaceId))
-        client <- Converter.toFuture(env.clients.getPartyParticipant(parties.head))
+        client <- Converter.toFuture(env.clients.getPartiesParticipant(parties))
         optR <- client.queryViewContractId(parties, interfaceId, cid)
         optR <- Converter.toFuture(
           optR.traverse(Converter.fromInterfaceView(env.valueTranslator, viewType, _))


### PR DESCRIPTION
Addresses comment: https://github.com/digital-asset/daml/pull/15286#discussion_r1006809483
Advances https://github.com/digital-asset/daml/issues/14830

In fact we should use all parties for all query ops. and never do `parties.head`
