### PR TITLE
Fix error handling in time service

### DIFF
--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TimeServiceIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TimeServiceIT.scala
@@ -53,6 +53,27 @@ final class TimeServiceIT extends LedgerTestSuite {
   })
 
   test(
+    "TSTimeAdvancementCanFail",
+    "Time advancement can fail when current time is not accurate",
+    allocate(NoParties),
+    runConcurrently = false,
+    enabled = _.staticTime,
+    disabledReason = "requires ledger static time feature",
+  )(implicit ec => { case Participants(Participant(ledger)) =>
+    for {
+      initialTime <- ledger.time()
+      invalidInitialTime = initialTime.plusSeconds(1)
+      thirtySecLater = initialTime.plusSeconds(30)
+      _ <- ledger
+        .setTime(invalidInitialTime, thirtySecLater)
+        .mustFailWith(
+          "current_time mismatch",
+          LedgerApiErrors.RequestValidation.InvalidArgument,
+        )
+    } yield ()
+  })
+
+  test(
     "TSFailWhenTimeNotAdvanced",
     "The submission of an exercise before time advancement should fail",
     allocate(SingleParty),


### PR DESCRIPTION
updateTime can return an error and the code correctly tried to turn
that into invalidArgument and logged it. However, the Either returned
by that then got completely discarded and the overall request
succeeded which definitely seems like a bug.

I added a test and verified that it fails withotu this change.

The code seems fairly messy. There are a few reasons for that:

1. We use Future[Either[…]] and we treat failures in the Either
   differently from future failures. I'm not quite convinced that
   makes sense but for this PR I didn’t want to introduce unrelated
   changed.
2. Future[Either[…]] without some form of EitherT is inherently messy
   but afaik you don’t use cats here so I kept it like this.

