### PR TITLE
Trigger LF default set to 1.15

### DIFF
--- a/daml-lf/language/daml-lf.bzl
+++ b/daml-lf/language/daml-lf.bzl
@@ -56,7 +56,7 @@ versions = struct(
 
 lf_version_configuration = {
     "legacy": "1.8",
-    "default": "1.14",
+    "default": "1.15",
     "latest": "1.15",
     #    "preview": "",
     "dev": "1.dev",
@@ -93,10 +93,10 @@ LF_VERSIONS = [
     "1.dev",
 ]
 
-PROTO_LF_VERSIONS = [ver for ver in LF_VERSIONS if versions.gte(ver, "1.14")]
+PROTO_LF_VERSIONS = [ver for ver in LF_VERSIONS if versions.gte(ver, "1.15")]
 
 # The subset of LF versions accepted by the compiler in the syntax
 # expected by the --target option.
-COMPILER_LF_VERSIONS = [ver for ver in LF_VERSIONS if versions.gte(ver, "1.14")]
+COMPILER_LF_VERSIONS = [ver for ver in LF_VERSIONS if versions.gte(ver, "1.15")]
 
 LF_MAJOR_VERSIONS = ["1"]


### PR DESCRIPTION
Modify trigger LF default to be version 1.15.

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
