### PR TITLE
[Speedy] Inline LedgerMode in the Machine

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -140,7 +140,7 @@ class Context(val contextId: Context.ContextId, languageVersion: LanguageVersion
   private val txSeeding =
     crypto.Hash.hashPrivateKey(s"scenario-service")
 
-  private[this] def buildMachine(defn: SDefinition): Speedy.Machine =
+  private[this] def buildMachine(defn: SDefinition): Speedy.OffLedgerMachine =
     Speedy.Machine.fromScenarioSExpr(
       PureCompiledPackages(allSignatures, defns, compilerConfig),
       defn.body,

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -10,7 +10,7 @@ import com.daml.lf.data.Ref.{Identifier, PackageId, ParticipantId, Party}
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.{InitialSeeding, Pretty, SError, SValue}
 import com.daml.lf.speedy.SExpr.{SEApp, SExpr}
-import com.daml.lf.speedy.Speedy.{Machine, OnLedger}
+import com.daml.lf.speedy.Speedy.{Machine, OffLedgerMachine, OnLedgerMachine}
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.transaction.{
   Node,
@@ -318,7 +318,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
       submissionTime: Time.Timestamp,
       seeding: speedy.InitialSeeding,
   )(implicit loggingContext: LoggingContext): Result[(SubmittedTransaction, Tx.Metadata)] = {
-    val machine = Machine(
+    val machine = OnLedgerMachine(
       compiledPackages = compiledPackages,
       submissionTime = submissionTime,
       initialSeeding = seeding,
@@ -365,11 +365,11 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
   // TODO SC remove 'return', notwithstanding a love of unhandled exceptions
   @SuppressWarnings(Array("org.wartremover.warts.Return"))
   private[engine] def interpretLoop(
-      machine: Machine,
+      machine: OnLedgerMachine,
       time: Time.Timestamp,
-  ): Result[(SubmittedTransaction, Tx.Metadata)] = machine.withOnLedger("Daml Engine") { onLedger =>
+  ): Result[(SubmittedTransaction, Tx.Metadata)] = {
     def detailMsg = Some(
-      s"Last location: ${Pretty.prettyLoc(machine.getLastLocation).render(80)}, partial transaction: ${onLedger.nodesToString}"
+      s"Last location: ${Pretty.prettyLoc(machine.getLastLocation).render(80)}, partial transaction: ${machine.nodesToString}"
     )
     def versionDisclosedContract(d: speedy.DisclosedContract): Versioned[DisclosedContract] =
       Versioned(
@@ -438,40 +438,28 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
       }
     }
 
-    machine.ledgerMode match {
-      case onLedger: OnLedger =>
-        onLedger.finish match {
-          case Right(OnLedger.Result(tx, _, nodeSeeds, globalKeyMapping, disclosedContracts)) =>
-            deps(tx).flatMap { deps =>
-              val meta = Tx.Metadata(
-                submissionSeed = None,
-                submissionTime = onLedger.submissionTime,
-                usedPackages = deps,
-                dependsOnTime = onLedger.getDependsOnTime,
-                nodeSeeds = nodeSeeds,
-                globalKeyMapping = globalKeyMapping,
-                disclosures = disclosedContracts.map(versionDisclosedContract),
-              )
-              config.profileDir.foreach { dir =>
-                val desc = Engine.profileDesc(tx)
-                val profileFile = dir.resolve(s"${meta.submissionTime}-$desc.json")
-                machine.profile.name = s"${meta.submissionTime}-$desc"
-                machine.profile.writeSpeedscopeJson(profileFile)
-              }
-              ResultDone((tx, meta))
-            }
-          case Left(err) =>
-            handleError(err)
-        }
-      case _ =>
-        ResultError(
-          Error.Interpretation.Internal(
-            NameOf.qualifiedNameOfCurrentFunc,
-            "unexpected off-ledger machine",
-            None,
+    machine.finish match {
+      case Right(OnLedgerMachine.Result(tx, _, nodeSeeds, globalKeyMapping, disclosedContracts)) =>
+        deps(tx).flatMap { deps =>
+          val meta = Tx.Metadata(
+            submissionSeed = None,
+            submissionTime = machine.submissionTime,
+            usedPackages = deps,
+            dependsOnTime = machine.getDependsOnTime,
+            nodeSeeds = nodeSeeds,
+            globalKeyMapping = globalKeyMapping,
+            disclosures = disclosedContracts.map(versionDisclosedContract),
           )
-        )
-
+          config.profileDir.foreach { dir =>
+            val desc = Engine.profileDesc(tx)
+            val profileFile = dir.resolve(s"${meta.submissionTime}-$desc.json")
+            machine.profile.name = s"${meta.submissionTime}-$desc"
+            machine.profile.writeSpeedscopeJson(profileFile)
+          }
+          ResultDone((tx, meta))
+        }
+      case Left(err) =>
+        handleError(err)
     }
   }
 
@@ -543,7 +531,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
       argument: Value,
       interfaceId: Identifier,
   )(implicit loggingContext: LoggingContext): Result[Versioned[Value]] = {
-    def interpret(machine: Machine): Result[SValue] = {
+    def interpret(machine: OffLedgerMachine): Result[SValue] = {
       machine.run() match {
         case SResultFinal(v) => ResultDone(v)
         case SResultError(err) => handleError(err, None)

--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -59,6 +59,7 @@ da_scala_library(
         "//daml-lf/transaction",
         "//daml-lf/validation",
         "//libs-scala/contextualized-logging",
+        "//libs-scala/nameof",
         "//libs-scala/scala-utils",
     ],
 )

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureLib.scala
@@ -264,7 +264,7 @@ object ExplicitDisclosureLib {
       getContract: PartialFunction[Value.ContractId, Value.VersionedContractInstance] =
         PartialFunction.empty,
       getKey: PartialFunction[GlobalKeyWithMaintainers, Value.ContractId] = PartialFunction.empty,
-  ): (Either[SError.SError, SValue], Speedy.OnLedger) = {
+  ): (Either[SError.SError, SValue], Speedy.OnLedgerMachine) = {
     import SpeedyTestLib.loggingContext
 
     // A token function closure is added as part of compiling the Expr
@@ -295,7 +295,7 @@ object ExplicitDisclosureLib {
       getKey = getKey,
     )
 
-    (result, machine.ledgerMode.asInstanceOf[Speedy.OnLedger])
+    (result, machine)
   }
 
   def evaluateSExpr(
@@ -305,7 +305,7 @@ object ExplicitDisclosureLib {
       getContract: PartialFunction[Value.ContractId, Value.VersionedContractInstance] =
         PartialFunction.empty,
       getKey: PartialFunction[GlobalKeyWithMaintainers, Value.ContractId] = PartialFunction.empty,
-  ): (Either[SError.SError, SValue], Speedy.OnLedger) = {
+  ): (Either[SError.SError, SValue], Speedy.OnLedgerMachine) = {
     import SpeedyTestLib.loggingContext
 
     val machine =
@@ -322,13 +322,13 @@ object ExplicitDisclosureLib {
       getKey = getKey,
     )
 
-    (result, machine.ledgerMode.asInstanceOf[Speedy.OnLedger])
+    (result, machine)
   }
 
-  def haveInactiveContractIds(contractIds: ContractId*): Matcher[Speedy.OnLedger] = Matcher {
-    ledger =>
+  def haveInactiveContractIds(contractIds: ContractId*): Matcher[Speedy.OnLedgerMachine] = Matcher {
+    machine =>
       val expectedResult = contractIds.toSet
-      val actualResult = ledger.ptx.contractState.activeState.consumedBy.keySet
+      val actualResult = machine.ptx.contractState.activeState.consumedBy.keySet
       val debugMessage = Seq(
         s"expected but missing contract IDs: ${expectedResult.filter(!actualResult.toSeq.contains(_))}",
         s"unexpected but found contract IDs: ${actualResult.filter(!expectedResult.toSeq.contains(_))}",
@@ -341,10 +341,12 @@ object ExplicitDisclosureLib {
       )
   }
 
-  def haveDisclosedContracts(disclosedContracts: DisclosedContract*): Matcher[Speedy.OnLedger] =
-    Matcher { ledger =>
+  def haveDisclosedContracts(
+      disclosedContracts: DisclosedContract*
+  ): Matcher[Speedy.OnLedgerMachine] =
+    Matcher { machine =>
       val expectedResult = ImmArray(disclosedContracts: _*)
-      val actualResult = ledger.ptx.disclosedContracts
+      val actualResult = machine.ptx.disclosedContracts
       val debugMessage = Seq(
         s"expected but missing contract IDs: ${expectedResult.filter(!actualResult.toSeq.contains(_)).map(_.contractId)}",
         s"unexpected but found contract IDs: ${actualResult.filter(!expectedResult.toSeq.contains(_)).map(_.contractId)}",

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureTest.scala
@@ -379,7 +379,7 @@ class ExplicitDisclosureTest extends ExplicitDisclosureTestMethods {
   }
 }
 
-trait ExplicitDisclosureTestMethods extends AnyFreeSpec with Inside with Matchers {
+private[lf] trait ExplicitDisclosureTestMethods extends AnyFreeSpec with Inside with Matchers {
 
   import ExplicitDisclosureLib._
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -20,7 +20,12 @@ import com.daml.lf.speedy.SBuiltin.{
 import com.daml.lf.speedy.SError.{SError, SErrorCrash}
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue.{SValue => _, _}
-import com.daml.lf.speedy.Speedy.{CachedContract, OnLedger, SKeyWithMaintainers}
+import com.daml.lf.speedy.Speedy.{
+  CachedContract,
+  OnLedgerMachine,
+  OffLedgerMachine,
+  SKeyWithMaintainers,
+}
 import com.daml.lf.testing.parser.Implicits._
 import com.daml.lf.transaction.{GlobalKey, GlobalKeyWithMaintainers, TransactionVersion}
 import com.daml.lf.value.Value
@@ -1874,11 +1879,10 @@ object SBuiltinTest {
       }
 
     SpeedyTestLib.run(machine, getContract = getContract).map { value =>
-      machine.ledgerMode match {
-        case onLedger: OnLedger =>
-          (value, onLedger.getCachedContracts, onLedger.disclosureKeyTable.toMap)
-
-        case _ =>
+      machine match {
+        case machine: OnLedgerMachine =>
+          (value, machine.getCachedContracts, machine.disclosureKeyTable.toMap)
+        case _: OffLedgerMachine =>
           (value, Map.empty, Map.empty)
       }
     }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -460,19 +460,19 @@ class SpeedyTest extends AnyWordSpec with Matchers with Inside {
   "checkContractVisibility" should {
 
     "warn about non-visible local contracts" in new VisibilityChecking {
-      machine.checkContractVisibility(ledger, localContractId, localCachedContract)
+      machine.checkContractVisibility(localContractId, localCachedContract)
 
       testLogger.iterator.size shouldBe 1
     }
 
     "accept non-visible disclosed contracts" in new VisibilityChecking {
-      machine.checkContractVisibility(ledger, disclosedContractId, disclosedCachedContract)
+      machine.checkContractVisibility(disclosedContractId, disclosedCachedContract)
 
       testLogger.iterator.size shouldBe 0
     }
 
     "warn about non-visible global contracts" in new VisibilityChecking {
-      machine.checkContractVisibility(ledger, globalContractId, globalCachedContract)
+      machine.checkContractVisibility(globalContractId, globalCachedContract)
 
       testLogger.iterator.size shouldBe 1
     }
@@ -483,7 +483,7 @@ class SpeedyTest extends AnyWordSpec with Matchers with Inside {
 
     "reject non-visible local contract keys" in new VisibilityChecking {
       val result: Try[Speedy.Control] = Try {
-        machine.checkKeyVisibility(ledger, localContractKey, localContractId, handleKeyFound)
+        machine.checkKeyVisibility(localContractKey, localContractId, handleKeyFound)
       }
 
       inside(result) {
@@ -505,7 +505,6 @@ class SpeedyTest extends AnyWordSpec with Matchers with Inside {
     "accept non-visible disclosed contract keys" in new VisibilityChecking {
       val result: Try[Speedy.Control] = Try {
         machine.checkKeyVisibility(
-          ledger,
           disclosedContractKey,
           disclosedContractId,
           handleKeyFound,
@@ -519,7 +518,7 @@ class SpeedyTest extends AnyWordSpec with Matchers with Inside {
 
     "reject non-visible global contract keys" in new VisibilityChecking {
       val result: Try[Speedy.Control] = Try {
-        machine.checkKeyVisibility(ledger, globalContractKey, globalContractId, handleKeyFound)
+        machine.checkKeyVisibility(globalContractKey, globalContractId, handleKeyFound)
       }
 
       inside(result) {
@@ -638,7 +637,7 @@ object SpeedyTest {
     val disclosedCachedContract: CachedContract =
       buildHouseCachedContract(alice, alice, label = "disclosed-label")
     val testLogger: WarningLog = new WarningLog(ContextualizedLogger.createFor("daml.warnings"))
-    val machine: Speedy.Machine = Speedy.Machine
+    val machine: Speedy.OnLedgerMachine = Speedy.Machine
       .fromUpdateSExpr(
         pkg,
         crypto.Hash.hashPrivateKey("VisibilityChecking"),
@@ -658,6 +657,5 @@ object SpeedyTest {
         houseTemplateType,
         disclosedContractKey.hash -> disclosedContractId,
       )
-    val ledger: Speedy.OnLedger = machine.ledgerMode.asInstanceOf[Speedy.OnLedger]
   }
 }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
@@ -9,11 +9,12 @@ import data.Ref.{PackageId, TypeConName}
 import data.Time
 import SResult._
 import com.daml.lf.language.{Ast, PackageInterface}
-import com.daml.lf.speedy.Speedy.{CachedContract, Machine, OffLedger, OnLedger}
+import com.daml.lf.speedy.Speedy.{CachedContract, OnLedgerMachine}
 import com.daml.lf.testing.parser.ParserParameters
 import com.daml.lf.validation.{Validation, ValidationError}
 import com.daml.lf.value.Value.ContractId
 import com.daml.logging.LoggingContext
+import com.daml.nameof.NameOf
 import transaction.{GlobalKey, GlobalKeyWithMaintainers, SubmittedTransaction}
 import value.Value
 import scalautil.Statement.discard
@@ -114,7 +115,7 @@ private[speedy] object SpeedyTestLib {
   ): Either[SError.SError, SubmittedTransaction] =
     runTx(machine, getPkg, getContract, getKey, getTime) match {
       case Right(SResultFinal(_)) =>
-        machine.withOnLedger("buildTransaction")(onLedger => onLedger.finish.map(_.tx))
+        machine.asOnLedger(NameOf.qualifiedNameOfCurrentFunc)(_.finish.map(_.tx))
       case Left(err) =>
         Left(err)
     }
@@ -134,65 +135,57 @@ private[speedy] object SpeedyTestLib {
   ): PureCompiledPackages =
     typeAndCompile(Map(parserParameter.defaultPackageId -> pkg))
 
-  private[lf] object Implicits {
+  private[speedy] object Implicits {
 
-    implicit class AddTestMethodsToMachine(machine: Machine) {
+    implicit class AddTestMethodsToMachine(machine: OnLedgerMachine) {
 
-      private[lf] def withWarningLog(warningLog: WarningLog): Machine = {
-        new Machine(
+      private[lf] def withWarningLog(warningLog: WarningLog): OnLedgerMachine =
+        new OnLedgerMachine(
           sexpr = machine.sexpr,
           traceLog = machine.traceLog,
           warningLog = warningLog,
-          loggingContext = machine.loggingContext,
           compiledPackages = machine.compiledPackages,
           profile = machine.profile,
-          ledgerMode = machine.ledgerMode,
+          validating = machine.validating,
+          submissionTime = machine.submissionTime,
+          contractKeyUniqueness = machine.contractKeyUniqueness,
+          ptx = machine.ptx,
+          committers = machine.committers,
+          readAs = machine.readAs,
+          commitLocation = machine.commitLocation,
+          limits = machine.limits,
+          disclosureKeyTable = machine.disclosureKeyTable,
         )
-      }
 
-      private[speedy] def withCachedContracts(
-          cachedContracts: (ContractId, CachedContract)*
-      ): Machine = {
-        machine.ledgerMode match {
-          case ledger: OnLedger =>
-            for ((contractId, cachedContract) <- cachedContracts) {
-              ledger.updateCachedContracts(contractId, cachedContract)
-            }
-
-          case OffLedger =>
-        }
-
+      def withCachedContracts(cachedContracts: (ContractId, CachedContract)*): OnLedgerMachine = {
+        for {
+          entry <- cachedContracts
+          (contractId, cachedContract) = entry
+        } machine.updateCachedContracts(contractId, cachedContract)
         machine
       }
 
-      private[speedy] def withLocalContractKey(contractId: ContractId, key: GlobalKey): Machine = {
-        machine.ledgerMode match {
-          case ledger: OnLedger =>
-            ledger.ptx = ledger.ptx.copy(
-              contractState = ledger.ptx.contractState.copy(
-                locallyCreated = ledger.ptx.contractState.locallyCreated + contractId,
-                activeState = ledger.ptx.contractState.activeState.createKey(key, contractId),
-              )
-            )
-
-          case OffLedger =>
-        }
-
+      private[speedy] def withLocalContractKey(
+          contractId: ContractId,
+          key: GlobalKey,
+      ): OnLedgerMachine = {
+        machine.ptx = machine.ptx.copy(
+          contractState = machine.ptx.contractState.copy(
+            locallyCreated = machine.ptx.contractState.locallyCreated + contractId,
+            activeState = machine.ptx.contractState.activeState.createKey(key, contractId),
+          )
+        )
         machine
       }
 
       private[speedy] def withDisclosedContractKeys(
           templateId: TypeConName,
           disclosedContractKeys: (crypto.Hash, ContractId)*
-      ): Machine = {
-        machine.ledgerMode match {
-          case ledger: OnLedger =>
-            for ((keyHash, contractId) <- disclosedContractKeys) {
-              ledger.disclosureKeyTable.addContractKey(templateId, keyHash, contractId)
-            }
-
-          case OffLedger =>
-        }
+      ): OnLedgerMachine = {
+        for {
+          entry <- disclosedContractKeys
+          (keyHash, contractId) = entry
+        } machine.disclosureKeyTable.addContractKey(templateId, keyHash, contractId)
 
         machine
       }

--- a/daml-lf/scenario-interpreter/BUILD.bazel
+++ b/daml-lf/scenario-interpreter/BUILD.bazel
@@ -33,7 +33,6 @@ da_scala_library(
         "//daml-lf/language",
         "//daml-lf/transaction",
         "//libs-scala/contextualized-logging",
-        "//libs-scala/nameof",
         "//libs-scala/scala-utils",
     ],
 )

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 
-class CollectAuthority {
+private[lf] class CollectAuthority {
   @Benchmark @BenchmarkMode(Array(Mode.AverageTime)) @OutputTimeUnit(TimeUnit.MILLISECONDS)
   def bench(state: CollectAuthorityState): Unit = {
     state.run()
@@ -32,7 +32,7 @@ class CollectAuthority {
 }
 
 @State(Scope.Benchmark)
-class CollectAuthorityState {
+private[lf] class CollectAuthorityState {
 
   @Param(Array("//daml-lf/scenario-interpreter/CollectAuthority.dar"))
   private[perf] var dar: String = _
@@ -162,7 +162,7 @@ class CollectAuthorityState {
 
 }
 
-class CachedLedgerApi(initStep: Int, ledger: ScenarioLedger)
+private[lf] class CachedLedgerApi(initStep: Int, ledger: ScenarioLedger)
     extends ScenarioRunner.ScenarioLedgerApi(ledger) {
   var step = initStep
   var cachedContract: Map[Int, Value.VersionedContractInstance] = Map()
@@ -182,7 +182,7 @@ class CachedLedgerApi(initStep: Int, ledger: ScenarioLedger)
   }
 }
 
-class CannedLedgerApi(
+private[lf] class CannedLedgerApi(
     initStep: Int,
     cachedContract: Map[Int, Value.VersionedContractInstance],
 ) extends ScenarioRunner.LedgerApi[Unit] {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -425,7 +425,7 @@ private[lf] class Runner(
       ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
       mat: Materializer,
-  ): (Speedy.Machine, Future[SValue]) = {
+  ): (Speedy.OffLedgerMachine, Future[SValue]) = {
     val machine =
       Speedy.Machine.fromPureSExpr(
         extendedCompiledPackages,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
@@ -19,7 +19,7 @@ import com.daml.lf.speedy.SExpr.{SEAppAtomic, SEValue}
 import com.daml.lf.speedy.{ArrayList, SError, SValue}
 import com.daml.lf.speedy.SExpr.SExpr
 import com.daml.lf.speedy.SValue._
-import com.daml.lf.speedy.Speedy.Machine
+import com.daml.lf.speedy.Speedy.OffLedgerMachine
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import scalaz.{Foldable, OneAnd}
@@ -60,7 +60,7 @@ object ScriptF {
       val scriptIds: ScriptIds,
       val timeMode: ScriptTimeMode,
       private var _clients: Participants[ScriptLedgerClient],
-      machine: Machine,
+      machine: OffLedgerMachine,
   ) {
     def clients = _clients
     def compiledPackages = machine.compiledPackages

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -13,7 +13,6 @@ import com.daml.ledger.api.v1.commands.{Command, Commands}
 import com.daml.ledger.api.v1.completion.Completion
 import com.daml.ledger.api.v1.event._
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
-import com.daml.ledger.api.v1.transaction.Transaction
 import com.daml.ledger.api.v1.transaction_filter.{
   Filters,
   InclusiveFilters,
@@ -64,12 +63,14 @@ import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.{FiniteDuration, _}
 import scala.concurrent.{ExecutionContext, Future}
 
-sealed trait TriggerMsg
-final case class CompletionMsg(c: Completion) extends TriggerMsg
-final case class TransactionMsg(t: Transaction) extends TriggerMsg
-final case class HeartbeatMsg() extends TriggerMsg
+private[lf] sealed trait TriggerMsg
+private[lf] object TriggerMsg {
+  final case class Completion(c: com.daml.ledger.api.v1.completion.Completion) extends TriggerMsg
+  final case class Transaction(t: com.daml.ledger.api.v1.transaction.Transaction) extends TriggerMsg
+  final case object Heartbeat extends TriggerMsg
+}
 
-final case class TriggerDefinition(
+private[lf] final case class TriggerDefinition(
     id: Identifier,
     ty: TypeConApp,
     version: Trigger.Version,
@@ -79,7 +80,7 @@ final case class TriggerDefinition(
   val triggerIds = TriggerIds(ty.tycon.packageId)
 }
 
-final case class Trigger(
+private[lf] final case class Trigger(
     defn: TriggerDefinition,
     filters: Filters, // We store Filters rather than
     // TransactionFilter since the latter is
@@ -90,9 +91,9 @@ final case class Trigger(
 )
 
 // Utilities for interacting with the speedy machine.
-object Machine extends StrictLogging {
+private[lf] object Machine extends StrictLogging {
   // Run speedy until we arrive at a value.
-  def stepToValue(machine: Speedy.Machine): SValue = {
+  def stepToValue(machine: Speedy.OffLedgerMachine): SValue = {
     machine.run() match {
       case SResultFinal(v) => v
       case SResultError(err) => {
@@ -344,7 +345,7 @@ object Trigger extends StrictLogging {
   }
 }
 
-class Runner(
+private[lf] class Runner(
     compiledPackages: CompiledPackages,
     trigger: Trigger,
     triggerConfig: TriggerRunnerConfig,
@@ -458,7 +459,7 @@ class Runner(
       v: SValue,
   ): UnfoldState[SValue, SubmitRequest] = {
     def evaluate(se: SExpr) = {
-      val machine: Speedy.Machine =
+      val machine: Speedy.OffLedgerMachine =
         Speedy.Machine.fromPureSExpr(compiledPackages, se)
       // Evaluate it.
       machine.setExpressionToEvaluate(se)
@@ -538,7 +539,7 @@ class Runner(
     val transactionSource: Source[TriggerMsg, NotUsed] =
       client.transactionClient
         .getTransactions(offset, None, filter)
-        .map(TransactionMsg)
+        .map(TriggerMsg.Transaction)
 
     // Command completion source (ledger completion stream +
     // synchronous submission failures).
@@ -553,14 +554,14 @@ class Runner(
               case CompletionElement(c, _) => List(c)
             }
         )
-        .map(CompletionMsg)
+        .map(TriggerMsg.Completion)
 
     // Heartbeats source (we produce these repetitively on a timer with
     // the given delay interval).
     val heartbeatSource: Source[TriggerMsg, NotUsed] = heartbeat match {
       case Some(interval) =>
         Source
-          .tick[TriggerMsg](interval, interval, HeartbeatMsg())
+          .tick[TriggerMsg](interval, interval, TriggerMsg.Heartbeat)
           .mapMaterializedValue(_ => NotUsed)
       case None => Source.empty[TriggerMsg]
     }
@@ -569,9 +570,10 @@ class Runner(
   }
 
   private def logReceivedMsg(tm: TriggerMsg): Unit = tm match {
-    case CompletionMsg(c) => logger.debug(s"trigger received completion message $c")
-    case TransactionMsg(t) => logger.debug(s"trigger received transaction, ID ${t.transactionId}")
-    case HeartbeatMsg() => ()
+    case TriggerMsg.Completion(c) => logger.debug(s"trigger received completion message $c")
+    case TriggerMsg.Transaction(t) =>
+      logger.debug(s"trigger received transaction, ID ${t.transactionId}")
+    case TriggerMsg.Heartbeat => ()
   }
 
   private[this] def getInitialStateFreeAndUpdate(acs: Seq[CreatedEvent]): (SValue, SValue) = {
@@ -601,7 +603,7 @@ class Runner(
         initialStateArgs,
       )
     // Prepare a speedy machine for evaluating expressions.
-    val machine: Speedy.Machine =
+    val machine: Speedy.OffLedgerMachine =
       Speedy.Machine.fromPureSExpr(compiledPackages, initialState)
     // Evaluate it.
     machine.setExpressionToEvaluate(initialState)
@@ -621,15 +623,15 @@ class Runner(
 
   private[this] def encodeMsgs: Flow[TriggerMsg, SValue, NotUsed] =
     Flow fromFunction {
-      case TransactionMsg(transaction) =>
+      case TriggerMsg.Transaction(transaction) =>
         converter.fromTransaction(transaction).orConverterException
-      case CompletionMsg(completion) =>
+      case TriggerMsg.Completion(completion) =>
         val status = completion.getStatus
         if (status.code != 0) {
           logger.warn(s"Command failed: ${status.message}, code: ${status.code}")
         }
         converter.fromCompletion(completion).orConverterException
-      case HeartbeatMsg() => converter.fromHeartbeat
+      case TriggerMsg.Heartbeat => converter.fromHeartbeat
     }
 
   // A flow for trigger messages representing a process for the
@@ -648,7 +650,7 @@ class Runner(
     val (initialStateFree, evaluatedUpdate) = getInitialStateFreeAndUpdate(acs)
 
     // Prepare another speedy machine for evaluating expressions.
-    val machine: Speedy.Machine =
+    val machine: Speedy.OffLedgerMachine =
       Speedy.Machine.fromPureSExpr(compiledPackages, SEValue(SUnit))
 
     import UnfoldState.{flatMapConcatNode, flatMapConcatNodeOps, toSource, toSourceOps}
@@ -723,21 +725,21 @@ class Runner(
 
   private[this] def hideIrrelevantMsgs: Flow[TriggerMsg, TriggerMsg, NotUsed] =
     Flow[TriggerMsg].mapConcat[TriggerMsg] {
-      case msg @ CompletionMsg(c) =>
+      case msg @ TriggerMsg.Completion(c) =>
         // This happens for invalid UUIDs which we might get for
         // completions not emitted by the trigger.
         val ouuid = catchIAE(UUID.fromString(c.commandId))
         ouuid.flatMap { uuid =>
           useCommandId(uuid, SeenMsgs.Completion) option msg
         }.toList
-      case msg @ TransactionMsg(t) =>
+      case msg @ TriggerMsg.Transaction(t) =>
         // This happens for invalid UUIDs which we might get for
         // transactions not emitted by the trigger.
         val ouuid = catchIAE(UUID.fromString(t.commandId))
         List(ouuid flatMap { uuid =>
           useCommandId(uuid, SeenMsgs.Transaction) option msg
-        } getOrElse TransactionMsg(t.copy(commandId = "")))
-      case x @ HeartbeatMsg() => List(x) // Heartbeats don't carry any information.
+        } getOrElse TriggerMsg.Transaction(t.copy(commandId = "")))
+      case x @ TriggerMsg.Heartbeat => List(x) // Heartbeats don't carry any information.
     }
 
   def makeApp(func: SExpr, values: Array[SValue]): SExpr = {

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/DevOnly.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/DevOnly.scala
@@ -14,7 +14,7 @@ import com.daml.ledger.api.v1.{value => LedgerApi}
 import org.scalatest._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
-import com.daml.lf.engine.trigger.{TransactionMsg, TriggerMsg}
+import com.daml.lf.engine.trigger.TriggerMsg
 
 import scala.collection.concurrent.TrieMap
 
@@ -116,7 +116,7 @@ class DevOnly
               offset,
               msgFlow = Flow[TriggerMsg]
                 .wireTap {
-                  case msg: TransactionMsg =>
+                  case msg: TriggerMsg.Transaction =>
                     transactionEvents.addOne(msg.t.transactionId -> msg.t.events)
                   case _ =>
                   // No evidence to collect
@@ -199,7 +199,7 @@ class DevOnly
               offset,
               msgFlow = Flow[TriggerMsg]
                 .wireTap {
-                  case msg: TransactionMsg =>
+                  case msg: TriggerMsg.Transaction =>
                     transactionEvents.addOne(msg.t.transactionId -> msg.t.events)
                   case _ =>
                   // No evidence to collect
@@ -282,7 +282,7 @@ class DevOnly
               offset,
               msgFlow = Flow[TriggerMsg]
                 .wireTap {
-                  case msg: TransactionMsg =>
+                  case msg: TriggerMsg.Transaction =>
                     transactionEvents.addOne(msg.t.transactionId -> msg.t.events)
                   case _ =>
                   // No evidence to collect


### PR DESCRIPTION
We can summarize this big change as follows:
```

LedgerMode=OnLedger|OffLedger
LedgerMode/Machine
-->
OnLedgerMachine|OffLedgerMachine
```

And the motivation is this:

A `Machine` is just a bucket of mutable data. The details of this mutable data determine what basic ops can be executed on the machine. We have two distinct types of machine (on/off ledger).

The basic execution model of a machine, as defined by the syntactic expressions and the runtime continuations, is invariant across both/all machine types.

We want to model this complexity better at the scala type level.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
