### PR TITLE
Fix non exhaustive matches in /ledger [DPP-1281]

### DIFF
--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/tls/TlsConfigurationTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/tls/TlsConfigurationTest.scala
@@ -10,12 +10,13 @@ import org.apache.commons.io.IOUtils
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
 import java.io.{File, InputStream}
 import java.net.ConnectException
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.security.Security
+
+import scala.annotation.nowarn
 
 class TlsConfigurationTest extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
@@ -35,7 +36,7 @@ class TlsConfigurationTest extends AnyWordSpec with Matchers with BeforeAndAfter
     List("server.crt", "server.pem", "ca.crt", "client.crt", "client.pem").map { src =>
       new File(rlocation("ledger/test-common/test-certificates/" + src))
     }
-  }
+  }: @nowarn("msg=match may not be exhaustive")
 
   println(clientCertChainFilePath)
   println(clientPrivateKeyFilePath)

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
@@ -398,11 +398,14 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
     for {
       _ <- ledger.create(alice, WithObservers(alice, Seq(alice, bob)))
       contracts <- ledger.activeContracts(alice)
-      Seq(ce) = contracts
-    } yield assert(
-      ce.observers == Seq(bob),
-      s"Expected observers to only contain $bob, but received ${ce.observers}",
-    )
+    } yield {
+      contracts.foreach(ce =>
+        assert(
+          ce.observers == Seq(bob),
+          s"Expected observers to only contain $bob, but received ${ce.observers}",
+        )
+      )
+    }
   })
 
   test(

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
@@ -399,6 +399,7 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
       _ <- ledger.create(alice, WithObservers(alice, Seq(alice, bob)))
       contracts <- ledger.activeContracts(alice)
     } yield {
+      assert(contracts.nonEmpty)
       contracts.foreach(ce =>
         assert(
           ce.observers == Seq(bob),

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/SemanticTests.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/SemanticTests.scala
@@ -310,9 +310,11 @@ final class SemanticTests extends LedgerTestSuite {
           .mustFail("fetching the offer with the wrong party")
 
         tree <- alpha.exercise(houseOwner, offer.exercisePaintOffer_Accept(iou))
-        (newIouEvent +: _, agreementEvent +: _) = createdEvents(tree).partition(
+        (newIouEvents, agreementEvents) = createdEvents(tree).partition(
           _.getTemplateId == Tag.unwrap(Iou.id)
         )
+        newIouEvent <- Future(newIouEvents.head)
+        agreementEvent <- Future(agreementEvents.head)
         newIou = Primitive.ContractId[Iou](newIouEvent.contractId)
         agreement = Primitive.ContractId[PaintAgree](agreementEvent.contractId)
         _ <- synchronize(alpha, beta)

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceStakeholdersIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceStakeholdersIT.scala
@@ -11,6 +11,7 @@ import com.daml.ledger.test.model.Test._
 import scalaz.Tag
 
 import scala.collection.immutable.Seq
+import scala.concurrent.Future
 
 class TransactionServiceStakeholdersIT extends LedgerTestSuite {
   test("TXStakeholders", "Expose the correct stakeholders", allocate(SingleParty, SingleParty))(
@@ -34,12 +35,10 @@ class TransactionServiceStakeholdersIT extends LedgerTestSuite {
   )(implicit ec => { case Participants(Participant(ledger, alice, bob)) =>
     for {
       _ <- ledger.create(alice, WithObservers(alice, Seq(alice, bob)))
-      flat <- ledger.flatTransactions(alice)
-      Seq(flatTx) = flat
-      Seq(flatWo) = createdEvents(flatTx)
-      tree <- ledger.transactionTrees(alice)
-      Seq(treeTx) = tree
-      Seq(treeWo) = createdEvents(treeTx)
+      flatTx <- ledger.flatTransactions(alice).flatMap(fs => Future(fs.head))
+      flatWo <- Future(createdEvents(flatTx).head)
+      treeTx <- ledger.transactionTrees(alice).flatMap(fs => Future(fs.head))
+      treeWo <- Future(createdEvents(treeTx).head)
     } yield {
       assert(
         flatWo.observers == Seq(bob),

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsCompletions.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsCompletions.scala
@@ -9,8 +9,6 @@ import org.scalatest.Inside
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.annotation.nowarn
-
 private[backend] trait StorageBackendTestsCompletions
     extends Matchers
     with Inside
@@ -95,12 +93,12 @@ private[backend] trait StorageBackendTestsCompletions
     )
 
     completions should have length 2
-    val List(completionWithSubmissionId, completionWithoutSubmissionId) =
-      completions: @nowarn("msg=match may not be exhaustive")
-    completionWithSubmissionId.completions should have length 1
-    completionWithSubmissionId.completions.head.submissionId should be(someSubmissionId)
-    completionWithoutSubmissionId.completions should have length 1
-    completionWithoutSubmissionId.completions.head.submissionId should be("")
+    inside(completions) { case List(completionWithSubmissionId, completionWithoutSubmissionId) =>
+      completionWithSubmissionId.completions should have length 1
+      completionWithSubmissionId.completions.head.submissionId should be(someSubmissionId)
+      completionWithoutSubmissionId.completions should have length 1
+      completionWithoutSubmissionId.completions.head.submissionId should be("")
+    }
   }
 
   it should "correctly persist and retrieve command deduplication offsets" in {
@@ -126,14 +124,15 @@ private[backend] trait StorageBackendTestsCompletions
     )
 
     completions should have length 2
-    val List(completionWithDeduplicationOffset, completionWithoutDeduplicationOffset) =
-      completions: @nowarn("msg=match may not be exhaustive")
-    completionWithDeduplicationOffset.completions should have length 1
-    completionWithDeduplicationOffset.completions.head.deduplicationPeriod.deduplicationOffset should be(
-      Some(anOffsetHex)
-    )
-    completionWithoutDeduplicationOffset.completions should have length 1
-    completionWithoutDeduplicationOffset.completions.head.deduplicationPeriod.deduplicationOffset should not be defined
+    inside(completions) {
+      case List(completionWithDeduplicationOffset, completionWithoutDeduplicationOffset) =>
+        completionWithDeduplicationOffset.completions should have length 1
+        completionWithDeduplicationOffset.completions.head.deduplicationPeriod.deduplicationOffset should be(
+          Some(anOffsetHex)
+        )
+        completionWithoutDeduplicationOffset.completions should have length 1
+        completionWithoutDeduplicationOffset.completions.head.deduplicationPeriod.deduplicationOffset should not be defined
+    }
   }
 
   it should "correctly persist and retrieve command deduplication durations" in {
@@ -167,14 +166,15 @@ private[backend] trait StorageBackendTestsCompletions
     )
 
     completions should have length 2
-    val List(completionWithDeduplicationOffset, completionWithoutDeduplicationOffset) =
-      completions: @nowarn("msg=match may not be exhaustive")
-    completionWithDeduplicationOffset.completions should have length 1
-    completionWithDeduplicationOffset.completions.head.deduplicationPeriod.deduplicationDuration should be(
-      Some(expectedDuration)
-    )
-    completionWithoutDeduplicationOffset.completions should have length 1
-    completionWithoutDeduplicationOffset.completions.head.deduplicationPeriod.deduplicationDuration should not be defined
+    inside(completions) {
+      case List(completionWithDeduplicationOffset, completionWithoutDeduplicationOffset) =>
+        completionWithDeduplicationOffset.completions should have length 1
+        completionWithDeduplicationOffset.completions.head.deduplicationPeriod.deduplicationDuration should be(
+          Some(expectedDuration)
+        )
+        completionWithoutDeduplicationOffset.completions should have length 1
+        completionWithoutDeduplicationOffset.completions.head.deduplicationPeriod.deduplicationDuration should not be defined
+    }
   }
 
   it should "fail on broken command deduplication durations in DB" in {

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsCompletions.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsCompletions.scala
@@ -9,6 +9,8 @@ import org.scalatest.Inside
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.annotation.nowarn
+
 private[backend] trait StorageBackendTestsCompletions
     extends Matchers
     with Inside
@@ -93,7 +95,8 @@ private[backend] trait StorageBackendTestsCompletions
     )
 
     completions should have length 2
-    val List(completionWithSubmissionId, completionWithoutSubmissionId) = completions
+    val List(completionWithSubmissionId, completionWithoutSubmissionId) =
+      completions: @nowarn("msg=match may not be exhaustive")
     completionWithSubmissionId.completions should have length 1
     completionWithSubmissionId.completions.head.submissionId should be(someSubmissionId)
     completionWithoutSubmissionId.completions should have length 1
@@ -124,7 +127,7 @@ private[backend] trait StorageBackendTestsCompletions
 
     completions should have length 2
     val List(completionWithDeduplicationOffset, completionWithoutDeduplicationOffset) =
-      completions
+      completions: @nowarn("msg=match may not be exhaustive")
     completionWithDeduplicationOffset.completions should have length 1
     completionWithDeduplicationOffset.completions.head.deduplicationPeriod.deduplicationOffset should be(
       Some(anOffsetHex)
@@ -165,7 +168,7 @@ private[backend] trait StorageBackendTestsCompletions
 
     completions should have length 2
     val List(completionWithDeduplicationOffset, completionWithoutDeduplicationOffset) =
-      completions
+      completions: @nowarn("msg=match may not be exhaustive")
     completionWithDeduplicationOffset.completions should have length 1
     completionWithDeduplicationOffset.completions.head.deduplicationPeriod.deduplicationDuration should be(
       Some(expectedDuration)

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsIngestion.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsIngestion.scala
@@ -10,6 +10,7 @@ import org.scalatest.{Inside, OptionValues}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.annotation.nowarn
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 import scala.util.Random
@@ -143,7 +144,7 @@ private[backend] trait StorageBackendTestsIngestion
   ) { connections =>
     import scala.concurrent.ExecutionContext.Implicits.global
 
-    val List(connection1, connection2) = connections
+    val List(connection1, connection2) = connections: @nowarn("msg=match may not be exhaustive")
     def packageFor(n: Int): DbDto.Package =
       dtoPackage(offset(n.toLong))
         .copy(

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionTreesSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionTreesSpec.scala
@@ -56,28 +56,28 @@ private[dao] trait JdbcLedgerDaoTransactionTreesSpec
         .lookupTransactionTreeById(tx.transactionId, tx.actAs.toSet)
     } yield {
       inside(result.value.transaction) { case Some(transaction) =>
-        val (nodeId, createNode: Node.Create) =
-          tx.transaction.nodes.head
-        transaction.commandId shouldBe tx.commandId.get
-        transaction.offset shouldBe ApiOffset.toApiString(offset)
-        TimestampConversion.toLf(
-          transaction.effectiveAt.value,
-          TimestampConversion.ConversionMode.Exact,
-        ) shouldBe tx.ledgerEffectiveTime
-        transaction.transactionId shouldBe tx.transactionId
-        transaction.workflowId shouldBe tx.workflowId.getOrElse("")
-        val created = transaction.eventsById.values.loneElement.getCreated
-        transaction.rootEventIds.loneElement shouldEqual created.eventId
-        created.eventId shouldBe EventId(tx.transactionId, nodeId).toLedgerString
-        created.witnessParties should contain only (tx.actAs: _*)
-        created.agreementText.getOrElse("") shouldBe createNode.agreementText
-        created.contractKey shouldBe None
-        created.createArguments shouldNot be(None)
-        created.signatories should contain theSameElementsAs createNode.signatories
-        created.observers should contain theSameElementsAs createNode.stakeholders.diff(
-          createNode.signatories
-        )
-        created.templateId shouldNot be(None)
+        inside(tx.transaction.nodes.headOption) { case Some((nodeId, createNode: Node.Create)) =>
+          transaction.commandId shouldBe tx.commandId.get
+          transaction.offset shouldBe ApiOffset.toApiString(offset)
+          TimestampConversion.toLf(
+            transaction.effectiveAt.value,
+            TimestampConversion.ConversionMode.Exact,
+          ) shouldBe tx.ledgerEffectiveTime
+          transaction.transactionId shouldBe tx.transactionId
+          transaction.workflowId shouldBe tx.workflowId.getOrElse("")
+          val created = transaction.eventsById.values.loneElement.getCreated
+          transaction.rootEventIds.loneElement shouldEqual created.eventId
+          created.eventId shouldBe EventId(tx.transactionId, nodeId).toLedgerString
+          created.witnessParties should contain only (tx.actAs: _*)
+          created.agreementText.getOrElse("") shouldBe createNode.agreementText
+          created.contractKey shouldBe None
+          created.createArguments shouldNot be(None)
+          created.signatories should contain theSameElementsAs createNode.signatories
+          created.observers should contain theSameElementsAs createNode.stakeholders.diff(
+            createNode.signatories
+          )
+          created.templateId shouldNot be(None)
+        }
       }
     }
   }
@@ -90,28 +90,29 @@ private[dao] trait JdbcLedgerDaoTransactionTreesSpec
         .lookupTransactionTreeById(exercise.transactionId, exercise.actAs.toSet)
     } yield {
       inside(result.value.transaction) { case Some(transaction) =>
-        val (nodeId, exerciseNode: Node.Exercise) =
-          exercise.transaction.nodes.head
-        transaction.commandId shouldBe exercise.commandId.get
-        transaction.offset shouldBe ApiOffset.toApiString(offset)
-        TimestampConversion.toLf(
-          transaction.effectiveAt.value,
-          TimestampConversion.ConversionMode.Exact,
-        ) shouldBe exercise.ledgerEffectiveTime
-        transaction.transactionId shouldBe exercise.transactionId
-        transaction.workflowId shouldBe exercise.workflowId.getOrElse("")
-        val exercised = transaction.eventsById.values.loneElement.getExercised
-        transaction.rootEventIds.loneElement shouldEqual exercised.eventId
-        exercised.eventId shouldBe EventId(transaction.transactionId, nodeId).toLedgerString
-        exercised.witnessParties should contain only (exercise.actAs: _*)
-        exercised.contractId shouldBe exerciseNode.targetCoid.coid
-        exercised.templateId shouldNot be(None)
-        exercised.actingParties should contain theSameElementsAs exerciseNode.actingParties
-        exercised.childEventIds shouldBe Seq.empty
-        exercised.choice shouldBe exerciseNode.choiceId
-        exercised.choiceArgument shouldNot be(None)
-        exercised.consuming shouldBe true
-        exercised.exerciseResult shouldNot be(None)
+        inside(exercise.transaction.nodes.headOption) {
+          case Some((nodeId, exerciseNode: Node.Exercise)) =>
+            transaction.commandId shouldBe exercise.commandId.get
+            transaction.offset shouldBe ApiOffset.toApiString(offset)
+            TimestampConversion.toLf(
+              transaction.effectiveAt.value,
+              TimestampConversion.ConversionMode.Exact,
+            ) shouldBe exercise.ledgerEffectiveTime
+            transaction.transactionId shouldBe exercise.transactionId
+            transaction.workflowId shouldBe exercise.workflowId.getOrElse("")
+            val exercised = transaction.eventsById.values.loneElement.getExercised
+            transaction.rootEventIds.loneElement shouldEqual exercised.eventId
+            exercised.eventId shouldBe EventId(transaction.transactionId, nodeId).toLedgerString
+            exercised.witnessParties should contain only (exercise.actAs: _*)
+            exercised.contractId shouldBe exerciseNode.targetCoid.coid
+            exercised.templateId shouldNot be(None)
+            exercised.actingParties should contain theSameElementsAs exerciseNode.actingParties
+            exercised.childEventIds shouldBe Seq.empty
+            exercised.choice shouldBe exerciseNode.choiceId
+            exercised.choiceArgument shouldNot be(None)
+            exercised.consuming shouldBe true
+            exercised.exerciseResult shouldNot be(None)
+        }
       }
     }
   }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
@@ -71,18 +71,18 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
         transaction.transactionId shouldBe tx.transactionId
         transaction.workflowId shouldBe tx.workflowId.getOrElse("")
         inside(transaction.events.loneElement.event.created) { case Some(created) =>
-          val (nodeId, createNode: Node.Create) =
-            tx.transaction.nodes.head
-          created.eventId shouldBe EventId(tx.transactionId, nodeId).toLedgerString
-          created.witnessParties should contain only (tx.actAs: _*)
-          created.agreementText.getOrElse("") shouldBe createNode.agreementText
-          created.contractKey shouldBe None
-          created.createArguments shouldNot be(None)
-          created.signatories should contain theSameElementsAs createNode.signatories
-          created.observers should contain theSameElementsAs createNode.stakeholders.diff(
-            createNode.signatories
-          )
-          created.templateId shouldNot be(None)
+          inside(tx.transaction.nodes.headOption) { case Some((nodeId, createNode: Node.Create)) =>
+            created.eventId shouldBe EventId(tx.transactionId, nodeId).toLedgerString
+            created.witnessParties should contain only (tx.actAs: _*)
+            created.agreementText.getOrElse("") shouldBe createNode.agreementText
+            created.contractKey shouldBe None
+            created.createArguments shouldNot be(None)
+            created.signatories should contain theSameElementsAs createNode.signatories
+            created.observers should contain theSameElementsAs createNode.stakeholders.diff(
+              createNode.signatories
+            )
+            created.templateId shouldNot be(None)
+          }
         }
       }
     }
@@ -105,12 +105,13 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
         ) shouldBe exercise.ledgerEffectiveTime
         transaction.workflowId shouldBe exercise.workflowId.getOrElse("")
         inside(transaction.events.loneElement.event.archived) { case Some(archived) =>
-          val (nodeId, exerciseNode: Node.Exercise) =
-            exercise.transaction.nodes.head
-          archived.eventId shouldBe EventId(transaction.transactionId, nodeId).toLedgerString
-          archived.witnessParties should contain only (exercise.actAs: _*)
-          archived.contractId shouldBe exerciseNode.targetCoid.coid
-          archived.templateId shouldNot be(None)
+          inside(exercise.transaction.nodes.headOption) {
+            case Some((nodeId, exerciseNode: Node.Exercise)) =>
+              archived.eventId shouldBe EventId(transaction.transactionId, nodeId).toLedgerString
+              archived.witnessParties should contain only (exercise.actAs: _*)
+              archived.contractId shouldBe exerciseNode.targetCoid.coid
+              archived.templateId shouldNot be(None)
+          }
         }
       }
     }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/meteringreport/HmacSha256Spec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/meteringreport/HmacSha256Spec.scala
@@ -7,8 +7,9 @@ import com.daml.platform.apiserver.meteringreport.HmacSha256.{Bytes, Key, genera
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import spray.json._
-
 import java.nio.charset.StandardCharsets
+
+import org.scalatest.Inside.inside
 
 class HmacSha256Spec extends AnyWordSpec with Matchers {
 
@@ -30,9 +31,10 @@ class HmacSha256Spec extends AnyWordSpec with Matchers {
     "compute MAC" in {
       val expected = "uFfrKWtNvoMl-GdCBrotl33cTFOqLeF8EjaooomUKOw="
       val key = MeteringReportKey.communityKey()
-      HmacSha256.compute(key, "some message".getBytes(StandardCharsets.UTF_8)).map { mac =>
-        val actual = toBase64(mac)
-        actual shouldBe expected
+      inside(HmacSha256.compute(key, "some message".getBytes(StandardCharsets.UTF_8))) {
+        case Right(mac) =>
+          val actual = toBase64(mac)
+          actual shouldBe expected
       }
     }
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/meteringreport/HmacSha256Spec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/meteringreport/HmacSha256Spec.scala
@@ -30,14 +30,15 @@ class HmacSha256Spec extends AnyWordSpec with Matchers {
     "compute MAC" in {
       val expected = "uFfrKWtNvoMl-GdCBrotl33cTFOqLeF8EjaooomUKOw="
       val key = MeteringReportKey.communityKey()
-      val Right(mac) = HmacSha256.compute(key, "some message".getBytes(StandardCharsets.UTF_8))
-      val actual = toBase64(mac)
-      actual shouldBe expected
+      HmacSha256.compute(key, "some message".getBytes(StandardCharsets.UTF_8)).map { mac =>
+        val actual = toBase64(mac)
+        actual shouldBe expected
+      }
     }
 
     "fail if key is invalid" in {
       val key = Key("invalid", Bytes(Array.empty), "")
-      val Left(_) = HmacSha256.compute(key, "some message".getBytes(StandardCharsets.UTF_8))
+      HmacSha256.compute(key, "some message".getBytes(StandardCharsets.UTF_8)).isLeft shouldBe true
     }
 
     "generate key" in {

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/meteringreport/MeteringReportGeneratorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/meteringreport/MeteringReportGeneratorSpec.scala
@@ -16,9 +16,10 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 import scalapb.json4s.JsonFormat
 import spray.json._
-
 import java.time.Duration
 import java.time.temporal.ChronoUnit
+
+import scala.annotation.nowarn
 
 class MeteringReportGeneratorSpec extends AsyncWordSpec with Matchers {
 
@@ -45,7 +46,9 @@ class MeteringReportGeneratorSpec extends AsyncWordSpec with Matchers {
       applications = Seq(ApplicationReport(appIdA, 4), ApplicationReport(appIdB, 2)),
       check = None,
     )
-    val Right(signedReport) = JcsSigner.sign(report, testKey)
+    val Right(signedReport) = JcsSigner.sign(report, testKey): @nowarn(
+      "msg=match may not be exhaustive"
+    )
     val json = signedReport.toJson.compactPrint
     val struct: Struct = JsonFormat.parser.fromJsonString[Struct](json)
     struct
@@ -67,7 +70,14 @@ class MeteringReportGeneratorSpec extends AsyncWordSpec with Matchers {
       )
 
       val Right(actual) =
-        underTest.generate(request, from, Some(to), Some(appIdX), reportData, generationTime)
+        underTest.generate(
+          request,
+          from,
+          Some(to),
+          Some(appIdX),
+          reportData,
+          generationTime,
+        ): @nowarn("msg=match may not be exhaustive")
 
       actual.meteringReportJson.get.fields
         .get("check") shouldBe expected.meteringReportJson.get.fields.get("check")

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/admin/ApiMeteringReportServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/admin/ApiMeteringReportServiceSpec.scala
@@ -16,9 +16,9 @@ import com.daml.platform.apiserver.services.admin.ApiMeteringReportService.toPro
 import org.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
-
 import java.time.temporal.ChronoUnit
 import java.time.{OffsetDateTime, ZoneOffset}
+
 import scala.concurrent.Future
 
 class ApiMeteringReportServiceSpec extends AsyncWordSpec with Matchers with MockitoSugar {
@@ -49,7 +49,7 @@ class ApiMeteringReportServiceSpec extends AsyncWordSpec with Matchers with Mock
 
       val request = GetMeteringReportRequest.defaultInstance.withFrom(toProtoTimestamp(from))
 
-      val Right(expected) =
+      val expected =
         new MeteringReportGenerator(someParticipantId, CommunityKey.key).generate(
           request,
           from,
@@ -63,7 +63,7 @@ class ApiMeteringReportServiceSpec extends AsyncWordSpec with Matchers with Mock
         .thenReturn(Future.successful(reportData))
 
       underTest.getMeteringReport(request).map { actual =>
-        actual shouldBe expected
+        expected.fold(_ => fail(), actual shouldBe _)
       }
 
     }
@@ -84,7 +84,7 @@ class ApiMeteringReportServiceSpec extends AsyncWordSpec with Matchers with Mock
         .withTo(toProtoTimestamp(to))
         .withApplicationId(appId)
 
-      val Right(expected) =
+      val expected =
         new MeteringReportGenerator(someParticipantId, CommunityKey.key).generate(
           request,
           from,
@@ -98,7 +98,7 @@ class ApiMeteringReportServiceSpec extends AsyncWordSpec with Matchers with Mock
         .thenReturn(Future.successful(reportData))
 
       underTest.getMeteringReport(request).map { actual =>
-        actual shouldBe expected
+        expected.fold(_ => fail(), actual shouldBe _)
       }
     }
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/ContractStoreBasedMaximumLedgerTimeServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/ContractStoreBasedMaximumLedgerTimeServiceSpec.scala
@@ -177,8 +177,7 @@ class ContractStoreBasedMaximumLedgerTimeServiceSpec extends AsyncFlatSpec with 
         contractId3,
         contractId4,
       )
-    ).map { result =>
-      val MaximumLedgerTime.Archived(archivedResults) = result
+    ).collect { case MaximumLedgerTime.Archived(archivedResults) =>
       archivedResults.size shouldBe 1
       val archivedResult = archivedResults.head
       Set(contractId1, contractId3) should contain(archivedResult)
@@ -198,8 +197,7 @@ class ContractStoreBasedMaximumLedgerTimeServiceSpec extends AsyncFlatSpec with 
         contractId3,
         contractId4,
       )
-    ).map { result =>
-      val MaximumLedgerTime.Archived(archivedResults) = result
+    ).collect { case MaximumLedgerTime.Archived(archivedResults) =>
       archivedResults.size shouldBe 1
       val archivedResult = archivedResults.head
       Set(contractId1, contractId2, contractId3, contractId4) should contain(archivedResult)
@@ -219,8 +217,7 @@ class ContractStoreBasedMaximumLedgerTimeServiceSpec extends AsyncFlatSpec with 
         contractId3,
         contractId4,
       )
-    ).map { result =>
-      val MaximumLedgerTime.Archived(archivedResults) = result
+    ).collect { case MaximumLedgerTime.Archived(archivedResults) =>
       archivedResults.size shouldBe 1
       val archivedResult = archivedResults.head
       Set(contractId1, contractId3) should contain(archivedResult)

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/ContractStoreBasedMaximumLedgerTimeServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/ContractStoreBasedMaximumLedgerTimeServiceSpec.scala
@@ -17,6 +17,7 @@ import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value.{ContractId, VersionedContractInstance}
 import com.daml.logging.LoggingContext
+import org.scalatest.Inside.inside
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -177,10 +178,12 @@ class ContractStoreBasedMaximumLedgerTimeServiceSpec extends AsyncFlatSpec with 
         contractId3,
         contractId4,
       )
-    ).collect { case MaximumLedgerTime.Archived(archivedResults) =>
-      archivedResults.size shouldBe 1
-      val archivedResult = archivedResults.head
-      Set(contractId1, contractId3) should contain(archivedResult)
+    ).map { result =>
+      inside(result) { case MaximumLedgerTime.Archived(archivedResults) =>
+        archivedResults.size shouldBe 1
+        val archivedResult = archivedResults.head
+        Set(contractId1, contractId3) should contain(archivedResult)
+      }
     }
   }
 
@@ -197,10 +200,12 @@ class ContractStoreBasedMaximumLedgerTimeServiceSpec extends AsyncFlatSpec with 
         contractId3,
         contractId4,
       )
-    ).collect { case MaximumLedgerTime.Archived(archivedResults) =>
-      archivedResults.size shouldBe 1
-      val archivedResult = archivedResults.head
-      Set(contractId1, contractId2, contractId3, contractId4) should contain(archivedResult)
+    ).map { result =>
+      inside(result) { case MaximumLedgerTime.Archived(archivedResults) =>
+        archivedResults.size shouldBe 1
+        val archivedResult = archivedResults.head
+        Set(contractId1, contractId2, contractId3, contractId4) should contain(archivedResult)
+      }
     }
   }
 
@@ -217,10 +222,12 @@ class ContractStoreBasedMaximumLedgerTimeServiceSpec extends AsyncFlatSpec with 
         contractId3,
         contractId4,
       )
-    ).collect { case MaximumLedgerTime.Archived(archivedResults) =>
-      archivedResults.size shouldBe 1
-      val archivedResult = archivedResults.head
-      Set(contractId1, contractId3) should contain(archivedResult)
+    ).map { result =>
+      inside(result) { case MaximumLedgerTime.Archived(archivedResults) =>
+        archivedResults.size shouldBe 1
+        val archivedResult = archivedResults.head
+        Set(contractId1, contractId3) should contain(archivedResult)
+      }
     }
   }
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/InMemoryFanoutBufferSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/InMemoryFanoutBufferSpec.scala
@@ -13,13 +13,13 @@ import com.daml.platform.store.cache.InMemoryFanoutBuffer.BufferSlice.LastBuffer
 import com.daml.platform.store.cache.InMemoryFanoutBuffer.{BufferSlice, UnorderedException}
 import com.daml.platform.store.interfaces.TransactionLogUpdate
 import com.daml.platform.store.interfaces.TransactionLogUpdate.CompletionDetails
+import org.scalatest.Inside.inside
 import org.scalatest.Succeeded
 import org.scalatest.compatible.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-import scala.annotation.nowarn
 import scala.collection.Searching.{Found, InsertionPoint}
 import scala.collection.{View, immutable}
 import scala.concurrent.duration.DurationInt
@@ -31,431 +31,446 @@ class InMemoryFanoutBufferSpec
     with ScalaCheckDrivenPropertyChecks {
   private val offsetIdx = Vector(2, 4, 6, 8, 10)
   private val BeginOffset = offset(0L)
-  private val offsets @ Seq(offset1, offset2, offset3, offset4, offset5) =
-    offsetIdx.map(i => offset(i.toLong)): @nowarn("msg=match may not be exhaustive")
+  private val offsets = offsetIdx.map(i => offset(i.toLong))
 
-  private val txAccepted1 = txAccepted(1L, offset1)
-  private val txAccepted2 = txAccepted(2L, offset2)
-  private val txAccepted3 = txAccepted(3L, offset3)
-  private val txAccepted4 = txAccepted(4L, offset4)
-  private val bufferValues = Seq(txAccepted1, txAccepted2, txAccepted3, txAccepted4)
-  private val txAccepted5 = txAccepted(5L, offset5)
-  private val bufferElements @ Seq(entry1, entry2, entry3, entry4) =
-    offsets.zip(bufferValues): @nowarn("msg=match may not be exhaustive")
-
-  private val LastOffset = offset4
   private val IdentityFilter: TransactionLogUpdate => Option[TransactionLogUpdate] = Some(_)
 
-  "push" when {
-    "max buffer size reached" should {
-      "drop oldest" in withBuffer(3) { buffer =>
-        // Assert data structure sizes
-        buffer._bufferLog.size shouldBe 3
-        buffer._lookupMap.size shouldBe 3
+  inside(offsets) { case Seq(offset1, offset2, offset3, offset4, offset5) =>
+    val txAccepted1 = txAccepted(1L, offset1)
+    val txAccepted2 = txAccepted(2L, offset2)
+    val txAccepted3 = txAccepted(3L, offset3)
+    val txAccepted4 = txAccepted(4L, offset4)
+    val bufferValues = Seq(txAccepted1, txAccepted2, txAccepted3, txAccepted4)
+    val txAccepted5 = txAccepted(5L, offset5)
+    val bufferElements = offsets.zip(bufferValues)
+    val LastOffset = offset4
 
-        buffer.slice(BeginOffset, LastOffset, IdentityFilter) shouldBe LastBufferChunkSuffix(
-          bufferedStartExclusive = offset2,
-          slice = Vector(entry3, entry4),
-        )
+    inside(bufferElements) { case Seq(entry1, entry2, entry3, entry4) =>
+      "push" when {
+        "max buffer size reached" should {
+          "drop oldest" in withBuffer(3) { buffer =>
+            // Assert data structure sizes
+            buffer._bufferLog.size shouldBe 3
+            buffer._lookupMap.size shouldBe 3
 
-        // Assert that all the entries are visible by lookup
-        verifyLookupPresent(buffer, txAccepted2, txAccepted3, txAccepted4)
+            buffer.slice(BeginOffset, LastOffset, IdentityFilter) shouldBe LastBufferChunkSuffix(
+              bufferedStartExclusive = offset2,
+              slice = Vector(entry3, entry4),
+            )
 
-        buffer.push(offset5, txAccepted5)
-        // Assert data structure sizes respect their limits after pushing a new element
-        buffer._bufferLog.size shouldBe 3
-        buffer._lookupMap.size shouldBe 3
+            // Assert that all the entries are visible by lookup
+            verifyLookupPresent(buffer, txAccepted2, txAccepted3, txAccepted4)
 
-        buffer.slice(BeginOffset, offset5, IdentityFilter) shouldBe LastBufferChunkSuffix(
-          bufferedStartExclusive = offset3,
-          slice = Vector(entry4, offset5 -> txAccepted5),
-        )
+            buffer.push(offset5, txAccepted5)
+            // Assert data structure sizes respect their limits after pushing a new element
+            buffer._bufferLog.size shouldBe 3
+            buffer._lookupMap.size shouldBe 3
 
-        // Assert that the new entry is visible by lookup
-        verifyLookupPresent(buffer, txAccepted5)
-        // Assert oldest entry is evicted
-        verifyLookupAbsent(buffer, txAccepted2.transactionId)
-      }
-    }
+            buffer.slice(BeginOffset, offset5, IdentityFilter) shouldBe LastBufferChunkSuffix(
+              bufferedStartExclusive = offset3,
+              slice = Vector(entry4, offset5 -> txAccepted5),
+            )
 
-    "element with smaller offset added" should {
-      "throw" in withBuffer(3) { buffer =>
-        intercept[UnorderedException[Int]] {
-          buffer.push(offset1, txAccepted2)
-        }.getMessage shouldBe s"Elements appended to the buffer should have strictly increasing offsets: $offset4 vs $offset1"
-      }
-    }
+            // Assert that the new entry is visible by lookup
+            verifyLookupPresent(buffer, txAccepted5)
+            // Assert oldest entry is evicted
+            verifyLookupAbsent(buffer, txAccepted2.transactionId)
+          }
+        }
 
-    "element with equal offset added" should {
-      "throw" in withBuffer(3) { buffer =>
-        intercept[UnorderedException[Int]] {
-          buffer.push(offset4, txAccepted2)
-        }.getMessage shouldBe s"Elements appended to the buffer should have strictly increasing offsets: $offset4 vs $offset4"
-      }
-    }
+        "element with smaller offset added" should {
+          "throw" in withBuffer(3) { buffer =>
+            intercept[UnorderedException[Int]] {
+              buffer.push(offset1, txAccepted2)
+            }.getMessage shouldBe s"Elements appended to the buffer should have strictly increasing offsets: $offset4 vs $offset1"
+          }
+        }
 
-    "maxBufferSize is 0" should {
-      "not enqueue the update" in withBuffer(0) { buffer =>
-        buffer.push(offset5, txAccepted5)
-        buffer.slice(BeginOffset, offset5, IdentityFilter) shouldBe LastBufferChunkSuffix(
-          bufferedStartExclusive = offset5,
-          slice = Vector.empty,
-        )
-        buffer._bufferLog shouldBe empty
-      }
-    }
+        "element with equal offset added" should {
+          "throw" in withBuffer(3) { buffer =>
+            intercept[UnorderedException[Int]] {
+              buffer.push(offset4, txAccepted2)
+            }.getMessage shouldBe s"Elements appended to the buffer should have strictly increasing offsets: $offset4 vs $offset4"
+          }
+        }
 
-    "maxBufferSize is -1" should {
-      "not enqueue the update" in withBuffer(-1) { buffer =>
-        buffer.push(offset5, txAccepted5)
-        buffer.slice(BeginOffset, offset5, IdentityFilter) shouldBe LastBufferChunkSuffix(
-          bufferedStartExclusive = offset5,
-          slice = Vector.empty,
-        )
-        buffer._bufferLog shouldBe empty
-      }
-    }
+        "maxBufferSize is 0" should {
+          "not enqueue the update" in withBuffer(0) { buffer =>
+            buffer.push(offset5, txAccepted5)
+            buffer.slice(BeginOffset, offset5, IdentityFilter) shouldBe LastBufferChunkSuffix(
+              bufferedStartExclusive = offset5,
+              slice = Vector.empty,
+            )
+            buffer._bufferLog shouldBe empty
+          }
+        }
 
-    s"does not update the lookupMap with ${TransactionLogUpdate.TransactionRejected.getClass.getSimpleName}" in withBuffer(
-      4
-    ) { buffer =>
-      // Assert that all the entries are visible by lookup
-      verifyLookupPresent(buffer, txAccepted1, txAccepted2, txAccepted3, txAccepted4)
+        "maxBufferSize is -1" should {
+          "not enqueue the update" in withBuffer(-1) { buffer =>
+            buffer.push(offset5, txAccepted5)
+            buffer.slice(BeginOffset, offset5, IdentityFilter) shouldBe LastBufferChunkSuffix(
+              bufferedStartExclusive = offset5,
+              slice = Vector.empty,
+            )
+            buffer._bufferLog shouldBe empty
+          }
+        }
 
-      // Enqueue a rejected transaction
-      buffer.push(offset5, txRejected(5L, offset5))
+        s"does not update the lookupMap with ${TransactionLogUpdate.TransactionRejected.getClass.getSimpleName}" in withBuffer(
+          4
+        ) { buffer =>
+          // Assert that all the entries are visible by lookup
+          verifyLookupPresent(buffer, txAccepted1, txAccepted2, txAccepted3, txAccepted4)
 
-      // Assert the last element is evicted on full buffer
-      verifyLookupAbsent(buffer, txAccepted1.transactionId)
+          // Enqueue a rejected transaction
+          buffer.push(offset5, txRejected(5L, offset5))
 
-      // Assert that the buffer does not include the rejected transaction
-      buffer._lookupMap should contain theSameElementsAs Map(
-        txAccepted2.transactionId -> txAccepted2,
-        txAccepted3.transactionId -> txAccepted3,
-        txAccepted4.transactionId -> txAccepted4,
-      )
-    }
-  }
+          // Assert the last element is evicted on full buffer
+          verifyLookupAbsent(buffer, txAccepted1.transactionId)
 
-  "slice" when {
-    "filters" in withBuffer() { buffer =>
-      buffer.slice(offset1, offset4, Some(_).filterNot(_ == entry3._2)) shouldBe BufferSlice
-        .Inclusive(
-          Vector(entry2, entry4)
-        )
-    }
-
-    "called with startExclusive gteq than the buffer start" should {
-      "return an Inclusive slice" in withBuffer() { buffer =>
-        buffer.slice(offset1, succ(offset3), IdentityFilter) shouldBe BufferSlice.Inclusive(
-          Vector(entry2, entry3)
-        )
-        buffer.slice(offset1, offset4, IdentityFilter) shouldBe BufferSlice.Inclusive(
-          Vector(entry2, entry3, entry4)
-        )
-        buffer.slice(succ(offset1), offset4, IdentityFilter) shouldBe BufferSlice.Inclusive(
-          Vector(entry2, entry3, entry4)
-        )
-      }
-
-      "return an Inclusive chunk result if resulting slice is bigger than maxFetchSize" in withBuffer(
-        maxFetchSize = 2
-      ) { buffer =>
-        buffer.slice(offset1, offset4, IdentityFilter) shouldBe BufferSlice.Inclusive(
-          Vector(entry2, entry3)
-        )
-      }
-    }
-
-    "called with endInclusive lteq startExclusive" should {
-      "return an empty Inclusive slice if startExclusive is gteq buffer start" in withBuffer() {
-        buffer =>
-          buffer.slice(offset1, offset1, IdentityFilter) shouldBe BufferSlice.Inclusive(
-            Vector.empty
+          // Assert that the buffer does not include the rejected transaction
+          buffer._lookupMap should contain theSameElementsAs Map(
+            txAccepted2.transactionId -> txAccepted2,
+            txAccepted3.transactionId -> txAccepted3,
+            txAccepted4.transactionId -> txAccepted4,
           )
-          buffer.slice(offset2, offset1, IdentityFilter) shouldBe BufferSlice.Inclusive(
-            Vector.empty
-          )
-      }
-      "return an empty LastBufferChunkSuffix slice if startExclusive is before buffer start" in withBuffer(
-        maxBufferSize = 2
-      ) { buffer =>
-        buffer.slice(offset1, offset1, IdentityFilter) shouldBe LastBufferChunkSuffix(
-          offset1,
-          Vector.empty,
-        )
-        buffer.slice(offset2, offset1, IdentityFilter) shouldBe LastBufferChunkSuffix(
-          offset1,
-          Vector.empty,
-        )
-      }
-    }
-
-    "called with startExclusive before the buffer start" should {
-      "return a LastBufferChunkSuffix slice" in withBuffer() { buffer =>
-        buffer.slice(Offset.beforeBegin, offset3, IdentityFilter) shouldBe LastBufferChunkSuffix(
-          offset1,
-          Vector(entry2, entry3),
-        )
-        buffer.slice(
-          Offset.beforeBegin,
-          succ(offset3),
-          IdentityFilter,
-        ) shouldBe LastBufferChunkSuffix(
-          offset1,
-          Vector(entry2, entry3),
-        )
+        }
       }
 
-      "return a the last filtered chunk as LastBufferChunkSuffix slice if resulting slice is bigger than maxFetchSize" in withBuffer(
-        maxFetchSize = 2
-      ) { buffer =>
-        buffer.slice(Offset.beforeBegin, offset4, IdentityFilter) shouldBe LastBufferChunkSuffix(
-          offset2,
-          Vector(entry3, entry4),
-        )
-      }
-    }
+      "slice" when {
+        "filters" in withBuffer() { buffer =>
+          buffer.slice(offset1, offset4, Some(_).filterNot(_ == entry3._2)) shouldBe BufferSlice
+            .Inclusive(
+              Vector(entry2, entry4)
+            )
+        }
 
-    "called after push from a different thread" should {
-      "always see the most recent updates" in withBuffer(1000, Vector.empty, maxFetchSize = 1000) {
-        buffer =>
-          (0 until 1000).foreach(idx => {
-            val updateOffset = offset(idx.toLong)
-            buffer.push(updateOffset, txAccepted(idx.toLong, updateOffset))
-          }) // fill buffer to max size
-
-          val pushExecutor, sliceExecutor =
-            ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(1))
-
-          (0 until 1000).foreach { idx =>
-            val expected = ((idx + 901) to (1000 + idx)).map(idx => {
-              val updateOffset = offset(idx.toLong)
-              updateOffset -> txAccepted(idx.toLong, updateOffset)
-            })
-
-            implicit val ec: ExecutionContextExecutorService = pushExecutor
-
-            Await.result(
-              // Simulate different thread accesses for push/slice
-              awaitable = {
-                val lastInsertedIdx = (1000 + idx).toLong
-                val updateOffset = offset(lastInsertedIdx)
-                for {
-                  _ <- Future(buffer.push(updateOffset, txAccepted(lastInsertedIdx, updateOffset)))(
-                    pushExecutor
-                  )
-                  _ <- Future(
-                    buffer.slice(
-                      offset((900 + idx).toLong),
-                      offset(lastInsertedIdx),
-                      IdentityFilter,
-                    )
-                  )(
-                    sliceExecutor
-                  )
-                    .map(_.slice should contain theSameElementsInOrderAs expected)(sliceExecutor)
-                } yield Succeeded
-              },
-              atMost = 1.seconds,
+        "called with startExclusive gteq than the buffer start" should {
+          "return an Inclusive slice" in withBuffer() { buffer =>
+            buffer.slice(offset1, succ(offset3), IdentityFilter) shouldBe BufferSlice.Inclusive(
+              Vector(entry2, entry3)
+            )
+            buffer.slice(offset1, offset4, IdentityFilter) shouldBe BufferSlice.Inclusive(
+              Vector(entry2, entry3, entry4)
+            )
+            buffer.slice(succ(offset1), offset4, IdentityFilter) shouldBe BufferSlice.Inclusive(
+              Vector(entry2, entry3, entry4)
             )
           }
-          Succeeded
+
+          "return an Inclusive chunk result if resulting slice is bigger than maxFetchSize" in withBuffer(
+            maxFetchSize = 2
+          ) { buffer =>
+            buffer.slice(offset1, offset4, IdentityFilter) shouldBe BufferSlice.Inclusive(
+              Vector(entry2, entry3)
+            )
+          }
+        }
+
+        "called with endInclusive lteq startExclusive" should {
+          "return an empty Inclusive slice if startExclusive is gteq buffer start" in withBuffer() {
+            buffer =>
+              buffer.slice(offset1, offset1, IdentityFilter) shouldBe BufferSlice.Inclusive(
+                Vector.empty
+              )
+              buffer.slice(offset2, offset1, IdentityFilter) shouldBe BufferSlice.Inclusive(
+                Vector.empty
+              )
+          }
+          "return an empty LastBufferChunkSuffix slice if startExclusive is before buffer start" in withBuffer(
+            maxBufferSize = 2
+          ) { buffer =>
+            buffer.slice(offset1, offset1, IdentityFilter) shouldBe LastBufferChunkSuffix(
+              offset1,
+              Vector.empty,
+            )
+            buffer.slice(offset2, offset1, IdentityFilter) shouldBe LastBufferChunkSuffix(
+              offset1,
+              Vector.empty,
+            )
+          }
+        }
+
+        "called with startExclusive before the buffer start" should {
+          "return a LastBufferChunkSuffix slice" in withBuffer() { buffer =>
+            buffer.slice(
+              Offset.beforeBegin,
+              offset3,
+              IdentityFilter,
+            ) shouldBe LastBufferChunkSuffix(
+              offset1,
+              Vector(entry2, entry3),
+            )
+            buffer.slice(
+              Offset.beforeBegin,
+              succ(offset3),
+              IdentityFilter,
+            ) shouldBe LastBufferChunkSuffix(
+              offset1,
+              Vector(entry2, entry3),
+            )
+          }
+
+          "return a the last filtered chunk as LastBufferChunkSuffix slice if resulting slice is bigger than maxFetchSize" in withBuffer(
+            maxFetchSize = 2
+          ) { buffer =>
+            buffer.slice(
+              Offset.beforeBegin,
+              offset4,
+              IdentityFilter,
+            ) shouldBe LastBufferChunkSuffix(
+              offset2,
+              Vector(entry3, entry4),
+            )
+          }
+        }
+
+        "called after push from a different thread" should {
+          "always see the most recent updates" in withBuffer(
+            1000,
+            Vector.empty,
+            maxFetchSize = 1000,
+          ) { buffer =>
+            (0 until 1000).foreach(idx => {
+              val updateOffset = offset(idx.toLong)
+              buffer.push(updateOffset, txAccepted(idx.toLong, updateOffset))
+            }) // fill buffer to max size
+
+            val pushExecutor, sliceExecutor =
+              ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(1))
+
+            (0 until 1000).foreach { idx =>
+              val expected = ((idx + 901) to (1000 + idx)).map(idx => {
+                val updateOffset = offset(idx.toLong)
+                updateOffset -> txAccepted(idx.toLong, updateOffset)
+              })
+
+              implicit val ec: ExecutionContextExecutorService = pushExecutor
+
+              Await.result(
+                // Simulate different thread accesses for push/slice
+                awaitable = {
+                  val lastInsertedIdx = (1000 + idx).toLong
+                  val updateOffset = offset(lastInsertedIdx)
+                  for {
+                    _ <- Future(
+                      buffer.push(updateOffset, txAccepted(lastInsertedIdx, updateOffset))
+                    )(
+                      pushExecutor
+                    )
+                    _ <- Future(
+                      buffer.slice(
+                        offset((900 + idx).toLong),
+                        offset(lastInsertedIdx),
+                        IdentityFilter,
+                      )
+                    )(
+                      sliceExecutor
+                    )
+                      .map(_.slice should contain theSameElementsInOrderAs expected)(sliceExecutor)
+                  } yield Succeeded
+                },
+                atMost = 1.seconds,
+              )
+            }
+            Succeeded
+          }
+        }
+      }
+
+      "prune" when {
+        "element found" should {
+          "prune inclusive" in withBuffer() { buffer =>
+            verifyLookupPresent(buffer, txAccepted1, txAccepted2, txAccepted3, txAccepted4)
+
+            buffer.prune(offset3)
+
+            buffer.slice(BeginOffset, LastOffset, IdentityFilter) shouldBe LastBufferChunkSuffix(
+              offset4,
+              bufferElements.drop(4),
+            )
+
+            verifyLookupAbsent(
+              buffer,
+              txAccepted1.transactionId,
+              txAccepted2.transactionId,
+              txAccepted3.transactionId,
+            )
+            verifyLookupPresent(buffer, txAccepted4)
+          }
+        }
+
+        "element not present" should {
+          "prune inclusive" in withBuffer() { buffer =>
+            verifyLookupPresent(buffer, txAccepted1, txAccepted2, txAccepted3, txAccepted4)
+
+            buffer.prune(offset(6))
+            buffer.slice(BeginOffset, LastOffset, IdentityFilter) shouldBe LastBufferChunkSuffix(
+              offset4,
+              bufferElements.drop(4),
+            )
+            verifyLookupAbsent(
+              buffer,
+              txAccepted1.transactionId,
+              txAccepted2.transactionId,
+              txAccepted3.transactionId,
+            )
+            verifyLookupPresent(buffer, txAccepted4)
+          }
+        }
+
+        "element before series" should {
+          "not prune" in withBuffer() { buffer =>
+            verifyLookupPresent(buffer, txAccepted1, txAccepted2, txAccepted3, txAccepted4)
+
+            buffer.prune(offset(1))
+            buffer.slice(BeginOffset, LastOffset, IdentityFilter) shouldBe LastBufferChunkSuffix(
+              offset1,
+              bufferElements.drop(1),
+            )
+
+            verifyLookupPresent(buffer, txAccepted1, txAccepted2, txAccepted3, txAccepted4)
+          }
+        }
+
+        "element after series" should {
+          "prune all" in withBuffer() { buffer =>
+            verifyLookupPresent(buffer, txAccepted1, txAccepted2, txAccepted3, txAccepted4)
+
+            buffer.prune(offset5)
+            buffer.slice(BeginOffset, LastOffset, IdentityFilter) shouldBe LastBufferChunkSuffix(
+              LastOffset,
+              Vector.empty,
+            )
+
+            verifyLookupAbsent(
+              buffer,
+              txAccepted1.transactionId,
+              txAccepted2.transactionId,
+              txAccepted3.transactionId,
+              txAccepted4.transactionId,
+            )
+          }
+        }
+
+        "one element in buffer" should {
+          "prune all" in withBuffer(1, Vector(offset(1) -> txAccepted2)) { buffer =>
+            verifyLookupPresent(buffer, txAccepted2)
+
+            buffer.prune(offset(1))
+            buffer.slice(BeginOffset, offset(1), IdentityFilter) shouldBe LastBufferChunkSuffix(
+              offset(1),
+              Vector.empty,
+            )
+
+            verifyLookupAbsent(buffer, txAccepted2.transactionId)
+          }
+        }
+      }
+
+      "flush" should {
+        "remove all entries from the buffer" in withBuffer(3) { buffer =>
+          verifyLookupPresent(buffer, txAccepted2, txAccepted3, txAccepted4)
+
+          buffer.slice(BeginOffset, LastOffset, IdentityFilter) shouldBe LastBufferChunkSuffix(
+            bufferedStartExclusive = offset2,
+            slice = Vector(entry3, entry4),
+          )
+
+          buffer.flush()
+
+          buffer._bufferLog shouldBe Vector.empty[(Offset, Int)]
+          buffer._lookupMap shouldBe Map.empty
+          buffer.slice(BeginOffset, LastOffset, IdentityFilter) shouldBe LastBufferChunkSuffix(
+            bufferedStartExclusive = LastOffset,
+            slice = Vector.empty,
+          )
+          verifyLookupAbsent(
+            buffer,
+            txAccepted2.transactionId,
+            txAccepted3.transactionId,
+            txAccepted4.transactionId,
+          )
+        }
+      }
+
+      "indexAfter" should {
+        "yield the index gt the searched entry" in {
+          InMemoryFanoutBuffer.indexAfter(InsertionPoint(3)) shouldBe 3
+          InMemoryFanoutBuffer.indexAfter(Found(3)) shouldBe 4
+        }
+      }
+
+      "filterAndChunkSlice" should {
+        "return an Inclusive result with filter" in {
+          val input = Vector(entry1, entry2, entry3, entry4).view
+
+          InMemoryFanoutBuffer.filterAndChunkSlice[TransactionLogUpdate](
+            sliceView = input,
+            filter = Option(_).filterNot(_ == entry2._2),
+            maxChunkSize = 3,
+          ) shouldBe Vector(entry1, entry3, entry4)
+
+          InMemoryFanoutBuffer.filterAndChunkSlice[TransactionLogUpdate](
+            sliceView = View.empty,
+            filter = Some(_),
+            maxChunkSize = 3,
+          ) shouldBe Vector.empty
+        }
+      }
+
+      "lastFilteredChunk" should {
+        val input = Vector(entry1, entry2, entry3, entry4)
+
+        "return a LastBufferChunkSuffix with the last maxChunkSize-sized chunk from the slice with filter" in {
+          InMemoryFanoutBuffer.lastFilteredChunk[TransactionLogUpdate](
+            bufferSlice = input,
+            filter = Option(_).filterNot(_ == entry2._2),
+            maxChunkSize = 1,
+          ) shouldBe LastBufferChunkSuffix(entry3._1, Vector(entry4))
+
+          InMemoryFanoutBuffer.lastFilteredChunk[TransactionLogUpdate](
+            bufferSlice = input,
+            filter = Option(_).filterNot(_ == entry2._2),
+            maxChunkSize = 2,
+          ) shouldBe LastBufferChunkSuffix(entry1._1, Vector(entry3, entry4))
+
+          InMemoryFanoutBuffer.lastFilteredChunk[TransactionLogUpdate](
+            bufferSlice = input,
+            filter = Option(_).filterNot(_ == entry2._2),
+            maxChunkSize = 3,
+          ) shouldBe LastBufferChunkSuffix(entry1._1, Vector(entry3, entry4))
+
+          InMemoryFanoutBuffer.lastFilteredChunk[TransactionLogUpdate](
+            bufferSlice = input,
+            filter = Some(_), // No filter
+            maxChunkSize = 4,
+          ) shouldBe LastBufferChunkSuffix(entry1._1, Vector(entry2, entry3, entry4))
+        }
+
+        "use the slice head as bufferedStartExclusive when filter yields an empty result slice" in {
+          InMemoryFanoutBuffer.lastFilteredChunk[TransactionLogUpdate](
+            bufferSlice = input,
+            filter = _ => None,
+            maxChunkSize = 2,
+          ) shouldBe LastBufferChunkSuffix(entry1._1, Vector.empty)
+        }
       }
     }
-  }
 
-  "prune" when {
-    "element found" should {
-      "prune inclusive" in withBuffer() { buffer =>
-        verifyLookupPresent(buffer, txAccepted1, txAccepted2, txAccepted3, txAccepted4)
-
-        buffer.prune(offset3)
-
-        buffer.slice(BeginOffset, LastOffset, IdentityFilter) shouldBe LastBufferChunkSuffix(
-          offset4,
-          bufferElements.drop(4),
-        )
-
-        verifyLookupAbsent(
-          buffer,
-          txAccepted1.transactionId,
-          txAccepted2.transactionId,
-          txAccepted3.transactionId,
-        )
-        verifyLookupPresent(buffer, txAccepted4)
-      }
-    }
-
-    "element not present" should {
-      "prune inclusive" in withBuffer() { buffer =>
-        verifyLookupPresent(buffer, txAccepted1, txAccepted2, txAccepted3, txAccepted4)
-
-        buffer.prune(offset(6))
-        buffer.slice(BeginOffset, LastOffset, IdentityFilter) shouldBe LastBufferChunkSuffix(
-          offset4,
-          bufferElements.drop(4),
-        )
-        verifyLookupAbsent(
-          buffer,
-          txAccepted1.transactionId,
-          txAccepted2.transactionId,
-          txAccepted3.transactionId,
-        )
-        verifyLookupPresent(buffer, txAccepted4)
-      }
-    }
-
-    "element before series" should {
-      "not prune" in withBuffer() { buffer =>
-        verifyLookupPresent(buffer, txAccepted1, txAccepted2, txAccepted3, txAccepted4)
-
-        buffer.prune(offset(1))
-        buffer.slice(BeginOffset, LastOffset, IdentityFilter) shouldBe LastBufferChunkSuffix(
-          offset1,
-          bufferElements.drop(1),
-        )
-
-        verifyLookupPresent(buffer, txAccepted1, txAccepted2, txAccepted3, txAccepted4)
-      }
-    }
-
-    "element after series" should {
-      "prune all" in withBuffer() { buffer =>
-        verifyLookupPresent(buffer, txAccepted1, txAccepted2, txAccepted3, txAccepted4)
-
-        buffer.prune(offset5)
-        buffer.slice(BeginOffset, LastOffset, IdentityFilter) shouldBe LastBufferChunkSuffix(
-          LastOffset,
-          Vector.empty,
-        )
-
-        verifyLookupAbsent(
-          buffer,
-          txAccepted1.transactionId,
-          txAccepted2.transactionId,
-          txAccepted3.transactionId,
-          txAccepted4.transactionId,
-        )
-      }
-    }
-
-    "one element in buffer" should {
-      "prune all" in withBuffer(1, Vector(offset(1) -> txAccepted2)) { buffer =>
-        verifyLookupPresent(buffer, txAccepted2)
-
-        buffer.prune(offset(1))
-        buffer.slice(BeginOffset, offset(1), IdentityFilter) shouldBe LastBufferChunkSuffix(
-          offset(1),
-          Vector.empty,
-        )
-
-        verifyLookupAbsent(buffer, txAccepted2.transactionId)
-      }
-    }
-  }
-
-  "flush" should {
-    "remove all entries from the buffer" in withBuffer(3) { buffer =>
-      verifyLookupPresent(buffer, txAccepted2, txAccepted3, txAccepted4)
-
-      buffer.slice(BeginOffset, LastOffset, IdentityFilter) shouldBe LastBufferChunkSuffix(
-        bufferedStartExclusive = offset2,
-        slice = Vector(entry3, entry4),
+    def withBuffer(
+        maxBufferSize: Int = 5,
+        elems: immutable.Vector[(Offset, TransactionLogUpdate)] = bufferElements,
+        maxFetchSize: Int = 10,
+    )(test: InMemoryFanoutBuffer => Assertion): Assertion = {
+      val buffer = new InMemoryFanoutBuffer(
+        maxBufferSize,
+        Metrics.ForTesting,
+        maxBufferedChunkSize = maxFetchSize,
       )
-
-      buffer.flush()
-
-      buffer._bufferLog shouldBe Vector.empty[(Offset, Int)]
-      buffer._lookupMap shouldBe Map.empty
-      buffer.slice(BeginOffset, LastOffset, IdentityFilter) shouldBe LastBufferChunkSuffix(
-        bufferedStartExclusive = LastOffset,
-        slice = Vector.empty,
-      )
-      verifyLookupAbsent(
-        buffer,
-        txAccepted2.transactionId,
-        txAccepted3.transactionId,
-        txAccepted4.transactionId,
-      )
+      elems.foreach { case (offset, event) => buffer.push(offset, event) }
+      test(buffer)
     }
-  }
-
-  "indexAfter" should {
-    "yield the index gt the searched entry" in {
-      InMemoryFanoutBuffer.indexAfter(InsertionPoint(3)) shouldBe 3
-      InMemoryFanoutBuffer.indexAfter(Found(3)) shouldBe 4
-    }
-  }
-
-  "filterAndChunkSlice" should {
-    "return an Inclusive result with filter" in {
-      val input = Vector(entry1, entry2, entry3, entry4).view
-
-      InMemoryFanoutBuffer.filterAndChunkSlice[TransactionLogUpdate](
-        sliceView = input,
-        filter = Option(_).filterNot(_ == entry2._2),
-        maxChunkSize = 3,
-      ) shouldBe Vector(entry1, entry3, entry4)
-
-      InMemoryFanoutBuffer.filterAndChunkSlice[TransactionLogUpdate](
-        sliceView = View.empty,
-        filter = Some(_),
-        maxChunkSize = 3,
-      ) shouldBe Vector.empty
-    }
-  }
-
-  "lastFilteredChunk" should {
-    val input = Vector(entry1, entry2, entry3, entry4)
-
-    "return a LastBufferChunkSuffix with the last maxChunkSize-sized chunk from the slice with filter" in {
-      InMemoryFanoutBuffer.lastFilteredChunk[TransactionLogUpdate](
-        bufferSlice = input,
-        filter = Option(_).filterNot(_ == entry2._2),
-        maxChunkSize = 1,
-      ) shouldBe LastBufferChunkSuffix(entry3._1, Vector(entry4))
-
-      InMemoryFanoutBuffer.lastFilteredChunk[TransactionLogUpdate](
-        bufferSlice = input,
-        filter = Option(_).filterNot(_ == entry2._2),
-        maxChunkSize = 2,
-      ) shouldBe LastBufferChunkSuffix(entry1._1, Vector(entry3, entry4))
-
-      InMemoryFanoutBuffer.lastFilteredChunk[TransactionLogUpdate](
-        bufferSlice = input,
-        filter = Option(_).filterNot(_ == entry2._2),
-        maxChunkSize = 3,
-      ) shouldBe LastBufferChunkSuffix(entry1._1, Vector(entry3, entry4))
-
-      InMemoryFanoutBuffer.lastFilteredChunk[TransactionLogUpdate](
-        bufferSlice = input,
-        filter = Some(_), // No filter
-        maxChunkSize = 4,
-      ) shouldBe LastBufferChunkSuffix(entry1._1, Vector(entry2, entry3, entry4))
-    }
-
-    "use the slice head as bufferedStartExclusive when filter yields an empty result slice" in {
-      InMemoryFanoutBuffer.lastFilteredChunk[TransactionLogUpdate](
-        bufferSlice = input,
-        filter = _ => None,
-        maxChunkSize = 2,
-      ) shouldBe LastBufferChunkSuffix(entry1._1, Vector.empty)
-    }
-  }
-
-  private def withBuffer(
-      maxBufferSize: Int = 5,
-      elems: immutable.Vector[(Offset, TransactionLogUpdate)] = bufferElements,
-      maxFetchSize: Int = 10,
-  )(test: InMemoryFanoutBuffer => Assertion): Assertion = {
-    val buffer = new InMemoryFanoutBuffer(
-      maxBufferSize,
-      Metrics.ForTesting,
-      maxBufferedChunkSize = maxFetchSize,
-    )
-    elems.foreach { case (offset, event) => buffer.push(offset, event) }
-    test(buffer)
   }
 
   private def offset(idx: Long): Offset = {

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/InMemoryFanoutBufferSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/InMemoryFanoutBufferSpec.scala
@@ -4,6 +4,7 @@
 package com.daml.platform.store.cache
 
 import java.util.concurrent.Executors
+
 import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
 import com.daml.ledger.offset.Offset
 import com.daml.lf.data.Time
@@ -18,6 +19,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
+import scala.annotation.nowarn
 import scala.collection.Searching.{Found, InsertionPoint}
 import scala.collection.{View, immutable}
 import scala.concurrent.duration.DurationInt
@@ -30,7 +32,7 @@ class InMemoryFanoutBufferSpec
   private val offsetIdx = Vector(2, 4, 6, 8, 10)
   private val BeginOffset = offset(0L)
   private val offsets @ Seq(offset1, offset2, offset3, offset4, offset5) =
-    offsetIdx.map(i => offset(i.toLong))
+    offsetIdx.map(i => offset(i.toLong)): @nowarn("msg=match may not be exhaustive")
 
   private val txAccepted1 = txAccepted(1L, offset1)
   private val txAccepted2 = txAccepted(2L, offset2)
@@ -39,7 +41,7 @@ class InMemoryFanoutBufferSpec
   private val bufferValues = Seq(txAccepted1, txAccepted2, txAccepted3, txAccepted4)
   private val txAccepted5 = txAccepted(5L, offset5)
   private val bufferElements @ Seq(entry1, entry2, entry3, entry4) =
-    offsets.zip(bufferValues)
+    offsets.zip(bufferValues): @nowarn("msg=match may not be exhaustive")
 
   private val LastOffset = offset4
   private val IdentityFilter: TransactionLogUpdate => Option[TransactionLogUpdate] = Some(_)

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/TransactionConversionSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/TransactionConversionSpec.scala
@@ -7,60 +7,57 @@ import com.daml.ledger.api.v1.event.{ArchivedEvent, CreatedEvent, Event}
 import com.daml.lf.transaction.test.TransactionBuilder
 import com.daml.lf.value.Value
 import com.daml.platform.store.dao.events.TransactionConversion.removeTransient
+import org.scalatest.Inside.inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.annotation.nowarn
-
 final class TransactionConversionSpec extends AnyWordSpec with Matchers {
-  private val List(contractId1, contractId2) = List.fill(2)(TransactionBuilder.newCid): @nowarn(
-    "msg=match may not be exhaustive"
-  )
-
-  private def create(contractId: Value.ContractId): Event =
-    Event.of(
-      Event.Event.Created(
-        CreatedEvent(
-          "",
-          contractId.coid,
-          None,
-          None,
-          None,
-          None,
-          Seq.empty,
-          Seq.empty,
-          Seq.empty,
-          Seq.empty,
-          None,
+  inside(List.fill(2)(TransactionBuilder.newCid)) { case List(contractId1, contractId2) =>
+    def create(contractId: Value.ContractId): Event =
+      Event.of(
+        Event.Event.Created(
+          CreatedEvent(
+            "",
+            contractId.coid,
+            None,
+            None,
+            None,
+            None,
+            Seq.empty,
+            Seq.empty,
+            Seq.empty,
+            Seq.empty,
+            None,
+          )
         )
       )
+
+    val create1 = create(contractId1)
+    val create2 = create(contractId2)
+    val archive1 = Event.of(
+      Event.Event.Archived(ArchivedEvent("", contractId1.coid, None, Seq.empty))
     )
 
-  private val create1 = create(contractId1)
-  private val create2 = create(contractId2)
-  private val archive1 = Event.of(
-    Event.Event.Archived(ArchivedEvent("", contractId1.coid, None, Seq.empty))
-  )
+    "removeTransient" should {
 
-  "removeTransient" should {
+      "remove Created and Archived events for the same contract from the transaction" in {
+        removeTransient(Vector(create1, archive1)) shouldEqual Nil
+      }
 
-    "remove Created and Archived events for the same contract from the transaction" in {
-      removeTransient(Vector(create1, archive1)) shouldEqual Nil
-    }
+      "do not touch events with different contract identifiers" in {
+        val events = Vector(create2, archive1)
+        removeTransient(events) shouldBe events
+      }
 
-    "do not touch events with different contract identifiers" in {
-      val events = Vector(create2, archive1)
-      removeTransient(events) shouldBe events
-    }
+      "do not touch individual Created events" in {
+        val events = Vector(create1)
+        removeTransient(events) shouldEqual events
+      }
 
-    "do not touch individual Created events" in {
-      val events = Vector(create1)
-      removeTransient(events) shouldEqual events
-    }
-
-    "do not touch individual Archived events" in {
-      val events = Vector(archive1)
-      removeTransient(events) shouldEqual events
+      "do not touch individual Archived events" in {
+        val events = Vector(archive1)
+        removeTransient(events) shouldEqual events
+      }
     }
   }
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/TransactionConversionSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/TransactionConversionSpec.scala
@@ -10,8 +10,12 @@ import com.daml.platform.store.dao.events.TransactionConversion.removeTransient
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.annotation.nowarn
+
 final class TransactionConversionSpec extends AnyWordSpec with Matchers {
-  private val List(contractId1, contractId2) = List.fill(2)(TransactionBuilder.newCid)
+  private val List(contractId1, contractId2) = List.fill(2)(TransactionBuilder.newCid): @nowarn(
+    "msg=match may not be exhaustive"
+  )
 
   private def create(contractId: Value.ContractId): Event =
     Event.of(

--- a/ledger/sandbox-on-x/src/test/it/scala/com/daml/ledger/platform/sandbox/EngineModeIT.scala
+++ b/ledger/sandbox-on-x/src/test/it/scala/com/daml/ledger/platform/sandbox/EngineModeIT.scala
@@ -29,7 +29,6 @@ import org.scalatest.wordspec.AsyncWordSpec
 import java.nio.file.{Files, Path, Paths}
 import java.util.UUID
 
-import scala.annotation.nowarn
 import scala.util.{Failure, Success}
 
 class EngineModeIT
@@ -40,13 +39,6 @@ class EngineModeIT
     with SandboxFixture {
   private[this] implicit val esf: ExecutionSequencerFactory =
     new SingleThreadExecutionSequencerPool("testSequencerPool")
-
-  private[this] val List(maxStableVersion, previewVersion, devVersion) =
-    List(
-      LanguageVersion.StableVersions.max,
-      LanguageVersion.EarlyAccessVersions.max,
-      LanguageVersion.DevVersions.max,
-    ): @nowarn("msg=match may not be exhaustive")
 
   private[this] val applicationId = ApplicationId("EngineModeIT")
 
@@ -150,21 +142,28 @@ class EngineModeIT
           }
         }
 
-    accept(maxStableVersion, LanguageVersion.StableVersions, "stable")
-    accept(maxStableVersion, LanguageVersion.EarlyAccessVersions, "early access")
-    accept(maxStableVersion, LanguageVersion.DevVersions, "dev")
+    inside(
+      List(
+        LanguageVersion.StableVersions.max,
+        LanguageVersion.EarlyAccessVersions.max,
+        LanguageVersion.DevVersions.max,
+      )
+    ) { case List(maxStableVersion, previewVersion, devVersion) =>
+      accept(maxStableVersion, LanguageVersion.StableVersions, "stable")
+      accept(maxStableVersion, LanguageVersion.EarlyAccessVersions, "early access")
+      accept(maxStableVersion, LanguageVersion.DevVersions, "dev")
 
-    if (LanguageVersion.EarlyAccessVersions != LanguageVersion.StableVersions) {
-      // a preview version is currently available
-      reject(previewVersion, LanguageVersion.StableVersions, "stable")
-      accept(previewVersion, LanguageVersion.EarlyAccessVersions, "early access")
-      accept(previewVersion, LanguageVersion.DevVersions, "dev")
+      if (LanguageVersion.EarlyAccessVersions != LanguageVersion.StableVersions) {
+        // a preview version is currently available
+        reject(previewVersion, LanguageVersion.StableVersions, "stable")
+        accept(previewVersion, LanguageVersion.EarlyAccessVersions, "early access")
+        accept(previewVersion, LanguageVersion.DevVersions, "dev")
+      }
+
+      reject(devVersion, LanguageVersion.StableVersions, "stable")
+      reject(devVersion, LanguageVersion.EarlyAccessVersions, "early access")
+      accept(devVersion, LanguageVersion.DevVersions, "dev")
     }
-
-    reject(devVersion, LanguageVersion.StableVersions, "stable")
-    reject(devVersion, LanguageVersion.EarlyAccessVersions, "early access")
-    accept(devVersion, LanguageVersion.DevVersions, "dev")
-
   }
 
 }

--- a/ledger/sandbox-on-x/src/test/it/scala/com/daml/ledger/platform/sandbox/EngineModeIT.scala
+++ b/ledger/sandbox-on-x/src/test/it/scala/com/daml/ledger/platform/sandbox/EngineModeIT.scala
@@ -26,9 +26,10 @@ import com.google.protobuf
 import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
-
 import java.nio.file.{Files, Path, Paths}
 import java.util.UUID
+
+import scala.annotation.nowarn
 import scala.util.{Failure, Success}
 
 class EngineModeIT
@@ -45,7 +46,7 @@ class EngineModeIT
       LanguageVersion.StableVersions.max,
       LanguageVersion.EarlyAccessVersions.max,
       LanguageVersion.DevVersions.max,
-    )
+    ): @nowarn("msg=match may not be exhaustive")
 
   private[this] val applicationId = ApplicationId("EngineModeIT")
 

--- a/ledger/sandbox-on-x/src/test/it/scala/com/daml/ledger/platform/sandbox/TlsIT.scala
+++ b/ledger/sandbox-on-x/src/test/it/scala/com/daml/ledger/platform/sandbox/TlsIT.scala
@@ -20,22 +20,18 @@ import com.daml.platform.sandbox.fixture.SandboxFixture
 import org.scalatest.wordspec.AsyncWordSpec
 import java.io.File
 
-import scala.annotation.nowarn
 import scala.concurrent.Future
 
 class TlsIT extends AsyncWordSpec with SandboxFixture with SuiteResourceManagementAroundAll {
 
-  private val List(
-    certChainFilePath,
-    privateKeyFilePath,
-    trustCertCollectionFilePath,
-    clientCertChainFilePath,
-    clientPrivateKeyFilePath,
-  ) = {
-    List("server.crt", "server.pem", "ca.crt", "client.crt", "client.pem").map { src =>
-      new File(rlocation("ledger/test-common/test-certificates/" + src))
-    }
-  }: @nowarn("msg=match may not be exhaustive")
+  private def getFilePath(fileName: String) = new File(
+    rlocation("ledger/test-common/test-certificates/" + fileName)
+  )
+  private val certChainFilePath = getFilePath("server.crt")
+  private val privateKeyFilePath = getFilePath("server.pem")
+  private val trustCertCollectionFilePath = getFilePath("ca.crt")
+  private val clientCertChainFilePath = getFilePath("client.crt")
+  private val clientPrivateKeyFilePath = getFilePath("client.pem")
 
   private lazy val baseConfig: LedgerClientConfiguration =
     LedgerClientConfiguration(

--- a/ledger/sandbox-on-x/src/test/it/scala/com/daml/ledger/platform/sandbox/TlsIT.scala
+++ b/ledger/sandbox-on-x/src/test/it/scala/com/daml/ledger/platform/sandbox/TlsIT.scala
@@ -18,8 +18,9 @@ import com.daml.ledger.client.configuration.{
 import com.daml.ledger.sandbox.SandboxOnXForTest.{ApiServerConfig, singleParticipant}
 import com.daml.platform.sandbox.fixture.SandboxFixture
 import org.scalatest.wordspec.AsyncWordSpec
-
 import java.io.File
+
+import scala.annotation.nowarn
 import scala.concurrent.Future
 
 class TlsIT extends AsyncWordSpec with SandboxFixture with SuiteResourceManagementAroundAll {
@@ -34,7 +35,7 @@ class TlsIT extends AsyncWordSpec with SandboxFixture with SuiteResourceManageme
     List("server.crt", "server.pem", "ca.crt", "client.crt", "client.pem").map { src =>
       new File(rlocation("ledger/test-common/test-certificates/" + src))
     }
-  }
+  }: @nowarn("msg=match may not be exhaustive")
 
   private lazy val baseConfig: LedgerClientConfiguration =
     LedgerClientConfiguration(

--- a/ledger/sandbox-on-x/src/test/it/scala/com/daml/ledger/platform/sandbox/services/configuration/LedgerConfigurationServiceIT.scala
+++ b/ledger/sandbox-on-x/src/test/it/scala/com/daml/ledger/platform/sandbox/services/configuration/LedgerConfigurationServiceIT.scala
@@ -23,16 +23,17 @@ sealed trait LedgerConfigurationServiceITBase extends AnyWordSpec with Matchers 
   "LedgerConfigurationService" when {
     "asked for ledger configuration" should {
       "return expected configuration" in {
-        val LedgerConfiguration(Some(maxDeduplicationDuration)) =
-          LedgerConfigurationServiceGrpc
-            .blockingStub(channel)
-            .getLedgerConfiguration(GetLedgerConfigurationRequest(ledgerId().unwrap))
-            .next()
-            .getLedgerConfiguration
-
-        maxDeduplicationDuration shouldEqual toProto(
-          BridgeConfig.DefaultMaximumDeduplicationDuration
-        )
+        LedgerConfigurationServiceGrpc
+          .blockingStub(channel)
+          .getLedgerConfiguration(GetLedgerConfigurationRequest(ledgerId().unwrap))
+          .next()
+          .getLedgerConfiguration match {
+          case LedgerConfiguration(Some(maxDeduplicationDuration)) =>
+            maxDeduplicationDuration shouldEqual toProto(
+              BridgeConfig.DefaultMaximumDeduplicationDuration
+            )
+          case _ => fail()
+        }
       }
     }
   }

--- a/ledger/sandbox-on-x/src/test/lib/scala/com/daml/platform/sandbox/BaseTlsServerIT.scala
+++ b/ledger/sandbox-on-x/src/test/lib/scala/com/daml/platform/sandbox/BaseTlsServerIT.scala
@@ -22,8 +22,9 @@ import io.netty.handler.ssl.ClientAuth
 import org.scalatest.Assertion
 import org.scalatest.exceptions.ModifiableMessage
 import org.scalatest.wordspec.AsyncWordSpec
-
 import java.io.File
+
+import scala.annotation.nowarn
 import scala.concurrent.Future
 
 abstract class BaseTlsServerIT(minimumServerProtocolVersion: Option[TlsVersion])
@@ -78,7 +79,7 @@ abstract class BaseTlsServerIT(minimumServerProtocolVersion: Option[TlsVersion])
     List("server.crt", "server.pem", "ca.crt", "client.crt", "client.pem").map { src =>
       new File(rlocation("ledger/test-common/test-certificates/" + src))
     }
-  }
+  }: @nowarn("msg=match may not be exhaustive")
 
   override protected def config: Config =
     super.config.copy(

--- a/ledger/sandbox-on-x/src/test/lib/scala/com/daml/platform/sandbox/BaseTlsServerIT.scala
+++ b/ledger/sandbox-on-x/src/test/lib/scala/com/daml/platform/sandbox/BaseTlsServerIT.scala
@@ -24,7 +24,6 @@ import org.scalatest.exceptions.ModifiableMessage
 import org.scalatest.wordspec.AsyncWordSpec
 import java.io.File
 
-import scala.annotation.nowarn
 import scala.concurrent.Future
 
 abstract class BaseTlsServerIT(minimumServerProtocolVersion: Option[TlsVersion])
@@ -69,17 +68,14 @@ abstract class BaseTlsServerIT(minimumServerProtocolVersion: Option[TlsVersion])
       throw new IllegalArgumentException(s"Not test cases found for TLS version: |${other}|!")
   }
 
-  protected val List(
-    certChainFilePath,
-    privateKeyFilePath,
-    trustCertCollectionFilePath,
-    clientCertChainFilePath,
-    clientPrivateKeyFilePath,
-  ) = {
-    List("server.crt", "server.pem", "ca.crt", "client.crt", "client.pem").map { src =>
-      new File(rlocation("ledger/test-common/test-certificates/" + src))
-    }
-  }: @nowarn("msg=match may not be exhaustive")
+  private def getFilePath(fileName: String) = new File(
+    rlocation("ledger/test-common/test-certificates/" + fileName)
+  )
+  private val certChainFilePath = getFilePath("server.crt")
+  private val privateKeyFilePath = getFilePath("server.pem")
+  private val trustCertCollectionFilePath = getFilePath("ca.crt")
+  private val clientCertChainFilePath = getFilePath("client.crt")
+  private val clientPrivateKeyFilePath = getFilePath("client.pem")
 
   override protected def config: Config =
     super.config.copy(


### PR DESCRIPTION
It fixes the warnings of the form
```
ledger/sandbox-on-x/src/test/it/scala/com/daml/ledger/platform/sandbox/EngineModeIT.scala:44: warning: match may not be exhaustive.
```
They stem from turning on the `-Xlint:valpattern` scalac flag