### PR TITLE
Fix race condition in gauge update [PLEN-86]

### DIFF
--- a/observability/metrics/src/main/scala/com/daml/metrics/api/MetricHandle.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/MetricHandle.scala
@@ -117,7 +117,7 @@ object MetricHandle {
 
     def updateValue(newValue: T): Unit
 
-    def updateValue(f: T => T): Unit = updateValue(f(getValue))
+    def updateValue(f: T => T): Unit
 
     def getValue: T
   }

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/dropwizard/Metrics.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/dropwizard/Metrics.scala
@@ -70,6 +70,8 @@ sealed case class DropwizardCounter(name: String, metric: codahale.Counter) exte
 sealed case class DropwizardGauge[T](name: String, metric: Gauges.VarGauge[T]) extends Gauge[T] {
   def updateValue(newValue: T): Unit = metric.updateValue(newValue)
   override def getValue: T = metric.getValue
+
+  override def updateValue(f: T => T): Unit = metric.updateValue(f)
 }
 
 sealed case class DropwizardHistogram(name: String, metric: codahale.Histogram)

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/noop/Metrics.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/noop/Metrics.scala
@@ -35,6 +35,7 @@ case class NoOpGauge[T](name: String, value: T) extends Gauge[T] {
 
   override def getValue: T = value
 
+  override def updateValue(f: T => T): Unit = ()
 }
 
 case class NoOpMeter(name: String) extends Meter {

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryFactory.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryFactory.scala
@@ -205,6 +205,7 @@ case class OpenTelemetryGauge[T](name: String, varGauge: VarGauge[T]) extends Ga
 
   override def getValue: T = varGauge.getValue
 
+  override def updateValue(f: T => T): Unit = varGauge.updateValue(f)
 }
 
 case class OpenTelemetryMeter(name: String, counter: LongCounter, meterContext: MetricsContext)

--- a/observability/metrics/src/test/lib/scala/com/daml/metrics/api/testing/InMemoryMetricsFactory.scala
+++ b/observability/metrics/src/test/lib/scala/com/daml/metrics/api/testing/InMemoryMetricsFactory.scala
@@ -108,6 +108,8 @@ object InMemoryMetricsFactory extends InMemoryMetricsFactory {
       value.set(newValue)
 
     override def getValue: T = value.get()
+
+    override def updateValue(f: T => T): Unit = discard(value.updateAndGet((t: T) => f(t)))
   }
 
   case class InMemoryMeter(initialContext: MetricsContext) extends Meter {


### PR DESCRIPTION
Use VarGauge update method based on previous value directly. This ensures that the underlying API is atomically updated

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
