### PR TITLE
Remove the metrics.Gauge update API based on the current value [PLEN-86]

### DIFF
--- a/observability/metrics/src/main/scala/com/daml/metrics/api/MetricHandle.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/MetricHandle.scala
@@ -117,8 +117,6 @@ object MetricHandle {
 
     def updateValue(newValue: T): Unit
 
-    def updateValue(f: T => T): Unit = updateValue(f(getValue))
-
     def getValue: T
   }
 


### PR DESCRIPTION
It is only used in canton, and we have refactored all the usages away.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
