### PR TITLE
Use `daml-base-anchors.json` when '--input-anchor' unspecified

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -19,6 +19,7 @@ damlc_data = [
     "@stackage-exe//hpp",
     "//compiler/damlc/pkg-db",
     "//compiler/damlc/stable-packages",
+    "//compiler/damlc:daml-base-anchors.json",
     "//compiler/repl-service/server:repl_service_jar",
     "//compiler/scenario-service/server:scenario_service_jar",
 ]
@@ -262,7 +263,7 @@ genrule(
     srcs = ["//compiler/damlc/daml-prim-src"],
     outs = ["daml-prim.json"],
     cmd = """
-        $(location //compiler/damlc) -- docs \
+        $(location //compiler/damlc:damlc-compile-only) -- docs \
             --output=$(OUTS) \
             --package-name=daml-prim \
             --format=Json \
@@ -270,7 +271,7 @@ genrule(
             $(locations //compiler/damlc/daml-prim-src)
     """.format(lf_docs_version),
     tools = [
-        "//compiler/damlc",
+        "//compiler/damlc:damlc-compile-only",
     ],
     visibility = ["//visibility:public"],
 )
@@ -280,7 +281,7 @@ genrule(
     srcs = ["//compiler/damlc/daml-stdlib-src"],
     outs = ["daml-stdlib.json"],
     cmd = """
-        $(location //compiler/damlc) -- docs \
+        $(location //compiler/damlc:damlc-compile-only) -- docs \
             --output=$(OUTS) \
             --package-name=daml-stdlib \
             --format=Json \
@@ -288,7 +289,7 @@ genrule(
             $(locations //compiler/damlc/daml-stdlib-src)
     """.format(lf_docs_version),
     tools = [
-        "//compiler/damlc",
+        "//compiler/damlc:damlc-compile-only",
     ],
     visibility = ["//visibility:public"],
 )
@@ -308,7 +309,7 @@ genrule(
         "daml-base-hoogle.txt",
     ],
     cmd = """
-        $(location //compiler/damlc) -- docs \\
+        $(location //compiler/damlc:damlc-compile-only) -- docs \\
             --output=daml-base-rst \\
             --input-format=json \\
             --format=Rst \\
@@ -327,7 +328,7 @@ genrule(
     """.format(lf_docs_version),
     tools = [
         "//bazel_tools/sh:mktgz",
-        "//compiler/damlc",
+        "//compiler/damlc:damlc-compile-only",
     ],
     visibility = ["//visibility:public"],
 )

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -318,6 +318,7 @@ genrule(
             --index-template=$(location :daml-base-rst-index-template) \\
             --hoogle-template=$(location :daml-base-hoogle-template) \\
             --base-url=https://docs.daml.com/daml/stdlib \\
+            --no-input-anchor \\
             --output-hoogle=$(location :daml-base-hoogle.txt) \\
             --output-anchor=$(location :daml-base-anchors.json) \\
             --target={} \\

--- a/compiler/damlc/daml-doc/BUILD.bazel
+++ b/compiler/damlc/daml-doc/BUILD.bazel
@@ -46,6 +46,7 @@ da_haskell_library(
         "//compiler/damlc/daml-opts",
         "//compiler/damlc/daml-opts:daml-opts-types",
         "//compiler/damlc/daml-rule-types",
+        "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
     ],
 )

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
@@ -7,6 +7,7 @@ module DA.Daml.Doc.Driver
     , OutputFormat(..)
     , RenderFormat(..)
     , TransformOptions(..)
+    , ExternalAnchorPath(..)
     , runDamlDoc
     , loadExternalAnchors
     ) where
@@ -18,6 +19,7 @@ import DA.Daml.Doc.Transform
 
 import DA.Daml.Options.Types
 
+import DA.Bazel.Runfiles
 import Development.IDE.Core.Shake (NotificationHandler)
 import Development.IDE.Types.Location
 
@@ -33,13 +35,13 @@ import System.Exit
 import System.Directory
 import System.FilePath
 
-import qualified Data.HashMap.Strict as HMS
 import qualified Data.Aeson as AE
 import qualified Data.Aeson.Encode.Pretty as AP
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Text.Extended as T
+import qualified Data.HashMap.Strict as HMS
 import qualified Data.Text.Encoding as T
+import qualified Data.Text.Extended as T
 
 data DamldocOptions = DamldocOptions
     { do_inputFormat :: InputFormat
@@ -58,7 +60,7 @@ data DamldocOptions = DamldocOptions
     , do_baseURL :: Maybe T.Text -- ^ base URL for generated documentation
     , do_hooglePath :: Maybe FilePath -- ^ hoogle database output path
     , do_anchorPath :: Maybe FilePath -- ^ anchor table output path
-    , do_externalAnchorPath :: Maybe FilePath -- ^ external anchor table input path
+    , do_externalAnchorPath :: ExternalAnchorPath -- ^ external anchor table input path
     }
 
 data InputFormat = InputJson | InputDaml
@@ -66,6 +68,16 @@ data InputFormat = InputJson | InputDaml
 
 data OutputFormat = OutputJson | OutputDocs RenderFormat
     deriving (Eq, Show, Read)
+
+data ExternalAnchorPath
+  = NoExternalAnchorPath
+      -- ^ Use an empty AnchorMap
+  | DefaultExternalAnchorPath
+      -- ^ Use the AnchorMap for daml-prim and daml-stdlib defined by
+      -- //compiler/damlc:daml-base-anchors.json
+  | ExplicitExternalAnchorPath FilePath
+      -- ^ Read the AnchorMap from the given file
+  deriving (Eq, Show, Read)
 
 -- | Run damldocs!
 runDamlDoc :: DamldocOptions -> IO ()
@@ -100,22 +112,31 @@ inputDocData DamldocOptions{..} = do
 -- | Load a database of external anchors from a file. Will abnormally
 -- terminate the program if there's an IOError or json decoding
 -- failure.
-loadExternalAnchors :: Maybe FilePath -> IO AnchorMap
-loadExternalAnchors path = do
+loadExternalAnchors :: ExternalAnchorPath -> IO AnchorMap
+loadExternalAnchors eapath = do
     let printAndExit err = do
             hPutStr stderr err
             exitFailure
-    anchors <- tryLoadAnchors path
+    anchors <- case eapath of
+        NoExternalAnchorPath -> pure . Right $ AnchorMap HMS.empty
+        DefaultExternalAnchorPath -> getDamlBaseAnchorsPath >>= tryLoadAnchors
+        ExplicitExternalAnchorPath path -> tryLoadAnchors path
     either printAndExit pure anchors
     where
-        tryLoadAnchors = \case
-            Just path -> runExceptT $ do
-              bytes <- ExceptT $ first readErr <$> try @IOError (LBS.fromStrict <$> BS.readFile path)
-              ExceptT $ pure (first decodeErr (AE.eitherDecode @AnchorMap bytes))
-              where
-                  readErr = const $ "Failed to read anchor table '" ++ path ++ "'"
-                  decodeErr err = unlines ["Failed to decode anchor table '" ++ path ++ "':", err]
-            Nothing -> pure . Right $ AnchorMap HMS.empty
+        tryLoadAnchors path = runExceptT $ do
+            bytes <- ExceptT $ first readErr <$> try @IOError (LBS.fromStrict <$> BS.readFile path)
+            ExceptT $ pure (first decodeErr (AE.eitherDecode @AnchorMap bytes))
+            where
+                readErr = const $ "Failed to read anchor table '" ++ path ++ "'"
+                decodeErr err = unlines ["Failed to decode anchor table '" ++ path ++ "':", err]
+        getDamlBaseAnchorsPath = locateResource Resource
+            -- //compiler/damlc:daml-base-anchors.json
+            { resourcesPath = "daml-base-anchors.json"
+              -- In a packaged application, this is stored directly underneath
+              -- the resources directory because it's a single file.
+              -- See @bazel_tools/packaging/packaging.bzl@.
+            , runfilesPathPrefix = mainWorkspace </> "compiler" </> "damlc"
+            }
 
 -- | Output doc data.
 renderDocData :: DamldocOptions -> [ModuleDoc] -> IO ()

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -13,6 +13,7 @@ import Development.IDE.Types.Location
 import Module (unitIdString)
 
 import Options.Applicative
+import Options.Applicative.Extended (lastOr)
 import Data.List.Extra
 import qualified Data.Text as T
 import qualified Data.Set as Set
@@ -97,12 +98,28 @@ documentation numProcessors = Damldoc
             <> help "Path to output anchor table."
             <> long "output-anchor"
 
-    optExternalAnchorPath :: Parser (Maybe FilePath)
+    optExternalAnchorPath :: Parser ExternalAnchorPath
     optExternalAnchorPath =
-        optional . option str
-            $ metavar "PATH"
-            <> help "Path to input anchor table (for external anchors)."
-            <> long "input-anchor"
+        lastOr DefaultExternalAnchorPath
+            $ defaultExternalAnchorPath
+            <|> noExternalAnchorPath
+            <|> explicitExternalAnchorPath
+        where
+            defaultExternalAnchorPath =
+                flag' DefaultExternalAnchorPath
+                  $ long "default-input-anchor"
+                  <> help "Use the default anchor table for daml-prim and daml-stdlib anchors."
+
+            noExternalAnchorPath =
+                flag' NoExternalAnchorPath
+                  $ long "no-input-anchor"
+                  <> help "Use no anchor table for external anchors."
+
+            explicitExternalAnchorPath =
+                fmap ExplicitExternalAnchorPath $ option str
+                    $ metavar "PATH"
+                    <> help "Path to input anchor table (for external anchors)."
+                    <> long "input-anchor"
 
     optTemplate :: Parser (Maybe FilePath)
     optTemplate =
@@ -255,7 +272,7 @@ data CmdArgs = Damldoc
     , cBaseURL :: Maybe T.Text
     , cHooglePath :: Maybe FilePath
     , cAnchorPath :: Maybe FilePath
-    , cExternalAnchorPath :: Maybe FilePath
+    , cExternalAnchorPath :: ExternalAnchorPath
     , cMainFiles :: [FilePath]
     }
 

--- a/compiler/damlc/tests/src/DA/Test/DamlDoc.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlDoc.hs
@@ -4,22 +4,17 @@
 
 module DA.Test.DamlDoc (main) where
 
-{- HLINT ignore "locateRunfiles/package_app" -}
-
-import DA.Daml.Doc.Driver (loadExternalAnchors)
+import DA.Daml.Doc.Driver (ExternalAnchorPath (DefaultExternalAnchorPath), loadExternalAnchors)
 import DA.Daml.Doc.Types
 import qualified DA.Daml.Doc.Tests as Damldoc
 import qualified DA.Daml.Doc.Render.Tests as Render
 import qualified Test.Tasty.Extended as Tasty
 import System.Environment.Blank
-import System.FilePath
-import DA.Bazel.Runfiles
 
 main :: IO ()
 main = do
     setEnv "TASTY_NUM_THREADS" "1" True
-    externalAnchorsPath <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "daml-base-anchors.json")
-    anchors <- loadExternalAnchors (Just externalAnchorsPath)
+    anchors <- loadExternalAnchors DefaultExternalAnchorPath
     Tasty.deterministicMain =<< allTests anchors
 
 allTests :: AnchorMap -> IO Tasty.TestTree


### PR DESCRIPTION
Fixes https://github.com/digital-asset/daml/issues/6039, specifically the "only thing missing":

> @\shayne-fletcher's work in  #6386 adds the `--input-anchor` flag and distributes the stdlib anchor table in the damlc runfiles. **The only thing missing is to make the anchor table shipped with `damlc` be used by default.**
> -- https://github.com/digital-asset/daml/issues/6039#issuecomment-648803005