### PR TITLE
[Triggers] fix versioning

### DIFF
--- a/triggers/daml/Daml/Trigger/Internal.daml
+++ b/triggers/daml/Daml/Trigger/Internal.daml
@@ -35,7 +35,7 @@ import Daml.Trigger.LowLevel hiding (Trigger)
 import qualified Daml.Trigger.LowLevel as LowLevel
 
 -- We use this singleton enumeration to track the version of the API between Daml code and Scala code of the trigger
-data Version = Version_2_6
+data Version = Version_2_5_1
 
 -- public API
 

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
@@ -173,7 +173,7 @@ final class Converter(
       viewValue <- view.viewValue.traverseU(fromRecord(viewType, _))
     } yield SOptional(viewValue.map(fromAnyView(viewType, _)))
 
-  private[this] def fromV25CreatedEvent(
+  private[this] def fromV250CreatedEvent(
       created: CreatedEvent
   ): Either[String, SValue] =
     for {
@@ -192,10 +192,10 @@ final class Converter(
     }
 
   private[this] val fromCreatedEvent: CreatedEvent => Either[String, SValue] =
-    if (triggerDef.version < Trigger.Version.`2.6`) {
+    if (triggerDef.version < Trigger.Version.`2.5.0`) {
       fromV20CreatedEvent
     } else {
-      fromV25CreatedEvent
+      fromV250CreatedEvent
     }
 
   private def fromEvent(ev: Event): Either[String, SValue] =

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -234,7 +234,7 @@ object Trigger {
       }
     }
 
-    def fromV26ExtractTriggerDefinition(
+    def fromV251ExtractTriggerDefinition(
         ty: TTyCon,
         tyArg: Type,
         triggerIds: TriggerIds,
@@ -275,10 +275,10 @@ object Trigger {
         val triggerIds = TriggerIds(tyCon.packageId)
         // Ensure version related trigger definition updates take into account the conflateMsgValue code
         detectVersion(pkgInterface, triggerIds).flatMap { version =>
-          if (version < Trigger.Version.`2.6`) {
+          if (version < Trigger.Version.`2.5.1`) {
             fromV20ExtractTriggerDefinition(ty, tyArg, triggerIds, version)
           } else {
-            fromV26ExtractTriggerDefinition(ty, tyArg, triggerIds, version)
+            fromV251ExtractTriggerDefinition(ty, tyArg, triggerIds, version)
           }
         }
 
@@ -404,15 +404,15 @@ object Trigger {
     override def compare(that: Version): Int = this.rank compare that.rank
   }
   object Version {
-    val `2.0` = new Version(0)
-    val `2.5` = new Version(5)
-    val `2.6` = new Version(6)
+    val `2.0.0` = new Version(0)
+    val `2.5.0` = new Version(50)
+    val `2.5.1` = new Version(51)
 
     def fromString(s: Option[String]): Either[String, Version] =
       s match {
-        case None => Right(`2.0`)
-        case Some("Version_2_5") => Right(`2.5`)
-        case Some("Version_2_6") => Right(`2.6`)
+        case None => Right(`2.0.0`)
+        case Some("Version_2_5") => Right(`2.5.0`)
+        case Some("Version_2_5_1") => Right(`2.5.1`)
         case Some(s) => Left(s"""cannot parse trigger version "$s".""")
       }
   }
@@ -780,7 +780,7 @@ private[lf] class Runner private (
     val noop = Flow.fromFunction[TriggerContext[SValue], TriggerContext[SValue]](identity)
 
     // Ensure version related trigger definition updates take into account the detectTriggerDefinition code
-    if (trigger.defn.version < Trigger.Version.`2.6`) {
+    if (trigger.defn.version < Trigger.Version.`2.5.1`) {
       noop
     } else {
       noop


### PR DESCRIPTION
- fix wrong comparison for create event
- add patch number in scala version names
- change 2.6 -> 2.5.1 in anticipantion of [#15902](https://github.com/digital-asset/daml/pull/15902) backport

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
