### PR TITLE
[BACKPORT #15842] Adding H2 to high-level-intro.rst

### DIFF
--- a/docs/source/high-level-intro.rst
+++ b/docs/source/high-level-intro.rst
@@ -5,6 +5,9 @@
 An Introduction To Multi-Party Applications and Daml
 ####################################################
 
+Multi-Party Applications
+************************
+
 Multi-party applications, and multi-party application platforms like Daml, solve problems that were nearly impossible to solve with the technologies and architectures that came before. Successfully building multi-party applications requires learning a few new concepts, including architectural principles and patterns. This document explains:
  - why multi-party applications matter
  - what a multi-party application is


### PR DESCRIPTION
Adds an H2 immediately following the H1, which should hopefully correct the formatting issue with this page in the TOC

[CHANGELOG_BEGIN]
[CHANGELOG_END]

Co-authored-by: carrie-laben <91496516+carrie-laben@users.noreply.github.com>