### PR TITLE
remove deprecated warnings everywhere [DPP-1281]

### DIFF
--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -63,6 +63,7 @@ common_scalacopts = version_specific.get(scala_major_version, []) + [
     # catch missing string interpolators
     "-Xlint:missing-interpolator",
     "-Xlint:constant",  # / 0
+    "-Xlint:deprecation",  # deprecated annotations without 'message' or 'since' fields
     "-Xlint:doc-detached",  # floating Scaladoc comment
     "-Xlint:inaccessible",  # method uses invisible types
     "-Xlint:infer-any",  # less thorough but less buggy version of the Any wart

--- a/docs/resources/generated-error-pages/error-codes-inventory.rst.inc
+++ b/docs/resources/generated-error-pages/error-codes-inventory.rst.inc
@@ -1500,7 +1500,7 @@ Generic submission rejection errors returned by the backing ledger's write servi
 DISPUTED
 ---------------------------------------------------------------------------------------------------------------------------------------
     
-    **Deprecation**: Corresponds to transaction submission rejections that are not produced anymore.
+    **Deprecation**: Corresponds to transaction submission rejections that are not produced anymore. Since: 1.18.0
     
     **Explanation**: An invalid transaction submission was not detected by the participant.
 
@@ -1518,7 +1518,7 @@ DISPUTED
 OUT_OF_QUOTA
 ---------------------------------------------------------------------------------------------------------------------------------------
     
-    **Deprecation**: Corresponds to transaction submission rejections that are not produced anymore.
+    **Deprecation**: Corresponds to transaction submission rejections that are not produced anymore. Since: 1.18.0
     
     **Explanation**: The Participant node did not have sufficient resource quota to submit the transaction.
 

--- a/ledger/error/generator/test/suite/scala/com/daml/error/generator/ErrorCodeDocumentationGeneratorSpec.scala
+++ b/ledger/error/generator/test/suite/scala/com/daml/error/generator/ErrorCodeDocumentationGeneratorSpec.scala
@@ -16,6 +16,7 @@ import org.scalatest.matchers.should.Matchers
 import scala.annotation.nowarn
 import scala.reflect.ClassTag
 
+@nowarn("msg=Specify both message and version")
 class ErrorCodeDocumentationGeneratorSpec extends AnyFlatSpec with Matchers {
 
   it should "return the correct doc items from the error classes" in {

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/WriteServiceRejections.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/WriteServiceRejections.scala
@@ -59,7 +59,10 @@ object WriteServiceRejections extends LedgerApiErrors.WriteServiceRejections {
         parties.map((ErrorResource.Party, _)).toSeq
     }
 
-    @deprecated
+    @deprecated(
+      "Corresponds to transaction submission rejections that are not produced anymore.",
+      since = "1.18.0",
+    )
     case class RejectDeprecated(
         description: String
     )(implicit loggingContext: ContextualizedErrorLogger)
@@ -70,7 +73,10 @@ object WriteServiceRejections extends LedgerApiErrors.WriteServiceRejections {
 
   @Explanation("An invalid transaction submission was not detected by the participant.")
   @Resolution("Contact support.")
-  @deprecated("Corresponds to transaction submission rejections that are not produced anymore.")
+  @deprecated(
+    "Corresponds to transaction submission rejections that are not produced anymore.",
+    since = "1.18.0",
+  )
   object Disputed
       extends ErrorCode(
         id = "DISPUTED",
@@ -90,7 +96,10 @@ object WriteServiceRejections extends LedgerApiErrors.WriteServiceRejections {
   @Resolution(
     "Inspect the error message and retry after after correcting the underlying issue."
   )
-  @deprecated("Corresponds to transaction submission rejections that are not produced anymore.")
+  @deprecated(
+    "Corresponds to transaction submission rejections that are not produced anymore.",
+    since = "1.18.0",
+  )
   object OutOfQuota
       extends ErrorCode(id = "OUT_OF_QUOTA", ErrorCategory.ContentionOnSharedResources) {
     case class Reject(reason: String)(implicit


### PR DESCRIPTION
It fixes the warnings of the form
```
ledger/error/generator/test/suite/scala/com/daml/error/generator/ErrorCodeDocumentationGeneratorSpec.scala:118: warning: Specify both message and version: @deprecated("message", since = "1.0")
```
They stem from turning on the `-Xlint:deprecation` scalac flag