### PR TITLE
gsg: hack around our tests to solve Node 18 support

### DIFF
--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -33,7 +33,7 @@ Make sure that you have the Daml SDK, Java 11 or higher, and Visual Studio Code 
 
 You will also need some common software tools to build and interact with the template project:
 
-- `Node <https://nodejs.org/en/>`_ and the associated package manager ``npm``. Use the `Active LTS <https://nodejs.org/en/about/releases/>`_ Node version, currently ``v16`` (check with ``node --version``). If you have another version, see `this link <https://docs.npmjs.com/downloading-and-installing-node-js-and-npm>`_ for additional installation options. 
+- `Node <https://nodejs.org/en/>`_ and the associated package manager ``npm``. This guide has been tested against Node 18.
 - A terminal application for command line interaction.
 
 

--- a/docs/source/getting-started/testing.rst
+++ b/docs/source/getting-started/testing.rst
@@ -18,7 +18,7 @@ Of course there are more to choose from, but this is one combination that works.
 To install Puppeteer and some other testing utilities we are going to use,
 run the following command in the ``ui`` directory::
 
-    npm add --only=dev puppeteer@18.2.1 wait-on @types/jest @types/node @types/puppeteer @types/wait-on
+    npm i --save-dev puppeteer@~18.1.0 wait-on@~6.0.1 @types/jest@~29.2.3 @types/node@~18.11.9 @types/puppeteer@~7.0.4 @types/wait-on@~5.3.1
 
 Because these things are easier to describe with concrete examples, this
 section will show how to set up end-to-end tests for the application you would

--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -96,6 +96,9 @@ genrule(
 
         ## special cases we should work to remove
 
+        # hack around our super inconvenient test harness for gsg tests
+        sed -i 's|react-scripts start|react-scripts --openssl-legacy-provider start|' "$$OUT/create-daml-app/ui/package.json.template"
+
         # quickstart-java template
         tar xf $(location //docs:quickstart-java.tar.gz) --strip-components=1 -C $$OUT/quickstart-java
 


### PR DESCRIPTION
This is a bit of a tricky one. This is obviously a grosshack that means we don't test what we ship. But, I think it's worth the hack, because:

- I really think this should be part of 2.5.0.
- Our users are tripping on this all the time. We've gotten to the point where even our internal testers are tripping on this as our windows VMs now come with Node 18 installed. Recent versions of macOS even exhibit the issue on Node 16.
- It's ok if we don' test this as part of our automated tests because this specifically is tested by our manual tests.
- I am not planning to stop working on a proper fix, but it's complicated. The tests don't seem to run on macOS at all on CI, the version of Nix we're currently using does not even include Node 18, and includes an old-enough version of Node 16 that the cli flag is not yet supported on it. So it's a bit of a long road.

Testing:

1. Run `daml-sdk-head` on this branch.
2. `cd $(mktemp -d); daml-head new --template=create-daml-app t`.
3. Check that `t/ui/package.json` has the expected change on line 19.
4. `cd t; daml build; daml codegen js`
5. Edit `ui/package.json` to point the daml-js libraries to `2.4.0` instead of `0.0.0`.
5. `npm install; npm start`