### PR TITLE
[compiler] daml feature: DAML_WITH_AUTHORITY

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -99,6 +99,13 @@ featureUnstable = Feature
     , featureCppFlag = Just "DAML_UNSTABLE"
     }
 
+featureWithAuthority :: Feature
+featureWithAuthority = Feature
+    { featureName = "withAuthorityOf primitive"
+    , featureMinVersion = versionDev
+    , featureCppFlag = Just "DAML_WITH_AUTHORITY"
+    }
+
 featureBigNumeric :: Feature
 featureBigNumeric = Feature
     { featureName = "BigNumeric type"
@@ -152,6 +159,7 @@ allFeatures =
     , featureExtendedInterfaces
     , featureUnstable
     , featureExperimental
+    , featureWithAuthority
     ]
 
 featureVersionMap :: MS.Map T.Text Version

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -48,7 +48,7 @@ module DA.Internal.LF
   , AnyException
   #endif
 
-  #ifdef DAML_UNSTABLE
+  #ifdef DAML_WITH_AUTHORITY
   , withAuthorityOf
   #endif
 
@@ -276,7 +276,7 @@ data AnyException = AnyException Opaque
 
 #endif
 
-#ifdef DAML_UNSTABLE
+#ifdef DAML_WITH_AUTHORITY
 
 -- | Authority operations.
 withAuthorityOf : [Party] -> Update a -> Update a

--- a/compiler/damlc/tests/daml-test-files/WithAuthorityOf.daml
+++ b/compiler/damlc/tests/daml-test-files/WithAuthorityOf.daml
@@ -1,5 +1,5 @@
 
--- @SINCE-LF-FEATURE DAML_UNSTABLE
+-- @SINCE-LF-FEATURE DAML_WITH_AUTHORITY
 
 module WithAuthorityOf where
 

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -4564,6 +4564,7 @@ Authority functions
 
   Request authorization from the ledger for the scope of an update operation.
 
+  [*Available in versions >= 1.dev*]
 
 Text map functions
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
New daml feature `DAML_WITH_AUTHORITY`, for use in preference to `DAML_UNSTABLE`.

Addressing comment: https://github.com/digital-asset/daml/pull/16029#discussion_r1071185846
Advances: https://github.com/digital-asset/daml/issues/15882