### PR TITLE
Remove "Module" from daml-doc H1 headers

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
@@ -38,7 +38,7 @@ instance RenderDoc ModuleDoc where
     renderDoc m | isModuleEmpty m = mempty
     renderDoc ModuleDoc{..} = mconcat
         [ renderDoc md_anchor
-        , RenderModuleHeader ("Module " <> unModulename md_name)
+        , RenderModuleHeader (unModulename md_name)
         , renderDoc md_descr
         , section "Templates" md_templates
         , section "Interfaces" md_interfaces

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -40,7 +40,10 @@ renderRst env = \case
         ] ++
         [ T.concat
             [ "   "
+            , unModulename moduleName
+            , " <"
             , T.pack (moduleNameToFileName moduleName)
+            , ">"
             ]
         | moduleName <- moduleNames
         ]

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -40,10 +40,7 @@ renderRst env = \case
         ] ++
         [ T.concat
             [ "   "
-            , unModulename moduleName
-            , " <"
             , T.pack (moduleNameToFileName moduleName)
-            , ">"
             ]
         | moduleName <- moduleNames
         ]

--- a/compiler/damlc/daml-doc/test/DA/Daml/Doc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/Doc/Render/Tests.hs
@@ -214,7 +214,7 @@ mkExpectRst ::
 mkExpectRst asFolder anchor name descr templates classes adts fcts = T.unlines . concat $
     [ [ ".. _" <> anchor <> ":"
       , ""
-      , h1 ("Module " <> name)
+      , h1 name
       , ""
       ]
     , if T.null descr then [] else [descr, ""]
@@ -327,7 +327,7 @@ mkExpectMD :: T.Text -> T.Text -> T.Text -> [T.Text] -> [T.Text] -> [T.Text] -> 
 mkExpectMD anchor name descr templates classes adts fcts
   | null templates && null classes && null adts && null fcts && T.null descr = T.empty
   | otherwise = T.unlines $
-  ["# <a name=\"" <> anchor <> "\"></a>Module " <> name]
+  ["# <a name=\"" <> anchor <> "\"></a>" <> name]
   <> concat
   [ if T.null descr
         then [""]

--- a/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.md
@@ -1,4 +1,4 @@
-# <a name="module-constrainedclassmethod-88436"></a>Module ConstrainedClassMethod
+# <a name="module-constrainedclassmethod-88436"></a>ConstrainedClassMethod
 
 This module tests the case where a class method contains a constraint
 not present in the class itself.

--- a/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.rst
@@ -1,7 +1,7 @@
 .. _module-constrainedclassmethod-88436:
 
-Module ConstrainedClassMethod
------------------------------
+ConstrainedClassMethod
+----------------------
 
 This module tests the case where a class method contains a constraint
 not present in the class itself\.

--- a/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.md
@@ -1,4 +1,4 @@
-# <a name="module-constrainttuples-79635"></a>Module ConstraintTuples
+# <a name="module-constrainttuples-79635"></a>ConstraintTuples
 
 ## Data Types
 

--- a/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.rst
@@ -1,7 +1,7 @@
 .. _module-constrainttuples-79635:
 
-Module ConstraintTuples
------------------------
+ConstraintTuples
+----------------
 
 Data Types
 ^^^^^^^^^^

--- a/compiler/damlc/tests/daml-test-files/DamlHasVersion.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/DamlHasVersion.EXPECTED.md
@@ -1,4 +1,4 @@
-# <a name="module-damlhasversion-92471"></a>Module DamlHasVersion
+# <a name="module-damlhasversion-92471"></a>DamlHasVersion
 
 Testing the daml version header.
 

--- a/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.md
@@ -1,4 +1,4 @@
-# <a name="module-defaultmethods-34992"></a>Module DefaultMethods
+# <a name="module-defaultmethods-34992"></a>DefaultMethods
 
 ## Typeclasses
 

--- a/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.rst
@@ -1,7 +1,7 @@
 .. _module-defaultmethods-34992:
 
-Module DefaultMethods
----------------------
+DefaultMethods
+--------------
 
 Typeclasses
 ^^^^^^^^^^^

--- a/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.md
@@ -1,4 +1,4 @@
-# <a name="module-deriving-95739"></a>Module Deriving
+# <a name="module-deriving-95739"></a>Deriving
 
 ## Data Types
 

--- a/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.rst
@@ -1,7 +1,7 @@
 .. _module-deriving-95739:
 
-Module Deriving
----------------
+Deriving
+--------
 
 Data Types
 ^^^^^^^^^^

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
@@ -1,4 +1,4 @@
-# <a name="module-exportlist-67331"></a>Module ExportList
+# <a name="module-exportlist-67331"></a>ExportList
 
 ## Templates
 

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
@@ -1,7 +1,7 @@
 .. _module-exportlist-67331:
 
-Module ExportList
------------------
+ExportList
+----------
 
 Templates
 ^^^^^^^^^

--- a/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.md
@@ -1,4 +1,4 @@
-# <a name="module-interface-72439"></a>Module Interface
+# <a name="module-interface-72439"></a>Interface
 
 ## Templates
 

--- a/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.rst
@@ -1,7 +1,7 @@
 .. _module-interface-72439:
 
-Module Interface
-----------------
+Interface
+---------
 
 Templates
 ^^^^^^^^^

--- a/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.md
@@ -1,4 +1,4 @@
-# <a name="module-iou12-76192"></a>Module Iou12
+# <a name="module-iou12-76192"></a>Iou12
 
 ## Templates
 

--- a/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.rst
@@ -1,7 +1,7 @@
 .. _module-iou12-76192:
 
-Module Iou12
-------------
+Iou12
+-----
 
 Templates
 ^^^^^^^^^

--- a/compiler/damlc/tests/daml-test-files/MultipleNames.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/MultipleNames.EXPECTED.md
@@ -1,4 +1,4 @@
-# <a name="module-multiplenames-16996"></a>Module MultipleNames
+# <a name="module-multiplenames-16996"></a>MultipleNames
 
 Test multiple names sharing the same type signature.
 

--- a/compiler/damlc/tests/daml-test-files/MultipleNames.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/MultipleNames.EXPECTED.rst
@@ -1,7 +1,7 @@
 .. _module-multiplenames-16996:
 
-Module MultipleNames
---------------------
+MultipleNames
+-------------
 
 Test multiple names sharing the same type signature\.
 

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
@@ -1,4 +1,4 @@
-# <a name="module-newtype-87936"></a>Module Newtype
+# <a name="module-newtype-87936"></a>Newtype
 
 ## Data Types
 

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
@@ -1,7 +1,7 @@
 .. _module-newtype-87936:
 
-Module Newtype
---------------
+Newtype
+-------
 
 Data Types
 ^^^^^^^^^^

--- a/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.md
@@ -1,4 +1,4 @@
-# <a name="module-qualifiedinterface-53968"></a>Module QualifiedInterface
+# <a name="module-qualifiedinterface-53968"></a>QualifiedInterface
 
 ## Templates
 

--- a/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.rst
@@ -1,7 +1,7 @@
 .. _module-qualifiedinterface-53968:
 
-Module QualifiedInterface
--------------------------
+QualifiedInterface
+------------------
 
 Templates
 ^^^^^^^^^

--- a/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.md
@@ -1,4 +1,4 @@
-# <a name="module-qualifiedretroactiveinterfaceinstance-76052"></a>Module QualifiedRetroactiveInterfaceInstance
+# <a name="module-qualifiedretroactiveinterfaceinstance-76052"></a>QualifiedRetroactiveInterfaceInstance
 
 ## Interfaces
 

--- a/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.rst
@@ -1,7 +1,7 @@
 .. _module-qualifiedretroactiveinterfaceinstance-76052:
 
-Module QualifiedRetroactiveInterfaceInstance
---------------------------------------------
+QualifiedRetroactiveInterfaceInstance
+-------------------------------------
 
 Interfaces
 ^^^^^^^^^^

--- a/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.md
@@ -1,4 +1,4 @@
-# <a name="module-retroactiveinterfaceinstance-60009"></a>Module RetroactiveInterfaceInstance
+# <a name="module-retroactiveinterfaceinstance-60009"></a>RetroactiveInterfaceInstance
 
 ## Interfaces
 

--- a/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.rst
@@ -1,7 +1,7 @@
 .. _module-retroactiveinterfaceinstance-60009:
 
-Module RetroactiveInterfaceInstance
------------------------------------
+RetroactiveInterfaceInstance
+----------------------------
 
 Interfaces
 ^^^^^^^^^^

--- a/compiler/damlc/tests/daml-test-files/SingleConEnum.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/SingleConEnum.EXPECTED.rst
@@ -1,7 +1,7 @@
 .. _module-singleconenum-33613:
 
-Module SingleConEnum
---------------------
+SingleConEnum
+-------------
 
 Data Types
 ^^^^^^^^^^


### PR DESCRIPTION
We are changing how we are managing the [ToC in the docs.daml.com repo](https://github.com/digital-asset/docs.daml.com/blob/main/docs/index/_toc.yml).
The `.. toctree` directives are replaced by a single yaml-based ToC file linked above. The way the pages are currently generated, [we need to override each page's title in the ToC to stop it showing "Module" over and over](https://github.com/digital-asset/docs.daml.com/blob/main/docs/index/_toc.yml#L928-L1007). This is annoying to keep in sync.

Instead, we'd like to just [use a glob](https://github.com/digital-asset/docs.daml.com/blob/globs/docs/index/_toc.yml#L640-L641).
That glob mechanism is even more valuable for Daml Finance docs where the set of pages is expected to change more frequently.

Since we can't override page titles in the ToC with globs, we need this change to not have "Module" repeated over and over in the ToC.

CHANGELOG_BEING
- Remove the word "Module" from the H1 page header of
- module pages and stop overriding the ToC headers to make
- the generated pages easier to use. 
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
