### PR TITLE
Improve akka http metrics tests

### DIFF
--- a/observability/akka-http-metrics/src/test/suite/scala/com/daml/metrics/akkahttp/AkkaHttpMetricsSpec.scala
+++ b/observability/akka-http-metrics/src/test/suite/scala/com/daml/metrics/akkahttp/AkkaHttpMetricsSpec.scala
@@ -257,6 +257,7 @@ class AkkaHttpMetricsSpec extends AnyWordSpec with Matchers with ScalatestRouteT
             Source(List(byteString1, byteString2)),
           ),
         ) ~> route ~> check {
+          responseAs[String] // force processing the request
           metrics.httpRequestsBytesTotalValue should be(byteString1Size + byteString2Size)
         }
       }
@@ -315,7 +316,9 @@ class AkkaHttpMetricsSpec extends AnyWordSpec with Matchers with ScalatestRouteT
             ContentTypes.`application/octet-stream`,
             Source(List(byteString1, byteString2)),
           ),
-        ) ~> route
+        ) ~> route ~> check {
+          responseAs[String] // force processing the request
+        }
         Get(
           "/exception",
           HttpEntity.Strict(ContentTypes.`application/octet-stream`, byteString1),


### PR DESCRIPTION
Removes possible flakiness.
With chunked data, if the request is not executed, the request data might not be processed, and its size not recorded.

CHANGELOG_BEGIN
CHANGELOG_END
