### PR TITLE
Backport improved type errors [#15712, #15731, #15855, #15999, #16017] to 2.5.x

### DIFF
--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -18,8 +18,8 @@ load("@dadew//:dadew.bzl", "dadew_tool_home")
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 load("//bazel_tools/ghc-lib:repositories.bzl", "ghc_lib_and_dependencies")
 
-GHCIDE_REV = "d54267ac4ee420e31de7e387822a67df5ec58d99"
-GHCIDE_SHA256 = "be236e684c3799951074bde26381a763e50752ff5b0362feede25a52c38ab60e"
+GHCIDE_REV = "4e3629a9ae4244e60f5a69288d2b9dd7c966acb9"
+GHCIDE_SHA256 = "c51b34790c08dcde124ba6328a21ca0bde81e6ed3a8f8b84ff1dca2e5fe76df6"
 JS_JQUERY_VERSION = "3.3.1"
 JS_DGTABLE_VERSION = "0.5.2"
 JS_FLOT_VERSION = "0.8.3"

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "17268c72ca9983883426e996287a284802a30539"
+GHC_REV = "f9ed5461d960dabe3e08e250a5c520bd1771baca"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "f9ed5461d960dabe3e08e250a5c520bd1771baca"
+GHC_REV = "15d63a239827bce4209eb3024ce8a7210e0f242e"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "dc88c062d0b0f6a88b8f8dfd1a4749ca22dd9aff"
+GHC_REV = "f8e5fdd47a2c66c43922b991e3a5c2b9a89cef34"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "2d6ee7416bdc412f7c3cc56276eb8c10703e6999"
+GHC_REV = "dc88c062d0b0f6a88b8f8dfd1a4749ca22dd9aff"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "15d63a239827bce4209eb3024ce8a7210e0f242e"
+GHC_REV = "2d6ee7416bdc412f7c3cc56276eb8c10703e6999"
 GHC_PATCHES = [
 ]
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -41,6 +41,8 @@ import "ghc-lib-parser" DataCon
 import "ghc-lib-parser" Class
 import "ghc-lib-parser" BasicTypes
 import "ghc-lib-parser" Bag (bagToList)
+import "ghc-lib-parser" RdrHsSyn (isDamlGenerated)
+import "ghc-lib-parser" RdrName (rdrNameOcc)
 
 import Control.Monad
 import Control.Monad.IO.Class
@@ -205,7 +207,7 @@ getInterfaceInstanceMap ctx@DocCtx{..} decls =
         , name <- case unLoc decl of
             SigD _ (TypeSig _ (L _ n :_) _) -> [packRdrName n]
             _ -> []
-        , Just _ <- [T.stripPrefix "_interface_instance_" name]
+        , Just _ <- [T.stripPrefix "_interface_instance$_" name]
         , Just id <- [MS.lookup (Fieldname name) dc_ids]
         , TypeApp _ (Typename "InterfaceInstance")
             [ TypeApp _ parent []
@@ -239,11 +241,7 @@ getFctDocs ctx@DocCtx{..} (DeclData decl docs) = do
         fct_descr = docs
 
     guard (exportsFunction dc_exports fct_name)
-    guard (not $ "_choice_" `T.isPrefixOf` packRdrName name)
-    guard (not $ "_interface_instance_" `T.isPrefixOf` packRdrName name)
-    guard (not $ "_requires_" `T.isPrefixOf` packRdrName name)
-    guard (not $ "_method_" `T.isPrefixOf` packRdrName name)
-    guard (not $ "_view_" `T.isPrefixOf` packRdrName name)
+    guard (not $ isDamlGenerated $ rdrNameOcc name)
     Just FunctionDoc {..}
 
 getClsDocs :: DocCtx -> DeclData -> Maybe ClassDoc

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -256,7 +256,7 @@ extractModuleContents env@Env{..} coreModule modIface details = do
     mcChoiceData = MS.fromListWith (++)
         [ (mkTypeCon [getOccText tplTy], [ChoiceData ty v])
         | (name, v) <- mcBinds
-        , "_choice_" `T.isPrefixOf` getOccText name
+        , "_choice$_" `T.isPrefixOf` getOccText name
         , ty@(TypeCon _ [_, _, TypeCon _ [TypeCon tplTy _], _]) <- [varType name]
         ]
     mcTemplateBinds = scrapeTemplateBinds mcBinds
@@ -490,7 +490,7 @@ scrapeInterfaceBinds lfVersion tyThings binds =
           HasMethodDFunId interface methodName retTy ->
             Just (interface, insertInterfaceMethod methodName retTy (convNameLoc name))
           name
-            | "_requires_" `T.isPrefixOf` getOccText name
+            | "_requires$_" `T.isPrefixOf` getOccText name
             , TypeCon requiresT [TypeCon iface1 [], TypeCon iface2 []] <- varType name
             , NameIn DA_Internal_Desugar "RequiresT" <- requiresT
             -> Just (iface1, insertInterfaceRequires iface2 (convNameLoc name))
@@ -505,7 +505,7 @@ data InterfaceInstanceBinds = InterfaceInstanceBinds
   { iibInterface :: GHC.TyCon
   , iibTemplate :: GHC.TyCon
   , iibLoc :: Maybe SourceLoc
-      -- ^ Location associated to the @_interface_instance_@ marker, which should
+      -- ^ Location associated to the @_interface_instance$_@ marker, which should
       -- point to the @interface instance@ line in the daml file.
   , iibMethods :: MS.Map MethodName (GHC.Expr GHC.CoreBndr)
       -- ^ Method implementations.
@@ -597,7 +597,7 @@ scrapeInterfaceInstanceBinds env binds =
         , singletonInterfaceInstanceGroup interface template (convNameLoc name)
         )
       | (name, _val) <- binds
-      , "_interface_instance_" `T.isPrefixOf` getOccText name
+      , "_interface_instance$_" `T.isPrefixOf` getOccText name
       , TypeCon (NameIn DA_Internal_Desugar "InterfaceInstance")
           [ TypeCon parent []
           , TypeCon interface []
@@ -1281,20 +1281,20 @@ convertBinds env mc =
 convertBind :: Env -> ModuleContents -> (Var, GHC.Expr Var) -> ConvertM [Definition]
 convertBind env mc (name, x)
     -- This is inlined in the choice in the template so we can just drop this.
-    | "_choice_" `T.isPrefixOf` getOccText name
+    | "_choice$_" `T.isPrefixOf` getOccText name
     = pure []
     -- We only need this to get additional info for interface choices.
-    | "_interface_choice_" `T.isPrefixOf` getOccText name
+    | "_interface_choice$_" `T.isPrefixOf` getOccText name
     = pure []
     -- These are only used as markers for the LF conversion.
-    | "_interface_instance_" `T.isPrefixOf` getOccText name
+    | "_interface_instance$_" `T.isPrefixOf` getOccText name
     = pure []
-    | "_requires_" `T.isPrefixOf` getOccText name
+    | "_requires$_" `T.isPrefixOf` getOccText name
     = pure []
     -- These are moved into interface implementations so we can drop them
-    | "_method_" `T.isPrefixOf` getOccText name
+    | "_method$_" `T.isPrefixOf` getOccText name
     = pure []
-    | "_view_" `T.isPrefixOf` getOccText name
+    | "_view$_" `T.isPrefixOf` getOccText name
     = pure []
 
     -- Remove guarded exercise when Extended Interfaces are unsupported

--- a/compiler/damlc/tests/daml-test-files/AmbiguousInterfaceInstance.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/AmbiguousInterfaceInstance.EXPECTED.desugared-daml
@@ -52,7 +52,7 @@ instance DA.Internal.Desugar.HasToAnyChoice Foo DA.Internal.Desugar.Archive (())
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice Foo DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_FooArchive :
+_choice$_FooArchive :
   (Foo -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Foo
    -> Foo
@@ -60,25 +60,25 @@ _choice_FooArchive :
    DA.Internal.Desugar.Consuming Foo,
    DA.Internal.Desugar.Optional (Foo
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_FooArchive
+_choice$_FooArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_Foo_Bar_Foo :
+_interface_instance$_Foo_Bar_Foo :
   DA.Internal.Desugar.InterfaceInstance Foo Bar Foo
-_interface_instance_Foo_Bar_Foo
+_interface_instance$_Foo_Bar_Foo
   = DA.Internal.Desugar.mkInterfaceInstance @Foo @Bar @Foo
-_method_Foo_Bar_Foo_bar :
+_method$_Foo_Bar_Foo_bar :
   DA.Internal.Desugar.Method Foo Bar Foo "bar"
-_method_Foo_Bar_Foo_bar
+_method$_Foo_Bar_Foo_bar
   = DA.Internal.Desugar.mkMethod
       @Foo
       @Bar
       @Foo
       @"bar"
       \ this@Foo {..} -> let _ = this in let $bar = False in $bar
-_view_Foo_Bar_Foo : DA.Internal.Desugar.InterfaceView Foo Bar Foo
-_view_Foo_Bar_Foo
+_view$_Foo_Bar_Foo : DA.Internal.Desugar.InterfaceView Foo Bar Foo
+_view$_Foo_Bar_Foo
   = DA.Internal.Desugar.mkInterfaceView
       @Foo
       @Bar
@@ -140,7 +140,7 @@ instance DA.Internal.Desugar.HasExercise Bar DA.Internal.Desugar.Archive (()) wh
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @Bar cid)
         arg
-_choice_BarArchive :
+_choice$_BarArchive :
   (Bar -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Bar
    -> Bar
@@ -148,7 +148,7 @@ _choice_BarArchive :
    DA.Internal.Desugar.Consuming Bar,
    DA.Internal.Desugar.Optional (Bar
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_BarArchive
+_choice$_BarArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
@@ -157,21 +157,21 @@ instance DA.Internal.Desugar.HasInterfaceView Bar BarView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Bar BarView where
   _fromAnyView = GHC.Types.primitive @"EFromAnyView"
-_interface_instance_Bar_Bar_Foo :
+_interface_instance$_Bar_Bar_Foo :
   DA.Internal.Desugar.InterfaceInstance Bar Bar Foo
-_interface_instance_Bar_Bar_Foo
+_interface_instance$_Bar_Bar_Foo
   = DA.Internal.Desugar.mkInterfaceInstance @Bar @Bar @Foo
-_method_Bar_Bar_Foo_bar :
+_method$_Bar_Bar_Foo_bar :
   DA.Internal.Desugar.Method Bar Bar Foo "bar"
-_method_Bar_Bar_Foo_bar
+_method$_Bar_Bar_Foo_bar
   = DA.Internal.Desugar.mkMethod
       @Bar
       @Bar
       @Foo
       @"bar"
       \ this@Foo {..} -> let _ = this in let $bar = True in $bar
-_view_Bar_Bar_Foo : DA.Internal.Desugar.InterfaceView Bar Bar Foo
-_view_Bar_Bar_Foo
+_view$_Bar_Bar_Foo : DA.Internal.Desugar.InterfaceView Bar Bar Foo
+_view$_Bar_Bar_Foo
   = DA.Internal.Desugar.mkInterfaceView
       @Bar
       @Bar

--- a/compiler/damlc/tests/daml-test-files/DotDotUpdateSyntaxError.daml
+++ b/compiler/damlc/tests/daml-test-files/DotDotUpdateSyntaxError.daml
@@ -1,0 +1,15 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DotDotUpdateSyntaxError where
+
+import Daml.Script
+
+data D = D with f1 : Int, f2 : Int
+
+-- @ERROR range=14:17-14:17; The syntax '..' can only be used with a record constructor
+setup : Script ()
+setup = script do
+  let d1 = D 1 2
+  debug(d2 with ..)
+  return ()

--- a/compiler/damlc/tests/daml-test-files/ExceptionCreate.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionCreate.EXPECTED.desugared-daml
@@ -54,7 +54,7 @@ instance DA.Internal.Desugar.HasToAnyChoice MyTemplate DA.Internal.Desugar.Archi
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice MyTemplate DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_MyTemplateArchive :
+_choice$_MyTemplateArchive :
   (MyTemplate
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId MyTemplate
@@ -63,7 +63,7 @@ _choice_MyTemplateArchive :
    DA.Internal.Desugar.Consuming MyTemplate,
    DA.Internal.Desugar.Optional (MyTemplate
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_MyTemplateArchive
+_choice$_MyTemplateArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)

--- a/compiler/damlc/tests/daml-test-files/ExceptionSemantics.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionSemantics.EXPECTED.desugared-daml
@@ -68,7 +68,7 @@ instance DA.Internal.Desugar.HasToAnyChoice K DA.Internal.Desugar.Archive (()) w
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice K DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_KArchive :
+_choice$_KArchive :
   (K -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId K
    -> K
@@ -76,7 +76,7 @@ _choice_KArchive :
    DA.Internal.Desugar.Consuming K,
    DA.Internal.Desugar.Optional (K
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_KArchive
+_choice$_KArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
@@ -273,7 +273,7 @@ instance DA.Internal.Desugar.HasToAnyChoice T NonRollbackArchive (()) where
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice T NonRollbackArchive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_TArchive :
+_choice$_TArchive :
   (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T
@@ -281,32 +281,32 @@ _choice_TArchive :
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TArchive
+_choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_TThrow :
+_choice$_TThrow :
   (T -> Throw -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> Throw -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming T,
    DA.Internal.Desugar.Optional (T
                                  -> Throw -> [DA.Internal.Desugar.Party]))
-_choice_TThrow
+_choice$_TThrow
   = (\ this@T {..} arg@Throw
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
      \ self this@T {..} arg@Throw
        -> let _ = self in let _ = this in let _ = arg in do throw E, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
-_choice_TCatch :
+_choice$_TCatch :
   (T -> Catch -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> Catch -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming T,
    DA.Internal.Desugar.Optional (T
                                  -> Catch -> [DA.Internal.Desugar.Party]))
-_choice_TCatch
+_choice$_TCatch
   = (\ this@T {..} arg@Catch
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
@@ -322,28 +322,28 @@ _choice_TCatch
                      -> DA.Internal.Desugar.Some pure ()
                    _ -> DA.Internal.Desugar.None, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
-_choice_TThrowArithmeticError :
+_choice$_TThrowArithmeticError :
   (T -> ThrowArithmeticError -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> ThrowArithmeticError -> DA.Internal.Desugar.Update (Int),
    DA.Internal.Desugar.NonConsuming T,
    DA.Internal.Desugar.Optional (T
                                  -> ThrowArithmeticError -> [DA.Internal.Desugar.Party]))
-_choice_TThrowArithmeticError
+_choice$_TThrowArithmeticError
   = (\ this@T {..} arg@ThrowArithmeticError
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
      \ self this@T {..} arg@ThrowArithmeticError
        -> let _ = self in let _ = this in let _ = arg in do pure (1 / 0), 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
-_choice_TCatchArithmeticError :
+_choice$_TCatchArithmeticError :
   (T -> CatchArithmeticError -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> CatchArithmeticError -> DA.Internal.Desugar.Update (Int),
    DA.Internal.Desugar.NonConsuming T,
    DA.Internal.Desugar.Optional (T
                                  -> CatchArithmeticError -> [DA.Internal.Desugar.Party]))
-_choice_TCatchArithmeticError
+_choice$_TCatchArithmeticError
   = (\ this@T {..} arg@CatchArithmeticError
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
@@ -359,14 +359,14 @@ _choice_TCatchArithmeticError
                      -> DA.Internal.Desugar.Some pure 42
                    _ -> DA.Internal.Desugar.None, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
-_choice_TUncatchableTry :
+_choice$_TUncatchableTry :
   (T -> UncatchableTry -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> UncatchableTry -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming T,
    DA.Internal.Desugar.Optional (T
                                  -> UncatchableTry -> [DA.Internal.Desugar.Party]))
-_choice_TUncatchableTry
+_choice$_TUncatchableTry
   = (\ this@T {..} arg@UncatchableTry {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
@@ -382,14 +382,14 @@ _choice_TUncatchableTry
                      -> DA.Internal.Desugar.Some pure ()
                    _ -> DA.Internal.Desugar.None, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
-_choice_TTransientDuplicate :
+_choice$_TTransientDuplicate :
   (T -> TransientDuplicate -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> TransientDuplicate -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming T,
    DA.Internal.Desugar.Optional (T
                                  -> TransientDuplicate -> [DA.Internal.Desugar.Party]))
-_choice_TTransientDuplicate
+_choice$_TTransientDuplicate
   = (\ this@T {..} arg@TransientDuplicate {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
@@ -408,14 +408,14 @@ _choice_TTransientDuplicate
                      -> DA.Internal.Desugar.Some pure ()
                    _ -> DA.Internal.Desugar.None, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
-_choice_TNonTransientDuplicate :
+_choice$_TNonTransientDuplicate :
   (T -> NonTransientDuplicate -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> NonTransientDuplicate -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming T,
    DA.Internal.Desugar.Optional (T
                                  -> NonTransientDuplicate -> [DA.Internal.Desugar.Party]))
-_choice_TNonTransientDuplicate
+_choice$_TNonTransientDuplicate
   = (\ this@T {..} arg@NonTransientDuplicate {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
@@ -433,14 +433,14 @@ _choice_TNonTransientDuplicate
                      -> DA.Internal.Desugar.Some pure ()
                    _ -> DA.Internal.Desugar.None, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
-_choice_TRollbackKey :
+_choice$_TRollbackKey :
   (T -> RollbackKey -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> RollbackKey -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming T,
    DA.Internal.Desugar.Optional (T
                                  -> RollbackKey -> [DA.Internal.Desugar.Party]))
-_choice_TRollbackKey
+_choice$_TRollbackKey
   = (\ this@T {..} arg@RollbackKey {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
@@ -458,14 +458,14 @@ _choice_TRollbackKey
                      -> DA.Internal.Desugar.Some create (K p i) >> pure ()
                    _ -> DA.Internal.Desugar.None, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
-_choice_TRollbackArchive :
+_choice$_TRollbackArchive :
   (T -> RollbackArchive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> RollbackArchive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming T,
    DA.Internal.Desugar.Optional (T
                                  -> RollbackArchive -> [DA.Internal.Desugar.Party]))
-_choice_TRollbackArchive
+_choice$_TRollbackArchive
   = (\ this@T {..} arg@RollbackArchive {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
@@ -482,14 +482,14 @@ _choice_TRollbackArchive
                      -> DA.Internal.Desugar.Some archive cid
                    _ -> DA.Internal.Desugar.None, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
-_choice_TNonRollbackArchive :
+_choice$_TNonRollbackArchive :
   (T -> NonRollbackArchive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> NonRollbackArchive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming T,
    DA.Internal.Desugar.Optional (T
                                  -> NonRollbackArchive -> [DA.Internal.Desugar.Party]))
-_choice_TNonRollbackArchive
+_choice$_TNonRollbackArchive
   = (\ this@T {..} arg@NonRollbackArchive {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
@@ -589,7 +589,7 @@ instance DA.Internal.Desugar.HasToAnyChoice Fetcher RollbackFetch (()) where
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice Fetcher RollbackFetch (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_FetcherArchive :
+_choice$_FetcherArchive :
   (Fetcher
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Fetcher
@@ -598,32 +598,32 @@ _choice_FetcherArchive :
    DA.Internal.Desugar.Consuming Fetcher,
    DA.Internal.Desugar.Optional (Fetcher
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_FetcherArchive
+_choice$_FetcherArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_FetcherFetch :
+_choice$_FetcherFetch :
   (Fetcher -> Fetch -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Fetcher
    -> Fetcher -> Fetch -> DA.Internal.Desugar.Update (K),
    DA.Internal.Desugar.Consuming Fetcher,
    DA.Internal.Desugar.Optional (Fetcher
                                  -> Fetch -> [DA.Internal.Desugar.Party]))
-_choice_FetcherFetch
+_choice$_FetcherFetch
   = (\ this@Fetcher {..} arg@Fetch {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (obs), 
      \ self this@Fetcher {..} arg@Fetch {..}
        -> let _ = self in let _ = this in let _ = arg in do fetch cid, 
      DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
-_choice_FetcherRollbackFetch :
+_choice$_FetcherRollbackFetch :
   (Fetcher -> RollbackFetch -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Fetcher
    -> Fetcher -> RollbackFetch -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Fetcher,
    DA.Internal.Desugar.Optional (Fetcher
                                  -> RollbackFetch -> [DA.Internal.Desugar.Party]))
-_choice_FetcherRollbackFetch
+_choice$_FetcherRollbackFetch
   = (\ this@Fetcher {..} arg@RollbackFetch {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (obs), 

--- a/compiler/damlc/tests/daml-test-files/ImplementsNonInterface.daml
+++ b/compiler/damlc/tests/daml-test-files/ImplementsNonInterface.daml
@@ -6,7 +6,7 @@
 -- is caught prior due to missing Eq and Show instances.
 
 -- @SINCE-LF-FEATURE DAML_INTERFACE
--- @ERROR range=19:7-19:16; Tried to make an interface implementation of ‘Bool’, but ‘Bool’ is not an interface.
+-- @ERROR range=19:7-19:16; Possible Daml-specific reason for the following type error: Tried to make an interface implementation of ‘Bool’, but ‘Bool’ is not an interface.
 
 module ImplementsNonInterface where
 

--- a/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.desugared-daml
@@ -178,7 +178,7 @@ instance DA.Internal.Record.HasField "byHowMuch" GetRich Int where
     = DA.Internal.Record.getFieldPrim @"byHowMuch" @GetRich @Int
   setField
     = DA.Internal.Record.setFieldPrim @"byHowMuch" @GetRich @Int
-_choice_TokenArchive :
+_choice$_TokenArchive :
   (Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
@@ -187,12 +187,12 @@ _choice_TokenArchive :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TokenArchive
+_choice$_TokenArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_TokenSplit :
+_choice$_TokenSplit :
   (Token -> Split -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
@@ -202,7 +202,7 @@ _choice_TokenSplit :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> Split -> [DA.Internal.Desugar.Party]))
-_choice_TokenSplit
+_choice$_TokenSplit
   = (\ this arg@Split {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
@@ -210,7 +210,7 @@ _choice_TokenSplit
        -> let _ = self in
           let _ = this in let _ = arg in do splitImpl this splitAmount, 
      DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
-_choice_TokenTransfer :
+_choice$_TokenTransfer :
   (Token -> Transfer -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
@@ -218,7 +218,7 @@ _choice_TokenTransfer :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> Transfer -> [DA.Internal.Desugar.Party]))
-_choice_TokenTransfer
+_choice$_TokenTransfer
   = (\ this arg@Transfer {..}
        -> let _ = this in
           let _ = arg
@@ -230,14 +230,14 @@ _choice_TokenTransfer
        -> let _ = self in
           let _ = this in let _ = arg in do transferImpl this newOwner, 
      DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
-_choice_TokenNoop :
+_choice$_TokenNoop :
   (Token -> Noop -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token -> Noop -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> Noop -> [DA.Internal.Desugar.Party]))
-_choice_TokenNoop
+_choice$_TokenNoop
   = (\ this arg@Noop {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
@@ -245,7 +245,7 @@ _choice_TokenNoop
        -> let _ = self in
           let _ = this in let _ = arg in do noopImpl this nothing, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
-_choice_TokenGetRich :
+_choice$_TokenGetRich :
   (Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
@@ -253,7 +253,7 @@ _choice_TokenGetRich :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]))
-_choice_TokenGetRich
+_choice$_TokenGetRich
   = (\ this arg@GetRich {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
@@ -326,7 +326,7 @@ instance DA.Internal.Desugar.HasToAnyChoice Asset DA.Internal.Desugar.Archive ((
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice Asset DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_AssetArchive :
+_choice$_AssetArchive :
   (Asset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Asset
@@ -335,17 +335,17 @@ _choice_AssetArchive :
    DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_AssetArchive
+_choice$_AssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_Asset_Token_Asset :
+_interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
-_interface_instance_Asset_Token_Asset
+_interface_instance$_Asset_Token_Asset
   = DA.Internal.Desugar.mkInterfaceInstance @Asset @Token @Asset
-_method_Asset_Token_Asset_getOwner :
+_method$_Asset_Token_Asset_getOwner :
   DA.Internal.Desugar.Method Asset Token Asset "getOwner"
-_method_Asset_Token_Asset_getOwner
+_method$_Asset_Token_Asset_getOwner
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -353,9 +353,9 @@ _method_Asset_Token_Asset_getOwner
       @"getOwner"
       \ this@Asset {..}
         -> let _ = this in let $getOwner = owner in $getOwner
-_method_Asset_Token_Asset_getAmount :
+_method$_Asset_Token_Asset_getAmount :
   DA.Internal.Desugar.Method Asset Token Asset "getAmount"
-_method_Asset_Token_Asset_getAmount
+_method$_Asset_Token_Asset_getAmount
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -363,9 +363,9 @@ _method_Asset_Token_Asset_getAmount
       @"getAmount"
       \ this@Asset {..}
         -> let _ = this in let $getAmount = amount in $getAmount
-_method_Asset_Token_Asset_setAmount :
+_method$_Asset_Token_Asset_setAmount :
   DA.Internal.Desugar.Method Asset Token Asset "setAmount"
-_method_Asset_Token_Asset_setAmount
+_method$_Asset_Token_Asset_setAmount
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -375,9 +375,9 @@ _method_Asset_Token_Asset_setAmount
         -> let _ = this in
            let $setAmount x = toInterface @Token (this {amount = x})
            in $setAmount
-_method_Asset_Token_Asset_splitImpl :
+_method$_Asset_Token_Asset_splitImpl :
   DA.Internal.Desugar.Method Asset Token Asset "splitImpl"
-_method_Asset_Token_Asset_splitImpl
+_method$_Asset_Token_Asset_splitImpl
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -395,9 +395,9 @@ _method_Asset_Token_Asset_splitImpl
                         (toInterfaceContractId @Token cid1, 
                          toInterfaceContractId @Token cid2)
            in $splitImpl
-_method_Asset_Token_Asset_transferImpl :
+_method$_Asset_Token_Asset_transferImpl :
   DA.Internal.Desugar.Method Asset Token Asset "transferImpl"
-_method_Asset_Token_Asset_transferImpl
+_method$_Asset_Token_Asset_transferImpl
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -410,9 +410,9 @@ _method_Asset_Token_Asset_transferImpl
                = do cid <- create this {owner = newOwner}
                     pure (toInterfaceContractId @Token cid)
            in $transferImpl
-_method_Asset_Token_Asset_noopImpl :
+_method$_Asset_Token_Asset_noopImpl :
   DA.Internal.Desugar.Method Asset Token Asset "noopImpl"
-_method_Asset_Token_Asset_noopImpl
+_method$_Asset_Token_Asset_noopImpl
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -425,9 +425,9 @@ _method_Asset_Token_Asset_noopImpl
                = do [1] === [1]
                     pure ()
            in $noopImpl
-_view_Asset_Token_Asset :
+_view$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceView Asset Token Asset
-_view_Asset_Token_Asset
+_view$_Asset_Token_Asset
   = DA.Internal.Desugar.mkInterfaceView
       @Asset
       @Token

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision.EXPECTED.desugared-daml
@@ -54,7 +54,7 @@ instance DA.Internal.Desugar.HasToAnyChoice T DA.Internal.Desugar.Archive (()) w
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice T DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_TArchive :
+_choice$_TArchive :
   (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T
@@ -62,27 +62,27 @@ _choice_TArchive :
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TArchive
+_choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_T_InterfaceChoiceCollision1:Interface_T :
+_interface_instance$_T_InterfaceChoiceCollision1:Interface_T :
   DA.Internal.Desugar.InterfaceInstance T InterfaceChoiceCollision1.Interface T
-_interface_instance_T_InterfaceChoiceCollision1:Interface_T
+_interface_instance$_T_InterfaceChoiceCollision1:Interface_T
   = DA.Internal.Desugar.mkInterfaceInstance
       @T @InterfaceChoiceCollision1.Interface @T
-_method_T_InterfaceChoiceCollision1:Interface_T_getOwner :
+_method$_T_InterfaceChoiceCollision1:Interface_T_getOwner :
   DA.Internal.Desugar.Method T InterfaceChoiceCollision1.Interface T "getOwner"
-_method_T_InterfaceChoiceCollision1:Interface_T_getOwner
+_method$_T_InterfaceChoiceCollision1:Interface_T_getOwner
   = DA.Internal.Desugar.mkMethod
       @T
       @InterfaceChoiceCollision1.Interface
       @T
       @"getOwner"
       \ this@T {..} -> let _ = this in let $getOwner = owner in $getOwner
-_view_T_InterfaceChoiceCollision1:Interface_T :
+_view$_T_InterfaceChoiceCollision1:Interface_T :
   DA.Internal.Desugar.InterfaceView T InterfaceChoiceCollision1.Interface T
-_view_T_InterfaceChoiceCollision1:Interface_T
+_view$_T_InterfaceChoiceCollision1:Interface_T
   = DA.Internal.Desugar.mkInterfaceView
       @T
       @InterfaceChoiceCollision1.Interface
@@ -95,23 +95,23 @@ instance DA.Internal.Desugar.HasToInterface T InterfaceChoiceCollision1.Interfac
 instance DA.Internal.Desugar.HasFromInterface T InterfaceChoiceCollision1.Interface where
   fromInterface = GHC.Types.primitive @"EFromInterface"
   unsafeFromInterface = GHC.Types.primitive @"EUnsafeFromInterface"
-_interface_instance_T_InterfaceChoiceCollision2:Interface_T :
+_interface_instance$_T_InterfaceChoiceCollision2:Interface_T :
   DA.Internal.Desugar.InterfaceInstance T InterfaceChoiceCollision2.Interface T
-_interface_instance_T_InterfaceChoiceCollision2:Interface_T
+_interface_instance$_T_InterfaceChoiceCollision2:Interface_T
   = DA.Internal.Desugar.mkInterfaceInstance
       @T @InterfaceChoiceCollision2.Interface @T
-_method_T_InterfaceChoiceCollision2:Interface_T_getOwner :
+_method$_T_InterfaceChoiceCollision2:Interface_T_getOwner :
   DA.Internal.Desugar.Method T InterfaceChoiceCollision2.Interface T "getOwner"
-_method_T_InterfaceChoiceCollision2:Interface_T_getOwner
+_method$_T_InterfaceChoiceCollision2:Interface_T_getOwner
   = DA.Internal.Desugar.mkMethod
       @T
       @InterfaceChoiceCollision2.Interface
       @T
       @"getOwner"
       \ this@T {..} -> let _ = this in let $getOwner = owner in $getOwner
-_view_T_InterfaceChoiceCollision2:Interface_T :
+_view$_T_InterfaceChoiceCollision2:Interface_T :
   DA.Internal.Desugar.InterfaceView T InterfaceChoiceCollision2.Interface T
-_view_T_InterfaceChoiceCollision2:Interface_T
+_view$_T_InterfaceChoiceCollision2:Interface_T
   = DA.Internal.Desugar.mkInterfaceView
       @T
       @InterfaceChoiceCollision2.Interface

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision2.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision2.EXPECTED.desugared-daml
@@ -17,9 +17,9 @@ instance DA.Internal.Desugar.HasToInterface Interface Interface where
 instance DA.Internal.Desugar.HasFromInterface Interface Interface where
   fromInterface this = DA.Internal.Desugar.Some this
   unsafeFromInterface _ this = this
-_requires_Interface_InterfaceChoiceCollision1:Interface :
+_requires$_Interface_InterfaceChoiceCollision1:Interface :
   DA.Internal.Desugar.RequiresT Interface InterfaceChoiceCollision1.Interface
-_requires_Interface_InterfaceChoiceCollision1:Interface
+_requires$_Interface_InterfaceChoiceCollision1:Interface
   = DA.Internal.Desugar.RequiresT
 instance DA.Internal.Desugar.HasToInterface Interface InterfaceChoiceCollision1.Interface where
   _toInterface = GHC.Types.primitive @"EToRequiredInterface"
@@ -86,7 +86,7 @@ instance DA.Internal.Desugar.HasExercise Interface MyArchive (()) where
 data MyArchive
   = MyArchive {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
-_choice_InterfaceArchive :
+_choice$_InterfaceArchive :
   (Interface
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Interface
@@ -95,19 +95,19 @@ _choice_InterfaceArchive :
    DA.Internal.Desugar.Consuming Interface,
    DA.Internal.Desugar.Optional (Interface
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_InterfaceArchive
+_choice$_InterfaceArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_InterfaceMyArchive :
+_choice$_InterfaceMyArchive :
   (Interface -> MyArchive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Interface
    -> Interface -> MyArchive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Interface,
    DA.Internal.Desugar.Optional (Interface
                                  -> MyArchive -> [DA.Internal.Desugar.Party]))
-_choice_InterfaceMyArchive
+_choice$_InterfaceMyArchive
   = (\ this arg@MyArchive
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailed.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailed.EXPECTED.desugared-daml
@@ -74,7 +74,7 @@ instance DA.Internal.Desugar.HasExercise I IChoice (()) where
 data IChoice
   = IChoice {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
-_choice_IArchive :
+_choice$_IArchive :
   (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I
@@ -82,19 +82,19 @@ _choice_IArchive :
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_IArchive
+_choice$_IArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_IIChoice :
+_choice$_IIChoice :
   (I -> IChoice -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I -> IChoice -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
                                  -> IChoice -> [DA.Internal.Desugar.Party]))
-_choice_IIChoice
+_choice$_IIChoice
   = (\ this arg@IChoice
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getController this), 
@@ -154,7 +154,7 @@ instance DA.Internal.Desugar.HasToAnyChoice T DA.Internal.Desugar.Archive (()) w
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice T DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_TArchive :
+_choice$_TArchive :
   (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T
@@ -162,17 +162,17 @@ _choice_TArchive :
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TArchive
+_choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_T_I_T :
+_interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
-_interface_instance_T_I_T
+_interface_instance$_T_I_T
   = DA.Internal.Desugar.mkInterfaceInstance @T @I @T
-_method_T_I_T_getController :
+_method$_T_I_T_getController :
   DA.Internal.Desugar.Method T I T "getController"
-_method_T_I_T_getController
+_method$_T_I_T_getController
   = DA.Internal.Desugar.mkMethod
       @T
       @I
@@ -180,8 +180,8 @@ _method_T_I_T_getController
       @"getController"
       \ this@T {..}
         -> let _ = this in let $getController = party in $getController
-_view_T_I_T : DA.Internal.Desugar.InterfaceView T I T
-_view_T_I_T
+_view$_T_I_T : DA.Internal.Desugar.InterfaceView T I T
+_view$_T_I_T
   = DA.Internal.Desugar.mkInterfaceView
       @T
       @I

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailedNotExtended.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailedNotExtended.EXPECTED.desugared-daml
@@ -74,7 +74,7 @@ instance DA.Internal.Desugar.HasExercise I IChoice (()) where
 data IChoice
   = IChoice {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
-_choice_IArchive :
+_choice$_IArchive :
   (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I
@@ -82,19 +82,19 @@ _choice_IArchive :
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_IArchive
+_choice$_IArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_IIChoice :
+_choice$_IIChoice :
   (I -> IChoice -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I -> IChoice -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
                                  -> IChoice -> [DA.Internal.Desugar.Party]))
-_choice_IIChoice
+_choice$_IIChoice
   = (\ this arg@IChoice
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getController this), 
@@ -154,7 +154,7 @@ instance DA.Internal.Desugar.HasToAnyChoice T DA.Internal.Desugar.Archive (()) w
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice T DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_TArchive :
+_choice$_TArchive :
   (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T
@@ -162,17 +162,17 @@ _choice_TArchive :
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TArchive
+_choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_T_I_T :
+_interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
-_interface_instance_T_I_T
+_interface_instance$_T_I_T
   = DA.Internal.Desugar.mkInterfaceInstance @T @I @T
-_method_T_I_T_getController :
+_method$_T_I_T_getController :
   DA.Internal.Desugar.Method T I T "getController"
-_method_T_I_T_getController
+_method$_T_I_T_getController
   = DA.Internal.Desugar.mkMethod
       @T
       @I
@@ -180,8 +180,8 @@ _method_T_I_T_getController
       @"getController"
       \ this@T {..}
         -> let _ = this in let $getController = party in $getController
-_view_T_I_T : DA.Internal.Desugar.InterfaceView T I T
-_view_T_I_T
+_view$_T_I_T : DA.Internal.Desugar.InterfaceView T I T
+_view$_T_I_T
   = DA.Internal.Desugar.mkInterfaceView
       @T
       @I

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceResultMismatch.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceResultMismatch.daml
@@ -1,0 +1,23 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module InterfaceChoiceResultMismatch where
+
+-- @ERROR range=23:12-23:27; Tried to get a result of type ‘Either Text ()’ by exercising choice ‘C’ on interface ‘I’ but exercising choice ‘C’ should return type ‘()’ instead.
+
+interface I where
+  getController : Party
+
+  choice C : ()
+    controller getController
+    do pure ()
+
+exerciseE : Choice t c (Either Text r) => ContractId t -> c -> Update r
+exerciseE cid c = do
+  r <- exercise cid c
+  case r of
+    Left err -> abort err
+    Right r -> pure r
+
+test : ContractId I -> Update ()
+test cid = exerciseE cid C

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceResultMismatch.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceResultMismatch.daml
@@ -3,7 +3,7 @@
 
 module InterfaceChoiceResultMismatch where
 
--- @ERROR range=23:12-23:27; Tried to get a result of type ‘Either Text ()’ by exercising choice ‘C’ on interface ‘I’ but exercising choice ‘C’ should return type ‘()’ instead.
+-- @ERROR range=23:12-23:27; Possible Daml-specific reason for the following type error: Tried to get a result of type ‘Either Text ()’ by exercising choice ‘C’ on interface ‘I’ but exercising choice ‘C’ should return type ‘()’ instead.
 
 interface I where
   getController : Party

--- a/compiler/damlc/tests/daml-test-files/InterfaceContractDoesNotImplementInterface.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceContractDoesNotImplementInterface.EXPECTED.desugared-daml
@@ -51,7 +51,7 @@ instance DA.Internal.Desugar.HasExercise I DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @I cid)
         arg
-_choice_IArchive :
+_choice$_IArchive :
   (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I
@@ -59,7 +59,7 @@ _choice_IArchive :
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_IArchive
+_choice$_IArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
@@ -79,8 +79,8 @@ instance DA.Internal.Desugar.HasToInterface J J where
 instance DA.Internal.Desugar.HasFromInterface J J where
   fromInterface this = DA.Internal.Desugar.Some this
   unsafeFromInterface _ this = this
-_requires_J_I : DA.Internal.Desugar.RequiresT J I
-_requires_J_I = DA.Internal.Desugar.RequiresT
+_requires$_J_I : DA.Internal.Desugar.RequiresT J I
+_requires$_J_I = DA.Internal.Desugar.RequiresT
 instance DA.Internal.Desugar.HasToInterface J I where
   _toInterface = GHC.Types.primitive @"EToRequiredInterface"
 instance DA.Internal.Desugar.HasFromInterface J I where
@@ -146,7 +146,7 @@ instance DA.Internal.Desugar.HasExercise J JChoice (()) where
 data JChoice
   = JChoice {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
-_choice_JArchive :
+_choice$_JArchive :
   (J -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId J
    -> J
@@ -154,19 +154,19 @@ _choice_JArchive :
    DA.Internal.Desugar.Consuming J,
    DA.Internal.Desugar.Optional (J
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_JArchive
+_choice$_JArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_JJChoice :
+_choice$_JJChoice :
   (J -> JChoice -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId J
    -> J -> JChoice -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming J,
    DA.Internal.Desugar.Optional (J
                                  -> JChoice -> [DA.Internal.Desugar.Party]))
-_choice_JJChoice
+_choice$_JJChoice
   = (\ this arg@JChoice
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getController this), 
@@ -226,7 +226,7 @@ instance DA.Internal.Desugar.HasToAnyChoice T DA.Internal.Desugar.Archive (()) w
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice T DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_TArchive :
+_choice$_TArchive :
   (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T
@@ -234,16 +234,16 @@ _choice_TArchive :
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TArchive
+_choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_T_I_T :
+_interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
-_interface_instance_T_I_T
+_interface_instance$_T_I_T
   = DA.Internal.Desugar.mkInterfaceInstance @T @I @T
-_view_T_I_T : DA.Internal.Desugar.InterfaceView T I T
-_view_T_I_T
+_view$_T_I_T : DA.Internal.Desugar.InterfaceView T I T
+_view$_T_I_T
   = DA.Internal.Desugar.mkInterfaceView
       @T
       @I

--- a/compiler/damlc/tests/daml-test-files/InterfaceConversions.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceConversions.EXPECTED.desugared-daml
@@ -76,7 +76,7 @@ instance DA.Internal.Desugar.HasExercise Iface MyChoice (()) where
 data MyChoice
   = MyChoice {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
-_choice_IfaceArchive :
+_choice$_IfaceArchive :
   (Iface
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Iface
@@ -85,19 +85,19 @@ _choice_IfaceArchive :
    DA.Internal.Desugar.Consuming Iface,
    DA.Internal.Desugar.Optional (Iface
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_IfaceArchive
+_choice$_IfaceArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_IfaceMyChoice :
+_choice$_IfaceMyChoice :
   (Iface -> MyChoice -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Iface
    -> Iface -> MyChoice -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Iface,
    DA.Internal.Desugar.Optional (Iface
                                  -> MyChoice -> [DA.Internal.Desugar.Party]))
-_choice_IfaceMyChoice
+_choice$_IfaceMyChoice
   = (\ this arg@MyChoice
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
@@ -178,7 +178,7 @@ instance DA.Internal.Desugar.HasExercise Iface2 MyChoice2 (()) where
 data MyChoice2
   = MyChoice2 {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
-_choice_Iface2Archive :
+_choice$_Iface2Archive :
   (Iface2
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Iface2
@@ -187,19 +187,19 @@ _choice_Iface2Archive :
    DA.Internal.Desugar.Consuming Iface2,
    DA.Internal.Desugar.Optional (Iface2
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_Iface2Archive
+_choice$_Iface2Archive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_Iface2MyChoice2 :
+_choice$_Iface2MyChoice2 :
   (Iface2 -> MyChoice2 -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Iface2
    -> Iface2 -> MyChoice2 -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Iface2,
    DA.Internal.Desugar.Optional (Iface2
                                  -> MyChoice2 -> [DA.Internal.Desugar.Party]))
-_choice_Iface2MyChoice2
+_choice$_Iface2MyChoice2
   = (\ this arg@MyChoice2
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner2 this), 
@@ -266,7 +266,7 @@ instance DA.Internal.Desugar.HasToAnyChoice Template1 DA.Internal.Desugar.Archiv
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice Template1 DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_Template1Archive :
+_choice$_Template1Archive :
   (Template1
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Template1
@@ -275,18 +275,18 @@ _choice_Template1Archive :
    DA.Internal.Desugar.Consuming Template1,
    DA.Internal.Desugar.Optional (Template1
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_Template1Archive
+_choice$_Template1Archive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_Template1_Iface_Template1 :
+_interface_instance$_Template1_Iface_Template1 :
   DA.Internal.Desugar.InterfaceInstance Template1 Iface Template1
-_interface_instance_Template1_Iface_Template1
+_interface_instance$_Template1_Iface_Template1
   = DA.Internal.Desugar.mkInterfaceInstance
       @Template1 @Iface @Template1
-_method_Template1_Iface_Template1_getOwner :
+_method$_Template1_Iface_Template1_getOwner :
   DA.Internal.Desugar.Method Template1 Iface Template1 "getOwner"
-_method_Template1_Iface_Template1_getOwner
+_method$_Template1_Iface_Template1_getOwner
   = DA.Internal.Desugar.mkMethod
       @Template1
       @Iface
@@ -294,9 +294,9 @@ _method_Template1_Iface_Template1_getOwner
       @"getOwner"
       \ this@Template1 {..}
         -> let _ = this in let $getOwner = owner1 in $getOwner
-_view_Template1_Iface_Template1 :
+_view$_Template1_Iface_Template1 :
   DA.Internal.Desugar.InterfaceView Template1 Iface Template1
-_view_Template1_Iface_Template1
+_view$_Template1_Iface_Template1
   = DA.Internal.Desugar.mkInterfaceView
       @Template1
       @Iface
@@ -364,7 +364,7 @@ instance DA.Internal.Desugar.HasToAnyChoice Template2 DA.Internal.Desugar.Archiv
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice Template2 DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_Template2Archive :
+_choice$_Template2Archive :
   (Template2
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Template2
@@ -373,18 +373,18 @@ _choice_Template2Archive :
    DA.Internal.Desugar.Consuming Template2,
    DA.Internal.Desugar.Optional (Template2
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_Template2Archive
+_choice$_Template2Archive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_Template2_Iface_Template2 :
+_interface_instance$_Template2_Iface_Template2 :
   DA.Internal.Desugar.InterfaceInstance Template2 Iface Template2
-_interface_instance_Template2_Iface_Template2
+_interface_instance$_Template2_Iface_Template2
   = DA.Internal.Desugar.mkInterfaceInstance
       @Template2 @Iface @Template2
-_method_Template2_Iface_Template2_getOwner :
+_method$_Template2_Iface_Template2_getOwner :
   DA.Internal.Desugar.Method Template2 Iface Template2 "getOwner"
-_method_Template2_Iface_Template2_getOwner
+_method$_Template2_Iface_Template2_getOwner
   = DA.Internal.Desugar.mkMethod
       @Template2
       @Iface
@@ -392,9 +392,9 @@ _method_Template2_Iface_Template2_getOwner
       @"getOwner"
       \ this@Template2 {..}
         -> let _ = this in let $getOwner = owner2 in $getOwner
-_view_Template2_Iface_Template2 :
+_view$_Template2_Iface_Template2 :
   DA.Internal.Desugar.InterfaceView Template2 Iface Template2
-_view_Template2_Iface_Template2
+_view$_Template2_Iface_Template2
   = DA.Internal.Desugar.mkInterfaceView
       @Template2
       @Iface

--- a/compiler/damlc/tests/daml-test-files/InterfaceDoubleSpend.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceDoubleSpend.EXPECTED.desugared-daml
@@ -89,7 +89,7 @@ instance DA.Internal.Record.HasField "newOwner" Transfer Party where
     = DA.Internal.Record.getFieldPrim @"newOwner" @Transfer @Party
   setField
     = DA.Internal.Record.setFieldPrim @"newOwner" @Transfer @Party
-_choice_TokenArchive :
+_choice$_TokenArchive :
   (Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
@@ -98,12 +98,12 @@ _choice_TokenArchive :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TokenArchive
+_choice$_TokenArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_TokenTransfer :
+_choice$_TokenTransfer :
   (Token -> Transfer -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
@@ -111,7 +111,7 @@ _choice_TokenTransfer :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> Transfer -> [DA.Internal.Desugar.Party]))
-_choice_TokenTransfer
+_choice$_TokenTransfer
   = (\ this arg@Transfer {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getIssuer this), 
@@ -178,7 +178,7 @@ instance DA.Internal.Desugar.HasToAnyChoice Asset DA.Internal.Desugar.Archive ((
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice Asset DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_AssetArchive :
+_choice$_AssetArchive :
   (Asset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Asset
@@ -187,17 +187,17 @@ _choice_AssetArchive :
    DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_AssetArchive
+_choice$_AssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_Asset_Token_Asset :
+_interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
-_interface_instance_Asset_Token_Asset
+_interface_instance$_Asset_Token_Asset
   = DA.Internal.Desugar.mkInterfaceInstance @Asset @Token @Asset
-_method_Asset_Token_Asset_getOwner :
+_method$_Asset_Token_Asset_getOwner :
   DA.Internal.Desugar.Method Asset Token Asset "getOwner"
-_method_Asset_Token_Asset_getOwner
+_method$_Asset_Token_Asset_getOwner
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -205,9 +205,9 @@ _method_Asset_Token_Asset_getOwner
       @"getOwner"
       \ this@Asset {..}
         -> let _ = this in let $getOwner = owner in $getOwner
-_method_Asset_Token_Asset_getIssuer :
+_method$_Asset_Token_Asset_getIssuer :
   DA.Internal.Desugar.Method Asset Token Asset "getIssuer"
-_method_Asset_Token_Asset_getIssuer
+_method$_Asset_Token_Asset_getIssuer
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -215,9 +215,9 @@ _method_Asset_Token_Asset_getIssuer
       @"getIssuer"
       \ this@Asset {..}
         -> let _ = this in let $getIssuer = issuer in $getIssuer
-_method_Asset_Token_Asset_getAmount :
+_method$_Asset_Token_Asset_getAmount :
   DA.Internal.Desugar.Method Asset Token Asset "getAmount"
-_method_Asset_Token_Asset_getAmount
+_method$_Asset_Token_Asset_getAmount
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -225,9 +225,9 @@ _method_Asset_Token_Asset_getAmount
       @"getAmount"
       \ this@Asset {..}
         -> let _ = this in let $getAmount = amount in $getAmount
-_method_Asset_Token_Asset_transferImpl :
+_method$_Asset_Token_Asset_transferImpl :
   DA.Internal.Desugar.Method Asset Token Asset "transferImpl"
-_method_Asset_Token_Asset_transferImpl
+_method$_Asset_Token_Asset_transferImpl
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -240,9 +240,9 @@ _method_Asset_Token_Asset_transferImpl
                = do cid <- create this {owner = newOwner}
                     pure (toInterfaceContractId @Token cid)
            in $transferImpl
-_view_Asset_Token_Asset :
+_view$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceView Asset Token Asset
-_view_Asset_Token_Asset
+_view$_Asset_Token_Asset
   = DA.Internal.Desugar.mkInterfaceView
       @Asset
       @Token

--- a/compiler/damlc/tests/daml-test-files/InterfaceEmpty.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceEmpty.EXPECTED.desugared-daml
@@ -53,7 +53,7 @@ instance DA.Internal.Desugar.HasExercise I DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @I cid)
         arg
-_choice_IArchive :
+_choice$_IArchive :
   (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I
@@ -61,7 +61,7 @@ _choice_IArchive :
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_IArchive
+_choice$_IArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
@@ -119,7 +119,7 @@ instance DA.Internal.Desugar.HasToAnyChoice T DA.Internal.Desugar.Archive (()) w
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice T DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_TArchive :
+_choice$_TArchive :
   (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T
@@ -127,16 +127,16 @@ _choice_TArchive :
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TArchive
+_choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_T_I_T :
+_interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
-_interface_instance_T_I_T
+_interface_instance$_T_I_T
   = DA.Internal.Desugar.mkInterfaceInstance @T @I @T
-_view_T_I_T : DA.Internal.Desugar.InterfaceView T I T
-_view_T_I_T
+_view$_T_I_T : DA.Internal.Desugar.InterfaceView T I T
+_view$_T_I_T
   = DA.Internal.Desugar.mkInterfaceView
       @T
       @I

--- a/compiler/damlc/tests/daml-test-files/InterfaceEmptyIndirect.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceEmptyIndirect.EXPECTED.desugared-daml
@@ -53,7 +53,7 @@ instance DA.Internal.Desugar.HasToAnyChoice T DA.Internal.Desugar.Archive (()) w
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice T DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_TArchive :
+_choice$_TArchive :
   (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T
@@ -61,16 +61,16 @@ _choice_TArchive :
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TArchive
+_choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_T_I_T :
+_interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
-_interface_instance_T_I_T
+_interface_instance$_T_I_T
   = DA.Internal.Desugar.mkInterfaceInstance @T @I @T
-_view_T_I_T : DA.Internal.Desugar.InterfaceView T I T
-_view_T_I_T
+_view$_T_I_T : DA.Internal.Desugar.InterfaceView T I T
+_view$_T_I_T
   = DA.Internal.Desugar.mkInterfaceView
       @T
       @I

--- a/compiler/damlc/tests/daml-test-files/InterfaceEq.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceEq.EXPECTED.desugared-daml
@@ -51,7 +51,7 @@ instance DA.Internal.Desugar.HasExercise I DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @I cid)
         arg
-_choice_IArchive :
+_choice$_IArchive :
   (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I
@@ -59,7 +59,7 @@ _choice_IArchive :
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_IArchive
+_choice$_IArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
@@ -120,7 +120,7 @@ instance DA.Internal.Desugar.HasToAnyChoice T DA.Internal.Desugar.Archive (()) w
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice T DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_TArchive :
+_choice$_TArchive :
   (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T
@@ -128,16 +128,16 @@ _choice_TArchive :
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TArchive
+_choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_T_I_T :
+_interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
-_interface_instance_T_I_T
+_interface_instance$_T_I_T
   = DA.Internal.Desugar.mkInterfaceInstance @T @I @T
-_view_T_I_T : DA.Internal.Desugar.InterfaceView T I T
-_view_T_I_T
+_view$_T_I_T : DA.Internal.Desugar.InterfaceView T I T
+_view$_T_I_T
   = DA.Internal.Desugar.mkInterfaceView
       @T
       @I
@@ -201,7 +201,7 @@ instance DA.Internal.Desugar.HasToAnyChoice U DA.Internal.Desugar.Archive (()) w
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice U DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_UArchive :
+_choice$_UArchive :
   (U -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId U
    -> U
@@ -209,16 +209,16 @@ _choice_UArchive :
    DA.Internal.Desugar.Consuming U,
    DA.Internal.Desugar.Optional (U
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_UArchive
+_choice$_UArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_U_I_U :
+_interface_instance$_U_I_U :
   DA.Internal.Desugar.InterfaceInstance U I U
-_interface_instance_U_I_U
+_interface_instance$_U_I_U
   = DA.Internal.Desugar.mkInterfaceInstance @U @I @U
-_view_U_I_U : DA.Internal.Desugar.InterfaceView U I U
-_view_U_I_U
+_view$_U_I_U : DA.Internal.Desugar.InterfaceView U I U
+_view$_U_I_U
   = DA.Internal.Desugar.mkInterfaceView
       @U
       @I

--- a/compiler/damlc/tests/daml-test-files/InterfaceErrors.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceErrors.EXPECTED.desugared-daml
@@ -76,7 +76,7 @@ instance DA.Internal.Desugar.HasExercise MyInterface MyVirtualChoice (()) where
 data MyVirtualChoice
   = MyVirtualChoice {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
-_choice_MyInterfaceArchive :
+_choice$_MyInterfaceArchive :
   (MyInterface
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId MyInterface
@@ -85,12 +85,12 @@ _choice_MyInterfaceArchive :
    DA.Internal.Desugar.Consuming MyInterface,
    DA.Internal.Desugar.Optional (MyInterface
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_MyInterfaceArchive
+_choice$_MyInterfaceArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_MyInterfaceMyVirtualChoice :
+_choice$_MyInterfaceMyVirtualChoice :
   (MyInterface -> MyVirtualChoice -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId MyInterface
    -> MyInterface
@@ -98,7 +98,7 @@ _choice_MyInterfaceMyVirtualChoice :
    DA.Internal.Desugar.Consuming MyInterface,
    DA.Internal.Desugar.Optional (MyInterface
                                  -> MyVirtualChoice -> [DA.Internal.Desugar.Party]))
-_choice_MyInterfaceMyVirtualChoice
+_choice$_MyInterfaceMyVirtualChoice
   = (\ this arg@MyVirtualChoice
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties ([] : [Party]), 
@@ -159,7 +159,7 @@ instance DA.Internal.Desugar.HasToAnyChoice MyTemplate DA.Internal.Desugar.Archi
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice MyTemplate DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_MyTemplateArchive :
+_choice$_MyTemplateArchive :
   (MyTemplate
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId MyTemplate
@@ -168,7 +168,7 @@ _choice_MyTemplateArchive :
    DA.Internal.Desugar.Consuming MyTemplate,
    DA.Internal.Desugar.Optional (MyTemplate
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_MyTemplateArchive
+_choice$_MyTemplateArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)

--- a/compiler/damlc/tests/daml-test-files/InterfaceFunctions.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceFunctions.EXPECTED.desugared-daml
@@ -55,7 +55,7 @@ instance DA.Internal.Desugar.HasExercise Token DA.Internal.Desugar.Archive (()) 
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @Token cid)
         arg
-_choice_TokenArchive :
+_choice$_TokenArchive :
   (Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
@@ -64,7 +64,7 @@ _choice_TokenArchive :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TokenArchive
+_choice$_TokenArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
@@ -130,7 +130,7 @@ instance DA.Internal.Desugar.HasToAnyChoice Asset DA.Internal.Desugar.Archive ((
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice Asset DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_AssetArchive :
+_choice$_AssetArchive :
   (Asset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Asset
@@ -139,17 +139,17 @@ _choice_AssetArchive :
    DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_AssetArchive
+_choice$_AssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_Asset_Token_Asset :
+_interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
-_interface_instance_Asset_Token_Asset
+_interface_instance$_Asset_Token_Asset
   = DA.Internal.Desugar.mkInterfaceInstance @Asset @Token @Asset
-_method_Asset_Token_Asset_getAmount :
+_method$_Asset_Token_Asset_getAmount :
   DA.Internal.Desugar.Method Asset Token Asset "getAmount"
-_method_Asset_Token_Asset_getAmount
+_method$_Asset_Token_Asset_getAmount
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -157,9 +157,9 @@ _method_Asset_Token_Asset_getAmount
       @"getAmount"
       \ this@Asset {..}
         -> let _ = this in let $getAmount = amount in $getAmount
-_view_Asset_Token_Asset :
+_view$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceView Asset Token Asset
-_view_Asset_Token_Asset
+_view$_Asset_Token_Asset
   = DA.Internal.Desugar.mkInterfaceView
       @Asset
       @Token

--- a/compiler/damlc/tests/daml-test-files/InterfaceGuarded.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceGuarded.EXPECTED.desugared-daml
@@ -87,7 +87,7 @@ instance DA.Internal.Record.HasField "byHowMuch" GetRich Int where
     = DA.Internal.Record.getFieldPrim @"byHowMuch" @GetRich @Int
   setField
     = DA.Internal.Record.setFieldPrim @"byHowMuch" @GetRich @Int
-_choice_TokenArchive :
+_choice$_TokenArchive :
   (Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
@@ -96,12 +96,12 @@ _choice_TokenArchive :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TokenArchive
+_choice$_TokenArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_TokenGetRich :
+_choice$_TokenGetRich :
   (Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
@@ -109,7 +109,7 @@ _choice_TokenGetRich :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]))
-_choice_TokenGetRich
+_choice$_TokenGetRich
   = (\ this arg@GetRich {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
@@ -137,9 +137,9 @@ instance DA.Internal.Desugar.HasToInterface SubToken SubToken where
 instance DA.Internal.Desugar.HasFromInterface SubToken SubToken where
   fromInterface this = DA.Internal.Desugar.Some this
   unsafeFromInterface _ this = this
-_requires_SubToken_Token :
+_requires$_SubToken_Token :
   DA.Internal.Desugar.RequiresT SubToken Token
-_requires_SubToken_Token = DA.Internal.Desugar.RequiresT
+_requires$_SubToken_Token = DA.Internal.Desugar.RequiresT
 instance DA.Internal.Desugar.HasToInterface SubToken Token where
   _toInterface = GHC.Types.primitive @"EToRequiredInterface"
 instance DA.Internal.Desugar.HasFromInterface SubToken Token where
@@ -182,7 +182,7 @@ instance DA.Internal.Desugar.HasExercise SubToken DA.Internal.Desugar.Archive ((
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @SubToken cid)
         arg
-_choice_SubTokenArchive :
+_choice$_SubTokenArchive :
   (SubToken
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId SubToken
@@ -191,7 +191,7 @@ _choice_SubTokenArchive :
    DA.Internal.Desugar.Consuming SubToken,
    DA.Internal.Desugar.Optional (SubToken
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_SubTokenArchive
+_choice$_SubTokenArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
@@ -255,7 +255,7 @@ instance DA.Internal.Desugar.HasToAnyChoice Asset DA.Internal.Desugar.Archive ((
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice Asset DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_AssetArchive :
+_choice$_AssetArchive :
   (Asset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Asset
@@ -264,17 +264,17 @@ _choice_AssetArchive :
    DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_AssetArchive
+_choice$_AssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_Asset_Token_Asset :
+_interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
-_interface_instance_Asset_Token_Asset
+_interface_instance$_Asset_Token_Asset
   = DA.Internal.Desugar.mkInterfaceInstance @Asset @Token @Asset
-_method_Asset_Token_Asset_getOwner :
+_method$_Asset_Token_Asset_getOwner :
   DA.Internal.Desugar.Method Asset Token Asset "getOwner"
-_method_Asset_Token_Asset_getOwner
+_method$_Asset_Token_Asset_getOwner
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -282,9 +282,9 @@ _method_Asset_Token_Asset_getOwner
       @"getOwner"
       \ this@Asset {..}
         -> let _ = this in let $getOwner = owner in $getOwner
-_method_Asset_Token_Asset_getAmount :
+_method$_Asset_Token_Asset_getAmount :
   DA.Internal.Desugar.Method Asset Token Asset "getAmount"
-_method_Asset_Token_Asset_getAmount
+_method$_Asset_Token_Asset_getAmount
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -292,9 +292,9 @@ _method_Asset_Token_Asset_getAmount
       @"getAmount"
       \ this@Asset {..}
         -> let _ = this in let $getAmount = amount in $getAmount
-_method_Asset_Token_Asset_setAmount :
+_method$_Asset_Token_Asset_setAmount :
   DA.Internal.Desugar.Method Asset Token Asset "setAmount"
-_method_Asset_Token_Asset_setAmount
+_method$_Asset_Token_Asset_setAmount
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -304,9 +304,9 @@ _method_Asset_Token_Asset_setAmount
         -> let _ = this in
            let $setAmount x = toInterface @Token (this {amount = x})
            in $setAmount
-_view_Asset_Token_Asset :
+_view$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceView Asset Token Asset
-_view_Asset_Token_Asset
+_view$_Asset_Token_Asset
   = DA.Internal.Desugar.mkInterfaceView
       @Asset
       @Token
@@ -374,7 +374,7 @@ instance DA.Internal.Desugar.HasToAnyChoice AnotherAsset DA.Internal.Desugar.Arc
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice AnotherAsset DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_AnotherAssetArchive :
+_choice$_AnotherAssetArchive :
   (AnotherAsset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId AnotherAsset
@@ -383,18 +383,18 @@ _choice_AnotherAssetArchive :
    DA.Internal.Desugar.Consuming AnotherAsset,
    DA.Internal.Desugar.Optional (AnotherAsset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_AnotherAssetArchive
+_choice$_AnotherAssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_AnotherAsset_Token_AnotherAsset :
+_interface_instance$_AnotherAsset_Token_AnotherAsset :
   DA.Internal.Desugar.InterfaceInstance AnotherAsset Token AnotherAsset
-_interface_instance_AnotherAsset_Token_AnotherAsset
+_interface_instance$_AnotherAsset_Token_AnotherAsset
   = DA.Internal.Desugar.mkInterfaceInstance
       @AnotherAsset @Token @AnotherAsset
-_method_AnotherAsset_Token_AnotherAsset_getOwner :
+_method$_AnotherAsset_Token_AnotherAsset_getOwner :
   DA.Internal.Desugar.Method AnotherAsset Token AnotherAsset "getOwner"
-_method_AnotherAsset_Token_AnotherAsset_getOwner
+_method$_AnotherAsset_Token_AnotherAsset_getOwner
   = DA.Internal.Desugar.mkMethod
       @AnotherAsset
       @Token
@@ -402,9 +402,9 @@ _method_AnotherAsset_Token_AnotherAsset_getOwner
       @"getOwner"
       \ this@AnotherAsset {..}
         -> let _ = this in let $getOwner = owner in $getOwner
-_method_AnotherAsset_Token_AnotherAsset_getAmount :
+_method$_AnotherAsset_Token_AnotherAsset_getAmount :
   DA.Internal.Desugar.Method AnotherAsset Token AnotherAsset "getAmount"
-_method_AnotherAsset_Token_AnotherAsset_getAmount
+_method$_AnotherAsset_Token_AnotherAsset_getAmount
   = DA.Internal.Desugar.mkMethod
       @AnotherAsset
       @Token
@@ -412,9 +412,9 @@ _method_AnotherAsset_Token_AnotherAsset_getAmount
       @"getAmount"
       \ this@AnotherAsset {..}
         -> let _ = this in let $getAmount = amount in $getAmount
-_method_AnotherAsset_Token_AnotherAsset_setAmount :
+_method$_AnotherAsset_Token_AnotherAsset_setAmount :
   DA.Internal.Desugar.Method AnotherAsset Token AnotherAsset "setAmount"
-_method_AnotherAsset_Token_AnotherAsset_setAmount
+_method$_AnotherAsset_Token_AnotherAsset_setAmount
   = DA.Internal.Desugar.mkMethod
       @AnotherAsset
       @Token
@@ -424,9 +424,9 @@ _method_AnotherAsset_Token_AnotherAsset_setAmount
         -> let _ = this in
            let $setAmount x = toInterface @Token (this {amount = x})
            in $setAmount
-_view_AnotherAsset_Token_AnotherAsset :
+_view$_AnotherAsset_Token_AnotherAsset :
   DA.Internal.Desugar.InterfaceView AnotherAsset Token AnotherAsset
-_view_AnotherAsset_Token_AnotherAsset
+_view$_AnotherAsset_Token_AnotherAsset
   = DA.Internal.Desugar.mkInterfaceView
       @AnotherAsset
       @Token
@@ -438,14 +438,14 @@ instance DA.Internal.Desugar.HasToInterface AnotherAsset Token where
 instance DA.Internal.Desugar.HasFromInterface AnotherAsset Token where
   fromInterface = GHC.Types.primitive @"EFromInterface"
   unsafeFromInterface = GHC.Types.primitive @"EUnsafeFromInterface"
-_interface_instance_AnotherAsset_SubToken_AnotherAsset :
+_interface_instance$_AnotherAsset_SubToken_AnotherAsset :
   DA.Internal.Desugar.InterfaceInstance AnotherAsset SubToken AnotherAsset
-_interface_instance_AnotherAsset_SubToken_AnotherAsset
+_interface_instance$_AnotherAsset_SubToken_AnotherAsset
   = DA.Internal.Desugar.mkInterfaceInstance
       @AnotherAsset @SubToken @AnotherAsset
-_view_AnotherAsset_SubToken_AnotherAsset :
+_view$_AnotherAsset_SubToken_AnotherAsset :
   DA.Internal.Desugar.InterfaceView AnotherAsset SubToken AnotherAsset
-_view_AnotherAsset_SubToken_AnotherAsset
+_view$_AnotherAsset_SubToken_AnotherAsset
   = DA.Internal.Desugar.mkInterfaceView
       @AnotherAsset
       @SubToken

--- a/compiler/damlc/tests/daml-test-files/InterfaceGuardedNotExtended.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceGuardedNotExtended.EXPECTED.desugared-daml
@@ -87,7 +87,7 @@ instance DA.Internal.Record.HasField "byHowMuch" GetRich Int where
     = DA.Internal.Record.getFieldPrim @"byHowMuch" @GetRich @Int
   setField
     = DA.Internal.Record.setFieldPrim @"byHowMuch" @GetRich @Int
-_choice_TokenArchive :
+_choice$_TokenArchive :
   (Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
@@ -96,12 +96,12 @@ _choice_TokenArchive :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TokenArchive
+_choice$_TokenArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_TokenGetRich :
+_choice$_TokenGetRich :
   (Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
@@ -109,7 +109,7 @@ _choice_TokenGetRich :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]))
-_choice_TokenGetRich
+_choice$_TokenGetRich
   = (\ this arg@GetRich {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
@@ -180,7 +180,7 @@ instance DA.Internal.Desugar.HasToAnyChoice Asset DA.Internal.Desugar.Archive ((
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice Asset DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_AssetArchive :
+_choice$_AssetArchive :
   (Asset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Asset
@@ -189,17 +189,17 @@ _choice_AssetArchive :
    DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_AssetArchive
+_choice$_AssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_Asset_Token_Asset :
+_interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
-_interface_instance_Asset_Token_Asset
+_interface_instance$_Asset_Token_Asset
   = DA.Internal.Desugar.mkInterfaceInstance @Asset @Token @Asset
-_method_Asset_Token_Asset_getOwner :
+_method$_Asset_Token_Asset_getOwner :
   DA.Internal.Desugar.Method Asset Token Asset "getOwner"
-_method_Asset_Token_Asset_getOwner
+_method$_Asset_Token_Asset_getOwner
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -207,9 +207,9 @@ _method_Asset_Token_Asset_getOwner
       @"getOwner"
       \ this@Asset {..}
         -> let _ = this in let $getOwner = owner in $getOwner
-_method_Asset_Token_Asset_getAmount :
+_method$_Asset_Token_Asset_getAmount :
   DA.Internal.Desugar.Method Asset Token Asset "getAmount"
-_method_Asset_Token_Asset_getAmount
+_method$_Asset_Token_Asset_getAmount
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -217,9 +217,9 @@ _method_Asset_Token_Asset_getAmount
       @"getAmount"
       \ this@Asset {..}
         -> let _ = this in let $getAmount = amount in $getAmount
-_method_Asset_Token_Asset_setAmount :
+_method$_Asset_Token_Asset_setAmount :
   DA.Internal.Desugar.Method Asset Token Asset "setAmount"
-_method_Asset_Token_Asset_setAmount
+_method$_Asset_Token_Asset_setAmount
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -229,9 +229,9 @@ _method_Asset_Token_Asset_setAmount
         -> let _ = this in
            let $setAmount x = toInterface @Token (this {amount = x})
            in $setAmount
-_view_Asset_Token_Asset :
+_view$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceView Asset Token Asset
-_view_Asset_Token_Asset
+_view$_Asset_Token_Asset
   = DA.Internal.Desugar.mkInterfaceView
       @Asset
       @Token
@@ -299,7 +299,7 @@ instance DA.Internal.Desugar.HasToAnyChoice AnotherAsset DA.Internal.Desugar.Arc
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice AnotherAsset DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_AnotherAssetArchive :
+_choice$_AnotherAssetArchive :
   (AnotherAsset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId AnotherAsset
@@ -308,18 +308,18 @@ _choice_AnotherAssetArchive :
    DA.Internal.Desugar.Consuming AnotherAsset,
    DA.Internal.Desugar.Optional (AnotherAsset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_AnotherAssetArchive
+_choice$_AnotherAssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_AnotherAsset_Token_AnotherAsset :
+_interface_instance$_AnotherAsset_Token_AnotherAsset :
   DA.Internal.Desugar.InterfaceInstance AnotherAsset Token AnotherAsset
-_interface_instance_AnotherAsset_Token_AnotherAsset
+_interface_instance$_AnotherAsset_Token_AnotherAsset
   = DA.Internal.Desugar.mkInterfaceInstance
       @AnotherAsset @Token @AnotherAsset
-_method_AnotherAsset_Token_AnotherAsset_getOwner :
+_method$_AnotherAsset_Token_AnotherAsset_getOwner :
   DA.Internal.Desugar.Method AnotherAsset Token AnotherAsset "getOwner"
-_method_AnotherAsset_Token_AnotherAsset_getOwner
+_method$_AnotherAsset_Token_AnotherAsset_getOwner
   = DA.Internal.Desugar.mkMethod
       @AnotherAsset
       @Token
@@ -327,9 +327,9 @@ _method_AnotherAsset_Token_AnotherAsset_getOwner
       @"getOwner"
       \ this@AnotherAsset {..}
         -> let _ = this in let $getOwner = owner in $getOwner
-_method_AnotherAsset_Token_AnotherAsset_getAmount :
+_method$_AnotherAsset_Token_AnotherAsset_getAmount :
   DA.Internal.Desugar.Method AnotherAsset Token AnotherAsset "getAmount"
-_method_AnotherAsset_Token_AnotherAsset_getAmount
+_method$_AnotherAsset_Token_AnotherAsset_getAmount
   = DA.Internal.Desugar.mkMethod
       @AnotherAsset
       @Token
@@ -337,9 +337,9 @@ _method_AnotherAsset_Token_AnotherAsset_getAmount
       @"getAmount"
       \ this@AnotherAsset {..}
         -> let _ = this in let $getAmount = amount in $getAmount
-_method_AnotherAsset_Token_AnotherAsset_setAmount :
+_method$_AnotherAsset_Token_AnotherAsset_setAmount :
   DA.Internal.Desugar.Method AnotherAsset Token AnotherAsset "setAmount"
-_method_AnotherAsset_Token_AnotherAsset_setAmount
+_method$_AnotherAsset_Token_AnotherAsset_setAmount
   = DA.Internal.Desugar.mkMethod
       @AnotherAsset
       @Token
@@ -349,9 +349,9 @@ _method_AnotherAsset_Token_AnotherAsset_setAmount
         -> let _ = this in
            let $setAmount x = toInterface @Token (this {amount = x})
            in $setAmount
-_view_AnotherAsset_Token_AnotherAsset :
+_view$_AnotherAsset_Token_AnotherAsset :
   DA.Internal.Desugar.InterfaceView AnotherAsset Token AnotherAsset
-_view_AnotherAsset_Token_AnotherAsset
+_view$_AnotherAsset_Token_AnotherAsset
   = DA.Internal.Desugar.mkInterfaceView
       @AnotherAsset
       @Token

--- a/compiler/damlc/tests/daml-test-files/InterfaceNameCollision.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNameCollision.EXPECTED.desugared-daml
@@ -77,7 +77,7 @@ instance DA.Internal.Desugar.HasExercise Iface FooBar (()) where
 data FooBar
   = FooBar {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
-_choice_IfaceArchive :
+_choice$_IfaceArchive :
   (Iface
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Iface
@@ -86,19 +86,19 @@ _choice_IfaceArchive :
    DA.Internal.Desugar.Consuming Iface,
    DA.Internal.Desugar.Optional (Iface
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_IfaceArchive
+_choice$_IfaceArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_IfaceFooBar :
+_choice$_IfaceFooBar :
   (Iface -> FooBar -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Iface
    -> Iface -> FooBar -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Iface,
    DA.Internal.Desugar.Optional (Iface
                                  -> FooBar -> [DA.Internal.Desugar.Party]))
-_choice_IfaceFooBar
+_choice$_IfaceFooBar
   = (\ this arg@FooBar
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (owner this), 

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseRequiring.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseRequiring.EXPECTED.desugared-daml
@@ -86,7 +86,7 @@ instance DA.Internal.Record.HasField "byHowMuch" GetRich Int where
     = DA.Internal.Record.getFieldPrim @"byHowMuch" @GetRich @Int
   setField
     = DA.Internal.Record.setFieldPrim @"byHowMuch" @GetRich @Int
-_choice_TokenArchive :
+_choice$_TokenArchive :
   (Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
@@ -95,12 +95,12 @@ _choice_TokenArchive :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TokenArchive
+_choice$_TokenArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_TokenGetRich :
+_choice$_TokenGetRich :
   (Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
@@ -108,7 +108,7 @@ _choice_TokenGetRich :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]))
-_choice_TokenGetRich
+_choice$_TokenGetRich
   = (\ this arg@GetRich {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
@@ -136,9 +136,9 @@ instance DA.Internal.Desugar.HasToInterface SubToken SubToken where
 instance DA.Internal.Desugar.HasFromInterface SubToken SubToken where
   fromInterface this = DA.Internal.Desugar.Some this
   unsafeFromInterface _ this = this
-_requires_SubToken_Token :
+_requires$_SubToken_Token :
   DA.Internal.Desugar.RequiresT SubToken Token
-_requires_SubToken_Token = DA.Internal.Desugar.RequiresT
+_requires$_SubToken_Token = DA.Internal.Desugar.RequiresT
 instance DA.Internal.Desugar.HasToInterface SubToken Token where
   _toInterface = GHC.Types.primitive @"EToRequiredInterface"
 instance DA.Internal.Desugar.HasFromInterface SubToken Token where
@@ -181,7 +181,7 @@ instance DA.Internal.Desugar.HasExercise SubToken DA.Internal.Desugar.Archive ((
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @SubToken cid)
         arg
-_choice_SubTokenArchive :
+_choice$_SubTokenArchive :
   (SubToken
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId SubToken
@@ -190,7 +190,7 @@ _choice_SubTokenArchive :
    DA.Internal.Desugar.Consuming SubToken,
    DA.Internal.Desugar.Optional (SubToken
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_SubTokenArchive
+_choice$_SubTokenArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseRequiring.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseRequiring.daml
@@ -25,7 +25,7 @@ interface Token where
 interface SubToken requires Token where
   viewtype EmptyInterfaceView
 
--- @ERROR range=31:3-32:26; The choice ‘GetRich’ belongs to interface ‘Token’ which ‘SubToken’ implements.
+-- @ERROR range=31:3-32:26; Possible Daml-specific reason for the following type error: Tried to exercise a choice ‘GetRich’ on interface ‘SubToken’ The choice ‘GetRich’ belongs to interface ‘Token’ which ‘SubToken’ implements.
 cannotExercise : ContractId SubToken -> Update (ContractId Token)
 cannotExercise sub = do
   exercise sub GetRich with

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseTemplate.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseTemplate.EXPECTED.desugared-daml
@@ -86,7 +86,7 @@ instance DA.Internal.Record.HasField "byHowMuch" GetRich Int where
     = DA.Internal.Record.getFieldPrim @"byHowMuch" @GetRich @Int
   setField
     = DA.Internal.Record.setFieldPrim @"byHowMuch" @GetRich @Int
-_choice_TokenArchive :
+_choice$_TokenArchive :
   (Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
@@ -95,12 +95,12 @@ _choice_TokenArchive :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TokenArchive
+_choice$_TokenArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_TokenGetRich :
+_choice$_TokenGetRich :
   (Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
@@ -108,7 +108,7 @@ _choice_TokenGetRich :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]))
-_choice_TokenGetRich
+_choice$_TokenGetRich
   = (\ this arg@GetRich {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
@@ -179,7 +179,7 @@ instance DA.Internal.Desugar.HasToAnyChoice Asset DA.Internal.Desugar.Archive ((
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice Asset DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_AssetArchive :
+_choice$_AssetArchive :
   (Asset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Asset
@@ -188,17 +188,17 @@ _choice_AssetArchive :
    DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_AssetArchive
+_choice$_AssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_Asset_Token_Asset :
+_interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
-_interface_instance_Asset_Token_Asset
+_interface_instance$_Asset_Token_Asset
   = DA.Internal.Desugar.mkInterfaceInstance @Asset @Token @Asset
-_method_Asset_Token_Asset_getOwner :
+_method$_Asset_Token_Asset_getOwner :
   DA.Internal.Desugar.Method Asset Token Asset "getOwner"
-_method_Asset_Token_Asset_getOwner
+_method$_Asset_Token_Asset_getOwner
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -206,9 +206,9 @@ _method_Asset_Token_Asset_getOwner
       @"getOwner"
       \ this@Asset {..}
         -> let _ = this in let $getOwner = owner in $getOwner
-_method_Asset_Token_Asset_getAmount :
+_method$_Asset_Token_Asset_getAmount :
   DA.Internal.Desugar.Method Asset Token Asset "getAmount"
-_method_Asset_Token_Asset_getAmount
+_method$_Asset_Token_Asset_getAmount
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -216,9 +216,9 @@ _method_Asset_Token_Asset_getAmount
       @"getAmount"
       \ this@Asset {..}
         -> let _ = this in let $getAmount = amount in $getAmount
-_method_Asset_Token_Asset_setAmount :
+_method$_Asset_Token_Asset_setAmount :
   DA.Internal.Desugar.Method Asset Token Asset "setAmount"
-_method_Asset_Token_Asset_setAmount
+_method$_Asset_Token_Asset_setAmount
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -228,9 +228,9 @@ _method_Asset_Token_Asset_setAmount
         -> let _ = this in
            let $setAmount x = toInterface @Token (this {amount = x})
            in $setAmount
-_view_Asset_Token_Asset :
+_view$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceView Asset Token Asset
-_view_Asset_Token_Asset
+_view$_Asset_Token_Asset
   = DA.Internal.Desugar.mkInterfaceView
       @Asset
       @Token

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseTemplate.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseTemplate.daml
@@ -36,7 +36,7 @@ template Asset
       getAmount = amount
       setAmount x = toInterface @Token (this with amount = x)
 
--- @ERROR range=42:3-43:26; The choice ‘GetRich’ belongs to interface ‘Token’ which ‘Asset’ implements.
+-- @ERROR range=42:3-43:26; Possible Daml-specific reason for the following type error: Tried to exercise a choice ‘GetRich’ on template ‘Asset’ The choice ‘GetRich’ belongs to interface ‘Token’ which ‘Asset’ implements.
 cannotExercise : ContractId Asset -> Update (ContractId Token)
 cannotExercise asset = do
   exercise asset GetRich with

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoMethodOnRequiring.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoMethodOnRequiring.EXPECTED.desugared-daml
@@ -61,7 +61,7 @@ instance DA.Internal.Desugar.HasExercise Token DA.Internal.Desugar.Archive (()) 
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @Token cid)
         arg
-_choice_TokenArchive :
+_choice$_TokenArchive :
   (Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
@@ -70,7 +70,7 @@ _choice_TokenArchive :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TokenArchive
+_choice$_TokenArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
@@ -91,9 +91,9 @@ instance DA.Internal.Desugar.HasToInterface SubToken SubToken where
 instance DA.Internal.Desugar.HasFromInterface SubToken SubToken where
   fromInterface this = DA.Internal.Desugar.Some this
   unsafeFromInterface _ this = this
-_requires_SubToken_Token :
+_requires$_SubToken_Token :
   DA.Internal.Desugar.RequiresT SubToken Token
-_requires_SubToken_Token = DA.Internal.Desugar.RequiresT
+_requires$_SubToken_Token = DA.Internal.Desugar.RequiresT
 instance DA.Internal.Desugar.HasToInterface SubToken Token where
   _toInterface = GHC.Types.primitive @"EToRequiredInterface"
 instance DA.Internal.Desugar.HasFromInterface SubToken Token where
@@ -136,7 +136,7 @@ instance DA.Internal.Desugar.HasExercise SubToken DA.Internal.Desugar.Archive ((
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @SubToken cid)
         arg
-_choice_SubTokenArchive :
+_choice$_SubTokenArchive :
   (SubToken
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId SubToken
@@ -145,7 +145,7 @@ _choice_SubTokenArchive :
    DA.Internal.Desugar.Consuming SubToken,
    DA.Internal.Desugar.Optional (SubToken
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_SubTokenArchive
+_choice$_SubTokenArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoMethodOnTemplate.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoMethodOnTemplate.EXPECTED.desugared-daml
@@ -61,7 +61,7 @@ instance DA.Internal.Desugar.HasExercise Token DA.Internal.Desugar.Archive (()) 
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @Token cid)
         arg
-_choice_TokenArchive :
+_choice$_TokenArchive :
   (Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
@@ -70,7 +70,7 @@ _choice_TokenArchive :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TokenArchive
+_choice$_TokenArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
@@ -134,7 +134,7 @@ instance DA.Internal.Desugar.HasToAnyChoice Asset DA.Internal.Desugar.Archive ((
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice Asset DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_AssetArchive :
+_choice$_AssetArchive :
   (Asset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Asset
@@ -143,17 +143,17 @@ _choice_AssetArchive :
    DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_AssetArchive
+_choice$_AssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_Asset_Token_Asset :
+_interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
-_interface_instance_Asset_Token_Asset
+_interface_instance$_Asset_Token_Asset
   = DA.Internal.Desugar.mkInterfaceInstance @Asset @Token @Asset
-_method_Asset_Token_Asset_getOwner :
+_method$_Asset_Token_Asset_getOwner :
   DA.Internal.Desugar.Method Asset Token Asset "getOwner"
-_method_Asset_Token_Asset_getOwner
+_method$_Asset_Token_Asset_getOwner
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -161,9 +161,9 @@ _method_Asset_Token_Asset_getOwner
       @"getOwner"
       \ this@Asset {..}
         -> let _ = this in let $getOwner = owner in $getOwner
-_method_Asset_Token_Asset_getAmount :
+_method$_Asset_Token_Asset_getAmount :
   DA.Internal.Desugar.Method Asset Token Asset "getAmount"
-_method_Asset_Token_Asset_getAmount
+_method$_Asset_Token_Asset_getAmount
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -171,9 +171,9 @@ _method_Asset_Token_Asset_getAmount
       @"getAmount"
       \ this@Asset {..}
         -> let _ = this in let $getAmount = amount in $getAmount
-_method_Asset_Token_Asset_setAmount :
+_method$_Asset_Token_Asset_setAmount :
   DA.Internal.Desugar.Method Asset Token Asset "setAmount"
-_method_Asset_Token_Asset_setAmount
+_method$_Asset_Token_Asset_setAmount
   = DA.Internal.Desugar.mkMethod
       @Asset
       @Token
@@ -183,9 +183,9 @@ _method_Asset_Token_Asset_setAmount
         -> let _ = this in
            let $setAmount x = toInterface @Token (this {amount = x})
            in $setAmount
-_view_Asset_Token_Asset :
+_view$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceView Asset Token Asset
-_view_Asset_Token_Asset
+_view$_Asset_Token_Asset
   = DA.Internal.Desugar.mkInterfaceView
       @Asset
       @Token

--- a/compiler/damlc/tests/daml-test-files/InterfaceNotSupported.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNotSupported.EXPECTED.desugared-daml
@@ -51,7 +51,7 @@ instance DA.Internal.Desugar.HasExercise A DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @A cid)
         arg
-_choice_AArchive :
+_choice$_AArchive :
   (A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId A
    -> A
@@ -59,7 +59,7 @@ _choice_AArchive :
    DA.Internal.Desugar.Consuming A,
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_AArchive
+_choice$_AArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircular.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircular.EXPECTED.desugared-daml
@@ -15,8 +15,8 @@ instance DA.Internal.Desugar.HasToInterface A A where
 instance DA.Internal.Desugar.HasFromInterface A A where
   fromInterface this = DA.Internal.Desugar.Some this
   unsafeFromInterface _ this = this
-_requires_A_A : DA.Internal.Desugar.RequiresT A A
-_requires_A_A = DA.Internal.Desugar.RequiresT
+_requires$_A_A : DA.Internal.Desugar.RequiresT A A
+_requires$_A_A = DA.Internal.Desugar.RequiresT
 instance DA.Internal.Desugar.HasToAnyTemplate A where
   _toAnyTemplate = GHC.Types.primitive @"EToAnyTemplate"
 instance DA.Internal.Desugar.HasFromAnyTemplate A where
@@ -53,7 +53,7 @@ instance DA.Internal.Desugar.HasExercise A DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @A cid)
         arg
-_choice_AArchive :
+_choice$_AArchive :
   (A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId A
    -> A
@@ -61,7 +61,7 @@ _choice_AArchive :
    DA.Internal.Desugar.Consuming A,
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_AArchive
+_choice$_AArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircularIndirect.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircularIndirect.EXPECTED.desugared-daml
@@ -15,8 +15,8 @@ instance DA.Internal.Desugar.HasToInterface A A where
 instance DA.Internal.Desugar.HasFromInterface A A where
   fromInterface this = DA.Internal.Desugar.Some this
   unsafeFromInterface _ this = this
-_requires_A_B : DA.Internal.Desugar.RequiresT A B
-_requires_A_B = DA.Internal.Desugar.RequiresT
+_requires$_A_B : DA.Internal.Desugar.RequiresT A B
+_requires$_A_B = DA.Internal.Desugar.RequiresT
 instance DA.Internal.Desugar.HasToInterface A B where
   _toInterface = GHC.Types.primitive @"EToRequiredInterface"
 instance DA.Internal.Desugar.HasFromInterface A B where
@@ -59,7 +59,7 @@ instance DA.Internal.Desugar.HasExercise A DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @A cid)
         arg
-_choice_AArchive :
+_choice$_AArchive :
   (A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId A
    -> A
@@ -67,7 +67,7 @@ _choice_AArchive :
    DA.Internal.Desugar.Consuming A,
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_AArchive
+_choice$_AArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
@@ -87,8 +87,8 @@ instance DA.Internal.Desugar.HasToInterface B B where
 instance DA.Internal.Desugar.HasFromInterface B B where
   fromInterface this = DA.Internal.Desugar.Some this
   unsafeFromInterface _ this = this
-_requires_B_A : DA.Internal.Desugar.RequiresT B A
-_requires_B_A = DA.Internal.Desugar.RequiresT
+_requires$_B_A : DA.Internal.Desugar.RequiresT B A
+_requires$_B_A = DA.Internal.Desugar.RequiresT
 instance DA.Internal.Desugar.HasToInterface B A where
   _toInterface = GHC.Types.primitive @"EToRequiredInterface"
 instance DA.Internal.Desugar.HasFromInterface B A where
@@ -131,7 +131,7 @@ instance DA.Internal.Desugar.HasExercise B DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @B cid)
         arg
-_choice_BArchive :
+_choice$_BArchive :
   (B -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId B
    -> B
@@ -139,7 +139,7 @@ _choice_BArchive :
    DA.Internal.Desugar.Consuming B,
    DA.Internal.Desugar.Optional (B
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_BArchive
+_choice$_BArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresClash.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresClash.EXPECTED.desugared-daml
@@ -17,10 +17,10 @@ instance DA.Internal.Desugar.HasToInterface C C where
 instance DA.Internal.Desugar.HasFromInterface C C where
   fromInterface this = DA.Internal.Desugar.Some this
   unsafeFromInterface _ this = this
-_requires_C_A:I : DA.Internal.Desugar.RequiresT C A.I
-_requires_C_A:I = DA.Internal.Desugar.RequiresT
-_requires_C_B:I : DA.Internal.Desugar.RequiresT C B.I
-_requires_C_B:I = DA.Internal.Desugar.RequiresT
+_requires$_C_A:I : DA.Internal.Desugar.RequiresT C A.I
+_requires$_C_A:I = DA.Internal.Desugar.RequiresT
+_requires$_C_B:I : DA.Internal.Desugar.RequiresT C B.I
+_requires$_C_B:I = DA.Internal.Desugar.RequiresT
 instance DA.Internal.Desugar.HasToInterface C A.I where
   _toInterface = GHC.Types.primitive @"EToRequiredInterface"
 instance DA.Internal.Desugar.HasFromInterface C A.I where
@@ -69,7 +69,7 @@ instance DA.Internal.Desugar.HasExercise C DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @C cid)
         arg
-_choice_CArchive :
+_choice$_CArchive :
   (C -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId C
    -> C
@@ -77,7 +77,7 @@ _choice_CArchive :
    DA.Internal.Desugar.Consuming C,
    DA.Internal.Desugar.Optional (C
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_CArchive
+_choice$_CArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresClashA.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresClashA.EXPECTED.desugared-daml
@@ -51,7 +51,7 @@ instance DA.Internal.Desugar.HasExercise I DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @I cid)
         arg
-_choice_IArchive :
+_choice$_IArchive :
   (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I
@@ -59,7 +59,7 @@ _choice_IArchive :
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_IArchive
+_choice$_IArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresClashB.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresClashB.EXPECTED.desugared-daml
@@ -51,7 +51,7 @@ instance DA.Internal.Desugar.HasExercise I DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @I cid)
         arg
-_choice_IArchive :
+_choice$_IArchive :
   (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I
@@ -59,7 +59,7 @@ _choice_IArchive :
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_IArchive
+_choice$_IArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresError.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresError.EXPECTED.desugared-daml
@@ -51,7 +51,7 @@ instance DA.Internal.Desugar.HasExercise A DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @A cid)
         arg
-_choice_AArchive :
+_choice$_AArchive :
   (A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId A
    -> A
@@ -59,7 +59,7 @@ _choice_AArchive :
    DA.Internal.Desugar.Consuming A,
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_AArchive
+_choice$_AArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
@@ -79,8 +79,8 @@ instance DA.Internal.Desugar.HasToInterface B B where
 instance DA.Internal.Desugar.HasFromInterface B B where
   fromInterface this = DA.Internal.Desugar.Some this
   unsafeFromInterface _ this = this
-_requires_B_A : DA.Internal.Desugar.RequiresT B A
-_requires_B_A = DA.Internal.Desugar.RequiresT
+_requires$_B_A : DA.Internal.Desugar.RequiresT B A
+_requires$_B_A = DA.Internal.Desugar.RequiresT
 instance DA.Internal.Desugar.HasToInterface B A where
   _toInterface = GHC.Types.primitive @"EToRequiredInterface"
 instance DA.Internal.Desugar.HasFromInterface B A where
@@ -123,7 +123,7 @@ instance DA.Internal.Desugar.HasExercise B DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @B cid)
         arg
-_choice_BArchive :
+_choice$_BArchive :
   (B -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId B
    -> B
@@ -131,7 +131,7 @@ _choice_BArchive :
    DA.Internal.Desugar.Consuming B,
    DA.Internal.Desugar.Optional (B
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_BArchive
+_choice$_BArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
@@ -189,7 +189,7 @@ instance DA.Internal.Desugar.HasToAnyChoice T DA.Internal.Desugar.Archive (()) w
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice T DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_TArchive :
+_choice$_TArchive :
   (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T
@@ -197,16 +197,16 @@ _choice_TArchive :
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TArchive
+_choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_T_B_T :
+_interface_instance$_T_B_T :
   DA.Internal.Desugar.InterfaceInstance T B T
-_interface_instance_T_B_T
+_interface_instance$_T_B_T
   = DA.Internal.Desugar.mkInterfaceInstance @T @B @T
-_view_T_B_T : DA.Internal.Desugar.InterfaceView T B T
-_view_T_B_T
+_view$_T_B_T : DA.Internal.Desugar.InterfaceView T B T
+_view$_T_B_T
   = DA.Internal.Desugar.mkInterfaceView
       @T
       @B

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresNotClosed.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresNotClosed.EXPECTED.desugared-daml
@@ -51,7 +51,7 @@ instance DA.Internal.Desugar.HasExercise A DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @A cid)
         arg
-_choice_AArchive :
+_choice$_AArchive :
   (A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId A
    -> A
@@ -59,7 +59,7 @@ _choice_AArchive :
    DA.Internal.Desugar.Consuming A,
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_AArchive
+_choice$_AArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
@@ -79,8 +79,8 @@ instance DA.Internal.Desugar.HasToInterface B B where
 instance DA.Internal.Desugar.HasFromInterface B B where
   fromInterface this = DA.Internal.Desugar.Some this
   unsafeFromInterface _ this = this
-_requires_B_A : DA.Internal.Desugar.RequiresT B A
-_requires_B_A = DA.Internal.Desugar.RequiresT
+_requires$_B_A : DA.Internal.Desugar.RequiresT B A
+_requires$_B_A = DA.Internal.Desugar.RequiresT
 instance DA.Internal.Desugar.HasToInterface B A where
   _toInterface = GHC.Types.primitive @"EToRequiredInterface"
 instance DA.Internal.Desugar.HasFromInterface B A where
@@ -123,7 +123,7 @@ instance DA.Internal.Desugar.HasExercise B DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @B cid)
         arg
-_choice_BArchive :
+_choice$_BArchive :
   (B -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId B
    -> B
@@ -131,7 +131,7 @@ _choice_BArchive :
    DA.Internal.Desugar.Consuming B,
    DA.Internal.Desugar.Optional (B
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_BArchive
+_choice$_BArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
@@ -151,8 +151,8 @@ instance DA.Internal.Desugar.HasToInterface C C where
 instance DA.Internal.Desugar.HasFromInterface C C where
   fromInterface this = DA.Internal.Desugar.Some this
   unsafeFromInterface _ this = this
-_requires_C_B : DA.Internal.Desugar.RequiresT C B
-_requires_C_B = DA.Internal.Desugar.RequiresT
+_requires$_C_B : DA.Internal.Desugar.RequiresT C B
+_requires$_C_B = DA.Internal.Desugar.RequiresT
 instance DA.Internal.Desugar.HasToInterface C B where
   _toInterface = GHC.Types.primitive @"EToRequiredInterface"
 instance DA.Internal.Desugar.HasFromInterface C B where
@@ -195,7 +195,7 @@ instance DA.Internal.Desugar.HasExercise C DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @C cid)
         arg
-_choice_CArchive :
+_choice$_CArchive :
   (C -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId C
    -> C
@@ -203,7 +203,7 @@ _choice_CArchive :
    DA.Internal.Desugar.Consuming C,
    DA.Internal.Desugar.Optional (C
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_CArchive
+_choice$_CArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 

--- a/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityArgument.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityArgument.EXPECTED.desugared-daml
@@ -86,7 +86,7 @@ instance DA.Internal.Record.HasField "f" NonSerializableArgument NonSerializable
   setField
     = DA.Internal.Record.setFieldPrim
         @"f" @NonSerializableArgument @NonSerializable
-_choice_IArchive :
+_choice$_IArchive :
   (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I
@@ -94,19 +94,19 @@ _choice_IArchive :
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_IArchive
+_choice$_IArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_INonSerializableArgument :
+_choice$_INonSerializableArgument :
   (I -> NonSerializableArgument -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I -> NonSerializableArgument -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
                                  -> NonSerializableArgument -> [DA.Internal.Desugar.Party]))
-_choice_INonSerializableArgument
+_choice$_INonSerializableArgument
   = (\ this arg@NonSerializableArgument {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p this), 

--- a/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityPayload.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityPayload.EXPECTED.desugared-daml
@@ -75,7 +75,7 @@ data Get
 instance DA.Internal.Record.HasField "anyActor" Get Party where
   getField = DA.Internal.Record.getFieldPrim @"anyActor" @Get @Party
   setField = DA.Internal.Record.setFieldPrim @"anyActor" @Get @Party
-_choice_GettableArchive :
+_choice$_GettableArchive :
   (Gettable
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Gettable
@@ -84,19 +84,19 @@ _choice_GettableArchive :
    DA.Internal.Desugar.Consuming Gettable,
    DA.Internal.Desugar.Optional (Gettable
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_GettableArchive
+_choice$_GettableArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_GettableGet :
+_choice$_GettableGet :
   (Gettable -> Get -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Gettable
    -> Gettable -> Get -> DA.Internal.Desugar.Update (Gettable),
    DA.Internal.Desugar.NonConsuming Gettable,
    DA.Internal.Desugar.Optional (Gettable
                                  -> Get -> [DA.Internal.Desugar.Party]))
-_choice_GettableGet
+_choice$_GettableGet
   = (\ this arg@Get {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (anyActor), 

--- a/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityResult.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityResult.EXPECTED.desugared-daml
@@ -79,7 +79,7 @@ instance DA.Internal.Desugar.HasExercise I NonSerializableResult (NonSerializabl
 data NonSerializableResult
   = NonSerializableResult {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
-_choice_IArchive :
+_choice$_IArchive :
   (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I
@@ -87,12 +87,12 @@ _choice_IArchive :
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_IArchive
+_choice$_IArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_INonSerializableResult :
+_choice$_INonSerializableResult :
   (I -> NonSerializableResult -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I
@@ -101,7 +101,7 @@ _choice_INonSerializableResult :
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
                                  -> NonSerializableResult -> [DA.Internal.Desugar.Party]))
-_choice_INonSerializableResult
+_choice$_INonSerializableResult
   = (\ this arg@NonSerializableResult
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p this), 

--- a/compiler/damlc/tests/daml-test-files/InterfaceSynonymNonExistentMethod.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSynonymNonExistentMethod.daml
@@ -1,15 +1,18 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module InterfaceSynonymTypeMismatchErrors where
+module InterfaceSynonymNonExistentMethod where
 
--- @ERROR range=23:7-23:24; Possible Daml-specific reason for the following type error: Implementation of method ‘getValueBad’ on interface ‘I’ should return ‘Int’ but instead returns ‘Text’
+-- @ERROR range=27:7-27:31; Possible Daml-specific reason for the following type error: Tried to implement method ‘getValueNonexistent’, but interface ‘I’ does not have a method with that name. Method ‘getValueNonexistent’ is only a method on the following interfaces: ‘J’
 
 type I = MyLongInterfaceNameI
 interface MyLongInterfaceNameI where
   getValueGood : Int
   getValueBad : Int
   viewtype TView
+
+interface J where
+  getValueNonexistent : ()
 
 data TView = TView {}
 
@@ -20,4 +23,5 @@ template T with p: Party
       view = TView
       -- Check that method return types matching resolves synonyms first
       getValueGood = 1 -- matching case
-      getValueBad = "c" -- mismatching case
+      -- Check that missing method warnings still considers I to be an interface
+      getValueNonexistent = ()

--- a/compiler/damlc/tests/daml-test-files/InterfaceSynonymTypeMismatchErrors.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSynonymTypeMismatchErrors.daml
@@ -1,0 +1,29 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module InterfaceSynonymTypeMismatchErrors where
+
+-- @ERROR range=27:7-27:24; Implementation of method ‘getValueBad’ on interface ‘I’ should return ‘Int’ but instead returns ‘Text’
+-- @ERROR range=29:7-29:31; Tried to implement method ‘getValueNonexistent’, but interface ‘I’ does not have a method with that name. Method ‘getValueNonexistent’ is only a method on the following interfaces: ‘J’
+
+type I = MyLongInterfaceNameI
+interface MyLongInterfaceNameI where
+  getValueGood : Int
+  getValueBad : Int
+  viewtype TView
+
+interface J where
+  getValueNonexistent : ()
+
+data TView = TView {}
+
+template T with p: Party
+  where
+    signatory p
+    interface instance I for T where
+      view = TView
+      -- Check that method return types matching resolves synonyms first
+      getValueGood = 1 -- matching case
+      getValueBad = "c" -- mismatching case
+      -- Check that missing method warnings still considers I to be an interface
+      getValueNonexistent = ()

--- a/compiler/damlc/tests/daml-test-files/InterfaceSyntax.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSyntax.EXPECTED.desugared-daml
@@ -58,7 +58,7 @@ instance DA.Internal.Desugar.HasExercise I DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @I cid)
         arg
-_choice_IArchive :
+_choice$_IArchive :
   (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I
@@ -66,7 +66,7 @@ _choice_IArchive :
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_IArchive
+_choice$_IArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
@@ -122,7 +122,7 @@ instance DA.Internal.Desugar.HasExercise J DA.Internal.Desugar.Archive (()) wher
         @"UExerciseInterface"
         (DA.Internal.Desugar.toInterfaceContractId @J cid)
         arg
-_choice_JArchive :
+_choice$_JArchive :
   (J -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId J
    -> J
@@ -130,7 +130,7 @@ _choice_JArchive :
    DA.Internal.Desugar.Consuming J,
    DA.Internal.Desugar.Optional (J
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_JArchive
+_choice$_JArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
@@ -196,7 +196,7 @@ instance DA.Internal.Desugar.HasToAnyChoice T DA.Internal.Desugar.Archive (()) w
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice T DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_TArchive :
+_choice$_TArchive :
   (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T
@@ -204,16 +204,16 @@ _choice_TArchive :
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TArchive
+_choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_T_I_T :
+_interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
-_interface_instance_T_I_T
+_interface_instance$_T_I_T
   = DA.Internal.Desugar.mkInterfaceInstance @T @I @T
-_method_T_I_T_m0 : DA.Internal.Desugar.Method T I T "m0"
-_method_T_I_T_m0
+_method$_T_I_T_m0 : DA.Internal.Desugar.Method T I T "m0"
+_method$_T_I_T_m0
   = DA.Internal.Desugar.mkMethod
       @T
       @I
@@ -225,8 +225,8 @@ _method_T_I_T_m0
              $m0 False = p0
              $m0 True = p1
            in $m0
-_method_T_I_T_m1 : DA.Internal.Desugar.Method T I T "m1"
-_method_T_I_T_m1
+_method$_T_I_T_m1 : DA.Internal.Desugar.Method T I T "m1"
+_method$_T_I_T_m1
   = DA.Internal.Desugar.mkMethod
       @T
       @I
@@ -241,8 +241,8 @@ _method_T_I_T_m1
              $m1 (Right True) = "true"
              $m1 (Right False) = "false"
            in $m1
-_view_T_I_T : DA.Internal.Desugar.InterfaceView T I T
-_view_T_I_T
+_view$_T_I_T : DA.Internal.Desugar.InterfaceView T I T
+_view$_T_I_T
   = DA.Internal.Desugar.mkInterfaceView
       @T
       @I
@@ -254,12 +254,12 @@ instance DA.Internal.Desugar.HasToInterface T I where
 instance DA.Internal.Desugar.HasFromInterface T I where
   fromInterface = GHC.Types.primitive @"EFromInterface"
   unsafeFromInterface = GHC.Types.primitive @"EUnsafeFromInterface"
-_interface_instance_T_J_T :
+_interface_instance$_T_J_T :
   DA.Internal.Desugar.InterfaceInstance T J T
-_interface_instance_T_J_T
+_interface_instance$_T_J_T
   = DA.Internal.Desugar.mkInterfaceInstance @T @J @T
-_view_T_J_T : DA.Internal.Desugar.InterfaceView T J T
-_view_T_J_T
+_view$_T_J_T : DA.Internal.Desugar.InterfaceView T J T
+_view$_T_J_T
   = DA.Internal.Desugar.mkInterfaceView
       @T
       @J

--- a/compiler/damlc/tests/daml-test-files/InterfaceTryImplementNonExistentMethod.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceTryImplementNonExistentMethod.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ERROR range=17:5-17:26; Tried to implement method ‘nonExistentMethod’, but interface ‘I’ does not have a method with that name.
+-- @ERROR range=17:5-17:26; Possible Daml-specific reason for the following type error: Tried to implement method ‘nonExistentMethod’, but interface ‘I’ does not have a method with that name.
 module InterfaceTryImplementNonExistentMethod where
 
 data View = View {}

--- a/compiler/damlc/tests/daml-test-files/InterfaceTryViewTemplate.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceTryViewTemplate.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ERROR range=18:15-18:34; Tried to get an interface view of type ‘View’ from template ‘T’
+-- @ERROR range=18:15-18:34; Possible Daml-specific reason for the following type error: Tried to get an interface view of type ‘View’ from template ‘T’
 module InterfaceTryViewTemplate where
 
 data View = View {}

--- a/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.EXPECTED.desugared-daml
@@ -77,7 +77,7 @@ instance DA.Internal.Desugar.HasExercise A ChoiceA (Int) where
 data ChoiceA
   = ChoiceA {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
-_choice_AArchive :
+_choice$_AArchive :
   (A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId A
    -> A
@@ -85,19 +85,19 @@ _choice_AArchive :
    DA.Internal.Desugar.Consuming A,
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_AArchive
+_choice$_AArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_AChoiceA :
+_choice$_AChoiceA :
   (A -> ChoiceA -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId A
    -> A -> ChoiceA -> DA.Internal.Desugar.Update (Int),
    DA.Internal.Desugar.NonConsuming A,
    DA.Internal.Desugar.Optional (A
                                  -> ChoiceA -> [DA.Internal.Desugar.Party]))
-_choice_AChoiceA
+_choice$_AChoiceA
   = (\ this arg@ChoiceA
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
@@ -119,8 +119,8 @@ instance DA.Internal.Desugar.HasToInterface B B where
 instance DA.Internal.Desugar.HasFromInterface B B where
   fromInterface this = DA.Internal.Desugar.Some this
   unsafeFromInterface _ this = this
-_requires_B_A : DA.Internal.Desugar.RequiresT B A
-_requires_B_A = DA.Internal.Desugar.RequiresT
+_requires$_B_A : DA.Internal.Desugar.RequiresT B A
+_requires$_B_A = DA.Internal.Desugar.RequiresT
 instance DA.Internal.Desugar.HasToInterface B A where
   _toInterface = GHC.Types.primitive @"EToRequiredInterface"
 instance DA.Internal.Desugar.HasFromInterface B A where
@@ -186,7 +186,7 @@ instance DA.Internal.Desugar.HasExercise B ChoiceB (Int) where
 data ChoiceB
   = ChoiceB {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
-_choice_BArchive :
+_choice$_BArchive :
   (B -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId B
    -> B
@@ -194,19 +194,19 @@ _choice_BArchive :
    DA.Internal.Desugar.Consuming B,
    DA.Internal.Desugar.Optional (B
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_BArchive
+_choice$_BArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_BChoiceB :
+_choice$_BChoiceB :
   (B -> ChoiceB -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId B
    -> B -> ChoiceB -> DA.Internal.Desugar.Update (Int),
    DA.Internal.Desugar.NonConsuming B,
    DA.Internal.Desugar.Optional (B
                                  -> ChoiceB -> [DA.Internal.Desugar.Party]))
-_choice_BChoiceB
+_choice$_BChoiceB
   = (\ this arg@ChoiceB
        -> let _ = this in
           let _ = arg
@@ -268,7 +268,7 @@ instance DA.Internal.Desugar.HasToAnyChoice T1 DA.Internal.Desugar.Archive (()) 
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice T1 DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_T1Archive :
+_choice$_T1Archive :
   (T1 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T1
    -> T1
@@ -276,25 +276,25 @@ _choice_T1Archive :
    DA.Internal.Desugar.Consuming T1,
    DA.Internal.Desugar.Optional (T1
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_T1Archive
+_choice$_T1Archive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_T1_A_T1 :
+_interface_instance$_T1_A_T1 :
   DA.Internal.Desugar.InterfaceInstance T1 A T1
-_interface_instance_T1_A_T1
+_interface_instance$_T1_A_T1
   = DA.Internal.Desugar.mkInterfaceInstance @T1 @A @T1
-_method_T1_A_T1_getOwner :
+_method$_T1_A_T1_getOwner :
   DA.Internal.Desugar.Method T1 A T1 "getOwner"
-_method_T1_A_T1_getOwner
+_method$_T1_A_T1_getOwner
   = DA.Internal.Desugar.mkMethod
       @T1
       @A
       @T1
       @"getOwner"
       \ this@T1 {..} -> let _ = this in let $getOwner = p1 in $getOwner
-_view_T1_A_T1 : DA.Internal.Desugar.InterfaceView T1 A T1
-_view_T1_A_T1
+_view$_T1_A_T1 : DA.Internal.Desugar.InterfaceView T1 A T1
+_view$_T1_A_T1
   = DA.Internal.Desugar.mkInterfaceView
       @T1
       @A
@@ -306,13 +306,13 @@ instance DA.Internal.Desugar.HasToInterface T1 A where
 instance DA.Internal.Desugar.HasFromInterface T1 A where
   fromInterface = GHC.Types.primitive @"EFromInterface"
   unsafeFromInterface = GHC.Types.primitive @"EUnsafeFromInterface"
-_interface_instance_T1_B_T1 :
+_interface_instance$_T1_B_T1 :
   DA.Internal.Desugar.InterfaceInstance T1 B T1
-_interface_instance_T1_B_T1
+_interface_instance$_T1_B_T1
   = DA.Internal.Desugar.mkInterfaceInstance @T1 @B @T1
-_method_T1_B_T1_getCoolness :
+_method$_T1_B_T1_getCoolness :
   DA.Internal.Desugar.Method T1 B T1 "getCoolness"
-_method_T1_B_T1_getCoolness
+_method$_T1_B_T1_getCoolness
   = DA.Internal.Desugar.mkMethod
       @T1
       @B
@@ -320,8 +320,8 @@ _method_T1_B_T1_getCoolness
       @"getCoolness"
       \ this@T1 {..}
         -> let _ = this in let $getCoolness = 20 in $getCoolness
-_view_T1_B_T1 : DA.Internal.Desugar.InterfaceView T1 B T1
-_view_T1_B_T1
+_view$_T1_B_T1 : DA.Internal.Desugar.InterfaceView T1 B T1
+_view$_T1_B_T1
   = DA.Internal.Desugar.mkInterfaceView
       @T1
       @B
@@ -382,7 +382,7 @@ instance DA.Internal.Desugar.HasToAnyChoice T2 DA.Internal.Desugar.Archive (()) 
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice T2 DA.Internal.Desugar.Archive (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_T2Archive :
+_choice$_T2Archive :
   (T2 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T2
    -> T2
@@ -390,25 +390,25 @@ _choice_T2Archive :
    DA.Internal.Desugar.Consuming T2,
    DA.Internal.Desugar.Optional (T2
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_T2Archive
+_choice$_T2Archive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_interface_instance_T2_A_T2 :
+_interface_instance$_T2_A_T2 :
   DA.Internal.Desugar.InterfaceInstance T2 A T2
-_interface_instance_T2_A_T2
+_interface_instance$_T2_A_T2
   = DA.Internal.Desugar.mkInterfaceInstance @T2 @A @T2
-_method_T2_A_T2_getOwner :
+_method$_T2_A_T2_getOwner :
   DA.Internal.Desugar.Method T2 A T2 "getOwner"
-_method_T2_A_T2_getOwner
+_method$_T2_A_T2_getOwner
   = DA.Internal.Desugar.mkMethod
       @T2
       @A
       @T2
       @"getOwner"
       \ this@T2 {..} -> let _ = this in let $getOwner = p2 in $getOwner
-_view_T2_A_T2 : DA.Internal.Desugar.InterfaceView T2 A T2
-_view_T2_A_T2
+_view$_T2_A_T2 : DA.Internal.Desugar.InterfaceView T2 A T2
+_view$_T2_A_T2
   = DA.Internal.Desugar.mkInterfaceView
       @T2
       @A

--- a/compiler/damlc/tests/daml-test-files/InterfaceViewtypeNotMatching.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceViewtypeNotMatching.daml
@@ -5,7 +5,7 @@
 -- generates a sensible error
 
 -- @SINCE-LF-FEATURE DAML_INTERFACE
--- @ERROR range=23:7-23:22;  Tried to implement a view of type ‘NotIView’ on interface ‘I’, but the definition of interface ‘I’ requires a view of type ‘IView’
+-- @ERROR range=23:7-23:22;  Possible Daml-specific reason for the following type error: Tried to implement a view of type ‘NotIView’ on interface ‘I’, but the definition of interface ‘I’ requires a view of type ‘IView’
 
 module InterfaceViewtypeNotMatching where
 

--- a/compiler/damlc/tests/daml-test-files/MethodResultMismatchError.daml
+++ b/compiler/damlc/tests/daml-test-files/MethodResultMismatchError.daml
@@ -1,0 +1,23 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module MethodResultMismatchError where
+
+-- @ERROR range=23:7-23:24; Implementation of method ‘getValueBad’ on interface ‘I’ should return ‘Int’ but instead returns ‘Text’
+
+interface I where
+  getController : Party
+  getValueGood : Int
+  getValueBad : Int
+  viewtype TView
+
+data TView = TView {}
+
+template T with p: Party
+  where
+    signatory p
+    interface instance I for T where
+      view = TView
+      getController = p
+      getValueGood = 1
+      getValueBad = "c"

--- a/compiler/damlc/tests/daml-test-files/MethodResultMismatchError.daml
+++ b/compiler/damlc/tests/daml-test-files/MethodResultMismatchError.daml
@@ -3,7 +3,7 @@
 
 module MethodResultMismatchError where
 
--- @ERROR range=23:7-23:24; Implementation of method ‘getValueBad’ on interface ‘I’ should return ‘Int’ but instead returns ‘Text’
+-- @ERROR range=23:7-23:24; Possible Daml-specific reason for the following type error: Implementation of method ‘getValueBad’ on interface ‘I’ should return ‘Int’ but instead returns ‘Text’
 
 interface I where
   getController : Party

--- a/compiler/damlc/tests/daml-test-files/NumericLitMonoScaleOOB.daml
+++ b/compiler/damlc/tests/daml-test-files/NumericLitMonoScaleOOB.daml
@@ -5,7 +5,7 @@
 -- `NumericScale` constraint.
 --
 -- @SINCE-LF 1.7
--- @ERROR range=16:12-16:19; Tried to define a Numeric with a scale of 38, but only scales between 0 and 37 are supported.
+-- @ERROR range=16:12-16:19; Possible Daml-specific reason for the following type error: Tried to define a Numeric with a scale of 38, but only scales between 0 and 37 are supported.
 
 
 

--- a/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.desugared-daml
@@ -183,7 +183,7 @@ instance DA.Internal.Record.HasField "byHowMuch" GetRich Int where
     = DA.Internal.Record.getFieldPrim @"byHowMuch" @GetRich @Int
   setField
     = DA.Internal.Record.setFieldPrim @"byHowMuch" @GetRich @Int
-_choice_TokenArchive :
+_choice$_TokenArchive :
   (Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
@@ -192,12 +192,12 @@ _choice_TokenArchive :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TokenArchive
+_choice$_TokenArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_TokenSplit :
+_choice$_TokenSplit :
   (Token -> Split -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
@@ -207,7 +207,7 @@ _choice_TokenSplit :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> Split -> [DA.Internal.Desugar.Party]))
-_choice_TokenSplit
+_choice$_TokenSplit
   = (\ this arg@Split {..}
        -> let _ = this in
           let _ = arg
@@ -218,7 +218,7 @@ _choice_TokenSplit
        -> let _ = self in
           let _ = this in let _ = arg in do splitImpl this splitAmount, 
      DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
-_choice_TokenTransfer :
+_choice$_TokenTransfer :
   (Token -> Transfer -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
@@ -226,7 +226,7 @@ _choice_TokenTransfer :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> Transfer -> [DA.Internal.Desugar.Party]))
-_choice_TokenTransfer
+_choice$_TokenTransfer
   = (\ this arg@Transfer {..}
        -> let _ = this in
           let _ = arg
@@ -239,14 +239,14 @@ _choice_TokenTransfer
        -> let _ = self in
           let _ = this in let _ = arg in do transferImpl this newOwner, 
      DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
-_choice_TokenNoop :
+_choice$_TokenNoop :
   (Token -> Noop -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token -> Noop -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> Noop -> [DA.Internal.Desugar.Party]))
-_choice_TokenNoop
+_choice$_TokenNoop
   = (\ this arg@Noop {..}
        -> let _ = this in
           let _ = arg
@@ -257,7 +257,7 @@ _choice_TokenNoop
        -> let _ = self in
           let _ = this in let _ = arg in do noopImpl this nothing, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
-_choice_TokenGetRich :
+_choice$_TokenGetRich :
   (Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
@@ -265,7 +265,7 @@ _choice_TokenGetRich :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]))
-_choice_TokenGetRich
+_choice$_TokenGetRich
   = (\ this arg@GetRich {..}
        -> let _ = this in
           let _ = arg
@@ -287,14 +287,14 @@ instance DA.Internal.Desugar.HasInterfaceView Token TokenView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token TokenView where
   _fromAnyView = GHC.Types.primitive @"EFromAnyView"
-_interface_instance_Token_Token_Asset:Asset :
+_interface_instance$_Token_Token_Asset:Asset :
   DA.Internal.Desugar.InterfaceInstance Token Token Asset.Asset
-_interface_instance_Token_Token_Asset:Asset
+_interface_instance$_Token_Token_Asset:Asset
   = DA.Internal.Desugar.mkInterfaceInstance
       @Token @Token @Asset.Asset
-_method_Token_Token_Asset:Asset_setAmount :
+_method$_Token_Token_Asset:Asset_setAmount :
   DA.Internal.Desugar.Method Token Token Asset.Asset "setAmount"
-_method_Token_Token_Asset:Asset_setAmount
+_method$_Token_Token_Asset:Asset_setAmount
   = DA.Internal.Desugar.mkMethod
       @Token
       @Token
@@ -304,9 +304,9 @@ _method_Token_Token_Asset:Asset_setAmount
         -> let _ = this in
            let $setAmount x = toInterface @Token (this {amount = x})
            in $setAmount
-_method_Token_Token_Asset:Asset_splitImpl :
+_method$_Token_Token_Asset:Asset_splitImpl :
   DA.Internal.Desugar.Method Token Token Asset.Asset "splitImpl"
-_method_Token_Token_Asset:Asset_splitImpl
+_method$_Token_Token_Asset:Asset_splitImpl
   = DA.Internal.Desugar.mkMethod
       @Token
       @Token
@@ -324,9 +324,9 @@ _method_Token_Token_Asset:Asset_splitImpl
                         (toInterfaceContractId @Token cid1, 
                          toInterfaceContractId @Token cid2)
            in $splitImpl
-_method_Token_Token_Asset:Asset_transferImpl :
+_method$_Token_Token_Asset:Asset_transferImpl :
   DA.Internal.Desugar.Method Token Token Asset.Asset "transferImpl"
-_method_Token_Token_Asset:Asset_transferImpl
+_method$_Token_Token_Asset:Asset_transferImpl
   = DA.Internal.Desugar.mkMethod
       @Token
       @Token
@@ -339,9 +339,9 @@ _method_Token_Token_Asset:Asset_transferImpl
                = do cid <- create this {owner = newOwner}
                     pure (toInterfaceContractId @Token cid)
            in $transferImpl
-_method_Token_Token_Asset:Asset_noopImpl :
+_method$_Token_Token_Asset:Asset_noopImpl :
   DA.Internal.Desugar.Method Token Token Asset.Asset "noopImpl"
-_method_Token_Token_Asset:Asset_noopImpl
+_method$_Token_Token_Asset:Asset_noopImpl
   = DA.Internal.Desugar.mkMethod
       @Token
       @Token
@@ -354,9 +354,9 @@ _method_Token_Token_Asset:Asset_noopImpl
                = do [1] === [1]
                     pure ()
            in $noopImpl
-_view_Token_Token_Asset:Asset :
+_view$_Token_Token_Asset:Asset :
   DA.Internal.Desugar.InterfaceView Token Token Asset.Asset
-_view_Token_Token_Asset:Asset
+_view$_Token_Token_Asset:Asset
   = DA.Internal.Desugar.mkInterfaceView
       @Token
       @Token

--- a/compiler/damlc/tests/daml-test-files/RecordMistypedFieldError.daml
+++ b/compiler/damlc/tests/daml-test-files/RecordMistypedFieldError.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=14:18-14:26; Tried to get field ‘b’ with type ‘Text’ on value of type ‘Record’, but that field has type ‘Int’
+-- @ERROR range=14:18-14:26; Possible Daml-specific reason for the following type error: Tried to get field ‘b’ with type ‘Text’ on value of type ‘Record’, but that field has type ‘Int’
 
 module RecordMistypedFieldError where
 

--- a/compiler/damlc/tests/daml-test-files/RecordNonexistentFieldError.daml
+++ b/compiler/damlc/tests/daml-test-files/RecordNonexistentFieldError.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=14:17-14:25; Tried to access nonexistent field ‘c’ with type ‘Int’ on value of type ‘Record’
+-- @ERROR range=14:17-14:25; Possible Daml-specific reason for the following type error: Tried to access nonexistent field ‘c’ with type ‘Int’ on value of type ‘Record’
 
 module RecordNonexistentFieldError where
 

--- a/compiler/damlc/tests/daml-test-files/RelTimeDetailsHidden1.daml
+++ b/compiler/damlc/tests/daml-test-files/RelTimeDetailsHidden1.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR range=11:10-11:25; Tried to access nonexistent field ‘microseconds’ with type ‘Int’ on value of type ‘RelTime’
+-- @ ERROR range=11:10-11:25; Possible Daml-specific reason for the following type error: Tried to access nonexistent field ‘microseconds’ with type ‘Int’ on value of type ‘RelTime’
 
 module RelTimeDetailsHidden1 where
 

--- a/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.desugared-daml
@@ -183,7 +183,7 @@ instance DA.Internal.Record.HasField "byHowMuch" GetRich Int where
     = DA.Internal.Record.getFieldPrim @"byHowMuch" @GetRich @Int
   setField
     = DA.Internal.Record.setFieldPrim @"byHowMuch" @GetRich @Int
-_choice_TokenArchive :
+_choice$_TokenArchive :
   (Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
@@ -192,12 +192,12 @@ _choice_TokenArchive :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TokenArchive
+_choice$_TokenArchive
   = (\ this arg@DA.Internal.Desugar.Archive
        -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_TokenSplit :
+_choice$_TokenSplit :
   (Token -> Split -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
@@ -207,7 +207,7 @@ _choice_TokenSplit :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> Split -> [DA.Internal.Desugar.Party]))
-_choice_TokenSplit
+_choice$_TokenSplit
   = (\ this arg@Split {..}
        -> let _ = this in
           let _ = arg
@@ -218,7 +218,7 @@ _choice_TokenSplit
        -> let _ = self in
           let _ = this in let _ = arg in do splitImpl this splitAmount, 
      DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
-_choice_TokenTransfer :
+_choice$_TokenTransfer :
   (Token -> Transfer -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
@@ -226,7 +226,7 @@ _choice_TokenTransfer :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> Transfer -> [DA.Internal.Desugar.Party]))
-_choice_TokenTransfer
+_choice$_TokenTransfer
   = (\ this arg@Transfer {..}
        -> let _ = this in
           let _ = arg
@@ -239,14 +239,14 @@ _choice_TokenTransfer
        -> let _ = self in
           let _ = this in let _ = arg in do transferImpl this newOwner, 
      DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
-_choice_TokenNoop :
+_choice$_TokenNoop :
   (Token -> Noop -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token -> Noop -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> Noop -> [DA.Internal.Desugar.Party]))
-_choice_TokenNoop
+_choice$_TokenNoop
   = (\ this arg@Noop {..}
        -> let _ = this in
           let _ = arg
@@ -257,7 +257,7 @@ _choice_TokenNoop
        -> let _ = self in
           let _ = this in let _ = arg in do noopImpl this nothing, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
-_choice_TokenGetRich :
+_choice$_TokenGetRich :
   (Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
@@ -265,7 +265,7 @@ _choice_TokenGetRich :
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]))
-_choice_TokenGetRich
+_choice$_TokenGetRich
   = (\ this arg@GetRich {..}
        -> let _ = this in
           let _ = arg
@@ -287,13 +287,13 @@ instance DA.Internal.Desugar.HasInterfaceView Token TokenView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token TokenView where
   _fromAnyView = GHC.Types.primitive @"EFromAnyView"
-_interface_instance_Token_Token_Asset :
+_interface_instance$_Token_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Token Token Asset
-_interface_instance_Token_Token_Asset
+_interface_instance$_Token_Token_Asset
   = DA.Internal.Desugar.mkInterfaceInstance @Token @Token @Asset
-_method_Token_Token_Asset_setAmount :
+_method$_Token_Token_Asset_setAmount :
   DA.Internal.Desugar.Method Token Token Asset "setAmount"
-_method_Token_Token_Asset_setAmount
+_method$_Token_Token_Asset_setAmount
   = DA.Internal.Desugar.mkMethod
       @Token
       @Token
@@ -303,9 +303,9 @@ _method_Token_Token_Asset_setAmount
         -> let _ = this in
            let $setAmount x = toInterface @Token (this {amount = x})
            in $setAmount
-_method_Token_Token_Asset_splitImpl :
+_method$_Token_Token_Asset_splitImpl :
   DA.Internal.Desugar.Method Token Token Asset "splitImpl"
-_method_Token_Token_Asset_splitImpl
+_method$_Token_Token_Asset_splitImpl
   = DA.Internal.Desugar.mkMethod
       @Token
       @Token
@@ -323,9 +323,9 @@ _method_Token_Token_Asset_splitImpl
                         (toInterfaceContractId @Token cid1, 
                          toInterfaceContractId @Token cid2)
            in $splitImpl
-_method_Token_Token_Asset_transferImpl :
+_method$_Token_Token_Asset_transferImpl :
   DA.Internal.Desugar.Method Token Token Asset "transferImpl"
-_method_Token_Token_Asset_transferImpl
+_method$_Token_Token_Asset_transferImpl
   = DA.Internal.Desugar.mkMethod
       @Token
       @Token
@@ -338,9 +338,9 @@ _method_Token_Token_Asset_transferImpl
                = do cid <- create this {owner = newOwner}
                     pure (toInterfaceContractId @Token cid)
            in $transferImpl
-_method_Token_Token_Asset_noopImpl :
+_method$_Token_Token_Asset_noopImpl :
   DA.Internal.Desugar.Method Token Token Asset "noopImpl"
-_method_Token_Token_Asset_noopImpl
+_method$_Token_Token_Asset_noopImpl
   = DA.Internal.Desugar.mkMethod
       @Token
       @Token
@@ -353,9 +353,9 @@ _method_Token_Token_Asset_noopImpl
                = do [1] === [1]
                     pure ()
            in $noopImpl
-_view_Token_Token_Asset :
+_view$_Token_Token_Asset :
   DA.Internal.Desugar.InterfaceView Token Token Asset
-_view_Token_Token_Asset
+_view$_Token_Token_Asset
   = DA.Internal.Desugar.mkInterfaceView
       @Token
       @Token

--- a/compiler/damlc/tests/daml-test-files/TemplateChoiceResultMismatch.daml
+++ b/compiler/damlc/tests/daml-test-files/TemplateChoiceResultMismatch.daml
@@ -1,0 +1,26 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module TemplateChoiceResultMismatch where
+
+-- @ERROR range=26:12-26:27; Tried to get a result of type ‘Either Text ()’ by exercising choice ‘C’ on template ‘T’ but exercising choice ‘C’ should return type ‘()’ instead.
+
+template T
+  with
+    p : Party
+  where
+    signatory p
+
+    choice C : ()
+      controller p
+      do pure ()
+
+exerciseE : Choice t c (Either Text r) => ContractId t -> c -> Update r
+exerciseE cid c = do
+  r <- exercise cid c
+  case r of
+    Left err -> abort err
+    Right r -> pure r
+
+test : ContractId T -> Update ()
+test cid = exerciseE cid C

--- a/compiler/damlc/tests/daml-test-files/TemplateChoiceResultMismatch.daml
+++ b/compiler/damlc/tests/daml-test-files/TemplateChoiceResultMismatch.daml
@@ -3,7 +3,7 @@
 
 module TemplateChoiceResultMismatch where
 
--- @ERROR range=26:12-26:27; Tried to get a result of type ‘Either Text ()’ by exercising choice ‘C’ on template ‘T’ but exercising choice ‘C’ should return type ‘()’ instead.
+-- @ERROR range=26:12-26:27; Possible Daml-specific reason for the following type error: Tried to get a result of type ‘Either Text ()’ by exercising choice ‘C’ on template ‘T’ but exercising choice ‘C’ should return type ‘()’ instead.
 
 template T
   with

--- a/compiler/damlc/tests/daml-test-files/UnusedMatchTests.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/UnusedMatchTests.EXPECTED.desugared-daml
@@ -105,7 +105,7 @@ instance DA.Internal.Desugar.HasToAnyChoice T Revoke (()) where
   _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
 instance DA.Internal.Desugar.HasFromAnyChoice T Revoke (()) where
   _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
-_choice_TArchive :
+_choice$_TArchive :
   (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T
@@ -113,18 +113,18 @@ _choice_TArchive :
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice_TArchive
+_choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
-_choice_TRevoke :
+_choice$_TRevoke :
   (T -> Revoke -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> Revoke -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
                                  -> Revoke -> [DA.Internal.Desugar.Party]))
-_choice_TRevoke
+_choice$_TRevoke
   = (\ this@T {..} arg@Revoke
        -> let
             (revokeRetVal, sig, obs, assertion, plainEnglish, ident)

--- a/ghc-lib/template-desugaring.md
+++ b/ghc-lib/template-desugaring.md
@@ -120,12 +120,12 @@ separate top-level identifier. Specifically, this is a tuple containing the cont
 the choice body and information on whether the choice is pre-, post- or nonconsuming:
 
 ```
-_choice_IouTransfer :
+_choice$_IouTransfer :
   (Iou -> Transfer -> [Party],
    ContractId Iou
    -> Iou -> Transfer -> Update (ContractId Iou),
    PreConsuming Iou)
-_choice_IouTransfer
+_choice$_IouTransfer
   = (\ this@Iou {..} arg@Transfer {..}
        -> let
           in


### PR DESCRIPTION
Backports the following PRs to 2.5.x:

* #15712
* #15731
* #15855
* #15999
* #16017 