### PR TITLE
Fix async gauges usages by returning only the value [PLEN-61]

### DIFF
--- a/ledger/caching/BUILD.bazel
+++ b/ledger/caching/BUILD.bazel
@@ -17,7 +17,6 @@ da_scala_library(
     deps = [
         "//ledger/metrics",
         "@maven//:com_github_ben_manes_caffeine_caffeine",
-        "@maven//:io_dropwizard_metrics_metrics_core",
     ],
 )
 

--- a/ledger/metrics/BUILD.bazel
+++ b/ledger/metrics/BUILD.bazel
@@ -28,6 +28,7 @@ da_scala_library(
         "//libs-scala/build-info",
         "//libs-scala/concurrent",
         "//libs-scala/resources",
+        "//libs-scala/scala-utils",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:io_dropwizard_metrics_metrics_graphite",

--- a/ledger/metrics/src/main/scala/com/daml/metrics/CacheMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/CacheMetrics.scala
@@ -3,11 +3,11 @@
 
 package com.daml.metrics
 
-import com.codahale.metrics.{Gauge, MetricRegistry}
+import com.codahale.metrics.MetricRegistry
 import com.daml.metrics.api.MetricDoc.MetricQualification.Debug
 import com.daml.metrics.api.MetricHandle.Counter
 import com.daml.metrics.api.dropwizard.DropwizardFactory
-import com.daml.metrics.api.{MetricDoc, MetricName, MetricsContext}
+import com.daml.metrics.api.{MetricDoc, MetricName}
 
 final class CacheMetrics(val prefix: MetricName, override val registry: MetricRegistry)
     extends DropwizardFactory {
@@ -42,9 +42,9 @@ final class CacheMetrics(val prefix: MetricName, override val registry: MetricRe
   )
   val evictionWeight: Counter = counter(prefix :+ "evicted_weight")
 
-  def registerSizeGauge(sizeGauge: Gauge[Long]): Unit =
-    gaugeWithSupplier(prefix :+ "size", () => () => sizeGauge.getValue -> MetricsContext.Empty)
-  def registerWeightGauge(weightGauge: Gauge[Long]): Unit =
-    gaugeWithSupplier(prefix :+ "weight", () => () => weightGauge.getValue -> MetricsContext.Empty)
+  def registerSizeGauge(sizeSupplier: () => Long): Unit =
+    gaugeWithSupplier(prefix :+ "size", sizeSupplier)
+  def registerWeightGauge(weightSupplier: () => Long): Unit =
+    gaugeWithSupplier(prefix :+ "weight", weightSupplier)
 
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/IndexerMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IndexerMetrics.scala
@@ -9,7 +9,7 @@ import com.codahale.metrics.MetricRegistry
 import com.daml.metrics.api.MetricDoc.MetricQualification.Debug
 import com.daml.metrics.api.MetricHandle.Gauge
 import com.daml.metrics.api.dropwizard.{DropwizardFactory, DropwizardGauge}
-import com.daml.metrics.api.{MetricDoc, MetricName, MetricsContext}
+import com.daml.metrics.api.{MetricDoc, MetricName}
 
 class IndexerMetrics(val prefix: MetricName, override val registry: MetricRegistry)
     extends DropwizardFactory {
@@ -59,7 +59,6 @@ class IndexerMetrics(val prefix: MetricName, override val registry: MetricRegist
 
   gaugeWithSupplier(
     prefix :+ "current_record_time_lag",
-    () =>
-      () => (Instant.now().toEpochMilli - lastReceivedRecordTime.getValue) -> MetricsContext.Empty,
+    () => () => Instant.now().toEpochMilli - lastReceivedRecordTime.getValue,
   )
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/api/dropwizard/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/api/dropwizard/Metrics.scala
@@ -82,3 +82,8 @@ sealed case class DropwizardHistogram(name: String, metric: codahale.Histogram)
       context: MetricsContext
   ): Unit = metric.update(value)
 }
+
+sealed case class AsyncGauge[T](valueSupplier: () => T) extends codahale.Gauge[T] {
+
+  override def getValue: T = valueSupplier()
+}


### PR DESCRIPTION
The async gauges were registered the value as string because we were passing objects as values (the tuple that included the metrics contexts as well) and not the actual value.
This happened during an update to the metrics API that removed the metrics context from the actual value passing.

Ideally this should be typesafe, but dropwizard doesn't limit what it can receive so our API doesn't too. 
We could extend the current API to add evidence for the values being of expected type (using an implicit that needs to be present for the type to serialize) but the effort is not justified for now, as in the 3.0 release we will be changing the gauges type to accept only numeric values anyway (prometheus only processes numeric values).

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
