### PR TITLE
close the gap between scalac -Xlint and our global options

### DIFF
--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -75,6 +75,7 @@ common_scalacopts = version_specific.get(scala_major_version, []) + [
     "-Xlint:package-object-classes",  # put them directly in the package
     "-Xlint:poly-implicit-overload",  # implicit conversions don't mix with overloads
     "-Xlint:private-shadow",  # name shadowing
+    "-Xlint:recurse-with-default",  # optional settings not passed through
     "-Xlint:serial",  # spurious @SerialVersionUID
     "-Xlint:type-parameter-shadow",  # name shadowing
     "-Ywarn-dead-code",

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -63,14 +63,19 @@ common_scalacopts = version_specific.get(scala_major_version, []) + [
     # catch missing string interpolators
     "-Xlint:missing-interpolator",
     "-Xlint:constant",  # / 0
+    "-Xlint:delayedinit-select",  # uses deprecated DelayedInit
     "-Xlint:deprecation",  # deprecated annotations without 'message' or 'since' fields
     "-Xlint:doc-detached",  # floating Scaladoc comment
+    "-Xlint:eta-sam",  # missing @FunctionalInterface for lambda
+    "-Xlint:eta-zero",  # ambiguous nullary method delay
+    "-Xlint:implicit-not-found",  # messages well-formed
     "-Xlint:inaccessible",  # method uses invisible types
     "-Xlint:infer-any",  # less thorough but less buggy version of the Any wart
     "-Xlint:option-implicit",  # implicit conversion arg might be null
     "-Xlint:package-object-classes",  # put them directly in the package
     "-Xlint:poly-implicit-overload",  # implicit conversions don't mix with overloads
     "-Xlint:private-shadow",  # name shadowing
+    "-Xlint:serial",  # spurious @SerialVersionUID
     "-Xlint:type-parameter-shadow",  # name shadowing
     "-Ywarn-dead-code",
     # Warn about implicit conversion between numerical types

--- a/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTestUserManagement.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTestUserManagement.scala
@@ -598,7 +598,7 @@ class HttpServiceIntegrationTestUserManagementNoAuth
               }
               .flatMap { statusCodes =>
                 all(statusCodes) shouldBe StatusCodes.OK
-                createUsers(remainingRequests)
+                createUsers(remainingRequests, chunkSize)
               }
         }
       }

--- a/libs-scala/oracle-testing/src/main/scala/testing/oracle/OracleAround.scala
+++ b/libs-scala/oracle-testing/src/main/scala/testing/oracle/OracleAround.scala
@@ -101,11 +101,11 @@ object OracleAround {
       }
 
     @tailrec
-    def retry[T](times: Int, sleepMillisBeforeReTry: Long = 0)(body: => T): T = Try(body) match {
+    def retry[T](times: Int, sleepMillisBeforeReTry: Long)(body: => T): T = Try(body) match {
       case Success(t) => t
       case Failure(_) if times > 0 =>
         if (sleepMillisBeforeReTry > 0) Thread.sleep(sleepMillisBeforeReTry)
-        retry(times - 1)(body)
+        retry(times - 1, 0)(body)
       case Failure(t) => throw t
     }
 


### PR DESCRIPTION
We define several options that are relatively newer and therefore weren't available in Scala 2.11 when we last seriously evaluated these, and for which our code already compiles, with at most minor changes for a few options.

I should restate [my position from here](https://github.com/digital-asset/daml/pull/15645#issuecomment-1324078509): there is no need for us to ever find a global set. The selection in this PR is done based on what our code already follows, not any "ideal".