### PR TITLE
Fix flaky gRPC server metrics test

### DIFF
--- a/ledger/metrics/src/test/suite/scala/com/daml/metrics/grpc/GrpcMetricsServerInterceptorSpec.scala
+++ b/ledger/metrics/src/test/suite/scala/com/daml/metrics/grpc/GrpcMetricsServerInterceptorSpec.scala
@@ -12,6 +12,7 @@ import com.daml.metrics.grpc.GrpcMetricsServerInterceptorSpec.TestingGrpcMetrics
 import com.daml.platform.hello.{HelloRequest, HelloResponse, HelloServiceGrpc}
 import com.daml.platform.testing.StreamConsumer
 import com.google.protobuf.ByteString
+import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -20,7 +21,8 @@ class GrpcMetricsServerInterceptorSpec
     with Matchers
     with AkkaBeforeAndAfterAll
     with TestResourceContext
-    with MetricValues {
+    with MetricValues
+    with Eventually {
 
   private val labelsForSimpleRequest = MetricsContext(
     Map(
@@ -45,9 +47,11 @@ class GrpcMetricsServerInterceptorSpec
     val metrics = new TestingGrpcMetrics
     withService(metrics).use { helloService =>
       helloService.single(new HelloRequest()).map { _ =>
-        metrics.callTimer.countsWithContext should contain theSameElementsAs Map(
-          labelsForSimpleRequestWithStatusCode -> 1
-        )
+        eventually {
+          metrics.callTimer.countsWithContext should contain theSameElementsAs Map(
+            labelsForSimpleRequestWithStatusCode -> 1
+          )
+        }
       }
     }
   }
@@ -56,12 +60,14 @@ class GrpcMetricsServerInterceptorSpec
     val metrics = new TestingGrpcMetrics
     withService(metrics).use { helloService =>
       helloService.single(new HelloRequest()).map { _ =>
-        metrics.callsStarted.valuesWithContext should contain theSameElementsAs Map(
-          labelsForSimpleRequest -> 1
-        )
-        metrics.callsHandled.valuesWithContext should contain theSameElementsAs Map(
-          labelsForSimpleRequestWithStatusCode -> 1
-        )
+        eventually {
+          metrics.callsStarted.valuesWithContext should contain theSameElementsAs Map(
+            labelsForSimpleRequest -> 1
+          )
+          metrics.callsHandled.valuesWithContext should contain theSameElementsAs Map(
+            labelsForSimpleRequestWithStatusCode -> 1
+          )
+        }
       }
     }
   }
@@ -82,13 +88,15 @@ class GrpcMetricsServerInterceptorSpec
             metricsContext -> value
           )
         }
-        meterHasValueForStreaming(metrics.callsStarted)
-        meterHasValueForStreaming(
-          metrics.callsHandled,
-          withStreamingLabels(labelsForSimpleRequestWithStatusCode),
-        )
-        meterHasValueForStreaming(metrics.messagesSent, value = 3)
-        meterHasValueForStreaming(metrics.messagesReceived)
+        eventually {
+          meterHasValueForStreaming(metrics.callsStarted)
+          meterHasValueForStreaming(
+            metrics.callsHandled,
+            withStreamingLabels(labelsForSimpleRequestWithStatusCode),
+          )
+          meterHasValueForStreaming(metrics.messagesSent, value = 3)
+          meterHasValueForStreaming(metrics.messagesReceived)
+        }
       }
     }
   }
@@ -99,12 +107,14 @@ class GrpcMetricsServerInterceptorSpec
       val payload = ByteString.copyFromUtf8("test message")
       val request = new HelloRequest(payload = payload)
       helloService.single(request).map { response =>
-        metrics.messagesSentSize.valuesWithContext should contain theSameElementsAs Map(
-          labelsForSimpleRequest -> Seq(request.serializedSize)
-        )
-        metrics.messagesReceivedSize.valuesWithContext should contain theSameElementsAs Map(
-          labelsForSimpleRequest -> Seq(response.serializedSize)
-        )
+        eventually {
+          metrics.messagesSentSize.valuesWithContext should contain theSameElementsAs Map(
+            labelsForSimpleRequest -> Seq(request.serializedSize)
+          )
+          metrics.messagesReceivedSize.valuesWithContext should contain theSameElementsAs Map(
+            labelsForSimpleRequest -> Seq(response.serializedSize)
+          )
+        }
       }
     }
   }


### PR DESCRIPTION
The assertions are wrapped in an `eventually` because we first call the `delegate` methods (eg: using `super.close`) and only afterwards we record the metrics. This means that metric recording does not impact the call before we respond, but it also means that there's a tiny delay between returning the answer and the metrics actually getting updated.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
