### PR TITLE
Fix eta-expansion warnings in /ledger [DPP-1281]

### DIFF
--- a/ledger/ledger-api-auth/src/test/suite/scala/com/digitalasset/ledger/api/auth/OngoingAuthorizationObserverSpec.scala
+++ b/ledger/ledger-api-auth/src/test/suite/scala/com/digitalasset/ledger/api/auth/OngoingAuthorizationObserverSpec.scala
@@ -50,7 +50,7 @@ class OngoingAuthorizationObserverSpec
         resolvedFromUser = true,
         applicationId = Some("some_user_id"),
       ),
-      nowF = clock.instant,
+      nowF = () => clock.instant,
       userManagementStore = mock[UserManagementStore],
       // This is also the user rights state refresh timeout
       userRightsCheckIntervalInSeconds = userRightsCheckIntervalInSeconds,
@@ -111,7 +111,7 @@ class OngoingAuthorizationObserverSpec
         applicationId = Some("some_user_id"),
         expiration = Some(clock.instant.plusSeconds(1)),
       ),
-      nowF = clock.instant,
+      nowF = () => clock.instant,
       userManagementStore = mock[UserManagementStore],
       userRightsCheckIntervalInSeconds = 10,
       akkaScheduler = mockScheduler,
@@ -154,7 +154,7 @@ class OngoingAuthorizationObserverSpec
         // the expiration claim will be invalid in the next second
         expiration = Some(expiration),
       ),
-      nowF = clock.instant,
+      nowF = () => clock.instant,
       userManagementStore = mock[UserManagementStore],
       userRightsCheckIntervalInSeconds = 10,
       akkaScheduler = mockScheduler,

--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
@@ -181,7 +181,7 @@ final class LedgerTestCasesRunner(
       }
   }
 
-  private def createActorSystem(): ActorSystem =
+  private def createActorSystem: ActorSystem =
     ActorSystem(classOf[LedgerTestCasesRunner].getSimpleName)
 
   private def runTestCases(
@@ -268,7 +268,7 @@ final class LedgerTestCasesRunner(
   ): Future[Vector[LedgerTestSummary]] = {
 
     val materializerResources =
-      ResourceOwner.forMaterializerDirectly(createActorSystem).acquire()
+      ResourceOwner.forMaterializerDirectly(() => createActorSystem).acquire()
 
     // When running the tests, explicitly use the materializer's execution context
     // The tests will then be executed on it instead of the implicit one -- which

--- a/ledger/participant-integration-api/src/main/scala/platform/DispatcherState.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/DispatcherState.scala
@@ -38,7 +38,7 @@ class DispatcherState(dispatcherShutdownTimeout: Duration)(implicit
 
   def getDispatcher: Dispatcher[Offset] = synchronized {
     dispatcherStateRef match {
-      case DispatcherStateShutdown | DispatcherNotRunning => throw dispatcherNotRunning()
+      case DispatcherStateShutdown | DispatcherNotRunning => throw dispatcherNotRunning
       case DispatcherRunning(dispatcher) => dispatcher
     }
   }
@@ -69,7 +69,7 @@ class DispatcherState(dispatcherShutdownTimeout: Duration)(implicit
       case DispatcherRunning(dispatcher) =>
         dispatcherStateRef = DispatcherNotRunning
         dispatcher
-          .cancel(dispatcherNotRunning)
+          .cancel(() => dispatcherNotRunning)
           .transform {
             case Success(_) =>
               logger.info(s"Active $ServiceName stopped.")
@@ -120,7 +120,7 @@ class DispatcherState(dispatcherShutdownTimeout: Duration)(implicit
       headAtInitialization = initializationOffset,
     )
 
-  private def dispatcherNotRunning(): StatusRuntimeException = {
+  private def dispatcherNotRunning: StatusRuntimeException = {
     val contextualizedErrorLogger = new DamlContextualizedErrorLogger(
       logger = logger,
       // TODO: Use request contextual LoggingContext once a correlation id can be provided


### PR DESCRIPTION
It fixes warnings of the form
```
ledger/participant-integration-api/src/main/scala/platform/DispatcherState.scala:72: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => Throwable), rather than applied to `()`.
```
They are triggered by inclusion of the `-Xlint:eta-zero` scalac flag