### PR TITLE
Define 'pool' for 'collect_build_data{,_failed}' jobs

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -374,6 +374,9 @@ jobs:
     - compatibility_linux
     - compatibility_stable_protobuf
     - check_for_release
+  pool:
+    name: "ubuntu_20_04"
+    demands: assignment -equals default
 
 - job: collect_build_data
   condition: always()
@@ -381,6 +384,9 @@ jobs:
     - collect_build_data_failed
   variables:
     failed_result: $[ dependencies.collect_build_data_failed.result ]
+  pool:
+    name: "ubuntu_20_04"
+    demands: assignment -equals default
   steps:
     - bash: "exit 1"
       # Since 'collect_build_data_failed' only runs when 'failed()', if it was


### PR DESCRIPTION
This was causing the `main` builds to fail on the `collect_build_data` or `collect_build_data_failed` jobs with errors like

```
collect_build_data

##[warning]An image label with the label Ubuntu16 does not exist.
,##[error]The remote provider was unable to process the request.
Pool: [Azure Pipelines](https://dev.azure.com/digitalasset/adadc18a-d7df-446a-aacb-86042c1619c6/_settings/agentqueues?poolId=&queueId=74)
Image: Ubuntu16
Started: Yesterday at 16:07
Duration: 18h 8m 27s
```

[example](https://dev.azure.com/digitalasset/daml/_build/results?buildId=127664&view=logs&j=da13fc49-12f2-5702-3415-6e3a1bb53047)

It seems that when no pool is specified, Azure falls back to "Ubuntu16", but there is no such image in our CI. Manually specifying `ubuntu_20_04` as we do everywhere should do the trick.

interestingly, this didn't cause failures in "regular" PR builds, where we see

```
collect_build_data

Pool: [Azure Pipelines](https://dev.azure.com/digitalasset/adadc18a-d7df-446a-aacb-86042c1619c6/_settings/agentqueues?poolId=&queueId=74)
Image: ubuntu-latest
Agent: Hosted Agent
Started: Today at 08:09
Duration: 16s
```

so the pool defaults to image `ubuntu-latest`, which _is_ available. In any case, switching these all to `ubuntu_20_04` is probably the right thing to do.