### PR TITLE
Flaky test fixes for Canton deduplication tests

### DIFF
--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
@@ -17,7 +17,7 @@ import scala.annotation.tailrec
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 import scala.language.implicitConversions
-import scala.util.{Success, Try}
+import scala.util.Try
 
 object Assertions {
   def fail(message: String): Nothing =
@@ -70,12 +70,10 @@ object Assertions {
   }
 
   def assertGrpcErrorOneOf(t: Throwable, errors: ErrorCode*): Unit = {
-    val hasErrorCode = errors.map(errorCode => Try(assertGrpcError(t, errorCode, None))).exists {
-      case Success(_) => true
-      case _ => false
-    }
-    if (hasErrorCode) ()
-    else fail(s"gRPC failure did not contain one of the expected error codes $errors.", t)
+    val hasErrorCode =
+      errors.map(errorCode => Try(assertGrpcError(t, errorCode, None))).exists(_.isSuccess)
+    if (!hasErrorCode)
+      fail(s"gRPC failure did not contain one of the expected error codes $errors.", t)
   }
 
   def assertGrpcError(

--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContexts.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContexts.scala
@@ -3,8 +3,9 @@
 
 package com.daml.ledger.api.testtool.infrastructure.participant
 
-import java.time.Instant
+import com.daml.error.ErrorCode
 
+import java.time.Instant
 import com.daml.ledger.api.refinements.ApiTypes.TemplateId
 import com.daml.ledger.api.testtool.infrastructure.Endpoint
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext.{
@@ -358,6 +359,10 @@ trait ParticipantTestContext extends UserManagementTestContext {
   def submitAndWaitForTransactionTree(
       request: SubmitAndWaitRequest
   ): Future[SubmitAndWaitForTransactionTreeResponse]
+  def submitRequestAndTolerateGrpcError[T](
+      errorCode: ErrorCode,
+      submitAndWaitGeneric: ParticipantTestContext => Future[T],
+  ): Future[T]
   def completionStreamRequest(from: LedgerOffset = referenceOffset)(
       parties: Primitive.Party*
   ): CompletionStreamRequest

--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/SingleParticipantTestContext.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/SingleParticipantTestContext.scala
@@ -3,8 +3,9 @@
 
 package com.daml.ledger.api.testtool.infrastructure.participant
 
-import java.time.{Clock, Instant}
+import com.daml.error.ErrorCode
 
+import java.time.{Clock, Instant}
 import com.daml.ledger.api.refinements.ApiTypes.TemplateId
 import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
 import com.daml.ledger.api.testtool.infrastructure.ProtobufConverters._
@@ -100,15 +101,18 @@ import com.daml.lf.data.Ref
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.platform.participant.util.HexOffset
 import com.daml.platform.testing.StreamConsumer
+import com.daml.timer.Delayed
 import com.google.protobuf.ByteString
+import io.grpc.StatusRuntimeException
 import io.grpc.health.v1.health.{HealthCheckRequest, HealthCheckResponse}
+import io.grpc.protobuf.StatusProto
 import io.grpc.stub.StreamObserver
 import scalaz.Tag
 import scalaz.syntax.tag._
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Failure
+import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
 
 /** Exposes services running on some participant server in a test case.
@@ -662,6 +666,37 @@ final class SingleParticipantTestContext private[participant] (
   ): Future[SubmitAndWaitForTransactionTreeResponse] =
     services.command
       .submitAndWaitForTransactionTree(request)
+
+  /** This addresses a narrow case in which we tolerate a
+    * single occurrence of a specific and transient (and rare) error
+    * by retrying only a single time.
+    */
+  override def submitRequestAndTolerateGrpcError[T](
+      errorCodeToTolerateOnce: ErrorCode,
+      submitAndWaitGeneric: ParticipantTestContext => Future[T],
+  ): Future[T] = for {
+    // Issue the `submitAndWaitGeneric` submit the first (and for the
+    // most part the only) time. Returns a top-level Left if we
+    // encounter the error that we are supposed to tolerate.
+    eitherInFlightOrSuccess <- submitAndWaitGeneric(this).transform {
+      case Failure(e: StatusRuntimeException)
+          if errorCodeToTolerateOnce.category.grpcCode
+            .map(_.value())
+            .contains(StatusProto.fromThrowable(e).getCode) =>
+        Success(Left(e))
+      case otherTry =>
+        // Otherwise return a Right with a nested Either that
+        // let's us create a failed or successful future in the
+        // default case of the step below.
+        Success(Right(otherTry.toEither))
+    }
+    originalOrRetry <- eitherInFlightOrSuccess.fold(
+      _ =>
+        // If we are retrying a single time, back off first for one second.
+        Delayed.Future.by(1.second)(submitAndWaitGeneric(this)),
+      _.fold(Future.failed, Future.successful),
+    )
+  } yield originalOrRetry
 
   override def completionStreamRequest(from: LedgerOffset = referenceOffset)(
       parties: Party*

--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/TimeoutParticipantTestContext.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/TimeoutParticipantTestContext.scala
@@ -3,9 +3,10 @@
 
 package com.daml.ledger.api.testtool.infrastructure.participant
 
+import com.daml.error.ErrorCode
+
 import java.time.Instant
 import java.util.concurrent.TimeoutException
-
 import com.daml.ledger.api.refinements.ApiTypes.TemplateId
 import com.daml.ledger.api.testtool.infrastructure.Endpoint
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext.IncludeInterfaceView
@@ -417,6 +418,11 @@ class TimeoutParticipantTestContext(timeoutScaleFactor: Double, delegate: Partic
     s"Submit and wait for transaction tree for request $request",
     delegate.submitAndWaitForTransactionTree(request),
   )
+  override def submitRequestAndTolerateGrpcError[T](
+      errorToTolerate: ErrorCode,
+      submitAndWaitGeneric: ParticipantTestContext => Future[T],
+  ): Future[T] = // timeout enforced by submitAndWaitGeneric
+    delegate.submitRequestAndTolerateGrpcError(errorToTolerate, submitAndWaitGeneric)
   override def completionStreamRequest(from: LedgerOffset)(
       parties: Primitive.Party*
   ): CompletionStreamRequest = delegate.completionStreamRequest(from)(parties: _*)

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/CommandServiceIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/CommandServiceIT.scala
@@ -178,7 +178,12 @@ final class CommandServiceIT extends LedgerTestSuite {
     val request = ledger.submitAndWaitRequest(party, Dummy(party).create.command)
     for {
       _ <- ledger.submitAndWait(request)
-      failure <- ledger.submitAndWait(request).mustFail("submitting a duplicate request")
+      failure <- ledger
+        .submitRequestAndTolerateGrpcError(
+          LedgerApiErrors.ConsistencyErrors.SubmissionAlreadyInFlight,
+          _.submitAndWait(request),
+        )
+        .mustFail("submitting a duplicate request")
     } yield {
       assertGrpcError(
         failure,
@@ -198,7 +203,10 @@ final class CommandServiceIT extends LedgerTestSuite {
     for {
       _ <- ledger.submitAndWaitForTransactionId(request)
       failure <- ledger
-        .submitAndWaitForTransactionId(request)
+        .submitRequestAndTolerateGrpcError(
+          LedgerApiErrors.ConsistencyErrors.SubmissionAlreadyInFlight,
+          _.submitAndWaitForTransactionId(request),
+        )
         .mustFail("submitting a duplicate request")
     } yield {
       assertGrpcError(
@@ -219,7 +227,10 @@ final class CommandServiceIT extends LedgerTestSuite {
     for {
       _ <- ledger.submitAndWaitForTransaction(request)
       failure <- ledger
-        .submitAndWaitForTransaction(request)
+        .submitRequestAndTolerateGrpcError(
+          LedgerApiErrors.ConsistencyErrors.SubmissionAlreadyInFlight,
+          _.submitAndWaitForTransaction(request),
+        )
         .mustFail("submitting a duplicate request")
     } yield {
       assertGrpcError(
@@ -240,7 +251,10 @@ final class CommandServiceIT extends LedgerTestSuite {
     for {
       _ <- ledger.submitAndWaitForTransactionTree(request)
       failure <- ledger
-        .submitAndWaitForTransactionTree(request)
+        .submitRequestAndTolerateGrpcError(
+          LedgerApiErrors.ConsistencyErrors.SubmissionAlreadyInFlight,
+          _.submitAndWaitForTransactionTree(request),
+        )
         .mustFail("submitting a duplicate request")
     } yield {
       assertGrpcError(

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ConfigManagementServiceIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ConfigManagementServiceIT.scala
@@ -165,7 +165,6 @@ final class ConfigManagementServiceIT extends LedgerTestSuite {
       )
       assertGrpcErrorOneOf(
         failure,
-        extendedChecks = None,
         LedgerApiErrors.Admin.ConfigurationEntryRejected,
         LedgerApiErrors.RequestValidation.InvalidArgument,
         KvErrors.Consistency.PostExecutionConflicts,


### PR DESCRIPTION
The earlier fix 936594f5 that added `SubmissionAlreadyInFlight` as a second option next to `DuplicateCommand` had two shortcomings addressed here:

- `SubmissionAlreadyInFlight` is raised at submission time, so the tests in `CommandDeduplicationIT` that expect a `Completion` still flaked.
- Checking the `DuplicateCommand`-specific `checkDefiniteAnswerMetadata` flag was incorrectly also set on `SubmissionAlreadyInFlight`.

The new approach issues one single retry after backoff when a transient `SubmissionAlreadyInFlight` is encountered.

CHANGELIST_BEGIN
CHANGELIST_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
