### PR TITLE
Mandatory config options in trigger service docs

### DIFF
--- a/docs/source/tools/trigger-service/index.rst
+++ b/docs/source/tools/trigger-service/index.rst
@@ -33,15 +33,15 @@ alongside a few annotations with regards to the meaning of the configuration key
 .. code-block:: none
 
     {
-      // Mandatory. Paths to the DAR files containing the code executed by the trigger.
+      // Paths to the DAR files containing the code executed by the trigger.
       dar-paths = [
         "./my-app.dar"
       ]
 
-      // Mandatory. Host address that the Trigger Service listens on. Defaults to 127.0.0.1.
+      // Host address that the Trigger Service listens on. Defaults to 127.0.0.1.
       address = "127.0.0.1"
 
-      // Mandatory. Trigger Service port number. Defaults to 8088.
+      // Trigger Service port number. Defaults to 8088.
       // A port number of 0 will let the system pick an ephemeral port.
       port = 8088
       // Optional. If using 0 as the port number, consider specifying the path to a `port-file` where the chosen port will be saved in textual format.


### PR DESCRIPTION
I found during testing related to support ticket 00003571, that the only necessary configuration option to define in the configuration file for the trigger service is the ledger-api section.

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
