### PR TITLE
Trigger service runner reports starting twice

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
@@ -128,7 +128,7 @@ object TriggerRunnerImpl {
               // Report to the server that this trigger is entering
               // the running state.
               config.server ! Server.TriggerStarted(triggerInstance)
-              logger.info(s"Trigger $name is starting")
+              logger.info(s"Trigger $name is running")
               running(killSwitch)
             } catch {
               case cause: Throwable =>


### PR DESCRIPTION
I believe the trigger service runner is meant to report running the second time.

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
