### PR TITLE
call library functions instead of generating code

### DIFF
--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/PrimitiveValueDecoders.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/PrimitiveValueDecoders.java
@@ -107,7 +107,14 @@ public final class PrimitiveValueDecoders {
     return new IllegalArgumentException(String.format("Expected field to be of type %s", typeName));
   }
 
-  /** @hidden */
+  /**
+   * <strong>INTERNAL API</strong>: this is meant for use by <a
+   * href="https://docs.daml.com/app-dev/bindings-java/codegen.html">the Java code generator</a>,
+   * and <em>should not be referenced directly</em>. Applications should use a code-generated {@code
+   * valueDecoder} method instead.
+   *
+   * @hidden
+   */
   public static List<com.daml.ledger.javaapi.data.DamlRecord.Field> recordCheck(
       int expectedFields, Value maybeRecord) {
     var record =
@@ -123,7 +130,14 @@ public final class PrimitiveValueDecoders {
     return fields;
   }
 
-  /** @hidden */
+  /**
+   * <strong>INTERNAL API</strong>: this is meant for use by <a
+   * href="https://docs.daml.com/app-dev/bindings-java/codegen.html">the Java code generator</a>,
+   * and <em>should not be referenced directly</em>. Applications should use a code-generated {@code
+   * valueDecoder} method instead.
+   *
+   * @hidden
+   */
   public static Value variantCheck(String expectedConstructor, Value variantMaybe) {
     var variant =
         variantMaybe

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/PrimitiveValueDecoders.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/PrimitiveValueDecoders.java
@@ -9,7 +9,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * {@link ValueDecoder}s for Daml types that are not code-generated.
@@ -108,27 +107,37 @@ public final class PrimitiveValueDecoders {
     return new IllegalArgumentException(String.format("Expected field to be of type %s", typeName));
   }
 
-  /**
-   *
-   * @hidden
-   */
-  public static List<com.daml.ledger.javaapi.data.DamlRecord.Field> recordCheck(int expectedFields, Value maybeRecord) {
-    var record = maybeRecord.asRecord().orElseThrow(() -> new IllegalArgumentException("Contracts must be constructed from Records"));
+  /** @hidden */
+  public static List<com.daml.ledger.javaapi.data.DamlRecord.Field> recordCheck(
+      int expectedFields, Value maybeRecord) {
+    var record =
+        maybeRecord
+            .asRecord()
+            .orElseThrow(
+                () -> new IllegalArgumentException("Contracts must be constructed from Records"));
     var fields = record.getFields();
     var numberOfFields = fields.size();
     if (numberOfFields != expectedFields)
-      throw new IllegalArgumentException("Expected " + expectedFields + " arguments, got " + numberOfFields);
+      throw new IllegalArgumentException(
+          "Expected " + expectedFields + " arguments, got " + numberOfFields);
     return fields;
   }
 
-  /**
-   *
-   * @hidden
-   */
+  /** @hidden */
   public static Value variantCheck(String expectedConstructor, Value variantMaybe) {
-    var variant = variantMaybe.asVariant().orElseThrow(() -> new IllegalArgumentException("Expected: Variant. Actual: " + variantMaybe.getClass().getName()));
+    var variant =
+        variantMaybe
+            .asVariant()
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "Expected: Variant. Actual: " + variantMaybe.getClass().getName()));
     if (!expectedConstructor.equals(variant.getConstructor()))
-      throw new IllegalArgumentException("Invalid constructor. Expected: " + expectedConstructor +  ". Actual: " + variant.getConstructor());
+      throw new IllegalArgumentException(
+          "Invalid constructor. Expected: "
+              + expectedConstructor
+              + ". Actual: "
+              + variant.getConstructor());
     return variant.getValue();
   }
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/PrimitiveValueDecoders.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/PrimitiveValueDecoders.java
@@ -112,6 +112,19 @@ public final class PrimitiveValueDecoders {
    *
    * @hidden
    */
+  public static List<com.daml.ledger.javaapi.data.DamlRecord.Field> recordCheck(int expectedFields, Value maybeRecord) {
+    var record = maybeRecord.asRecord().orElseThrow(() -> new IllegalArgumentException("Contracts must be constructed from Records"));
+    var fields = record.getFields();
+    var numberOfFields = fields.size();
+    if (numberOfFields != expectedFields)
+      throw new IllegalArgumentException("Expected " + expectedFields + " arguments, got " + numberOfFields);
+    return fields;
+  }
+
+  /**
+   *
+   * @hidden
+   */
   public static Value variantCheck(String expectedConstructor, Value variantMaybe) {
     var variant = variantMaybe.asVariant().orElseThrow(() -> new IllegalArgumentException("Expected: Variant. Actual: " + variantMaybe.getClass().getName()));
     if (!expectedConstructor.equals(variant.getConstructor()))

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/PrimitiveValueDecoders.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/PrimitiveValueDecoders.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * {@link ValueDecoder}s for Daml types that are not code-generated.
@@ -105,5 +106,16 @@ public final class PrimitiveValueDecoders {
   private static IllegalArgumentException mismatched(Class<?> clazz) {
     String typeName = clazz.getName();
     return new IllegalArgumentException(String.format("Expected field to be of type %s", typeName));
+  }
+
+  /**
+   *
+   * @hidden
+   */
+  public static Value variantCheck(String expectedConstructor, Value variantMaybe) {
+    var variant = variantMaybe.asVariant().orElseThrow(() -> new IllegalArgumentException("Expected: Variant. Actual: " + variantMaybe.getClass().getName()));
+    if (!expectedConstructor.equals(variant.getConstructor()))
+      throw new IllegalArgumentException("Invalid constructor. Expected: " + expectedConstructor +  ". Actual: " + variant.getConstructor());
+    return variant.getValue();
   }
 }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromValueGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromValueGenerator.scala
@@ -165,19 +165,13 @@ private[inner] object FromValueGenerator extends StrictLogging {
     CodeBlock
       .builder()
       .addStatement(
-        "$T variant$$ = $L.asVariant().orElseThrow(() -> new IllegalArgumentException($S + $L.getClass().getName()))",
-        classOf[javaapi.data.Variant],
-        inputVar,
-        s"Expected: Variant. Actual: ",
-        inputVar,
-      )
-      .addStatement(
-        "if (!$S.equals(variant$$.getConstructor())) throw new $T($S + variant$$.getConstructor())",
+        "$T $L =$W$T.variantCheck($S,$W$L)",
+        classOf[javaapi.data.Value],
+        outputVar,
+        classOf[PrimitiveValueDecoders],
         constructorName,
-        classOf[IllegalArgumentException],
-        s"Invalid constructor. Expected: $constructorName. Actual: ",
+        inputVar,
       )
-      .addStatement("$T $L = variant$$.getValue()", classOf[javaapi.data.Value], outputVar)
       .build()
   }
 

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromValueGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromValueGenerator.scala
@@ -93,23 +93,12 @@ private[inner] object FromValueGenerator extends StrictLogging {
       .builder()
       .add(recordValueExtractor("value$", "recordValue$"))
       .addStatement(
-        "$T record$$ = recordValue$$.asRecord().orElseThrow(() -> new IllegalArgumentException($S))",
-        classOf[javaapi.data.DamlRecord],
-        "Contracts must be constructed from Records",
-      )
-      .addStatement(
-        "$T fields$$ = record$$.getFields()",
+        "$T fields$$ = $T.recordCheck($L,$WrecordValue$$)",
         ParameterizedTypeName
           .get(classOf[java.util.List[_]], classOf[javaapi.data.DamlRecord.Field]),
+        classOf[PrimitiveValueDecoders],
+        fields.size,
       )
-      .addStatement("int numberOfFields = fields$$.size()")
-      .beginControlFlow(s"if (numberOfFields != ${fields.size})")
-      .addStatement(
-        "throw new $T($S + numberOfFields)",
-        classOf[IllegalArgumentException],
-        s"Expected ${fields.size} arguments, got ",
-      )
-      .endControlFlow()
 
     fields.iterator.zip(accessors).foreach { case (FieldInfo(_, damlType, javaName, _), accessor) =>
       fromValueCode.addStatement(


### PR DESCRIPTION
Hand-write boilerplate in the bindings library instead of outputting it repeatedly in generated code.