### PR TITLE
fix eta-expansion and nullary method warnings [DPP-1281]

### DIFF
--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/TypeOrderingSpec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/TypeOrderingSpec.scala
@@ -26,7 +26,7 @@ class TypeOrderingSpec extends AnyWordSpec with Matchers {
           .collect(protoMapping)
 
       primTypesInProtoOrder.sortBy(Ast.TBuiltin)(
-        TypeOrdering.compare
+        TypeOrdering.compare _
       ) shouldBe primTypesInProtoOrder
     }
   }

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/NumericSpec.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/NumericSpec.scala
@@ -549,7 +549,7 @@ class NumericSpec
 
       forEvery(testCases) { numerics =>
         val suffled = random.shuffle(numerics)
-        suffled.sorted(compareTo).map(BigDec(_)) shouldBe suffled.map(BigDec(_)).sorted
+        suffled.sorted(compareTo _).map(BigDec(_)) shouldBe suffled.map(BigDec(_)).sorted
       }
     }
   }

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionsServiceImpl.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionsServiceImpl.scala
@@ -116,7 +116,7 @@ final class TransactionsServiceImpl(ledgerContent: Observable[LedgerItem])
           GetLedgerEndResponse(Option(LedgerOffset(Absolute(t.offset))))
         )
         .last(GetLedgerEndResponse(Option(LedgerOffset(Boundary(LEDGER_BEGIN)))))
-    result.subscribe(promise.success, promise.failure)
+    result.subscribe(promise.success _, promise.failure _)
     promise.future
   }
 

--- a/ledger-service/fetch-contracts/BUILD.bazel
+++ b/ledger-service/fetch-contracts/BUILD.bazel
@@ -59,12 +59,10 @@ da_scala_test(
         "@maven//:org_scalatestplus_scalacheck_1_15",
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_scalaz_scalaz_scalacheck_binding",
-        "@maven//:org_tpolecat_doobie_core",
     ],
     scalacopts = hj_scalacopts,
     deps = [
         ":fetch-contracts",
-        "//ledger-service/db-backend",
         "//libs-scala/scalatest-utils",
         "@maven//:org_scalatest_scalatest_compatible",
     ],

--- a/ledger-service/fetch-contracts/src/test/scala/fetchcontracts/util/InsertDeleteStepTest.scala
+++ b/ledger-service/fetch-contracts/src/test/scala/fetchcontracts/util/InsertDeleteStepTest.scala
@@ -62,7 +62,7 @@ object InsertDeleteStepTest {
   implicit val `Alpha arb`: Arbitrary[Cid] =
     Cid subst Arbitrary(Gen.alphaUpperChar map (_.toString))
 
-  private[util] implicit val `test Cid`: InsertDeleteStep.Cid[Cid] = Cid.unwrap
+  private[util] implicit val `test Cid`: InsertDeleteStep.Cid[Cid] = Cid.unwrap(_)
 
   implicit val `IDS arb`: Arbitrary[IDS] =
     Arbitrary(arbitrary[(Vector[Cid], Map[Cid, Unit])] map { case (is, ds) =>

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/MultiUserQueryScenario.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/MultiUserQueryScenario.scala
@@ -133,7 +133,7 @@ class MultiUserQueryScenario
           .inject(atOnceUsers(numWriters))
           .andThen(
             // single fetch to populate the cache
-            currQueryScn(numIterations = 1, () => randomCurrency())
+            currQueryScn(numIterations = 1, randomCurrency _)
               .inject(
                 nothingFor(2.seconds),
                 atOnceUsers(1),
@@ -144,7 +144,7 @@ class MultiUserQueryScenario
           atOnceUsers(numReaders)
         )
       case FetchByQuery =>
-        currQueryScn(numQueries / numReaders, randomCurrency).inject(
+        currQueryScn(numQueries / numReaders, randomCurrency _).inject(
           atOnceUsers(numReaders)
         )
       case PopulateAndFetch =>
@@ -157,7 +157,7 @@ class MultiUserQueryScenario
                 atOnceUsers(numReaders),
               )
               .andThen(
-                currQueryScn(numQueries / numReaders, randomCurrency)
+                currQueryScn(numQueries / numReaders, randomCurrency _)
                   .inject(
                     nothingFor(2.seconds),
                     atOnceUsers(numReaders),

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/InsertBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/InsertBenchmark.scala
@@ -44,7 +44,7 @@ trait InsertBenchmark extends ContractDaoBenchmark {
   }
 
   @TearDown(Level.Invocation)
-  def dropContracts: Unit = {
+  def dropContracts(): Unit = {
     val deleted = dao.transact(queries.deleteContracts(Map(tpid -> contractCids))).unsafeRunSync()
     assert(deleted == numContracts)
   }

--- a/libs-scala/jwt/src/test/scala/com/digitalasset/jwt/JwtTimestampLeewaySpec.scala
+++ b/libs-scala/jwt/src/test/scala/com/digitalasset/jwt/JwtTimestampLeewaySpec.scala
@@ -153,7 +153,7 @@ class JwtTimestampLeewaySpec extends AnyWordSpec with Matchers with TableDrivenP
           val now = new Date()
           val token: String = JWT
             .create()
-            .withIssuedAt(fiveSecondsLaterFrom(now))
+            .withIssuedAt(oneSecondLaterFrom(now))
             .sign(algorithm)
 
           assertThrows[InvalidClaimException] {

--- a/libs-scala/jwt/src/test/scala/com/digitalasset/jwt/JwtTimestampLeewaySpec.scala
+++ b/libs-scala/jwt/src/test/scala/com/digitalasset/jwt/JwtTimestampLeewaySpec.scala
@@ -153,7 +153,7 @@ class JwtTimestampLeewaySpec extends AnyWordSpec with Matchers with TableDrivenP
           val now = new Date()
           val token: String = JWT
             .create()
-            .withIssuedAt(oneSecondLaterFrom(now))
+            .withIssuedAt(fiveSecondsLaterFrom(now))
             .sign(algorithm)
 
           assertThrows[InvalidClaimException] {

--- a/libs-scala/ports/src/main/scala/com/digitalasset/ports/FreePort.scala
+++ b/libs-scala/ports/src/main/scala/com/digitalasset/ports/FreePort.scala
@@ -70,7 +70,7 @@ object FreePort {
         n - numLowerPorts + maxExcl + 1
       }
     }
-    genPort
+    () => genPort()
   }
 
   private def dynamicPortRange(): (Int, Int) = {

--- a/libs-scala/resources/src/test/suite/scala/com/digitalasset/resources/ResourceOwnerSpec.scala
+++ b/libs-scala/resources/src/test/suite/scala/com/digitalasset/resources/ResourceOwnerSpec.scala
@@ -630,7 +630,7 @@ final class ResourceOwnerSpec extends AsyncWordSpec with Matchers {
       )
 
       val resource = for {
-        releasable <- Factories.forReleasable(newReleasable.apply)(r => Future(r.close())).acquire()
+        releasable <- Factories.forReleasable(newReleasable.apply _)(r => Future(r.close())).acquire()
       } yield {
         withClue("after acquiring,") {
           newReleasable.hasBeenAcquired should be(true)

--- a/libs-scala/resources/src/test/suite/scala/com/digitalasset/resources/ResourceOwnerSpec.scala
+++ b/libs-scala/resources/src/test/suite/scala/com/digitalasset/resources/ResourceOwnerSpec.scala
@@ -630,7 +630,9 @@ final class ResourceOwnerSpec extends AsyncWordSpec with Matchers {
       )
 
       val resource = for {
-        releasable <- Factories.forReleasable(newReleasable.apply _)(r => Future(r.close())).acquire()
+        releasable <- Factories
+          .forReleasable(newReleasable.apply _)(r => Future(r.close()))
+          .acquire()
       } yield {
         withClue("after acquiring,") {
           newReleasable.hasBeenAcquired should be(true)


### PR DESCRIPTION
It fixes the warnings of the form
```
daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/TypeOrderingSpec.scala:29: warning: Eta-expansion performed to meet expected type Ordering[com.daml.lf.language.Ast.TBuiltin], which is SAM-equivalent to (com.daml.lf.language.Ast.TBuiltin, com.daml.lf.language.Ast.TBuiltin) => Int,
```
then
```
ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/MultiUserQueryScenario.scala:147: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => String), rather than applied to `()`.
```
and
```
ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/InsertBenchmark.scala:47: warning: side-effecting nullary methods are discouraged: suggest defining as `def dropContracts()` instead
```
They stem from turning on the scalac flags: `-Xlint:eta-sam`, `-Xlint:eta-zero` and  `-Xlint:nullary-unit` respectively
