### PR TITLE
[script] rename: queryView --> queryInterface

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/ScriptService_1_15.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService_1_15.hs
@@ -165,25 +165,25 @@ main =
                     , "  let i2c1 = toInterfaceContractId @MyInterface2 c1"
                     , "  let i2c2 = toInterfaceContractId @MyInterface2 c2"
 
-                    -- Test queryViewContractId (Interface1)
-                    , "  Some v <- queryViewContractId p i1a1"
+                    -- Test queryInterfaceContractId (Interface1)
+                    , "  Some v <- queryInterfaceContractId p i1a1"
                     , "  v.info === 142"
-                    , "  Some v <- queryViewContractId p i1a2"
+                    , "  Some v <- queryInterfaceContractId p i1a2"
                     , "  v.info === 143"
-                    , "  Some v <- queryViewContractId p i1b1"
+                    , "  Some v <- queryInterfaceContractId p i1b1"
                     , "  v.info === 244"
-                    , "  None <- queryViewContractId p i1a3" -- contract is archived
-                    , "  None <- queryViewContractId p i1a4" -- not a stakeholder
+                    , "  None <- queryInterfaceContractId p i1a3" -- contract is archived
+                    , "  None <- queryInterfaceContractId p i1a4" -- not a stakeholder
 
-                    -- Test queryViewContractId (Interface2)
-                    , "  Some v <- queryViewContractId p i2b1"
+                    -- Test queryInterfaceContractId (Interface2)
+                    , "  Some v <- queryInterfaceContractId p i2b1"
                     , "  v.info === \"B:44\""
-                    , "  Some v <- queryViewContractId p i2c1"
+                    , "  Some v <- queryInterfaceContractId p i2c1"
                     , "  v.info === \"C:I-am-c1\""
-                    , "  None <- queryViewContractId p i2c2" -- view function failed
+                    , "  None <- queryInterfaceContractId p i2c2" -- view function failed
 
-                    -- Test queryView (Interface1)
-                    , "  [(i1,Some v1),(i2,Some v2),(i3,Some v3)] <- sortOn snd <$> queryView @MyInterface1 p"
+                    -- Test queryInterface (Interface1)
+                    , "  [(i1,Some v1),(i2,Some v2),(i3,Some v3)] <- sortOn snd <$> queryInterface @MyInterface1 p"
                     , "  i1 === i1a1"
                     , "  i2 === i1a2"
                     , "  i3 === i1b1"
@@ -191,8 +191,8 @@ main =
                     , "  v2.info === 143"
                     , "  v3.info === 244"
 
-                    -- Test queryView (Interface2)
-                    , "  [(i1,None),(i2,Some v2),(i3,Some v3)] <- sortOn snd <$> queryView @MyInterface2 p"
+                    -- Test queryInterface (Interface2)
+                    , "  [(i1,None),(i2,Some v2),(i3,Some v3)] <- sortOn snd <$> queryInterface @MyInterface2 p"
                     , "  i1 === i2c2" -- view function failed, so no info
                     , "  i2 === i2b1"
                     , "  i3 === i2c1"

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -12,9 +12,9 @@ module Daml.Script
   , submitTree
   , submitTreeMulti
   , query
-  , queryView
+  , queryInterface
   , queryContractId
-  , queryViewContractId
+  , queryInterfaceContractId
   , queryContractKey
   , queryFilter
   , PartyIdHint (..)
@@ -129,8 +129,8 @@ data ScriptF a
   | SubmitTree (SubmitTreePayload a)
   | Query (QueryACS a)
   | QueryContractId (QueryContractIdPayload a)
-  | QueryView (QueryViewPayload a)
-  | QueryViewContractId (QueryViewContractIdPayload a)
+  | QueryInterface (QueryInterfacePayload a)
+  | QueryInterfaceContractId (QueryInterfaceContractIdPayload a)
   | QueryContractKey (QueryContractKeyPayload a)
   | AllocParty (AllocateParty a)
   | ListKnownParties (ListKnownPartiesPayload a)
@@ -220,7 +220,7 @@ queryContractId p c = lift $ Free $ QueryContractId QueryContractIdPayload with
   continue = pure . fmap (fromSome . fromAnyTemplate)
   locations = getCallStack callStack
 
-data QueryViewPayload a = QueryViewPayload
+data QueryInterfacePayload a = QueryInterfacePayload
   { parties : [Party]
   , interfaceId : TemplateTypeRep
   , continue : [LedgerValue] -> a
@@ -229,14 +229,14 @@ data QueryViewPayload a = QueryViewPayload
 
 -- | Query the set of active contracts views for an interface
 -- that are visible to the given party.
-queryView : forall i v p. (TemplateOrInterface i, HasInterfaceView i v, IsParties p) => p -> Script [(ContractId i, Optional v)]
-queryView p = lift $ Free $ QueryView QueryViewPayload with
+queryInterface : forall i v p. (TemplateOrInterface i, HasInterfaceView i v, IsParties p) => p -> Script [(ContractId i, Optional v)]
+queryInterface p = lift $ Free $ QueryInterface QueryInterfacePayload with
   parties = toParties p
   interfaceId = templateTypeRep @i
   continue = pure . map (fromLedgerValue @(ContractId i, Optional v))
   locations = getCallStack callStack
 
-data QueryViewContractIdPayload a = QueryViewContractIdPayload
+data QueryInterfaceContractIdPayload a = QueryInterfaceContractIdPayload
   { parties : [Party]
   , interfaceId : TemplateTypeRep
   , cid : ContractId ()
@@ -244,8 +244,8 @@ data QueryViewContractIdPayload a = QueryViewContractIdPayload
   , locations : [(Text, SrcLoc)]
   } deriving Functor
 
-queryViewContractId : forall i v p. (TemplateOrInterface i, HasInterfaceView i v, IsParties p) => HasCallStack => p -> ContractId i -> Script (Optional v)
-queryViewContractId p c = lift $ Free $ QueryViewContractId QueryViewContractIdPayload with
+queryInterfaceContractId : forall i v p. (TemplateOrInterface i, HasInterfaceView i v, IsParties p) => HasCallStack => p -> ContractId i -> Script (Optional v)
+queryInterfaceContractId p c = lift $ Free $ QueryInterfaceContractId QueryInterfaceContractIdPayload with
   parties = toParties p
   interfaceId = templateTypeRep @i
   cid = coerceContractId c

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
@@ -259,13 +259,13 @@ object ScriptF {
       } yield SEAppAtomic(SEValue(continue), Array(SEValue(SOptional(optR))))
   }
 
-  final case class QueryView(
+  final case class QueryInterface(
       parties: OneAnd[Set, Party],
       interfaceId: Identifier,
       stackTrace: StackTrace,
       continue: SValue,
   ) extends Cmd {
-    override def description = "queryView"
+    override def description = "queryInterface"
 
     override def execute(env: Env)(implicit
         ec: ExecutionContext,
@@ -282,7 +282,7 @@ object ScriptF {
       for {
         viewType <- Converter.toFuture(env.lookupInterfaceViewTy(interfaceId))
         client <- Converter.toFuture(env.clients.getPartiesParticipant(parties))
-        list <- client.queryView(parties, interfaceId)
+        list <- client.queryInterface(parties, interfaceId)
         list <- Converter.toFuture(
           list
             .to(FrontStack)
@@ -307,14 +307,14 @@ object ScriptF {
     }
   }
 
-  final case class QueryViewContractId(
+  final case class QueryInterfaceContractId(
       parties: OneAnd[Set, Party],
       interfaceId: Identifier,
       cid: ContractId,
       stackTrace: StackTrace,
       continue: SValue,
   ) extends Cmd {
-    override def description = "queryViewContractId"
+    override def description = "queryInterfaceContractId"
 
     override def execute(env: Env)(implicit
         ec: ExecutionContext,
@@ -324,7 +324,7 @@ object ScriptF {
       for {
         viewType <- Converter.toFuture(env.lookupInterfaceViewTy(interfaceId))
         client <- Converter.toFuture(env.clients.getPartiesParticipant(parties))
-        optR <- client.queryViewContractId(parties, interfaceId, cid)
+        optR <- client.queryInterfaceContractId(parties, interfaceId, cid)
         optR <- Converter.toFuture(
           optR.traverse(Converter.fromInterfaceView(env.valueTranslator, viewType, _))
         )
@@ -774,10 +774,10 @@ object ScriptF {
     }
   }
 
-  private def parseQueryView(
+  private def parseQueryInterface(
       ctx: Ctx,
       v: SValue,
-  ): Either[String, QueryView] = {
+  ): Either[String, QueryInterface] = {
     def convert(
         actAs: SValue,
         interfaceId: SValue,
@@ -788,18 +788,18 @@ object ScriptF {
         actAs <- Converter.toParties(actAs)
         interfaceId <- Converter.typeRepToIdentifier(interfaceId)
         stackTrace <- toStackTrace(ctx, stackTrace)
-      } yield QueryView(actAs, interfaceId, stackTrace, continue)
+      } yield QueryInterface(actAs, interfaceId, stackTrace, continue)
     v match {
       case SRecord(_, _, ArrayList(actAs, interfaceId, continue, stackTrace)) =>
         convert(actAs, interfaceId, Some(stackTrace), continue)
-      case _ => Left(s"Expected QueryView payload but got $v")
+      case _ => Left(s"Expected QueryInterface payload but got $v")
     }
   }
 
-  private def parseQueryViewContractId(
+  private def parseQueryInterfaceContractId(
       ctx: Ctx,
       v: SValue,
-  ): Either[String, QueryViewContractId] = {
+  ): Either[String, QueryInterfaceContractId] = {
     def convert(
         actAs: SValue,
         interfaceId: SValue,
@@ -812,11 +812,11 @@ object ScriptF {
         interfaceId <- Converter.typeRepToIdentifier(interfaceId)
         cid <- toContractId(cid)
         stackTrace <- toStackTrace(ctx, stackTrace)
-      } yield QueryViewContractId(actAs, interfaceId, cid, stackTrace, continue)
+      } yield QueryInterfaceContractId(actAs, interfaceId, cid, stackTrace, continue)
     v match {
       case SRecord(_, _, ArrayList(actAs, interfaceId, cid, continue, stackTrace)) =>
         convert(actAs, interfaceId, cid, Some(stackTrace), continue)
-      case _ => Left(s"Expected QueryViewContractId payload but got $v")
+      case _ => Left(s"Expected QueryInterfaceContractId payload but got $v")
     }
   }
 
@@ -1058,8 +1058,8 @@ object ScriptF {
       case "SubmitTree" => parseSubmit(ctx, v).map(SubmitTree(_))
       case "Query" => parseQuery(ctx, v)
       case "QueryContractId" => parseQueryContractId(ctx, v)
-      case "QueryView" => parseQueryView(ctx, v)
-      case "QueryViewContractId" => parseQueryViewContractId(ctx, v)
+      case "QueryInterface" => parseQueryInterface(ctx, v)
+      case "QueryInterfaceContractId" => parseQueryInterfaceContractId(ctx, v)
       case "QueryContractKey" => parseQueryContractKey(ctx, v)
       case "AllocParty" => parseAllocParty(ctx, v)
       case "ListKnownParties" => parseListKnownParties(ctx, v)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/GrpcLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/GrpcLedgerClient.scala
@@ -139,7 +139,7 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
     }
   }
 
-  override def queryView(parties: OneAnd[Set, Ref.Party], interfaceId: Identifier)(implicit
+  override def queryInterface(parties: OneAnd[Set, Ref.Party], interfaceId: Identifier)(implicit
       ec: ExecutionContext,
       mat: Materializer,
   ): Future[Seq[(ContractId, Option[Value])]] = {
@@ -173,7 +173,7 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
     }
   }
 
-  override def queryViewContractId(
+  override def queryInterfaceContractId(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
       cid: ContractId,
@@ -182,7 +182,7 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
       mat: Materializer,
   ): Future[Option[Value]] = {
     for {
-      activeViews <- queryView(parties, interfaceId)
+      activeViews <- queryInterface(parties, interfaceId)
     } yield {
       activeViews.collectFirst {
         case (k, Some(v)) if (k == cid) => v

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -173,7 +173,7 @@ class IdeLedgerClient(
     compiledPackages.pkgInterface.lookupInterfaceInstance(interfaceId, templateId).isRight
   }
 
-  override def queryView(
+  override def queryInterface(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
   )(implicit ec: ExecutionContext, mat: Materializer): Future[Seq[(ContractId, Option[Value])]] = {
@@ -202,7 +202,7 @@ class IdeLedgerClient(
     Future.successful(res)
   }
 
-  override def queryViewContractId(
+  override def queryInterfaceContractId(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
       cid: ContractId,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
@@ -209,13 +209,13 @@ class JsonLedgerClient(
       })
     }
   }
-  override def queryView(
+  override def queryInterface(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
   )(implicit ec: ExecutionContext, mat: Materializer): Future[Seq[(ContractId, Option[Value])]] = {
     sys.error("not implemented") // TODO https://github.com/digital-asset/daml/issues/14830
   }
-  override def queryViewContractId(
+  override def queryInterfaceContractId(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
       cid: ContractId,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/ScriptLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/ScriptLedgerClient.scala
@@ -84,7 +84,7 @@ trait ScriptLedgerClient {
       mat: Materializer,
   ): Future[Option[ScriptLedgerClient.ActiveContract]]
 
-  def queryView(
+  def queryInterface(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
   )(implicit
@@ -92,7 +92,7 @@ trait ScriptLedgerClient {
       mat: Materializer,
   ): Future[Seq[(ContractId, Option[Value])]]
 
-  def queryViewContractId(
+  def queryInterfaceContractId(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
       cid: ContractId,

--- a/daml-script/test/daml/TestInterfaces.daml
+++ b/daml-script/test/daml/TestInterfaces.daml
@@ -87,7 +87,7 @@ test = script do
   pure ()
 
 
--- Tests for queryView/queryViewContractId
+-- Tests for queryInterface/queryInterfaceContractId
 
 -- Two interfaces (1,2)...
 interface MyInterface1 where
@@ -130,8 +130,8 @@ template MyTemplateC
       view = (if isError then error else MyView2) ("C:" <> text)
 
 
-test_queryView : Script ()
-test_queryView = script do
+test_queryInterface : Script ()
+test_queryInterface = script do
 
   p <- allocateParty "Alice" -- primary party in the test script
   p2 <- allocateParty "Bob" -- other/different party
@@ -161,25 +161,25 @@ test_queryView = script do
   let i2c1 = toInterfaceContractId @MyInterface2 c1
   let i2c2 = toInterfaceContractId @MyInterface2 c2
 
-  -- Test queryViewContractId (Interface1)
-  Some v <- queryViewContractId p i1a1
+  -- Test queryInterfaceContractId (Interface1)
+  Some v <- queryInterfaceContractId p i1a1
   v.info === 142
-  Some v <- queryViewContractId p i1a2
+  Some v <- queryInterfaceContractId p i1a2
   v.info === 143
-  Some v <- queryViewContractId p i1b1
+  Some v <- queryInterfaceContractId p i1b1
   v.info === 244
-  None <- queryViewContractId p i1a3 -- contract is archived
-  None <- queryViewContractId p i1a4 -- not a stakeholder
+  None <- queryInterfaceContractId p i1a3 -- contract is archived
+  None <- queryInterfaceContractId p i1a4 -- not a stakeholder
 
-  -- Test queryViewContractId (Interface2)
-  Some v <- queryViewContractId p i2b1
+  -- Test queryInterfaceContractId (Interface2)
+  Some v <- queryInterfaceContractId p i2b1
   v.info === "B:44"
-  Some v <- queryViewContractId p i2c1
+  Some v <- queryInterfaceContractId p i2c1
   v.info === "C:I-am-c1"
-  None <- queryViewContractId p i2c2 -- view function failed
+  None <- queryInterfaceContractId p i2c2 -- view function failed
 
-  -- Test queryView (Interface1)
-  [(i1,Some v1),(i2,Some v2),(i3,Some v3)] <- sortOn snd <$> queryView @MyInterface1 p
+  -- Test queryInterface (Interface1)
+  [(i1,Some v1),(i2,Some v2),(i3,Some v3)] <- sortOn snd <$> queryInterface @MyInterface1 p
   i1 === i1a1
   i2 === i1a2
   i3 === i1b1
@@ -187,8 +187,8 @@ test_queryView = script do
   v2.info === 143
   v3.info === 244
 
-  -- Test queryView (Interface2)
-  [(i1,None),(i2,Some v2),(i3,Some v3)] <- sortOn snd <$> queryView @MyInterface2 p
+  -- Test queryInterface (Interface2)
+  [(i1,None),(i2,Some v2),(i3,Some v3)] <- sortOn snd <$> queryInterface @MyInterface2 p
   i1 === i2c2 -- view function failed, so no info
   i2 === i2b1
   i3 === i2c1

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
@@ -331,13 +331,13 @@ abstract class AbstractFuncIT
         }
       }
     }
-    "Interface:test_queryView" should {
+    "Interface:test_queryInterface" should {
       "succeed" in {
         for {
           clients <- participantClients()
           v <- run(
             clients,
-            QualifiedName.assertFromString("TestInterfaces:test_queryView"),
+            QualifiedName.assertFromString("TestInterfaces:test_queryInterface"),
             dar = devDar,
           )
         } yield {


### PR DESCRIPTION
Improve name for new `daml-script` functions: 
- `queryInterface` and `queryInterfaceContractId`

Advances https://github.com/digital-asset/daml/issues/14830