### PR TITLE
Documented metrics for oauth2-middleware [PLEN-57]

### DIFF
--- a/docs/source/json-api/production-setup/metrics.rst
+++ b/docs/source/json-api/production-setup/metrics.rst
@@ -13,9 +13,9 @@ To enable metrics and configure reporting, you can use the below config block in
 .. code-block:: none
 
     metrics {
-      //Start a metrics reporter. Must be one of "console", "csv:///PATH", "graphite://HOST[:PORT][/METRIC_PREFIX]", or "prometheus://HOST[:PORT]".
-      reporter = "console"
-      //Set metric reporting interval , examples : 1s, 30s, 1m, 1h
+      // Start a metrics reporter. Must be one of "console", "csv:///PATH", "graphite://HOST[:PORT][/METRIC_PREFIX]", or "prometheus://HOST[:PORT]".
+      reporter = "prometheus://localhost:9000"
+      // Set metric reporting interval , examples : 1s, 30s, 1m, 1h
       reporting-interval = 30s
     }
 

--- a/docs/source/tools/auth-middleware/oauth2.rst
+++ b/docs/source/tools/auth-middleware/oauth2.rst
@@ -264,8 +264,8 @@ You can pass the command-line flag ``--cookie-secure no`` for testing and develo
 Metrics
 *******
 
-You may configure the oauth2-middleware to expose the :doc:`common HTTP metrics </ops/common-metrics>` via Prometheus
-by adding the below section to the application config:
+You may configure the oauth2-middleware to expose the :doc:`common HTTP metrics </ops/common-metrics>` via a Prometheus
+reporter by adding the below section to the application config:
 
 .. code-block:: none
 

--- a/docs/source/tools/auth-middleware/oauth2.rst
+++ b/docs/source/tools/auth-middleware/oauth2.rst
@@ -261,6 +261,21 @@ The oauth2-middleware can also be started using cli-args.
 Some browsers reject ``Secure`` cookies on unencrypted connections even on localhost.
 You can pass the command-line flag ``--cookie-secure no`` for testing and development on localhost to avoid this.
 
+Metrics
+*******
+
+You may configure the oauth2-middleware to expose the :doc:`common HTTP metrics </ops/common-metrics>` via Prometheus
+by adding the below section to the application config:
+
+.. code-block:: none
+
+    metrics {
+      // Start a metrics reporter. Must be one of "console", "csv:///PATH", "graphite://HOST[:PORT][/METRIC_PREFIX]", or "prometheus://HOST[:PORT]".
+      reporter = "prometheus://localhost:9000"
+      // Set metric reporting interval , examples : 1s, 30s, 1m, 1h
+      reporting-interval = 30s
+    }
+
 Liveness and Readiness Endpoints
 ********************************
 


### PR DESCRIPTION
Summary of changes:
* Added new section with an example metrics config snippet and reference to common HTTP metrics.
* Aligned example metrics config snippets to showcase a Prometheus reporter for all HTTP-JSON services.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
