### PR TITLE
Deduplication flake: allow inflight-request error

### DIFF
--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
@@ -69,13 +69,41 @@ object Assertions {
     assertSameElements(actual, Seq.empty)
   }
 
-  def assertGrpcErrorOneOf(t: Throwable, errors: ErrorCode*): Unit = {
-    val hasErrorCode = errors.map(errorCode => Try(assertGrpcError(t, errorCode, None))).exists {
-      case Success(_) => true
-      case _ => false
+  case class ExtendedAsserts(
+      exceptionMessageSubstring: Option[String] = None,
+      checkDefiniteAnswerMetadata: Boolean = false,
+      additionalErrorAssertions: Throwable => Unit = _ => (),
+  )
+
+  def assertGrpcErrorOneOf(
+      t: Throwable,
+      extendedChecks: Option[ExtendedAsserts],
+      errors: ErrorCode*
+  ): Unit = {
+    errors.map(errorCode => (errorCode, Try(assertGrpcError(t, errorCode, None)))).collectFirst {
+      case (errorCode, Success(_)) => errorCode
+    } match {
+      case Some(matchedErrorCode) =>
+        // In order to catch errors related to the "extended checks" rerun the check on the matching error code.
+        // This results in a more specific error message if one of the error codes matches, but the other checks fail.
+        extendedChecks.foreach {
+          case ExtendedAsserts(
+                exceptionMessageSubstring,
+                checkDefiniteAnswerMetadata,
+                additionalErrorAssertions,
+              ) =>
+            assertGrpcError(
+              t,
+              matchedErrorCode,
+              exceptionMessageSubstring,
+              checkDefiniteAnswerMetadata,
+              additionalErrorAssertions,
+            )
+        }
+
+      case None =>
+        fail(s"gRPC failure did not contain one of the expected error codes $errors.", t)
     }
-    if (hasErrorCode) ()
-    else fail(s"gRPC failure did not contain one of the expected error codes $errors.", t)
   }
 
   def assertGrpcError(

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ConfigManagementServiceIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ConfigManagementServiceIT.scala
@@ -165,6 +165,7 @@ final class ConfigManagementServiceIT extends LedgerTestSuite {
       )
       assertGrpcErrorOneOf(
         failure,
+        extendedChecks = None,
         LedgerApiErrors.Admin.ConfigurationEntryRejected,
         LedgerApiErrors.RequestValidation.InvalidArgument,
         KvErrors.Consistency.PostExecutionConflicts,


### PR DESCRIPTION
In rare situations a canton participant returns a SUBMISSION_ALREADY_IN_FLIGHT error instead of DUPLICATE_COMMAND due to a possible race condition between publishing the TransactionAccepted read service update and updating internal in-flight transactions. Particularly in Oracle runs this can result in a subsequence "duplicate" command to still be considered in-flight.

Extended the tests to also accept the "in-flight" error code.

Changelog_begin
Changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
