### PR TITLE
[engine] withAuthorityOf: support from Daml --> Speedy

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -301,6 +301,9 @@ data BuiltinExpr
   | BEFoldr                      -- :: ∀a b. (a -> b -> b) -> b -> List a -> b
   | BEEqualList                  -- :: ∀a. (a -> a -> Bool) -> List a -> List a -> Bool
 
+  -- Authority operations
+  | BEWithAuthorityOf            -- :: ∀ a. List Party -> Update a -> Update a
+
   -- Map operations
   | BETextMapEmpty               -- :: ∀ a. TextMap a
   | BETextMapInsert              -- :: ∀ a. Text -> a -> TextMap a -> TextMap a

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -267,6 +267,7 @@ instance Pretty BuiltinExpr where
     BEExpInt64 -> "EXP_INT64"
     BEFoldl -> "FOLDL"
     BEFoldr -> "FOLDR"
+    BEWithAuthorityOf -> "WITH_AUTHORITY_OF"
     BETextMapEmpty -> "TEXTMAP_EMPTY"
     BETextMapInsert -> "TEXTMAP_INSERT"
     BETextMapLookup -> "TEXTMAP_LOOKUP"

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -473,6 +473,7 @@ decodeBuiltinFunction = \case
 
   LF1.BuiltinFunctionFOLDL          -> pure BEFoldl
   LF1.BuiltinFunctionFOLDR          -> pure BEFoldr
+  LF1.BuiltinFunctionWITH_AUTHORITY_OF -> pure BEWithAuthorityOf
   LF1.BuiltinFunctionEQUAL_LIST     -> pure BEEqualList
   LF1.BuiltinFunctionAPPEND_TEXT    -> pure BEAppendText
 

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -516,6 +516,7 @@ encodeBuiltinExpr = \case
 
     BEFoldl -> builtin P.BuiltinFunctionFOLDL
     BEFoldr -> builtin P.BuiltinFunctionFOLDR
+    BEWithAuthorityOf -> builtin P.BuiltinFunctionWITH_AUTHORITY_OF
     BEEqualList -> builtin P.BuiltinFunctionEQUAL_LIST
     BEExplodeText -> builtin P.BuiltinFunctionEXPLODE_TEXT
     BEAppendText -> builtin P.BuiltinFunctionAPPEND_TEXT

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -137,6 +137,7 @@ safetyStep = \case
       BEExpInt64          -> Safe 1
       BEFoldl             -> Safe 2
       BEFoldr             -> Safe 2
+      BEWithAuthorityOf   -> undefined -- NICK
       BETextMapEmpty      -> Safe 0
       BETextMapInsert     -> Safe 3
       BETextMapLookup     -> Safe 2

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -137,7 +137,7 @@ safetyStep = \case
       BEExpInt64          -> Safe 1
       BEFoldl             -> Safe 2
       BEFoldr             -> Safe 2
-      BEWithAuthorityOf   -> undefined -- NICK
+      BEWithAuthorityOf   -> undefined -- TODO https://github.com/digital-asset/daml/issues/15882
       BETextMapEmpty      -> Safe 0
       BETextMapInsert     -> Safe 3
       BETextMapLookup     -> Safe 2

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -276,6 +276,13 @@ typeOfBuiltin = \case
              (tBeta :-> tAlpha :-> tBeta) :-> tBeta :-> TList tAlpha :-> tBeta
   BEFoldr -> pure $ TForall (alpha, KStar) $ TForall (beta, KStar) $
              (tAlpha :-> tBeta :-> tBeta) :-> tBeta :-> TList tAlpha :-> tBeta
+
+  BEWithAuthorityOf ->
+    pure $ TForall (alpha, KStar) $
+    TList TParty :->
+    TUpdate tAlpha :->
+    TUpdate tAlpha
+
   BETextMapEmpty  -> pure $ TForall (alpha, KStar) $ TTextMap tAlpha
   BETextMapInsert -> pure $ TForall (alpha, KStar) $ TText :-> tAlpha :-> TTextMap tAlpha :-> TTextMap tAlpha
   BETextMapLookup -> pure $ TForall (alpha, KStar) $ TText :-> TTextMap tAlpha :-> TOptional tAlpha

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -88,6 +88,10 @@ convertPrim _ "BEFoldl" ((b1 :-> a1 :-> b2) :-> b3 :-> TList a2 :-> b4) | a1 == 
 convertPrim _ "BEFoldr" ((a1 :-> b1 :-> b2) :-> b3 :-> TList a2 :-> b4) | a1 == a2, b1 == b2, b2 == b3, b3 == b4 =
     pure $ EBuiltin BEFoldr `ETyApp` a1 `ETyApp` b1
 
+-- Authority operations
+convertPrim _ "BEWithAuthorityOf" (TList TParty :-> TUpdate a1 :-> TUpdate a2) | a1 == a2 =
+    pure $ EBuiltin BEWithAuthorityOf `ETyApp` a1
+
 -- Error
 convertPrim _ "BEError" (TText :-> t2) =
     pure $ ETyApp (EBuiltin BEError) t2

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -47,6 +47,8 @@ module DA.Internal.LF
   #ifdef DAML_EXCEPTIONS
   , AnyException
   #endif
+
+  , withAuthorityOf
   ) where
 
 import GHC.Stack.Types (HasCallStack)
@@ -270,3 +272,7 @@ instance Ord TypeRep where
 data AnyException = AnyException Opaque
 
 #endif
+
+-- | Authority operations.
+withAuthorityOf : [Party] -> Update a -> Update a
+withAuthorityOf = primitive @"BEWithAuthorityOf"

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -48,7 +48,10 @@ module DA.Internal.LF
   , AnyException
   #endif
 
+  #ifdef DAML_UNSTABLE
   , withAuthorityOf
+  #endif
+
   ) where
 
 import GHC.Stack.Types (HasCallStack)
@@ -273,6 +276,10 @@ data AnyException = AnyException Opaque
 
 #endif
 
+#ifdef DAML_UNSTABLE
+
 -- | Authority operations.
 withAuthorityOf : [Party] -> Update a -> Update a
 withAuthorityOf = primitive @"BEWithAuthorityOf"
+
+#endif

--- a/compiler/damlc/tests/daml-test-files/WithAuthorityOf.daml
+++ b/compiler/damlc/tests/daml-test-files/WithAuthorityOf.daml
@@ -3,8 +3,6 @@
 
 module WithAuthorityOf where
 
---import Daml.Script -- NICK
-
 template HasConsortiumAutority
   with
     consortiumParty: Party
@@ -31,27 +29,3 @@ template ProposeConsortiumAuthority
         withAuthorityOf accepted $ do
           withAuthorityOf [consortiumParty] $ do
             create HasConsortiumAutority with consortiumParty
-
-{-
-test : Script () -- NICK
-test = do
-  alice <- allocateParty "Alice"
-  bob <- allocateParty "Bob"
-  charlie <- allocateParty "Charlie"
-
-  org <- allocateParty "TheOrg"
-
-  prop <- submit alice do
-    createCmd ProposeConsortiumAuthority with
-      proposer = alice
-      accepted = []
-      obs = [bob,charlie]
-      consortiumParty = org
-
-  prop <- submit bob do exerciseCmd prop Accept with who = bob
-  prop <- submit charlie do exerciseCmd prop Accept with who = charlie
-
-  submitMustFail alice do exerciseCmd prop Ratify -- TODO: make this not fail
-
-  pure ()
--}

--- a/compiler/damlc/tests/daml-test-files/WithAuthorityOf.daml
+++ b/compiler/damlc/tests/daml-test-files/WithAuthorityOf.daml
@@ -1,4 +1,6 @@
 
+-- @SINCE-LF-FEATURE DAML_UNSTABLE
+
 module WithAuthorityOf where
 
 --import Daml.Script -- NICK

--- a/compiler/damlc/tests/daml-test-files/WithAuthorityOf.daml
+++ b/compiler/damlc/tests/daml-test-files/WithAuthorityOf.daml
@@ -1,0 +1,55 @@
+
+module WithAuthorityOf where
+
+--import Daml.Script -- NICK
+
+template HasConsortiumAutority
+  with
+    consortiumParty: Party
+  where
+    signatory consortiumParty
+
+template ProposeConsortiumAuthority
+  with
+    proposer: Party
+    accepted: [Party]
+    obs: [Party]
+    consortiumParty: Party
+  where
+    signatory proposer, accepted
+    observer obs
+
+    choice Accept : ContractId ProposeConsortiumAuthority
+      with who: Party
+      controller who
+      do create this with accepted = who :: this.accepted
+
+    choice Ratify : ContractId HasConsortiumAutority controller proposer
+      do
+        withAuthorityOf accepted $ do
+          withAuthorityOf [consortiumParty] $ do
+            create HasConsortiumAutority with consortiumParty
+
+{-
+test : Script () -- NICK
+test = do
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
+  charlie <- allocateParty "Charlie"
+
+  org <- allocateParty "TheOrg"
+
+  prop <- submit alice do
+    createCmd ProposeConsortiumAuthority with
+      proposer = alice
+      accepted = []
+      obs = [bob,charlie]
+      consortiumParty = org
+
+  prop <- submit bob do exerciseCmd prop Accept with who = bob
+  prop <- submit charlie do exerciseCmd prop Accept with who = charlie
+
+  submitMustFail alice do exerciseCmd prop Ratify -- TODO: make this not fail
+
+  pure ()
+-}

--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -450,6 +450,7 @@ enum BuiltinFunction {
 
   FOLDL = 20;
   FOLDR = 21;
+  WITH_AUTHORITY_OF = 149;
 
   TEXTMAP_EMPTY = 96;
   TEXTMAP_INSERT = 97;
@@ -571,7 +572,7 @@ enum BuiltinFunction {
 
   TYPEREP_TYCON_NAME = 148; // *Available in versions >= 1.dev*
 
-  // Next id is 149.
+  // Next id is 150.
 
   // EXPERIMENTAL TEXT PRIMITIVES -- these do not yet have stable numbers.
   TEXT_TO_UPPER = 9901; // *Available in versions >= 1.dev*

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -2054,6 +2054,7 @@ private[archive] object DecodeV1 {
       BuiltinFunctionInfo(NUMERIC_TO_INT64, BNumericToInt64, minVersion = numeric),
       BuiltinFunctionInfo(FOLDL, BFoldl),
       BuiltinFunctionInfo(FOLDR, BFoldr),
+      BuiltinFunctionInfo(WITH_AUTHORITY_OF, BWithAuthorityOf),
       BuiltinFunctionInfo(TEXTMAP_EMPTY, BTextMapEmpty),
       BuiltinFunctionInfo(TEXTMAP_INSERT, BTextMapInsert),
       BuiltinFunctionInfo(TEXTMAP_LOOKUP, BTextMapLookup),

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PhaseOne.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PhaseOne.scala
@@ -458,6 +458,7 @@ private[lf] final class PhaseOne(
           // List functions
           case BFoldl => SBFoldl
           case BFoldr => SBFoldr
+          case BWithAuthorityOf => SBWithAuthorityOf
           case BEqualList => SBEqualList
 
           // Errors

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -660,7 +660,7 @@ private[lf] object SBuiltin {
         args: util.ArrayList[SValue],
         machine: Machine[Q],
     ): Control[Q] = {
-      sys.error("SBWithAuthorityOf/NICK")
+      sys.error("SBWithAuthorityOf") // TODO https://github.com/digital-asset/daml/issues/15882
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -655,6 +655,15 @@ private[lf] object SBuiltin {
     }
   }
 
+  final case object SBWithAuthorityOf extends SBuiltin(2) {
+    override private[speedy] def execute[Q](
+        args: util.ArrayList[SValue],
+        machine: Machine[Q],
+    ): Control[Q] = {
+      sys.error("SBWithAuthorityOf/NICK")
+    }
+  }
+
   final case object SBMapToList extends SBuiltinPure(1) {
 
     override private[speedy] def executePure(args: util.ArrayList[SValue]): SList =

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -441,6 +441,10 @@ object Ast {
   final case object BFoldl extends BuiltinFunction // : ∀a b. (b → a → b) → b → List a → b
   final case object BFoldr extends BuiltinFunction // : ∀a b. (a → b → b) → b → List a → b
 
+  // Authority
+  final case object BWithAuthorityOf
+      extends BuiltinFunction // : ∀ a. List Party → Update a → Update a
+
   // Maps
   final case object BTextMapEmpty extends BuiltinFunction // : ∀ a. TextMap a
   final case object BTextMapInsert

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -324,6 +324,7 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
     "UNIX_MICROSECONDS_TO_TIMESTAMP" -> BUnixMicrosecondsToTimestamp,
     "FOLDL" -> BFoldl,
     "FOLDR" -> BFoldr,
+    "WITH_AUTHORITY_OF" -> BWithAuthorityOf,
     "TEXTMAP_EMPTY" -> BTextMapEmpty,
     "TEXTMAP_INSERT" -> BTextMapInsert,
     "TEXTMAP_LOOKUP" -> BTextMapLookup,

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -209,6 +209,7 @@ class ParsersSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matcher
         "UNIX_MICROSECONDS_TO_TIMESTAMP" -> BUnixMicrosecondsToTimestamp,
         "FOLDL" -> BFoldl,
         "FOLDR" -> BFoldr,
+        "WITH_AUTHORITY_OF" -> BWithAuthorityOf,
         "EXPLODE_TEXT" -> BExplodeText,
         "IMPLODE_TEXT" -> BImplodeText,
         "APPEND_TEXT" -> BAppendText,

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -4557,6 +4557,14 @@ List functions
   predicate give as first argument.
 
 
+Authority functions
+~~~~~~~~~~~~~~~~~~~
+
+* ``WITH_AUTHORITY_OF : ∀ (α : ⋆) . 'List' 'Party' → 'Update' α → 'Update' α``
+
+  Request authorization from the ledger for the scope of an update operation.
+
+
 Text map functions
 ~~~~~~~~~~~~~~~~~~
 

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -136,6 +136,12 @@ private[validation] object Typing {
           alpha.name -> KStar,
           TForall(beta.name -> KStar, (alpha ->: beta ->: beta) ->: beta ->: TList(alpha) ->: beta),
         ),
+      // Authority
+      BWithAuthorityOf ->
+        TForall(
+          alpha.name -> KStar,
+          TList(TParty) ->: TUpdate(alpha) ->: TUpdate(alpha),
+        ),
       // Maps
       BTextMapEmpty ->
         TForall(

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -69,6 +69,7 @@ genrule(
       cp -L $(location :daml/TestContractId.daml) $$TMP_DIR/daml
       cp -L $(location :daml/TestExceptions.daml) $$TMP_DIR/daml
       cp -L $(location :daml/TestInterfaces.daml) $$TMP_DIR/daml
+      cp -L $(location :daml/TestWithAuthorityOf.daml) $$TMP_DIR/daml
       cp -L $(location //daml-script/daml:daml-script-1.dev.dar) $$TMP_DIR/
       cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: {sdk}

--- a/daml-script/test/daml/TestWithAuthorityOf.daml
+++ b/daml-script/test/daml/TestWithAuthorityOf.daml
@@ -1,0 +1,56 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module TestWithAuthorityOf where
+
+import Daml.Script
+
+template HasConsortiumAutority
+  with
+    consortiumParty: Party
+  where
+    signatory consortiumParty
+
+template ProposeConsortiumAuthority
+  with
+    proposer: Party
+    accepted: [Party]
+    obs: [Party]
+    consortiumParty: Party
+  where
+    signatory proposer, accepted
+    observer obs
+
+    choice Accept : ContractId ProposeConsortiumAuthority
+      with who: Party
+      controller who
+      do create this with accepted = who :: this.accepted
+
+    choice Ratify : ContractId HasConsortiumAutority controller proposer
+      do
+        withAuthorityOf accepted $ do
+          withAuthorityOf [consortiumParty] $ do
+            create HasConsortiumAutority with consortiumParty
+
+
+test : Script ()
+test = do
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
+  charlie <- allocateParty "Charlie"
+
+  org <- allocateParty "TheOrg"
+
+  prop <- submit alice do
+    createCmd ProposeConsortiumAuthority with
+      proposer = alice
+      accepted = []
+      obs = [bob,charlie]
+      consortiumParty = org
+
+  prop <- submit bob do exerciseCmd prop Accept with who = bob
+  prop <- submit charlie do exerciseCmd prop Accept with who = charlie
+
+  --submitMustFail alice do exerciseCmd prop Ratify -- TODO: https://github.com/digital-asset/daml/issues/15882
+
+  pure ()

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
@@ -359,6 +359,20 @@ abstract class AbstractFuncIT
         }
       }
     }
+    "WithAuthorityOf:test" should {
+      "succeed" in {
+        for {
+          clients <- participantClients()
+          v <- run(
+            clients,
+            QualifiedName.assertFromString("TestWithAuthorityOf:test"),
+            dar = devDar,
+          )
+        } yield {
+          v shouldBe (SUnit)
+        }
+      }
+    }
     "testMultiPartyQuery" should {
       "should return contracts for all listed parties" in {
         for {

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -119,7 +119,8 @@ conformance_test(
     lf_versions = [
         "default",
         "preview",
-        "dev",
+        # TODO https://github.com/digital-asset/daml/issues/15882
+        #"dev", # reactivate when canton uses the updated snapshot
     ],
     ports = conformance_test_ports,
     preview_mod_flag = "",


### PR DESCRIPTION
Support for new Daml primitive `withAuthorityOf`

-  New Daml primitive: `withAuthorityOf`
- (Haskell) compilation in `LFConversion/Primitives.hs`
- (Haskell) type checker
-  (Haskell) `.dar` encode(decode)
- extension of LF `.proto` format
- (Scala) `.dar` decode(encode)
- New LF primitive `BWithAuthorityOf` in `Ast.scala`
- Internal LF parser `ExprParser.scala`
- Scala type checker `Typing.scala`
- Compilation to speedy `PhaseOne.scala`
- New speedy builtin: `SBWithAuthorityOf` in `SBuiltin.scala` (`execute` not yet implemented)

Advances: https://github.com/digital-asset/daml/issues/15882
