### PR TITLE
Ensure git tags are fetched in job 'compatibility_stable_protobuf'

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -329,6 +329,7 @@ jobs:
     demands: assignment -equals default
   steps:
     - checkout: self
+      fetchTags: true
     - bash: ci/check-protobuf-stability.sh
     - template: tell-slack-failed.yml
 


### PR DESCRIPTION
Done by setting 'fetchTags: true' in the 'checkout' step before running the bash script
