### PR TITLE
[engine] Question.Update.NeedAuthority

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -377,6 +377,8 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
 
         case SResultQuestion(question) =>
           question match {
+            case _: Question.Update.NeedAuthority => ??? // TODO #15882
+
             case Question.Update.NeedTime(callback) =>
               callback(time)
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -47,6 +47,12 @@ object Question {
         callback: Option[ContractId] => Boolean,
     ) extends Update
 
+    final case class NeedAuthority(
+        using: Set[Party],
+        requesting: Set[Party],
+        // Callback: the request is granted
+        callback: Boolean => Unit,
+    ) extends Update
   }
 
   sealed abstract class Scenario extends Product with Serializable

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
@@ -65,6 +65,7 @@ private[speedy] object SpeedyTestLib {
       machine.run() match {
         case SResultQuestion(question) =>
           question match {
+            case _: Question.Update.NeedAuthority => ??? // TODO #15882
             case Question.Update.NeedTime(callback) =>
               getTime.lift(()) match {
                 case Some(value) =>

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -417,6 +417,7 @@ private[lf] object ScenarioRunner {
           SubmissionError(Error.RunnerException(err), enrich(ledgerMachine.incompleteTransaction))
         case SResultQuestion(question) =>
           question match {
+            case _: Question.Update.NeedAuthority => ??? // TODO #15882
             case Question.Update.NeedContract(coid, committers, callback) =>
               ledger.lookupContract(
                 coid,


### PR DESCRIPTION
New question type for update machine:
- add `Question.Update.NeedAuthority` 
- fix scala compile for 3 matches with: ` case _: Question.Update.NeedAuthority => ??? // TODO #15882`

TODO:
- what are the correct args for `Question.Update.NeedAuthority` ?
- test!

Advances #15882
