### PR TITLE
Clean up uses of `locateRunfiles`

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -58,6 +58,25 @@
 - warn: {lhs: System.Environment.setEnv, rhs: System.Environment.Blank.setEnv}
 - warn: {lhs: toNormalizedFilePath, rhs: "toNormalizedFilePath'"}
 
+## DA+Bazel specific hints
+- warn:
+    name: locateRunfiles/package_app
+    lhs: DA.Bazel.Runfiles.locateRunfiles
+    rhs: locateResources
+    note: |-
+      When used from a packaged application (bazel_tools/packaging/packaging.bzl#package_app),
+      'locateRunfiles' ignores its argument and simply returns the "resources" directory.
+      This is probably not what you want in a packaged application. For that
+      use case, prefer instead 'locateResources', which allows you to specify
+      the path to the resource in a packaged application, and the prefix to be
+      prepended to it to obtain the runfiles path.
+
+      When only used from a 'bazel run' or 'bazel test' target this is fine and
+      the warning can be selectively disabled by adding the following comment
+      near the top of the relevant module:
+
+        {- HLINT ignore "locateRunfiles/package_app" -}
+
 # Hints that do not always make sense
 - ignore: {name: "Use if", within: [DA.Daml.LF.Proto3.EncodeV1, DA.Daml.LF.Ast.Pretty]}
 

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -65,7 +65,9 @@
     rhs: locateResources
     note: |-
       When used from a packaged application (bazel_tools/packaging/packaging.bzl#package_app),
-      'locateRunfiles' ignores its argument and simply returns the "resources" directory.
+      the bazel "runfiles" directory is not available, so 'locateRunfiles' simply
+      crashes at runtime.
+
       This is probably not what you want in a packaged application. For that
       use case, prefer instead 'locateResources', which allows you to specify
       the path to the resource in a packaged application, and the prefix to be

--- a/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
@@ -6,6 +6,8 @@
 module DA.Daml.Doc.Tests(mkTestTree)
   where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import DA.Bazel.Runfiles
 import DA.Daml.Compiler.Output (diagnosticsLogger)
 import DA.Daml.Options.Types

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -632,11 +632,13 @@ generateStablePackages lfVersion fp = do
 -- | Find the directory containing the stable packages if it exists.
 locateStablePackages :: IO FilePath
 locateStablePackages = locateResource Resource
-  { runfilesPath = mainWorkspace </> "compiler" </> "damlc" </> "stable-packages"
-  , resourcesPath = "stable-packages"
-    -- In a packaged application, the directory structure of //compiler/damlc/stable-packages
-    -- is preserved underneath the resources directory because it includes multiple files.
+  -- //compiler/damlc/stable-packages
+  { resourcesPath = "stable-packages"
+    -- In a packaged application, the directory "stable-packages" is preserved
+    -- underneath the resources directory because the bazel target includes
+    -- multiple files.
     -- See @bazel_tools/packaging/packaging.bzl@.
+  , runfilesPathPrefix = mainWorkspace </> "compiler" </> "damlc"
   }
 
 generateStablePackagesRule :: Options -> Rules ()
@@ -1224,11 +1226,12 @@ dlintSettings (DlintEnabled DlintOptions {..}) = do
       getDlintRulesFile :: DlintRulesFile -> IO FilePath
       getDlintRulesFile = \case
         DefaultDlintRulesFile -> locateResource Resource
-          { runfilesPath = mainWorkspace </> "compiler" </> "damlc" </> "daml-ide-core" </> "dlint.yaml"
-          , resourcesPath = "dlint.yaml"
-            -- In a packaged application, //compiler/damlc/daml-ide-core:dlint.yaml
-            -- is stored directly underneath the resources directory because it's a single file.
+          -- //compiler/damlc/daml-ide-core:dlint.yaml
+          { resourcesPath = "dlint.yaml"
+            -- In a packaged application, this is stored directly underneath
+            -- the resources directory because it's a single file.
             -- See @bazel_tools/packaging/packaging.bzl@.
+          , runfilesPathPrefix = mainWorkspace </> "compiler" </> "damlc" </> "daml-ide-core"
           }
         ExplicitDlintRulesFile path -> pure path
 

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -1227,8 +1227,13 @@ dlintSettings (DlintEnabled DlintOptions {..}) = do
     where
       getDlintRulesFile :: DlintRulesFile -> IO FilePath
       getDlintRulesFile = \case
-        DefaultDlintRulesFile -> locateRunfiles $
-          mainWorkspace </> "compiler" </> "damlc" </> "daml-ide-core" </> "dlint.yaml"
+        DefaultDlintRulesFile -> locateResource Resource
+          { runfilesPath = mainWorkspace </> "compiler" </> "damlc" </> "daml-ide-core" </> "dlint.yaml"
+          , resourcesPath = "dlint.yaml"
+            -- In a packaged application, //compiler/damlc/daml-ide-core:dlint.yaml
+            -- is stored directly underneath the resources directory because it's a single file.
+            -- See @bazel_tools/packaging/packaging.bzl@.
+          }
         ExplicitDlintRulesFile path -> pure path
 
       getHintFiles :: DlintHintFiles -> IO [FilePath]

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -21,7 +21,6 @@ module DA.Daml.Options.Types
     , ModRenaming(..)
     , PackageArg(..)
     , defaultOptions
-    , getBaseDir
     , damlArtifactDir
     , projectPackageDatabase
     , projectDependenciesDatabase
@@ -257,9 +256,6 @@ defaultOptions mbVersion =
         , optAccessTokenPath = Nothing
         , optAllowLargeTuples = AllowLargeTuples False
         }
-
-getBaseDir :: IO FilePath
-getBaseDir = locateRunfiles (mainWorkspace </> "compiler/damlc")
 
 pkgNameVersion :: LF.PackageName -> Maybe LF.PackageVersion -> UnitId
 pkgNameVersion (LF.PackageName n) mbV =

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -209,7 +209,13 @@ basePackages = ["daml-prim", "daml-stdlib"]
 locateBuiltinPackageDbs :: Maybe NormalizedFilePath -> IO [FilePath]
 locateBuiltinPackageDbs mbProjRoot = do
     -- package db for daml-stdlib and daml-prim
-    internalPackageDb <- fmap (</> "pkg-db_dir") $ locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "pkg-db")
+    internalPackageDb <- locateResource Resource
+      { runfilesPath = mainWorkspace </> "compiler" </> "damlc" </> "pkg-db" </> "pkg-db_dir"
+      , resourcesPath = "pkg-db_dir"
+        -- In a packaged application, the directory structure of //compiler/damlc/pkg-db
+        -- is preserved underneath the resources directory because it includes multiple files.
+        -- See @bazel_tools/packaging/packaging.bzl@.
+      }
     -- If these directories do not exist, we just discard them.
     filterM Dir.doesDirectoryExist (internalPackageDb : [fromNormalizedFilePath projRoot </> projectPackageDatabase | Just projRoot <- [mbProjRoot]])
 

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -209,11 +209,13 @@ locateBuiltinPackageDbs :: Maybe NormalizedFilePath -> IO [FilePath]
 locateBuiltinPackageDbs mbProjRoot = do
     -- package db for daml-stdlib and daml-prim
     internalPackageDb <- locateResource Resource
-      { runfilesPath = mainWorkspace </> "compiler" </> "damlc" </> "pkg-db" </> "pkg-db_dir"
-      , resourcesPath = "pkg-db_dir"
-        -- In a packaged application, the directory structure of //compiler/damlc/pkg-db
-        -- is preserved underneath the resources directory because it includes multiple files.
+      -- //compiler/damlc/pkg-db
+      { resourcesPath = "pkg-db_dir"
+        -- In a packaged application, the directory "pkg-db_dir" is preserved
+        -- underneath the resources directory because it is the target's
+        -- only output (even if it's a directory).
         -- See @bazel_tools/packaging/packaging.bzl@.
+      , runfilesPathPrefix = mainWorkspace </> "compiler" </> "damlc" </> "pkg-db"
       }
     -- If these directories do not exist, we just discard them.
     filterM Dir.doesDirectoryExist (internalPackageDb : [fromNormalizedFilePath projRoot </> projectPackageDatabase | Just projRoot <- [mbProjRoot]])

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -448,21 +448,28 @@ setImports paths dflags = dflags { importPaths = paths }
 
 locateGhcVersionHeader :: IO GhcVersionHeader
 locateGhcVersionHeader = GhcVersionHeader <$> locateResource Resource
-  { runfilesPath = mainWorkspace </> "compiler" </> "damlc" </> "ghcversion.h"
-  , resourcesPath = "ghcversion.h"
-    -- In a packaged application, //compiler/damlc:ghcversion is stored
-    -- directly underneath the resources directory because it's a single file.
+  -- //compiler/damlc:ghcversion
+  { resourcesPath = "ghcversion.h"
+    -- In a packaged application, this is stored directly underneath the
+    -- resources directory because it's a single file.
     -- See @bazel_tools/packaging/packaging.bzl@.
+  , runfilesPathPrefix = mainWorkspace </> "compiler" </> "damlc"
   }
 
 locateCppPath :: IO (Maybe FilePath)
 locateCppPath = do
     path <- locateResource Resource
-      { runfilesPath = "stackage" </> "hpp-0.6.4" </> "_install" </> "bin" </> exe "hpp"
-      , resourcesPath = exe "hpp"
+      { resourcesPath = exe "hpp"
+        -- //compiler/damlc:hpp-dist
         -- In a packaged application, the executable is stored directly underneath
-        -- the resources directory because //compiler/damlc:hpp-dist produces a
-        -- tarball which has the executable directly under the top directory.
+        -- the resources directory because the target produces a tarball which
+        -- has the executable directly under the top directory.
+        -- See @bazel_tools/packaging/packaging.bzl@.
+      , runfilesPathPrefix = "stackage" </> "hpp-0.6.4" </> "_install" </> "bin"
+        -- @stackage-exe//hpp
+        -- when running as a bazel target, the executable has the same name
+        -- but comes from the stackage target, so the prefix is different
+        -- from that of the dist target.
       }
     exists <- doesFileExist path
     pure (guard exists >> Just path)

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -447,12 +447,13 @@ setImports :: [FilePath] -> DynFlags -> DynFlags
 setImports paths dflags = dflags { importPaths = paths }
 
 locateGhcVersionHeader :: IO GhcVersionHeader
-locateGhcVersionHeader = GhcVersionHeader <$> do
-    resourcesDir <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "ghcversion.h")
-    isDirectory <- doesDirectoryExist resourcesDir
-    let path | isDirectory = resourcesDir </> "ghcversion.h"
-             | otherwise = resourcesDir
-    pure path
+locateGhcVersionHeader = GhcVersionHeader <$> locateResource Resource
+  { runfilesPath = mainWorkspace </> "compiler" </> "damlc" </> "ghcversion.h"
+  , resourcesPath = "ghcversion.h"
+    -- In a packaged application, //compiler/damlc:ghcversion is stored
+    -- directly underneath the resources directory because it's a single file.
+    -- See @bazel_tools/packaging/packaging.bzl@.
+  }
 
 locateCppPath :: IO (Maybe FilePath)
 locateCppPath = do

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -457,8 +457,13 @@ locateGhcVersionHeader = GhcVersionHeader <$> locateResource Resource
 
 locateCppPath :: IO (Maybe FilePath)
 locateCppPath = do
-    resourcesDir <- locateRunfiles $ "stackage" </> "hpp-0.6.4" </> "_install" </> "bin"
-    let path  = resourcesDir </> exe "hpp"
+    path <- locateResource Resource
+      { runfilesPath = "stackage" </> "hpp-0.6.4" </> "_install" </> "bin" </> exe "hpp"
+      , resourcesPath = exe "hpp"
+        -- In a packaged application, the executable is stored directly underneath
+        -- the resources directory because //compiler/damlc:hpp-dist produces a
+        -- tarball which has the executable directly under the top directory.
+      }
     exists <- doesFileExist path
     pure (guard exists >> Just path)
 

--- a/compiler/damlc/daml-visual/src/DA/Daml/Visual.hs
+++ b/compiler/damlc/daml-visual/src/DA/Daml/Visual.hs
@@ -395,16 +395,18 @@ execVisualHtml darFilePath webFilePath oBrowser = do
     dalfs <- either fail pure $
                 readDalfs $ ZIPArchive.toArchive (BSL.fromStrict darBytes)
     d3js <- readFile =<< locateResource Resource
-      { runfilesPath = "static_asset_d3plus" </> "js" </> "d3.min.js"
-      , resourcesPath = "d3.min.js"
-        -- In a packaged application, @static_asset_d3plus//:js/d3.min.js is stored
-        -- directly underneath the resources directory because it's a single file.
+      -- @static_asset_d3plus//:js/d3.min.js
+      { resourcesPath = "d3.min.js"
+        -- In a packaged application, this is stored directly underneath the
+        -- resources directory because it's a single file.
         -- See @bazel_tools/packaging/packaging.bzl@.
+      , runfilesPathPrefix = "static_asset_d3plus" </> "js"
       }
     d3plusjs <- readFile =<< locateResource Resource
-      { runfilesPath = "static_asset_d3plus" </> "js" </> "d3plus.min.js"
-      , resourcesPath = "d3plus.min.js"
-        -- as above but for @static_asset_d3plus//:js/d3plus.min.js
+      -- @static_asset_d3plus//:js/d3plus.min.js
+      { resourcesPath = "d3plus.min.js"
+        -- as above
+      , runfilesPathPrefix = "static_asset_d3plus" </> "js"
       }
     let world = darToWorld dalfs
         graph = graphFromWorld world

--- a/compiler/damlc/daml-visual/src/DA/Daml/Visual.hs
+++ b/compiler/damlc/daml-visual/src/DA/Daml/Visual.hs
@@ -394,9 +394,18 @@ execVisualHtml darFilePath webFilePath oBrowser = do
     darBytes <- B.readFile darFilePath
     dalfs <- either fail pure $
                 readDalfs $ ZIPArchive.toArchive (BSL.fromStrict darBytes)
-    staticDir <- locateRunfiles $ "static_asset_d3plus" </> "js"
-    d3js <-   readFile $ staticDir </> "d3.min.js"
-    d3plusjs <- readFile $ staticDir </> "d3plus.min.js"
+    d3js <- readFile =<< locateResource Resource
+      { runfilesPath = "static_asset_d3plus" </> "js" </> "d3.min.js"
+      , resourcesPath = "d3.min.js"
+        -- In a packaged application, @static_asset_d3plus//:js/d3.min.js is stored
+        -- directly underneath the resources directory because it's a single file.
+        -- See @bazel_tools/packaging/packaging.bzl@.
+      }
+    d3plusjs <- readFile =<< locateResource Resource
+      { runfilesPath = "static_asset_d3plus" </> "js" </> "d3plus.min.js"
+      , resourcesPath = "d3plus.min.js"
+        -- as above but for @static_asset_d3plus//:js/d3plus.min.js
+      }
     let world = darToWorld dalfs
         graph = graphFromWorld world
         d3G = graphToD3Graph graph

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -767,11 +767,12 @@ execRepl dars importPkgs mbLedgerConfig mbAuthToken mbAppId mbSslConf mbMaxInbou
                 }
             logger <- getLogger opts "repl"
             jar <- locateResource Resource
-                { runfilesPath = mainWorkspace </> "compiler" </> "repl-service" </> "server" </> "repl-service.jar"
-                , resourcesPath = "repl-service.jar"
-                  -- In a packaged application, //compiler/repl-service/server:repl_service_jar is stored
-                  -- directly underneath the resources directory because it's a single file.
+                -- //compiler/repl-service/server:repl_service_jar
+                { resourcesPath = "repl-service.jar"
+                  -- In a packaged application, this is stored directly underneath
+                  -- the resources directory because it's the target's only output.
                   -- See @bazel_tools/packaging/packaging.bzl@.
+                , runfilesPathPrefix = mainWorkspace </> "compiler" </> "repl-service" </> "server"
                 }
             ReplClient.withReplClient (ReplClient.Options jar mbLedgerConfig mbAuthToken mbAppId mbSslConf mbMaxInboundMessageSize timeMode Inherit) $ \replHandle ->
                 withTempDir $ \dir ->

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -766,8 +766,13 @@ execRepl dars importPkgs mbLedgerConfig mbAuthToken mbAppId mbSslConf mbMaxInbou
                 , optPackageImports = optPackageImports opts ++ pkgFlags
                 }
             logger <- getLogger opts "repl"
-            runfilesDir <- locateRunfiles (mainWorkspace </> "compiler/repl-service/server")
-            let jar = runfilesDir </> "repl-service.jar"
+            jar <- locateResource Resource
+                { runfilesPath = mainWorkspace </> "compiler" </> "repl-service" </> "server" </> "repl-service.jar"
+                , resourcesPath = "repl-service.jar"
+                  -- In a packaged application, //compiler/repl-service/server:repl_service_jar is stored
+                  -- directly underneath the resources directory because it's a single file.
+                  -- See @bazel_tools/packaging/packaging.bzl@.
+                }
             ReplClient.withReplClient (ReplClient.Options jar mbLedgerConfig mbAuthToken mbAppId mbSslConf mbMaxInboundMessageSize timeMode Inherit) $ \replHandle ->
                 withTempDir $ \dir ->
                 withCurrentDirectory dir $ do

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -531,15 +531,23 @@ writeSrc (fp, content) = do
 -- | Locate ghc-pkg
 getGhcPkgExe :: IO FilePath
 getGhcPkgExe = locateResource Resource
-  { runfilesPath = if isWindows
-      then "rules_haskell_ghc_windows_amd64" </> "bin" </> exe "ghc-pkg"
-      else "ghc_nix" </> "lib" </> "ghc-9.0.2" </> "bin" </> exe "ghc-pkg"
-      -- see @compiler/damlc/util.bzl@
-  , resourcesPath = exe "ghc-pkg"
+  { resourcesPath = exe "ghc-pkg"
+    -- //compiler/damlc:ghc-pkg-dist
     -- In a packaged application, the executable is stored directly underneath
-    -- the resources directory because //compiler/damlc:ghc-pkg-dist produces
-    -- a tarball which has the executable directly under the top directory.
+    -- the resources directory because the target produces a tarball which has
+    -- the executable directly under the top directory.
     -- See @bazel_tools/packaging/packaging.bzl@.
+  , runfilesPathPrefix =
+      -- when running as a bazel target, the executable has the same name
+      -- but comes from the a different target depending on the OS, so the
+      -- prefix used changes.
+      -- see @compiler/damlc/util.bzl@
+      if isWindows then
+        -- @rules_haskell_ghc_windows_amd64//:bin/ghc-pkg.exe
+        "rules_haskell_ghc_windows_amd64" </> "bin"
+      else
+        -- @ghc_nix//:lib/ghc-9.0.2/bin/ghc-pkg
+        "ghc_nix" </> "lib" </> "ghc-9.0.2" </> "bin"
   }
 
 -- | Fail with an exit failure and errror message when Nothing is returned.

--- a/compiler/damlc/tests/src/DA/Test/DamlDesugar.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlDesugar.hs
@@ -3,6 +3,8 @@
 
 module DA.Test.DamlDesugar (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import DA.Bazel.Runfiles (locateRunfiles, mainWorkspace)
 import DA.Daml.Desugar.Tests (mkTestTree)
 import System.Environment.Blank (setEnv)

--- a/compiler/damlc/tests/src/DA/Test/DamlDoc.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlDoc.hs
@@ -4,6 +4,8 @@
 
 module DA.Test.DamlDoc (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import DA.Daml.Doc.Driver (loadExternalAnchors)
 import DA.Daml.Doc.Types
 import qualified DA.Daml.Doc.Tests as Damldoc

--- a/compiler/damlc/tests/src/DA/Test/DamlDocTestIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlDocTestIntegration.hs
@@ -3,6 +3,8 @@
 
 module DA.Test.DamlDocTestIntegration (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import DA.Bazel.Runfiles
 import Data.List
 import System.Exit

--- a/compiler/damlc/tests/src/DA/Test/DamlRenamer.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlRenamer.hs
@@ -5,6 +5,8 @@
 
 module DA.Test.DamlRenamer (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Control.Monad (filterM)
 import DA.Bazel.Runfiles (exe, locateRunfiles, mainWorkspace)
 import Data.List.Extra (nubOrd)

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -8,6 +8,8 @@ module DA.Test.DamlcIntegration
   ( main
   ) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import           DA.Bazel.Runfiles
 import           DA.Daml.Options
 import           DA.Daml.Options.Types

--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -2,6 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 module DA.Test.DataDependencies (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import qualified "zip-archive" Codec.Archive.Zip as Zip
 import Control.Monad.Extra
 import DA.Bazel.Runfiles

--- a/compiler/damlc/tests/src/DA/Test/IncrementalBuilds.hs
+++ b/compiler/damlc/tests/src/DA/Test/IncrementalBuilds.hs
@@ -3,6 +3,8 @@
 
 module DA.Test.IncrementalBuilds (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Control.Monad.Extra
 import DA.Bazel.Runfiles
 import Data.Foldable

--- a/compiler/damlc/tests/src/DA/Test/IncrementalPackageDb.hs
+++ b/compiler/damlc/tests/src/DA/Test/IncrementalPackageDb.hs
@@ -3,6 +3,8 @@
 
 module DA.Test.IncrementalPackageDb (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Control.Monad.Extra
 import DA.Bazel.Runfiles
 import Data.Foldable

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -2,6 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 module DA.Test.Packaging (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import qualified "zip-archive" Codec.Archive.Zip as Zip
 import Control.Monad.Extra
 import Control.Exception.Safe

--- a/compiler/damlc/tests/src/DA/Test/Repl.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl.hs
@@ -3,6 +3,8 @@
 
 module DA.Test.Repl (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Control.Exception
 import Control.Monad.Extra
 import DA.Bazel.Runfiles

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -2,6 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 module DA.Test.Repl.FuncTests (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Control.Concurrent
 import Control.Concurrent.Async
 import Control.Exception

--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -3,6 +3,8 @@
 
 module DA.Test.ScriptService (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Control.Exception
 import Control.Monad
 import DA.Bazel.Runfiles

--- a/compiler/damlc/tests/src/DA/Test/ScriptService_1_15.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService_1_15.hs
@@ -3,6 +3,8 @@
 
 module DA.Test.ScriptService (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Control.Exception
 import Control.Monad
 import DA.Bazel.Runfiles

--- a/compiler/damlc/tests/src/DA/Test/UnstableTypes.hs
+++ b/compiler/damlc/tests/src/DA/Test/UnstableTypes.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE MultiWayIf #-}
 module DA.Test.UnstableTypes (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Data.Bifunctor
 import Control.Monad.Extra
 import DA.Bazel.Runfiles

--- a/compiler/damlc/tests/src/DamlcLint.hs
+++ b/compiler/damlc/tests/src/DamlcLint.hs
@@ -4,6 +4,8 @@ module DamlcLint
    ( main
    ) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Data.List.Extra (isSuffixOf)
 import System.Environment.Blank
 import System.Directory

--- a/compiler/damlc/tests/src/DamlcPkgManager.hs
+++ b/compiler/damlc/tests/src/DamlcPkgManager.hs
@@ -4,6 +4,8 @@ module DamlcPkgManager
     ( main
     ) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import DA.Bazel.Runfiles
 import DA.Cli.Damlc.InspectDar
 import DA.Daml.Helper.Ledger (downloadAllReachablePackages)

--- a/compiler/damlc/tests/src/DamlcTest.hs
+++ b/compiler/damlc/tests/src/DamlcTest.hs
@@ -4,6 +4,8 @@ module DamlcTest
    ( main
    ) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Data.List.Extra (isInfixOf, isPrefixOf)
 import System.Directory
 import System.Environment.Blank

--- a/compiler/damlc/tests/src/DamlcVisualize.hs
+++ b/compiler/damlc/tests/src/DamlcVisualize.hs
@@ -5,6 +5,8 @@
 
 module DamlcVisualize (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import qualified "zip-archive" Codec.Archive.Zip as Zip
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE TypeOperators #-}
 module Main (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Control.Concurrent
 import Control.Applicative.Combinators
 import Control.Lens hiding (List, children, (.=))

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -122,11 +122,12 @@ instance NFData Error where
 
 findServerJar :: IO FilePath
 findServerJar = locateResource Resource
-  { runfilesPath = mainWorkspace </> "compiler" </> "scenario-service" </> "server" </> "scenario-service.jar"
-  , resourcesPath = "scenario-service.jar"
-    -- In a packaged application, //compiler/scenario-service/server:scenario_service_jar
-    -- is stored directly underneath the resources directory because it's a single file.
+  -- //compiler/scenario-service/server:scenario_service_jar
+  { resourcesPath = "scenario-service.jar"
+    -- In a packaged application, this is stored directly underneath the
+    -- resources directory because it's the targets only output.
     -- See @bazel_tools/packaging/packaging.bzl@.
+  , runfilesPathPrefix = mainWorkspace </> "compiler" </> "scenario-service" </> "server"
   }
 
 -- | Return the 'CreateProcess' for running java.

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -121,9 +121,13 @@ instance NFData Error where
     rnf = rwhnf
 
 findServerJar :: IO FilePath
-findServerJar = do
-  runfilesDir <- locateRunfiles (mainWorkspace </> "compiler/scenario-service/server")
-  pure (runfilesDir </> "scenario-service.jar")
+findServerJar = locateResource Resource
+  { runfilesPath = mainWorkspace </> "compiler" </> "scenario-service" </> "server" </> "scenario-service.jar"
+  , resourcesPath = "scenario-service.jar"
+    -- In a packaged application, //compiler/scenario-service/server:scenario_service_jar
+    -- is stored directly underneath the resources directory because it's a single file.
+    -- See @bazel_tools/packaging/packaging.bzl@.
+  }
 
 -- | Return the 'CreateProcess' for running java.
 -- Uses 'java' from JAVA_HOME if set, otherwise calls java via

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -125,7 +125,7 @@ findServerJar = locateResource Resource
   -- //compiler/scenario-service/server:scenario_service_jar
   { resourcesPath = "scenario-service.jar"
     -- In a packaged application, this is stored directly underneath the
-    -- resources directory because it's the targets only output.
+    -- resources directory because it's the target's only output.
     -- See @bazel_tools/packaging/packaging.bzl@.
   , runfilesPathPrefix = mainWorkspace </> "compiler" </> "scenario-service" </> "server"
   }

--- a/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Deployment.hs
+++ b/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Deployment.hs
@@ -3,6 +3,8 @@
 
 module DA.Daml.Helper.Test.Deployment (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Control.Exception
 import qualified Data.UUID.V4 as UUID
 import System.Directory.Extra (withCurrentDirectory)

--- a/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Ledger.hs
+++ b/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Ledger.hs
@@ -4,6 +4,8 @@ module DA.Daml.Helper.Test.Ledger
   ( main
   ) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import qualified "zip-archive" Codec.Archive.Zip as Zip
 import DA.Bazel.Runfiles
 import DA.Cli.Damlc.InspectDar

--- a/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Packages.hs
+++ b/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Packages.hs
@@ -4,6 +4,8 @@ module DA.Daml.Helper.Test.Packages
   ( main
   ) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import DA.Bazel.Runfiles
 import DA.Test.HttpJson
 import DA.Test.Sandbox

--- a/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Tls.hs
+++ b/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Tls.hs
@@ -3,6 +3,8 @@
 
 module DA.Daml.Helper.Test.Tls (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import DA.Bazel.Runfiles
 import DA.Test.Sandbox
 import DA.Test.Util

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/CreateDamlAppTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/CreateDamlAppTests.hs
@@ -2,6 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 module DA.Daml.Assistant.CreateDamlAppTests (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Conduit
 import Control.Exception.Extra
 import Control.Monad

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTestUtils.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTestUtils.hs
@@ -7,6 +7,8 @@ module DA.Daml.Assistant.IntegrationTestUtils
   , throwError
   ) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Conduit hiding (connect)
 import Control.Monad (forM_)
 import qualified Data.Conduit.Tar.Extra as Tar.Conduit.Extra

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -2,6 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 module DA.Daml.Assistant.IntegrationTests (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Control.Concurrent
 import Control.Concurrent.STM
 import Control.Lens

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/QuickstartTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/QuickstartTests.hs
@@ -2,6 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 module DA.Daml.Assistant.QuickstartTests (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Conduit hiding (connect)
 import Control.Concurrent
 import qualified Data.ByteString.Lazy.Char8 as LBS8

--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -5,6 +5,8 @@
 
 module DA.Ledger.Tests (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Control.Monad
 import Control.Monad.IO.Class(liftIO)
 import DA.Bazel.Runfiles

--- a/language-support/ts/codegen/tests/src/DA/Test/Daml2js.hs
+++ b/language-support/ts/codegen/tests/src/DA/Test/Daml2js.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE DerivingStrategies #-}
 module DA.Test.Daml2js (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import System.FilePath
 import System.IO.Extra
 import System.Environment.Blank

--- a/language-support/ts/codegen/tests/src/DA/Test/Daml2jsUtils.hs
+++ b/language-support/ts/codegen/tests/src/DA/Test/Daml2jsUtils.hs
@@ -8,6 +8,8 @@ module DA.Test.Daml2jsUtils (
     setupYarnEnv,
     ) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import qualified Data.Text.Extended as T
 import qualified Data.ByteString.Lazy as BSL
 import Control.Monad

--- a/libs-haskell/bazel-runfiles/test/DA/Bazel/RunfilesTest.hs
+++ b/libs-haskell/bazel-runfiles/test/DA/Bazel/RunfilesTest.hs
@@ -3,6 +3,8 @@
 
 module Main (main) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import           System.Directory
 import           System.FilePath
 import           Test.Tasty

--- a/libs-haskell/test-utils/DA/Test/HttpJson.hs
+++ b/libs-haskell/test-utils/DA/Test/HttpJson.hs
@@ -9,6 +9,8 @@ module DA.Test.HttpJson
   , defaultHttpJsonConf
   ) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Control.Exception
 import DA.Bazel.Runfiles
 import DA.PortFile

--- a/libs-haskell/test-utils/DA/Test/Sandbox.hs
+++ b/libs-haskell/test-utils/DA/Test/Sandbox.hs
@@ -14,6 +14,8 @@ module DA.Test.Sandbox
     , makeSignedJwt
     ) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Control.Exception
 import DA.Bazel.Runfiles
 import DA.Daml.Helper.Ledger


### PR DESCRIPTION
Fixes #15443

The problem was that `locateRunfiles` behaves differently depending on how the current executable was built:
* When the executable is a `bazel run` or `bazel test` target, it returns the input prefixed by the runfiles directory assigned by Bazel for that target
* When it's a packaged app produced with `bazel_tools/packaging/packaging.bzl`, `locateRunfiles` *ignores the argument* and returns the `"resources"` directory, a sibling of the packaged executable.

One of the changes from #15290 was using a rules _file_ instead of a rules _directory_ expected to contain a `dlint.yaml` file. Since the tests always use runfiles, they worked fine, but in Daml Studio it meant the `locateRunfiles` call with the `dlint.yaml` file returned a directory. 

We'd had similar problems before due to the unexpected behavior of `locateRunfiles`, see https://github.com/digital-asset/daml/pull/8278#discussion_r542474714. Each time we resorted to workarounds using `locateRunfiles` to find a base directory and _then_ appending the filename - which only worked because in packaged apps the file was stored directly in the `"resources"` directory.

The fix proposed here makes the two resolution mechanisms explicit by introducing a new function `locateResource` which takes one path to use for each mechanism. All the uses of `locateRunfiles` outside of tests or `compatibility/` have been replaced with `locateResource`, removing the workarounds described above.

EDIT: additionally, this PR adds an hlint warning recommending `locateResource` instead of `locateRunfiles` - which can be disabled when the codepath is never used by a packaged application. Also, `locateRunfiles` now simply crashes when used from a packaged application (instead of returning the `EXECUTABLE/../resources` directory).