### PR TITLE
Specify that parties are allocated only if necessary

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -255,7 +255,7 @@ commandParser = subparser $ fold
                 (progDesc "List parties known to ledger")
             , command "allocate-parties" $ info
                 (ledgerAllocatePartiesCmd <**> helper)
-                (progDesc "Allocate parties on ledger")
+                (progDesc "Allocate parties on ledger if they don't exist")
             , command "upload-dar" $ info
                 (ledgerUploadDarCmd <**> helper)
                 (progDesc "Upload DAR file to ledger")
@@ -269,7 +269,7 @@ commandParser = subparser $ fold
         , subparser $ internal <> fold -- hidden subcommands
             [ command "allocate-party" $ info
                 (ledgerAllocatePartyCmd <**> helper)
-                (progDesc "Allocate a single party on ledger")
+                (progDesc "Allocate a single party on ledger if it doesn't exist")
             , command "reset" $ info
                 (ledgerResetCmd <**> helper)
                 (progDesc "Archive all currently active contracts.")
@@ -309,12 +309,12 @@ commandParser = subparser $ fold
 
     ledgerAllocatePartiesCmd = LedgerAllocateParties
         <$> ledgerFlags (ShowJsonApi True)
-        <*> many (argument str (metavar "PARTY" <> help "Parties to be allocated on the ledger (defaults to project parties if empty)"))
+        <*> many (argument str (metavar "PARTY" <> help "Parties to be allocated on the ledger if they don't exist (defaults to project parties if empty)"))
 
     -- same as allocate-parties but requires a single party.
     ledgerAllocatePartyCmd = LedgerAllocateParties
         <$> ledgerFlags (ShowJsonApi True)
-        <*> fmap (:[]) (argument str (metavar "PARTY" <> help "Party to be allocated on the ledger"))
+        <*> fmap (:[]) (argument str (metavar "PARTY" <> help "Party to be allocated on the ledger if it doesn't exist"))
 
     ledgerUploadDarCmd = LedgerUploadDar
         <$> ledgerFlags (ShowJsonApi True)

--- a/docs/source/deploy/generic_ledger.rst
+++ b/docs/source/deploy/generic_ledger.rst
@@ -55,7 +55,7 @@ ledger --help`` to get a list of available ledger commands:
 
    Available commands:
      list-parties             List parties known to ledger
-     allocate-parties         Allocate parties on ledger
+     allocate-parties         Allocate parties on ledger if they don't exist
      upload-dar               Upload DAR file to ledger
      fetch-dar                Fetch DAR from ledger into file
      metering-report          Report on Ledger Use


### PR DESCRIPTION
Makes the behavior of `daml ledger allocate-parties` more explicit

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
