### PR TITLE
Add `coerceInterfaceContractId : (...) => ContractId i -> ContractId j`

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Interface.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Interface.daml
@@ -27,16 +27,16 @@ import DA.Internal.Template.Functions
 import DA.Internal.LF
 import DA.Internal.Any
 
--- | (1.dev only) Exposes the `interfaceTypeRep` function. Available only for interfaces.
+-- | (Daml-LF >= 1.15) Exposes the `interfaceTypeRep` function. Available only for interfaces.
 class HasInterfaceTypeRep i where
   -- | HIDE
   _interfaceTypeRep : i -> TypeRep
 
--- | (1.dev only) Obtain the `TemplateTypeRep` for the template given in the interface value.
+-- | (Daml-LF >= 1.15) Obtain the `TemplateTypeRep` for the template given in the interface value.
 interfaceTypeRep : HasInterfaceTypeRep i => i -> TemplateTypeRep
 interfaceTypeRep x = TemplateTypeRep (_interfaceTypeRep x)
 
--- | (1.dev only) Exposes the `toInterface` and `toInterfaceContractId` functions.
+-- | (Daml-LF >= 1.15) Exposes the `toInterface` and `toInterfaceContractId` functions.
 class HasToInterface t i where
   -- | HIDE
   _toInterface : t -> i
@@ -59,16 +59,16 @@ class HasToInterface t i where
 -- @
 --
 
--- | (1.dev only) Convert a template value into an interface value.
+-- | (Daml-LF >= 1.15) Convert a template value into an interface value.
 -- For example `toInterface @MyInterface value` converts a template
 -- `value` into a `MyInterface` type.
 toInterface : forall i t. HasToInterface t i => t -> i
 toInterface = _toInterface
 
--- | (1.dev only) Exposes `fromInterface` and `fromInterfaceContractId`
+-- | (Daml-LF >= 1.15) Exposes `fromInterface` and `fromInterfaceContractId`
 -- functions.
 class HasFromInterface t i where
-  -- | (1.dev only) Attempt to convert an interface value back into a
+  -- | (Daml-LF >= 1.15) Attempt to convert an interface value back into a
   -- template value. A `None` indicates that the expected template
   -- type doesn't match the underyling template type for the
   -- interface value.
@@ -82,19 +82,19 @@ class HasFromInterface t i where
   -- underlying template type of the interface value doesn't match the desired type.
   unsafeFromInterface : ContractId i -> i -> t
 
--- | (1.dev only) Constraint that indicates that a template implements an interface.
+-- | (Daml-LF >= 1.15) Constraint that indicates that a template implements an interface.
 type Implements t i =
   ( HasInterfaceTypeRep i
   , HasToInterface t i
   , HasFromInterface t i
   )
 
--- | (1.dev only) Convert a template contract id into an interface
+-- | (Daml-LF >= 1.15) Convert a template contract id into an interface
 -- contract id. For example, `toInterfaceContractId @MyInterface cid`.
 toInterfaceContractId : forall i t. HasToInterface t i => ContractId t -> ContractId i
 toInterfaceContractId = coerceContractId
 
--- | (1.dev only) Convert an interface contract id into a template
+-- | (Daml-LF >= 1.15) Convert an interface contract id into a template
 -- contract id. For example, `fromInterfaceContractId @MyTemplate cid`.
 --
 -- Can also be used to convert an interface contract id into a contract id of
@@ -117,7 +117,7 @@ toInterfaceContractId = coerceContractId
 fromInterfaceContractId : forall t i. HasFromInterface t i => ContractId i -> ContractId t
 fromInterfaceContractId = coerceContractId
 
--- | (1.dev only) Fetch an interface and convert it to a specific
+-- | (Daml-LF >= 1.15) Fetch an interface and convert it to a specific
 -- template type. If conversion is succesful, this function returns
 -- the converted contract and its converted contract id. Otherwise,
 -- this function returns `None`.

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Interface.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Interface.daml
@@ -16,6 +16,7 @@ module DA.Internal.Interface (
   toInterface,
   toInterfaceContractId,
   fromInterfaceContractId,
+  coerceInterfaceContractId,
   fetchFromInterface,
   _exerciseInterfaceGuard,
   HasInterfaceView(..),
@@ -116,6 +117,26 @@ toInterfaceContractId = coerceContractId
 -- In all other cases, consider using `fetchFromInterface` instead.
 fromInterfaceContractId : forall t i. HasFromInterface t i => ContractId i -> ContractId t
 fromInterfaceContractId = coerceContractId
+
+-- | (Daml-LF >= 1.15) Convert an interface contract id into a contract id of a
+-- different interface. For example, given two interfaces `Source` and `Target`,
+-- and `cid : ContractId Source`,
+-- `coerceInterfaceContractId @Target @Source cid : ContractId Target`.
+--
+-- This function does not verify that the contract id
+-- actually points to a contract that implements either interface. This means
+-- that a subsequent `fetch`, `exercise`, or `archive` may fail, if,
+-- for example, the contract id points to a contract of template `A` but it was
+-- coerced into a `ContractId B` where `B` is an interface and there's no
+-- interface instance B for A.
+--
+-- Therefore, you should only use `coerceInterfaceContractId` in situations
+-- where you already know that the contract id points to a contract of the right
+-- type. You can also use it in situations where you will fetch, exercise, or
+-- archive the contract right away, when a transaction failure is the
+-- appropriate response to the contract having the wrong type.
+coerceInterfaceContractId : forall j i. (HasInterfaceTypeRep i, HasInterfaceTypeRep j) => ContractId i -> ContractId j
+coerceInterfaceContractId = coerceContractId
 
 -- | (Daml-LF >= 1.15) Fetch an interface and convert it to a specific
 -- template type. If conversion is succesful, this function returns

--- a/compiler/damlc/tests/daml-test-files/InterfaceContractDoesNotImplementInterface.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceContractDoesNotImplementInterface.EXPECTED.desugared-daml
@@ -255,9 +255,15 @@ instance DA.Internal.Desugar.HasToInterface T I where
 instance DA.Internal.Desugar.HasFromInterface T I where
   fromInterface = GHC.Types.primitive @"EFromInterface"
   unsafeFromInterface = GHC.Types.primitive @"EUnsafeFromInterface"
-main
+testFromTo
   = do alice <- getParty "alice"
        cidT <- alice `submit` create T {party = alice}
        let cidI = toInterfaceContractId @I cidT
        let cidJ = fromInterfaceContractId @J cidI
+       alice `submit` exercise cidJ JChoice
+testCoerce
+  = do alice <- getParty "alice"
+       cidT <- alice `submit` create T {party = alice}
+       let cidI = toInterfaceContractId @I cidT
+       let cidJ = coerceInterfaceContractId @J cidI
        alice `submit` exercise cidJ JChoice

--- a/compiler/damlc/tests/daml-test-files/InterfaceContractDoesNotImplementInterface.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceContractDoesNotImplementInterface.daml
@@ -25,10 +25,18 @@ template T
       view = EmptyInterfaceView
 
 -- @ENABLE-SCENARIOS
--- @ERROR range=29:1-29:5; Attempt to use a contract via an interface that the contract does not implement
-main = do
+-- @ERROR range=29:1-29:11; Attempt to use a contract via an interface that the contract does not implement
+testFromTo = do
   alice <- getParty "alice"
   cidT <- alice `submit` create T with party = alice
   let cidI = toInterfaceContractId @I cidT
       cidJ = fromInterfaceContractId @J cidI
+  alice `submit` exercise cidJ JChoice
+
+-- @ERROR range=37:1-37:11; Attempt to use a contract via an interface that the contract does not implement
+testCoerce = do
+  alice <- getParty "alice"
+  cidT <- alice `submit` create T with party = alice
+  let cidI = toInterfaceContractId @I cidT
+      cidJ = coerceInterfaceContractId @J cidI
   alice `submit` exercise cidJ JChoice

--- a/compiler/damlc/tests/daml-test-files/InterfaceConversions.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceConversions.EXPECTED.desugared-daml
@@ -108,6 +108,108 @@ instance DA.Internal.Desugar.HasInterfaceView Iface EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Iface EmptyInterfaceView where
   _fromAnyView = GHC.Types.primitive @"EFromAnyView"
+data GHC.Types.DamlInterface => Iface2 = Iface2 GHC.Types.Opaque
+instance DA.Internal.Desugar.HasInterfaceTypeRep Iface2 where
+  _interfaceTypeRep
+    = GHC.Types.primitive @"EInterfaceTemplateTypeRep"
+instance DA.Internal.Desugar.HasFetch Iface2 where
+  fetch = GHC.Types.primitive @"UFetchInterface"
+instance DA.Internal.Desugar.HasToInterface Iface2 Iface2 where
+  _toInterface this = this
+instance DA.Internal.Desugar.HasFromInterface Iface2 Iface2 where
+  fromInterface this = DA.Internal.Desugar.Some this
+  unsafeFromInterface _ this = this
+instance DA.Internal.Desugar.HasMethod Iface2 "getOwner2" (Party)
+getOwner2 : Iface2 -> Party
+getOwner2 = GHC.Types.primitiveInterface @"getOwner2"
+instance DA.Internal.Desugar.HasToAnyTemplate Iface2 where
+  _toAnyTemplate = GHC.Types.primitive @"EToAnyTemplate"
+instance DA.Internal.Desugar.HasFromAnyTemplate Iface2 where
+  _fromAnyTemplate = GHC.Types.primitive @"EFromAnyTemplate"
+instance DA.Internal.Desugar.HasTemplateTypeRep Iface2 where
+  _templateTypeRep = GHC.Types.primitive @"ETemplateTypeRep"
+instance DA.Internal.Desugar.HasSignatory Iface2 where
+  signatory = GHC.Types.primitive @"ESignatoryInterface"
+instance DA.Internal.Desugar.HasObserver Iface2 where
+  observer = GHC.Types.primitive @"EObserverInterface"
+instance DA.Internal.Desugar.HasCreate Iface2 where
+  create = GHC.Types.primitive @"UCreateInterface"
+instance DA.Internal.Desugar.HasIsInterfaceType Iface2 where
+  _isInterfaceType _ = DA.Internal.Desugar.True
+instance DA.Internal.Desugar.Eq Iface2 where
+  (==) = GHC.Types.primitive @"BEEqual"
+instance DA.Internal.Desugar.HasArchive Iface2 where
+  archive cid
+    = DA.Internal.Desugar.exercise cid DA.Internal.Desugar.Archive
+instance DA.Internal.Desugar.HasToAnyChoice Iface2 DA.Internal.Desugar.Archive (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice Iface2 DA.Internal.Desugar.Archive (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasExerciseGuarded Iface2 DA.Internal.Desugar.Archive (()) where
+  exerciseGuarded pred cid arg
+    = GHC.Types.primitive
+        @"UExerciseInterfaceGuarded"
+        (DA.Internal.Desugar.toInterfaceContractId @Iface2 cid)
+        arg
+        (DA.Internal.Desugar._exerciseInterfaceGuard @Iface2 cid pred)
+instance DA.Internal.Desugar.HasExercise Iface2 DA.Internal.Desugar.Archive (()) where
+  exercise cid arg
+    = GHC.Types.primitive
+        @"UExerciseInterface"
+        (DA.Internal.Desugar.toInterfaceContractId @Iface2 cid)
+        arg
+instance DA.Internal.Desugar.HasToAnyChoice Iface2 MyChoice2 (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice Iface2 MyChoice2 (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasExerciseGuarded Iface2 MyChoice2 (()) where
+  exerciseGuarded pred cid arg
+    = GHC.Types.primitive
+        @"UExerciseInterfaceGuarded"
+        (DA.Internal.Desugar.toInterfaceContractId @Iface2 cid)
+        arg
+        (DA.Internal.Desugar._exerciseInterfaceGuard @Iface2 cid pred)
+instance DA.Internal.Desugar.HasExercise Iface2 MyChoice2 (()) where
+  exercise cid arg
+    = GHC.Types.primitive
+        @"UExerciseInterface"
+        (DA.Internal.Desugar.toInterfaceContractId @Iface2 cid)
+        arg
+data MyChoice2
+  = MyChoice2 {}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+_choice_Iface2Archive :
+  (Iface2
+   -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId Iface2
+   -> Iface2
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming Iface2,
+   DA.Internal.Desugar.Optional (Iface2
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+_choice_Iface2Archive
+  = (\ this arg@DA.Internal.Desugar.Archive
+       -> DA.Internal.Desugar.signatory this, 
+     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
+     DA.Internal.Desugar.None)
+_choice_Iface2MyChoice2 :
+  (Iface2 -> MyChoice2 -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId Iface2
+   -> Iface2 -> MyChoice2 -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming Iface2,
+   DA.Internal.Desugar.Optional (Iface2
+                                 -> MyChoice2 -> [DA.Internal.Desugar.Party]))
+_choice_Iface2MyChoice2
+  = (\ this arg@MyChoice2
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (getOwner2 this), 
+     \ self this arg@MyChoice2
+       -> let _ = self in let _ = this in let _ = arg in do pure (), 
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+instance DA.Internal.Desugar.HasInterfaceView Iface2 EmptyInterfaceView where
+  _view = GHC.Types.primitive @"EViewInterface"
+instance DA.Internal.Desugar.HasFromAnyView Iface2 EmptyInterfaceView where
+  _fromAnyView = GHC.Types.primitive @"EFromAnyView"
 data GHC.Types.DamlTemplate => Template1
   = Template1 {owner1 : Party, value1 : Int}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
@@ -335,5 +437,13 @@ main
                = do cid <- create (toInterface @Iface (Template1 p 10))
                     action (fromInterfaceContractId @Template2 cid)
          submit p do useAction $ \ _cid -> pure ()
+         submitMustFail p do useAction $ \ cid -> void (fetch cid)
+         submitMustFail p do useAction $ \ cid -> archive cid
+         let useAction : (ContractId Iface2 -> Update ()) -> Update ()
+             useAction action
+               = do cid <- create (toInterface @Iface (Template1 p 10))
+                    action (coerceInterfaceContractId @Iface2 cid)
+         submit p do useAction $ \ _cid -> pure ()
+         submitMustFail p do useAction $ \ cid -> exercise cid MyChoice2
          submitMustFail p do useAction $ \ cid -> void (fetch cid)
          submitMustFail p do useAction $ \ cid -> archive cid

--- a/compiler/damlc/tests/daml-test-files/InterfaceConversions.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceConversions.daml
@@ -18,6 +18,13 @@ interface Iface where
         controller getOwner this
         do pure ()
 
+interface Iface2 where
+    viewtype EmptyInterfaceView
+    getOwner2 : Party
+    choice MyChoice2 : ()
+        controller getOwner2 this
+        do pure ()
+
 template Template1
     with
         owner1: Party
@@ -77,6 +84,18 @@ main = scenario do
             cid <- create (toInterface @Iface (Template1 p 10))
             action (fromInterfaceContractId @Template2 cid)
     submit p do useAction $ \_cid -> pure ()
+    submitMustFail p do useAction $ \cid -> void (fetch cid)
+    submitMustFail p do useAction $ \cid -> archive cid
+
+    -- Test that using coerceInterfaceContractId incorrectly will result
+    -- in failed fetch/exercise/archives. I.e. using an Iface contract
+    -- id as if it were a Iface2 contract id will always fail.
+    let useAction : (ContractId Iface2 -> Update ()) -> Update ()
+        useAction action = do
+            cid <- create (toInterface @Iface (Template1 p 10))
+            action (coerceInterfaceContractId @Iface2 cid)
+    submit p do useAction $ \_cid -> pure ()
+    submitMustFail p do useAction $ \cid -> exercise cid MyChoice2
     submitMustFail p do useAction $ \cid -> void (fetch cid)
     submitMustFail p do useAction $ \cid -> archive cid
 

--- a/docs/source/daml/reference/interfaces.rst
+++ b/docs/source/daml/reference/interfaces.rst
@@ -317,6 +317,27 @@ Interface Functions
        is the desired behavior in case of mismatch.
        In all other cases, consider using ``fetchFromInterface`` instead.
 
+``coerceInterfaceContractId``
+-----------------------------
+
+.. list-table::
+
+   * - Type
+     - | ``forall j i.``
+       | ``(HasInterfaceTypeRep i, HasInterfaceTypeRep j) =>``
+       | ``ContractId i -> ContractId j``
+   * - Instantiated Type
+     - ``ContractId SourceInterface -> ContractId TargetInterface``
+   * - Notes
+     - Converts an interface contract id into a contract id of a different interface.
+       This function does not verify that the given contract id actually points
+       to a contract of the resulting type; if that is not the case, a
+       subsequent ``fetch``, ``exercise`` or ``archive`` will fail.
+       Therefore, this should only be used when the underlying contract is known
+       to be of the resulting type, or when the result is immediately used by a
+       ``fetch``, ``exercise`` or ``archive`` action and a transaction failure
+       is the desired behavior in case of mismatch.
+
 ``fetchFromInterface``
 ----------------------
 


### PR DESCRIPTION
In a previous iteration this PR simply added documentation for and un`HIDE`'d the function `coerceContractId` from `DA.Internal.LF`. Now, it instead adds a more constrained synonym `coerceInterfaceContractId` into `DA.Internal.Interface` (and thus in scope whenever the `Prelude` is imported).