### PR TITLE
TraceId in LAPI [DPP-1372].

### DIFF
--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/CommandCompletionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/CommandCompletionService.scala
@@ -8,6 +8,7 @@ import akka.stream.scaladsl.Source
 import com.daml.ledger.api.domain.LedgerOffset
 import com.daml.ledger.api.messages.command.completion.CompletionStreamRequest
 import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
+import com.daml.logging.LoggingContext
 
 import scala.concurrent.Future
 
@@ -17,6 +18,6 @@ trait CommandCompletionService {
 
   def completionStreamSource(
       request: CompletionStreamRequest
-  ): Source[CompletionStreamResponse, NotUsed]
+  )(implicit loggingContext: LoggingContext): Source[CompletionStreamResponse, NotUsed]
 
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/CommandSubmissionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/CommandSubmissionService.scala
@@ -4,10 +4,13 @@
 package com.daml.platform.server.api.services.domain
 
 import com.daml.ledger.api.messages.command.submission.SubmitRequest
+import com.daml.logging.LoggingContext
 import com.daml.tracing.TelemetryContext
 
 import scala.concurrent.Future
 
 trait CommandSubmissionService {
-  def submit(request: SubmitRequest)(implicit telemetryContext: TelemetryContext): Future[Unit]
+  def submit(
+      request: SubmitRequest
+  )(implicit telemetryContext: TelemetryContext, loggingContext: LoggingContext): Future[Unit]
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/TransactionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/TransactionService.scala
@@ -18,6 +18,7 @@ import com.daml.ledger.api.v1.transaction_service.{
   GetTransactionTreesResponse,
   GetTransactionsResponse,
 }
+import com.daml.logging.LoggingContext
 
 import scala.concurrent.Future
 
@@ -25,19 +26,29 @@ trait TransactionService {
 
   def getLedgerEnd(ledgerId: String): Future[LedgerOffset.Absolute]
 
-  def getTransactions(req: GetTransactionsRequest): Source[GetTransactionsResponse, NotUsed]
+  def getTransactions(req: GetTransactionsRequest)(implicit
+      loggingContext: LoggingContext
+  ): Source[GetTransactionsResponse, NotUsed]
 
   def getTransactionTrees(
       req: GetTransactionTreesRequest
+  )(implicit
+      loggingContext: LoggingContext
   ): Source[GetTransactionTreesResponse, NotUsed]
 
-  def getTransactionById(req: GetTransactionByIdRequest): Future[GetTransactionResponse]
+  def getTransactionById(req: GetTransactionByIdRequest)(implicit
+      loggingContext: LoggingContext
+  ): Future[GetTransactionResponse]
 
-  def getTransactionByEventId(req: GetTransactionByEventIdRequest): Future[GetTransactionResponse]
+  def getTransactionByEventId(req: GetTransactionByEventIdRequest)(implicit
+      loggingContext: LoggingContext
+  ): Future[GetTransactionResponse]
 
-  def getFlatTransactionById(req: GetTransactionByIdRequest): Future[GetFlatTransactionResponse]
+  def getFlatTransactionById(req: GetTransactionByIdRequest)(implicit
+      loggingContext: LoggingContext
+  ): Future[GetFlatTransactionResponse]
 
   def getFlatTransactionByEventId(
       req: GetTransactionByEventIdRequest
-  ): Future[GetFlatTransactionResponse]
+  )(implicit loggingContext: LoggingContext): Future[GetFlatTransactionResponse]
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/Logging.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/Logging.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.server.api.services.grpc
+
+import com.daml.logging.entries.LoggingEntry
+
+object Logging {
+
+  def traceId(id: Option[String]): LoggingEntry =
+    "tid" -> (id.getOrElse(""): String)
+
+}

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandSubmissionServiceSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandSubmissionServiceSpec.scala
@@ -39,7 +39,10 @@ class GrpcCommandSubmissionServiceSpec
       val span = anEmptySpan()
       val scope = span.makeCurrent()
       val mockCommandSubmissionService = mock[CommandSubmissionService with AutoCloseable]
-      when(mockCommandSubmissionService.submit(any[SubmitRequest])(any[TelemetryContext]))
+      when(
+        mockCommandSubmissionService
+          .submit(any[SubmitRequest])(any[TelemetryContext], any[LoggingContext])
+      )
         .thenReturn(Future.unit)
 
       try {
@@ -64,13 +67,17 @@ class GrpcCommandSubmissionServiceSpec
         aSubmitRequest.update(_.commands.submissionId := expectedSubmissionId)
       val requestCaptor = ArgCaptor[com.daml.ledger.api.messages.command.submission.SubmitRequest]
       val mockCommandSubmissionService = mock[CommandSubmissionService with AutoCloseable]
-      when(mockCommandSubmissionService.submit(any[SubmitRequest])(any[TelemetryContext]))
+      when(
+        mockCommandSubmissionService
+          .submit(any[SubmitRequest])(any[TelemetryContext], any[LoggingContext])
+      )
         .thenReturn(Future.unit)
 
       grpcCommandSubmissionService(mockCommandSubmissionService)
         .submit(requestWithSubmissionId)
         .map { _ =>
-          verify(mockCommandSubmissionService).submit(requestCaptor.capture)(any[TelemetryContext])
+          verify(mockCommandSubmissionService)
+            .submit(requestCaptor.capture)(any[TelemetryContext], any[LoggingContext])
           requestCaptor.value.commands.submissionId shouldBe Some(expectedSubmissionId)
         }
     }
@@ -79,13 +86,17 @@ class GrpcCommandSubmissionServiceSpec
       val requestCaptor = ArgCaptor[com.daml.ledger.api.messages.command.submission.SubmitRequest]
 
       val mockCommandSubmissionService = mock[CommandSubmissionService with AutoCloseable]
-      when(mockCommandSubmissionService.submit(any[SubmitRequest])(any[TelemetryContext]))
+      when(
+        mockCommandSubmissionService
+          .submit(any[SubmitRequest])(any[TelemetryContext], any[LoggingContext])
+      )
         .thenReturn(Future.unit)
 
       grpcCommandSubmissionService(mockCommandSubmissionService)
         .submit(aSubmitRequest)
         .map { _ =>
-          verify(mockCommandSubmissionService).submit(requestCaptor.capture)(any[TelemetryContext])
+          verify(mockCommandSubmissionService)
+            .submit(requestCaptor.capture)(any[TelemetryContext], any[LoggingContext])
           requestCaptor.value.commands.submissionId shouldBe Some(generatedSubmissionId)
         }
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -152,7 +152,7 @@ private[daml] object ApiServices {
         checkOverloaded: TelemetryContext => Option[state.SubmissionResult],
     )(implicit executionContext: ExecutionContext): List[BindableService] = {
       val apiTransactionService =
-        ApiTransactionService.create(ledgerId, transactionsService, metrics)
+        ApiTransactionService.create(ledgerId, transactionsService, metrics, telemetry)
 
       val apiLedgerIdentityService =
         ApiLedgerIdentityService.create(ledgerId)
@@ -164,7 +164,7 @@ private[daml] object ApiServices {
         )
 
       val apiPackageService =
-        ApiPackageService.create(ledgerId, packagesService)
+        ApiPackageService.create(ledgerId, packagesService, telemetry)
 
       val apiConfigurationService =
         ApiLedgerConfigurationService.create(ledgerId, configurationService)
@@ -174,6 +174,7 @@ private[daml] object ApiServices {
           ledgerId,
           completionsService,
           metrics,
+          telemetry,
         )
 
       val apiActiveContractsService =
@@ -181,6 +182,7 @@ private[daml] object ApiServices {
           ledgerId,
           activeContractsService,
           metrics,
+          telemetry,
         )
 
       val apiTimeServiceOpt =
@@ -224,7 +226,7 @@ private[daml] object ApiServices {
         }
 
       val apiMeteringReportService =
-        new ApiMeteringReportService(participantId, meteringStore, meteringReportKey)
+        new ApiMeteringReportService(participantId, meteringStore, meteringReportKey, telemetry)
 
       apiTimeServiceOpt.toList :::
         writeServiceBackedApiServices :::
@@ -335,6 +337,7 @@ private[daml] object ApiServices {
             indexService,
             writeService,
             metrics,
+            telemetry,
           )
 
         List(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -81,7 +81,7 @@ private[apiserver] final class ApiSubmissionService private[services] (
     commandExecutor: CommandExecutor,
     checkOverloaded: TelemetryContext => Option[state.SubmissionResult],
     metrics: Metrics,
-)(implicit executionContext: ExecutionContext, loggingContext: LoggingContext)
+)(implicit executionContext: ExecutionContext)
     extends CommandSubmissionService
     with AutoCloseable {
 
@@ -89,7 +89,7 @@ private[apiserver] final class ApiSubmissionService private[services] (
 
   override def submit(
       request: SubmitRequest
-  )(implicit telemetryContext: TelemetryContext): Future[Unit] =
+  )(implicit telemetryContext: TelemetryContext, loggingContext: LoggingContext): Future[Unit] =
     withEnrichedLoggingContext(logging.commands(request.commands)) { implicit loggingContext =>
       logger.info("Submitting commands for interpretation")
       logger.trace(s"Commands: ${request.commands.commands.commands}")
@@ -173,7 +173,10 @@ private[apiserver] final class ApiSubmissionService private[services] (
   private def submitTransaction(
       transactionInfo: CommandExecutionResult,
       ledgerConfig: Configuration,
-  )(implicit telemetryContext: TelemetryContext): Future[state.SubmissionResult] =
+  )(implicit
+      telemetryContext: TelemetryContext,
+      loggingContext: LoggingContext,
+  ): Future[state.SubmissionResult] =
     timeProviderType match {
       case TimeProviderType.WallClock =>
         // Submit transactions such that they arrive at the ledger sequencer exactly when record time equals ledger time.
@@ -197,7 +200,10 @@ private[apiserver] final class ApiSubmissionService private[services] (
 
   private def submitTransaction(
       result: CommandExecutionResult
-  )(implicit telemetryContext: TelemetryContext): Future[state.SubmissionResult] = {
+  )(implicit
+      telemetryContext: TelemetryContext,
+      loggingContext: LoggingContext,
+  ): Future[state.SubmissionResult] = {
     metrics.daml.commands.validSubmissions.mark()
     logger.debug("Submitting transaction to ledger")
     writeService

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
@@ -91,6 +91,9 @@ package object logging {
   private[services] def workflowId(id: String): LoggingEntry =
     "workflowId" -> id
 
+  private[services] def packageId(id: String): LoggingEntry =
+    "packageId" -> id
+
   private[services] def commands(cmds: Commands): LoggingEntry =
     "commands" -> cmds
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -35,6 +35,7 @@ import com.daml.metrics.Metrics
 import com.daml.platform.apiserver.services.{StreamMetrics, logging}
 import com.daml.platform.server.api.services.domain.TransactionService
 import com.daml.platform.server.api.services.grpc.GrpcTransactionService
+import com.daml.tracing.Telemetry
 import io.grpc._
 import scalaz.syntax.tag._
 
@@ -45,6 +46,7 @@ private[apiserver] object ApiTransactionService {
       ledgerId: LedgerId,
       transactionsService: IndexTransactionsService,
       metrics: Metrics,
+      telemetry: Telemetry,
   )(implicit
       ec: ExecutionContext,
       mat: Materializer,
@@ -55,6 +57,7 @@ private[apiserver] object ApiTransactionService {
       new ApiTransactionService(transactionsService, metrics),
       ledgerId,
       PartyNameChecker.AllowAllParties,
+      telemetry,
     )
 }
 
@@ -71,7 +74,7 @@ private[apiserver] final class ApiTransactionService private (
 
   override def getTransactions(
       request: GetTransactionsRequest
-  ): Source[GetTransactionsResponse, NotUsed] = {
+  )(implicit loggingContext: LoggingContext): Source[GetTransactionsResponse, NotUsed] = {
     withEnrichedLoggingContext(
       logging.ledgerId(request.ledgerId),
       logging.startExclusive(request.startExclusive),
@@ -91,7 +94,7 @@ private[apiserver] final class ApiTransactionService private (
 
   override def getTransactionTrees(
       request: GetTransactionTreesRequest
-  ): Source[GetTransactionTreesResponse, NotUsed] = {
+  )(implicit loggingContext: LoggingContext): Source[GetTransactionTreesResponse, NotUsed] = {
     withEnrichedLoggingContext(
       logging.ledgerId(request.ledgerId),
       logging.startExclusive(request.startExclusive),
@@ -118,7 +121,7 @@ private[apiserver] final class ApiTransactionService private (
 
   override def getTransactionByEventId(
       request: GetTransactionByEventIdRequest
-  ): Future[GetTransactionResponse] = {
+  )(implicit loggingContext: LoggingContext): Future[GetTransactionResponse] = {
     implicit val enrichedLoggingContext: LoggingContext = LoggingContext.enriched(
       logging.ledgerId(request.ledgerId),
       logging.eventId(request.eventId),
@@ -143,7 +146,7 @@ private[apiserver] final class ApiTransactionService private (
 
   override def getTransactionById(
       request: GetTransactionByIdRequest
-  ): Future[GetTransactionResponse] = {
+  )(implicit loggingContext: LoggingContext): Future[GetTransactionResponse] = {
     val errorLogger: DamlContextualizedErrorLogger = withEnrichedLoggingContext(
       logging.ledgerId(request.ledgerId),
       logging.transactionId(request.transactionId),
@@ -160,7 +163,7 @@ private[apiserver] final class ApiTransactionService private (
 
   override def getFlatTransactionByEventId(
       request: GetTransactionByEventIdRequest
-  ): Future[GetFlatTransactionResponse] = {
+  )(implicit loggingContext: LoggingContext): Future[GetFlatTransactionResponse] = {
     implicit val errorLogger: DamlContextualizedErrorLogger = withEnrichedLoggingContext(
       logging.ledgerId(request.ledgerId),
       logging.eventId(request.eventId),
@@ -185,7 +188,7 @@ private[apiserver] final class ApiTransactionService private (
 
   override def getFlatTransactionById(
       request: GetTransactionByIdRequest
-  ): Future[GetFlatTransactionResponse] = {
+  )(implicit loggingContext: LoggingContext): Future[GetFlatTransactionResponse] = {
     val errorLogger = withEnrichedLoggingContext(
       logging.ledgerId(request.ledgerId),
       logging.transactionId(request.transactionId),

--- a/ledger/participant-integration-api/src/test/resources/logback-test.xml
+++ b/ledger/participant-integration-api/src/test/resources/logback-test.xml
@@ -27,6 +27,14 @@
         <appender-ref ref="RecoveringIndexerLoggerCapture"/>
     </logger>
 
+    <appender name="ApiPackageManagementServiceLoggerCapture" class="com.daml.platform.testing.LogCollector">
+        <test>com.daml.platform.apiserver.services.admin.ApiPackageManagementServiceSpec</test>
+    </appender>
+
+    <logger name="com.daml.platform.apiserver.services.admin.ApiPackageManagementService" level="INFO">
+        <appender-ref ref="ApiPackageManagementServiceLoggerCapture"/>
+    </logger>
+
     <appender name="BuffersUpdaterLoggerCapture" class="com.daml.platform.testing.LogCollector">
         <test>com.daml.platform.index.BuffersUpdaterSpec</test>
     </appender>

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/ApiSubmissionServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/ApiSubmissionServiceSpec.scala
@@ -285,13 +285,13 @@ class ApiSubmissionServiceSpec
       .thenReturn(Future.successful(Right(commandExecutionResult)))
     when(
       writeService.submitTransaction(
-        submitterInfo,
-        transactionMeta,
-        transaction,
-        estimatedInterpretationCost,
-        Map.empty,
-        explicitlyDisclosedContracts,
-      )
+        eqTo(submitterInfo),
+        eqTo(transactionMeta),
+        eqTo(transaction),
+        eqTo(estimatedInterpretationCost),
+        eqTo(Map.empty),
+        eqTo(explicitlyDisclosedContracts),
+      )(any[LoggingContext], any[TelemetryContext])
     ).thenReturn(CompletableFuture.completedFuture(SubmissionResult.Acknowledged))
 
     def apiSubmissionService(

--- a/ledger/test-common/src/main/scala/com/digitalasset/platform/testing/LogCollector.scala
+++ b/ledger/test-common/src/main/scala/com/digitalasset/platform/testing/LogCollector.scala
@@ -18,6 +18,7 @@ import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 import scala.reflect.ClassTag
 
+// An appender and a logger must be defined in the logback.xml or logback-test.xml to capture the log entries.
 object LogCollector {
 
   case class ThrowableCause(className: String, message: String)
@@ -58,6 +59,14 @@ object LogCollector {
     log
       .get(test.runtimeClass.getName.stripSuffix("$"))
       .flatMap(_.get(logger.runtimeClass.getName.stripSuffix("$")))
+      .fold(IndexedSeq.empty[Entry])(_.result())
+
+  def readAsEntries[Test](loggerClassName: String)(implicit
+      test: ClassTag[Test]
+  ): Seq[Entry] =
+    log
+      .get(test.runtimeClass.getName.stripSuffix("$"))
+      .flatMap(_.get(loggerClassName))
       .fold(IndexedSeq.empty[Entry])(_.result())
 
   def clear[Test](implicit test: ClassTag[Test]): Unit = {

--- a/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/ContextualizedLoggerSpec.scala
+++ b/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/ContextualizedLoggerSpec.scala
@@ -36,6 +36,7 @@ final class ContextualizedLoggerSpec
       val m = logger.withoutContext
       verify(m).info(toStringEqTo[Marker]("""{id: "foobar"}"""), eqTo("a"))
     }
+
   it should "decorate the logs with rich, structured context" in
     withContext("id" -> 7, "parties" -> Seq("one", "two", "three"))() {
       logger => implicit loggingContext =>

--- a/observability/tracing/src/main/scala/com/daml/tracing/Telemetry.scala
+++ b/observability/tracing/src/main/scala/com/daml/tracing/Telemetry.scala
@@ -79,6 +79,13 @@ abstract class Telemetry(protected val tracer: Tracer) {
     * Any span create from this context should be the first span of a new trace.
     */
   protected def rootContext: TelemetryContext
+
+  /** Returns the trace-id of the telemetry context from the OpenTelemetry context stored in the gRPC
+    * thread local context.
+    * This is used to obtain the tracing id from an incoming gRPC call.
+    */
+  def traceIdFromGrpcContext: Option[String] = contextFromGrpcThreadLocalContext().traceId
+
 }
 
 abstract class DefaultTelemetry(override protected val tracer: Tracer) extends Telemetry(tracer) {

--- a/observability/tracing/src/main/scala/com/daml/tracing/TelemetryContext.scala
+++ b/observability/tracing/src/main/scala/com/daml/tracing/TelemetryContext.scala
@@ -83,6 +83,8 @@ trait TelemetryContext {
     */
   def openTelemetryContext: Context
 
+  def traceId: Option[String]
+
 }
 
 /** Default implementation of TelemetryContext. Uses OpenTelemetry to generate and gather traces.
@@ -168,6 +170,11 @@ protected class DefaultTelemetryContext(protected val tracer: Tracer, protected 
   }
 
   override def openTelemetryContext: Context = Context.current.`with`(span)
+
+  val traceId: Option[String] = Option(span)
+    .filter(_.getSpanContext.isValid)
+    .map(_.getSpanContext.getTraceId)
+
 }
 
 object DefaultTelemetryContext {
@@ -233,4 +240,6 @@ object NoOpTelemetryContext extends TelemetryContext {
   override def encodeMetadata(): jMap[String, String] = new jHashMap()
 
   override def openTelemetryContext: Context = Context.root.`with`(Span.getInvalid)
+
+  override def traceId: Option[String] = None
 }


### PR DESCRIPTION
[DPP-1372](https://digitalasset.atlassian.net/browse/DPP-1372)

[Design doc](https://docs.google.com/document/d/10X-fbC2MuLI2wD5xe-jvwrU25G8t5DGK0_yve-NqPvw/edit?pli=1#heading=h.j1o9vy5fqmrz)

Currently ledger-api server lacks the trace id which is used extensively in canton to trace the requests and appears in the logfiles of canton consistently. The trace-id is derived by the open telemetry context.

As described in [design-doc](https://docs.google.com/document/d/10X-fbC2MuLI2wD5xe-jvwrU25G8t5DGK0_yve-NqPvw/edit?pli=1#heading=h.j1o9vy5fqmrz) currently the ledger-api server logs are matched with the canton logs only by a rosetta-stone log entry which states both the trace-id from canton and submission-id from ledger-api server. With this PR, the trace-id is passed via the grpc context to ledger-api server and identifying of log entries from both codebases is happening with the use of the trace-id.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->


[DPP-1372]: https://digitalasset.atlassian.net/browse/DPP-1372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ