### PR TITLE
Add notNull function

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
@@ -620,6 +620,10 @@ null : [a] -> Bool
 null [] = True
 null _ = False
 
+-- | Inverse of `null`, to avoid brackets when checking for a non-empty list
+notNull : [a] -> Bool
+notNull = not . null
+
 -- | Filters the list using the function: keep only the elements where the predicate holds.
 filter : (a -> Bool) -> [a] -> [a]
 filter p = foldr (\x xs -> if p x then x :: xs else xs) []

--- a/compiler/damlc/daml-stdlib-src/DA/List.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/List.daml
@@ -74,6 +74,7 @@ module DA.List
   , unzip
   , unzip3
   , null
+  , notNull
   , filter
 
   , head


### PR DESCRIPTION
This allows a check for non-empty lists to be written as `notNull list` instead of the more verbose `not (null list)`. It makes a bigger difference when you have more complicated nested boolean conditions `not (null (filter (\x -> x.someField == "A") list))`.

CHANGELOG_BEGIN
* [daml-stdlib] Add notNull function
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
