### PR TITLE
Add interfaces & interface choices to coverage report

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -311,7 +311,7 @@ printTestCoverage ShowCoverage{getShowCoverage} allPackages results
 
             showCoverageReport :: (k -> String) -> String -> M.Map k a -> [String]
             showCoverageReport printer variety names
-              | getShowCoverage = []
+              | not getShowCoverage = []
               | otherwise =
                 [ printf "  %s: %d" variety (M.size names)
                 ] ++ [ "    " ++ printer id | id <- M.keys names ]

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -211,46 +211,19 @@ data Report = Report
     deriving (Show, Eq, Ord)
 
 lfTemplateIdentifier :: LF.Qualified LF.Template -> TemplateIdentifier
-lfTemplateIdentifier LF.Qualified { qualPackage, qualModule, qualObject } =
-    let package =
-            case qualPackage of
-              LF.PRSelf -> Nothing
-              LF.PRImport (LF.PackageId pid) -> Just pid
-        qualifiedTemplate =
-            LF.moduleNameString qualModule
-                <> ":"
-                <> T.concat (LF.unTypeConName (LF.tplTypeCon qualObject))
-    in
-    TemplateIdentifier { package, qualifiedTemplate }
+lfTemplateIdentifier = lfTemplateNameIdentifier . fmap LF.tplTypeCon
 
 lfInterfaceIdentifier :: LF.Qualified LF.DefInterface -> InterfaceIdentifier
-lfInterfaceIdentifier LF.Qualified { qualPackage, qualModule, qualObject } =
-    let package =
-            case qualPackage of
-              LF.PRSelf -> Nothing
-              LF.PRImport (LF.PackageId pid) -> Just pid
-        qualifiedInterface =
-            LF.moduleNameString qualModule
-                <> ":"
-                <> T.concat (LF.unTypeConName (LF.intName qualObject))
-    in
-    InterfaceIdentifier { package, qualifiedInterface }
+lfInterfaceIdentifier = lfInterfaceNameIdentifier . fmap LF.intName
 
 lfTemplateNameIdentifier :: LF.Qualified LF.TypeConName -> TemplateIdentifier
-lfTemplateNameIdentifier LF.Qualified { qualPackage, qualModule, qualObject } =
-    let package =
-            case qualPackage of
-              LF.PRSelf -> Nothing
-              LF.PRImport (LF.PackageId pid) -> Just pid
-        qualifiedTemplate =
-            LF.moduleNameString qualModule
-                <> ":"
-                <> T.concat (LF.unTypeConName qualObject)
-    in
-    TemplateIdentifier { package, qualifiedTemplate }
+lfTemplateNameIdentifier = lfMkNameIdentifier TemplateIdentifier
 
 lfInterfaceNameIdentifier :: LF.Qualified LF.TypeConName -> InterfaceIdentifier
-lfInterfaceNameIdentifier LF.Qualified { qualPackage, qualModule, qualObject } =
+lfInterfaceNameIdentifier = lfMkNameIdentifier InterfaceIdentifier
+
+lfMkNameIdentifier :: (Maybe T.Text -> T.Text -> a) -> LF.Qualified LF.TypeConName -> a
+lfMkNameIdentifier handler LF.Qualified { qualPackage, qualModule, qualObject } =
     let package =
             case qualPackage of
               LF.PRSelf -> Nothing
@@ -260,7 +233,7 @@ lfInterfaceNameIdentifier LF.Qualified { qualPackage, qualModule, qualObject } =
                 <> ":"
                 <> T.concat (LF.unTypeConName qualObject)
     in
-    InterfaceIdentifier { package, qualifiedInterface }
+    handler package qualifiedInterface
 
 ssIdentifierToIdentifier :: SS.Identifier -> TemplateIdentifier
 ssIdentifierToIdentifier SS.Identifier {SS.identifierPackage, SS.identifierName} =

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -338,7 +338,7 @@ printTestCoverage _ allPackages results
           , printf "    %d internal interfaces" internal
           , printf "    %d external interfaces" external
           ]
-        , let defined = localImplementationChoices
+        , let defined = M.size localImplementationChoices
               exercised = M.size localImplementationChoicesExercised
           in
           [ printf "- Interface choices"
@@ -375,7 +375,7 @@ printTestCoverage _ allPackages results
           [ printf "- External interfaces"
           , printf "  %d implementations defined" defined
           ]
-        , let defined = externalImplementationChoices
+        , let defined = M.size externalImplementationChoices
               exercisedAny = M.size externalImplementationChoicesExercised
               exercisedInternal = countWhere (any isLocal) externalImplementationChoicesExercised
               exercisedExternal = countWhere (not . all isLocal) externalImplementationChoicesExercised

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -326,7 +326,7 @@ printTestCoverage _ allPackages results
                 def <- maybeToList mdef
                 choice <- NM.toList $ LF.intChoices $ LF.qualObject def
                 let name = LF.unChoiceName $ LF.chcName choice
-                guard (name == "Archive")
+                guard (name /= "Archive")
                 pure (ChoiceIdentifier contractId name, (k, loe, body, def, choice))
             allExercisedImplementationChoices = M.intersection allExercisedChoices allImplementationChoices
         in

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -382,10 +382,10 @@ printTestCoverage ShowCoverage{getShowCoverage} allPackages results
           , printf "  %d (%5.1f%%) exercised in internal tests" exercisedInternal (pctage exercisedInternal defined)
           , printf "  %d (%5.1f%%) exercised in external tests" exercisedExternal (pctage exercisedExternal defined)
           ] ++ showCoverageReport printChoiceIdentifier "never exercised" neverExercised
-        , let defined = countWhere (isLocal . fst) allImplementations
+        , let defined = countWhere (not . isLocal . fst) allImplementations
           in
-          [ printf "- External interfaces"
-          , printf "  %d implementations defined" defined
+          [ printf "- External interface implementations"
+          , printf "  %d defined" defined
           ]
         , let defined = M.size externalImplementationChoices
               exercisedAny = M.size externalImplementationChoicesExercised

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -286,7 +286,6 @@ printTestCoverage _ allPackages results
                 let name = LF.unChoiceName $ LF.chcName choice
                 guard (name /= "Archive")
                 pure (ChoiceIdentifier contractId name, (k, loe, body, def, choice))
-            allExercisedImplementationChoices = M.intersection allExercisedChoices allImplementationChoices
 
             localImplementationChoices = M.filter pred allImplementationChoices
               where

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -255,8 +255,9 @@ printTestCoverage _ allPackages results
     printReport :: IO ()
     printReport =
         let countWhere pred = M.size . M.filter pred
-            pctage :: Int -> Int -> Int
-            pctage n d = max 0 $ min 100 $ floor (100 * fromIntegral n / fromIntegral d :: Double)
+            pctage :: Int -> Int -> Double
+            pctage _ 0 = 100
+            pctage n d = max 0 $ min 100 $ 100 * fromIntegral n / fromIntegral d
 
             allContracts = contractsDefinedIn allPackages
             localTemplates = M.filterWithKey pred allContracts
@@ -319,14 +320,14 @@ printTestCoverage _ allPackages results
           in
           [ printf "- Internal templates"
           , printf "  %d defined" defined
-          , printf "  %d (%d%%) created" created (pctage created defined)
+          , printf "  %d (%3.1f%%) created" created (pctage created defined)
           ]
         , let defined = M.size localTemplateChoices
               exercised = M.size localTemplateChoicesExercised
           in
           [ printf "- Internal template choices"
           , printf "  %d defined" defined
-          , printf "  %d (%d%%) exercised" exercised (pctage exercised defined)
+          , printf "  %d (%3.1f%%) exercised" exercised (pctage exercised defined)
           ]
         , let defined = countWhere (isLocal . fst) allImplementations
               internal = countWhere (isLocal . fst) allImplementations
@@ -342,7 +343,7 @@ printTestCoverage _ allPackages results
           in
           [ printf "- Interface choices"
           , printf "  %d defined" defined
-          , printf "  %d (%d%%) exercised" exercised (pctage exercised defined)
+          , printf "  %d (%3.1f%%) exercised" exercised (pctage exercised defined)
           ]
         , [ printf "Modules external to this package:" ]
         -- Here, interface instances can only refer to external templates and
@@ -354,9 +355,9 @@ printTestCoverage _ allPackages results
           in
           [ printf "- External templates"
           , printf "  %d defined" defined
-          , printf "  %d (%d%%) created in any tests" createdAny (pctage createdAny defined)
-          , printf "  %d (%d%%) created in internal tests" createdInternal (pctage createdInternal defined)
-          , printf "  %d (%d%%) created in external tests" createdExternal (pctage createdExternal defined)
+          , printf "  %d (%3.1f%%) created in any tests" createdAny (pctage createdAny defined)
+          , printf "  %d (%3.1f%%) created in internal tests" createdInternal (pctage createdInternal defined)
+          , printf "  %d (%3.1f%%) created in external tests" createdExternal (pctage createdExternal defined)
           ]
         , let defined = M.size externalTemplateChoices
               exercisedAny = M.size externalTemplateChoicesExercised
@@ -365,9 +366,9 @@ printTestCoverage _ allPackages results
           in
           [ printf "- External template choices"
           , printf "  %d defined" defined
-          , printf "  %d (%d%%) exercised in any tests" exercisedAny (pctage exercisedAny defined)
-          , printf "  %d (%d%%) exercised in internal tests" exercisedInternal (pctage exercisedInternal defined)
-          , printf "  %d (%d%%) exercised in external tests" exercisedExternal (pctage exercisedExternal defined)
+          , printf "  %d (%3.1f%%) exercised in any tests" exercisedAny (pctage exercisedAny defined)
+          , printf "  %d (%3.1f%%) exercised in internal tests" exercisedInternal (pctage exercisedInternal defined)
+          , printf "  %d (%3.1f%%) exercised in external tests" exercisedExternal (pctage exercisedExternal defined)
           ]
         , let defined = countWhere (isLocal . fst) allImplementations
           in
@@ -381,9 +382,9 @@ printTestCoverage _ allPackages results
           in
           [ printf "- External interface choices"
           , printf "  %d defined" defined
-          , printf "  %d (%d%%) exercised in any tests" exercisedAny (pctage exercisedAny defined)
-          , printf "  %d (%d%%) exercised in internal tests" exercisedInternal (pctage exercisedInternal defined)
-          , printf "  %d (%d%%) exercised in external tests" exercisedExternal (pctage exercisedExternal defined)
+          , printf "  %d (%3.1f%%) exercised in any tests" exercisedAny (pctage exercisedAny defined)
+          , printf "  %d (%3.1f%%) exercised in internal tests" exercisedInternal (pctage exercisedInternal defined)
+          , printf "  %d (%3.1f%%) exercised in external tests" exercisedExternal (pctage exercisedExternal defined)
           ]
         ]
 

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -328,7 +328,7 @@ printTestCoverage ShowCoverage{getShowCoverage} allPackages results
           in
           [ printf "- Internal templates"
           , printf "  %d defined" defined
-          , printf "  %d (%3.1f%%) created" created (pctage created defined)
+          , printf "  %d (%5.1f%%) created" created (pctage created defined)
           ] ++ showCoverageReport printContractIdentifier "never created" neverCreated
         , let defined = M.size localTemplateChoices
               exercised = M.size localTemplateChoicesExercised
@@ -336,7 +336,7 @@ printTestCoverage ShowCoverage{getShowCoverage} allPackages results
           in
           [ printf "- Internal template choices"
           , printf "  %d defined" defined
-          , printf "  %d (%3.1f%%) exercised" exercised (pctage exercised defined)
+          , printf "  %d (%5.1f%%) exercised" exercised (pctage exercised defined)
           ] ++ showCoverageReport printChoiceIdentifier "never exercised" neverExercised
         , let defined = countWhere (isLocal . fst) allImplementations
               internal = countWhere (isLocal . fst) allImplementations
@@ -353,7 +353,7 @@ printTestCoverage ShowCoverage{getShowCoverage} allPackages results
           in
           [ printf "- Interface choices"
           , printf "  %d defined" defined
-          , printf "  %d (%3.1f%%) exercised" exercised (pctage exercised defined)
+          , printf "  %d (%5.1f%%) exercised" exercised (pctage exercised defined)
           ] ++ showCoverageReport printChoiceIdentifier "never exercised" neverExercised
         , [ printf "Modules external to this package:" ]
         -- Here, interface instances can only refer to external templates and
@@ -366,9 +366,9 @@ printTestCoverage ShowCoverage{getShowCoverage} allPackages results
           in
           [ printf "- External templates"
           , printf "  %d defined" defined
-          , printf "  %d (%3.1f%%) created in any tests" createdAny (pctage createdAny defined)
-          , printf "  %d (%3.1f%%) created in internal tests" createdInternal (pctage createdInternal defined)
-          , printf "  %d (%3.1f%%) created in external tests" createdExternal (pctage createdExternal defined)
+          , printf "  %d (%5.1f%%) created in any tests" createdAny (pctage createdAny defined)
+          , printf "  %d (%5.1f%%) created in internal tests" createdInternal (pctage createdInternal defined)
+          , printf "  %d (%5.1f%%) created in external tests" createdExternal (pctage createdExternal defined)
           ] ++ showCoverageReport printContractIdentifier "never created" neverCreated
         , let defined = M.size externalTemplateChoices
               exercisedAny = M.size externalTemplateChoicesExercised
@@ -378,9 +378,9 @@ printTestCoverage ShowCoverage{getShowCoverage} allPackages results
           in
           [ printf "- External template choices"
           , printf "  %d defined" defined
-          , printf "  %d (%3.1f%%) exercised in any tests" exercisedAny (pctage exercisedAny defined)
-          , printf "  %d (%3.1f%%) exercised in internal tests" exercisedInternal (pctage exercisedInternal defined)
-          , printf "  %d (%3.1f%%) exercised in external tests" exercisedExternal (pctage exercisedExternal defined)
+          , printf "  %d (%5.1f%%) exercised in any tests" exercisedAny (pctage exercisedAny defined)
+          , printf "  %d (%5.1f%%) exercised in internal tests" exercisedInternal (pctage exercisedInternal defined)
+          , printf "  %d (%5.1f%%) exercised in external tests" exercisedExternal (pctage exercisedExternal defined)
           ] ++ showCoverageReport printChoiceIdentifier "never exercised" neverExercised
         , let defined = countWhere (isLocal . fst) allImplementations
           in
@@ -395,9 +395,9 @@ printTestCoverage ShowCoverage{getShowCoverage} allPackages results
           in
           [ printf "- External interface choices"
           , printf "  %d defined" defined
-          , printf "  %d (%3.1f%%) exercised in any tests" exercisedAny (pctage exercisedAny defined)
-          , printf "  %d (%3.1f%%) exercised in internal tests" exercisedInternal (pctage exercisedInternal defined)
-          , printf "  %d (%3.1f%%) exercised in external tests" exercisedExternal (pctage exercisedExternal defined)
+          , printf "  %d (%5.1f%%) exercised in any tests" exercisedAny (pctage exercisedAny defined)
+          , printf "  %d (%5.1f%%) exercised in internal tests" exercisedInternal (pctage exercisedInternal defined)
+          , printf "  %d (%5.1f%%) exercised in external tests" exercisedExternal (pctage exercisedExternal defined)
           ] ++ showCoverageReport printChoiceIdentifier "never exercised" neverExercised
         ]
 

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -185,17 +185,6 @@ data InterfaceIdentifier = InterfaceIdentifier
     }
     deriving (Eq, Ord, Show)
 
---data ContractIdentifier = ContractIdentifier
---    { package :: Maybe T.Text -- `package == Nothing` means local package
---    , qualifiedTemplate :: T.Text
---    }
---    deriving (Eq, Ord, Show)
---
---data ChoiceIdentifier' = ChoiceIdentifier'
---    { choice :: T.Text
---    }
---    deriving (Eq, Ord, Show)
-
 data TemplateChoiceIdentifier = TemplateChoiceIdentifier
     { packageTemplate :: TemplateIdentifier
     , choice :: T.Text
@@ -220,62 +209,6 @@ data Report = Report
     , externalCreatedInternal :: S.Set TemplateIdentifier
     }
     deriving (Show, Eq, Ord)
-
--- templatesCreatedLocally :: S.Set TemplateIdentifier
--- templatesCreatedExternally :: S.Set TemplateIdentifier
--- templateChoicesExercisedLocally :: S.Set TemplateChoiceIdentifier
--- templateChoicesExercisedExternally :: S.Set TemplateChoiceIdentifier
--- interfaceChoices
-
-    {-
-newtype Created = Created LocalOrExternal deriving (Show, Eq)
-newtype Exercised = Exercised LocalOrExternal deriving (Show, Eq)
-
-mergeMapWithMonoid :: (Ord k, Monoid m) => M.Map k m -> M.Map k m -> M.Map k m
-mergeMapWithMonoid = M.merge M.preserveMissing M.preserveMissing (M.zipWithMatched (const (<>)))
-
-instance Semigroup ContractSummary where
-    (<>) (ContractSummary a0 b0) (ContractSummary a1 b1) =
-        ContractSummary (a0 <> a1) (mergeMapWithMonoid b0 b1)
-instance Monoid ContractSummary where
-    mempty = ContractSummary [] M.empty
-
-data ContractSummary = ContractSummary
-    { created :: ![Created]
-    , choices :: !(M.Map ChoiceIdentifier' [Exercised])
-    }
-
-instance Semigroup Summary where
-    (<>) (Summary a0 b0) (Summary a1 b1) =
-        Summary (mergeMapWithMonoid a0 a1) (mergeMapWithMonoid b0 b1)
-instance Monoid Summary where
-    mempty = Summary M.empty M.empty
-
-data Summary = Summary
-    { templates :: !(M.Map ContractIdentifier ContractSummary)
-    , interfaces :: !(M.Map (ContractIdentifier, TemplateIdentifier) ContractSummary)
-    }
-
-class Summarize a where
-    summarize :: a -> Summary
-
-instance Summary LocalOrExternal where
-    summarize = foldMap (summarize . uncurry (flip ($))) . loeGetModules
-instance Summary (LF.Qualified LF.Module) where
-    summarize =
-        foldMap summarize . traverse (NM.elems . moduleTemplates)
-        <> foldMap summarize . traverse (NM.elems . moduleInterfaces)
-instance Summary (LF.Qualified LF.Template) where
-    summarize qualTemplate =
-        let tid = lfTemplateIdentifier qualTemplate
-        in
-        Summary
-            { interfaces = M.empty
-            , templates =
-                M.singleton tid
-                  (qualObject )
-            }
-    -}
 
 lfTemplateIdentifier :: LF.Qualified LF.Template -> TemplateIdentifier
 lfTemplateIdentifier LF.Qualified { qualPackage, qualModule, qualObject } =

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -1,9 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE LambdaCase #-}
 
 -- | Main entry-point of the Daml compiler
 module DA.Cli.Damlc.Test (

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -253,7 +253,6 @@ printTestCoverage ::
     -> [(LocalOrExternal, [(VirtualResource, Either SSC.Error SS.ScenarioResult)])]
     -> IO ()
 printTestCoverage ShowCoverage {getShowCoverage} allPackages results
-  -- | undefined (summarize <$> allPackages) = undefined
   | any (isLeft . snd) $ concatMap snd results = pure ()
   | otherwise = do
       printReport $ report "defined in local modules" isLocal

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -297,7 +297,7 @@ printTestCoverage ShowCoverage{getShowCoverage} allPackages results
           [ printf "- Internal templates"
           , printf "  %d defined" defined
           , printf "  %d (%5.1f%%) created" created (pctage created defined)
-          ] ++ showCoverageReport printContractIdentifier "never created" neverCreated
+          ] ++ showCoverageReport printContractIdentifier "internal templates never created" neverCreated
         , let defined = M.size localTemplateChoices
               exercised = M.size localTemplateChoicesExercised
               neverExercised = M.difference localTemplateChoices localTemplateChoicesExercised
@@ -305,7 +305,7 @@ printTestCoverage ShowCoverage{getShowCoverage} allPackages results
           [ printf "- Internal template choices"
           , printf "  %d defined" defined
           , printf "  %d (%5.1f%%) exercised" exercised (pctage exercised defined)
-          ] ++ showCoverageReport printChoiceIdentifier "never exercised" neverExercised
+          ] ++ showCoverageReport printChoiceIdentifier "internal template choices never exercised" neverExercised
         , let defined = countWhere (isLocal . fst) allImplementations
               internal = countWhere (isLocal . fst) allImplementations
               external = countWhere (not . isLocal . fst) allImplementations
@@ -319,10 +319,10 @@ printTestCoverage ShowCoverage{getShowCoverage} allPackages results
               exercised = M.size localImplementationChoicesExercised
               neverExercised = M.difference localImplementationChoices localImplementationChoicesExercised
           in
-          [ printf "- Interface choices"
+          [ printf "- Internal interface choices"
           , printf "  %d defined" defined
           , printf "  %d (%5.1f%%) exercised" exercised (pctage exercised defined)
-          ] ++ showCoverageReport printChoiceIdentifier "never exercised" neverExercised
+          ] ++ showCoverageReport printChoiceIdentifier "internal interface choices never exercised" neverExercised
         , [ printf "Modules external to this package:" ]
         -- Here, interface instances can only refer to external templates and
         -- interfaces, so we only report external interface instances
@@ -337,7 +337,7 @@ printTestCoverage ShowCoverage{getShowCoverage} allPackages results
           , printf "  %d (%5.1f%%) created in any tests" createdAny (pctage createdAny defined)
           , printf "  %d (%5.1f%%) created in internal tests" createdInternal (pctage createdInternal defined)
           , printf "  %d (%5.1f%%) created in external tests" createdExternal (pctage createdExternal defined)
-          ] ++ showCoverageReport printContractIdentifier "never created" neverCreated
+          ] ++ showCoverageReport printContractIdentifier "external templates never created" neverCreated
         , let defined = M.size externalTemplateChoices
               exercisedAny = M.size externalTemplateChoicesExercised
               exercisedInternal = countWhere (any isLocal) externalTemplateChoicesExercised
@@ -349,7 +349,7 @@ printTestCoverage ShowCoverage{getShowCoverage} allPackages results
           , printf "  %d (%5.1f%%) exercised in any tests" exercisedAny (pctage exercisedAny defined)
           , printf "  %d (%5.1f%%) exercised in internal tests" exercisedInternal (pctage exercisedInternal defined)
           , printf "  %d (%5.1f%%) exercised in external tests" exercisedExternal (pctage exercisedExternal defined)
-          ] ++ showCoverageReport printChoiceIdentifier "never exercised" neverExercised
+          ] ++ showCoverageReport printChoiceIdentifier "external template choices never exercised" neverExercised
         , let defined = countWhere (not . isLocal . fst) allImplementations
           in
           [ printf "- External interface implementations"
@@ -366,7 +366,7 @@ printTestCoverage ShowCoverage{getShowCoverage} allPackages results
           , printf "  %d (%5.1f%%) exercised in any tests" exercisedAny (pctage exercisedAny defined)
           , printf "  %d (%5.1f%%) exercised in internal tests" exercisedInternal (pctage exercisedInternal defined)
           , printf "  %d (%5.1f%%) exercised in external tests" exercisedExternal (pctage exercisedExternal defined)
-          ] ++ showCoverageReport printChoiceIdentifier "never exercised" neverExercised
+          ] ++ showCoverageReport printChoiceIdentifier "external interface choices never exercised" neverExercised
         ]
 
     templatesDefinedIn :: [LocalOrExternal] -> M.Map ContractIdentifier (LF.Qualified LF.Template)

--- a/compiler/damlc/tests/src/DamlcTest.hs
+++ b/compiler/damlc/tests/src/DamlcTest.hs
@@ -317,7 +317,16 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
             exitCode @?= ExitSuccess
             let out = lines stdout
             assertBool ("test coverage is reported correctly: " <> stdout)
-                       ("defined in local modules:\n  choices: 1 / 3 (33%)\n  templates: 1 / 2 (50%)" `isInfixOf` stdout)
+                       ( unlines
+                       [ "Modules internal to this package:"
+                       , "- Internal templates"
+                       , "  2 defined"
+                       , "  1 ( 50.0%) created"
+                       , "- Internal template choices"
+                       , "  3 defined"
+                       , "  1 ( 33.3%) exercised"
+                       ]
+                       `isInfixOf` stdout)
             assertBool ("test summary is reported correctly: " <> out!!1)
                        ("Test Summary" `isPrefixOf` (out!!1))
             assertBool ("test summary is reported correctly: " <> out!!3)
@@ -356,13 +365,18 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
                   ""
             exitCode @?= ExitSuccess
             assertBool
-                ("test coverage is reported correctly: " <> stdout)
+                ("template creation coverage is reported correctly: " <> stdout)
                 (unlines
-                     [ "  templates never created:"
+                     [ "  never created: 1"
                      , "    Foo:S"
-                     , "  choices never executed:"
+                     ] `isInfixOf`
+                 stdout)
+            assertBool
+                ("template choice coverage is reported correctly: " <> stdout)
+                (unlines
+                     [ "  never exercised: 2"
                      , "    Foo:S:Archive"
-                     , "    Foo:T:Archive\n"
+                     , "    Foo:T:Archive"
                      ] `isInfixOf`
                  stdout)
 -- TODO: https://github.com/digital-asset/daml/issues/13044
@@ -509,16 +523,37 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
                  , "a:testA: ok, 0 active contracts, 2 transactions."
                  ] `isInfixOf`
              stdout)
-          assertBool ("Test coverage is reported correctly: " <> stdout)
+          assertBool ("Internal module test coverage is reported correctly: " <> stdout)
             (unlines
-                 [ "defined anywhere:"
-                 , "  choices: 2 / 5 (40%)"
-                 , "  templates: 2 / 3 (67%)"
-                 , "  templates never created:"
+                 [ "Modules internal to this package:"
+                 , "- Internal templates"
+                 , "  2 defined"
+                 , "  1 ( 50.0%) created"
+                 , "  never created: 1"
                  , "    B:S"
-                 , "  choices never executed:"
+                 , "- Internal template choices"
+                 , "  3 defined"
+                 , "  1 ( 33.3%) exercised"
+                 , "  never exercised: 2"
                  , "    B:S:Archive"
                  , "    B:T:Archive"
+                 ] `isInfixOf`
+             stdout)
+          assertBool ("External module test coverage is reported correctly: " <> stdout)
+            (unlines
+                 [ "Modules external to this package:"
+                 , "- External templates"
+                 , "  1 defined"
+                 , "  1 (100.0%) created in any tests"
+                 , "  0 (  0.0%) created in internal tests"
+                 , "  1 (100.0%) created in external tests"
+                 , "  never created: 0"
+                 , "- External template choices"
+                 , "  2 defined"
+                 , "  1 ( 50.0%) exercised in any tests"
+                 , "  0 (  0.0%) exercised in internal tests"
+                 , "  1 ( 50.0%) exercised in external tests"
+                 , "  never exercised: 1"
                  , "    a:A:U:Archive"
                  ] `isInfixOf`
              stdout)
@@ -577,9 +612,13 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
             (unlines
               ["B.daml:needleHaystack: ok, 0 active contracts, 0 transactions."
               , "a:test_needleHaystack: ok, 0 active contracts, 0 transactions."
-              , "defined in local modules:"
-              , "  choices: 0 / 0 (100%)"
-              , "  templates: 0 / 0 (100%)"
+              , "Modules internal to this package:"
+              , "- Internal templates"
+              , "  0 defined"
+              , "  0 (100.0%) created"
+              , "- Internal template choices"
+              , "  0 defined"
+              , "  0 (100.0%) exercised"
               ] `isInfixOf` stdout)
           exitCode @?= ExitSuccess
     , testCase "Full test coverage report without --all set (but imports)" $ withTempDir $ \projDir -> do
@@ -647,14 +686,18 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
           assertBool ("Test coverage is reported correctly: " <> stdout)
             (unlines
                  [ "B.daml:x: ok, 0 active contracts, 2 transactions."
-                 , "defined in local modules:"
-                 , "  choices: 1 / 3 (33%)"
-                 , "  templates: 1 / 2 (50%)"
-                 , "  templates never created:"
+                 , "Modules internal to this package:"
+                 , "- Internal templates"
+                 , "  2 defined"
+                 , "  1 ( 50.0%) created"
+                 , "  never created: 1"
                  , "    B:S"
-                 , "  choices never executed:"
+                 , "- Internal template choices"
+                 , "  3 defined"
+                 , "  1 ( 33.3%) exercised"
+                 , "  never exercised: 2"
                  , "    B:S:Archive"
-                 , "    B:T:Archive\n"
+                 , "    B:T:Archive"
                  ] `isInfixOf`
              stdout)
           exitCode @?= ExitSuccess

--- a/compiler/damlc/tests/src/DamlcTest.hs
+++ b/compiler/damlc/tests/src/DamlcTest.hs
@@ -367,14 +367,14 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
             assertBool
                 ("template creation coverage is reported correctly: " <> stdout)
                 (unlines
-                     [ "  never created: 1"
+                     [ "  internal templates never created: 1"
                      , "    Foo:S"
                      ] `isInfixOf`
                  stdout)
             assertBool
                 ("template choice coverage is reported correctly: " <> stdout)
                 (unlines
-                     [ "  never exercised: 2"
+                     [ "  internal template choices never exercised: 2"
                      , "    Foo:S:Archive"
                      , "    Foo:T:Archive"
                      ] `isInfixOf`
@@ -529,12 +529,12 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
                  , "- Internal templates"
                  , "  2 defined"
                  , "  1 ( 50.0%) created"
-                 , "  never created: 1"
+                 , "  internal templates never created: 1"
                  , "    B:S"
                  , "- Internal template choices"
                  , "  3 defined"
                  , "  1 ( 33.3%) exercised"
-                 , "  never exercised: 2"
+                 , "  internal template choices never exercised: 2"
                  , "    B:S:Archive"
                  , "    B:T:Archive"
                  ] `isInfixOf`
@@ -547,13 +547,13 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
                  , "  1 (100.0%) created in any tests"
                  , "  0 (  0.0%) created in internal tests"
                  , "  1 (100.0%) created in external tests"
-                 , "  never created: 0"
+                 , "  external templates never created: 0"
                  , "- External template choices"
                  , "  2 defined"
                  , "  1 ( 50.0%) exercised in any tests"
                  , "  0 (  0.0%) exercised in internal tests"
                  , "  1 ( 50.0%) exercised in external tests"
-                 , "  never exercised: 1"
+                 , "  external template choices never exercised: 1"
                  , "    a:A:U:Archive"
                  ] `isInfixOf`
              stdout)
@@ -690,12 +690,12 @@ testsForDamlcTest damlc scriptDar _ = testGroup "damlc test" $
                  , "- Internal templates"
                  , "  2 defined"
                  , "  1 ( 50.0%) created"
-                 , "  never created: 1"
+                 , "  internal templates never created: 1"
                  , "    B:S"
                  , "- Internal template choices"
                  , "  3 defined"
                  , "  1 ( 33.3%) exercised"
-                 , "  never exercised: 2"
+                 , "  internal template choices never exercised: 2"
                  , "    B:S:Archive"
                  , "    B:T:Archive"
                  ] `isInfixOf`


### PR DESCRIPTION
https://github.com/digital-asset/daml/issues/13044

New report format:
```
Test Summary

Main.daml:main: ok, 0 active contracts, 12 transactions.
other:main: ok, 0 active contracts, 4 transactions.
Modules internal to this package:
- Internal templates
  1 defined
  1 (100.0%) created
  never created: 0
- Internal template choices
  4 defined
  4 (100.0%) exercised
  never exercised: 0
- Internal interface implementations
  2 defined
    2 internal interfaces
    1 external interfaces
- Interface choices
  2 defined
  1 ( 50.0%) exercised
  never exercised: 1
    other:Other:T1:I00
Modules external to this package:
- External templates
  1 defined
  1 (100.0%) created in any tests
  1 (100.0%) created in internal tests
  1 (100.0%) created in external tests
  never created: 0
- External template choices
  5 defined
  5 (100.0%) exercised in any tests
  4 ( 80.0%) exercised in internal tests
  2 ( 40.0%) exercised in external tests
  never exercised: 0
- External interface implementations
  1 defined
- External interface choices
  3 defined
  2 ( 66.7%) exercised in any tests
  1 ( 33.3%) exercised in internal tests
  1 ( 33.3%) exercised in external tests
  never exercised: 1
    other:Other:T1:OtherI2
```

`Main.daml`
```
-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
-- SPDX-License-Identifier: Apache-2.0

module Main where

import Other
import Daml.Script

template T0 with p : Party where
  signatory p
  nonconsuming choice T00 : ()
    controller p
    do pure ()
  nonconsuming choice T01 : ()
    controller p
    do pure ()
  nonconsuming choice T02 : ()
    controller p
    do pure ()
  interface instance I for T0 where
    view = IView

data IView = IView {}
interface I where
  viewtype IView
  nonconsuming choice I00 : ()
    controller (signatory this)
    do pure ()
  interface instance I for T1 where
    view = IView

main : Script ()
main = do
  alice <- allocateParty "alice"
  t0 <- submit alice $ createCmd (T0 alice)
  t1 <- submit alice $ createCmd (T1 alice)
  submit alice $ exerciseCmd t0 T00
  submit alice $ exerciseCmd t0 T01
  submit alice $ exerciseCmd t0 T02
  submit alice $ exerciseCmd t1 T10
  submit alice $ exerciseCmd t1 T11
  submit alice $ exerciseCmd t1 T12
  submit alice $ exerciseCmd (toInterfaceContractId @I t0) I00
  submit alice $ exerciseCmd (toInterfaceContractId @OtherI t1) OtherI1
  submit alice $ archiveCmd t0
  submit alice $ archiveCmd t1
  pure ()
```

`other/Other.daml` (in external module, `other`)
```
module Other where

import Daml.Script

template T1 with p : Party where
  signatory p
  nonconsuming choice T10 : ()
    controller p
    do pure ()
  nonconsuming choice T11 : ()
    controller p
    do pure ()
  nonconsuming choice T12 : ()
    controller p
    do pure ()
  nonconsuming choice T13 : ()
    controller p
    do pure ()
  interface instance OtherI for T1 where
    view = OtherIView
    otherIController = p

data OtherIView = OtherIView {}
interface OtherI where
  viewtype OtherIView
  otherIController : Party
  nonconsuming choice OtherI0 : ()
    controller (otherIController this)
    do pure ()
  nonconsuming choice OtherI1 : ()
    controller (otherIController this)
    do pure ()
  nonconsuming choice OtherI2 : ()
    controller (otherIController this)
    do pure ()

main = do
  alice <- allocateParty "alice"
  t1 <- submit alice $ createCmd (T1 alice)
  submit alice $ exerciseCmd t1 T13
  submit alice $ exerciseCmd (toInterfaceContractId @OtherI t1) OtherI0
  submit alice $ archiveCmd t1
  pure ()
```