### PR TITLE
Rework the definition of error groups

### DIFF
--- a/ledger/error/src/main/scala/com/daml/error/definitions/CommonErrors.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/CommonErrors.scala
@@ -4,12 +4,11 @@
 package com.daml.error.definitions
 
 import com.daml.error._
-import com.daml.error.definitions.ErrorGroups.ParticipantErrorGroup.CommonErrorGroup
+import com.daml.error.definitions.ErrorGroups.ParticipantErrorGroup
 
-@Explanation(
-  "Common errors raised in Daml services and components."
-)
-object CommonErrors extends CommonErrorGroup {
+object CommonErrors {
+
+  import ParticipantErrorGroup.CommonErrors.errorClass
 
   @Explanation(
     """This error category is used to signal that an unimplemented code-path has been triggered by a client or participant operator request."""

--- a/ledger/error/src/main/scala/com/daml/error/definitions/ErrorGroups.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/ErrorGroups.scala
@@ -9,24 +9,24 @@ object ErrorGroups {
   val rootErrorClass: ErrorClass = ErrorClass.root()
 
   object ParticipantErrorGroup extends ErrorGroup()(rootErrorClass) {
-    @Explanation(
-      "Common errors raised in Daml services and components."
-    )
+
+    @Explanation("Common errors raised in Daml services and components.")
     object CommonErrors extends ErrorGroup()
+
     @Explanation("Errors raised by the Participant Index persistence layer.")
     object IndexErrors extends ErrorGroup() {
       object DatabaseErrors extends ErrorGroup()
     }
 
-    @Explanation(
-      "Errors raised by or forwarded by the Ledger API."
-    )
+    @Explanation("Errors raised by or forwarded by the Ledger API.")
     object LedgerApiErrors extends ErrorGroup() {
+
       @Explanation("Errors raised by Ledger API admin services.")
       object AdminServices extends ErrorGroup() {
         object UserManagementServiceErrorGroup extends ErrorGroup()
         object PartyManagementServiceErrorGroup extends ErrorGroup()
       }
+
       @Explanation("Authentication and authorization errors.")
       object AuthorizationChecks extends ErrorGroup()
 
@@ -40,14 +40,10 @@ object ErrorGroups {
       )
       object ConsistencyErrors extends ErrorGroup()
 
-      @Explanation(
-        "Errors raised by the Package Management Service on package uploads."
-      )
+      @Explanation("Errors raised by the Package Management Service on package uploads.")
       object PackageServiceError extends ErrorGroup()
 
-      @Explanation(
-        "Validation errors raised when evaluating requests in the Ledger API."
-      )
+      @Explanation("Validation errors raised when evaluating requests in the Ledger API.")
       object RequestValidation extends ErrorGroup()
 
       @Explanation(

--- a/ledger/error/src/main/scala/com/daml/error/definitions/ErrorGroups.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/ErrorGroups.scala
@@ -3,27 +3,57 @@
 
 package com.daml.error.definitions
 
-import com.daml.error.{ErrorClass, ErrorGroup}
+import com.daml.error.{ErrorClass, ErrorGroup, Explanation}
 
 object ErrorGroups {
   val rootErrorClass: ErrorClass = ErrorClass.root()
 
   object ParticipantErrorGroup extends ErrorGroup()(rootErrorClass) {
-    abstract class CommonErrorGroup extends ErrorGroup()
-    abstract class IndexErrorGroup extends ErrorGroup() {
-      abstract class DatabaseErrorGroup extends ErrorGroup()
+    @Explanation(
+      "Common errors raised in Daml services and components."
+    )
+    object CommonErrors extends ErrorGroup()
+    @Explanation("Errors raised by the Participant Index persistence layer.")
+    object IndexErrors extends ErrorGroup() {
+      object DatabaseErrors extends ErrorGroup()
     }
-    abstract class LedgerApiErrorGroup extends ErrorGroup() {
-      abstract class AdminServicesErrorGroup extends ErrorGroup() {
-        abstract class UserManagementServiceErrorGroup extends ErrorGroup()
-        abstract class PartyManagementServiceErrorGroup extends ErrorGroup()
+
+    @Explanation(
+      "Errors raised by or forwarded by the Ledger API."
+    )
+    object LedgerApiErrors extends ErrorGroup() {
+      @Explanation("Errors raised by Ledger API admin services.")
+      object AdminServices extends ErrorGroup() {
+        object UserManagementServiceErrorGroup extends ErrorGroup()
+        object PartyManagementServiceErrorGroup extends ErrorGroup()
       }
-      abstract class AuthorizationChecks extends ErrorGroup()
-      abstract class CommandExecutionErrorGroup extends ErrorGroup()
-      abstract class ConsistencyErrors extends ErrorGroup()
-      abstract class PackageServiceErrorGroup extends ErrorGroup()
-      abstract class RequestValidation extends ErrorGroup()
-      abstract class WriteServiceRejections extends ErrorGroup()
+      @Explanation("Authentication and authorization errors.")
+      object AuthorizationChecks extends ErrorGroup()
+
+      @Explanation(
+        "Errors raised during the command execution phase of the command submission evaluation."
+      )
+      object CommandExecution extends ErrorGroup()
+
+      @Explanation(
+        "Potential consistency errors raised due to race conditions during command submission or returned as submission rejections by the backing ledger."
+      )
+      object ConsistencyErrors extends ErrorGroup()
+
+      @Explanation(
+        "Errors raised by the Package Management Service on package uploads."
+      )
+      object PackageServiceError extends ErrorGroup()
+
+      @Explanation(
+        "Validation errors raised when evaluating requests in the Ledger API."
+      )
+      object RequestValidation extends ErrorGroup()
+
+      @Explanation(
+        "Generic submission rejection errors returned by the backing ledger's write service."
+      )
+      object WriteServiceRejections extends ErrorGroup()
     }
   }
 }

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/IndexErrors.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/IndexErrors.scala
@@ -5,11 +5,13 @@ package com.daml.error.definitions
 
 import com.daml.error.ErrorCode.LoggedApiException
 import com.daml.error._
-import com.daml.error.definitions.ErrorGroups.ParticipantErrorGroup.IndexErrorGroup
+import com.daml.error.definitions.ErrorGroups.ParticipantErrorGroup
 
-@Explanation("Errors raised by the Participant Index persistence layer.")
-object IndexErrors extends IndexErrorGroup {
-  object DatabaseErrors extends DatabaseErrorGroup {
+object IndexErrors {
+  object DatabaseErrors {
+
+    import ParticipantErrorGroup.IndexErrors.DatabaseErrors.errorClass
+
     @Explanation(
       "This error occurs if a transient error arises when executing a query against the index database."
     )

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/LedgerApiErrors.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/LedgerApiErrors.scala
@@ -4,15 +4,14 @@
 package com.daml.error.definitions
 
 import com.daml.error._
-import com.daml.error.definitions.ErrorGroups.ParticipantErrorGroup.LedgerApiErrorGroup
+import com.daml.error.definitions.ErrorGroups.ParticipantErrorGroup
 import com.daml.lf.engine.Error.Validation.ReplayMismatch
 import com.daml.lf.engine.{Error => LfError}
 import org.slf4j.event.Level
 
-@Explanation(
-  "Errors raised by or forwarded by the Ledger API."
-)
-object LedgerApiErrors extends LedgerApiErrorGroup {
+object LedgerApiErrors {
+
+  import ParticipantErrorGroup.LedgerApiErrors.errorClass
 
   val Admin: groups.AdminServices.type = groups.AdminServices
   val CommandExecution: groups.CommandExecution.type = groups.CommandExecution

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/PackageServiceError.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/PackageServiceError.scala
@@ -4,16 +4,17 @@
 package com.daml.error.definitions
 
 import com.daml.error._
+import com.daml.error.definitions.ErrorGroups.ParticipantErrorGroup
 import com.daml.lf.archive.{Error => LfArchiveError}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.engine.Error
 import com.daml.lf.{VersionRange, language, validation}
 
-@Explanation(
-  "Errors raised by the Package Management Service on package uploads."
-)
-object PackageServiceError extends LedgerApiErrors.PackageServiceErrorGroup {
+object PackageServiceError {
+
+  import ParticipantErrorGroup.LedgerApiErrors.PackageServiceError.errorClass
+
   @Explanation("Package parsing errors raised during package upload.")
   object Reading extends ErrorGroup {
     @Explanation(

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/AdminServices.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/AdminServices.scala
@@ -3,12 +3,14 @@
 
 package com.daml.error.definitions.groups
 
-import com.daml.error.definitions.{DamlErrorWithDefiniteAnswer, LedgerApiErrors}
-import com.daml.error.definitions.groups
-import com.daml.error.{ContextualizedErrorLogger, ErrorCategory, ErrorCode, Explanation, Resolution}
+import com.daml.error._
+import com.daml.error.definitions.ErrorGroups.ParticipantErrorGroup.LedgerApiErrors
+import com.daml.error.definitions.{DamlErrorWithDefiniteAnswer, groups}
 
 @Explanation("Errors raised by Ledger API admin services.")
-object AdminServices extends LedgerApiErrors.AdminServicesErrorGroup {
+object AdminServices {
+
+  import LedgerApiErrors.AdminServices.errorClass
 
   val UserManagement: groups.UserManagementServiceErrorGroup.type =
     groups.UserManagementServiceErrorGroup

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/AuthorizationChecks.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/AuthorizationChecks.scala
@@ -3,20 +3,15 @@
 
 package com.daml.error.definitions.groups
 
-import com.daml.error.definitions.{DamlErrorWithDefiniteAnswer, LedgerApiErrors}
-import com.daml.error.{
-  ContextualizedErrorLogger,
-  ErrorCategory,
-  ErrorCategoryRetry,
-  ErrorCode,
-  Explanation,
-  Resolution,
-}
+import com.daml.error._
+import com.daml.error.definitions.DamlErrorWithDefiniteAnswer
+import com.daml.error.definitions.ErrorGroups.ParticipantErrorGroup.LedgerApiErrors
 
 import scala.concurrent.duration._
 
-@Explanation("Authentication and authorization errors.")
-object AuthorizationChecks extends LedgerApiErrors.AuthorizationChecks {
+object AuthorizationChecks {
+
+  import LedgerApiErrors.AuthorizationChecks.errorClass
 
   @Explanation("""The stream was aborted because the authenticated user's rights changed,
                  |and the user might thus no longer be authorized to this stream.

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/CommandExecution.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/CommandExecution.scala
@@ -3,16 +3,9 @@
 
 package com.daml.error.definitions.groups
 
-import com.daml.error.definitions.{DamlErrorWithDefiniteAnswer, LedgerApiErrors}
-import com.daml.error.{
-  ContextualizedErrorLogger,
-  ErrorCategory,
-  ErrorCode,
-  ErrorGroup,
-  ErrorResource,
-  Explanation,
-  Resolution,
-}
+import com.daml.error._
+import com.daml.error.definitions.DamlErrorWithDefiniteAnswer
+import com.daml.error.definitions.ErrorGroups.ParticipantErrorGroup.LedgerApiErrors
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.engine.{Error => LfError}
@@ -21,10 +14,9 @@ import com.daml.lf.language.LanguageVersion
 import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.{VersionRange, language}
 
-@Explanation(
-  "Errors raised during the command execution phase of the command submission evaluation."
-)
-object CommandExecution extends LedgerApiErrors.CommandExecutionErrorGroup {
+object CommandExecution {
+
+  import LedgerApiErrors.CommandExecution.errorClass
   @Explanation(
     """This error occurs if the participant fails to determine the max ledger time of the used
       |contracts. Most likely, this means that one of the contracts is not active anymore which can

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/ConsistencyErrors.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/ConsistencyErrors.scala
@@ -3,25 +3,18 @@
 
 package com.daml.error.definitions.groups
 
-import java.time.Instant
-
-import com.daml.error.definitions.{DamlErrorWithDefiniteAnswer, LedgerApiErrors}
-import com.daml.error.{
-  ContextualizedErrorLogger,
-  ErrorCategory,
-  ErrorCode,
-  ErrorResource,
-  Explanation,
-  Resolution,
-}
+import com.daml.error._
+import com.daml.error.definitions.DamlErrorWithDefiniteAnswer
+import com.daml.error.definitions.ErrorGroups.ParticipantErrorGroup.LedgerApiErrors
 import com.daml.ledger.participant.state.v2.ChangeId
 import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 
-@Explanation(
-  "Potential consistency errors raised due to race conditions during command submission or returned as submission rejections by the backing ledger."
-)
-object ConsistencyErrors extends LedgerApiErrors.ConsistencyErrors {
+import java.time.Instant
+
+object ConsistencyErrors {
+
+  import LedgerApiErrors.ConsistencyErrors.errorClass
 
   @Explanation("A command with the given command id has already been successfully processed.")
   @Resolution(

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/PartyManagementServiceErrorGroup.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/PartyManagementServiceErrorGroup.scala
@@ -3,17 +3,13 @@
 
 package com.daml.error.definitions.groups
 
-import com.daml.error.{
-  ContextualizedErrorLogger,
-  ErrorCategory,
-  ErrorCode,
-  ErrorResource,
-  Explanation,
-  Resolution,
-}
+import com.daml.error._
+import com.daml.error.definitions.ErrorGroups.ParticipantErrorGroup
 import com.daml.error.definitions.{DamlError, DamlErrorWithDefiniteAnswer}
 
-object PartyManagementServiceErrorGroup extends AdminServices.PartyManagementServiceErrorGroup {
+object PartyManagementServiceErrorGroup {
+
+  import ParticipantErrorGroup.LedgerApiErrors.AdminServices.PartyManagementServiceErrorGroup.errorClass
 
   @Explanation("There was an attempt to update a party using an invalid update request.")
   @Resolution(

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/RequestValidation.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/RequestValidation.scala
@@ -3,26 +3,19 @@
 
 package com.daml.error.definitions.groups
 
-import java.time.Duration
-
+import com.daml.error.definitions.ErrorGroups.ParticipantErrorGroup.LedgerApiErrors
 import com.daml.error.definitions.LedgerApiErrors.EarliestOffsetMetadataKey
-import com.daml.error.definitions.{DamlError, DamlErrorWithDefiniteAnswer, LedgerApiErrors}
-import com.daml.error.{
-  ContextualizedErrorLogger,
-  ErrorCategory,
-  ErrorCode,
-  ErrorGroup,
-  ErrorResource,
-  Explanation,
-  Resolution,
-}
+import com.daml.error.definitions.{DamlError, DamlErrorWithDefiniteAnswer}
+import com.daml.error._
 import com.daml.lf.data.Ref.{Identifier, PackageId}
 import com.daml.lf.language.{LookupError, Reference}
 
-@Explanation(
-  "Validation errors raised when evaluating requests in the Ledger API."
-)
-object RequestValidation extends LedgerApiErrors.RequestValidation {
+import java.time.Duration
+
+object RequestValidation {
+
+  import LedgerApiErrors.RequestValidation.errorClass
+
   object NotFound extends ErrorGroup() {
     @Explanation(
       "This rejection is given when a read request tries to access a package which does not exist on the ledger."

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/UserManagementServiceErrorGroup.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/UserManagementServiceErrorGroup.scala
@@ -3,17 +3,13 @@
 
 package com.daml.error.definitions.groups
 
+import com.daml.error._
+import com.daml.error.definitions.ErrorGroups.ParticipantErrorGroup
 import com.daml.error.definitions.{DamlError, DamlErrorWithDefiniteAnswer}
-import com.daml.error.{
-  ContextualizedErrorLogger,
-  ErrorCategory,
-  ErrorCode,
-  ErrorResource,
-  Explanation,
-  Resolution,
-}
 
-object UserManagementServiceErrorGroup extends AdminServices.UserManagementServiceErrorGroup {
+object UserManagementServiceErrorGroup {
+
+  import ParticipantErrorGroup.LedgerApiErrors.AdminServices.UserManagementServiceErrorGroup.errorClass
 
   @Explanation("There was an attempt to update a user using an invalid update request.")
   @Resolution(

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/WriteServiceRejections.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/WriteServiceRejections.scala
@@ -3,22 +3,15 @@
 
 package com.daml.error.definitions.groups
 
-import com.daml.error.definitions.{DamlErrorWithDefiniteAnswer, LedgerApiErrors}
-import com.daml.error.{
-  ContextualizedErrorLogger,
-  ErrorCategory,
-  ErrorCode,
-  ErrorGroup,
-  ErrorResource,
-  Explanation,
-  Resolution,
-}
+import com.daml.error._
+import com.daml.error.definitions.DamlErrorWithDefiniteAnswer
+import com.daml.error.definitions.ErrorGroups.ParticipantErrorGroup.LedgerApiErrors
 import com.daml.lf.transaction.GlobalKey
 
-@Explanation(
-  "Generic submission rejection errors returned by the backing ledger's write service."
-)
-object WriteServiceRejections extends LedgerApiErrors.WriteServiceRejections {
+object WriteServiceRejections {
+
+  import LedgerApiErrors.WriteServiceRejections.errorClass
+
   @Explanation("The submitting party has not been allocated.")
   @Resolution(
     "Check that the party identifier is correct, allocate the submitting party, " +


### PR DESCRIPTION
This is to avoid a deadlock during class initialization from two threads. See DPP-1303

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
