### PR TITLE
[engine] add new tx node type: Node.Authority

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -556,6 +556,7 @@ final class Conversions(
       .map(eventId => builder.setConsumedBy(convertEventId(eventId)))
 
     nodeInfo.node match {
+      case _: Node.Authority => ??? // TODO #15882 -- we need to extend IDE-communication proto
       case rollback: Node.Rollback =>
         val rollbackBuilder = proto.Node.Rollback.newBuilder
           .addAllChildren(
@@ -650,6 +651,7 @@ final class Conversions(
       .setNodeId(proto.NodeId.newBuilder.setId(nodeId.index.toString).build)
     // FIXME(JM): consumedBy, parent, ...
     node match {
+      case _: Node.Authority => ??? // TODO #15882 -- we need to extend IDE-communication proto
       case rollback: Node.Rollback =>
         val rollbackBuilder =
           proto.Node.Rollback.newBuilder

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -63,6 +63,8 @@ object Blinding {
             go(filteredRoots :+ root, remainingRoots)
           } else {
             tx.nodes(root) match {
+              case na: Node.Authority =>
+                go(filteredRoots, na.children ++: remainingRoots)
               case nr: Node.Rollback =>
                 go(filteredRoots, nr.children ++: remainingRoots)
               case _: Node.Fetch | _: Node.Create | _: Node.LookupByKey =>
@@ -87,6 +89,7 @@ object Blinding {
     val entries = blindingInfo.disclosure.view.flatMap { case (nodeId, parties) =>
       def toEntries(tyCon: Ref.TypeConName) = parties.view.map(_ -> tyCon.packageId)
       tx.nodes(nodeId) match {
+        case _: Node.Authority => ??? // TODO #15882 -- we are not sure. leave for now
         case action: Node.LeafOnlyAction =>
           toEntries(action.templateId)
         case exe: Node.Exercise =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -549,6 +549,7 @@ object Engine {
       val makeDesc = (kind: String, tmpl: Ref.Identifier, extra: Option[String]) =>
         s"$kind:${tmpl.qualifiedName.name}${extra.map(extra => s":$extra").getOrElse("")}"
       tx.nodes.get(tx.roots(0)).toList.head match {
+        case _: Node.Authority => "authority"
         case _: Node.Rollback => "rollback"
         case create: Node.Create => makeDesc("create", create.templateId, None)
         case exercise: Node.Exercise =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
@@ -155,6 +155,8 @@ final class ValueEnricher(
 
   def enrichNode(node: Node): Result[Node] =
     node match {
+      case na: Node.Authority =>
+        ResultDone(na)
       case rb @ Node.Rollback(_) =>
         ResultDone(rb)
       case create: Node.Create =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
@@ -95,6 +95,8 @@ private[preprocessing] final class TransactionPreprocessor(
             case _: Node.LookupByKey =>
               invalidRootNode(id, s"Transaction contains a lookup by key root node $id")
           }
+        case Some(_: Node.Authority) =>
+          invalidRootNode(id, s"invalid transaction, root refers to a authority node $id")
         case Some(_: Node.Rollback) =>
           invalidRootNode(id, s"invalid transaction, root refers to a rollback node $id")
         case None =>

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -2674,6 +2674,8 @@ object EngineTest {
                   exe.choiceId,
                   exe.chosenValue,
                 )
+              case _: Node.Authority =>
+                sys.error("unexpected authority node")
               case _: Node.Rollback =>
                 sys.error("unexpected rollback node")
             }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
@@ -97,6 +97,9 @@ object BlindingTransaction {
                 )
               }
           }
+
+        case Some(_: Node.Authority) => ??? // TODO #15882 -- we unsure what to do here
+
         case Some(rollback: Node.Rollback) =>
           // Rollback nodes are disclosed to the witnesses of the parent exercise.
           val state = state0.discloseNode(parentExerciseWitnesses, nodeId)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -633,7 +633,8 @@ final case class ScenarioLedger(
                 create.stakeholders,
               )
 
-          case _: Node.Exercise | _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback =>
+          case _: Node.Exercise | _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback |
+              _: Node.Authority =>
             LookupContractNotFound(coid)
         }
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -187,6 +187,8 @@ private[lf] object Pretty {
   // A minimal pretty-print of an update transaction node, without recursing into child nodes..
   def prettyPartialTransactionNode(node: Node): Doc =
     node match {
+      case _: Node.Authority =>
+        text("authority")
       case Node.Rollback(_) =>
         text("rollback")
       case create: Node.Create =>
@@ -281,6 +283,8 @@ private[lf] object Pretty {
     val eventId = EventId(txId.id, nodeId)
     val ni = l.ledgerData.nodeInfos(eventId)
     val ppNode = ni.node match {
+      case na: Node.Authority =>
+        text("authority:") / stack(na.children.toList.map(prettyEventInfo(l, txId)))
       case Node.Rollback(children) =>
         text("rollback:") / stack(children.toList.map(prettyEventInfo(l, txId)))
       case create: Node.Create =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
@@ -63,6 +63,11 @@ private[lf] object NormalizeRollbacks {
                   k(Vector(Norm.Exe(exe, norms.toList)))
                 }
 
+              case aut: Node.Authority =>
+                traverseNodeIds(aut.children.toList) { norms =>
+                  k(Vector(Norm.Aut(aut, norms.toList)))
+                }
+
               case leaf: Node.LeafOnlyAction =>
                 k(Vector(Norm.Leaf(leaf)))
             }
@@ -180,6 +185,13 @@ private[lf] object NormalizeRollbacks {
                 s.push(me, node)(k)
               }
             }
+          case Norm.Aut(aut, subs) =>
+            s.pushSeedId(me) { s =>
+              pushNorms(s, subs) { (s, children) =>
+                val node = aut.copy(children = children.to(ImmArray))
+                s.push(me, node)(k)
+              }
+            }
         }
       }
     }
@@ -247,6 +259,7 @@ private[lf] object NormalizeRollbacks {
       sealed abstract class Act extends Norm
       final case class Leaf(node: Node.LeafOnlyAction) extends Act
       final case class Exe(node: Node.Exercise, children: List[Norm]) extends Act
+      final case class Aut(node: Node.Authority, children: List[Norm]) extends Act
 
       // A *normalized* rollback tx/node. 2 cases:
       // - rollback containing a single non-rollback tx/node.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -259,6 +259,7 @@ private[speedy] case class PartialTransaction(
       // so we need to compute them.
       val rootNodes = {
         val allChildNodeIds: Set[NodeId] = nodes.values.iterator.flatMap {
+          case au: Node.Authority => au.children.toSeq
           case rb: Node.Rollback => rb.children.toSeq
           case _: Node.LeafOnlyAction => Nil
           case ex: Node.Exercise => ex.children.toSeq

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/NormalizeRollbacksSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/NormalizeRollbacksSpec.scala
@@ -200,6 +200,7 @@ object NormalizeRollbackSpec {
         case _: Node.LeafOnlyAction => acc
         case node: Node.Exercise => fromNids(acc, node.children.toList)
         case node: Node.Rollback => fromNids(acc, node.children.toList)
+        case node: Node.Authority => fromNids(acc, node.children.toList)
       }
     }
     fromNids(Nil, tx.roots.toList).reverse
@@ -247,6 +248,7 @@ object NormalizeRollbackSpec {
     final case class Create(x: Long) extends Shape
     final case class Exercise(x: List[Shape]) extends Shape
     final case class Rollback(x: List[Shape]) extends Shape
+    final case class Authority(x: List[Shape]) extends Shape
 
     def toTransaction(top: Top): TX = {
       val ids = Iterator.from(0).map(NodeId(_))
@@ -265,6 +267,9 @@ object NormalizeRollbackSpec {
           case Rollback(shapes) =>
             val children = shapes.map(toNid)
             add(Node.Rollback(children = children.to(ImmArray)))
+          case Authority(shapes) =>
+            val children = shapes.map(toNid)
+            add(dummyAuthorityNode(children.to(ImmArray)))
         }
       }
       val roots: List[NodeId] = top.xs.map(toNid)
@@ -283,6 +288,7 @@ object NormalizeRollbackSpec {
             sys.error(s"Shape.ofTransaction, unexpected leaf: $leaf")
           case node: Node.Exercise => Exercise(node.children.toList.map(ofNid))
           case node: Node.Rollback => Rollback(node.children.toList.map(ofNid))
+          case node: Node.Authority => Authority(node.children.toList.map(ofNid))
         }
       }
       Top(tx.roots.toList.map(nid => ofNid(nid)))
@@ -303,6 +309,15 @@ object NormalizeRollbackSpec {
       key = None,
       version = TransactionVersion.minVersion,
     )
+
+  private def dummyAuthorityNode(
+      children: ImmArray[NodeId]
+  ): Node.Authority = {
+    Node.Authority(
+      obtained = Set.empty,
+      children = children,
+    )
+  }
 
   private def dummyExerciseNode(
       children: ImmArray[NodeId]

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
@@ -206,6 +206,7 @@ object RollbackTest {
   final case class C(x: Long) extends Tree // Create Node
   final case class X(x: List[Tree]) extends Tree // Exercise Node
   final case class R(x: List[Tree]) extends Tree // Rollback Node
+  final case class A(x: List[Tree]) extends Tree // Authority Node
 
   private def shapeOfTransaction(tx: SubmittedTransaction): List[Tree] = {
     def trees(nid: NodeId): List[Tree] = {
@@ -223,6 +224,8 @@ object RollbackTest {
           List(X(node.children.toList.flatMap(nid => trees(nid))))
         case node: Node.Rollback =>
           List(R(node.children.toList.flatMap(nid => trees(nid))))
+        case node: Node.Authority =>
+          List(A(node.children.toList.flatMap(nid => trees(nid))))
       }
     }
     tx.roots.toList.flatMap(nid => trees(nid))

--- a/daml-lf/snapshot/src/main/scala/com/daml/Adapter.scala
+++ b/daml-lf/snapshot/src/main/scala/com/daml/Adapter.scala
@@ -27,6 +27,8 @@ final class Adapter(
   // drop value version and children
   private[this] def adapt(node: Node): Node =
     node match {
+      case authority: Node.Authority =>
+        authority.copy(children = ImmArray.Empty)
       case rollback: Node.Rollback =>
         rollback.copy(children = ImmArray.Empty)
       case create: Node.Create =>

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -17,6 +17,7 @@ sealed abstract class Node extends Product with Serializable with CidContainer[N
   def optVersion: Option[TransactionVersion] = this match {
     case node: Node.Action => Some(node.version)
     case _: Node.Rollback => None
+    case _: Node.Authority => None
   }
 
   def mapNodeId(f: NodeId => NodeId): Node
@@ -234,6 +235,18 @@ object Node {
     override def mapCid(f: ContractId => ContractId): Node.Rollback = this
     override def mapNodeId(f: NodeId => NodeId): Node.Rollback =
       copy(children.map(f))
+
+    override protected def self: Node = this
+  }
+
+  final case class Authority(
+      obtained: Set[Party],
+      children: ImmArray[NodeId],
+  ) extends Node {
+
+    override def mapCid(f: ContractId => ContractId): Node.Authority = this
+    override def mapNodeId(f: NodeId => NodeId): Node.Authority =
+      copy(children = children.map(f))
 
     override protected def self: Node = this
   }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Normalization.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Normalization.scala
@@ -50,6 +50,8 @@ class Normalization {
     import scala.Ordering.Implicits.infixOrderingOps
     node match {
 
+      case old: Node.Authority => old
+
       case old: Node.Create =>
         old
           .copy(arg = normValue(old.version)(old.arg))

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -252,6 +252,7 @@ object TransactionCoder {
       TransactionOuterClass.Node.newBuilder().setNodeId(encodeNid.asString(nodeId))
 
     node match {
+      case _: Node.Authority => ??? // TODO #15882 -- we need to extend the transaction proto
       case Node.Rollback(children) =>
         val builder = TransactionOuterClass.NodeRollback.newBuilder()
         children.foreach(id => discard(builder.addChildren(encodeNid.asString(id))))

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -52,6 +52,7 @@ object TransactionVersion {
   private[lf] val minByKey = V14
   private[lf] val minInterfaces = V15
   private[lf] val minExplicitDisclosure = VDev
+  private[lf] val minWithAuthority = VDev
 
   private[lf] val assignNodeVersion: LanguageVersion => TransactionVersion = {
     import LanguageVersion._
@@ -73,6 +74,7 @@ object TransactionVersion {
     tx.nodes.valuesIterator.foldLeft(TransactionVersion.minVersion) {
       case (acc, action: Node.Action) => acc max action.version
       case (acc, _: Node.Rollback) => acc max minExceptions
+      case (acc, _: Node.Authority) => acc max minWithAuthority
     }
   }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/ContractStateMachineSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/ContractStateMachineSpec.scala
@@ -622,6 +622,7 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
     case _: Node.Create | _: Node.Fetch | _: Node.LookupByKey => ImmArray.empty[NodeId]
     case exercise: Node.Exercise => exercise.children
     case rollback: Node.Rollback => rollback.children
+    case authority: Node.Authority => authority.children
   }
 
   /** Visits the `root` node and all its children in execution order and updates the `state` accordingly,
@@ -651,6 +652,8 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
     val node = nodes(root)
     for {
       next <- node match {
+        case _: Node.Authority =>
+          ??? // TODO #15882 -- treat like exercise with no keys. recurse directly on children
         case actionNode: Node.Action =>
           lazy val gkeyO =
             actionNode.keyOpt.map(key => GlobalKey.assertBuild(actionNode.templateId, key.key))
@@ -662,6 +665,7 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
         visitSubtrees(ksm)(nodes, children(node).toSeq, resolver, next)
       }
       exited = node match {
+        case _: Node.Authority => ??? // TODO #15882
         case _: Node.Rollback => afterChildren.endRollback()
         case _ => afterChildren
       }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -895,6 +895,7 @@ class TransactionCoderSpec
 
   private[this] def normalizeNode(node: Node) =
     node match {
+      case na: Node.Authority => na // nothing to normalize
       case rb: Node.Rollback => rb // nothing to normalize
       case exe: Node.Exercise => normalizeExe(exe)
       case fetch: Node.Fetch => normalizeFetch(fetch)
@@ -971,6 +972,7 @@ class TransactionCoderSpec
       node: Node,
       version: TransactionVersion,
   ): Node = node match {
+    case node: Node.Authority => node
     case node: Node.Action => node.updateVersion(version)
     case node: Node.Rollback => node
   }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -193,6 +193,8 @@ class TransactionSpec
       for {
         entry <- danglingRefGenNode
         node = entry match {
+          case (_, na: Node.Authority) =>
+            na.copy(children = ImmArray.Empty)
           case (_, nr: Node.Rollback) =>
             nr.copy(children = ImmArray.Empty)
           case (_, n: Node.LeafOnlyAction) => n
@@ -217,6 +219,7 @@ class TransactionSpec
       forAll(genEmptyNode, minSuccessful(10)) { n =>
         val version = n.optVersion.getOrElse(TransactionVersion.minExceptions)
         n match {
+          case _: Node.Authority => ()
           case _: Node.Rollback => ()
           case n: Node.Action =>
             val m = n.updateVersion(diffVersion(version))

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -319,7 +319,7 @@ class IdeLedgerClient(
                 exercise.choiceId,
                 exercise.exerciseResult.get,
               )
-            case _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback =>
+            case _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback | _: Node.Authority =>
               throw new IllegalArgumentException(s"Invalid root node: $node")
           }
         }
@@ -376,7 +376,7 @@ class IdeLedgerClient(
                   exercise.children.collect(Function.unlift(convEvent(_))).toList,
                 )
               )
-            case _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback => None
+            case _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback | _: Node.Authority => None
           }
         ScriptLedgerClient.TransactionTree(
           transaction.roots.collect(Function.unlift(convEvent(_))).toList


### PR DESCRIPTION
Add new TX node type `Node.Authority` (is currently never constructed by the engine)
- new node type records `obtained` authority as `Set[Party]` 
- fixup scala matches: `case _: Node.Authority => ??? // TODO #15882`
- implement easy/structural cases, leaving:
```
$ git grep 'TODO #15882' | wc -l
8
```
Advances: https://github.com/digital-asset/daml/issues/15882
