### PR TITLE
Add counter for all indexed events [PLEN-70]

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/IndexedUpdatesMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IndexedUpdatesMetrics.scala
@@ -21,7 +21,7 @@ class IndexedUpdatesMetrics(prefix: MetricName, metricFactory: Factory) {
   )
 
   @MetricDoc.Tag(
-    summary = "Updated processed by the indexer",
+    summary = "Updates processed by the indexer",
     description = "Represents the total number of updates processed and indexed by the indexer.",
     qualification = Debug,
   )

--- a/ledger/metrics/src/main/scala/com/daml/metrics/IndexedUpdatesMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IndexedUpdatesMetrics.scala
@@ -20,13 +20,38 @@ class IndexedUpdatesMetrics(prefix: MetricName, metricFactory: Factory) {
     "Number of events that will be metered.",
   )
 
+  @MetricDoc.Tag(
+    summary = "Updated processed by the indexer",
+    description =
+      """Represents the total number of updates processed and indexed by the indexer.""".stripMargin,
+    qualification = Debug,
+  )
+  val eventsMeter: MetricHandle.Meter =
+    metricFactory.meter(prefix :+ "events", "Number of events ingested by the indexer.")
+
 }
 
 object IndexedUpdatesMetrics {
 
   object Labels {
-
     val applicationId = "application_id"
+    val grpcCode = "grpc_code"
+    object eventType {
+
+      val key = "event_type"
+
+      val configurationChange = "configuration_change"
+      val partyAllocation = "party_allocation"
+      val packageUpload = "package_upload"
+      val transaction = "transaction"
+    }
+
+    object status {
+      val key = "status"
+
+      val accepted = "accepted"
+      val rejected = "rejected"
+    }
 
   }
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/IndexedUpdatesMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IndexedUpdatesMetrics.scala
@@ -12,7 +12,7 @@ class IndexedUpdatesMetrics(prefix: MetricName, metricFactory: Factory) {
   @MetricDoc.Tag(
     summary = "Number of events that will be metered",
     description = """Represents the number of events that will be included in the metering report.
-        |This is an estimate of the total number and not a substitute for the metering report.""".stripMargin,
+        |This is an estimate of the total number and not a substitute for the metering report.""",
     qualification = Debug,
   )
   val meteredEventsMeter: MetricHandle.Meter = metricFactory.meter(
@@ -22,8 +22,7 @@ class IndexedUpdatesMetrics(prefix: MetricName, metricFactory: Factory) {
 
   @MetricDoc.Tag(
     summary = "Updated processed by the indexer",
-    description =
-      """Represents the total number of updates processed and indexed by the indexer.""".stripMargin,
+    description = "Represents the total number of updates processed and indexed by the indexer.",
     qualification = Debug,
   )
   val eventsMeter: MetricHandle.Meter =

--- a/ledger/metrics/src/main/scala/com/daml/metrics/IndexedUpdatesMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IndexedUpdatesMetrics.scala
@@ -22,7 +22,7 @@ class IndexedUpdatesMetrics(prefix: MetricName, metricFactory: Factory) {
 
   @MetricDoc.Tag(
     summary = "Updates processed by the indexer",
-    description = "Represents the total number of updates processed and indexed by the indexer.",
+    description = "Represents the total number of updates processed, that are sent for indexing.",
     qualification = Debug,
   )
   val eventsMeter: MetricHandle.Meter =

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerSubscription.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerSubscription.scala
@@ -66,6 +66,7 @@ private[platform] case class ParallelIndexerSubscription[DB_BATCH](
               participantId = participantId,
               translation = translation,
               compressionStrategy = compressionStrategy,
+              metrics,
             ),
             UpdateToMeteringDbDto(metrics = metrics.daml.indexerEvents),
           )

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/UpdateToDbDto.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/UpdateToDbDto.scala
@@ -3,6 +3,8 @@
 
 package com.daml.platform.store.backend
 
+import java.util.UUID
+
 import com.daml.ledger.api.DeduplicationPeriod.{DeduplicationDuration, DeduplicationOffset}
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.offset.Offset
@@ -12,11 +14,14 @@ import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.engine.Blinding
 import com.daml.lf.ledger.EventId
 import com.daml.lf.transaction.Transaction.ChildrenRecursion
+import com.daml.metrics.api.MetricsContext
+import com.daml.metrics.api.MetricsContext.withExtraMetricLabels
+import com.daml.metrics.{IndexedUpdatesMetrics, Metrics}
+import com.daml.platform._
 import com.daml.platform.index.index.StatusDetails
 import com.daml.platform.store.dao.JdbcLedgerDao
 import com.daml.platform.store.dao.events._
-import com.daml.platform._
-import java.util.UUID
+import io.grpc.Status
 
 object UpdateToDbDto {
 
@@ -24,10 +29,23 @@ object UpdateToDbDto {
       participantId: Ref.ParticipantId,
       translation: LfValueSerialization,
       compressionStrategy: CompressionStrategy,
-  ): Offset => state.Update => Iterator[DbDto] = { offset =>
+      metrics: Metrics,
+  )(implicit mc: MetricsContext): Offset => state.Update => Iterator[DbDto] = { offset =>
     import state.Update._
     {
       case u: CommandRejected =>
+        withExtraMetricLabels(
+          IndexedUpdatesMetrics.Labels.grpcCode -> Status
+            .fromCodeValue(u.reasonTemplate.code)
+            .getCode
+            .name()
+        ) { implicit mc: MetricsContext =>
+          incrementCounterForEvent(
+            metrics.daml.indexerEvents,
+            IndexedUpdatesMetrics.Labels.eventType.transaction,
+            IndexedUpdatesMetrics.Labels.status.rejected,
+          )
+        }
         Iterator(
           commandCompletion(offset, u.recordTime, transactionId = None, u.completionInfo).copy(
             rejection_status_code = Some(u.reasonTemplate.code),
@@ -38,6 +56,11 @@ object UpdateToDbDto {
         )
 
       case u: ConfigurationChanged =>
+        incrementCounterForEvent(
+          metrics.daml.indexerEvents,
+          IndexedUpdatesMetrics.Labels.eventType.configurationChange,
+          IndexedUpdatesMetrics.Labels.status.accepted,
+        )
         Iterator(
           DbDto.ConfigurationEntry(
             ledger_offset = offset.toHexString,
@@ -50,6 +73,11 @@ object UpdateToDbDto {
         )
 
       case u: ConfigurationChangeRejected =>
+        incrementCounterForEvent(
+          metrics.daml.indexerEvents,
+          IndexedUpdatesMetrics.Labels.eventType.configurationChange,
+          IndexedUpdatesMetrics.Labels.status.rejected,
+        )
         Iterator(
           DbDto.ConfigurationEntry(
             ledger_offset = offset.toHexString,
@@ -62,6 +90,11 @@ object UpdateToDbDto {
         )
 
       case u: PartyAddedToParticipant =>
+        incrementCounterForEvent(
+          metrics.daml.indexerEvents,
+          IndexedUpdatesMetrics.Labels.eventType.partyAllocation,
+          IndexedUpdatesMetrics.Labels.status.accepted,
+        )
         Iterator(
           DbDto.PartyEntry(
             ledger_offset = offset.toHexString,
@@ -76,6 +109,11 @@ object UpdateToDbDto {
         )
 
       case u: PartyAllocationRejected =>
+        incrementCounterForEvent(
+          metrics.daml.indexerEvents,
+          IndexedUpdatesMetrics.Labels.eventType.partyAllocation,
+          IndexedUpdatesMetrics.Labels.status.rejected,
+        )
         Iterator(
           DbDto.PartyEntry(
             ledger_offset = offset.toHexString,
@@ -90,6 +128,11 @@ object UpdateToDbDto {
         )
 
       case u: PublicPackageUpload =>
+        incrementCounterForEvent(
+          metrics.daml.indexerEvents,
+          IndexedUpdatesMetrics.Labels.eventType.packageUpload,
+          IndexedUpdatesMetrics.Labels.status.accepted,
+        )
         val uploadId = u.submissionId.getOrElse(UUID.randomUUID().toString)
         val packages = u.archives.iterator.map { archive =>
           DbDto.Package(
@@ -114,6 +157,11 @@ object UpdateToDbDto {
         packages ++ packageEntries
 
       case u: PublicPackageUploadRejected =>
+        incrementCounterForEvent(
+          metrics.daml.indexerEvents,
+          IndexedUpdatesMetrics.Labels.eventType.packageUpload,
+          IndexedUpdatesMetrics.Labels.status.rejected,
+        )
         Iterator(
           DbDto.PackageEntry(
             ledger_offset = offset.toHexString,
@@ -125,6 +173,11 @@ object UpdateToDbDto {
         )
 
       case u: TransactionAccepted =>
+        incrementCounterForEvent(
+          metrics.daml.indexerEvents,
+          IndexedUpdatesMetrics.Labels.eventType.transaction,
+          IndexedUpdatesMetrics.Labels.status.accepted,
+        )
         val blinding = u.blindingInfo.getOrElse(Blinding.blind(u.transaction))
         // TODO LLP: Extract in common functionality together with duplicated code in [[InMemoryStateUpdater]]
         val preorderTraversal = u.transaction
@@ -311,6 +364,20 @@ object UpdateToDbDto {
     }
   }
 
+  private def incrementCounterForEvent(
+      metrics: IndexedUpdatesMetrics,
+      eventType: String,
+      status: String,
+  )(implicit
+      mc: MetricsContext
+  ): Unit = {
+    withExtraMetricLabels(
+      IndexedUpdatesMetrics.Labels.eventType.key -> eventType,
+      IndexedUpdatesMetrics.Labels.status.key -> status,
+    ) { implicit mc =>
+      metrics.eventsMeter.mark()
+    }
+  }
   private def commandCompletion(
       offset: Offset,
       recordTime: Time.Timestamp,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/SequentialWriteDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/SequentialWriteDao.scala
@@ -10,6 +10,7 @@ import com.daml.ledger.participant.state.v2.Update
 import com.daml.ledger.participant.state.{v2 => state}
 import com.daml.lf.data.Ref
 import com.daml.metrics.Metrics
+import com.daml.metrics.api.MetricsContext
 import com.daml.platform.store.dao.events.{CompressionStrategy, LfValueTranslation}
 import com.daml.platform.store.backend.{
   DbDto,
@@ -41,23 +42,27 @@ object SequentialWriteDao {
       stringInterningView: StringInterning with InternizingStringInterningView,
       ingestionStorageBackend: IngestionStorageBackend[_],
       parameterStorageBackend: ParameterStorageBackend,
-  ): SequentialWriteDao =
-    SequentialWriteDaoImpl(
-      ingestionStorageBackend = ingestionStorageBackend,
-      parameterStorageBackend = parameterStorageBackend,
-      updateToDbDtos = UpdateToDbDto(
-        participantId = participantId,
-        translation = new LfValueTranslation(
-          metrics = metrics,
-          engineO = None,
-          loadPackage = (_, _) => Future.successful(None),
+  ): SequentialWriteDao = {
+    MetricsContext.withMetricLabels("participant_id" -> participantId) { implicit mc =>
+      SequentialWriteDaoImpl(
+        ingestionStorageBackend = ingestionStorageBackend,
+        parameterStorageBackend = parameterStorageBackend,
+        updateToDbDtos = UpdateToDbDto(
+          participantId = participantId,
+          translation = new LfValueTranslation(
+            metrics = metrics,
+            engineO = None,
+            loadPackage = (_, _) => Future.successful(None),
+          ),
+          compressionStrategy = compressionStrategy,
+          metrics,
         ),
-        compressionStrategy = compressionStrategy,
-      ),
-      ledgerEndCache = ledgerEndCache,
-      stringInterningView = stringInterningView,
-      dbDtosToStringsForInterning = DbDtoToStringsForInterning(_),
-    )
+        ledgerEndCache = ledgerEndCache,
+        stringInterningView = stringInterningView,
+        dbDtosToStringsForInterning = DbDtoToStringsForInterning(_),
+      )
+    }
+  }
 
   val noop: SequentialWriteDao = NoopSequentialWriteDao
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/UpdateToMeteringDbDtoSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/UpdateToMeteringDbDtoSpec.scala
@@ -23,7 +23,7 @@ class UpdateToMeteringDbDtoSpec extends AnyWordSpec with MetricValues {
 
   import DbDtoEq._
 
-  private val updateEventsMetrics = newUpdateMetrics
+  private val IndexedUpdatesMetrics = newUpdateMetrics
 
   "UpdateMeteringToDbDto" should {
 
@@ -75,7 +75,7 @@ class UpdateToMeteringDbDtoSpec extends AnyWordSpec with MetricValues {
     "extract transaction metering" in {
 
       val actual =
-        UpdateToMeteringDbDto(clock = () => timestamp, updateEventsMetrics)(MetricsContext.Empty)(
+        UpdateToMeteringDbDto(clock = () => timestamp, IndexedUpdatesMetrics)(MetricsContext.Empty)(
           List((Offset.fromHexString(offset), someTransactionAccepted))
         )
 
@@ -104,7 +104,7 @@ class UpdateToMeteringDbDtoSpec extends AnyWordSpec with MetricValues {
       val expected: Vector[DbDto.TransactionMetering] = Vector(metering)
 
       val actual =
-        UpdateToMeteringDbDto(clock = () => timestamp, updateEventsMetrics)(MetricsContext.Empty)(
+        UpdateToMeteringDbDto(clock = () => timestamp, IndexedUpdatesMetrics)(MetricsContext.Empty)(
           List(
             (
               Offset.fromHexString(Ref.HexString.assertFromString("01")),
@@ -123,7 +123,7 @@ class UpdateToMeteringDbDtoSpec extends AnyWordSpec with MetricValues {
 
     "return empty vector if input iterable is empty" in {
       val expected: Vector[DbDto.TransactionMetering] = Vector.empty
-      val actual = UpdateToMeteringDbDto(clock = () => timestamp, updateEventsMetrics)(
+      val actual = UpdateToMeteringDbDto(clock = () => timestamp, IndexedUpdatesMetrics)(
         MetricsContext.Empty
       )(List.empty)
       actual should equal(expected)(decided by DbDtoSeqEq)
@@ -137,7 +137,7 @@ class UpdateToMeteringDbDtoSpec extends AnyWordSpec with MetricValues {
       )
 
       val actual =
-        UpdateToMeteringDbDto(clock = () => timestamp, updateEventsMetrics)(MetricsContext.Empty)(
+        UpdateToMeteringDbDto(clock = () => timestamp, IndexedUpdatesMetrics)(MetricsContext.Empty)(
           List((Offset.fromHexString(offset), txWithNoActionCount))
         )
 
@@ -145,11 +145,11 @@ class UpdateToMeteringDbDtoSpec extends AnyWordSpec with MetricValues {
     }
 
     "increment metered events counter" in {
-      val updateEventsMetrics = newUpdateMetrics
-      UpdateToMeteringDbDto(clock = () => timestamp, updateEventsMetrics)(MetricsContext.Empty)(
+      val IndexedUpdatesMetrics = newUpdateMetrics
+      UpdateToMeteringDbDto(clock = () => timestamp, IndexedUpdatesMetrics)(MetricsContext.Empty)(
         List((Offset.fromHexString(offset), someTransactionAccepted))
       )
-      updateEventsMetrics.meteredEventsMeter.value shouldBe (statistics.committed.actions + statistics.rolledBack.actions)
+      IndexedUpdatesMetrics.meteredEventsMeter.value shouldBe (statistics.committed.actions + statistics.rolledBack.actions)
     }
   }
 


### PR DESCRIPTION
Adds the `daml_indexed_events_total` meter, with labels for the event type and status. For rejections it also contains the gRPC status code. 
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
