### PR TITLE
Quick fixes to stablise trigger behaviour

### DIFF
--- a/docs/source/tools/trigger-service/index.rst
+++ b/docs/source/tools/trigger-service/index.rst
@@ -90,10 +90,6 @@ alongside a few annotations with regards to the meaning of the configuration key
         // handled by trigger rules. Defaults to 6.
         max-retries = 6
 
-        // Maximum number of in-flight commands that we shall allow *before* the ledger client automatically fails
-        // ledger client submission requests. Failed submission requests may be handled by trigger rules. Defaults to 50.
-        max-in-flight-commands = 50
-
         // Used to control maximum rate at which we perform ledger client submission requests.
         max-submission-requests = 100 // Defaults to 100.
         max-submission-duration = 5s  // Defaults to 5s.

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/PrettyPrint.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/PrettyPrint.scala
@@ -152,7 +152,7 @@ object PrettyPrint {
       str(value)
 
     case SValue.SText(value) =>
-      text(value)
+      text(s"$value")
 
     case SValue.STimestamp(value) =>
       str(value)

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerConfig.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerConfig.scala
@@ -10,8 +10,6 @@ import scala.concurrent.duration._
   *                    way bound the number of already-submitted, but not completed,
   *                    commands that may be pending.
   * @param maxRetries Maximum number of retries for a failing ledger API command submission.
-  * @param maxInFlightCommands Maximum number of in-flight commands that we shall allow
-  *                            *before* the ledger client automatically fails ledger client submission requests.
   * @param maxSubmissionRequests Used to control rate at which we throttle ledger client submission requests.
   * @param maxSubmissionDuration Used to control rate at which we throttle ledger client submission requests.
   * @param submissionFailureQueueSize Size of the queue holding ledger API command submission failures.
@@ -19,7 +17,6 @@ import scala.concurrent.duration._
 final case class TriggerRunnerConfig(
     parallelism: Int,
     maxRetries: Int,
-    maxInFlightCommands: Int,
     maxSubmissionRequests: Int,
     maxSubmissionDuration: FiniteDuration,
     submissionFailureQueueSize: Int,
@@ -32,7 +29,6 @@ object TriggerRunnerConfig {
     TriggerRunnerConfig(
       parallelism = parallelism,
       maxRetries = 6,
-      maxInFlightCommands = 1000000,
       maxSubmissionRequests = 100,
       maxSubmissionDuration = 5.seconds,
       // 256 here comes from the default ExecutionContext.

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerConfig.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerConfig.scala
@@ -32,7 +32,7 @@ object TriggerRunnerConfig {
     TriggerRunnerConfig(
       parallelism = parallelism,
       maxRetries = 6,
-      maxInFlightCommands = 50,
+      maxInFlightCommands = 1000000,
       maxSubmissionRequests = 100,
       maxSubmissionDuration = 5.seconds,
       // 256 here comes from the default ExecutionContext.


### PR DESCRIPTION
- [x] bug fix for pretty printing trigger messages during logging
- [x] quick fix to revert in-flight rate limiting (since this control causes internal buffers to overflow)
    - [x] update docs
    - [x] remove televant config
    - [x] remove trigger rate-limit control

PR #15434 introduced rate limiting controls. When these controls kick in, the internal submission failure queue can overflow killing the trigger.

CHANGELOG_BEGIN
* effectively we disable the in-flight rate limits controls by setting them to be 1,000,000 

CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
