### PR TITLE
Simplify daml test CLI example

### DIFF
--- a/docs/source/daml/intro/2_DamlScript.rst
+++ b/docs/source/daml/intro/2_DamlScript.rst
@@ -87,7 +87,7 @@ What this display means:
 
 - The remaining columns, labelled vertically, show which parties know about which contracts. In this simple script, the sole party "Alice" knows about the contract she created.
 
-To run the same test from the command line, save your module in a file ``Token_Test.daml`` and run ``daml damlc -- test --files Token_Test.daml``. If your file contains more than one script, all of them will be run.
+To run the same test from the command line, save your module in a file ``Token_Test.daml`` and run ``daml test --files Token_Test.daml``. If your file contains more than one script, all of them will be run.
 
 .. _intro_2_failure:
 


### PR DESCRIPTION
I don't see any reason to use `daml damlc -- test --files Token_Test.daml`, when `daml test --files Token_Test.daml` appears to have identical output:

```
➜  intro2 git:(main) ✗ daml damlc -- test --files daml/Token_Test.daml

Test Summary
daml/Token_Test.daml:token_test: ok, 1 active contracts, 6 transactions.
daml/Token_Test.daml:token_test_1: ok, 1 active contracts, 1 transactions.
daml/Token_Test.daml:token_test_2: ok, 2 active contracts, 4 transactions.
daml/Token_Test.daml:token_test_3: ok, 0 active contracts, 3 transactions.
test coverage: templates 100%, choices 100%

➜  intro2 git:(main) ✗ daml test --files daml/Token_Test.daml

Test Summary
daml/Token_Test.daml:token_test: ok, 1 active contracts, 6 transactions.
daml/Token_Test.daml:token_test_1: ok, 1 active contracts, 1 transactions.
daml/Token_Test.daml:token_test_2: ok, 2 active contracts, 4 transactions.
daml/Token_Test.daml:token_test_3: ok, 0 active contracts, 3 transactions.
test coverage: templates 100%, choices 100%
➜  intro2 git:(main) ✗
```

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
