### PR TITLE
update & pin puppeteer dependencies for gsg test

### DIFF
--- a/compatibility/bazel_tools/create-daml-app/testDeps.json
+++ b/compatibility/bazel_tools/create-daml-app/testDeps.json
@@ -1,10 +1,10 @@
 {
   "devDependencies": {
-    "@types/jest": "^26.0.23",
-    "@types/node": "^13.11.1",
-    "@types/puppeteer": "^3.0.1",
-    "@types/wait-on": "^4.0.0",
-    "puppeteer": "^4.0.1",
-    "wait-on": "^4.0.2"
+    "@types/jest": "~29.2.3",
+    "@types/node": "~18.11.9",
+    "@types/puppeteer": "~7.0.4",
+    "@types/wait-on": "~5.3.1",
+    "puppeteer": "~18.1.0",
+    "wait-on": "~6.0.1"
   }
 }

--- a/compatibility/bazel_tools/create-daml-app/testDeps.json
+++ b/compatibility/bazel_tools/create-daml-app/testDeps.json
@@ -1,10 +1,10 @@
 {
   "devDependencies": {
-    "@types/jest": "~26.0.23",
-    "@types/node": "~13.11.1",
-    "@types/puppeteer": "~3.0.1",
-    "@types/wait-on": "~4.0.0",
-    "puppeteer": "~18.1.0",
+    "@types/jest": "~29.2.3",
+    "@types/node": "~18.11.9",
+    "@types/puppeteer": "~7.0.4",
+    "@types/wait-on": "~5.3.1",
+    "puppeteer": "~4.0.2",
     "wait-on": "~6.0.1"
   }
 }

--- a/compatibility/bazel_tools/create-daml-app/testDeps.json
+++ b/compatibility/bazel_tools/create-daml-app/testDeps.json
@@ -4,7 +4,7 @@
     "@types/node": "~13.11.1",
     "@types/puppeteer": "~3.0.1",
     "@types/wait-on": "~4.0.0",
-    "puppeteer": "~4.0.1",
+    "puppeteer": "~18.1.0",
     "wait-on": "~6.0.1"
   }
 }

--- a/compatibility/bazel_tools/create-daml-app/testDeps.json
+++ b/compatibility/bazel_tools/create-daml-app/testDeps.json
@@ -4,7 +4,7 @@
     "@types/node": "~18.11.9",
     "@types/puppeteer": "~7.0.4",
     "@types/wait-on": "~5.3.1",
-    "puppeteer": "~4.0.2",
+    "puppeteer": "~16.2.0",
     "wait-on": "~6.0.1"
   }
 }

--- a/compatibility/bazel_tools/create-daml-app/testDeps.json
+++ b/compatibility/bazel_tools/create-daml-app/testDeps.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@types/jest": "~26.0.23,
+    "@types/jest": "~26.0.23",
     "@types/node": "~13.11.1",
     "@types/puppeteer": "~3.0.1",
     "@types/wait-on": "~4.0.0",

--- a/compatibility/bazel_tools/create-daml-app/testDeps.json
+++ b/compatibility/bazel_tools/create-daml-app/testDeps.json
@@ -4,7 +4,7 @@
     "@types/node": "~18.11.9",
     "@types/puppeteer": "~7.0.4",
     "@types/wait-on": "~5.3.1",
-    "puppeteer": "~12.0.0",
+    "puppeteer": "~10.0.0",
     "wait-on": "~6.0.1"
   }
 }

--- a/compatibility/bazel_tools/create-daml-app/testDeps.json
+++ b/compatibility/bazel_tools/create-daml-app/testDeps.json
@@ -5,6 +5,6 @@
     "@types/puppeteer": "~3.0.1",
     "@types/wait-on": "~4.0.0",
     "puppeteer": "~4.0.1",
-    "wait-on": "~4.0.2"
+    "wait-on": "~6.0.1"
   }
 }

--- a/compatibility/bazel_tools/create-daml-app/testDeps.json
+++ b/compatibility/bazel_tools/create-daml-app/testDeps.json
@@ -4,7 +4,7 @@
     "@types/node": "~18.11.9",
     "@types/puppeteer": "~7.0.4",
     "@types/wait-on": "~5.3.1",
-    "puppeteer": "~16.2.0",
+    "puppeteer": "~12.0.0",
     "wait-on": "~6.0.1"
   }
 }

--- a/compatibility/bazel_tools/create-daml-app/testDeps.json
+++ b/compatibility/bazel_tools/create-daml-app/testDeps.json
@@ -1,10 +1,10 @@
 {
   "devDependencies": {
-    "@types/jest": "~29.2.3",
-    "@types/node": "~18.11.9",
-    "@types/puppeteer": "~7.0.4",
-    "@types/wait-on": "~5.3.1",
-    "puppeteer": "~18.1.0",
-    "wait-on": "~6.0.1"
+    "@types/jest": "~26.0.23,
+    "@types/node": "~13.11.1",
+    "@types/puppeteer": "~3.0.1",
+    "@types/wait-on": "~4.0.0",
+    "puppeteer": "~4.0.1",
+    "wait-on": "~4.0.2"
   }
 }

--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 load("//bazel_tools:haskell.bzl", "da_haskell_library", "da_haskell_test")
-load("@os_info//:os_info.bzl", "is_darwin_arm64", "is_windows")
+load("@os_info//:os_info.bzl", "is_windows")
 load("@build_environment//:configuration.bzl", "mvn_version")
 
 genrule(
@@ -229,7 +229,7 @@ genrule(
     ],
     # Broken on M1 due to puppeteer failing to install Chromium.
     # See https://github.com/digital-asset/daml/pull/13250.
-) if not (is_darwin_arm64 or is_windows) else None
+) if not is_windows else None
 
 da_haskell_library(
     name = "create-daml-app-tests-lib",
@@ -264,7 +264,7 @@ da_haskell_library(
         "//libs-haskell/da-hs-base",
         "//libs-haskell/test-utils",
     ],
-) if not (is_darwin_arm64 or is_windows) else None
+) if not is_windows else None
 
 da_haskell_test(
     name = "create-daml-app-tests-proj-name",
@@ -289,4 +289,4 @@ da_haskell_test(
         # Exclusive until we stop hardcoding port numbers in index.test.ts
         ["exclusive"],
     deps = [":create-daml-app-tests-lib"],
-) if not (is_darwin_arm64 or is_windows) else None
+) if not is_windows else None

--- a/docs/source/getting-started/testing.rst
+++ b/docs/source/getting-started/testing.rst
@@ -18,7 +18,9 @@ Of course there are more to choose from, but this is one combination that works.
 To install Puppeteer and some other testing utilities we are going to use,
 run the following command in the ``ui`` directory::
 
-    npm add --only=dev puppeteer@18.2.1 wait-on @types/jest @types/node @types/puppeteer @types/wait-on
+    npm i --save-dev puppeteer@~18.1.0 wait-on@~6.0.1 @types/jest@~29.2.3 @types/node@~18.11.9 @types/puppeteer@~7.0.4 @types/wait-on@~5.3.1
+
+You may need to run ``npm install`` again afterwards.
 
 Because these things are easier to describe with concrete examples, this
 section will show how to set up end-to-end tests for the application you would

--- a/docs/source/getting-started/testing.rst
+++ b/docs/source/getting-started/testing.rst
@@ -18,7 +18,7 @@ Of course there are more to choose from, but this is one combination that works.
 To install Puppeteer and some other testing utilities we are going to use,
 run the following command in the ``ui`` directory::
 
-    npm i --save-dev puppeteer@~18.1.0 wait-on@~6.0.1 @types/jest@~29.2.3 @types/node@~18.11.9 @types/puppeteer@~7.0.4 @types/wait-on@~5.3.1
+    npm i --save-dev puppeteer@~10.0.0 wait-on@~6.0.1 @types/jest@~29.2.3 @types/node@~18.11.9 @types/puppeteer@~7.0.4 @types/wait-on@~5.3.1
 
 You may need to run ``npm install`` again afterwards.
 

--- a/templates/create-daml-app-test-resources/testDeps.json
+++ b/templates/create-daml-app-test-resources/testDeps.json
@@ -1,10 +1,10 @@
 {
   "devDependencies": {
-    "@types/jest": "^26.0.23",
-    "@types/node": "^13.11.1",
-    "@types/puppeteer": "^3.0.1",
-    "@types/wait-on": "^4.0.0",
-    "puppeteer": "^4.0.1",
-    "wait-on": "^4.0.2"
+    "@types/jest": "~29.2.3",
+    "@types/node": "~18.11.9",
+    "@types/puppeteer": "~7.0.4",
+    "@types/wait-on": "~5.3.1",
+    "puppeteer": "~18.1.0",
+    "wait-on": "~6.0.1"
   }
 }

--- a/templates/create-daml-app-test-resources/testDeps.json
+++ b/templates/create-daml-app-test-resources/testDeps.json
@@ -1,10 +1,10 @@
 {
   "devDependencies": {
-    "@types/jest": "~26.0.23",
-    "@types/node": "~13.11.1",
-    "@types/puppeteer": "~3.0.1",
-    "@types/wait-on": "~4.0.0",
-    "puppeteer": "~18.1.0",
+    "@types/jest": "~29.2.3",
+    "@types/node": "~18.11.9",
+    "@types/puppeteer": "~7.0.4",
+    "@types/wait-on": "~5.3.1",
+    "puppeteer": "~4.0.2",
     "wait-on": "~6.0.1"
   }
 }

--- a/templates/create-daml-app-test-resources/testDeps.json
+++ b/templates/create-daml-app-test-resources/testDeps.json
@@ -4,7 +4,7 @@
     "@types/node": "~18.11.9",
     "@types/puppeteer": "~7.0.4",
     "@types/wait-on": "~5.3.1",
-    "puppeteer": "~10.0.0",
+    "puppeteer": "~11.0.0",
     "wait-on": "~6.0.1"
   }
 }

--- a/templates/create-daml-app-test-resources/testDeps.json
+++ b/templates/create-daml-app-test-resources/testDeps.json
@@ -4,7 +4,7 @@
     "@types/node": "~13.11.1",
     "@types/puppeteer": "~3.0.1",
     "@types/wait-on": "~4.0.0",
-    "puppeteer": "~4.0.1",
+    "puppeteer": "~18.1.0",
     "wait-on": "~6.0.1"
   }
 }

--- a/templates/create-daml-app-test-resources/testDeps.json
+++ b/templates/create-daml-app-test-resources/testDeps.json
@@ -4,7 +4,7 @@
     "@types/node": "~18.11.9",
     "@types/puppeteer": "~7.0.4",
     "@types/wait-on": "~5.3.1",
-    "puppeteer": "~4.0.2",
+    "puppeteer": "~16.2.0",
     "wait-on": "~6.0.1"
   }
 }

--- a/templates/create-daml-app-test-resources/testDeps.json
+++ b/templates/create-daml-app-test-resources/testDeps.json
@@ -4,7 +4,7 @@
     "@types/node": "~18.11.9",
     "@types/puppeteer": "~7.0.4",
     "@types/wait-on": "~5.3.1",
-    "puppeteer": "~11.0.0",
+    "puppeteer": "~10.0.0",
     "wait-on": "~6.0.1"
   }
 }

--- a/templates/create-daml-app-test-resources/testDeps.json
+++ b/templates/create-daml-app-test-resources/testDeps.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@types/jest": "~26.0.23,
+    "@types/jest": "~26.0.23",
     "@types/node": "~13.11.1",
     "@types/puppeteer": "~3.0.1",
     "@types/wait-on": "~4.0.0",

--- a/templates/create-daml-app-test-resources/testDeps.json
+++ b/templates/create-daml-app-test-resources/testDeps.json
@@ -4,7 +4,7 @@
     "@types/node": "~18.11.9",
     "@types/puppeteer": "~7.0.4",
     "@types/wait-on": "~5.3.1",
-    "puppeteer": "~12.0.0",
+    "puppeteer": "~10.0.0",
     "wait-on": "~6.0.1"
   }
 }

--- a/templates/create-daml-app-test-resources/testDeps.json
+++ b/templates/create-daml-app-test-resources/testDeps.json
@@ -5,6 +5,6 @@
     "@types/puppeteer": "~3.0.1",
     "@types/wait-on": "~4.0.0",
     "puppeteer": "~4.0.1",
-    "wait-on": "~4.0.2"
+    "wait-on": "~6.0.1"
   }
 }

--- a/templates/create-daml-app-test-resources/testDeps.json
+++ b/templates/create-daml-app-test-resources/testDeps.json
@@ -4,7 +4,7 @@
     "@types/node": "~18.11.9",
     "@types/puppeteer": "~7.0.4",
     "@types/wait-on": "~5.3.1",
-    "puppeteer": "~16.2.0",
+    "puppeteer": "~12.0.0",
     "wait-on": "~6.0.1"
   }
 }

--- a/templates/create-daml-app-test-resources/testDeps.json
+++ b/templates/create-daml-app-test-resources/testDeps.json
@@ -1,10 +1,10 @@
 {
   "devDependencies": {
-    "@types/jest": "~29.2.3",
-    "@types/node": "~18.11.9",
-    "@types/puppeteer": "~7.0.4",
-    "@types/wait-on": "~5.3.1",
-    "puppeteer": "~18.1.0",
-    "wait-on": "~6.0.1"
+    "@types/jest": "~26.0.23,
+    "@types/node": "~13.11.1",
+    "@types/puppeteer": "~3.0.1",
+    "@types/wait-on": "~4.0.0",
+    "puppeteer": "~4.0.1",
+    "wait-on": "~4.0.2"
   }
 }


### PR DESCRIPTION
Not that I relish the added flakiness on CI, but I want to be able to run those tests locally.