### PR TITLE
Log insufficient permission at info level

### DIFF
--- a/docs/resources/generated-error-pages/error-categories-inventory.rst.inc
+++ b/docs/resources/generated-error-pages/error-categories-inventory.rst.inc
@@ -64,7 +64,7 @@ AuthInterceptorInvalidAuthenticationCredentials
 
     **gRPC status code**: UNAUTHENTICATED
 
-    **Default log level**: WARN
+    **Default log level**: INFO
 
     **Description**: The request does not have valid authentication credentials for the operation. This error is exposed on the API with grpc-status UNAUTHENTICATED without any details for security reasons
 

--- a/docs/resources/generated-error-pages/error-categories-inventory.rst.inc
+++ b/docs/resources/generated-error-pages/error-categories-inventory.rst.inc
@@ -79,7 +79,7 @@ InsufficientPermission
 
     **gRPC status code**: PERMISSION_DENIED
 
-    **Default log level**: WARN
+    **Default log level**: INFO
 
     **Description**: The caller does not have permission to execute the specified operation. This error is exposed on the API with grpc-status PERMISSION_DENIED without any details for security reasons
 

--- a/ledger/error/src/main/scala/com/daml/error/ErrorCategory.scala
+++ b/ledger/error/src/main/scala/com/daml/error/ErrorCategory.scala
@@ -187,7 +187,7 @@ object ErrorCategory {
   object AuthInterceptorInvalidAuthenticationCredentials
       extends ErrorCategoryImpl(
         grpcCode = Some(Code.UNAUTHENTICATED),
-        logLevel = Level.WARN,
+        logLevel = Level.INFO,
         retryable = None,
         securitySensitive = true,
         asInt = 6,

--- a/ledger/error/src/main/scala/com/daml/error/ErrorCategory.scala
+++ b/ledger/error/src/main/scala/com/daml/error/ErrorCategory.scala
@@ -208,7 +208,7 @@ object ErrorCategory {
   object InsufficientPermission
       extends ErrorCategoryImpl(
         grpcCode = Some(Code.PERMISSION_DENIED),
-        logLevel = Level.WARN,
+        logLevel = Level.INFO,
         retryable = None,
         securitySensitive = true,
         asInt = 7,

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/ErrorFactoriesSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/ErrorFactoriesSpec.scala
@@ -354,7 +354,7 @@ class ErrorFactoriesSpec
         message = expectedInternalErrorMessage,
         details = expectedInternalErrorDetails,
         logEntry = ExpectedLogEntry(
-          Level.WARN,
+          Level.INFO,
           s"PERMISSION_DENIED(7,$truncatedCorrelationId): some cause",
           Some(expectedLocationLogMarkerRegex),
         ),

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/ErrorFactoriesSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/ErrorFactoriesSpec.scala
@@ -467,7 +467,7 @@ class ErrorFactoriesSpec
         message = expectedInternalErrorMessage,
         details = expectedInternalErrorDetails,
         logEntry = ExpectedLogEntry(
-          Level.WARN,
+          Level.INFO,
           s"UNAUTHENTICATED(6,$truncatedCorrelationId): The command is missing a (valid) JWT token",
           Some(expectedLocationLogMarkerRegex),
         ),


### PR DESCRIPTION
This PR demotes all log lines corresponding to `UNAUTHENTICATED` and `PERMISSION_DENIED` gRPC errors from WARN to INFO.

> this is an application bug or application misconfiguration

Application bugs should (IMO) not produce WARNING level log lines in the server. On the other hand, this will make it less obvious when malicious users try to gain unauthorized access.

This was motivated by Canton Coin, where applications may use access tokens for a user before that user has been allocated on the participant, leading to spurious (and confusing) "Could not resolve is_deactivated status for user" warnings.


