### PR TITLE
add markers for Canton's doc snippets

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -33,7 +33,9 @@ final class Hash private (val bytes: Bytes) {
 
 object Hash {
 
+  // canton-user-manual-entry-begin: version
   val version = 0.toByte
+  // canton-user-manual-entry-end: version
   val underlyingHashLength = 32
 
   private case class HashingError(msg: String) extends Exception with NoStackTrace
@@ -221,7 +223,12 @@ object Hash {
 
   // The purpose of a hash serves to avoid hash collisions due to equal encodings for different objects.
   // Each purpose should be used at most once.
+  // canton-user-manual-entry-begin: Purpose
   private[crypto] case class Purpose(id: Byte)
+  // canton-user-manual-entry-end: Purpose
+  {
+    require(id != 0, "Purpose 0 must not be used to prevent clashes with Canton's hash purpose.")
+  }
 
   private[crypto] object Purpose {
     val Testing = Purpose(1)


### PR DESCRIPTION
Part of https://github.com/DACH-NY/canton/issues/10756

Adds markers so that the Canton docs can reference snippets in LF's hash function.
Also forbid hash purpose 0 so that LF hash purposes cannot clash with Cantons.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
