### PR TITLE
Precompute ScalaPB serializedSize for heavy grpc streams [DPP-1301]

### DIFF
--- a/ledger-api/rs-grpc-akka/BUILD.bazel
+++ b/ledger-api/rs-grpc-akka/BUILD.bazel
@@ -9,6 +9,7 @@ da_scala_library(
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
+        "@maven//:com_thesamet_scalapb_scalapb_runtime",
     ],
     tags = ["maven_coordinates=com.daml:rs-grpc-akka:__VERSION__"],
     visibility = [

--- a/ledger-api/rs-grpc-akka/src/main/scala/com/digitalasset/grpc/adapter/server/akka/StreamingServiceLifecycleManagement.scala
+++ b/ledger-api/rs-grpc-akka/src/main/scala/com/digitalasset/grpc/adapter/server/akka/StreamingServiceLifecycleManagement.scala
@@ -8,6 +8,7 @@ import akka.stream.scaladsl.{Keep, Source}
 import akka.stream.{KillSwitch, KillSwitches, Materializer}
 import com.daml.grpc.adapter.ExecutionSequencerFactory
 import io.grpc.stub.StreamObserver
+import scalapb.GeneratedMessage
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.ExecutionContext
@@ -15,6 +16,7 @@ import scala.concurrent.ExecutionContext
 trait StreamingServiceLifecycleManagement extends AutoCloseable {
   @volatile private var _closed = false
   private val _killSwitches = TrieMap.empty[KillSwitch, Object]
+  protected def optimizeGrpcStreamsThroughput: Boolean
 
   def close(): Unit = synchronized {
     if (!_closed) {
@@ -24,7 +26,7 @@ trait StreamingServiceLifecycleManagement extends AutoCloseable {
     }
   }
 
-  protected def registerStream[RespT](
+  protected def registerStream[RespT <: GeneratedMessage with AnyRef](
       buildSource: () => Source[RespT, NotUsed],
       responseObserver: StreamObserver[RespT],
   )(implicit
@@ -38,16 +40,20 @@ trait StreamingServiceLifecycleManagement extends AutoCloseable {
     ifNotClosed { () =>
       val sink = ServerAdapter.toSink(responseObserver)
       val source = buildSource()
+      val sourceWithPotentialOptimization =
+        if (optimizeGrpcStreamsThroughput) source.precomputeSerializedSize
+        else source
 
       // Double-checked locking to keep the (potentially expensive)
       // buildSource() step out of the synchronized block
       synchronized {
         ifNotClosed { () =>
-          val (killSwitch, doneF) = source
-            .viaMat(KillSwitches.single)(Keep.right)
-            .watchTermination()(Keep.both)
-            .toMat(sink)(Keep.left)
-            .run()
+          val (killSwitch, doneF) =
+            sourceWithPotentialOptimization
+              .viaMat(KillSwitches.single)(Keep.right)
+              .watchTermination()(Keep.both)
+              .toMat(sink)(Keep.left)
+              .run()
 
           _killSwitches += killSwitch -> NotUsed
 
@@ -57,5 +63,40 @@ trait StreamingServiceLifecycleManagement extends AutoCloseable {
         }
       }
     }
+  }
+
+  implicit class ScalaPbOptimizationsFlow[ScalaPbMessage <: GeneratedMessage with AnyRef, Mat](
+      val original: Source[ScalaPbMessage, Mat]
+  ) {
+
+    /** Optimization for gRPC stream throughput.
+      *
+      * gRPC internal logic marshalls the protobuf response payloads sequentially before
+      * sending them over the wire (see io.grpc.ServerCallImpl.sendMessageInternal), imposing as limit
+      * the maximum marshalling throughput of a payload type.
+      *
+      * We've observed empirically that ScalaPB-generated message classes have associated marshallers
+      * with significant latencies when encoding complex payloads (e.g. [[com.daml.ledger.api.v1.transaction_service.GetTransactionTreesResponse]]),
+      * with the gRPC marshalling bottleneck appearing in some performance tests.
+      *
+      * As an alleviation of the problem, we can leverage the fact that ScalaPB message classes have the serializedSize value memoized,
+      * (see [[scalapb.GeneratedMessage.writeTo]]), whose computation is roughly half of the entire marshalling step.
+      *
+      * This optimization method takes advantage of the memoized value and forces the message's serializedSize computation,
+      * roughly doubling the maximum theoretical ScalaPB stream throughput over the gRPC server layer.
+      *
+      * @return A new source with precomputed serializedSize for the [[scalapb.GeneratedMessage]]
+      */
+    def precomputeSerializedSize: Source[ScalaPbMessage, Mat] =
+      original.map { msg =>
+        // At ScalaPB 0.11.8, computation of serializedSize is thread-safe but the memoization mechanism
+        // which this optimization is relying on is not.
+        // Hence, synchronize on the message to ensure across-threads visibility of the memoized value,
+        // with minimal performance impact since the monitor is un-contended.
+        msg.synchronized {
+          val _ = msg.serializedSize
+        }
+        msg
+      }.async
   }
 }

--- a/ledger-api/rs-grpc-bridge/src/main/java/com/daml/grpc/adapter/server/rs/ServerSubscriber.java
+++ b/ledger-api/rs-grpc-bridge/src/main/java/com/daml/grpc/adapter/server/rs/ServerSubscriber.java
@@ -94,7 +94,10 @@ public class ServerSubscriber<Resp> implements Subscriber<Resp> {
     executionSequencer.sequence(
         () -> {
           if (!responseObserver.isCancelled()) {
-            responseObserver.onNext(response);
+            synchronized (response) {
+              // Ensure memory visibility of precomputation of message's serializedSize
+              responseObserver.onNext(response);
+            }
             if (responseObserver.isReady()) {
               onReadyHandler.run();
             } else {

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandCompletionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandCompletionService.scala
@@ -19,6 +19,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class GrpcCommandCompletionService(
     service: CommandCompletionService,
     validator: CompletionServiceRequestValidator,
+    protected val optimizeGrpcStreamsThroughput: Boolean,
 )(implicit
     protected val mat: Materializer,
     protected val esf: ExecutionSequencerFactory,
@@ -53,5 +54,4 @@ class GrpcCommandCompletionService(
               CompletionEndResponse(Some(LedgerOffset(LedgerOffset.Value.Absolute(abs.value))))
             ),
       )
-
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcHealthService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcHealthService.scala
@@ -41,6 +41,10 @@ class GrpcHealthService(
   private val errorLogger: ContextualizedErrorLogger =
     new DamlContextualizedErrorLogger(logger, loggingContext, None)
 
+  // This optimization targets services with potentially complex protobuf payloads.
+  // Not applicable for this service.
+  protected val optimizeGrpcStreamsThroughput: Boolean = false
+
   override def bindService(): ServerServiceDefinition =
     HealthGrpc.bindService(this, executionContext)
 

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcTransactionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcTransactionService.scala
@@ -25,6 +25,7 @@ final class GrpcTransactionService(
     protected val service: TransactionService,
     val ledgerId: LedgerId,
     partyNameChecker: PartyNameChecker,
+    protected val optimizeGrpcStreamsThroughput: Boolean,
 )(implicit
     protected val esf: ExecutionSequencerFactory,
     protected val mat: Materializer,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServerConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServerConfig.scala
@@ -31,6 +31,7 @@ case class ApiServerConfig(
     timeProviderType: TimeProviderType = ApiServerConfig.DefaultTimeProviderType,
     tls: Option[TlsConfiguration] = ApiServerConfig.DefaultTls,
     userManagement: UserManagementConfig = ApiServerConfig.DefaultUserManagement,
+    optimizeGrpcStreamsThroughput: Boolean = ApiServerConfig.DefaultOptimizeGrpcStreamsThroughput,
 )
 
 object ApiServerConfig {
@@ -50,4 +51,5 @@ object ApiServerConfig {
   val DefaultTimeProviderType: TimeProviderType = TimeProviderType.WallClock
   val DefaultApiStreamShutdownTimeout: FiniteDuration = FiniteDuration(5, "seconds")
   val DefaultRateLimitingConfig: Option[RateLimitingConfig] = Some(RateLimitingConfig.Default)
+  val DefaultOptimizeGrpcStreamsThroughput: Boolean = true
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServiceOwner.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServiceOwner.scala
@@ -121,6 +121,7 @@ object ApiServiceOwner {
         meteringReportKey = meteringReportKey,
         explicitDisclosureUnsafeEnabled = explicitDisclosureUnsafeEnabled,
         createExternalServices = createExternalServices,
+        optimizeGrpcStreamsThroughput = config.optimizeGrpcStreamsThroughput,
       )(materializer, executionSequencerFactory, loggingContext)
         .map(_.withServices(otherServices))
       apiService <- new LedgerApiService(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -90,6 +90,7 @@ private[daml] object ApiServices {
       meteringReportKey: MeteringReportKey,
       explicitDisclosureUnsafeEnabled: Boolean,
       createExternalServices: () => List[BindableService] = () => Nil,
+      optimizeGrpcStreamsThroughput: Boolean,
   )(implicit
       materializer: Materializer,
       esf: ExecutionSequencerFactory,
@@ -145,16 +146,18 @@ private[daml] object ApiServices {
         checkOverloaded: TelemetryContext => Option[state.SubmissionResult],
     )(implicit executionContext: ExecutionContext): List[BindableService] = {
       val apiTransactionService =
-        ApiTransactionService.create(ledgerId, transactionsService, metrics)
+        ApiTransactionService.create(
+          ledgerId,
+          transactionsService,
+          metrics,
+          optimizeGrpcStreamsThroughput,
+        )
 
       val apiLedgerIdentityService =
         ApiLedgerIdentityService.create(ledgerId)
 
       val apiVersionService =
-        ApiVersionService.create(
-          ledgerFeatures,
-          userManagementConfig = userManagementConfig,
-        )
+        ApiVersionService.create(ledgerFeatures, userManagementConfig)
 
       val apiPackageService =
         ApiPackageService.create(ledgerId, packagesService)
@@ -167,6 +170,7 @@ private[daml] object ApiServices {
           ledgerId,
           completionsService,
           metrics,
+          optimizeGrpcStreamsThroughput,
         )
 
       val apiActiveContractsService =
@@ -174,6 +178,7 @@ private[daml] object ApiServices {
           ledgerId,
           activeContractsService,
           metrics,
+          optimizeGrpcStreamsThroughput,
         )
 
       val apiTimeServiceOpt =

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiActiveContractsService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiActiveContractsService.scala
@@ -26,6 +26,7 @@ import scala.concurrent.ExecutionContext
 private[apiserver] final class ApiActiveContractsService private (
     backend: ACSBackend,
     metrics: Metrics,
+    protected val optimizeGrpcStreamsThroughput: Boolean,
 )(implicit
     protected val mat: Materializer,
     protected val esf: ExecutionSequencerFactory,
@@ -64,6 +65,7 @@ private[apiserver] object ApiActiveContractsService {
       ledgerId: LedgerId,
       backend: ACSBackend,
       metrics: Metrics,
+      optimizeGrpcStreamsThroughput: Boolean,
   )(implicit
       mat: Materializer,
       esf: ExecutionSequencerFactory,
@@ -73,6 +75,7 @@ private[apiserver] object ApiActiveContractsService {
     val service = new ApiActiveContractsService(
       backend = backend,
       metrics = metrics,
+      optimizeGrpcStreamsThroughput = optimizeGrpcStreamsThroughput,
     )
     new ActiveContractsServiceValidation(
       service = service,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
@@ -89,6 +89,7 @@ private[apiserver] object ApiCommandCompletionService {
       ledgerId: LedgerId,
       completionsService: IndexCompletionsService,
       metrics: Metrics,
+      optimizeGrpcStreamsThroughput: Boolean,
   )(implicit
       materializer: Materializer,
       esf: ExecutionSequencerFactory,
@@ -103,8 +104,9 @@ private[apiserver] object ApiCommandCompletionService {
       new ApiCommandCompletionService(completionsService, validator, metrics)
 
     impl -> new GrpcCommandCompletionService(
-      impl,
-      validator,
+      service = impl,
+      validator = validator,
+      optimizeGrpcStreamsThroughput = optimizeGrpcStreamsThroughput,
     ) with GrpcApiService {
       override def bindService(): ServerServiceDefinition =
         CommandCompletionServiceGrpc.bindService(this, executionContext)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiLedgerConfigurationService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiLedgerConfigurationService.scala
@@ -29,6 +29,9 @@ private[apiserver] final class ApiLedgerConfigurationService private (
     with GrpcApiService {
 
   private val logger = ContextualizedLogger.get(this.getClass)
+  // This optimization targets services with potentially complex protobuf payloads.
+  // Not applicable for this service.
+  protected val optimizeGrpcStreamsThroughput: Boolean = false
 
   override protected def getLedgerConfigurationSource(
       request: GetLedgerConfigurationRequest

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiTimeService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiTimeService.scala
@@ -47,6 +47,9 @@ private[apiserver] final class ApiTimeService private (
     new DamlContextualizedErrorLogger(logger, loggingContext, None)
 
   private val dispatcher = SignalDispatcher[Instant]()
+  // This optimization targets services with potentially complex protobuf payloads.
+  // Not applicable for this service.
+  protected val optimizeGrpcStreamsThroughput: Boolean = false
 
   import FieldValidations._
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -45,6 +45,7 @@ private[apiserver] object ApiTransactionService {
       ledgerId: LedgerId,
       transactionsService: IndexTransactionsService,
       metrics: Metrics,
+      optimizeGrpcStreamsThroughput: Boolean,
   )(implicit
       ec: ExecutionContext,
       mat: Materializer,
@@ -52,9 +53,10 @@ private[apiserver] object ApiTransactionService {
       loggingContext: LoggingContext,
   ): GrpcTransactionService with BindableService =
     new GrpcTransactionService(
-      new ApiTransactionService(transactionsService, metrics),
-      ledgerId,
-      PartyNameChecker.AllowAllParties,
+      service = new ApiTransactionService(transactionsService, metrics),
+      ledgerId = ledgerId,
+      partyNameChecker = PartyNameChecker.AllowAllParties,
+      optimizeGrpcStreamsThroughput = optimizeGrpcStreamsThroughput,
     )
 }
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/error/ErrorInterceptorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/error/ErrorInterceptorSpec.scala
@@ -327,6 +327,8 @@ object ErrorInterceptorSpec {
       with HelloServiceResponding
       with HelloServiceBase {
 
+    protected val optimizeGrpcStreamsThroughput: Boolean = true
+
     override protected def serverStreamingSource(
         request: HelloRequest
     ): Source[HelloResponse, NotUsed] = {

--- a/ledger/sandbox-on-x/reference.conf
+++ b/ledger/sandbox-on-x/reference.conf
@@ -268,6 +268,9 @@ ledger {
           # Maximum number of users that the server can return in a single response.
           max-users-page-size = 1000
         }
+
+        # Optimizes gRPC streams throughput for complex protobuf payloads.
+        optimize-grpc-streams-throughput = false
       }
 
       authentication {


### PR DESCRIPTION
Precompute ScalaPB serializedSize for stream messages. As context for reviewers, reference, see https://github.com/digital-asset/daml/pull/15396/files#diff-237ce07081c1122a0e2e82a41e833be5c653ad08222c3bfa41488f3a015563dcR68-R101
    
changelog_begin
Introduces a gRPC streams optimization targeting complex protobuf payloads.
When enabled, it can allow 60-80% throughput increase for GetTransactions/GetTransactionTrees/GetActiveContracts.
The optimization is toggleable by an additional config parameter for the API server: `api-server.optimize-grpc-streams-throughput`
changelog_end


<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
