### PR TITLE
move fromContractId and fromCreatedEvent to ContractTypeCompanion

### DIFF
--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/TransactionFilter.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/TransactionFilter.java
@@ -25,7 +25,7 @@ public abstract class TransactionFilter {
   public abstract Set<String> getParties();
 
   public static TransactionFilter transactionFilter(
-      ContractTypeCompanion<?, ?> contractCompanion, Set<String> parties) {
+      ContractTypeCompanion<?, ?, ?, ?> contractCompanion, Set<String> parties) {
     Filter filter =
         (contractCompanion instanceof ContractCompanion)
             ? new InclusiveFilter(Set.of(contractCompanion.TEMPLATE_ID), Collections.emptyMap())

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ByKey.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ByKey.java
@@ -27,7 +27,7 @@ public abstract class ByKey implements Exercises<ExerciseByKeyCommand> {
   }
 
   /** The origin of the choice, not the template relevant to contractKey. */
-  protected abstract ContractTypeCompanion<?, ?> getCompanion();
+  protected abstract ContractTypeCompanion<?, ?, ?, ?> getCompanion();
 
   /**
    * Parent of all generated {@code ByKey} classes within interfaces. These need to pass both the

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/Contract.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/Contract.java
@@ -56,7 +56,7 @@ public abstract class Contract<Id, Data> implements com.daml.ledger.javaapi.data
     return getCompanion().TEMPLATE_ID;
   }
 
-  // concrete 1st type param would need a self-reference type param in Contract
+  // concrete 3rd type param would need a self-reference type param in Contract
   /**
    * <strong>INTERNAL API</strong>: this is meant for use by {@link Contract}, and <em>should not be
    * referenced directly</em>. Applications should refer to other methods like {@link
@@ -64,7 +64,7 @@ public abstract class Contract<Id, Data> implements com.daml.ledger.javaapi.data
    *
    * @hidden
    */
-  protected abstract ContractTypeCompanion<?, Data> getCompanion();
+  protected abstract ContractTypeCompanion<? extends Contract<?, Data>, Id, ?, Data> getCompanion();
 
   @Override
   public boolean equals(Object object) {

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractCompanion.java
@@ -63,20 +63,6 @@ public abstract class ContractCompanion<Ct, Id, Data>
   }
 
   /**
-   * Tries to parse a contract from an event expected to create a {@code Ct} contract.
-   *
-   * @param event the event to try to parse a contract from
-   * @throws IllegalArgumentException when the {@link CreatedEvent#arguments} cannot be parsed as
-   *     {@code Data}, or the {@link CreatedEvent#contractKey} cannot be parsed as {@code Key}.
-   * @return The parsed contract, with payload and metadata, if present.
-   */
-  public abstract Ct fromCreatedEvent(CreatedEvent event);
-
-  public Id toContractId(ContractId<Data> parameterizedContractId) {
-    return newContractId.apply(parameterizedContractId.contractId);
-  }
-
-  /**
    * <strong>INTERNAL API</strong>: this is meant for use by {@link WithoutKey} and {@link WithKey},
    * and <em>should not be referenced directly</em>. Applications should refer to the {@code
    * COMPANION} field on generated {@link com.daml.ledger.javaapi.data.Template} subclasses instead.
@@ -89,8 +75,7 @@ public abstract class ContractCompanion<Ct, Id, Data>
       Function<String, Id> newContractId,
       Function<DamlRecord, Data> fromValue,
       List<Choice<Data, ?, ?>> choices) {
-    super(templateId, templateClassName, choices);
-    this.newContractId = newContractId;
+    super(templateId, templateClassName, newContractId, choices);
     this.fromValue = fromValue;
   }
 

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractCompanion.java
@@ -20,14 +20,17 @@ import java.util.function.Function;
  * COMPANION} field on generated {@link com.daml.ledger.javaapi.data.Template} subclasses. All
  * {@code protected} members herein are considered part of the <strong>INTERNAL API</strong>.
  *
+ * <p>Every instance is either a {@link WithKey} or {@link WithoutKey}, depending on whether the
+ * template defined a {@code key} type. {@link WithKey} defines extra utilities for working with
+ * contract keys.
+ *
  * @param <Ct> The {@link Contract} subclass generated within the template class.
  * @param <Id> The {@link ContractId} subclass generated within the template class.
  * @param <Data> The generated {@link com.daml.ledger.javaapi.data.Template} subclass named after
  *     the template, whose instances contain only the payload.
  */
-public abstract class ContractCompanion<Ct, Id, Data> extends ContractTypeCompanion<Data, Data> {
-  /** @hidden */
-  protected final Function<String, Id> newContractId;
+public abstract class ContractCompanion<Ct, Id, Data>
+    extends ContractTypeCompanion<Ct, Id, Data, Data> {
   /** @hidden */
   protected final Function<DamlRecord, Data> fromValue;
 

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractId.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractId.java
@@ -68,7 +68,9 @@ public class ContractId<T> implements Exercises<ExerciseCommand> {
    *
    * @hidden
    */
-  protected ContractTypeCompanion<T, ?> getCompanion() {
+  protected ContractTypeCompanion<
+          ? extends Contract<? extends ContractId<T>, ?>, ? extends ContractId<T>, T, ?>
+      getCompanion() {
     throw new UnsupportedOperationException(
         "Cannot exercise on a contract ID type without code-generated exercise methods");
   }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractTypeCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractTypeCompanion.java
@@ -83,7 +83,7 @@ public abstract class ContractTypeCompanion<Ct, Id, ContractType, Data> {
    * ContractId<t>} that need to be passed to this function before e.g. {@code exercise*} methods
    * can be used.
    */
-  public final Id toContractId(ContractId<Data> parameterizedContractId) {
+  public final Id toContractId(ContractId<ContractType> parameterizedContractId) {
     return newContractId.apply(parameterizedContractId.contractId);
   }
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractTypeCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractTypeCompanion.java
@@ -12,12 +12,16 @@ import java.util.stream.Collectors;
 /**
  * The commonality between {@link ContractCompanion} and {@link InterfaceCompanion}.
  *
+ * @param <Ct> The specific type of {@link Contract} representing contracts from the ledger. Always
+ *     a subtype of {@code Contract<Id, Data>}.
+ * @param <Id> The code-generated class of {@link ContractId}s specific to this template or
+ *     interface. Always a subtype of {@code ContractId<ContractType>}.
  * @param <ContractType> The type argument to {@link ContractId}s of this contract type. This is the
  *     same as {@code Data} for templates, but is a pure marker type for interfaces.
  * @param <Data> The "payload" data model for a contract. This is the template payload for
  *     templates, and the view type for interfaces.
  */
-public abstract class ContractTypeCompanion<ContractType, Data> {
+public abstract class ContractTypeCompanion<Ct, Id, ContractType, Data> {
   /** The full template ID of the template or interface that defined this companion. */
   public final Identifier TEMPLATE_ID;
 

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractTypeCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractTypeCompanion.java
@@ -76,10 +76,12 @@ public abstract class ContractTypeCompanion<Ct, Id, ContractType, Data> {
   public abstract Ct fromCreatedEvent(CreatedEvent event) throws IllegalArgumentException;
 
   /**
-   * TODO
-   *
-   * @param parameterizedContractId
-   * @return
+   * Convert from a generic {@link ContractId} to the specific contract ID subclass generated as
+   * part of this companion's template or interface. Most applications should not need this
+   * function, but if your Daml data types include types like {@code ContractId t} where {@code t}
+   * is any type parameter, that is likely to result in code-generated types like {@code
+   * ContractId<t>} that need to be passed to this function before e.g. {@code exercise*} methods
+   * can be used.
    */
   public final Id toContractId(ContractId<Data> parameterizedContractId) {
     return newContractId.apply(parameterizedContractId.contractId);

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractWithInterfaceView.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractWithInterfaceView.java
@@ -8,10 +8,10 @@ import java.util.Set;
 
 final class ContractWithInterfaceView<Id, View> extends Contract<Id, View> {
 
-  private final ContractTypeCompanion<?, View> contractTypeCompanion;
+  private final InterfaceCompanion<?, Id, View> contractTypeCompanion;
 
   ContractWithInterfaceView(
-      ContractTypeCompanion<?, View> contractTypeCompanion,
+      InterfaceCompanion<?, Id, View> contractTypeCompanion,
       Id id,
       View interfaceView,
       Optional<String> agreementText,
@@ -22,7 +22,7 @@ final class ContractWithInterfaceView<Id, View> extends Contract<Id, View> {
   }
 
   @Override
-  protected ContractTypeCompanion<?, View> getCompanion() {
+  protected InterfaceCompanion<?, Id, View> getCompanion() {
     return contractTypeCompanion;
   }
 

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/CreateAnd.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/CreateAnd.java
@@ -27,7 +27,7 @@ public abstract class CreateAnd implements Exercises<CreateAndExerciseCommand> {
   }
 
   /** The origin of the choice, not the createArguments. */
-  protected abstract ContractTypeCompanion<?, ?> getCompanion();
+  protected abstract ContractTypeCompanion<?, ?, ?, ?> getCompanion();
 
   /**
    * Parent of all generated {@code CreateAnd} classes within interfaces. These need to pass both

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/InterfaceCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/InterfaceCompanion.java
@@ -39,8 +39,7 @@ public abstract class InterfaceCompanion<I, Id, View>
       Function<String, Id> newContractId,
       ValueDecoder<View> valueDecoder,
       List<Choice<I, ?, ?>> choices) {
-    super(templateId, templateClassName, choices);
-    this.newContractId = newContractId;
+    super(templateId, templateClassName, newContractId, choices);
     this.valueDecoder = valueDecoder;
   }
 
@@ -75,6 +74,7 @@ public abstract class InterfaceCompanion<I, Id, View>
                                 "interface view of " + TEMPLATE_ID + " not found.")));
   }
 
+  @Override
   public final Contract<Id, View> fromCreatedEvent(CreatedEvent event)
       throws IllegalArgumentException {
     return fromIdAndRecord(

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/InterfaceCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/InterfaceCompanion.java
@@ -20,9 +20,8 @@ import java.util.function.Function;
  * @param <View> The {@link DamlRecord} subclass representing the interface view, as may be
  *     retrieved from the ACS or transaction stream.
  */
-public abstract class InterfaceCompanion<I, Id, View> extends ContractTypeCompanion<I, View> {
-
-  private final Function<String, Id> newContractId;
+public abstract class InterfaceCompanion<I, Id, View>
+    extends ContractTypeCompanion<Contract<Id, View>, Id, I, View> {
 
   public final ValueDecoder<View> valueDecoder;
 

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClass.scala
@@ -106,12 +106,14 @@ object ContractClass {
     }
 
     private[this] val contractIdClassName = ClassName bestGuess "ContractId"
+    private[this] val contractClassName = ClassName bestGuess "Contract"
 
     private[this] def generateGetCompanion(templateClassName: ClassName): MethodSpec = {
       ClassGenUtils.generateGetCompanion(
         ParameterizedTypeName.get(
-          ClassName get classOf[javaapi.data.codegen.ContractTypeCompanion[_, _]],
-          templateClassName,
+          ClassName get classOf[javaapi.data.codegen.ContractCompanion[_, _, _]],
+          contractClassName,
+          contractIdClassName,
           templateClassName,
         ),
         companionFieldName,
@@ -169,7 +171,6 @@ object ContractClass {
 
       classBuilder.addMethod(constructor)
 
-      val contractClassName = ClassName.bestGuess("Contract")
       classBuilder
         .addMethod(generateGetCompanion(templateClassName))
       new Builder(

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
@@ -193,7 +193,13 @@ object ContractIdClass {
     def generateGetCompanion(markerName: ClassName, kind: For) =
       ClassGenUtils.generateGetCompanion(
         ParameterizedTypeName.get(
-          ClassName get classOf[javaapi.data.codegen.ContractTypeCompanion[_, _]],
+          ClassName get classOf[javaapi.data.codegen.ContractTypeCompanion[_, _, _, _]],
+          WildcardTypeName subtypeOf ParameterizedTypeName.get(
+            ClassName get classOf[javaapi.data.codegen.Contract[_, _]],
+            contractIdClassName,
+            WildcardTypeName subtypeOf classOf[Object],
+          ),
+          contractIdClassName,
           markerName,
           WildcardTypeName subtypeOf classOf[Object],
         ),
@@ -234,6 +240,8 @@ object ContractIdClass {
       spec.build()
     }
 
+    private[this] val contractIdClassName = ClassName bestGuess "ContractId"
+
     def create(
         templateClassName: ClassName,
         choices: Map[ChoiceName, TemplateChoice[typesig.Type]],
@@ -241,7 +249,6 @@ object ContractIdClass {
         packagePrefixes: Map[PackageId, String],
     ): Builder = {
 
-      val contractIdClassName = ClassName bestGuess "ContractId"
       val idClassBuilder =
         TypeSpec
           .classBuilder("ContractId")


### PR DESCRIPTION
The problem in #14299 also occurs for interface contract IDs, so we can move `fromContractId` up to `ContractTypeCompanion` to solve it.

We also have `fromCreatedEvent` on both template and interface, so make it accessible from `ContractTypeCompanion`.