### PR TITLE
Fix flaky jwt leeway test

### DIFF
--- a/libs-scala/jwt/src/test/scala/com/digitalasset/jwt/JwtTimestampLeewaySpec.scala
+++ b/libs-scala/jwt/src/test/scala/com/digitalasset/jwt/JwtTimestampLeewaySpec.scala
@@ -153,7 +153,7 @@ class JwtTimestampLeewaySpec extends AnyWordSpec with Matchers with TableDrivenP
           val now = new Date()
           val token: String = JWT
             .create()
-            .withIssuedAt(oneSecondLaterFrom(now))
+            .withIssuedAt(fiveSecondsLaterFrom(now))
             .sign(algorithm)
 
           assertThrows[InvalidClaimException] {


### PR DESCRIPTION
[Example flake](https://dev.azure.com/digitalasset/daml/_build/results?buildId=128598&view=logs&jobId=09a372ad-d8e0-55bd-c4ff-5e98ed8964a7&j=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&t=ac0b0b0f-051f-52f7-8fb3-a7e384b0dde9&s=96ac2280-8cb4-5df5-99de-dd2da759617d)