### PR TITLE
Be nice to Bash 3 users

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,4 +5,4 @@ eval "$(dev-env/bin/dade assist)"
 [[ -f .envrc.private ]] && source_env .envrc.private
 
 # install pre-commit hook (opt-out by setting `DADE_NO_PRE_COMMIT`)
-[ -v DADE_NO_PRE_COMMIT ] || pre-commit install
+test "x$DADE_NO_PRE_COMMIT" = x && pre-commit install

--- a/shell.nix
+++ b/shell.nix
@@ -6,6 +6,6 @@ pkgs.mkShell {
 
   shellHook = ''
     # install pre-commit hook (opt-out by setting `DADE_NO_PRE_COMMIT`)
-    [ -v DADE_NO_PRE_COMMIT ] || pre-commit install
+    test "x$DADE_NO_PRE_COMMIT" = x && pre-commit install
   '';
 }


### PR DESCRIPTION
It did not work when using an old Bash version:
```
./.envrc: line 8: [: -v: unary operator expected
```

