### PR TITLE
Only warn about errors loading test suites by default

### DIFF
--- a/libs-scala/test-evidence/generator/src/main/scala/org/scalatest/ScalaTestAdapter.scala
+++ b/libs-scala/test-evidence/generator/src/main/scala/org/scalatest/ScalaTestAdapter.scala
@@ -14,7 +14,7 @@ object ScalaTestAdapter {
 
   val IgnoreTagName: String = Suite.IgnoreTagName
 
-  def loadTestSuites(runpathList: List[String]): List[Suite] = {
+  def loadTestSuites(runpathList: List[String], fatalWarnings: Boolean = false): List[Suite] = {
     val loader = Runner.getRunpathClassLoader(runpathList)
     val testSuiteNames = SuiteDiscoveryHelper.discoverSuiteNames(runpathList, loader, None)
     val suites = for {
@@ -26,7 +26,7 @@ object ScalaTestAdapter {
       throwable.printStackTrace()
       suiteClassName
     }
-    if (abortedSuites.nonEmpty) {
+    if (fatalWarnings && abortedSuites.nonEmpty) {
       sys.error(s"Could not load test suites: ${abortedSuites.mkString(", ")}")
     } else {
       suites

--- a/test-evidence/src/main/scala/com/daml/test/evidence/generator/TestEntryLookup.scala
+++ b/test-evidence/src/main/scala/com/daml/test/evidence/generator/TestEntryLookup.scala
@@ -39,7 +39,7 @@ object TestEntryLookup {
       .concat(suites.v1_14.default(timeoutScaleFactor = 0L))
       .concat(suites.v1_14.optional(tlsConfig = None))
 
-    val testSuites: List[Suite] = ScalaTestAdapter.loadTestSuites(runpathList)
+    val testSuites: List[Suite] = ScalaTestAdapter.loadTestSuites(runpathList, fatalWarnings = true)
 
     collectTestEvidence[TT, TS, TE](
       testSuites,


### PR DESCRIPTION
It turned out that throwing an exception is too strict for the downstream Canton project which currently fails on CI (https://github.com/DACH-NY/canton/pull/11074) caused by errors in a number of test suites.

Until they have adapted (see https://github.com/DACH-NY/canton/issues/11083) we only warn about the errors by default.

For this project we still ensure that warnings are fatal.
