### PR TITLE
Fix build status message in `#team-daml-ci` notifications

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -362,8 +362,8 @@ jobs:
     - bash: ci/check-protobuf-stability.sh
     - template: tell-slack-failed.yml
 
-- job: collect_build_data
-  condition: always()
+- job: collect_build_data_failed
+  condition: failed()
   dependsOn:
     - Linux
     - Linux_oracle
@@ -374,6 +374,16 @@ jobs:
     - compatibility_linux
     - compatibility_stable_protobuf
     - check_for_release
-  pool:
-    name: "ubuntu_20_04"
-    demands: assignment -equals default
+
+- job: collect_build_data
+  condition: always()
+  dependsOn:
+    - collect_build_data_failed
+  variables:
+    failed_result: $[ dependencies.collect_build_data_failed.result ]
+  steps:
+    - bash: "exit 1"
+      # Since 'collect_build_data_failed' only runs when 'failed()', if it was
+      # successful that means at least one of its dependencies failed, so we set
+      # the result of 'collect_build_data' to 'Failed' with 'exit 1'
+      condition: eq(variables.failed_result, 'Succeeded')


### PR DESCRIPTION
Currently, the status reported on slack comes from job `notify_user` (resp. `notify_release_pr`) comes from variable `build_status` (resp. `status`), defined as the result of job `collect_build_data`,

https://github.com/digital-asset/daml/blob/da0f63d3f212ed6d4cbd995278803792c9050dd7/ci/prs.yml#L129

the problem with this is that since #14710, `collect_build_data` has had no build steps, which means that its result is always `Succeeded`, regardless of any of its dependencies failing.

This PR fixes that by introducing an intermediate job `collect_build_data_failed` with all the dependencies of the current `collect_build_data`, no steps, and with condition `failed()` instead of `collect_build_data`'s `always()`. This means that `collect_build_data_failed`'s result can only be `Skipped` if all of its dependencies succeeded, or `Succeeded` if any of them failed. This way, `collect_build_data` (which now only depends on `collect_build_data_failed`) can check if the result of `collect_build_data_succeeded` is `Succeeded`, and if so it fails with `exit 1` so _its_ result is `Failed`.

Ideally we would just use `succeeded()` to define a variable in `collect_build_data` without an intermediate job, but 

> You can use the following status check functions as expressions in conditions, ***but not in variable definitions***
> -- [Expressions - Azure Pipelines](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#job-status-functions)