### PR TITLE
[DPP-1356] Fix not logging some exceptions from streaming endpoints (B)

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/error/ErrorInterceptor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/error/ErrorInterceptor.scala
@@ -35,16 +35,17 @@ final class ErrorInterceptor extends ServerInterceptor {
 
       /** Here we are trying to detect status/trailers pairs that:
         * - originated from the server implementation (i.e. Participant services as opposed to internal to gRPC implementation) AND
-        * - did not originate from self-service errors infrastructure.
+        * - did not originate from LAPI error codes.
         * NOTE: We are not attempting to detect if a status/trailers pair originates from exceptional conditions within gRPC implementation itself.
         *
-        * We are handling unary endpoints that returned failed Futures,
+        * We are handling unary endpoints that returned failed Futures or other direct invocation of [[io.grpc.stub.StreamObserver#onError]].
         * We are NOT handling here exceptions thrown outside of Futures or Akka streams. These are handled separately in
         * [[com.daml.platform.apiserver.error.ErrorListener]].
         * We are NOT handling here exceptions thrown inside Akka streaming. These are handled in
         * [[com.daml.grpc.adapter.server.akka.ServerAdapter.toSink]]
         *
         * Details:
+        * 1. Handling of Status.INTERNAL:
         * The gRPC services that we generate via scalapb are using [[scalapb.grpc.Grpc.completeObserver]]
         * when bridging from Future[T] and into io.grpc.stub.StreamObserver[T].
         * [[scalapb.grpc.Grpc.completeObserver]] does the following:
@@ -54,24 +55,28 @@ final class ErrorInterceptor extends ServerInterceptor {
         * Knowing that Status.INTERNAL is used only by [[com.daml.error.ErrorCategory.SystemInternalAssumptionViolated]],
         * which is marked a security sensitive, we have the following heuristic: check whether gRPC status is Status.INTERNAL
         * and gRPC status description is not security sanitized.
+        * 2. Handling of Status.UNKNOWN:
+        * We do not have an error category that uses UNKNOWN so there is no risk of catching a legitimate Ledger API error code.
+        * A Status.UNKNOWN can arise when someone calls [[io.grpc.stub.StreamObserver#onError]] directly
+        * providing an exception that is not a Status(Runtime)Exception (see [[io.grpc.stub.ServerCalls.ServerCallStreamObserverImpl#onError]]
+        * and [[io.grpc.Status#fromThrowable]]).
         */
       override def close(status: Status, trailers: Metadata): Unit = {
         if (
-          status.getCode == Status.Code.INTERNAL &&
-          (status.getDescription == null || !BaseError.isSanitizedSecuritySensitiveMessage(
-            status.getDescription
-          ))
+          isInternalErrorThrownFromScalapbGrpcCompleteObserver(
+            status
+          ) || status.getCode == Status.Code.UNKNOWN
         ) {
           val recreatedException = status.asRuntimeException(trailers)
-          val selfServiceException = LedgerApiErrors.InternalError
+          val errorCodeException = LedgerApiErrors.InternalError
             .UnexpectedOrUnknownException(t = recreatedException)(
               new DamlContextualizedErrorLogger(logger, emptyLoggingContext, None)
             )
             .asGrpcError
           // Retrieving status and metadata in the same way as in `io.grpc.stub.ServerCalls.ServerCallStreamObserverImpl.onError`.
           val newMetadata =
-            Option(Status.trailersFromThrowable(selfServiceException)).getOrElse(new Metadata())
-          val newStatus = Status.fromThrowable(selfServiceException)
+            Option(Status.trailersFromThrowable(errorCodeException)).getOrElse(new Metadata())
+          val newStatus = Status.fromThrowable(errorCodeException)
           LogOnUnhandledFailureInClose(superClose(newStatus, newMetadata))
         } else {
           LogOnUnhandledFailureInClose(superClose(status, trailers))
@@ -96,6 +101,12 @@ final class ErrorInterceptor extends ServerInterceptor {
     )
   }
 
+  private def isInternalErrorThrownFromScalapbGrpcCompleteObserver[RespT, ReqT](status: Status) = {
+    status.getCode == Status.Code.INTERNAL &&
+    (status.getDescription == null || !BaseError.isSanitizedSecuritySensitiveMessage(
+      status.getDescription
+    ))
+  }
 }
 
 class ErrorListener[ReqT, RespT](delegate: ServerCall.Listener[ReqT], call: ServerCall[ReqT, RespT])

--- a/ledger/participant-integration-api/src/test/resources/logback-test.xml
+++ b/ledger/participant-integration-api/src/test/resources/logback-test.xml
@@ -51,6 +51,14 @@
         <appender-ref ref="LogOnUnhandledFailureInCloseCapture"/>
     </logger>
 
+    <appender name="ErrorInterceptor" class="com.daml.platform.testing.LogCollector">
+        <test>com.daml.platform.apiserver.error.ErrorInterceptorSpec</test>
+    </appender>
+
+    <logger name="com.daml.platform.apiserver.error.ErrorInterceptor" level="INFO">
+        <appender-ref ref="ErrorInterceptor"/>
+    </logger>
+
     <logger name="com.daml.platform.store.dao.HikariConnection" level="INFO">
         <appender-ref ref="JdbcIndexerSpecAppender"/>
         <appender-ref ref="IndexerStabilitySpecAppender"/>

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/error/ErrorInterceptorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/error/ErrorInterceptorSpec.scala
@@ -378,7 +378,7 @@ object ErrorInterceptorSpec {
     ): Source[HelloResponse, NotUsed] = Assertions.fail("This method should have been unreachable")
 
     override def single(request: HelloRequest): Future[HelloResponse] =
-      Assertions.fail("This class is not designed to test unary endpoints")
+      Assertions.fail("This class is not intended to test unary endpoints")
   }
 
 }


### PR DESCRIPTION
(An alternative fix: https://github.com/digital-asset/daml/pull/15749)


Sample error logged by the server:
```
18:11:30.818 [ForkJoinPool-4-worker-19] ERROR c.d.p.a.error.ErrorInterceptor - LEDGER_API_INTERNAL_ERROR(4,0): Unexpected or unknown exception occurred., context: {err-context: "{location=ErrorInterceptor.scala:73}"}
io.grpc.StatusRuntimeException: UNKNOWN
	at io.grpc.Status.asRuntimeException(Status.java:535)
	at com.daml.platform.apiserver.error.ErrorInterceptor$$anon$1.close(ErrorInterceptor.scala:70)
	at io.grpc.PartialForwardingServerCall.close(PartialForwardingServerCall.java:48)
	at io.grpc.ForwardingServerCall.close(ForwardingServerCall.java:22)
	at io.grpc.ForwardingServerCall$SimpleForwardingServerCall.close(ForwardingServerCall.java:39)
	at com.daml.platform.apiserver.TruncatedStatusInterceptor$$anon$1.close(TruncatedStatusInterceptor.scala:19)
	at com.daml.platform.apiserver.MetricsInterceptor$TimedServerCall.close(MetricsInterceptor.scala:56)
	at io.grpc.PartialForwardingServerCall.close(PartialForwardingServerCall.java:48)
	at io.grpc.ForwardingServerCall.close(ForwardingServerCall.java:22)
	at io.grpc.ForwardingServerCall$SimpleForwardingServerCall.close(ForwardingServerCall.java:39)
	at com.daml.metrics.grpc.GrpcMetricsServerInterceptor$MetricsCall.close(GrpcMetricsServerInterceptor.scala:100)
	at io.grpc.stub.ServerCalls$ServerCallStreamObserverImpl.onError(ServerCalls.java:389)
	at com.daml.ledger.api.auth.Authorizer.$anonfun$authorizeWithReq$2(Authorizer.scala:283)
	at com.daml.ledger.api.auth.Authorizer.$anonfun$authorizeWithReq$2$adapted(Authorizer.scala:282)
	at scala.util.Success.fold(Try.scala:281)
	at com.daml.ledger.api.auth.Authorizer.$anonfun$authorizeWithReq$1(Authorizer.scala:285)
	at com.daml.ledger.api.auth.Authorizer.$anonfun$authorizeWithReq$1$adapted(Authorizer.scala:278)
	at com.daml.ledger.api.auth.services.TransactionServiceAuthorization.getTransactions(TransactionServiceAuthorization.scala:32)
	at com.daml.ledger.api.v1.transaction_service.TransactionServiceGrpc$TransactionService$$anon$1.invoke(TransactionServiceGrpc.scala:129)
	at com.daml.ledger.api.v1.transaction_service.TransactionServiceGrpc$TransactionService$$anon$1.invoke(TransactionServiceGrpc.scala:127)
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
	at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
	at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
	at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
	at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
	at com.daml.ledger.api.auth.interceptor.AsyncForwardingListener.$anonfun$onHalfClose$1(AsyncForwardingListener.scala:37)
	at com.daml.ledger.api.auth.interceptor.AsyncForwardingListener.$anonfun$onHalfClose$1$adapted(AsyncForwardingListener.scala:37)
	at com.daml.ledger.api.auth.interceptor.AsyncForwardingListener.enqueueOrProcess(AsyncForwardingListener.scala:24)
	at com.daml.ledger.api.auth.interceptor.AsyncForwardingListener.onHalfClose(AsyncForwardingListener.scala:37)
	at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
	at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
	at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
	at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
	at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
	at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
	at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
	at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
	at com.daml.platform.apiserver.error.ErrorListener.onHalfClose(ErrorInterceptor.scala:125)
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:340)
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:866)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at com.codahale.metrics.InstrumentedExecutorService$InstrumentedRunnable.run(InstrumentedExecutorService.java:180)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: java.lang.RuntimeException: ALA123 11111111111
	at scala.sys.package$.error(package.scala:27)
	at com.daml.platform.server.api.services.grpc.GrpcTransactionService.getTransactionsSource(GrpcTransactionService.scala:47)
	at com.daml.ledger.api.v1.transaction_service.TransactionServiceAkkaGrpc.$anonfun$getTransactions$1(TransactionServiceAkkaGrpc.scala:11)
	at com.daml.grpc.adapter.server.akka.StreamingServiceLifecycleManagement.$anonfun$registerStream$1(StreamingServiceLifecycleManagement.scala:40)
	at com.daml.grpc.adapter.server.akka.StreamingServiceLifecycleManagement.ifNotClosed$1(StreamingServiceLifecycleManagement.scala:36)
	at com.daml.grpc.adapter.server.akka.StreamingServiceLifecycleManagement.registerStream(StreamingServiceLifecycleManagement.scala:38)
	at com.daml.grpc.adapter.server.akka.StreamingServiceLifecycleManagement.registerStream$(StreamingServiceLifecycleManagement.scala:27)
	at com.daml.platform.server.api.services.grpc.GrpcTransactionService.registerStream(GrpcTransactionService.scala:24)
	at com.daml.ledger.api.v1.transaction_service.TransactionServiceAkkaGrpc.getTransactions(TransactionServiceAkkaGrpc.scala:11)
	at com.daml.ledger.api.v1.transaction_service.TransactionServiceAkkaGrpc.getTransactions$(TransactionServiceAkkaGrpc.scala:7)
	at com.daml.platform.server.api.services.grpc.GrpcTransactionService.getTransactions(GrpcTransactionService.scala:24)
	at com.daml.ledger.api.auth.services.TransactionServiceAuthorization.$anonfun$getTransactions$1(TransactionServiceAuthorization.scala:31)
	at com.daml.ledger.api.auth.services.TransactionServiceAuthorization.$anonfun$getTransactions$1$adapted(TransactionServiceAuthorization.scala:31)
	at com.daml.ledger.api.auth.Authorizer.$anonfun$authorizeWithReq$3(Authorizer.scala:293)
	at com.daml.ledger.api.auth.Authorizer.$anonfun$authorizeWithReq$3$adapted(Authorizer.scala:285)
	... 35 common frames omitted
```