### PR TITLE
Fix for canton documentation build

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/IndexedUpdatesMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IndexedUpdatesMetrics.scala
@@ -12,7 +12,7 @@ class IndexedUpdatesMetrics(prefix: MetricName, metricFactory: Factory) {
   @MetricDoc.Tag(
     summary = "Number of events that will be metered",
     description = """Represents the number of events that will be included in the metering report.
-        |This is an estimate of the total number and not a substitute for the metering report.""".stripMargin,
+        |This is an estimate of the total number and not a substitute for the metering report.""",
     qualification = Debug,
   )
   val meteredEventsMeter: MetricHandle.Meter = metricFactory.meter(


### PR DESCRIPTION
Canton extracts metric metadata for documentation via reflection and needs the summary and description fields to be literal strings to avoid the following error:

```
Failed to process Tag annotation:
            |summary and description need to be constant-string, i.e. don't apply stripmargin here ...),
            |and MetricQualification must be an object of MetricQualification:
            |new com.daml.metrics.api.MetricDoc.Tag("Number of events that will be metered", scala.Predef.augmentString("Represents the number of events that will be included in the metering report.\n        |This is an estimate of the total number and not a substitute for the metering report.").stripMargin, com.daml.metrics.api.MetricDoc.MetricQualification.Debug)
```

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
