### PR TITLE
ignore build-and-lint-test `yarn.lock` inconsistency on release

### DIFF
--- a/language-support/ts/codegen/tests/build-and-lint.sh
+++ b/language-support/ts/codegen/tests/build-and-lint.sh
@@ -77,10 +77,12 @@ hide_changing_paths() {
 # Build, lint, test.
 cd build-and-lint-test
 $YARN install > /dev/null
-# simulating what yarn install --frozen-lockfile is supposed to do,
-# because --frozen-lockfile appears to behave exactly like
-# --pure-lockfile - #14873
-if ! "$DIFF" -du <(hide_changing_paths $TS_DIR/yarn.lock) <(hide_changing_paths $TMP_DIR/yarn.lock); then
+# when testing 0.0.0 only, simulate what
+# yarn install --frozen-lockfile is supposed to do, because
+# --frozen-lockfile appears to behave exactly like --pure-lockfile
+# (see #14873)
+if grep -qE '^    "@daml/types" "0.0.0"$' $TMP_DIR/yarn.lock && \
+        ! "$DIFF" -du <(hide_changing_paths $TS_DIR/yarn.lock) <(hide_changing_paths $TMP_DIR/yarn.lock); then
     echo "FAIL: $TS_DIR/yarn.lock could not satisfy $TS_DIR/build-and-lint-test/package.json" 1>&2
     echo "FAIL: yarn.lock requires all of the above changes" 1>&2
     exit 1


### PR DESCRIPTION
We disable the check from #14873 when releasing, as it is meant to ensure we're keeping the lockfile for the test up-to-date with respect to `package.json` changes during `main`-line development.  `sed` does not really make it convenient to munge the relevant `version` lines, anyway.

*With this change:*

With the below command, with or without the entry for `@types/prettier@2.6.0` removed, this command passes.

```sh
DAML_SDK_RELEASE_VERSION=0.0.0-head bazel test --test_output=streamed //language-support/ts/codegen/tests:build-and-lint-test
```

With the below command with the entry for `@types/prettier@2.6.0` removed, this command fails with the expected error about a missing entry.  With the entry restored, it passes.

```sh
bazel test --test_output=streamed //language-support/ts/codegen/tests:build-and-lint-test
```

Reported by @garyverhaegen-da; thanks.
