### PR TITLE
Require `HasAgreement t` in template-only daml script functions

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -182,7 +182,8 @@ data QueryACS a = QueryACS
 
 -- | Query the set of active contracts of the template
 -- that are visible to the given party.
-query : forall t p. (Template t, IsParties p) => p -> Script [(ContractId t, t)]
+query : forall t p. (Template t, HasAgreement t, IsParties p) => p -> Script [(ContractId t, t)]
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 query p = lift $ Free $ Query QueryACS with
   parties = toParties p
   tplId = templateTypeRep @t
@@ -191,7 +192,8 @@ query p = lift $ Free $ Query QueryACS with
 
 -- | Query the set of active contracts of the template
 -- that are visible to the given party and match the given predicate.
-queryFilter : (Template c, IsParties p) => p -> (c -> Bool) -> Script [(ContractId c, c)]
+queryFilter : (Template c, HasAgreement c, IsParties p) => p -> (c -> Bool) -> Script [(ContractId c, c)]
+-- The 'HasAgreement c' constraint prevents this function from being used on interface types.
 queryFilter p f = filter (\(_, c) -> f c) <$> query p
 
 data QueryContractIdPayload a = QueryContractIdPayload
@@ -212,7 +214,8 @@ data QueryContractIdPayload a = QueryContractIdPayload
 --
 -- This is semantically equivalent to calling `query`
 -- and filtering on the client side.
-queryContractId : forall t p. (Template t, IsParties p) => HasCallStack => p -> ContractId t -> Script (Optional t)
+queryContractId : forall t p. (Template t, HasAgreement t, IsParties p) => HasCallStack => p -> ContractId t -> Script (Optional t)
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 queryContractId p c = lift $ Free $ QueryContractId QueryContractIdPayload with
   parties = toParties p
   tplId = templateTypeRep @t
@@ -601,7 +604,8 @@ internalCreateAndExerciseCmd : forall r. AnyTemplate -> AnyChoice -> Commands r
 internalCreateAndExerciseCmd tplArg choiceArg = Commands $ Ap (\f -> f (CreateAndExercise tplArg choiceArg identity) (pure (fromLedgerValue @r)))
 
 -- | Create a contract of the given template.
-createCmd : Template t => t -> Commands (ContractId t)
+createCmd : (Template t, HasAgreement t) => t -> Commands (ContractId t)
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 createCmd arg = internalCreateCmd (toAnyTemplate arg)
 
 -- | Exercise a choice on the given contract.
@@ -613,7 +617,8 @@ exerciseByKeyCmd : forall t k c r. (TemplateKey t k, Choice t c r) => k -> c -> 
 exerciseByKeyCmd key arg = internalExerciseByKeyCmd (templateTypeRep @t) (toAnyContractKey @t key) (toAnyChoice @t arg)
 
 -- | Create a contract and exercise a choice on it in the same transaction.
-createAndExerciseCmd : forall t c r. (Template t, Choice t c r) => t -> c -> Commands r
+createAndExerciseCmd : forall t c r. (Template t, Choice t c r, HasAgreement t) => t -> c -> Commands r
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 createAndExerciseCmd tplArg choiceArg = internalCreateAndExerciseCmd (toAnyTemplate tplArg) (toAnyChoice @t choiceArg)
 
 -- | Archive the given contract.

--- a/daml-script/test/daml/MultiTest.daml
+++ b/daml-script/test/daml/MultiTest.daml
@@ -68,7 +68,7 @@ tries : Int
 tries = 60
 
 
-waitForCid : Template t => Int -> Party -> ContractId t -> Script ()
+waitForCid : (Template t, HasAgreement t) => Int -> Party -> ContractId t -> Script ()
 waitForCid tries p cid
   | tries <= 0 = abort $ "Cid " <> show cid <> " did not appear"
   | otherwise = do

--- a/docs/source/daml-script/template-root/src/ScriptExample.daml
+++ b/docs/source/daml-script/template-root/src/ScriptExample.daml
@@ -126,7 +126,7 @@ initializeUser = do
 tries : Int
 tries = 60
 
-waitForCid : Template t => Int -> Party -> ContractId t -> Script ()
+waitForCid : (Template t, HasAgreement t) => Int -> Party -> ContractId t -> Script ()
 waitForCid tries p cid
   | tries <= 0 = abort $ "Cid " <> show cid <> " did not appear"
   | otherwise = do

--- a/triggers/daml/Daml/Trigger/Assert.daml
+++ b/triggers/daml/Daml/Trigger/Assert.daml
@@ -44,7 +44,7 @@ buildACS party (ACSBuilder fetches) = do
 
 -- | Include the given contract in the 'ACS'. Note that the `ContractId`
 -- must point to an active contract.
-toACS : Template t => ContractId t -> ACSBuilder
+toACS : (Template t, HasAgreement t) => ContractId t -> ACSBuilder
 toACS cid = ACSBuilder $ \p ->
   [ do t <-
          queryContractId p cid >>= \case
@@ -101,7 +101,7 @@ expectCommand commands fromCommand assertion = foldl step (Left []) commands
 
 -- | Check that at least one command is a create command whose payload fulfills the given assertions.
 assertCreateCmd
-  : (Template t, CanAbort m)
+  : (Template t, HasAgreement t, CanAbort m)
   => [Command]  -- ^ Check these commands.
   -> (t -> Either Text ())  -- ^ Perform these assertions.
   -> m ()
@@ -113,7 +113,7 @@ assertCreateCmd commands assertion =
 
 -- | Check that at least one command is an exercise command whose contract id and choice argument fulfill the given assertions.
 assertExerciseCmd
-  : (Template t, Choice t c r, CanAbort m)
+  : (Template t, HasAgreement t, Choice t c r, CanAbort m)
   => [Command]  -- ^ Check these commands.
   -> ((ContractId t, c) -> Either Text ())  -- ^ Perform these assertions.
   -> m ()


### PR DESCRIPTION
Short-term fix for https://github.com/digital-asset/daml/issues/15840

With this change, attempting to use one of the functions `query`, `queryFilter`, `queryContractId`, `createCmd` or `createAndExerciseCmd` with `t ~ SomeInterfaceType` will result in a compile time error about a missing instance for `HasAgreement SomeInterfaceType`. This isn't great, since users might simply try to write their own instance instead, but at least it's not a crash at runtime.