### PR TITLE
Add //triggers/runner:trigger-runner-lib to binary_deps

### DIFF
--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -111,6 +111,7 @@ binary_deps = [
     "//libs-scala/scala-utils",
     "//triggers/service/auth:middleware-api",
     "@maven//:org_slf4j_slf4j_api",
+    "//triggers/runner:trigger-runner-lib",
 ]
 
 trigger_service_runtime_deps = {


### PR DESCRIPTION
This seems to fix targets `//triggers/service:trigger-service-binary-{ce,ee}`. I'm not familiar enough with Scala/Java to say why the transitive dependency through `trigger-service` isn't enough, but it seems that there are already duplicates between `trigger-service`'s deps and `binary_deps` (e.g. `//daml-lf/data`, `//daml-lf/interpreter` and `//language-support/scala/bindings` to name a few)