### PR TITLE
[Speedy] Drop second argument of SResultFinal

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -8,7 +8,7 @@ import com.daml.lf.command._
 import com.daml.lf.data._
 import com.daml.lf.data.Ref.{Identifier, PackageId, ParticipantId, Party}
 import com.daml.lf.language.Ast._
-import com.daml.lf.speedy.{InitialSeeding, PartialTransaction, Pretty, SError, SValue}
+import com.daml.lf.speedy.{InitialSeeding, Pretty, SError, SValue}
 import com.daml.lf.speedy.SExpr.{SEApp, SExpr}
 import com.daml.lf.speedy.Speedy.{Machine, OnLedger}
 import com.daml.lf.speedy.SResult._
@@ -440,15 +440,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
     machine.ledgerMode match {
       case onLedger: OnLedger =>
         onLedger.finish match {
-          case Right(
-                PartialTransaction.Result(
-                  tx,
-                  _,
-                  nodeSeeds,
-                  globalKeyMapping,
-                  disclosedContracts,
-                )
-              ) =>
+          case Right(OnLedger.Result(tx, _, nodeSeeds, globalKeyMapping, disclosedContracts)) =>
             deps(tx).flatMap { deps =>
               val meta = Tx.Metadata(
                 submissionSeed = None,

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -10,7 +10,7 @@ import com.daml.lf.data.Ref.{Identifier, PackageId, ParticipantId, Party}
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.{InitialSeeding, PartialTransaction, Pretty, SError, SValue}
 import com.daml.lf.speedy.SExpr.{SEApp, SExpr}
-import com.daml.lf.speedy.Speedy.Machine
+import com.daml.lf.speedy.Speedy.{Machine, OnLedger}
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.transaction.{
   Node,
@@ -352,7 +352,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
     ResultDone(deps)
   }
 
-  private def handleError(err: SError.SError, detailMsg: Option[String]): ResultError = {
+  private def handleError(err: SError.SError, detailMsg: Option[String] = None): ResultError = {
     err match {
       case SError.SErrorDamlException(error) =>
         ResultError(Error.Interpretation.DamlException(error), detailMsg)
@@ -437,46 +437,48 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
       }
     }
 
-    finalValue match {
-      case SResultFinal(
-            _,
-            Some(
-              PartialTransaction.Result(
-                tx,
-                _,
-                nodeSeeds,
-                globalKeyMapping,
-                disclosedContracts,
+    machine.ledgerMode match {
+      case onLedger: OnLedger =>
+        onLedger.finish match {
+          case Right(
+                PartialTransaction.Result(
+                  tx,
+                  _,
+                  nodeSeeds,
+                  globalKeyMapping,
+                  disclosedContracts,
+                )
+              ) =>
+            deps(tx).flatMap { deps =>
+              val meta = Tx.Metadata(
+                submissionSeed = None,
+                submissionTime = onLedger.submissionTime,
+                usedPackages = deps,
+                dependsOnTime = onLedger.getDependsOnTime,
+                nodeSeeds = nodeSeeds,
+                globalKeyMapping = globalKeyMapping,
+                disclosures = disclosedContracts.map(versionDisclosedContract),
               )
-            ),
-          ) =>
-        deps(tx).flatMap { deps =>
-          val meta = Tx.Metadata(
-            submissionSeed = None,
-            submissionTime = onLedger.submissionTime,
-            usedPackages = deps,
-            dependsOnTime = onLedger.getDependsOnTime,
-            nodeSeeds = nodeSeeds,
-            globalKeyMapping = globalKeyMapping,
-            disclosures = disclosedContracts.map(versionDisclosedContract),
-          )
-          config.profileDir.foreach { dir =>
-            val desc = Engine.profileDesc(tx)
-            machine.profile.name = s"${meta.submissionTime}-$desc"
-            val profileFile = dir.resolve(s"${meta.submissionTime}-$desc.json")
-            machine.profile.writeSpeedscopeJson(profileFile)
-          }
-          ResultDone((tx, meta))
+              config.profileDir.foreach { dir =>
+                val desc = Engine.profileDesc(tx)
+                machine.profile.name = s"${meta.submissionTime}-$desc"
+                val profileFile = dir.resolve(s"${meta.submissionTime}-$desc.json")
+                machine.profile.writeSpeedscopeJson(profileFile)
+              }
+              ResultDone((tx, meta))
+            }
+          case Left(err) =>
+            handleError(err)
         }
-
-      case SResultFinal(_, None) =>
+      case _ =>
         ResultError(
           Error.Interpretation.Internal(
             NameOf.qualifiedNameOfCurrentFunc,
-            "Interpretation error: completed transaction expected",
+            "unexpected off-ledger machine",
             None,
           )
         )
+
     }
   }
 
@@ -550,7 +552,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
   )(implicit loggingContext: LoggingContext): Result[Versioned[Value]] = {
     def interpret(machine: Machine): Result[SValue] = {
       machine.run() match {
-        case SResultFinal(v, _) => ResultDone(v)
+        case SResultFinal(v) => ResultDone(v)
         case SResultError(err) => handleError(err, None)
         case err @ (_: SResultNeedPackage | _: SResultNeedContract | _: SResultNeedKey |
             _: SResultNeedTime | _: SResultScenarioGetParty | _: SResultScenarioPassTime |

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -453,8 +453,8 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
               )
               config.profileDir.foreach { dir =>
                 val desc = Engine.profileDesc(tx)
-                machine.profile.name = s"${meta.submissionTime}-$desc"
                 val profileFile = dir.resolve(s"${meta.submissionTime}-$desc.json")
+                machine.profile.name = s"${meta.submissionTime}-$desc"
                 machine.profile.writeSpeedscopeJson(profileFile)
               }
               ResultDone((tx, meta))

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -73,7 +73,7 @@ object PlaySpeedy {
     println(s"example name: $name")
 
     machine.run() match {
-      case SResultFinal(value, _) =>
+      case SResultFinal(value) =>
         println(s"final-value: $value")
         value match {
           case SInt64(got) =>

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
@@ -103,7 +103,7 @@ object PlaySpeedy {
     val result: SValue = {
       println("Run...")
       machine.run() match {
-        case SResultFinal(value, _) => value
+        case SResultFinal(value) => value
         case res => throw new MachineProblem(s"Unexpected result from machine $res")
       }
     }

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
@@ -42,7 +42,7 @@ object LoadDarFunction extends App {
       val machine = Machine.fromPureSExpr(compiledPackages, expr)
 
       machine.run() match {
-        case SResultFinal(SInt64(result), _) => result
+        case SResultFinal(SInt64(result)) => result
         case res => throw new RuntimeException(s"Unexpected result from machine $res")
       }
     }

--- a/daml-lf/interpreter/src/bench/com/daml/lf/interpreter/StructProjBench.scala
+++ b/daml-lf/interpreter/src/bench/com/daml/lf/interpreter/StructProjBench.scala
@@ -64,7 +64,7 @@ class StructProjBench {
   def bench(): SValue = {
     val machine = Speedy.Machine.fromPureSExpr(compiledPackages, sexpr)
     machine.run() match {
-      case SResult.SResultFinal(v, _) =>
+      case SResult.SResultFinal(v) =>
         v
       case otherwise =>
         throw new UnknownError(otherwise.toString)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -23,7 +23,7 @@ object SResult {
   /** The speedy machine has completed evaluation to reach a final value.
     * And, if the evaluation was on-ledger, a completed transaction.
     */
-  final case class SResultFinal(v: SValue, tx: Option[PartialTransaction.Result]) extends SResult
+  final case class SResultFinal(v: SValue) extends SResult
 
   /** Update or scenario interpretation requires the current
     * ledger time.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -247,6 +247,8 @@ private[lf] object Speedy {
         IError.Limit.ChoiceObservers(cid, templateId, choiceName, arg, observers, _),
       )
 
+    def finish = ptx.finish
+
   }
 
   final case object OffLedger extends LedgerMode
@@ -529,12 +531,7 @@ private[lf] object Speedy {
               res
             case Control.Complete(value: SValue) =>
               if (enableInstrumentation) track.print()
-              ledgerMode match {
-                case OffLedger => SResultFinal(value, None)
-                case onLedger: OnLedger =>
-                  val ctx = onLedger.ptx.finish
-                  SResultFinal(value, Some(ctx))
-              }
+              SResultFinal(value)
             case Control.Error(ie) =>
               SResultError(SErrorDamlException(ie))
           }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -13,11 +13,10 @@ import com.daml.lf.transaction.{
   GlobalKey,
   Node,
   NodeId,
-  SubmittedTransaction,
+  SubmittedTransaction => SubmittedTx,
   Transaction => Tx,
   TransactionVersion => TxVersion,
 }
-import com.daml.lf.transaction.ContractStateMachine.KeyMapping
 import com.daml.lf.value.Value
 import com.daml.nameof.NameOf
 import com.daml.scalautil.Statement.discard
@@ -196,14 +195,6 @@ private[lf] object PartialTransaction {
     }
 
   type NodeSeeds = ImmArray[(NodeId, crypto.Hash)]
-
-  private[lf] final case class Result(
-      tx: SubmittedTransaction,
-      locationInfo: Map[NodeId, Location],
-      seeds: NodeSeeds,
-      globalKeyMapping: Map[GlobalKey, KeyMapping],
-      disclosedContracts: ImmArray[DisclosedContract],
-  )
 }
 
 /** A transaction under construction
@@ -283,8 +274,8 @@ private[speedy] case class PartialTransaction(
       sb.toString
     }
 
-  private def locationInfo(): Map[NodeId, Location] = {
-    this.actionNodeLocations.toImmArray.toSeq.zipWithIndex.collect { case (Some(loc), n) =>
+  private[speedy] def locationInfo(): Map[NodeId, Location] = {
+    this.actionNodeLocations.toImmArray.toSeq.view.zipWithIndex.collect { case (Some(loc), n) =>
       (NodeId(n), loc)
     }.toMap
   }
@@ -305,24 +296,14 @@ private[speedy] case class PartialTransaction(
     * - an error in case the transaction cannot be serialized using
     *   the `outputTransactionVersions`.
     */
-  private[speedy] def finish: Either[SError.SErrorCrash, PartialTransaction.Result] =
+  private[speedy] def finish: Either[SError.SErrorCrash, (SubmittedTx, ImmArray[NodeId])] =
     context.info match {
       case _: RootContextInfo =>
         val roots = context.children.toImmArray
         val tx0 = Tx(nodes, roots)
         val (tx, seeds) = NormalizeRollbacks.normalizeTx(tx0)
-        val txResult = SubmittedTransaction(TxVersion.asVersionedTransaction(tx))
-        Right(
-          Result(
-            txResult,
-            locationInfo(),
-            seeds.zip(actionNodeSeeds.toImmArray),
-            contractState.globalKeyInputs.transform((_, v) => v.toKeyMapping),
-            disclosedContracts.filter(disclosedContract =>
-              txResult.inputContracts.contains(disclosedContract.contractId.value)
-            ),
-          )
-        )
+        val txResult = SubmittedTx(TxVersion.asVersionedTransaction(tx))
+        Right((txResult, seeds))
 
       case _ =>
         Left(

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
@@ -127,7 +127,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
 
     forEvery(testCases) { (exp: String, num: Long) =>
       s"eval[$exp] --> $num" in {
-        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v, _) =>
+        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v) =>
           v shouldBe SValue.SInt64(num)
         }
       }
@@ -164,7 +164,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
 
     forEvery(testCases) { (exp: String, num: Long) =>
       s"eval[$exp] --> $num" in {
-        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v, _) =>
+        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v) =>
           v shouldBe SValue.SInt64(num)
         }
       }
@@ -247,7 +247,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
 
     forEvery(testCases) { (exp: String, num: Long) =>
       s"eval[$exp] --> $num" in {
-        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v, _) =>
+        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v) =>
           v shouldBe SValue.SInt64(num)
         }
       }
@@ -316,7 +316,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
 
     forEvery(testCases) { (exp: String, num: Long) =>
       s"eval[$exp] --> $num" in {
-        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v, _) =>
+        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v) =>
           v shouldBe SValue.SInt64(num)
         }
       }
@@ -388,7 +388,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
 
     forEvery(testCases) { (exp: String, num: Long) =>
       s"eval[$exp] --> $num" in {
-        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v, _) =>
+        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v) =>
           v shouldBe SValue.SInt64(num)
         }
       }
@@ -469,7 +469,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
 
     forEvery(testCases) { (exp: String, str: String) =>
       s"eval[$exp] --> $str" in {
-        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v, _) =>
+        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v) =>
           v shouldBe SValue.SText(str)
         }
       }
@@ -605,7 +605,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
           .fromUpdateSExpr(pkgs, transactionSeed, applyToParty(pkgs, expr, party), Set(party))
           .run()
         if (description.contains("can be caught"))
-          inside(res) { case SResultFinal(SUnit, _) =>
+          inside(res) { case SResultFinal(SUnit) =>
           }
         else if (description.contains("cannot be caught"))
           inside(res) { case SResultError(SErrorDamlException(err)) =>
@@ -628,7 +628,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
       val res = Speedy.Machine
         .fromUpdateSExpr(pkgs, transactionSeed, applyToParty(pkgs, example, party), Set(party))
         .run()
-      inside(res) { case SResultFinal(SUnit, _) =>
+      inside(res) { case SResultFinal(SUnit) =>
       }
     }
 
@@ -836,7 +836,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
     "create rollback when old contacts are not within try-catch context" in {
       val res =
         Speedy.Machine.fromUpdateSExpr(pkgs, transactionSeed, causeRollback, Set(party)).run()
-      inside(res) { case SResultFinal(SUnit, _) =>
+      inside(res) { case SResultFinal(SUnit) =>
       }
     }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
@@ -29,7 +29,7 @@ class InterpreterTest extends AnyWordSpec with Inside with Matchers with TableDr
   private def runExpr(e: Expr): SValue = {
     val machine = Speedy.Machine.fromPureExpr(PureCompiledPackages.Empty, e)
     machine.run() match {
-      case SResultFinal(v, _) => v
+      case SResultFinal(v) => v
       case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
     }
   }
@@ -138,7 +138,7 @@ class InterpreterTest extends AnyWordSpec with Inside with Matchers with TableDr
     }
     "interpret" in {
       val value = machine.run() match {
-        case SResultFinal(v, _) => v
+        case SResultFinal(v) => v
         case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
       }
       value match {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -30,13 +30,12 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
   )
 
   private[this] def contractIdsInOrder(ptx: PartialTransaction): Seq[Value.ContractId] = {
-    ptx.finish match {
-      case PartialTransaction.Result(tx, _, _, _, _) =>
-        tx.fold(Vector.empty[Value.ContractId]) {
-          case (acc, (_, create: Node.Create)) => acc :+ create.coid
-          case (acc, _) => acc
-        }
-    }
+    ptx.finish.toOption.get.tx
+      .fold(List.empty[Value.ContractId]) {
+        case (acc, (_, create: Node.Create)) => acc :+ create.coid
+        case (acc, _) => acc
+      }
+      .reverse
   }
 
   private[this] implicit class PartialTransactionExtra(val ptx: PartialTransaction) {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -29,8 +29,8 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
     ImmArray.Empty,
   )
 
-  private[this] def contractIdsInOrder(ptx: PartialTransaction): Seq[Value.ContractId] = {
-    ptx.finish.toOption.get.tx
+  private[this] def contractIdsInOrder(ptx: PartialTransaction): List[Value.ContractId] = {
+    ptx.finish.toOption.get._1
       .fold(List.empty[Value.ContractId]) {
         case (acc, (_, create: Node.Create)) => acc :+ create.coid
         case (acc, _) => acc

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ProfilerTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ProfilerTest.scala
@@ -73,7 +73,7 @@ class ProfilerTest extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
       Speedy.Machine.fromUpdateSExpr(compiledPackages, transactionSeed, example, Set(party))
     val res = machine.run()
     res match {
-      case SResultFinal(_, Some(_)) =>
+      case SResultFinal(_) =>
         machine.profile.events.asScala.toList.map(ev => (ev.open, ev.rawLabel))
       case _ =>
         sys.error(s"Unexpected res: $res")

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
@@ -47,7 +47,7 @@ private[speedy] object SpeedyTestLib {
   ): Either[SError.SError, SValue] = {
     runTx(machine, getPkg, getContract, getKey, getTime) match {
       case Left(e) => Left(e)
-      case Right(SResultFinal(v, _)) => Right(v)
+      case Right(SResultFinal(v)) => Right(v)
     }
   }
 
@@ -113,13 +113,8 @@ private[speedy] object SpeedyTestLib {
       getTime: PartialFunction[Unit, Time.Timestamp] = PartialFunction.empty,
   ): Either[SError.SError, SubmittedTransaction] =
     runTx(machine, getPkg, getContract, getKey, getTime) match {
-      case Right(SResultFinal(_, None)) =>
-        throw SError.SErrorCrash("buildTransaction", "unexpected missing transaction")
-      case Right(SResultFinal(_, Some(ctx))) =>
-        ctx match {
-          case PartialTransaction.Result(tx, _, _, _, _) =>
-            Right(tx)
-        }
+      case Right(SResultFinal(_)) =>
+        machine.withOnLedger("buildTransaction")(onLedger => onLedger.ptx.finish.map(_.tx))
       case Left(err) =>
         Left(err)
     }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
@@ -114,7 +114,7 @@ private[speedy] object SpeedyTestLib {
   ): Either[SError.SError, SubmittedTransaction] =
     runTx(machine, getPkg, getContract, getKey, getTime) match {
       case Right(SResultFinal(_)) =>
-        machine.withOnLedger("buildTransaction")(onLedger => onLedger.ptx.finish.map(_.tx))
+        machine.withOnLedger("buildTransaction")(onLedger => onLedger.finish.map(_.tx))
       case Left(err) =>
         Left(err)
     }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala
@@ -128,7 +128,7 @@ class TailCallTest extends AnyWordSpec with Matchers with TableDrivenPropertyChe
     }
     // run the machine
     machine.run() match {
-      case SResultFinal(v, _) => v
+      case SResultFinal(v) => v
       case res => crash(s"runExpr, unexpected result $res")
     }
   }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -195,7 +195,7 @@ class OrderingSpec
     )
 
     machine.run() match {
-      case SResultFinal(value, _) => value
+      case SResultFinal(value) => value
       case _ => throw new Error(s"error while translating value $v")
     }
   }

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -477,7 +477,7 @@ object Repl {
               case SResultError(err) =>
                 println(prettyError(err).render(128))
                 None
-              case SResultFinal(v, _) =>
+              case SResultFinal(v) =>
                 Some(v)
               case other =>
                 sys.error("unimplemented callback: " + other.toString)

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -14,6 +14,7 @@ import com.daml.lf.value.Value.{ContractId, VersionedContractInstance}
 import com.daml.lf.speedy._
 import com.daml.lf.speedy.SExpr.{SExpr, SEValue, SEApp}
 import com.daml.lf.speedy.SResult._
+import com.daml.lf.speedy.Speedy.OnLedger
 import com.daml.lf.transaction.IncompleteTransaction
 import com.daml.lf.value.Value
 import com.daml.logging.LoggingContext
@@ -415,7 +416,7 @@ object ScenarioRunner {
           ledgerMachine.ledgerMode match {
             case onLedger: Speedy.OnLedger =>
               onLedger.finish match {
-                case Right(PartialTransaction.Result(tx, locationInfo, _, _, _)) =>
+                case Right(OnLedger.Result(tx, locationInfo, _, _, _)) =>
                   ledger.commit(committers, readAs, location, enrich(tx), locationInfo) match {
                     case Left(err) =>
                       SubmissionError(err, enrich(onLedger.incompleteTransaction))

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -49,7 +49,7 @@ final class ScenarioRunner private (
       steps += 1 // this counts the number of external `Need` interactions
       val res: SResult = machine.run()
       res match {
-        case SResultFinal(v, _) =>
+        case SResultFinal(v) =>
           finalValue = v
 
         case SResultError(err) =>
@@ -411,18 +411,23 @@ object ScenarioRunner {
     @tailrec
     def go(): SubmissionResult[R] = {
       ledgerMachine.run() match {
-        case SResult.SResultFinal(resultValue, Some(ctx)) =>
-          ctx match {
-            case PartialTransaction.Result(tx, locationInfo, _, _, _) =>
-              ledger.commit(committers, readAs, location, enrich(tx), locationInfo) match {
+        case SResult.SResultFinal(resultValue) =>
+          ledgerMachine.ledgerMode match {
+            case onLedger: Speedy.OnLedger =>
+              onLedger.finish match {
+                case Right(PartialTransaction.Result(tx, locationInfo, _, _, _)) =>
+                  ledger.commit(committers, readAs, location, enrich(tx), locationInfo) match {
+                    case Left(err) =>
+                      SubmissionError(err, enrich(onLedger.incompleteTransaction))
+                    case Right(r) =>
+                      Commit(r, resultValue, enrich(onLedger.incompleteTransaction))
+                  }
                 case Left(err) =>
-                  SubmissionError(err, enrich(onLedger.incompleteTransaction))
-                case Right(r) =>
-                  Commit(r, resultValue, enrich(onLedger.incompleteTransaction))
+                  throw err
               }
+            case _ =>
+              throw Error.Internal("Unexpected off ledger machine")
           }
-        case SResult.SResultFinal(_, None) =>
-          throw new RuntimeException(s"Unexpected missing transaction")
         case SResultError(err) =>
           SubmissionError(Error.RunnerException(err), enrich(onLedger.incompleteTransaction))
         case SResultNeedContract(coid, committers, callback) =>

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -104,7 +104,7 @@ class CollectAuthorityState {
           }
         case SResultNeedContract(_, _, _) =>
           crash("Off-ledger need contract callback")
-        case SResultFinal(v, _) => finalValue = v
+        case SResultFinal(v) => finalValue = v
         case r => crash(s"bench run: unexpected result from speedy: ${r}")
       }
     }
@@ -148,7 +148,7 @@ class CollectAuthorityState {
               cachedContract ++= api.cachedContract
               step = api.step
           }
-        case SResultFinal(v, _) =>
+        case SResultFinal(v) =>
           finalValue = v
         case r =>
           crash(s"setup run: unexpected result from speedy: ${r}")

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -320,7 +320,7 @@ object Converter {
         Script.DummyLoggingContext
       )
     machine.run() match {
-      case SResultFinal(v, _) =>
+      case SResultFinal(v) =>
         v match {
           case SStruct(_, values) if values.size == 2 =>
             Right((values.get(fstOutputIdx), values.get(sndOutputIdx)))

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -436,7 +436,7 @@ private[lf] class Runner(
 
     def stepToValue(): Either[RuntimeException, SValue] =
       machine.run() match {
-        case SResultFinal(v, _) =>
+        case SResultFinal(v) =>
           Right(v)
         case SResultError(err) =>
           Left(Runner.InterpretationError(err))

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -154,7 +154,7 @@ class IdeLedgerClient(
         val machine = Machine.fromPureSExpr(compiledPackages, sexpr)(Script.DummyLoggingContext)
 
         machine.run() match {
-          case SResultFinal(svalue, _) =>
+          case SResultFinal(svalue) =>
             val version = machine.tmplId2TxVersion(templateId)
             Some(svalue.toNormalizedValue(version))
 

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -93,7 +93,7 @@ object Machine extends StrictLogging {
   // Run speedy until we arrive at a value.
   def stepToValue(machine: Speedy.Machine): SValue = {
     machine.run() match {
-      case SResultFinal(v, _) => v
+      case SResultFinal(v) => v
       case SResultError(err) => {
         logger.error(Pretty.prettyError(err).render(80))
         throw err


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
