### PR TITLE
bump copyright header in compat update script

### DIFF
--- a/compatibility/versions/UpdateVersions.hs
+++ b/compatibility/versions/UpdateVersions.hs
@@ -43,7 +43,7 @@ headVersion = SemVer.initial
 -- We include this here so buildifier does not modify this file.
 copyrightHeader :: [T.Text]
 copyrightHeader =
-    [ "# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved."
+    [ "# Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved."
     , "# SPDX-License-Identifier: Apache-2.0"
     ]
 


### PR DESCRIPTION
Ideally we'd instead read in the COPY file here, but between Bazel and Haskell that's more effort than I'm willing to put in right now.