### PR TITLE
Updated documented JSON API encoding for decimals

### DIFF
--- a/daml-lf/transaction/src/main/protobuf/com/daml/lf/value.proto
+++ b/daml-lf/transaction/src/main/protobuf/com/daml/lf/value.proto
@@ -36,9 +36,8 @@ message Value {
 
         sint64 int64 = 5;
 
-        // Between v1 and v5 this field expressed a number in base-10 with up
-        // to 28 digits before the decimal point and up to 10 after the decimal
-        // point.
+        // Between v1 and v5 this field expressed a number in base-10 with a
+        // fixed point anywhere within the digits except at the start.
         //
         // Starting from v5 this field expressed a number in base-10 with at most
         // 38 digits from which at most 37 can be used in the right hand side

--- a/daml-lf/transaction/src/main/protobuf/com/daml/lf/value.proto
+++ b/daml-lf/transaction/src/main/protobuf/com/daml/lf/value.proto
@@ -37,7 +37,7 @@ message Value {
         sint64 int64 = 5;
 
         // Between v1 and v5 this field expressed a number in base-10 with a
-        // fixed point anywhere within the digits except at the start.
+        // fixed point anywhere within the digits except at the start. 
         //
         // Starting from v5 this field expressed a number in base-10 with at most
         // 38 digits from which at most 37 can be used in the right hand side


### PR DESCRIPTION
Fixes #15302

I updated the JSON API docs for decimals, which were outdated. Now, it states (as per LF numerics ), that the fixpoint can be anywhere within the digits except at the start.

see https://github.com/digital-asset/daml/blob/main/daml-lf/transaction/src/main/protobuf/com/daml/lf/value.proto#L39-L48
