### PR TITLE
Drop comments about 0.x when talking about upgrades

### DIFF
--- a/docs/source/upgrade/extend.rst
+++ b/docs/source/upgrade/extend.rst
@@ -7,12 +7,6 @@ Extending Daml Applications
 .. toctree::
    :hidden:
 
-
-**Note:** Cross-SDK extensions require Daml-LF 1.8 or newer.
-This is the default starting from SDK 1.0. For older releases add
-``build-options: ["--target=1.8"]`` to your ``daml.yaml`` to select
-Daml-LF 1.8.
-
 Consider the following simple Daml model for carbon certificates:
 
 .. literalinclude:: example/carbon-1.0.0/daml/CarbonV1.daml

--- a/docs/source/upgrade/upgrade.rst
+++ b/docs/source/upgrade/upgrade.rst
@@ -9,11 +9,6 @@ Upgrading Daml Applications
 .. toctree::
    :hidden:
 
-**Note:** Cross-SDK upgrades require Daml-LF 1.8 or newer.
-This is the default starting from SDK 1.0. For older releases add
-``build-options: ["--target=1.8"]`` to your ``daml.yaml`` to select
-Daml-LF 1.8.
-
 In applications backed by a centralized database controlled by a
 single operator, it is possible to upgrade an application in a single
 step that migrates all existing data to a new data model.


### PR DESCRIPTION
The comments refer to 0.x and can be misleading for 2.x users (since the default is not 1.8 anymore and have not been for a long time at this point). Furthermore, I am also relatively sure that 1.8 is not even an option at all for 2.x users.

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
