### PR TITLE
Ensure logging context is present in release logback.xml and trigger logging is INFO by default

### DIFF
--- a/triggers/service/release/trigger-service-logback.xml
+++ b/triggers/service/release/trigger-service-logback.xml
@@ -6,7 +6,7 @@
             </then>
             <else>
                 <encoder>
-                    <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                    <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $', ''} %n</pattern>
                 </encoder>
             </else>
         </if>
@@ -18,7 +18,7 @@
 
     <logger name="io.netty" level="WARN"/>
     <logger name="io.grpc.netty" level="WARN"/>
-    <logger name="com.daml.lf.engine.trigger" level="DEBUG"/>
+    <logger name="com.daml.lf.engine.trigger" level="INFO"/>
 
     <root level="${LOG_LEVEL_ROOT:-INFO}">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
(release) trigger service logging failed to capture the logging context, so when logging was modified to be DEBUG, context logging would be missing from logging output (thanks for reporting @arturpoor-da).

- [x] add trigger logging context to release logback.xml file
- [x] ensure trigger context logging is INFO by default for release logback.xml file


<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
