### PR TITLE
[speedy] refactor continuations

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1150,7 +1150,7 @@ private[lf] object SBuiltin {
 
         case None =>
           def continue(coinst: V.ContractInstance): Control = {
-            machine.pushKont(KCacheContract(machine, coid))
+            machine.pushKont(KCacheContract(coid))
             val e = coinst match {
               case V.ContractInstance(actualTmplId, arg, _) =>
                 SELet1(
@@ -1193,7 +1193,7 @@ private[lf] object SBuiltin {
       val coid = getSContractId(args, 2)
 
       val e = SEAppAtomic(SEValue(guard), Array(SEValue(SAnyContract(templateId, record))))
-      machine.pushKont(KCheckChoiceGuard(machine, coid, templateId, choiceName, byInterface))
+      machine.pushKont(KCheckChoiceGuard(coid, templateId, choiceName, byInterface))
       Control.Expression(e)
     }
   }
@@ -1603,9 +1603,7 @@ private[lf] object SBuiltin {
                 case ContractStateMachine.KeyActive(coid) =>
                   // We do not call directly machine.checkKeyVisibility as it may throw an SError,
                   // and such error cannot be throw inside a ledger-question continuation.
-                  machine.pushKont(
-                    KCheckKeyVisibility(machine, gkey, coid, operation.handleKeyFound)
-                  )
+                  machine.pushKont(KCheckKeyVisibility(gkey, coid, operation.handleKeyFound))
                   if (onLedger.hasCachedContract(coid)) {
                     (Control.Value(SUnit), true)
                   } else {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -310,7 +310,7 @@ object SExpr {
     */
   final case class SELabelClosure(label: Profile.Label, expr: SExpr) extends SExpr {
     override def execute(machine: Machine): Control = {
-      machine.pushKont(KLabelClosure(machine, label))
+      machine.pushKont(KLabelClosure(label))
       Control.Expression(expr)
     }
   }
@@ -340,14 +340,14 @@ object SExpr {
   /** Exercise scope (begin..end) */
   final case class SEScopeExercise(body: SExpr) extends SExpr {
     override def execute(machine: Machine): Control = {
-      machine.pushKont(KCloseExercise(machine))
+      machine.pushKont(KCloseExercise)
       Control.Expression(body)
     }
   }
 
   final case class SEPreventCatch(body: SExpr) extends SExpr {
     override def execute(machine: Machine): Control = {
-      machine.pushKont(KPreventException(machine))
+      machine.pushKont(KPreventException)
       Control.Expression(body)
     }
   }


### PR DESCRIPTION
The idea behind this refactoring is to make possible to parametrize machine and control by the Question.

with this change we will be able to define execute for continuation, SExpr, and SBuiltin as: 
```
def execute[Question](machine: Machine[Question], ...): Control[Question]   
```

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
