### PR TITLE
[daml-script] interfaces over JSON API

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
@@ -282,7 +282,7 @@ object ScriptF {
       for {
         viewType <- Converter.toFuture(env.lookupInterfaceViewTy(interfaceId))
         client <- Converter.toFuture(env.clients.getPartiesParticipant(parties))
-        list <- client.queryInterface(parties, interfaceId)
+        list <- client.queryInterface(parties, interfaceId, viewType)
         list <- Converter.toFuture(
           list
             .to(FrontStack)
@@ -324,7 +324,7 @@ object ScriptF {
       for {
         viewType <- Converter.toFuture(env.lookupInterfaceViewTy(interfaceId))
         client <- Converter.toFuture(env.clients.getPartiesParticipant(parties))
-        optR <- client.queryInterfaceContractId(parties, interfaceId, cid)
+        optR <- client.queryInterfaceContractId(parties, interfaceId, viewType, cid)
         optR <- Converter.toFuture(
           optR.traverse(Converter.fromInterfaceView(env.valueTranslator, viewType, _))
         )

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/GrpcLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/GrpcLedgerClient.scala
@@ -31,6 +31,7 @@ import com.daml.lf.command
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.engine.script.Converter
+import com.daml.lf.language.Ast
 import com.daml.lf.speedy.{SValue, svalue}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
@@ -139,7 +140,11 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
     }
   }
 
-  override def queryInterface(parties: OneAnd[Set, Ref.Party], interfaceId: Identifier)(implicit
+  override def queryInterface(
+      parties: OneAnd[Set, Ref.Party],
+      interfaceId: Identifier,
+      viewType: Ast.Type,
+  )(implicit
       ec: ExecutionContext,
       mat: Materializer,
   ): Future[Seq[(ContractId, Option[Value])]] = {
@@ -176,13 +181,14 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
   override def queryInterfaceContractId(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
+      viewType: Ast.Type,
       cid: ContractId,
   )(implicit
       ec: ExecutionContext,
       mat: Materializer,
   ): Future[Option[Value]] = {
     for {
-      activeViews <- queryInterface(parties, interfaceId)
+      activeViews <- queryInterface(parties, interfaceId, viewType)
     } yield {
       activeViews.collectFirst {
         case (k, Some(v)) if (k == cid) => v

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -12,6 +12,7 @@ import com.daml.ledger.api.domain.{ObjectMeta, PartyDetails, User, UserRight}
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{ImmArray, Ref, Time}
 import com.daml.lf.engine.preprocessing.ValueTranslator
+import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast.TTyCon
 import com.daml.lf.scenario.{ScenarioLedger, ScenarioRunner}
 import com.daml.lf.speedy.SResult._
@@ -176,6 +177,7 @@ class IdeLedgerClient(
   override def queryInterface(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
+      viewType: Ast.Type,
   )(implicit ec: ExecutionContext, mat: Materializer): Future[Seq[(ContractId, Option[Value])]] = {
 
     val acs: Seq[ScenarioLedger.LookupOk] = ledger.query(
@@ -205,6 +207,7 @@ class IdeLedgerClient(
   override def queryInterfaceContractId(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
+      viewType: Ast.Type,
       cid: ContractId,
   )(implicit
       ec: ExecutionContext,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
@@ -28,6 +28,7 @@ import com.daml.lf.command
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.engine.script.{Converter, LfValueCodec}
+import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SValue
 import com.daml.lf.typesig.EnvironmentSignature
@@ -185,6 +186,7 @@ class JsonLedgerClient(
       parsedResults
     }
   }
+
   override def queryContractId(
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,
@@ -209,19 +211,65 @@ class JsonLedgerClient(
       })
     }
   }
+
   override def queryInterface(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
+      viewType: Ast.Type,
   )(implicit ec: ExecutionContext, mat: Materializer): Future[Seq[(ContractId, Option[Value])]] = {
-    sys.error("not implemented") // TODO https://github.com/digital-asset/daml/issues/14830
+    for {
+      parties <- validateTokenParties(parties, "queryinterface")
+      queryResponse <- queryRequestSuccess[QueryArgs, QueryResponse](
+        uri.path./("v1")./("query"),
+        QueryArgs(interfaceId),
+        parties,
+      )
+    } yield {
+      val ctx = interfaceId.qualifiedName
+      val ifaceType = Converter.toIfaceType(ctx, viewType).toOption.get
+      val parsedResults = queryResponse.results.map(r => {
+        val payload = r.payload.convertTo[Value](
+          LfValueCodec.apiValueJsonReader(ifaceType, damlLfTypeLookup(_))
+        )
+        val cid = ContractId.assertFromString(r.contractId)
+        // TODO https://github.com/digital-asset/daml/issues/14830
+        // contracts with failed-views are not returned over the Json API
+        (cid, Some(payload))
+      })
+      parsedResults
+    }
   }
+
   override def queryInterfaceContractId(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
+      viewType: Ast.Type,
       cid: ContractId,
   )(implicit ec: ExecutionContext, mat: Materializer): Future[Option[Value]] = {
-    sys.error("not implemented") // TODO https://github.com/digital-asset/daml/issues/14830
+    // Unfortunately, queryInterfaceContractId is linear in the ACS, since it must use the "query"
+    // interface, unlike queryContractId which makes use of the "fetch" interface.
+    for {
+      parties <- validateTokenParties(parties, "queryinterfaceContractId")
+      queryResponse <- queryRequestSuccess[QueryArgs, QueryResponse](
+        uri.path./("v1")./("query"),
+        QueryArgs(interfaceId),
+        parties,
+      )
+    } yield {
+      val ctx = interfaceId.qualifiedName
+      val ifaceType = Converter.toIfaceType(ctx, viewType).toOption.get
+      queryResponse.results.collectFirst(Function.unlift { r =>
+        if (ContractId.assertFromString(r.contractId) != cid) None
+        else {
+          val payload = r.payload.convertTo[Value](
+            LfValueCodec.apiValueJsonReader(ifaceType, damlLfTypeLookup(_))
+          )
+          Some(payload)
+        }
+      })
+    }
   }
+
   override def queryContractKey(
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
@@ -29,7 +29,6 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.engine.script.{Converter, LfValueCodec}
 import com.daml.lf.language.Ast
-import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SValue
 import com.daml.lf.typesig.EnvironmentSignature
 import com.daml.lf.typesig.PackageSignature.TypeDecl
@@ -175,7 +174,7 @@ class JsonLedgerClient(
       )
     } yield {
       val ctx = templateId.qualifiedName
-      val ifaceType = Converter.toIfaceType(ctx, TTyCon(templateId)).toOption.get
+      val ifaceType = Converter.toIfaceType(ctx, Ast.TTyCon(templateId)).toOption.get
       val parsedResults = queryResponse.results.map(r => {
         val payload = r.payload.convertTo[Value](
           LfValueCodec.apiValueJsonReader(ifaceType, damlLfTypeLookup(_))
@@ -201,7 +200,7 @@ class JsonLedgerClient(
       )
     } yield {
       val ctx = templateId.qualifiedName
-      val ifaceType = Converter.toIfaceType(ctx, TTyCon(templateId)).toOption.get
+      val ifaceType = Converter.toIfaceType(ctx, Ast.TTyCon(templateId)).toOption.get
       fetchResponse.result.map(r => {
         val payload = r.payload.convertTo[Value](
           LfValueCodec.apiValueJsonReader(ifaceType, damlLfTypeLookup(_))
@@ -285,7 +284,7 @@ class JsonLedgerClient(
       )
     } yield {
       val ctx = templateId.qualifiedName
-      val ifaceType = Converter.toIfaceType(ctx, TTyCon(templateId)).toOption.get
+      val ifaceType = Converter.toIfaceType(ctx, Ast.TTyCon(templateId)).toOption.get
       fetchResponse.result.map(r => {
         val payload = r.payload.convertTo[Value](
           LfValueCodec.apiValueJsonReader(ifaceType, damlLfTypeLookup(_))

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/ScriptLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/ScriptLedgerClient.scala
@@ -9,6 +9,7 @@ import com.daml.ledger.api.domain.{PartyDetails, User, UserRight}
 import com.daml.lf.command
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{Ref, Time}
+import com.daml.lf.language.Ast
 import com.daml.lf.speedy.SValue
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
@@ -87,6 +88,7 @@ trait ScriptLedgerClient {
   def queryInterface(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
+      viewType: Ast.Type,
   )(implicit
       ec: ExecutionContext,
       mat: Materializer,
@@ -95,6 +97,7 @@ trait ScriptLedgerClient {
   def queryInterfaceContractId(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
+      viewType: Ast.Type,
       cid: ContractId,
   )(implicit
       ec: ExecutionContext,

--- a/daml-script/test/daml/TestInterfaces.daml
+++ b/daml-script/test/daml/TestInterfaces.daml
@@ -92,11 +92,11 @@ test = script do
 -- Two interfaces (1,2)...
 interface MyInterface1 where
   viewtype MyView1
-data MyView1 = MyView1 { info : Int } deriving (Eq,Ord)
+data MyView1 = MyView1 { info : Int } deriving (Eq,Ord,Show)
 
 interface MyInterface2 where
   viewtype MyView2
-data MyView2 = MyView2 { info : Text } deriving (Eq,Ord)
+data MyView2 = MyView2 { info : Text } deriving (Eq,Ord,Show)
 
 -- ...which are variously implemented by three templates (A,B,C)
 template MyTemplateA
@@ -132,9 +132,17 @@ template MyTemplateC
 
 test_queryInterface : Script ()
 test_queryInterface = script do
-
   p <- allocateParty "Alice" -- primary party in the test script
-  p2 <- allocateParty "Bob" -- other/different party
+  sharedQueryInterfaceTest GRPC p
+
+jsonQueryInterface : Party -> Script ()
+jsonQueryInterface p = script do
+  sharedQueryInterfaceTest JSON p
+
+data Caller = JSON | GRPC
+
+sharedQueryInterfaceTest : Caller -> Party -> Script ()
+sharedQueryInterfaceTest caller p = script do
 
   -- Create various contract-instances of A,B,C (for p)
   a1 <- submit p do createCmd (MyTemplateA p 42)
@@ -147,15 +155,11 @@ test_queryInterface = script do
   a3 <- submit p do createCmd (MyTemplateA p 999)
   submit p do archiveCmd a3
 
-  -- Contracts created by another party (p2) wont be visible when querying (by p)
-  a4 <- submit p2 do createCmd (MyTemplateA p2 911)
-
   -- Refer to p's instances via interface-contract-ids
   -- (Note: we can refer to b1 via either Interface 1 or 2)
   let i1a1 = toInterfaceContractId @MyInterface1 a1
   let i1a2 = toInterfaceContractId @MyInterface1 a2
   let i1a3 = toInterfaceContractId @MyInterface1 a3
-  let i1a4 = toInterfaceContractId @MyInterface1 a4
   let i1b1 = toInterfaceContractId @MyInterface1 b1
   let i2b1 = toInterfaceContractId @MyInterface2 b1
   let i2c1 = toInterfaceContractId @MyInterface2 c1
@@ -166,10 +170,10 @@ test_queryInterface = script do
   v.info === 142
   Some v <- queryInterfaceContractId p i1a2
   v.info === 143
+
   Some v <- queryInterfaceContractId p i1b1
   v.info === 244
   None <- queryInterfaceContractId p i1a3 -- contract is archived
-  None <- queryInterfaceContractId p i1a4 -- not a stakeholder
 
   -- Test queryInterfaceContractId (Interface2)
   Some v <- queryInterfaceContractId p i2b1
@@ -188,11 +192,23 @@ test_queryInterface = script do
   v3.info === 244
 
   -- Test queryInterface (Interface2)
-  [(i1,None),(i2,Some v2),(i3,Some v3)] <- sortOn snd <$> queryInterface @MyInterface2 p
-  i1 === i2c2 -- view function failed, so no info
-  i2 === i2b1
-  i3 === i2c1
-  v2.info === "B:44"
-  v3.info === "C:I-am-c1"
+  case caller of
+
+    GRPC -> do
+      [(i1,None),(i2,Some v2),(i3,Some v3)] <- sortOn snd <$> queryInterface @MyInterface2 p
+      i1 === i2c2 -- view function failed, so no info
+      i2 === i2b1
+      i3 === i2c1
+      v2.info === "B:44"
+      v3.info === "C:I-am-c1"
+
+    -- TODO https://github.com/digital-asset/daml/issues/14830
+    -- contracts with failed-views are not returned over the Json API
+    JSON -> do
+      [(i2,Some v2),(i3,Some v3)] <- sortOn snd <$> queryInterface @MyInterface2 p
+      i2 === i2b1
+      i3 === i2c1
+      v2.info === "B:44"
+      v3.info === "C:I-am-c1"
 
   pure ()

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -93,7 +93,10 @@ trait JsonApiFixture
 
   override protected def darFile = new File(rlocation("daml-script/test/script-test.dar"))
 
+  protected val darFileDev = new File(rlocation("daml-script/test/script-test-1.dev.dar"))
   protected val darFileNoLedger = new File(rlocation("daml-script/test/script-test-no-ledger.dar"))
+
+  override protected def packageFiles: List[File] = List(darFile, darFileDev)
 
   override protected def serverPort: Port = suiteResource.value._1
   override protected def channel: Channel = suiteResource.value._2
@@ -239,6 +242,7 @@ final class JsonApiIt
 
   val (dar, envIface) = readDar(darFile)
   val (darNoLedger, envIfaceNoLedger) = readDar(darFileNoLedger)
+  val (darDev, envIfaceDev) = readDar(darFileDev)
 
   private def getClients(
       parties: List[String] = List(party),
@@ -529,6 +533,18 @@ final class JsonApiIt
       for {
         clients <- getClients()
         result <- run(clients, QualifiedName.assertFromString("ScriptTest:jsonQueryContractId"))
+      } yield {
+        assert(result == SUnit)
+      }
+    }
+    "queryInterface" in {
+      for {
+        clients <- getClients(envIface = envIfaceDev)
+        result <- run(
+          clients,
+          QualifiedName.assertFromString("TestInterfaces:jsonQueryInterface"),
+          dar = darDev,
+        )
       } yield {
         assert(result == SUnit)
       }


### PR DESCRIPTION
This PR adds support to daml-script for `queryInterface` and `queryInterfaceContractId` running over the JSON API.

There are a couple of issues to note:

- The JSON API does not return information to `queryInterface` about contracts for which the view function failed. This is in contrast to the GRPC and IDE APIs.

- The JSON API is unfortunately linear in the ACS for `queryInterfaceContractId` (as is `queryInterfaceContractId` over GRPC) but unlike JSON/`queryContractId` which can use the `"fetch"` interface, and so benefit from better performance.


Advances https://github.com/digital-asset/daml/issues/14830