### PR TITLE
fix node 18 again (other issue)

### DIFF
--- a/templates/create-daml-app-test-resources/index.test.ts
+++ b/templates/create-daml-app-test-resources/index.test.ts
@@ -164,7 +164,7 @@ const newUiPage = async (): Promise<Page> => {
       `${message.type().substr(0, 3).toUpperCase()} ${message.text()}`,
     ),
   );
-  await page.goto(`http://localhost:${UI_PORT}`); // ignore the Response
+  await page.goto(`http://127.0.0.1:${UI_PORT}`); // ignore the Response
   return page;
 };
 

--- a/templates/create-daml-app/README.md.template
+++ b/templates/create-daml-app/README.md.template
@@ -46,7 +46,7 @@ This starts a server on `http://localhost:3000` which:
 - Builds all of your TypeScript (or JavaScript) code (including type
   definitions from the codegen).
 - Serves the result on :3000, redirecting `/v1` to the JSON API server (on
-  `localhost:7575`) so API calls are on the same origin as far as your browser
+  `127.0.0.1:7575`) so API calls are on the same origin as far as your browser
   is concerned.
 - Watch for changes in TS/JS code (including codegen), and immediately rebuild.
 

--- a/templates/create-daml-app/ui/package.json.template
+++ b/templates/create-daml-app/ui/package.json.template
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "react-scripts --openssl-legacy-provider start",
     "build": "react-scripts --openssl-legacy-provider build",
-    "test": "react-scripts test --testURL='http://localhost:7575'",
+    "test": "react-scripts test --testURL='http://127.0.0.1:7575'",
     "eject": "react-scripts eject",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src/"
   },

--- a/templates/create-daml-app/ui/src/setupProxy.js
+++ b/templates/create-daml-app/ui/src/setupProxy.js
@@ -4,7 +4,7 @@
 const { createProxyMiddleware } = require("http-proxy-middleware");
 
 const httpJsonDevUrl =
-  process.env.REACT_APP_HTTP_JSON ? process.env.REACT_APP_HTTP_JSON : "http://localhost:7575";
+  process.env.REACT_APP_HTTP_JSON ? process.env.REACT_APP_HTTP_JSON : "http://127.0.0.1:7575";
 
 /**
  * @return {Boolean}


### PR DESCRIPTION
It looks like, at least on some machnes, recent Node versions will not resove localhost to 127.0.0.1 anymore.

There wasn't really a good reason for us going through DNS resolution for these anyway, so here's a simple fix. Hopefully.