### PR TITLE
[daml-script] handle view computations which fail

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -229,11 +229,11 @@ data QueryViewPayload a = QueryViewPayload
 
 -- | Query the set of active contracts views for an interface
 -- that are visible to the given party.
-queryView : forall i v p. (TemplateOrInterface i, HasInterfaceView i v, IsParties p) => p -> Script [(ContractId i, v)]
+queryView : forall i v p. (TemplateOrInterface i, HasInterfaceView i v, IsParties p) => p -> Script [(ContractId i, Optional v)]
 queryView p = lift $ Free $ QueryView QueryViewPayload with
   parties = toParties p
   interfaceId = templateTypeRep @i
-  continue = pure . map (fromLedgerValue @(ContractId i, v))
+  continue = pure . map (fromLedgerValue @(ContractId i, Optional v))
   locations = getCallStack callStack
 
 data QueryViewContractIdPayload a = QueryViewContractIdPayload

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
@@ -286,15 +286,20 @@ object ScriptF {
         list <- Converter.toFuture(
           list
             .to(FrontStack)
-            .traverse { case (cid, view) =>
-              for {
-                view <- Converter.fromInterfaceView(
-                  env.valueTranslator,
-                  viewType,
-                  view,
-                )
-              } yield {
-                makePair(SContractId(cid), view)
+            .traverse { case (cid, optView) =>
+              optView match {
+                case None =>
+                  Right(makePair(SContractId(cid), SOptional(None)))
+                case Some(view) =>
+                  for {
+                    view <- Converter.fromInterfaceView(
+                      env.valueTranslator,
+                      viewType,
+                      view,
+                    )
+                  } yield {
+                    makePair(SContractId(cid), SOptional(Some(view)))
+                  }
               }
             }
         )

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/GrpcLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/GrpcLedgerClient.scala
@@ -119,7 +119,7 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
   override def queryView(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
-  )(implicit ec: ExecutionContext, mat: Materializer): Future[Seq[(ContractId, Value)]] = {
+  )(implicit ec: ExecutionContext, mat: Materializer): Future[Seq[(ContractId, Option[Value])]] = {
     sys.error("not implemented") // TODO https://github.com/digital-asset/daml/issues/14830
   }
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
@@ -212,7 +212,7 @@ class JsonLedgerClient(
   override def queryView(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
-  )(implicit ec: ExecutionContext, mat: Materializer): Future[Seq[(ContractId, Value)]] = {
+  )(implicit ec: ExecutionContext, mat: Materializer): Future[Seq[(ContractId, Option[Value])]] = {
     sys.error("not implemented") // TODO https://github.com/digital-asset/daml/issues/14830
   }
   override def queryViewContractId(

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/ScriptLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/ScriptLedgerClient.scala
@@ -90,7 +90,7 @@ trait ScriptLedgerClient {
   )(implicit
       ec: ExecutionContext,
       mat: Materializer,
-  ): Future[Seq[(ContractId, Value)]]
+  ): Future[Seq[(ContractId, Option[Value])]]
 
   def queryViewContractId(
       parties: OneAnd[Set, Ref.Party],


### PR DESCRIPTION
Handle view computations which fail.

Changing type of daml-script API for `queryView` as suggested by:  https://github.com/digital-asset/daml/pull/15286#discussion_r1006751403

Advances: https://github.com/digital-asset/daml/issues/14830
