### PR TITLE
Align gRPC and HTTP metric naming [PLEN-56]

### DIFF
--- a/ledger/metrics/src/test/lib/scala/com/daml/metrics/api/testing/MetricValues.scala
+++ b/ledger/metrics/src/test/lib/scala/com/daml/metrics/api/testing/MetricValues.scala
@@ -80,13 +80,6 @@ trait MetricValues {
         throw new IllegalArgumentException(s"Snapshot not supported for $other")
     }
 
-    def valuesWithContext: Map[MetricsContext, Seq[Long]] = histogram match {
-      case histogram: InMemoryHistogram =>
-        histogram.values.toMap
-      case other =>
-        throw new IllegalArgumentException(s"Values not supported for $other")
-    }
-
     def values: Seq[Long] = histogram match {
       case histogram: InMemoryHistogram =>
         singleValueFromContexts(histogram.values.toMap)
@@ -94,6 +87,15 @@ trait MetricValues {
         throw new IllegalArgumentException(s"Values not supported for $other")
     }
 
+    def valuesWithContext: Map[MetricsContext, Seq[Long]] = histogram match {
+      case histogram: InMemoryHistogram =>
+        histogram.values.toMap
+      case other =>
+        throw new IllegalArgumentException(s"Values not supported for $other")
+    }
+
+    def valuesFilteredOnLabels(labelFilters: LabelFilter*): Seq[Long] =
+      singleValueFromContextsFilteredOnLabels(valuesWithContext, labelFilters: _*)
   }
 
   class TimerValues(timer: Timer) {

--- a/observability/akka-http-metrics/src/main/scala/com/daml/metrics/http/DamlHttpMetrics.scala
+++ b/observability/akka-http-metrics/src/main/scala/com/daml/metrics/http/DamlHttpMetrics.scala
@@ -3,7 +3,7 @@
 
 package com.daml.metrics.http
 
-import com.daml.metrics.api.MetricHandle.{Factory, Meter, Timer}
+import com.daml.metrics.api.MetricHandle.{Factory, Histogram, Meter, Timer}
 import com.daml.metrics.api.{MetricName, MetricsContext}
 
 class DamlHttpMetrics(metricsFactory: Factory, component: String) extends HttpMetrics {
@@ -15,11 +15,10 @@ class DamlHttpMetrics(metricsFactory: Factory, component: String) extends HttpMe
   )
 
   override val requestsTotal: Meter = metricsFactory.meter(httpMetricsPrefix :+ "requests")
-  override val errorsTotal: Meter = metricsFactory.meter(httpMetricsPrefix :+ "errors")
   override val latency: Timer = metricsFactory.timer(httpMetricsPrefix :+ "requests")
-  override val requestsPayloadBytesTotal: Meter =
-    metricsFactory.meter(httpMetricsPrefix :+ "requests" :+ "payload" :+ "bytes")
-  override val responsesPayloadBytesTotal: Meter =
-    metricsFactory.meter(httpMetricsPrefix :+ "responses" :+ "payload" :+ "bytes")
+  override val requestsPayloadBytes: Histogram =
+    metricsFactory.histogram(httpMetricsPrefix :+ "requests" :+ "payload" :+ Histogram.Bytes)
+  override val responsesPayloadBytes: Histogram =
+    metricsFactory.histogram(httpMetricsPrefix :+ "responses" :+ "payload" :+ Histogram.Bytes)
 
 }

--- a/observability/akka-http-metrics/src/main/scala/com/daml/metrics/http/DamlWebSocketMetrics.scala
+++ b/observability/akka-http-metrics/src/main/scala/com/daml/metrics/http/DamlWebSocketMetrics.scala
@@ -3,7 +3,7 @@
 
 package com.daml.metrics.http
 
-import com.daml.metrics.api.MetricHandle.{Factory, Meter}
+import com.daml.metrics.api.MetricHandle.{Factory, Histogram, Meter}
 import com.daml.metrics.api.{MetricName, MetricsContext}
 
 class DamlWebSocketMetrics(metricsFactory: Factory, component: String) extends WebSocketMetrics {
@@ -16,11 +16,15 @@ class DamlWebSocketMetrics(metricsFactory: Factory, component: String) extends W
 
   override val messagesReceivedTotal: Meter =
     metricsFactory.meter(httpMetricsPrefix :+ "websocket" :+ "messages" :+ "received")
-  override val messagesReceivedBytesTotal: Meter =
-    metricsFactory.meter(httpMetricsPrefix :+ "websocket" :+ "messages" :+ "received" :+ "bytes")
+  override val messagesReceivedBytes: Histogram =
+    metricsFactory.histogram(
+      httpMetricsPrefix :+ "websocket" :+ "messages" :+ "received" :+ Histogram.Bytes
+    )
   override val messagesSentTotal: Meter =
     metricsFactory.meter(httpMetricsPrefix :+ "websocket" :+ "messages" :+ "sent")
-  override val messagesSentBytesTotal: Meter =
-    metricsFactory.meter(httpMetricsPrefix :+ "websocket" :+ "messages" :+ "sent" :+ "bytes")
+  override val messagesSentBytes: Histogram =
+    metricsFactory.histogram(
+      httpMetricsPrefix :+ "websocket" :+ "messages" :+ "sent" :+ Histogram.Bytes
+    )
 
 }

--- a/observability/akka-http-metrics/src/main/scala/com/daml/metrics/http/HttpMetrics.scala
+++ b/observability/akka-http-metrics/src/main/scala/com/daml/metrics/http/HttpMetrics.scala
@@ -3,12 +3,11 @@
 
 package com.daml.metrics.http
 
-import com.daml.metrics.api.MetricHandle.{Meter, Timer}
+import com.daml.metrics.api.MetricHandle.{Histogram, Meter, Timer}
 
 trait HttpMetrics {
   val requestsTotal: Meter
-  val errorsTotal: Meter
   val latency: Timer
-  val requestsPayloadBytesTotal: Meter
-  val responsesPayloadBytesTotal: Meter
+  val requestsPayloadBytes: Histogram
+  val responsesPayloadBytes: Histogram
 }

--- a/observability/akka-http-metrics/src/main/scala/com/daml/metrics/http/WebSocketMetrics.scala
+++ b/observability/akka-http-metrics/src/main/scala/com/daml/metrics/http/WebSocketMetrics.scala
@@ -3,11 +3,11 @@
 
 package com.daml.metrics.http
 
-import com.daml.metrics.api.MetricHandle.Meter
+import com.daml.metrics.api.MetricHandle.{Histogram, Meter}
 
 trait WebSocketMetrics {
   val messagesReceivedTotal: Meter
-  val messagesReceivedBytesTotal: Meter
+  val messagesReceivedBytes: Histogram
   val messagesSentTotal: Meter
-  val messagesSentBytesTotal: Meter
+  val messagesSentBytes: Histogram
 }

--- a/observability/akka-http-metrics/src/test/suite/scala/com/daml/metrics/akkahttp/WebSocketMetricsInterceptorSpec.scala
+++ b/observability/akka-http-metrics/src/test/suite/scala/com/daml/metrics/akkahttp/WebSocketMetricsInterceptorSpec.scala
@@ -8,7 +8,7 @@ import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.util.ByteString
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.metrics.akkahttp.AkkaUtils._
-import com.daml.metrics.api.MetricHandle.Meter
+import com.daml.metrics.api.MetricHandle.{Histogram, Meter}
 import com.daml.metrics.api.testing.{InMemoryMetricsFactory, MetricValues}
 import com.daml.metrics.api.{MetricName, MetricsContext}
 import com.daml.metrics.http.WebSocketMetrics
@@ -68,19 +68,19 @@ class WebSocketMetricsInterceptorSpec
 
   "websocket_message_received_total" should {
     "count passing strict text messages" in {
-      checkCountThroughFlow(strictTextMessage, getMessagesReceivedTotalValue, 1)
+      checkCountThroughFlow(strictTextMessage, getMessagesReceivedTotalValue, 1L)
     }
 
     "count passing streamed text messages" in {
-      checkCountThroughFlow(streamedTextMessage, getMessagesReceivedTotalValue, 1)
+      checkCountThroughFlow(streamedTextMessage, getMessagesReceivedTotalValue, 1L)
     }
 
     "count passing strict binary messages" in {
-      checkCountThroughFlow(strictBinaryMessage, getMessagesReceivedTotalValue, 1)
+      checkCountThroughFlow(strictBinaryMessage, getMessagesReceivedTotalValue, 1L)
     }
 
     "count passing streamed binary messages" in {
-      checkCountThroughFlow(streamedBinaryMessage, getMessagesReceivedTotalValue, 1)
+      checkCountThroughFlow(streamedBinaryMessage, getMessagesReceivedTotalValue, 1L)
     }
 
     "count a set of passing messages" in {
@@ -92,7 +92,7 @@ class WebSocketMetricsInterceptorSpec
           streamedBinaryMessage,
         ),
         getMessagesReceivedTotalValue,
-        4,
+        4L,
       )
     }
 
@@ -100,7 +100,7 @@ class WebSocketMetricsInterceptorSpec
       checkCountThroughFlowForLabels(
         List(strictTextMessage),
         getMessagesReceivedTotalValue,
-        1,
+        1L,
         labelFilters: _*
       )
     }
@@ -111,19 +111,19 @@ class WebSocketMetricsInterceptorSpec
     // of messages given as test data.
 
     "count passing strict text messages" in {
-      checkCountThroughFlow(strictTextMessage, getMessagesSentTotalValue, 2)
+      checkCountThroughFlow(strictTextMessage, getMessagesSentTotalValue, 2L)
     }
 
     "count passing streamed text messages" in {
-      checkCountThroughFlow(streamedTextMessage, getMessagesSentTotalValue, 2)
+      checkCountThroughFlow(streamedTextMessage, getMessagesSentTotalValue, 2L)
     }
 
     "count passing strict binary messages" in {
-      checkCountThroughFlow(strictBinaryMessage, getMessagesSentTotalValue, 2)
+      checkCountThroughFlow(strictBinaryMessage, getMessagesSentTotalValue, 2L)
     }
 
     "count passing streamed binary messages" in {
-      checkCountThroughFlow(streamedBinaryMessage, getMessagesSentTotalValue, 2)
+      checkCountThroughFlow(streamedBinaryMessage, getMessagesSentTotalValue, 2L)
     }
 
     "count a set of passing messages" in {
@@ -135,7 +135,7 @@ class WebSocketMetricsInterceptorSpec
           streamedBinaryMessage,
         ),
         getMessagesSentTotalValue,
-        8,
+        8L,
       )
     }
 
@@ -143,42 +143,42 @@ class WebSocketMetricsInterceptorSpec
       checkCountThroughFlowForLabels(
         List(strictTextMessage),
         getMessagesSentTotalValue,
-        2,
+        2L,
         labelFilters: _*
       )
     }
   }
 
-  "websocket_message_received_bytes_total" should {
+  "websocket_message_received_bytes" should {
     "count size of passing strict text messages" in {
       checkCountThroughFlow(
         strictTextMessage,
-        getMessagesReceivedBytesTotalValue,
-        strictTextMessageSize,
+        getMessagesReceivedBytesValues,
+        Seq(strictTextMessageSize),
       )
     }
 
     "count size of passing streamed text messages" in {
       checkCountThroughFlow(
         streamedTextMessage,
-        getMessagesReceivedBytesTotalValue,
-        streamedTextMessageSize,
+        getMessagesReceivedBytesValues,
+        Seq(streamedTextMessageSize),
       )
     }
 
     "count size of passing strict binary messages" in {
       checkCountThroughFlow(
         strictBinaryMessage,
-        getMessagesReceivedBytesTotalValue,
-        strictBinaryMessageSize,
+        getMessagesReceivedBytesValues,
+        Seq(strictBinaryMessageSize),
       )
     }
 
     "count size of passing streamed binary messages" in {
       checkCountThroughFlow(
         streamedBinaryMessage,
-        getMessagesReceivedBytesTotalValue,
-        streamedBinaryMessageSize,
+        getMessagesReceivedBytesValues,
+        Seq(streamedBinaryMessageSize),
       )
     }
 
@@ -190,16 +190,21 @@ class WebSocketMetricsInterceptorSpec
           strictBinaryMessage,
           streamedBinaryMessage,
         ),
-        getMessagesReceivedBytesTotalValue,
-        strictTextMessageSize + streamedTextMessageSize + strictBinaryMessageSize + streamedBinaryMessageSize,
+        getMessagesReceivedBytesValues,
+        Seq(
+          strictTextMessageSize,
+          streamedTextMessageSize,
+          strictBinaryMessageSize,
+          streamedBinaryMessageSize,
+        ),
       )
     }
 
     "contains the configured labels" in {
       checkCountThroughFlowForLabels(
         List(strictTextMessage),
-        getMessagesReceivedBytesTotalValue,
-        strictTextMessageSize,
+        getMessagesReceivedBytesValues,
+        Seq(strictTextMessageSize),
         labelFilters: _*
       )
     }
@@ -212,32 +217,32 @@ class WebSocketMetricsInterceptorSpec
     "count size of passing strict text messages" in {
       checkCountThroughFlow(
         strictTextMessage,
-        getMessagesSentBytesTotalValue,
-        strictTextMessageSize * 2,
+        getMessagesSentBytesValues,
+        Seq(strictTextMessageSize, strictTextMessageSize),
       )
     }
 
     "count size of passing streamed text messages" in {
       checkCountThroughFlow(
         streamedTextMessage,
-        getMessagesSentBytesTotalValue,
-        streamedTextMessageSize * 2,
+        getMessagesSentBytesValues,
+        Seq(streamedTextMessageSize, streamedTextMessageSize),
       )
     }
 
     "count size of passing strict binary messages" in {
       checkCountThroughFlow(
         strictBinaryMessage,
-        getMessagesSentBytesTotalValue,
-        strictBinaryMessageSize * 2,
+        getMessagesSentBytesValues,
+        Seq(strictBinaryMessageSize, strictBinaryMessageSize),
       )
     }
 
     "count size of passing streamed binary messages" in {
       checkCountThroughFlow(
         streamedBinaryMessage,
-        getMessagesSentBytesTotalValue,
-        streamedBinaryMessageSize * 2,
+        getMessagesSentBytesValues,
+        Seq(streamedBinaryMessageSize, streamedBinaryMessageSize),
       )
     }
 
@@ -249,16 +254,25 @@ class WebSocketMetricsInterceptorSpec
           strictBinaryMessage,
           streamedBinaryMessage,
         ),
-        getMessagesSentBytesTotalValue,
-        (strictTextMessageSize + streamedTextMessageSize + strictBinaryMessageSize + streamedBinaryMessageSize) * 2,
+        getMessagesSentBytesValues,
+        Seq(
+          strictTextMessageSize,
+          strictTextMessageSize,
+          streamedTextMessageSize,
+          streamedTextMessageSize,
+          strictBinaryMessageSize,
+          strictBinaryMessageSize,
+          streamedBinaryMessageSize,
+          streamedBinaryMessageSize,
+        ),
       )
     }
 
     "contains the configured labels" in {
       checkCountThroughFlowForLabels(
         List(strictTextMessage),
-        getMessagesSentBytesTotalValue,
-        strictTextMessageSize * 2,
+        getMessagesSentBytesValues,
+        Seq(strictTextMessageSize, strictTextMessageSize),
         labelFilters: _*
       )
     }
@@ -288,19 +302,22 @@ class WebSocketMetricsInterceptorSpec
   private def getMessagesSentTotalValue(metrics: TestMetrics, labels: Seq[LabelFilter]): Long =
     metrics.messagesSentTotalValue(labels: _*)
 
-  private def getMessagesReceivedBytesTotalValue(
+  private def getMessagesReceivedBytesValues(
       metrics: TestMetrics,
       labels: Seq[LabelFilter],
-  ): Long =
-    metrics.messagesReceivedBytesTotalValue(labels: _*)
+  ): Seq[Long] =
+    metrics.messagesReceivedBytesValues(labels: _*)
 
-  private def getMessagesSentBytesTotalValue(metrics: TestMetrics, labels: Seq[LabelFilter]): Long =
-    metrics.messagesSentBytesTotalValue(labels: _*)
+  private def getMessagesSentBytesValues(
+      metrics: TestMetrics,
+      labels: Seq[LabelFilter],
+  ): Seq[Long] =
+    metrics.messagesSentBytesValues(labels: _*)
 
-  private def checkCountThroughFlowForLabels(
+  private def checkCountThroughFlowForLabels[T](
       messages: List[Message],
-      metricExtractor: (TestMetrics, Seq[LabelFilter]) => Long,
-      expected: Long,
+      metricExtractor: (TestMetrics, Seq[LabelFilter]) => T,
+      expected: T,
       labels: LabelFilter*
   ): Future[Assertion] = {
     withDuplicatingFlowAndMetrics { (flow, metrics) =>
@@ -311,18 +328,18 @@ class WebSocketMetricsInterceptorSpec
     }
   }
 
-  private def checkCountThroughFlow(
+  private def checkCountThroughFlow[T](
       messages: List[Message],
-      metricExtractor: (TestMetrics, Seq[LabelFilter]) => Long,
-      expected: Long,
+      metricExtractor: (TestMetrics, Seq[LabelFilter]) => T,
+      expected: T,
   ): Future[Assertion] = {
     checkCountThroughFlowForLabels(messages, metricExtractor, expected)
   }
 
-  private def checkCountThroughFlow(
+  private def checkCountThroughFlow[T](
       message: Message,
-      metricExtractor: (TestMetrics, Seq[LabelFilter]) => Long,
-      expected: Long,
+      metricExtractor: (TestMetrics, Seq[LabelFilter]) => T,
+      expected: T,
   ): Future[Assertion] = {
     checkCountThroughFlow(List(message), metricExtractor, expected)
   }
@@ -381,19 +398,19 @@ object WebSocketMetricsSpec extends MetricValues {
   // The metrics being tested
   case class TestMetrics(
       messagesReceivedTotal: Meter,
-      messagesReceivedBytesTotal: Meter,
+      messagesReceivedBytes: Histogram,
       messagesSentTotal: Meter,
-      messagesSentBytesTotal: Meter,
+      messagesSentBytes: Histogram,
   ) extends WebSocketMetrics {
 
     def messagesReceivedTotalValue(labels: LabelFilter*): Long =
       messagesReceivedTotal.valueFilteredOnLabels(labels: _*)
-    def messagesReceivedBytesTotalValue(labels: LabelFilter*): Long =
-      messagesReceivedBytesTotal.valueFilteredOnLabels(labels: _*)
+    def messagesReceivedBytesValues(labels: LabelFilter*): Seq[Long] =
+      messagesReceivedBytes.valuesFilteredOnLabels(labels: _*)
     def messagesSentTotalValue(labels: LabelFilter*): Long =
       messagesSentTotal.valueFilteredOnLabels(labels: _*)
-    def messagesSentBytesTotalValue(labels: LabelFilter*): Long =
-      messagesSentBytesTotal.valueFilteredOnLabels(labels: _*)
+    def messagesSentBytesValues(labels: LabelFilter*): Seq[Long] =
+      messagesSentBytes.valuesFilteredOnLabels(labels: _*)
 
   }
 
@@ -403,12 +420,12 @@ object WebSocketMetricsSpec extends MetricValues {
     def apply(): TestMetrics = {
       val baseName = MetricName("test")
 
-      val receivedTotal = metricsFactory.meter(baseName)
-      val receivedBytesTotal = metricsFactory.meter(baseName)
-      val sentTotal = metricsFactory.meter(baseName)
-      val sentBytesTotal = metricsFactory.meter(baseName)
+      val receivedTotal = metricsFactory.meter(baseName :+ "received")
+      val receivedBytes = metricsFactory.histogram(baseName :+ "received" :+ Histogram.Bytes)
+      val sentTotal = metricsFactory.meter(baseName :+ "sent")
+      val sentBytes = metricsFactory.histogram(baseName :+ "sent" :+ Histogram.Bytes)
 
-      TestMetrics(receivedTotal, receivedBytesTotal, sentTotal, sentBytesTotal)
+      TestMetrics(receivedTotal, receivedBytes, sentTotal, sentBytes)
     }
   }
 


### PR DESCRIPTION
Alignment with the gRPC metrics.

* `_bytes` metrics are using histograms
* `_errors` metric has been removed. The `http_status` label in the general `_requests_total` metric to be used to get information about the errors.

CHANGELOG_BEGIN
CHANGELOG_END