### PR TITLE
[compatibility test] add sleep between canton start and script start

### DIFF
--- a/compatibility/bazel_tools/daml_script/daml_script.bzl
+++ b/compatibility/bazel_tools/daml_script/daml_script.bzl
@@ -98,14 +98,14 @@ runner=$$(canonicalize_rlocation $(rootpath {runner}))
 # Cleanup the trigger runner process but maintain the script runner exit code.
 trap 'status=$$?; kill -TERM $$PID; wait $$PID; exit $$status' INT TERM
 
+sleep 2
+
 if [ {upload_dar} -eq 1 ] ; then
   $$runner ledger upload-dar \\
     --host localhost \\
     --port 6865 \\
     $$(canonicalize_rlocation $(rootpath {dar}))
 fi
-
-sleep 2
 
 $$runner script \\
   --ledger-host localhost \\

--- a/compatibility/bazel_tools/daml_script/daml_script.bzl
+++ b/compatibility/bazel_tools/daml_script/daml_script.bzl
@@ -104,6 +104,9 @@ if [ {upload_dar} -eq 1 ] ; then
     --port 6865 \\
     $$(canonicalize_rlocation $(rootpath {dar}))
 fi
+
+sleep 2
+
 $$runner script \\
   --ledger-host localhost \\
   --ledger-port 6865 \\

--- a/compatibility/bazel_tools/daml_trigger/daml_trigger.bzl
+++ b/compatibility/bazel_tools/daml_trigger/daml_trigger.bzl
@@ -162,6 +162,7 @@ runner=$$(canonicalize_rlocation $(rootpath {runner}))
 # Cleanup the trigger runner process but maintain the script runner exit code.
 trap 'status=$$?; kill -TERM $$PID; wait $$PID; exit $$status' INT TERM
 
+sleep 2
 SCRIPTOUTPUT=$$(mktemp -d)
 if [ {upload_dar} -eq 1 ] ; then
   $$runner ledger upload-dar \\
@@ -169,9 +170,6 @@ if [ {upload_dar} -eq 1 ] ; then
     --port 6865 \\
     $$(canonicalize_rlocation $(rootpath {dar}))
 fi
-
-sleep 2
-
 $$runner script \\
   --ledger-host localhost \\
   --ledger-port 6865 \\

--- a/compatibility/bazel_tools/daml_trigger/daml_trigger.bzl
+++ b/compatibility/bazel_tools/daml_trigger/daml_trigger.bzl
@@ -169,6 +169,9 @@ if [ {upload_dar} -eq 1 ] ; then
     --port 6865 \\
     $$(canonicalize_rlocation $(rootpath {dar}))
 fi
+
+sleep 2
+
 $$runner script \\
   --ledger-host localhost \\
   --ledger-port 6865 \\

--- a/compatibility/bazel_tools/daml_trigger/daml_trigger.bzl
+++ b/compatibility/bazel_tools/daml_trigger/daml_trigger.bzl
@@ -163,6 +163,7 @@ runner=$$(canonicalize_rlocation $(rootpath {runner}))
 trap 'status=$$?; kill -TERM $$PID; wait $$PID; exit $$status' INT TERM
 
 sleep 2
+
 SCRIPTOUTPUT=$$(mktemp -d)
 if [ {upload_dar} -eq 1 ] ; then
   $$runner ledger upload-dar \\


### PR DESCRIPTION
Canton seams to be slower to start since 20221101

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
