### PR TITLE
LedgerClient admin pruning hook

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/LedgerClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/LedgerClient.scala
@@ -4,12 +4,12 @@
 package com.daml.ledger.client
 
 import java.io.Closeable
-
 import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.daml.ledger.api.auth.client.LedgerCallCredentials.authenticatingStub
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.v1.active_contracts_service.ActiveContractsServiceGrpc
 import com.daml.ledger.api.v1.admin.package_management_service.PackageManagementServiceGrpc
+import com.daml.ledger.api.v1.admin.participant_pruning_service.ParticipantPruningServiceGrpc
 import com.daml.ledger.api.v1.admin.party_management_service.PartyManagementServiceGrpc
 import com.daml.ledger.api.v1.admin.user_management_service.UserManagementServiceGrpc
 import com.daml.ledger.api.v1.command_completion_service.CommandCompletionServiceGrpc
@@ -26,6 +26,7 @@ import com.daml.ledger.client.configuration.{
 import com.daml.ledger.client.services.acs.ActiveContractSetClient
 import com.daml.ledger.client.services.admin.{
   PackageManagementClient,
+  ParticipantPruningManagementClient,
   PartyManagementClient,
   UserManagementClient,
 }
@@ -91,6 +92,11 @@ final class LedgerClient private (
   val userManagementClient: UserManagementClient =
     new UserManagementClient(
       LedgerClient.stub(UserManagementServiceGrpc.stub(channel), config.token)
+    )
+
+  val participantPruningManagementClient: ParticipantPruningManagementClient =
+    new ParticipantPruningManagementClient(
+      LedgerClient.stub(ParticipantPruningServiceGrpc.stub(channel), config.token)
     )
 
   override def close(): Unit = GrpcChannel.close(channel)

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/admin/ParticipantPruningManagementClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/admin/ParticipantPruningManagementClient.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.client.services.admin
+
+import com.daml.ledger.api.v1.admin.participant_pruning_service.ParticipantPruningServiceGrpc.ParticipantPruningServiceStub
+import com.daml.ledger.api.v1.admin.participant_pruning_service.{PruneRequest, PruneResponse}
+import com.daml.ledger.client.LedgerClient
+
+import scala.concurrent.Future
+
+object ParticipantPruningManagementClient {
+
+  private def pruneRequest(pruneUpTo: String) = PruneRequest(pruneUpTo = pruneUpTo)
+
+}
+
+final class ParticipantPruningManagementClient(service: ParticipantPruningServiceStub) {
+
+  def prune(pruneUpTo: String, token: Option[String] = None): Future[PruneResponse] =
+    LedgerClient
+      .stub(service, token)
+      .prune(ParticipantPruningManagementClient.pruneRequest(pruneUpTo))
+
+}


### PR DESCRIPTION
Adding the missing convenience hook to the `LedgerClient` for the `ParticipantPruningService`. This makes it a bit easier to invoke pruning through the ledger-api-server from canton.

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
