### PR TITLE
configuration for controlling ledger command submission controls

### DIFF
--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
@@ -11,7 +11,7 @@ import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId, Party}
 import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.ledger.api.tls.TlsConfigurationCli
 import com.daml.ledger.client.LedgerClient
-import com.daml.lf.engine.trigger.TriggerRunnerConfig.DefaultTriggerConfig
+import com.daml.lf.engine.trigger.TriggerRunnerConfig.DefaultTriggerRunnerConfig
 import com.daml.platform.services.time.TimeProviderType
 import com.daml.lf.speedy.Compiler
 
@@ -297,6 +297,6 @@ object RunnerConfig {
     tlsConfig = TlsConfiguration(enabled = false, None, None, None),
     applicationId = DefaultApplicationId,
     compilerConfig = DefaultCompilerConfig,
-    triggerConfig = DefaultTriggerConfig,
+    triggerConfig = DefaultTriggerRunnerConfig,
   )
 }

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
@@ -5,13 +5,13 @@ package com.daml.lf.engine.trigger
 
 import java.nio.file.{Path, Paths}
 import java.time.Duration
-
 import com.daml.lf.data.Ref
 import com.daml.ledger.api.domain
 import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId, Party}
 import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.ledger.api.tls.TlsConfigurationCli
 import com.daml.ledger.client.LedgerClient
+import com.daml.lf.engine.trigger.TriggerRunnerConfig.DefaultTriggerConfig
 import com.daml.platform.services.time.TimeProviderType
 import com.daml.lf.speedy.Compiler
 
@@ -33,6 +33,7 @@ case class RunnerConfig(
     applicationId: ApplicationId,
     tlsConfig: TlsConfiguration,
     compilerConfig: Compiler.Config,
+    triggerConfig: TriggerRunnerConfig,
 ) {
   private def updatePartySpec(f: TriggerParties => TriggerParties): RunnerConfig =
     if (ledgerClaims == null) {
@@ -70,12 +71,16 @@ sealed abstract class ClaimsSpecification {
 }
 
 final case class PartySpecification(claims: TriggerParties) extends ClaimsSpecification {
-  override def resolveClaims(client: LedgerClient)(implicit ec: ExecutionContext) =
+  override def resolveClaims(client: LedgerClient)(implicit
+      ec: ExecutionContext
+  ): Future[TriggerParties] =
     Future.successful(claims)
 }
 
 final case class UserSpecification(userId: Ref.UserId) extends ClaimsSpecification {
-  override def resolveClaims(client: LedgerClient)(implicit ec: ExecutionContext) = for {
+  override def resolveClaims(
+      client: LedgerClient
+  )(implicit ec: ExecutionContext): Future[TriggerParties] = for {
     user <- client.userManagementClient.getUser(userId)
     primaryParty <- user.primaryParty.fold[Future[Ref.Party]](
       Future.failed(
@@ -83,7 +88,7 @@ final case class UserSpecification(userId: Ref.UserId) extends ClaimsSpecificati
           s"User $user has no primary party. Specify a party explicitly via --ledger-party"
         )
       )
-    )(Future.successful(_))
+    )(Future.successful)
     rights <- client.userManagementClient.listUserRights(userId)
     readAs = rights.collect { case domain.UserRight.CanReadAs(party) =>
       party
@@ -289,8 +294,9 @@ object RunnerConfig {
     timeProviderType = None,
     commandTtl = Duration.ofSeconds(30L),
     accessTokenFile = None,
-    tlsConfig = TlsConfiguration(false, None, None, None),
+    tlsConfig = TlsConfiguration(enabled = false, None, None, None),
     applicationId = DefaultApplicationId,
     compilerConfig = DefaultCompilerConfig,
+    triggerConfig = DefaultTriggerConfig,
   )
 }

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
@@ -110,6 +110,7 @@ object RunnerMain {
             config.applicationId,
             parties,
             config.compilerConfig,
+            config.triggerConfig,
           )
         } yield ()
 

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerConfig.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerConfig.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.engine.trigger
+
+import scala.concurrent.duration._
+
+/** @param parallelism The number of submitSingleCommand invocations each trigger will
+  *                    attempt to execute in parallel. Note that this does not in any
+  *                    way bound the number of already-submitted, but not completed,
+  *                    commands that may be pending.
+  * @param maxRetries Maximum number of retries for a failing ledger API command submission.
+  * @param maxInFlightCommands Maximum number of in-flight commands that we shall allow
+  *                            *before* the ledger client automatically fails ledger client submission requests.
+  * @param maxSubmissionRequests Used to control rate at which we throttle ledger client submission requests.
+  * @param maxSubmissionDuration Used to control rate at which we throttle ledger client submission requests.
+  * @param submissionFailureQueueSize Size of the queue holding ledger API command submission failures.
+  */
+final case class TriggerRunnerConfig(
+    parallelism: Int,
+    maxRetries: Int,
+    maxInFlightCommands: Int,
+    maxSubmissionRequests: Int,
+    maxSubmissionDuration: FiniteDuration,
+    submissionFailureQueueSize: Int,
+)
+
+object TriggerRunnerConfig {
+  val DefaultTriggerConfig: TriggerRunnerConfig = {
+    val parallelism = 8
+
+    TriggerRunnerConfig(
+      parallelism = parallelism,
+      maxRetries = 6,
+      maxInFlightCommands = 50,
+      maxSubmissionRequests = 100,
+      maxSubmissionDuration = 5.seconds,
+      // 256 here comes from the default ExecutionContext.
+      submissionFailureQueueSize = 256 + parallelism,
+    )
+  }
+}

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerConfig.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerConfig.scala
@@ -26,7 +26,7 @@ final case class TriggerRunnerConfig(
 )
 
 object TriggerRunnerConfig {
-  val DefaultTriggerConfig: TriggerRunnerConfig = {
+  val DefaultTriggerRunnerConfig: TriggerRunnerConfig = {
     val parallelism = 8
 
     TriggerRunnerConfig(

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -111,6 +111,7 @@ binary_deps = [
     "//libs-scala/scala-utils",
     "//triggers/service/auth:middleware-api",
     "@maven//:org_slf4j_slf4j_api",
+    "//triggers/runner:trigger-runner-lib",
 ]
 
 trigger_service_runtime_deps = {
@@ -194,6 +195,7 @@ da_scala_library(
         "//libs-scala/resources",
         "//libs-scala/scala-utils",
         "//libs-scala/timer-utils",
+        "//triggers/runner:trigger-runner-lib",
         "//triggers/service/auth:middleware-api",
         "//triggers/service/auth:oauth2-middleware",
         "//triggers/service/auth:oauth2-test-server",
@@ -249,6 +251,7 @@ da_scala_test_suite(
         "//libs-scala/ports",
         "//libs-scala/postgresql-testing",
         "//libs-scala/resources",
+        "//triggers/runner:trigger-runner-lib",
         "//triggers/service/auth:middleware-api",
         "//triggers/service/auth:oauth2-test-server",
         "@maven//:eu_rekawek_toxiproxy_toxiproxy_java_2_1_3",

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Cli.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Cli.scala
@@ -15,6 +15,7 @@ import com.daml.cliopts
 import scala.concurrent.duration.FiniteDuration
 import com.daml.auth.middleware.api.{Client => AuthClient}
 import com.daml.dbutils.{DBConfig, JdbcConfig}
+import com.daml.lf.engine.trigger.TriggerRunnerConfig.DefaultTriggerConfig
 import com.typesafe.scalalogging.StrictLogging
 import pureconfig.ConfigSource
 import pureconfig.error.ConfigReaderFailures
@@ -50,6 +51,7 @@ private[trigger] final case class Cli(
     portFile: Option[Path],
     allowExistingSchema: Boolean,
     compilerConfig: Compiler.Config,
+    triggerConfig: TriggerRunnerConfig,
 ) extends StrictLogging {
 
   def loadFromConfigFile: Option[Either[ConfigReaderFailures, TriggerServiceAppConf]] =
@@ -81,6 +83,7 @@ private[trigger] final case class Cli(
       portFile = portFile,
       allowExistingSchema = allowExistingSchema,
       compilerConfig = compilerConfig,
+      triggerConfig = triggerConfig,
     )
   }
 
@@ -90,7 +93,7 @@ private[trigger] final case class Cli(
         case Right(cfg) => Some(cfg.toServiceConfig)
         case Left(ex) =>
           logger.error(
-            s"Error loading trigger service config from file ${configFile}",
+            s"Error loading trigger service config from file $configFile",
             ex.prettyPrint(),
           )
           None
@@ -152,6 +155,7 @@ private[trigger] object Cli {
     portFile = None,
     allowExistingSchema = false,
     compilerConfig = DefaultCompilerConfig,
+    triggerConfig = DefaultTriggerConfig,
   )
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // scopt builders

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Cli.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Cli.scala
@@ -15,7 +15,7 @@ import com.daml.cliopts
 import scala.concurrent.duration.FiniteDuration
 import com.daml.auth.middleware.api.{Client => AuthClient}
 import com.daml.dbutils.{DBConfig, JdbcConfig}
-import com.daml.lf.engine.trigger.TriggerRunnerConfig.DefaultTriggerConfig
+import com.daml.lf.engine.trigger.TriggerRunnerConfig.DefaultTriggerRunnerConfig
 import com.typesafe.scalalogging.StrictLogging
 import pureconfig.ConfigSource
 import pureconfig.error.ConfigReaderFailures
@@ -155,7 +155,7 @@ private[trigger] object Cli {
     portFile = None,
     allowExistingSchema = false,
     compilerConfig = DefaultCompilerConfig,
-    triggerConfig = DefaultTriggerConfig,
+    triggerConfig = DefaultTriggerRunnerConfig,
   )
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // scopt builders

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -536,6 +536,7 @@ object Server {
       jdbcConfig: Option[JdbcConfig],
       allowExistingSchema: Boolean,
       compilerConfig: speedy.Compiler.Config,
+      triggerConfig: TriggerRunnerConfig,
       logTriggerStatus: (UUID, String) => Unit = (_, _) => (),
   ): Behavior[Message] = Behaviors.setup { implicit ctx =>
     // Implicit boilerplate.
@@ -609,6 +610,7 @@ object Server {
             runningTrigger.triggerRefreshToken,
             compiledPackages,
             trigger,
+            triggerConfig,
             ledgerConfig,
             restartConfig,
             runningTrigger.triggerReadAs,
@@ -644,7 +646,7 @@ object Server {
         .asInstanceOf[Option[ActorRef[TriggerRunner.Message]]]
     }
 
-    def getRunner(req: GetRunner) = {
+    def getRunner(req: GetRunner): Unit = {
       req.replyTo ! getRunnerRef(req.uuid)
     }
 

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -41,4 +41,5 @@ private[trigger] final case class ServiceConfig(
     portFile: Option[Path],
     allowExistingSchema: Boolean,
     compilerConfig: Compiler.Config,
+    triggerConfig: TriggerRunnerConfig,
 )

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -52,6 +52,7 @@ object ServiceMain {
       jdbcConfig: Option[JdbcConfig],
       allowExistingSchema: Boolean,
       compilerConfig: Compiler.Config,
+      triggerConfig: TriggerRunnerConfig,
       logTriggerStatus: (UUID, String) => Unit = (_, _) => (),
   ): Future[(ServerBinding, ActorSystem[Server.Message])] = {
 
@@ -73,6 +74,7 @@ object ServiceMain {
           jdbcConfig,
           allowExistingSchema,
           compilerConfig,
+          triggerConfig,
           logTriggerStatus,
         ),
         "TriggerService",
@@ -105,7 +107,7 @@ object ServiceMain {
             case (None, None, Some(both)) => AuthMiddleware(both, both)
             case (Some(int), Some(ext), None) => AuthMiddleware(int, ext)
             case (int, ext, both) =>
-              // Note that this should never happen, as it should be caucht by
+              // Note that this should never happen, as it should be caught by
               // the checkConfig part of our scopt configuration
               logger.withoutContext.error(
                 s"Must specify either both --auth-internal and --auth-external or just --auth. Got: auth-internal: $int, auth-external: $ext, auth: $both."
@@ -167,6 +169,7 @@ object ServiceMain {
               config.jdbcConfig,
               config.allowExistingSchema,
               config.compilerConfig,
+              config.triggerConfig,
             ),
             "TriggerService",
           )

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
@@ -39,6 +39,7 @@ object TriggerRunnerImpl {
       refreshToken: Option[RefreshToken],
       compiledPackages: CompiledPackages,
       trigger: Trigger,
+      triggerConfig: TriggerRunnerConfig,
       ledgerConfig: LedgerConfig,
       restartConfig: TriggerRestartConfig,
       readAs: Set[Party],
@@ -190,6 +191,7 @@ object TriggerRunnerImpl {
         runner = new Runner(
           config.compiledPackages,
           config.trigger,
+          config.triggerConfig,
           client,
           config.ledgerConfig.timeProvider,
           config.applicationId,

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceAppConf.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceAppConf.scala
@@ -9,6 +9,7 @@ import com.daml.lf.speedy.Compiler
 import com.daml.platform.services.time.TimeProviderType
 import pureconfig.{ConfigReader, ConvertHelpers}
 import com.daml.auth.middleware.api.{Client => AuthClient}
+import com.daml.lf.engine.trigger.TriggerRunnerConfig.DefaultTriggerConfig
 import com.daml.pureconfigutils.LedgerApiConfig
 import com.daml.pureconfigutils.SharedConfigReaders._
 import pureconfig.error.FailureReason
@@ -64,6 +65,9 @@ private[trigger] object TriggerServiceAppConf {
 
   implicit val serviceCfgReader: ConfigReader[TriggerServiceAppConf] =
     deriveReader[TriggerServiceAppConf]
+
+  implicit val triggerConfigReader: ConfigReader[TriggerRunnerConfig] =
+    deriveReader[TriggerRunnerConfig]
 }
 
 /* An intermediate config representation allowing us to define our HOCON config in a more modular fashion,
@@ -87,6 +91,7 @@ private[trigger] final case class TriggerServiceAppConf(
     triggerStore: Option[JdbcConfig] = None,
     allowExistingSchema: Boolean = false,
     compilerConfig: Compiler.Config = Compiler.Config.Default,
+    triggerConfig: TriggerRunnerConfig = DefaultTriggerConfig,
 ) {
   def toServiceConfig: ServiceConfig = {
     ServiceConfig(
@@ -115,6 +120,7 @@ private[trigger] final case class TriggerServiceAppConf(
       portFile = portFile,
       allowExistingSchema = allowExistingSchema,
       compilerConfig = compilerConfig,
+      triggerConfig = triggerConfig,
     )
   }
 }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceAppConf.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceAppConf.scala
@@ -9,7 +9,7 @@ import com.daml.lf.speedy.Compiler
 import com.daml.platform.services.time.TimeProviderType
 import pureconfig.{ConfigReader, ConvertHelpers}
 import com.daml.auth.middleware.api.{Client => AuthClient}
-import com.daml.lf.engine.trigger.TriggerRunnerConfig.DefaultTriggerConfig
+import com.daml.lf.engine.trigger.TriggerRunnerConfig.DefaultTriggerRunnerConfig
 import com.daml.pureconfigutils.LedgerApiConfig
 import com.daml.pureconfigutils.SharedConfigReaders._
 import pureconfig.error.FailureReason
@@ -91,7 +91,7 @@ private[trigger] final case class TriggerServiceAppConf(
     triggerStore: Option[JdbcConfig] = None,
     allowExistingSchema: Boolean = false,
     compilerConfig: Compiler.Config = Compiler.Config.Default,
-    triggerConfig: TriggerRunnerConfig = DefaultTriggerConfig,
+    triggerConfig: TriggerRunnerConfig = DefaultTriggerRunnerConfig,
 ) {
   def toServiceConfig: ServiceConfig = {
     ServiceConfig(

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -47,6 +47,7 @@ import com.daml.ledger.sandbox.SandboxOnXForTest._
 import com.daml.ledger.sandbox.{BridgeConfig, SandboxOnXRunner}
 import com.daml.lf.archive.Dar
 import com.daml.lf.data.Ref._
+import com.daml.lf.engine.trigger.TriggerRunnerConfig.DefaultTriggerRunnerConfig
 import com.daml.lf.engine.trigger.dao.DbTriggerDao
 import com.daml.lf.speedy.Compiler
 import com.daml.platform.apiserver.SeedService.Seeding
@@ -574,6 +575,7 @@ trait TriggerServiceFixture
                 jdbcConfig,
                 false,
                 Compiler.Config.Dev,
+                DefaultTriggerRunnerConfig,
                 logTriggerStatus,
               )
             } yield r

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
@@ -25,7 +25,7 @@ import com.daml.ledger.client.configuration.{
 import com.daml.ledger.sandbox.SandboxOnXForTest.ParticipantId
 import com.daml.lf.archive.DarDecoder
 import com.daml.lf.data.Ref._
-import com.daml.lf.engine.trigger.TriggerRunnerConfig.DefaultTriggerConfig
+import com.daml.lf.engine.trigger.TriggerRunnerConfig.DefaultTriggerRunnerConfig
 import com.daml.lf.speedy.SValue
 import com.daml.lf.speedy.SValue._
 import com.daml.platform.sandbox.{SandboxBackend, SandboxRequiringAuthorizationFuns}
@@ -106,7 +106,7 @@ trait AbstractTriggerTest
         new Runner(
           compiledPackages,
           trigger,
-          DefaultTriggerConfig,
+          DefaultTriggerRunnerConfig,
           client,
           config.participants(ParticipantId).apiServer.timeProviderType,
           applicationId,

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
@@ -25,6 +25,7 @@ import com.daml.ledger.client.configuration.{
 import com.daml.ledger.sandbox.SandboxOnXForTest.ParticipantId
 import com.daml.lf.archive.DarDecoder
 import com.daml.lf.data.Ref._
+import com.daml.lf.engine.trigger.TriggerRunnerConfig.DefaultTriggerConfig
 import com.daml.lf.speedy.SValue
 import com.daml.lf.speedy.SValue._
 import com.daml.platform.sandbox.{SandboxBackend, SandboxRequiringAuthorizationFuns}
@@ -32,6 +33,7 @@ import com.daml.platform.sandbox.services.TestCommands
 import org.scalatest._
 import scalaz.syntax.tag._
 import com.daml.platform.sandbox.fixture.SandboxFixture
+
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
@@ -104,6 +106,7 @@ trait AbstractTriggerTest
         new Runner(
           compiledPackages,
           trigger,
+          DefaultTriggerConfig,
           client,
           config.participants(ParticipantId).apiServer.timeProviderType,
           applicationId,


### PR DESCRIPTION
- [x] verified that unbased PR passes in CI
- [ ] rebase once https://github.com/digital-asset/daml/pull/15434 is merged

CHANGELOG_BEGIN
* triggers may now control (via configuration) the rate at which they submit commands to the ledger. Command submission may be rate limited (to control trigger burst behaviour) and ledger submissions will *only* occur if in-flight command submissions are below threshold values.

CHANGELOG_END

This PR partially resolves https://github.com/digital-asset/daml/pull/14453

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
