### PR TITLE
[engine] dummy implemention of withAuthorityOf primitive

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -660,7 +660,12 @@ private[lf] object SBuiltin {
         args: util.ArrayList[SValue],
         machine: Machine[Q],
     ): Control[Q] = {
-      sys.error("SBWithAuthorityOf") // TODO https://github.com/digital-asset/daml/issues/15882
+      // TODO https://github.com/digital-asset/daml/issues/15882
+      // For development, implement this primitive as the identity operation. No authority is gained.
+      // val parties = args.get(0)
+      // println(s"**SBWithAuthorityOf/execute, parties=$parties")
+      val action = args.get(1)
+      Control.Value(action)
     }
   }
 

--- a/daml-script/test/daml/TestWithAuthorityOf.daml
+++ b/daml-script/test/daml/TestWithAuthorityOf.daml
@@ -46,11 +46,16 @@ test = do
       proposer = alice
       accepted = []
       obs = [bob,charlie]
-      consortiumParty = org
+
+      -- Currently we have only a dummy implememation for the withAuthorityOf primitive.
+      -- It ignores the parties and returns it's 2nd argument; no authority is gained.
+      -- So to make this example work for now...
+      consortiumParty = alice
+      -- consortiumParty = org -- TODO #15882 -- This is what we want to write
 
   prop <- submit bob do exerciseCmd prop Accept with who = bob
   prop <- submit charlie do exerciseCmd prop Accept with who = charlie
 
-  --submitMustFail alice do exerciseCmd prop Ratify -- TODO: https://github.com/digital-asset/daml/issues/15882
+  submit alice do exerciseCmd prop Ratify
 
   pure ()


### PR DESCRIPTION
Small step.
No authority is gained. But the primitive doesn't crash.
Advances: https://github.com/digital-asset/daml/issues/15882