### PR TITLE
Fix return type error for methods

### DIFF
--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "2d6ee7416bdc412f7c3cc56276eb8c10703e6999"
+GHC_REV = "d403082314aa7dc330606ece624ae111a79de6ac"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "f7f6dfffcf27a83884864e530fdcf92b753e3f9d"
+GHC_REV = "bfd819382d4e11b704acae872a46d5b9efff53ee"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "a45a10d65d7a1df7dc14f7d2c42467f7891362e2"
+GHC_REV = "55a70322e55880be795697bbeb385bdf750e8acf"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "b2346518c1f434f4f58bc43a1f0037bbe4d381fd"
+GHC_REV = "dc88c062d0b0f6a88b8f8dfd1a4749ca22dd9aff"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "55a70322e55880be795697bbeb385bdf750e8acf"
+GHC_REV = "b2346518c1f434f4f58bc43a1f0037bbe4d381fd"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "bfd819382d4e11b704acae872a46d5b9efff53ee"
+GHC_REV = "a45a10d65d7a1df7dc14f7d2c42467f7891362e2"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "d403082314aa7dc330606ece624ae111a79de6ac"
+GHC_REV = "f7f6dfffcf27a83884864e530fdcf92b753e3f9d"
 GHC_PATCHES = [
 ]
 

--- a/compiler/damlc/tests/daml-test-files/InterfaceSynonymTypeMismatchErrors.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSynonymTypeMismatchErrors.daml
@@ -1,0 +1,29 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module InterfaceSynonymTypeMismatchErrors where
+
+-- @ERROR range=27:7-27:24; Implementation of method ‘getValueBad’ on interface ‘I’ should return ‘Int’ but instead returns ‘Text’
+-- @ERROR range=29:7-29:31; Tried to implement method ‘getValueNonexistent’, but interface ‘I’ does not have a method with that name. Method ‘getValueNonexistent’ is only a method on the following interfaces: ‘J’
+
+type I = MyLongInterfaceNameI
+interface MyLongInterfaceNameI where
+  getValueGood : Int
+  getValueBad : Int
+  viewtype TView
+
+interface J where
+  getValueNonexistent : ()
+
+data TView = TView {}
+
+template T with p: Party
+  where
+    signatory p
+    interface instance I for T where
+      view = TView
+      -- Check that method return types matching resolves synonyms first
+      getValueGood = 1 -- matching case
+      getValueBad = "c" -- mismatching case
+      -- Check that missing method warnings still considers I to be an interface
+      getValueNonexistent = ()

--- a/compiler/damlc/tests/daml-test-files/MethodResultMismatchError.daml
+++ b/compiler/damlc/tests/daml-test-files/MethodResultMismatchError.daml
@@ -1,0 +1,23 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module MethodResultMismatchError where
+
+-- @ERROR range=23:7-23:24; Implementation of method ‘getValueBad’ on interface ‘I’ should return ‘Int’ but instead returns ‘Text’
+
+interface I where
+  getController : Party
+  getValueGood : Int
+  getValueBad : Int
+  viewtype TView
+
+data TView = TView {}
+
+template T with p: Party
+  where
+    signatory p
+    interface instance I for T where
+      view = TView
+      getController = p
+      getValueGood = 1
+      getValueBad = "c"


### PR DESCRIPTION
Tackling issue: https://github.com/digital-asset/daml/issues/15890
Corresponding GHC changes: https://github.com/digital-asset/ghc/pull/153

- Separates missing methods from mistyped methods in the custom error checker.
- Resolves type synonyms inside of our custom error detector before checking for mismatches.