### PR TITLE
Set default LF version to 1.14 in LanguageVersion.scala

### DIFF
--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -82,8 +82,7 @@ object LanguageVersion {
   val DevVersions: VersionRange[LanguageVersion] =
     EarlyAccessVersions.copy(max = v1_dev)
 
-  val defaultV1: LanguageVersion = StableVersions.max
-
-  val default: LanguageVersion = defaultV1
+  // This refers to the default output LF version in the compiler
+  val default: LanguageVersion = v1_14
 
 }

--- a/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/AstSpec.scala
+++ b/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/AstSpec.scala
@@ -18,7 +18,7 @@ import scala.collection.immutable.VectorMap
 
 class AstSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
 
-  private def defaultVersion = LanguageVersion.defaultV1
+  private def defaultVersion = LanguageVersion.default
 
   "Package.build" should {
 

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -448,7 +448,7 @@ object Repl {
   implicit val parserParameters: parser.ParserParameters[Repl.this.type] =
     parser.ParserParameters(
       defaultPackageId = Ref.PackageId.assertFromString("-dummy-"),
-      languageVersion = LV.defaultV1,
+      languageVersion = LV.default,
     )
 
   // Invoke the given top-level function with given arguments.


### PR DESCRIPTION
I noticed that `LanguageVersion.default === v1_15`, which doesn't match the definition in `load("//daml-lf/language:daml-lf.bzl", "lf_version_configuration")`, which has `"default": "1.14"`.