### PR TITLE
Refine "component" of asset field

### DIFF
--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -62,7 +62,10 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
     with BeforeAndAfterAll {
 
   private val authorizationSecurity =
-    SecurityTest(property = Authorization, asset = s"WebsocketService $integration")
+    SecurityTest(
+      property = Authorization,
+      asset = s"HTTP JSON API Service: WebsocketService $integration",
+    )
 
   private def attackUnauthorized(threat: String): Attack = Attack(
     actor = s"Websocket client",

--- a/test-evidence/README.md
+++ b/test-evidence/README.md
@@ -1,0 +1,12 @@
+## Security Test Evidence
+
+As a convention, in order to being able to group test evidence by component, the component is
+the part of the `asset` field prior to the first colon, or the whole string when there is no colon.
+
+For example:
+
+| Asset                     | Component             |
+|---------------------------|-----------------------|
+| HTTP JSON API service     | HTTP JSON API service |
+| OAuth2 middleware: routes | OAuth2 middleware     |
+


### PR DESCRIPTION
Fixes #15222 

After #15732, the `asset` field of the relevant components contained the "component" already except in a single file.

Note, I did not touch the following files which would need to be adapted too:

- `libs-scala/jwt/src/test/scala/com/digitalasset/jwt/JwksSpec.scala`
- `ledger/sandbox-on-x/src/test/lib/scala/com/daml/platform/sandbox/auth/ServiceCallAuthTests.scala`
- `daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala`
- `ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceVisibilityIT.scala`


