### PR TITLE
Add comma after user ID in `toString`

### DIFF
--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/User.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/User.java
@@ -51,7 +51,12 @@ public final class User {
 
   @Override
   public String toString() {
-    return "User{" + "id='" + id + '\'' + "primaryParty='" + primaryParty.orElse(null) + '\'' + '}';
+    return "User{"
+        + "id='"
+        + id
+        + '\''
+        + primaryParty.map(p -> ", primaryParty='" + p + '\'').orElse("")
+        + '}';
   }
 
   @Override


### PR DESCRIPTION
Currently the `toString` for `User` in Java bindings returns the following:

    User{id='participant_admin'primaryParty='null'}

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
