### PR TITLE
Change OpenTelemetry timer unit to seconds [PLEN-44]

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/OpenTelemetryMeterOwner.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/OpenTelemetryMeterOwner.scala
@@ -54,7 +54,7 @@ object OpenTelemetryMeterOwner {
       .registerView(
         histogramSelectorEndingWith(OpenTelemetryTimer.TimerUnitAndSuffix),
         explicitHistogramBucketsView(
-          Seq(0.01d, 0.025d, 0.050d, 0.075d, 0.1d, 0.15d, 0.2d, 0.25d, 0.35d, 0.5d, 0.75d, 1d, 2_5d,
+          Seq(0.01d, 0.025d, 0.050d, 0.075d, 0.1d, 0.15d, 0.2d, 0.25d, 0.35d, 0.5d, 0.75d, 1d, 2.5d,
             5d, 10d)
         ),
       )

--- a/ledger/metrics/src/main/scala/com/daml/metrics/OpenTelemetryMeterOwner.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/OpenTelemetryMeterOwner.scala
@@ -5,7 +5,6 @@ package com.daml.metrics
 
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.metrics.OpenTelemetryMeterOwner.buildProviderWithViews
-import com.daml.metrics.api.MetricHandle.Histogram
 import com.daml.metrics.api.opentelemetry.OpenTelemetryTimer
 import com.daml.metrics.api.reporters.MetricsReporter
 import com.daml.metrics.api.reporters.MetricsReporter.Prometheus
@@ -55,8 +54,8 @@ object OpenTelemetryMeterOwner {
       .registerView(
         histogramSelectorEndingWith(OpenTelemetryTimer.TimerUnitAndSuffix),
         explicitHistogramBucketsView(
-          Seq(0.005d, 0.01d, 0.025d, 0.050d, 0.075d, 0.1d, 0.15d, 0.2d, 0.25d, 0.35d, 0.5d, 0.75d,
-            1d, 2_5d, 5d, 7_5d, 10d, 25d)
+          Seq(0.01d, 0.025d, 0.050d, 0.075d, 0.1d, 0.15d, 0.2d, 0.25d, 0.35d, 0.5d, 0.75d,
+            1d, 2_5d, 5d, 10d)
         ),
       )
   }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/OpenTelemetryMeterOwner.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/OpenTelemetryMeterOwner.scala
@@ -60,23 +60,19 @@ object OpenTelemetryMeterOwner {
       )
   }
 
-  private def histogramSelectorEndingWith(endingWith: String) = {
-    InstrumentSelector
-      .builder()
-      .setType(InstrumentType.HISTOGRAM)
-      .setName((t: String) => t.endsWith(endingWith))
-      .build()
-  }
+  private def histogramSelectorEndingWith(endingWith: String) = InstrumentSelector
+    .builder()
+    .setType(InstrumentType.HISTOGRAM)
+    .setName((t: String) => t.endsWith(endingWith))
+    .build()
 
-  private def explicitHistogramBucketsView(buckets: Seq[Double]) = {
-    View
-      .builder()
-      .setAggregation(
-        Aggregation.explicitBucketHistogram(
-          buckets.map(Double.box).asJava
-        )
+  private def explicitHistogramBucketsView(buckets: Seq[Double]) = View
+    .builder()
+    .setAggregation(
+      Aggregation.explicitBucketHistogram(
+        buckets.map(Double.box).asJava
       )
-      .build()
-  }
+    )
+    .build()
 
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/OpenTelemetryMeterOwner.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/OpenTelemetryMeterOwner.scala
@@ -5,6 +5,8 @@ package com.daml.metrics
 
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.metrics.OpenTelemetryMeterOwner.buildProviderWithViews
+import com.daml.metrics.api.MetricHandle.Histogram
+import com.daml.metrics.api.opentelemetry.OpenTelemetryTimer
 import com.daml.metrics.api.reporters.MetricsReporter
 import com.daml.metrics.api.reporters.MetricsReporter.Prometheus
 import io.opentelemetry.api.metrics.Meter
@@ -47,23 +49,35 @@ case class OpenTelemetryMeterOwner(enabled: Boolean, reporter: Option[MetricsRep
 }
 object OpenTelemetryMeterOwner {
 
-  def buildProviderWithViews: SdkMeterProviderBuilder =
+  def buildProviderWithViews: SdkMeterProviderBuilder = {
     SdkMeterProvider
       .builder()
       .registerView(
-        InstrumentSelector
-          .builder()
-          .setType(InstrumentType.HISTOGRAM)
-          .setName((t: String) => t.endsWith("duration.ms"))
-          .build(),
-        View
-          .builder()
-          .setAggregation(
-            Aggregation.explicitBucketHistogram(
-              Seq(5d, 10d, 15d, 25d, 35d, 50d, 75d, 100d, 150d, 200d, 250d, 350d, 500d, 750d,
-                1_000d, 2_500d, 5_000d, 7_500d, 10_000d, 25_000d, 50_000d).map(Double.box).asJava
-            )
-          )
-          .build(),
+        histogramSelectorEndingWith(OpenTelemetryTimer.TimerUnitAndSuffix),
+        explicitHistogramBucketsView(
+          Seq(0.005d, 0.01d, 0.025d, 0.050d, 0.075d, 0.1d, 0.15d, 0.2d, 0.25d, 0.35d, 0.5d, 0.75d,
+            1d, 2_5d, 5d, 7_5d, 10d, 25d)
+        ),
       )
+  }
+
+  private def histogramSelectorEndingWith(endingWith: String) = {
+    InstrumentSelector
+      .builder()
+      .setType(InstrumentType.HISTOGRAM)
+      .setName((t: String) => t.endsWith(endingWith))
+      .build()
+  }
+
+  private def explicitHistogramBucketsView(buckets: Seq[Double]) = {
+    View
+      .builder()
+      .setAggregation(
+        Aggregation.explicitBucketHistogram(
+          buckets.map(Double.box).asJava
+        )
+      )
+      .build()
+  }
+
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/OpenTelemetryMeterOwner.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/OpenTelemetryMeterOwner.scala
@@ -54,8 +54,8 @@ object OpenTelemetryMeterOwner {
       .registerView(
         histogramSelectorEndingWith(OpenTelemetryTimer.TimerUnitAndSuffix),
         explicitHistogramBucketsView(
-          Seq(0.01d, 0.025d, 0.050d, 0.075d, 0.1d, 0.15d, 0.2d, 0.25d, 0.35d, 0.5d, 0.75d,
-            1d, 2_5d, 5d, 10d)
+          Seq(0.01d, 0.025d, 0.050d, 0.075d, 0.1d, 0.15d, 0.2d, 0.25d, 0.35d, 0.5d, 0.75d, 1d, 2_5d,
+            5d, 10d)
         ),
       )
   }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryFactory.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryFactory.scala
@@ -186,8 +186,8 @@ object OpenTelemetryTimer {
 
   private val NanoSecondsInASecond = 1_000_000_000
 
-  private def convertNanosecondsToSeconds[T](nanoseconds: Long) = {
-    nanoseconds / NanoSecondsInASecond
+  private def convertNanosecondsToSeconds[T](nanoseconds: Long): Double = {
+    nanoseconds.toDouble / NanoSecondsInASecond
   }
 }
 

--- a/ledger/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryFactory.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryFactory.scala
@@ -184,10 +184,10 @@ object OpenTelemetryTimer {
   private[opentelemetry] val TimerUnit: String = "seconds"
   val TimerUnitAndSuffix: MetricName = MetricName("duration", TimerUnit)
 
-  private val NanoSecondsInASecond = 1_000_000_000
+  private val NanosecondsInASecond = 1_000_000_000
 
   private def convertNanosecondsToSeconds[T](nanoseconds: Long): Double = {
-    nanoseconds.toDouble / NanoSecondsInASecond
+    nanoseconds.toDouble / NanosecondsInASecond
   }
 }
 

--- a/ledger/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryFactory.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryFactory.scala
@@ -10,9 +10,15 @@ import com.daml.buildinfo.BuildInfo
 import com.daml.metrics.api.Gauges.VarGauge
 import com.daml.metrics.api.MetricHandle.Timer.TimerHandle
 import com.daml.metrics.api.MetricHandle.{Counter, Factory, Gauge, Histogram, Meter, Timer}
+import com.daml.metrics.api.opentelemetry.OpenTelemetryTimer.{
+  TimerUnit,
+  TimerUnitAndSuffix,
+  convertNanosecondsToSeconds,
+}
 import com.daml.metrics.api.{MetricHandle, MetricName, MetricsContext}
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.metrics.{
+  DoubleHistogram,
   LongCounter,
   LongHistogram,
   LongUpDownCounter,
@@ -30,10 +36,10 @@ class OpenTelemetryFactory(otelMeter: OtelMeter) extends Factory {
   )(implicit
       context: MetricsContext = MetricsContext.Empty
   ): MetricHandle.Timer = {
-    val nameWithSuffix = name :+ "duration" :+ "ms"
+    val nameWithSuffix = name :+ TimerUnitAndSuffix
     OpenTelemetryTimer(
       nameWithSuffix,
-      otelMeter.histogramBuilder(nameWithSuffix).ofLongs().setUnit("ms").build(),
+      otelMeter.histogramBuilder(nameWithSuffix).setUnit(TimerUnit).build(),
       globalMetricsContext.merge(context),
     )
   }
@@ -132,14 +138,17 @@ class OpenTelemetryFactory(otelMeter: OtelMeter) extends Factory {
 
 }
 
-case class OpenTelemetryTimer(name: String, histogram: LongHistogram, timerContext: MetricsContext)
-    extends Timer {
+case class OpenTelemetryTimer(
+    name: String,
+    histogram: DoubleHistogram,
+    timerContext: MetricsContext,
+) extends Timer {
 
   override def update(duration: Long, unit: TimeUnit)(implicit
       context: MetricsContext
   ): Unit =
     histogram.record(
-      TimeUnit.MILLISECONDS.convert(duration, unit),
+      convertNanosecondsToSeconds(TimeUnit.NANOSECONDS.convert(duration, unit)),
       AttributesHelper.multiContextAsAttributes(timerContext, context),
     )
   override def time[T](call: => T)(implicit
@@ -148,7 +157,7 @@ case class OpenTelemetryTimer(name: String, histogram: LongHistogram, timerConte
     val start = System.nanoTime()
     val result = call
     histogram.record(
-      TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS),
+      convertNanosecondsToSeconds(System.nanoTime() - start),
       AttributesHelper.multiContextAsAttributes(timerContext, context),
     )
     result
@@ -159,7 +168,7 @@ case class OpenTelemetryTimer(name: String, histogram: LongHistogram, timerConte
     new TimerHandle {
       override def stop()(implicit stopContext: MetricsContext): Unit = {
         histogram.record(
-          TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS),
+          convertNanosecondsToSeconds(System.nanoTime() - start),
           AttributesHelper.multiContextAsAttributes(timerContext, startContext, stopContext),
         )
       }
@@ -169,6 +178,17 @@ case class OpenTelemetryTimer(name: String, histogram: LongHistogram, timerConte
   override def update(duration: Duration)(implicit
       context: MetricsContext
   ): Unit = update(duration.toNanos, TimeUnit.NANOSECONDS)
+}
+object OpenTelemetryTimer {
+
+  private[opentelemetry] val TimerUnit: String = "seconds"
+  val TimerUnitAndSuffix: MetricName = MetricName("duration", TimerUnit)
+
+  private val NanoSecondsInASecond = 1_000_000_000
+
+  private def convertNanosecondsToSeconds[T](nanoseconds: Long) = {
+    nanoseconds / NanoSecondsInASecond
+  }
 }
 
 case class OpenTelemetryGauge[T](name: String, varGauge: VarGauge[T]) extends Gauge[T] {


### PR DESCRIPTION
This also impacts the buckets used for the timer histogram.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
