### PR TITLE
[DPP-1356] Fix not logging some exceptions from streaming endpoints

### DIFF
--- a/ledger/participant-integration-api/src/test/resources/logback-test.xml
+++ b/ledger/participant-integration-api/src/test/resources/logback-test.xml
@@ -51,6 +51,14 @@
         <appender-ref ref="LogOnUnhandledFailureInCloseCapture"/>
     </logger>
 
+    <appender name="ErrorInterceptor" class="com.daml.platform.testing.LogCollector">
+        <test>com.daml.platform.apiserver.error.ErrorInterceptorSpec</test>
+    </appender>
+
+    <logger name="com.daml.platform.apiserver.error.ErrorInterceptor" level="INFO">
+        <appender-ref ref="ErrorInterceptor"/>
+    </logger>
+
     <logger name="com.daml.platform.store.dao.HikariConnection" level="INFO">
         <appender-ref ref="JdbcIndexerSpecAppender"/>
         <appender-ref ref="IndexerStabilitySpecAppender"/>

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/error/ErrorInterceptorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/error/ErrorInterceptorSpec.scala
@@ -16,13 +16,14 @@ import com.daml.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, TestingServerIn
 import com.daml.ledger.resources.{ResourceOwner, TestResourceContext}
 import com.daml.platform.hello.HelloServiceGrpc.HelloService
 import com.daml.platform.hello.{HelloRequest, HelloResponse, HelloServiceAkkaGrpc, HelloServiceGrpc}
-import com.daml.platform.testing.LogCollector.ThrowableEntry
+import com.daml.platform.testing.LogCollector.{ThrowableCause, ThrowableEntry}
 import com.daml.platform.testing.{LogCollector, LogCollectorAssertions, StreamConsumer}
 import io.grpc._
+import io.grpc.stub.StreamObserver
 import org.scalatest.concurrent.Eventually
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.{Assertion, Assertions, BeforeAndAfter, Checkpoints}
+import org.scalatest.{Assertion, Assertions, BeforeAndAfter, Checkpoints, OptionValues}
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 
@@ -31,6 +32,7 @@ final class ErrorInterceptorSpec
     with BeforeAndAfter
     with AkkaBeforeAndAfterAll
     with Matchers
+    with OptionValues
     with Eventually
     with TestResourceContext
     with Checkpoints
@@ -127,6 +129,23 @@ final class ErrorInterceptorSpec
             .map { t: StatusRuntimeException =>
               assertSecuritySanitizedError(t)
             }
+        }
+
+        "outside a Stream by directly calling stream-observer.onError" in {
+          exerciseStreamingAkkaEndpoint(
+            new HelloServiceFailingDirectlyObserverOnError
+          ).map { t: StatusRuntimeException =>
+            assertSecuritySanitizedError(t)
+            val loggedEntries = LogCollector.readAsEntries[this.type, ErrorInterceptor.type]
+            loggedEntries should have size 1
+            loggedEntries.head.throwableEntryO.flatMap(_.causeO).value shouldBe
+              ThrowableCause(
+                className = "java.lang.IllegalArgumentException",
+                message =
+                  "Failing the stream by passing a non error-code based error directly to observer.onError",
+              )
+            Assertions.succeed
+          }
         }
       }
 
@@ -335,6 +354,31 @@ object ErrorInterceptorSpec {
         throw t
       }
     }
+  }
+
+  class HelloServiceFailingDirectlyObserverOnError(implicit
+      protected val esf: ExecutionSequencerFactory,
+      protected val mat: Materializer,
+  ) extends HelloServiceAkkaGrpc
+      with HelloServiceResponding
+      with HelloServiceBase {
+
+    override def serverStreaming(
+        request: HelloRequest,
+        responseObserver: StreamObserver[HelloResponse],
+    ): Unit =
+      responseObserver.onError(
+        new IllegalArgumentException(
+          s"Failing the stream by passing a non error-code based error directly to observer.onError"
+        )
+      )
+
+    override protected def serverStreamingSource(
+        request: HelloRequest
+    ): Source[HelloResponse, NotUsed] = Assertions.fail("This method should have been unreachable")
+
+    override def single(request: HelloRequest): Future[HelloResponse] =
+      Assertions.fail("This class is not intended to test unary endpoints")
   }
 
 }


### PR DESCRIPTION
Backport https://github.com/digital-asset/daml/pull/15765


changelog_begin
Ledger API:
Previously non-error-code exceptions coming from streaming endpoints but thrown outside of Akka streams were not logged, and reported to clients with gRPC status UNKNOWN. Now they are logged on the server side and reported to clients as errors with LEDGER_API_INTERNAL_ERROR error code
changelog_end