### PR TITLE
Added a flag checkAuthorization to EngineConfig that allows clients to disable the authorization checks (for security testing).

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -325,6 +325,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
       expr = SEApp(sexpr, Array(SValue.SToken)),
       committers = submitters,
       readAs = readAs,
+      checkAuthorization = config.checkAuthorization,
       validating = validating,
       contractKeyUniqueness = config.contractKeyUniqueness,
       limits = config.limits,

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -21,10 +21,12 @@ import com.daml.lf.transaction.ContractKeyUniquenessMode
   * @param profileDir The optional specifies the directory where to
   *     save the output of the Daml scenario profiler. The profiler is
   *     disabled if the option is empty.
-  * @param requireSuffixedGlobalCids Since August 2018 we expect new
+  * @param requireSuffixedGlobalContractId Since August 2018 we expect new
   *     ledgers to suffix CIDs before committing a transaction.
   *     This option should be disable for backward compatibility in ledger
   *     that do not (i.e. Sandboxes, KV, Corda).
+  * @param checkAuthorization Whether to check authorization of transaction.
+  *     A value of false is insecure and should be used for security testing only.
   */
 final case class EngineConfig(
     allowedLanguageVersions: VersionRange[language.LanguageVersion],
@@ -35,6 +37,7 @@ final case class EngineConfig(
     forbidV0ContractId: Boolean = false,
     requireSuffixedGlobalContractId: Boolean = false,
     limits: interpretation.Limits = interpretation.Limits.Lenient,
+    checkAuthorization: Boolean = true,
 ) {
 
   private[lf] def getCompilerConfig: speedy.Compiler.Config =

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -386,6 +386,7 @@ private[lf] object Speedy {
         expr: SExpr,
         committers: Set[Party],
         readAs: Set[Party],
+        checkAuthorization: Boolean,
         validating: Boolean = false,
         traceLog: TraceLog = newTraceLog,
         warningLog: WarningLog = newWarningLog,
@@ -407,6 +408,7 @@ private[lf] object Speedy {
             initialSeeding,
             committers,
             disclosedContracts,
+            checkAuthorization,
           ),
         committers = committers,
         readAs = readAs,
@@ -1048,6 +1050,7 @@ private[lf] object Speedy {
         transactionSeed: crypto.Hash,
         updateE: Expr,
         committers: Set[Party],
+        checkAuthorization: Boolean,
         disclosedContracts: ImmArray[speedy.DisclosedContract] = ImmArray.Empty,
         limits: interpretation.Limits = interpretation.Limits.Lenient,
     )(implicit loggingContext: LoggingContext): OnLedgerMachine = {
@@ -1058,6 +1061,7 @@ private[lf] object Speedy {
         transactionSeed,
         updateSE,
         committers,
+        checkAuthorization,
         disclosedContracts,
         limits,
       )
@@ -1071,6 +1075,7 @@ private[lf] object Speedy {
         transactionSeed: crypto.Hash,
         updateSE: SExpr,
         committers: Set[Party],
+        checkAuthorization: Boolean,
         disclosedContracts: ImmArray[speedy.DisclosedContract] = ImmArray.Empty,
         limits: interpretation.Limits = interpretation.Limits.Lenient,
         traceLog: TraceLog = newTraceLog,
@@ -1085,6 +1090,7 @@ private[lf] object Speedy {
         limits = limits,
         traceLog = traceLog,
         disclosedContracts = disclosedContracts,
+        checkAuthorization = checkAuthorization,
       )
     }
 


### PR DESCRIPTION
CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
