### PR TITLE
gsg test: pin puppeteer

### DIFF
--- a/docs/source/getting-started/testing.rst
+++ b/docs/source/getting-started/testing.rst
@@ -18,7 +18,7 @@ Of course there are more to choose from, but this is one combination that works.
 To install Puppeteer and some other testing utilities we are going to use,
 run the following command in the ``ui`` directory::
 
-    npm add --only=dev puppeteer wait-on @types/jest @types/node @types/puppeteer @types/wait-on
+    npm add --only=dev puppeteer@18.2.1 wait-on @types/jest @types/node @types/puppeteer @types/wait-on
 
 Because these things are easier to describe with concrete examples, this
 section will show how to set up end-to-end tests for the application you would


### PR DESCRIPTION
Somehow our setup doesn't work with puppeteer 19+.

CHANGELOG_BEGIN
- GSG: Several TypeScript warnings have been fixed in the final "Testing Your Web App" section of the Getting Started Guide. The `create-daml-app` template includes an updated `config.ts` file, and the documentation page as been updated to pin the `puppeteer` version to a known-working one and tweak the `index.test.ts` file. CHANGELOG_END