### PR TITLE
Update supported version of PostgreSQL

### DIFF
--- a/docs/source/ops/requirements.rst
+++ b/docs/source/ops/requirements.rst
@@ -12,7 +12,7 @@ Unless otherwise stated, all Daml runtime components require the following depen
 2. Java 11 or greater.
 3. An RDBMS system,
   
-  1. Either PostgreSQL 10.0 or greater.
+  1. Either PostgreSQL 11.0 or greater.
   2. Or Oracle Database 19.11 or greater.
 
 4. JDBC drivers compatible with the chosen RDBMS.
@@ -26,7 +26,7 @@ Daml is tested using the following specific dependencies in default installation
   3. MacOS 10.15 Catalina
 
 2. `Eclipse Adoptium <https://adoptium.net>`_ version 11 for Java.
-3. PostgreSQL 10.0
+3. PostgreSQL 11.0
 4. Oracle Database 19.11
 
 In terms of hardware requirements, minimal deployments running simple Daml applications


### PR DESCRIPTION
PostgreSQL 10 has been EoL since November 10, 2022 ([source](https://www.postgresql.org/support/versioning/)).

As such, we are now moving on to test on PostgreSQL 11 as of https://github.com/digital-asset/daml/pull/15628.

This documents this change.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
