### PR TITLE
Add no-op metrics factory

### DIFF
--- a/observability/metrics/src/main/scala/com/daml/metrics/api/noop/Metrics.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/noop/Metrics.scala
@@ -6,8 +6,8 @@ package com.daml.metrics.api.noop
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
-import com.daml.metrics.api.MetricHandle.Timer
 import com.daml.metrics.api.MetricHandle.Timer.TimerHandle
+import com.daml.metrics.api.MetricHandle.{Counter, Gauge, Histogram, Meter, Timer}
 import com.daml.metrics.api.MetricsContext
 
 sealed case class NoOpTimer(name: String) extends Timer {
@@ -27,4 +27,40 @@ sealed case class NoOpTimer(name: String) extends Timer {
 
 case object NoOpTimerHandle extends TimerHandle {
   override def stop()(implicit context: MetricsContext): Unit = ()
+}
+
+case class NoOpGauge[T](name: String, value: T) extends Gauge[T] {
+
+  override def updateValue(newValue: T): Unit = ()
+
+  override def getValue: T = value
+
+}
+
+case class NoOpMeter(name: String) extends Meter {
+  override def mark(value: Long)(implicit
+      context: MetricsContext
+  ): Unit = ()
+}
+
+case class NoOpCounter(name: String) extends Counter {
+
+  override def inc(n: Long)(implicit context: MetricsContext): Unit =
+    ()
+
+  override def dec(n: Long)(implicit context: _root_.com.daml.metrics.api.MetricsContext): Unit =
+    ()
+
+  override def getCount: Long = 0
+}
+
+case class NoOpHistogram(name: String) extends Histogram {
+
+  override def update(value: Long)(implicit
+      context: MetricsContext
+  ): Unit = ()
+
+  override def update(value: Int)(implicit
+      context: _root_.com.daml.metrics.api.MetricsContext
+  ): Unit = ()
 }

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/noop/Metrics.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/noop/Metrics.scala
@@ -10,7 +10,7 @@ import com.daml.metrics.api.MetricHandle.Timer.TimerHandle
 import com.daml.metrics.api.MetricHandle.{Counter, Gauge, Histogram, Meter, Timer}
 import com.daml.metrics.api.MetricsContext
 
-sealed case class NoOpTimer(name: String) extends Timer {
+case class NoOpTimer(name: String) extends Timer {
   override def update(duration: Long, unit: TimeUnit)(implicit
       context: MetricsContext = MetricsContext.Empty
   ): Unit = ()

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/noop/NoOpMetricsFactory.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/noop/NoOpMetricsFactory.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package com.daml.metrics.api.noop

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/noop/NoOpMetricsFactory.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/noop/NoOpMetricsFactory.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.metrics.api.noop
+
+import com.daml.metrics.api.MetricHandle.Factory
+import com.daml.metrics.api.{MetricHandle, MetricName, MetricsContext}
+
+object NoOpMetricsFactory extends Factory {
+
+  override def timer(
+      name: MetricName,
+      description: String,
+  )(implicit
+      context: MetricsContext
+  ): MetricHandle.Timer = NoOpTimer(name)
+
+  override def gauge[T](
+      name: MetricName,
+      initial: T,
+      description: String,
+  )(implicit
+      context: MetricsContext
+  ): MetricHandle.Gauge[T] = NoOpGauge(name, initial)
+
+  override def gaugeWithSupplier[T](
+      name: MetricName,
+      gaugeSupplier: () => T,
+      description: String,
+  )(implicit context: MetricsContext): Unit = ()
+
+  override def meter(
+      name: MetricName,
+      description: String,
+  )(implicit
+      context: MetricsContext
+  ): MetricHandle.Meter = NoOpMeter(name)
+
+  override def counter(
+      name: MetricName,
+      description: String,
+  )(implicit
+      context: MetricsContext
+  ): MetricHandle.Counter = NoOpCounter(name)
+
+  override def histogram(
+      name: MetricName,
+      description: String,
+  )(implicit
+      context: MetricsContext
+  ): MetricHandle.Histogram = NoOpHistogram(name)
+}


### PR DESCRIPTION
Will allow us to clean-up the code in places where metrics are not important/we want to run without metrics
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
