### PR TITLE
Add pre-commit config and install hook in dev-env

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,3 +3,6 @@ eval "$(dev-env/bin/dade assist)"
 
 # Load private overrides
 [[ -f .envrc.private ]] && source_env .envrc.private
+
+# install pre-commit hook (opt-out by setting `DADE_NO_PRE_COMMIT`)
+[ -v DADE_NO_PRE_COMMIT ] || pre-commit install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,47 @@
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+repos:
+- repo: local
+  hooks:
+    - id: hlint
+      name: hlint
+      language: system
+      entry: "hlint -j"
+      require_serial: true
+      types: [haskell]
+    - id: scalafmt
+      name: scalafmt
+      language: system
+      require_serial: true
+      entry: "scalafmt --respect-project-filters"
+      types: [scala]
+    - id: javafmt
+      name: javafmt
+      language: system
+      require_serial: true
+      entry: "javafmt --set-exit-if-changed --replace"
+      types: [java]
+    - id: buildifier
+      name: buildifier
+      language: system
+      require_serial: true
+      entry: "bazel run //:buildifier-fix"
+      types: [bazel]
+    - id: pprettier
+      name: pprettier
+      language: system
+      require_serial: true
+      entry: "bash -c 'yarn install --silent && yarn run pprettier --write \"$@\"'"
+      types: [ts]
+    - id: copyrights
+      name: copyright headers
+      description: Idempotently add DA copyright headers to source files.
+      language: system
+      pass_filenames: false
+      entry: "dade-copyright-headers update"
+      types: [text]
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       name: buildifier
       language: system
       require_serial: true
-      entry: "bazel run //:buildifier-fix"
+      entry: "bazel run //:buildifier-pre-commit -- -mode=fix -v=true"
       types: [bazel]
     - id: pprettier
       name: pprettier

--- a/BUILD
+++ b/BUILD
@@ -243,6 +243,19 @@ buildifier(
     verbose = True,
 )
 
+# Run by the git pre-commit hook
+genrule(
+    name = "buildifier-pre-commit",
+    outs = ["buildifier-hook"],
+    cmd = """cat <<'EOF' > "$@"
+# !/usr/bin/env bash
+exec "$(execpath @com_github_bazelbuild_buildtools//buildifier)" "$$@"
+EOF
+""",
+    executable = True,
+    tools = ["@com_github_bazelbuild_buildtools//buildifier"],
+)
+
 # Default target for da-ghci, da-ghcid.
 da_haskell_repl(
     name = "repl",

--- a/dev-env/bin/pre-commit
+++ b/dev-env/bin/pre-commit
@@ -1,0 +1,1 @@
+../lib/dade-exec-nix-tool

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -122,6 +122,8 @@ in rec {
     pex = pkgs.python38Packages.pex;
     pipenv = pkgs.pipenv;
 
+    pre-commit = pkgs.pre-commit;
+ 
     sphinx-build      = sphinx;
     sphinx-quickstart = sphinx;
 

--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,7 @@ pkgs.mkShell {
   buildInputs = pkgs.lib.attrsets.mapAttrsToList (name: value: value) default.toolAttrs;
 
   shellHook = ''
-    pre-commit install
+    # install pre-commit hook (opt-out by setting `DADE_NO_PRE_COMMIT`)
+    [ -v DADE_NO_PRE_COMMIT ] || pre-commit install
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -3,4 +3,8 @@
 }:
 pkgs.mkShell {
   buildInputs = pkgs.lib.attrsets.mapAttrsToList (name: value: value) default.toolAttrs;
+
+  shellHook = ''
+    pre-commit install
+  '';
 }


### PR DESCRIPTION
This PR adds a [pre-commit](https://pre-commit.com/) configuration for

* javafmt
* scalafmt
* hlint
* buildifier
* pprettier
* copyright header check

Fixes #15522

_Note_: all of these checks only run on the files to be committed (during the pre-commit hook), except the "copyright header check" which always runs on *all* files if any text file has been changed. This could be improved, by making the `dade-copyright-headers` tool accept a list of files to update and not always scan all files. However, running the tool currently takes ~0.2s wall time.

edit: ~Unfortunately, the buildifier task also runs on all files every time. See https://github.com/bazelbuild/buildtools/issues/1067~

Example output:
```console
$ git commit -m "Test"
hlint................................................(no files to check)Skipped
scalafmt.............................................(no files to check)Skipped
javafmt..............................................(no files to check)Skipped
buildifier...........................................(no files to check)Skipped
pprettier............................................(no files to check)Skipped
copyright headers........................................................Passed
[pre-commit eadbeef] Test
 1 file changed, 6 insertions(+)
```
