### PR TITLE
Ensure high level triggers project their user state

### DIFF
--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -866,7 +866,7 @@ class Runner(
 
 object Runner extends StrictLogging {
 
-  def triggerUserState(state: SValue, level: Trigger.Level): SValue = {
+  private def triggerUserState(state: SValue, level: Trigger.Level): SValue = {
     level match {
       case Trigger.Level.High =>
         state


### PR DESCRIPTION
Currently, trigger logging prints the raw `SValue` state. For high level triggers this means that the ACS will be logged! This PR ensures the user state is projected from high level trigger state.

This PR has been cherry picked from https://github.com/digital-asset/daml/pull/15564

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
