### PR TITLE
use LF 1.15 instead of dev for interface-related bazel tests

### DIFF
--- a/daml-lf/api-type-signature/BUILD.bazel
+++ b/daml-lf/api-type-signature/BUILD.bazel
@@ -44,7 +44,7 @@ da_scala_library(
 daml_compile(
     name = "InterfaceTestPackage",
     srcs = glob(["src/test/daml/**/*.daml"]),
-    target = lf_version_configuration.get("dev"),  # TODO(#13296) remove when interfaces in default
+    target = lf_version_configuration.get("latest"),  # TODO(#13296) remove when interfaces in default
 )
 
 da_scala_test(

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -659,8 +659,8 @@ daml_test(
     name = "bindings-java-daml-test",
     srcs = glob(["source/app-dev/bindings-java/code-snippets/**/*.daml"]),
     # FIXME: https://github.com/digital-asset/daml/issues/12051
-    #  replace "dev" by "default", once interfaces are stable.
-    target = lf_version_configuration.get("dev"),
+    #  remove target, once interfaces are stable.
+    target = lf_version_configuration.get("latest"),
 )
 
 daml_test(

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -158,8 +158,8 @@ daml_compile(
         "src/test/daml/Bar.daml",
         "src/test/daml/Retro.daml",
     ],
-    # TODO(#13296) change to "latest" when interfaces released
-    target = lf_version_configuration.get("dev"),
+    # TODO(#13296) remove when interfaces in default
+    target = lf_version_configuration.get("latest"),
 )
 
 dar_to_java(
@@ -380,8 +380,8 @@ daml_compile(
     srcs = glob(["src/ledger-tests/daml/**/*.daml"]),
     enable_scenarios = True,
     # FIXME: https://github.com/digital-asset/daml/issues/12051
-    #  replace "dev" by "default", once interfaces are stable.
-    target = lf_version_configuration.get("dev"),
+    # remove target, once interfaces are stable.
+    target = lf_version_configuration.get("latest"),
 )
 
 dar_to_java(

--- a/language-support/scala/codegen-sample-app/BUILD.bazel
+++ b/language-support/scala/codegen-sample-app/BUILD.bazel
@@ -18,7 +18,7 @@ load(
 )
 
 # TODO(#13296) change to "latest" when interfaces released
-tested_lf_config = "dev"
+tested_lf_config = "latest"
 
 daml_compile(
     name = "MyMain",

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -189,7 +189,7 @@ daml_compile(
         "Account",
         "IAccount",
     ]],
-    target = lf_version_configuration.get("dev"),  # TODO(SC #13296) remove when interfaces in default
+    target = lf_version_configuration.get("latest"),  # TODO(SC #13296) remove when interfaces in default
     visibility = ["//ledger-service:__subpackages__"],
 )
 
@@ -207,7 +207,7 @@ daml_compile(
         "RIIou",
         "Transferrable",
     ]],
-    target = lf_version_configuration.get("dev"),  # TODO(SC #13296) remove when interfaces in default
+    target = lf_version_configuration.get("latest"),  # TODO(SC #13296) remove when interfaces in default
     visibility = ["//ledger-service:__subpackages__"],
 )
 
@@ -217,7 +217,7 @@ daml_compile(
         "RIou",
     ]],
     data_dependencies = ["//ledger/test-common:model-tests-%s.dar" % lf_version_configuration.get("default")],
-    target = lf_version_configuration.get("dev"),  # TODO(SC #13296) remove when interfaces in default
+    target = lf_version_configuration.get("latest"),  # TODO(SC #13296) remove when interfaces in default
     visibility = ["//ledger-service:__subpackages__"],
 )
 


### PR DESCRIPTION
Start running these tests against 1.15; pursuant to #13296 all of these targets should be removed when `"default"` is 1.15 or later.