### PR TITLE
[DPP-1363] Handle outstanding ETQ TODOs: Part 2

### DIFF
--- a/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/CliConfig.scala
+++ b/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/CliConfig.scala
@@ -579,6 +579,12 @@ object CliConfig {
         .action((acsContractFetchingParallelism, config) =>
           config.copy(acsContractFetchingParallelism = acsContractFetchingParallelism)
         ),
+      opt[Int]("acs-global-parallelism-limit")
+        .optional()
+        .text(
+          s"This configuration option is deprecated and has no effect on the application"
+        )
+        .action((_, config) => config),
       opt[Long]("max-lf-value-translation-cache-entries")
         .optional()
         .text(

--- a/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/CliConfig.scala
+++ b/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/CliConfig.scala
@@ -12,7 +12,7 @@ import com.daml.platform.apiserver.{AuthServiceConfig, AuthServiceConfigCli}
 import com.daml.platform.apiserver.SeedService.Seeding
 import com.daml.platform.config.ParticipantConfig
 import com.daml.platform.configuration.Readers._
-import com.daml.platform.configuration.{CommandConfiguration, IndexServiceConfig}
+import com.daml.platform.configuration.{AcsStreamsConfig, CommandConfiguration, IndexServiceConfig}
 import com.daml.platform.indexer.{IndexerConfig, IndexerStartupMode}
 import com.daml.platform.localstore.UserManagementConfig
 import com.daml.platform.services.time.TimeProviderType
@@ -31,7 +31,6 @@ final case class CliConfig[Extra](
     engineConfig: EngineConfig,
     authService: AuthServiceConfig,
     acsContractFetchingParallelism: Int,
-    acsGlobalParallelism: Int,
     acsIdFetchingParallelism: Int,
     acsIdPageSize: Int,
     configurationLoadTimeout: Duration,
@@ -78,13 +77,12 @@ object CliConfig {
         forbidV0ContractId = true,
       ),
       authService = AuthServiceConfig.Wildcard,
-      acsContractFetchingParallelism = IndexServiceConfig.DefaultAcsContractFetchingParallelism,
-      acsGlobalParallelism = IndexServiceConfig.DefaultAcsGlobalParallelism,
-      acsIdFetchingParallelism = IndexServiceConfig.DefaultAcsIdFetchingParallelism,
-      acsIdPageSize = IndexServiceConfig.DefaultAcsIdPageSize,
+      acsContractFetchingParallelism = AcsStreamsConfig.DefaultAcsContractFetchingParallelism,
+      acsIdFetchingParallelism = AcsStreamsConfig.DefaultAcsIdFetchingParallelism,
+      acsIdPageSize = AcsStreamsConfig.DefaultAcsIdPageSize,
       configurationLoadTimeout = Duration.ofSeconds(10),
       commandConfig = CommandConfiguration.Default,
-      eventsPageSize = IndexServiceConfig.DefaultEventsPageSize,
+      eventsPageSize = AcsStreamsConfig.DefaultEventsPageSize,
       bufferedStreamsPageSize = IndexServiceConfig.DefaultBufferedStreamsPageSize,
       eventsProcessingParallelism = IndexServiceConfig.DefaultEventsProcessingParallelism,
       extra = extra,
@@ -503,7 +501,7 @@ object CliConfig {
       opt[Int]("events-page-size")
         .optional()
         .text(
-          s"Number of events fetched from the index for every round trip when serving streaming calls. Default is ${IndexServiceConfig.DefaultEventsPageSize}."
+          s"Number of events fetched from the index for every round trip when serving streaming calls. Default is ${AcsStreamsConfig.DefaultEventsPageSize}."
         )
         .validate { pageSize =>
           if (pageSize > 0) Right(())
@@ -550,7 +548,7 @@ object CliConfig {
       opt[Int]("acs-id-page-size")
         .optional()
         .text(
-          s"Number of contract ids fetched from the index for every round trip when serving ACS calls. Default is ${IndexServiceConfig.DefaultAcsIdPageSize}."
+          s"Number of contract ids fetched from the index for every round trip when serving ACS calls. Default is ${AcsStreamsConfig.DefaultAcsIdPageSize}."
         )
         .validate { acsIdPageSize =>
           if (acsIdPageSize > 0) Right(())
@@ -560,7 +558,7 @@ object CliConfig {
       opt[Int]("acs-id-fetching-parallelism")
         .optional()
         .text(
-          s"Number of contract id pages fetched in parallel when serving ACS calls. Default is ${IndexServiceConfig.DefaultAcsIdFetchingParallelism}."
+          s"Number of contract id pages fetched in parallel when serving ACS calls. Default is ${AcsStreamsConfig.DefaultAcsIdFetchingParallelism}."
         )
         .validate { acsIdFetchingParallelism =>
           if (acsIdFetchingParallelism > 0) Right(())
@@ -572,7 +570,7 @@ object CliConfig {
       opt[Int]("acs-contract-fetching-parallelism")
         .optional()
         .text(
-          s"Number of event pages fetched in parallel when serving ACS calls. Default is ${IndexServiceConfig.DefaultAcsContractFetchingParallelism}."
+          s"Number of event pages fetched in parallel when serving ACS calls. Default is ${AcsStreamsConfig.DefaultAcsContractFetchingParallelism}."
         )
         .validate { acsContractFetchingParallelism =>
           if (acsContractFetchingParallelism > 0) Right(())
@@ -580,14 +578,6 @@ object CliConfig {
         }
         .action((acsContractFetchingParallelism, config) =>
           config.copy(acsContractFetchingParallelism = acsContractFetchingParallelism)
-        ),
-      opt[Int]("acs-global-parallelism-limit")
-        .optional()
-        .text(
-          s"Maximum number of concurrent ACS queries to the index database. Default is ${IndexServiceConfig.DefaultAcsGlobalParallelism}."
-        )
-        .action((acsGlobalParallelism, config) =>
-          config.copy(acsGlobalParallelism = acsGlobalParallelism)
         ),
       opt[Long]("max-lf-value-translation-cache-entries")
         .optional()

--- a/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/LegacyCliConfigConverter.scala
+++ b/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/LegacyCliConfigConverter.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.runner.common
 
 import com.daml.platform.apiserver.ApiServerConfig
 import com.daml.platform.config.{MetricsConfig, ParticipantConfig}
-import com.daml.platform.configuration.IndexServiceConfig
+import com.daml.platform.configuration.{AcsStreamsConfig, IndexServiceConfig}
 import com.daml.platform.store.DbSupport.{
   ConnectionPoolConfig,
   DataSourceProperties,
@@ -26,11 +26,12 @@ object LegacyCliConfigConverter {
     authentication = cliConfig.authService,
     indexer = config.indexerConfig,
     indexService = IndexServiceConfig(
-      acsContractFetchingParallelism = cliConfig.acsContractFetchingParallelism,
-      acsGlobalParallelism = cliConfig.acsGlobalParallelism,
-      acsIdFetchingParallelism = cliConfig.acsIdFetchingParallelism,
-      acsIdPageSize = cliConfig.acsIdPageSize,
-      eventsPageSize = cliConfig.eventsPageSize,
+      acsStreams = AcsStreamsConfig(
+        maxParallelPayloadCreateQueries = cliConfig.acsContractFetchingParallelism,
+        maxParallelIdCreateQueries = cliConfig.acsIdFetchingParallelism,
+        maxIdsPerIdPage = cliConfig.acsIdPageSize,
+        maxPayloadsPerPayloadsPage = cliConfig.eventsPageSize,
+      ),
       bufferedStreamsPageSize = cliConfig.bufferedStreamsPageSize,
       eventsProcessingParallelism = cliConfig.eventsProcessingParallelism,
       maxContractStateCacheSize = config.maxContractStateCacheSize,

--- a/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/PureConfigReaderWriter.scala
+++ b/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/PureConfigReaderWriter.scala
@@ -18,6 +18,7 @@ import com.daml.platform.apiserver.configuration.RateLimitingConfig
 import com.daml.platform.apiserver.{ApiServerConfig, AuthServiceConfig}
 import com.daml.platform.config.{MetricsConfig, ParticipantConfig}
 import com.daml.platform.configuration.{
+  AcsStreamsConfig,
   CommandConfiguration,
   IndexServiceConfig,
   InitialLedgerConfiguration,
@@ -342,6 +343,9 @@ class PureConfigReaderWriter(secure: Boolean = true) {
 
   implicit val indexServiceConfigHint =
     ProductHint[IndexServiceConfig](allowUnknownKeys = false)
+
+  implicit val acsStreamsConfigConvert: ConfigConvert[AcsStreamsConfig] =
+    deriveConvert[AcsStreamsConfig]
 
   implicit val transactionTreeStreamsConfigConvert: ConfigConvert[TransactionTreeStreamsConfig] =
     deriveConvert[TransactionTreeStreamsConfig]

--- a/ledger/ledger-runner-common/src/test/lib/com/daml/ledger/runner/common/ArbitraryConfig.scala
+++ b/ledger/ledger-runner-common/src/test/lib/com/daml/ledger/runner/common/ArbitraryConfig.scala
@@ -18,6 +18,7 @@ import com.daml.platform.apiserver.configuration.RateLimitingConfig
 import com.daml.platform.config.{MetricsConfig, ParticipantConfig}
 import com.daml.platform.config.MetricsConfig.MetricRegistryType
 import com.daml.platform.configuration.{
+  AcsStreamsConfig,
   CommandConfiguration,
   IndexServiceConfig,
   InitialLedgerConfiguration,
@@ -383,25 +384,25 @@ object ArbitraryConfig {
     acsIdPageWorkingMemoryBytes <- Gen.chooseNum(0, Int.MaxValue)
     acsIdFetchingParallelism <- Gen.chooseNum(0, Int.MaxValue)
     acsContractFetchingParallelism <- Gen.chooseNum(0, Int.MaxValue)
-    acsGlobalParallelism <- Gen.chooseNum(0, Int.MaxValue)
     maxContractStateCacheSize <- Gen.long
     maxContractKeyStateCacheSize <- Gen.long
     maxTransactionsInMemoryFanOutBufferSize <- Gen.chooseNum(0, Int.MaxValue)
     apiStreamShutdownTimeout <- Gen.finiteDuration
   } yield IndexServiceConfig(
-    eventsPageSize,
     eventsProcessingParallelism,
     bufferedStreamsPageSize,
-    acsIdPageSize,
-    acsIdPageBufferSize,
-    acsIdPageWorkingMemoryBytes,
-    acsIdFetchingParallelism,
-    acsContractFetchingParallelism,
-    acsGlobalParallelism,
     maxContractStateCacheSize,
     maxContractKeyStateCacheSize,
     maxTransactionsInMemoryFanOutBufferSize,
     apiStreamShutdownTimeout,
+    acsStreams = AcsStreamsConfig(
+      maxIdsPerIdPage = acsIdPageSize,
+      maxPayloadsPerPayloadsPage = eventsPageSize,
+      maxPagesPerIdPagesBuffer = acsIdPageBufferSize,
+      maxWorkingMemoryInBytesForIdPages = acsIdPageWorkingMemoryBytes,
+      maxParallelIdCreateQueries = acsIdFetchingParallelism,
+      maxParallelPayloadCreateQueries = acsContractFetchingParallelism,
+    ),
   )
 
   val participantConfig = for {

--- a/ledger/ledger-runner-common/src/test/lib/com/daml/ledger/runner/common/ArbitraryConfig.scala
+++ b/ledger/ledger-runner-common/src/test/lib/com/daml/ledger/runner/common/ArbitraryConfig.scala
@@ -22,6 +22,8 @@ import com.daml.platform.configuration.{
   CommandConfiguration,
   IndexServiceConfig,
   InitialLedgerConfiguration,
+  TransactionFlatStreamsConfig,
+  TransactionTreeStreamsConfig,
 }
 import com.daml.platform.indexer.{IndexerConfig, IndexerStartupMode, PackageMetadataViewConfig}
 import com.daml.platform.indexer.ha.HaConfig
@@ -33,12 +35,12 @@ import com.daml.platform.store.backend.postgresql.PostgresDataSourceConfig
 import com.daml.platform.store.backend.postgresql.PostgresDataSourceConfig.SynchronousCommitValue
 import com.daml.ports.Port
 import io.netty.handler.ssl.ClientAuth
-
 import java.io.File
 import java.net.InetSocketAddress
 import java.nio.file.Paths
 import java.time.Duration
 import java.time.temporal.ChronoUnit
+
 import com.daml.metrics.api.reporters.MetricsReporter
 
 object ArbitraryConfig {
@@ -375,15 +377,83 @@ object ArbitraryConfig {
     packageMetadataView = packageMetadataViewConfig,
   )
 
-  val indexServiceConfig = for {
-    eventsPageSize <- Gen.chooseNum(0, Int.MaxValue)
+  def genAcsStreamConfig: Gen[AcsStreamsConfig] =
+    for {
+      eventsPageSize <- Gen.chooseNum(0, Int.MaxValue)
+      acsIdPageSize <- Gen.chooseNum(0, Int.MaxValue)
+      acsIdPageBufferSize <- Gen.chooseNum(0, Int.MaxValue)
+      acsIdPageWorkingMemoryBytes <- Gen.chooseNum(0, Int.MaxValue)
+      acsIdFetchingParallelism <- Gen.chooseNum(0, Int.MaxValue)
+      acsContractFetchingParallelism <- Gen.chooseNum(0, Int.MaxValue)
+    } yield AcsStreamsConfig(
+      maxIdsPerIdPage = acsIdPageSize,
+      maxPayloadsPerPayloadsPage = eventsPageSize,
+      maxPagesPerIdPagesBuffer = acsIdPageBufferSize,
+      maxWorkingMemoryInBytesForIdPages = acsIdPageWorkingMemoryBytes,
+      maxParallelIdCreateQueries = acsIdFetchingParallelism,
+      maxParallelPayloadCreateQueries = acsContractFetchingParallelism,
+    )
+
+  def genTransactionFlatStreams: Gen[TransactionFlatStreamsConfig] =
+    for {
+      maxIdsPerIdPage <- Gen.chooseNum(0, Int.MaxValue)
+      maxPayloadsPerPayloadsPage <- Gen.chooseNum(0, Int.MaxValue)
+      maxPagesPerIdPagesBuffer <- Gen.chooseNum(0, Int.MaxValue)
+      maxWorkingMemoryInBytesForIdPages <- Gen.chooseNum(0, Int.MaxValue)
+      maxParallelIdCreateQueries <- Gen.chooseNum(0, Int.MaxValue)
+      maxParallelPayloadCreateQueries <- Gen.chooseNum(0, Int.MaxValue)
+      maxParallelIdConsumingQueries <- Gen.chooseNum(0, Int.MaxValue)
+      maxParallelPayloadConsumingQueries <- Gen.chooseNum(0, Int.MaxValue)
+      maxParallelPayloadQueries <- Gen.chooseNum(0, Int.MaxValue)
+      transactionsProcessingParallelism <- Gen.chooseNum(0, Int.MaxValue)
+    } yield TransactionFlatStreamsConfig(
+      maxIdsPerIdPage = maxIdsPerIdPage,
+      maxPagesPerIdPagesBuffer = maxPayloadsPerPayloadsPage,
+      maxWorkingMemoryInBytesForIdPages = maxPagesPerIdPagesBuffer,
+      maxPayloadsPerPayloadsPage = maxWorkingMemoryInBytesForIdPages,
+      maxParallelIdCreateQueries = maxParallelIdCreateQueries,
+      maxParallelIdConsumingQueries = maxParallelPayloadCreateQueries,
+      maxParallelPayloadCreateQueries = maxParallelIdConsumingQueries,
+      maxParallelPayloadConsumingQueries = maxParallelPayloadConsumingQueries,
+      maxParallelPayloadQueries = maxParallelPayloadQueries,
+      transactionsProcessingParallelism = transactionsProcessingParallelism,
+    )
+
+  def genTransactionTreeStreams: Gen[TransactionTreeStreamsConfig] =
+    for {
+      maxIdsPerIdPage <- Gen.chooseNum(0, Int.MaxValue)
+      maxPayloadsPerPayloadsPage <- Gen.chooseNum(0, Int.MaxValue)
+      maxPagesPerIdPagesBuffer <- Gen.chooseNum(0, Int.MaxValue)
+      maxWorkingMemoryInBytesForIdPages <- Gen.chooseNum(0, Int.MaxValue)
+      maxParallelIdCreateQueries <- Gen.chooseNum(0, Int.MaxValue)
+      maxParallelPayloadCreateQueries <- Gen.chooseNum(0, Int.MaxValue)
+      maxParallelIdConsumingQueries <- Gen.chooseNum(0, Int.MaxValue)
+      maxParallelPayloadConsumingQueries <- Gen.chooseNum(0, Int.MaxValue)
+      maxParallelPayloadQueries <- Gen.chooseNum(0, Int.MaxValue)
+      transactionsProcessingParallelism <- Gen.chooseNum(0, Int.MaxValue)
+      maxParallelIdNonConsumingQueries <- Gen.chooseNum(0, Int.MaxValue)
+      maxParallelPayloadNonConsumingQueries <- Gen.chooseNum(0, Int.MaxValue)
+    } yield TransactionTreeStreamsConfig(
+      maxIdsPerIdPage = maxIdsPerIdPage,
+      maxPagesPerIdPagesBuffer = maxPayloadsPerPayloadsPage,
+      maxWorkingMemoryInBytesForIdPages = maxPagesPerIdPagesBuffer,
+      maxPayloadsPerPayloadsPage = maxWorkingMemoryInBytesForIdPages,
+      maxParallelIdCreateQueries = maxParallelIdCreateQueries,
+      maxParallelIdConsumingQueries = maxParallelPayloadCreateQueries,
+      maxParallelPayloadCreateQueries = maxParallelIdConsumingQueries,
+      maxParallelPayloadConsumingQueries = maxParallelPayloadConsumingQueries,
+      maxParallelPayloadQueries = maxParallelPayloadQueries,
+      transactionsProcessingParallelism = transactionsProcessingParallelism,
+      maxParallelIdNonConsumingQueries = maxParallelIdNonConsumingQueries,
+      maxParallelPayloadNonConsumingQueries = maxParallelPayloadNonConsumingQueries,
+    )
+
+  val indexServiceConfig: Gen[IndexServiceConfig] = for {
+    acsStreams <- genAcsStreamConfig
+    transactionFlatStreams <- genTransactionFlatStreams
+    transactionTreeStreams <- genTransactionTreeStreams
     eventsProcessingParallelism <- Gen.chooseNum(0, Int.MaxValue)
     bufferedStreamsPageSize <- Gen.chooseNum(0, Int.MaxValue)
-    acsIdPageSize <- Gen.chooseNum(0, Int.MaxValue)
-    acsIdPageBufferSize <- Gen.chooseNum(0, Int.MaxValue)
-    acsIdPageWorkingMemoryBytes <- Gen.chooseNum(0, Int.MaxValue)
-    acsIdFetchingParallelism <- Gen.chooseNum(0, Int.MaxValue)
-    acsContractFetchingParallelism <- Gen.chooseNum(0, Int.MaxValue)
     maxContractStateCacheSize <- Gen.long
     maxContractKeyStateCacheSize <- Gen.long
     maxTransactionsInMemoryFanOutBufferSize <- Gen.chooseNum(0, Int.MaxValue)
@@ -395,14 +465,9 @@ object ArbitraryConfig {
     maxContractKeyStateCacheSize,
     maxTransactionsInMemoryFanOutBufferSize,
     apiStreamShutdownTimeout,
-    acsStreams = AcsStreamsConfig(
-      maxIdsPerIdPage = acsIdPageSize,
-      maxPayloadsPerPayloadsPage = eventsPageSize,
-      maxPagesPerIdPagesBuffer = acsIdPageBufferSize,
-      maxWorkingMemoryInBytesForIdPages = acsIdPageWorkingMemoryBytes,
-      maxParallelIdCreateQueries = acsIdFetchingParallelism,
-      maxParallelPayloadCreateQueries = acsContractFetchingParallelism,
-    ),
+    acsStreams = acsStreams,
+    transactionFlatStreams = transactionFlatStreams,
+    transactionTreeStreams = transactionTreeStreams,
   )
 
   val participantConfig = for {

--- a/ledger/ledger-runner-common/src/test/scala/com/daml/ledger/runner/common/PureConfigReaderWriterSpec.scala
+++ b/ledger/ledger-runner-common/src/test/scala/com/daml/ledger/runner/common/PureConfigReaderWriterSpec.scala
@@ -750,15 +750,8 @@ class PureConfigReaderWriterSpec
 
   val validIndexServiceConfigValue =
     """
-      |  acs-contract-fetching-parallelism = 2
-      |  acs-global-parallelism = 10
-      |  acs-id-fetching-parallelism = 2
-      |  acs-id-page-buffer-size = 1
-      |  acs-id-page-size = 20000
-      |  acs-id-page-working-memory-bytes = 104857600
       |  api-stream-shutdown-timeout = "5s"
       |  buffered-streams-page-size = 100
-      |  events-page-size = 1000
       |  events-processing-parallelism = 8
       |  max-contract-key-state-cache-size = 100000
       |  max-contract-state-cache-size = 100000

--- a/ledger/ledger-runner-common/src/test/scala/com/daml/ledger/runner/common/PureConfigReaderWriterSpec.scala
+++ b/ledger/ledger-runner-common/src/test/scala/com/daml/ledger/runner/common/PureConfigReaderWriterSpec.scala
@@ -749,17 +749,53 @@ class PureConfigReaderWriterSpec
   behavior of "IndexServiceConfig"
 
   val validIndexServiceConfigValue =
-    """
-      |  api-stream-shutdown-timeout = "5s"
-      |  buffered-streams-page-size = 100
-      |  events-processing-parallelism = 8
-      |  max-contract-key-state-cache-size = 100000
-      |  max-contract-state-cache-size = 100000
-      |  max-transactions-in-memory-fan-out-buffer-size = 10000
-      |  in-memory-state-updater-parallelism = 2
-      |  in-memory-fan-out-thread-pool-size = 16
-      |  prepare-package-metadata-time-out-warning = 5 second
-      |  """.stripMargin
+    """|
+      |acs-streams {
+      |    max-ids-per-id-page=20000
+      |    max-pages-per-id-pages-buffer=1
+      |    max-parallel-id-create-queries=2
+      |    max-parallel-payload-create-queries=2
+      |    max-payloads-per-payloads-page=1000
+      |    max-working-memory-in-bytes-for-id-pages=104857600
+      |}
+      |api-stream-shutdown-timeout="5s"
+      |buffered-streams-page-size=100
+      |completions-page-size=1000
+      |events-processing-parallelism=8
+      |global-max-event-id-queries=20
+      |global-max-event-payload-queries=10
+      |in-memory-fan-out-thread-pool-size=16
+      |in-memory-state-updater-parallelism=2
+      |max-contract-key-state-cache-size=100000
+      |max-contract-state-cache-size=100000
+      |max-transactions-in-memory-fan-out-buffer-size=10000
+      |prepare-package-metadata-time-out-warning="5s"
+      |transaction-flat-streams {
+      |    max-ids-per-id-page=20000
+      |    max-pages-per-id-pages-buffer=1
+      |    max-parallel-id-consuming-queries=4
+      |    max-parallel-id-create-queries=4
+      |    max-parallel-payload-consuming-queries=2
+      |    max-parallel-payload-create-queries=2
+      |    max-parallel-payload-queries=2
+      |    max-payloads-per-payloads-page=1000
+      |    max-working-memory-in-bytes-for-id-pages=104857600
+      |    transactions-processing-parallelism=8
+      |}
+      |transaction-tree-streams {
+      |    max-ids-per-id-page=20000
+      |    max-pages-per-id-pages-buffer=1
+      |    max-parallel-id-consuming-queries=8
+      |    max-parallel-id-create-queries=8
+      |    max-parallel-id-non-consuming-queries=4
+      |    max-parallel-payload-consuming-queries=2
+      |    max-parallel-payload-create-queries=2
+      |    max-parallel-payload-non-consuming-queries=2
+      |    max-parallel-payload-queries=2
+      |    max-payloads-per-payloads-page=1000
+      |    max-working-memory-in-bytes-for-id-pages=104857600
+      |    transactions-processing-parallelism=8
+      |}""".stripMargin
 
   it should "support current defaults" in {
     val value = validIndexServiceConfigValue

--- a/ledger/participant-integration-api/src/main/scala/platform/configuration/IndexServiceConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/configuration/IndexServiceConfig.scala
@@ -6,16 +6,8 @@ package com.daml.platform.configuration
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
 final case class IndexServiceConfig(
-    eventsPageSize: Int = IndexServiceConfig.DefaultEventsPageSize,
     eventsProcessingParallelism: Int = IndexServiceConfig.DefaultEventsProcessingParallelism,
     bufferedStreamsPageSize: Int = IndexServiceConfig.DefaultBufferedStreamsPageSize,
-    acsIdPageSize: Int = IndexServiceConfig.DefaultAcsIdPageSize,
-    acsIdPageBufferSize: Int = IndexServiceConfig.DefaultAcsIdPageBufferSize,
-    acsIdPageWorkingMemoryBytes: Int = IndexServiceConfig.DefaultAcsIdPageWorkingMemoryBytes,
-    acsIdFetchingParallelism: Int = IndexServiceConfig.DefaultAcsIdFetchingParallelism,
-    // Must be a power of 2
-    acsContractFetchingParallelism: Int = IndexServiceConfig.DefaultAcsContractFetchingParallelism,
-    acsGlobalParallelism: Int = IndexServiceConfig.DefaultAcsGlobalParallelism,
     maxContractStateCacheSize: Long = IndexServiceConfig.DefaultMaxContractStateCacheSize,
     maxContractKeyStateCacheSize: Long = IndexServiceConfig.DefaultMaxContractKeyStateCacheSize,
     maxTransactionsInMemoryFanOutBufferSize: Int =
@@ -27,6 +19,7 @@ final case class IndexServiceConfig(
     preparePackageMetadataTimeOutWarning: FiniteDuration =
       IndexServiceConfig.PreparePackageMetadataTimeOutWarning,
     completionsPageSize: Int = 1000,
+    acsStreams: AcsStreamsConfig = AcsStreamsConfig.default,
     transactionFlatStreams: TransactionFlatStreamsConfig = TransactionFlatStreamsConfig.default,
     transactionTreeStreams: TransactionTreeStreamsConfig = TransactionTreeStreamsConfig.default,
     globalMaxEventIdQueries: Int = 20,
@@ -34,16 +27,8 @@ final case class IndexServiceConfig(
 )
 
 object IndexServiceConfig {
-  val DefaultEventsPageSize: Int = 1000
   val DefaultEventsProcessingParallelism: Int = 8
   val DefaultBufferedStreamsPageSize: Int = 100
-  val DefaultAcsIdPageSize: Int = 20000
-  val DefaultAcsIdPageBufferSize: Int = 1
-  val DefaultAcsIdPageWorkingMemoryBytes: Int = 100 * 1024 * 1024
-  val DefaultAcsIdFetchingParallelism: Int = 2
-  // Must be a power of 2
-  val DefaultAcsContractFetchingParallelism: Int = 2
-  val DefaultAcsGlobalParallelism: Int = 10
   val DefaultMaxContractStateCacheSize: Long = 100000L
   val DefaultMaxContractKeyStateCacheSize: Long = 100000L
   val DefaultMaxTransactionsInMemoryFanOutBufferSize: Int = 10000
@@ -51,6 +36,28 @@ object IndexServiceConfig {
   val DefaultInMemoryStateUpdaterParallelism: Int = 2
   val DefaultInMemoryFanOutThreadPoolSize: Int = 16
   val PreparePackageMetadataTimeOutWarning: FiniteDuration = FiniteDuration(5, "second")
+}
+
+case class AcsStreamsConfig(
+    maxIdsPerIdPage: Int = AcsStreamsConfig.DefaultAcsIdPageSize,
+    maxPagesPerIdPagesBuffer: Int = AcsStreamsConfig.DefaultAcsIdPageBufferSize,
+    maxWorkingMemoryInBytesForIdPages: Int = AcsStreamsConfig.DefaultAcsIdPageWorkingMemoryBytes,
+    maxPayloadsPerPayloadsPage: Int = AcsStreamsConfig.DefaultEventsPageSize,
+    maxParallelIdCreateQueries: Int = AcsStreamsConfig.DefaultAcsIdFetchingParallelism,
+    // Must be a power of 2
+    maxParallelPayloadCreateQueries: Int = AcsStreamsConfig.DefaultAcsContractFetchingParallelism,
+)
+
+object AcsStreamsConfig {
+  val DefaultEventsPageSize: Int = 1000
+  val DefaultAcsIdPageSize: Int = 20000
+  val DefaultAcsIdPageBufferSize: Int = 1
+  val DefaultAcsIdPageWorkingMemoryBytes: Int = 100 * 1024 * 1024
+  val DefaultAcsIdFetchingParallelism: Int = 2
+  // Must be a power of 2
+  val DefaultAcsContractFetchingParallelism: Int = 2
+
+  val default: AcsStreamsConfig = AcsStreamsConfig()
 }
 
 case class TransactionFlatStreamsConfig(

--- a/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceOwner.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceOwner.scala
@@ -164,14 +164,7 @@ final class IndexServiceOwner(
   ): LedgerReadDao =
     JdbcLedgerDao.read(
       dbSupport = dbSupport,
-      eventsPageSize = config.eventsPageSize,
       eventsProcessingParallelism = config.eventsProcessingParallelism,
-      acsIdPageSize = config.acsIdPageSize,
-      acsIdPageBufferSize = config.acsIdPageBufferSize,
-      acsIdPageWorkingMemoryBytes = config.acsIdPageWorkingMemoryBytes,
-      acsIdFetchingParallelism = config.acsIdFetchingParallelism,
-      acsContractFetchingParallelism = config.acsContractFetchingParallelism,
-      acsGlobalParallelism = config.acsGlobalParallelism,
       servicesExecutionContext = servicesExecutionContext,
       metrics = metrics,
       engine = Some(engine),
@@ -179,6 +172,7 @@ final class IndexServiceOwner(
       ledgerEndCache = ledgerEndCache,
       stringInterning = stringInterning,
       completionsPageSize = config.completionsPageSize,
+      acsStreamsConfig = config.acsStreams,
       transactionFlatStreamsConfig = config.transactionFlatStreams,
       transactionTreeStreamsConfig = config.transactionTreeStreams,
       globalMaxEventIdQueries = config.globalMaxEventIdQueries,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/IndexMetadata.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/IndexMetadata.scala
@@ -91,14 +91,7 @@ object IndexMetadata {
           participantId = Ref.ParticipantId.assertFromString("1"),
           ledgerEndCache = MutableLedgerEndCache(), // not used
           stringInterning = new StringInterningView(), // not used
-          acsStreamsConfig = AcsStreamsConfig(
-            maxPayloadsPerPayloadsPage = 1000,
-            maxIdsPerIdPage = 20000,
-            maxPagesPerIdPagesBuffer = 1,
-            maxWorkingMemoryInBytesForIdPages = 100 * 1024 * 1024,
-            maxParallelIdCreateQueries = 2,
-            maxParallelPayloadCreateQueries = 2,
-          ),
+          acsStreamsConfig = AcsStreamsConfig.default,
           transactionFlatStreamsConfig = TransactionFlatStreamsConfig.default,
           transactionTreeStreamsConfig = TransactionTreeStreamsConfig.default,
           globalMaxEventIdQueries = 20,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/IndexMetadata.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/IndexMetadata.scala
@@ -15,6 +15,7 @@ import com.daml.metrics.api.dropwizard.DropwizardMetricsFactory
 import com.daml.metrics.api.opentelemetry.OpenTelemetryFactory
 import com.daml.platform.ApiOffset
 import com.daml.platform.configuration.{
+  AcsStreamsConfig,
   ServerRole,
   TransactionFlatStreamsConfig,
   TransactionTreeStreamsConfig,
@@ -82,14 +83,7 @@ object IndexMetadata {
       .map(dbSupport =>
         JdbcLedgerDao.read(
           dbSupport = dbSupport,
-          eventsPageSize = 1000,
           eventsProcessingParallelism = 8,
-          acsIdPageSize = 20000,
-          acsIdPageBufferSize = 1,
-          acsIdPageWorkingMemoryBytes = 100 * 1024 * 1024,
-          acsIdFetchingParallelism = 2,
-          acsContractFetchingParallelism = 2,
-          acsGlobalParallelism = 10,
           completionsPageSize = 1000,
           servicesExecutionContext = executionContext,
           metrics = metrics,
@@ -97,6 +91,14 @@ object IndexMetadata {
           participantId = Ref.ParticipantId.assertFromString("1"),
           ledgerEndCache = MutableLedgerEndCache(), // not used
           stringInterning = new StringInterningView(), // not used
+          acsStreamsConfig = AcsStreamsConfig(
+            maxPayloadsPerPayloadsPage = 1000,
+            maxIdsPerIdPage = 20000,
+            maxPagesPerIdPagesBuffer = 1,
+            maxWorkingMemoryInBytesForIdPages = 100 * 1024 * 1024,
+            maxParallelIdCreateQueries = 2,
+            maxParallelPayloadCreateQueries = 2,
+          ),
           transactionFlatStreamsConfig = TransactionFlatStreamsConfig.default,
           transactionTreeStreamsConfig = TransactionTreeStreamsConfig.default,
           globalMaxEventIdQueries = 20,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
@@ -464,7 +464,7 @@ abstract class EventStorageBackendTemplate(
       .asVectorOf(rawFlatEventParser(allInternedFilterParties, stringInterning))(connection)
   }
 
-  // TODO etq: Implement pruning queries in terms of event sequential id in order to be able to drop offset based indices.
+  // Improvement idea: Implement pruning queries in terms of event sequential id in order to be able to drop offset based indices.
   /** Deletes a subset of the indexed data (up to the pruning offset) in the following order and in the manner specified:
     * 1.a if pruning-all-divulged-contracts is enabled: all divulgence events (retroactive divulgence),
     * 1.b otherwise: divulgence events for which there are archive events (retroactive divulgence),
@@ -867,9 +867,10 @@ abstract class EventStorageBackendTemplate(
        """
   }
 
-  // TODO etq: Currently we query two additional tables: create and consuming events tables.
-  //           This can be simplified to query only the create events table if we impose the ordering
-  //           that create events tables has already been pruned.
+  // Improvement idea:
+  // In order to prune an id filter table we query two additional tables: create and consuming events tables.
+  // This can be simplified to query only the create events table if we ensure the ordering
+  // that create events tables are pruned before id filter tables.
   /** Prunes create events id filter table only for contracts archived before the specified offset
     */
   private def pruneIdFilterCreate(tableName: String, pruneUpToInclusive: Offset): SimpleSql[Row] = {
@@ -894,9 +895,11 @@ abstract class EventStorageBackendTemplate(
           )"""
   }
 
-  // TODO etq: Currently we query an events table to discover the event offset corresponding to a row from the id filter
-  //           table. This query can simplified not to query the events table at all if we pruned by the event sequential
-  //           id rather than by the event offset.
+  // Improvement idea:
+  // In order to prune an id filter table we query an events table to discover
+  // the event offset corresponding.
+  // This query can simplified not to query the events table at all
+  // if we were to prune by the sequential id rather than by the offset.
   private def pruneIdFilterConsumingOrNonConsuming(
       idFilterTableName: String,
       eventsTableName: String,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/TransactionPointwiseQueries.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/TransactionPointwiseQueries.scala
@@ -122,7 +122,7 @@ class TransactionPointwiseQueries(
       .map(stringInterning.party.tryInternalize)
       .flatMap(_.iterator)
       .toSet
-    // TODO etq: Consider implementing support for `fetchSizeHint` and `limit`.
+    // Improvement idea: Add support for `fetchSizeHint` and `limit`.
     def selectFrom(tableName: String, selectColumns: String) = cSQL"""
         (
           SELECT

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/PaginatingAsyncStream.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/PaginatingAsyncStream.scala
@@ -90,7 +90,6 @@ private[platform] object PaginatingAsyncStream {
   )(
       fetchPage: IdPaginationState => Future[Vector[Long]]
   ): Source[Long, NotUsed] = {
-    // TODO etq: Make sure this requirement is documented in the config
     assert(idPageBufferSize > 0)
     val initialState = IdPaginationState(
       fromIdExclusive = initialFromIdExclusive,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsTreeStreamReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsTreeStreamReader.scala
@@ -166,7 +166,6 @@ class TransactionsTreeStreamReader(
                     eventSequentialIds = ids,
                     allFilterParties = requestingParties,
                   )(connection),
-                  // TODO etq: Consider rolling out event-seq-id based queryNonPruned
                   minOffsetExclusive = startExclusiveOffset,
                   error = (prunedOffset: Offset) =>
                     s"Transactions request from ${startExclusiveOffset.toHexString} to ${endInclusiveOffset.toHexString} precedes pruned offset ${prunedOffset.toHexString}",

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
@@ -528,7 +528,6 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
         acsIdPageSize = 2,
         acsIdFetchingParallelism = 2,
         acsContractFetchingParallelism = 2,
-        acsGlobalParallelism = 10,
       ).use(
         _.transactionsReader
           .getFlatTransactions(
@@ -670,7 +669,6 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
       acsIdPageSize: Int,
       acsIdFetchingParallelism: Int,
       acsContractFetchingParallelism: Int,
-      acsGlobalParallelism: Int,
   ) =
     LoggingContext.newLoggingContext { implicit loggingContext =>
       daoOwner(
@@ -679,7 +677,6 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
         acsIdPageSize = acsIdPageSize,
         acsIdFetchingParallelism = acsIdFetchingParallelism,
         acsContractFetchingParallelism = acsContractFetchingParallelism,
-        acsGlobalParallelism = acsGlobalParallelism,
       )
     }
 

--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -507,10 +507,12 @@ server_conformance_test(
           }
         }
         index-service {
+          acs-streams {
+             max-ids-per-id-page = 2
+             max-payloads-per-payloads-page = 2
+          }
           max-contract-key-state-cache-size = 2
           max-contract-state-cache-size = 2
-          acs-id-page-size = 2
-          events-page-size = 2
           max-transactions-in-memory-fan-out-buffer-size = 3
           buffered-streams-page-size = 1
         }

--- a/ledger/sandbox-on-x/reference.conf
+++ b/ledger/sandbox-on-x/reference.conf
@@ -381,23 +381,24 @@ ledger {
 
       index-service {
 
-        # Number of event pages fetched in parallel when serving ACS calls. Must be a power of 2.
-        acs-contract-fetching-parallelism = 2
-
-        # Maximum number of concurrent ACS queries to the index database.
-        acs-global-parallelism = 10
-
-        # Number of contract id pages fetched in parallel when serving ACS calls.
-        acs-id-fetching-parallelism = 2
-
-        # The buffer size for ACS ID queries
-        acs-id-page-buffer-size = 1
-
-        # Number of contract ids fetched from the index for every round trip when serving ACS calls.
-        acs-id-page-size = 20000
-
-        # Working memory in bytes: specifies a maximum memory for allocating ID Pages for one ACS stream.
-        acs-id-page-working-memory-bytes = 104857600
+        acs-streams {
+          # Number of contract ids fetched from the index for every round trip when serving ACS calls.
+          max-ids-per-id-page=20000
+          # The buffer size for ACS ID queries.authentication.
+          # Must be positive.
+          max-pages-per-id-pages-buffer=1
+          # Number of contract id pages fetched in parallel when serving ACS calls.
+          max-parallel-id-create-queries=2
+          # Number of event pages fetched in parallel when serving ACS calls. Must be a power of 2.
+          max-parallel-payload-create-queries=2
+          # Number of events fetched from the index for every round trip when serving ACS streaming calls.
+          # When streaming, the API server will query the database for events in pages
+          # defaulting to a size of 1000. Increasing the page size can increase
+          # performance on servers with enough available memory.
+          max-payloads-per-payloads-page=1000
+          # Working memory in bytes: specifies a maximum memory for allocating ID Pages for one ACS stream.
+          max-working-memory-in-bytes-for-id-pages=104857600
+        }
 
         # The maximum duration that the Ledger API waits on teardown
         # for shutdown of the client stream subscriptions.
@@ -405,12 +406,6 @@ ledger {
 
         # Number of transactions fetched from the buffer when serving streaming calls.
         buffered-streams-page-size = 100
-
-        # Number of events fetched from the index for every round trip when serving streaming calls.
-        # When streaming transactions, the API server will query the database in pages
-        # defaulting to a size of 1000. Increasing the page size can increase
-        # performance on servers with enough available memory.
-        events-page-size = 1000
 
         # Number of events fetched/decoded in parallel for populating the Ledger API internal buffers.
         events-processing-parallelism = 8
@@ -446,6 +441,7 @@ ledger {
             # Upper bound on the number of event ids to retrieve in a single event id page (i.e. in a single event id fetch query).
             max-ids-per-id-page=20000
             # Upper bound on the number of id pages to fetch and store in a per-simple-filtering-constraint buffer before back-pressuring.
+            # Must be positive.
             max-pages-per-id-pages-buffer=1
             # Upper bound on the number of per-stream parallel id fetching queries for consuming events.
             max-parallel-id-consuming-queries=4
@@ -477,6 +473,7 @@ ledger {
             # Upper bound on the number of event ids to retrieve in a single event id page (i.e. in a single event id fetch query).
             max-ids-per-id-page=20000
             # Upper bound on the number of id pages to fetch and store in a per-simple-filtering-constraint buffer before back-pressuring.
+            # Must be positive.
             max-pages-per-id-pages-buffer=1
             # Upper bound on the number of per-stream parallel id fetching queries for consuming events.
             max-parallel-id-consuming-queries=8
@@ -503,11 +500,9 @@ ledger {
         # Upper bound on the number of completions to retrieve in a single page (i.e. in a single completion fetch query).
         completions-page-size=1000
 
-        # TODO etq: Limit ACS stream as well
         # Per participant server global upper bound on the number of parallel event id fetching queries across all flat and tree transactions streams.
         global-max-event-id-queries=20
 
-        # TODO etq: Limit ACS stream as well
         # Per participant server global upper bound on the number of parallel event payload fetching queries across all flat and tree transactions streams.
         global-max-event-payload-queries=10
       }

--- a/ledger/sandbox-on-x/resources/generated-default.conf
+++ b/ledger/sandbox-on-x/resources/generated-default.conf
@@ -83,16 +83,17 @@ ledger {
                 postgres {}
             }
             index-service {
-                acs-contract-fetching-parallelism=2
-                acs-global-parallelism=10
-                acs-id-fetching-parallelism=2
-                acs-id-page-buffer-size=1
-                acs-id-page-size=20000
-                acs-id-page-working-memory-bytes=104857600
+                acs-streams {
+                    max-ids-per-id-page=20000
+                    max-pages-per-id-pages-buffer=1
+                    max-parallel-id-create-queries=2
+                    max-parallel-payload-create-queries=2
+                    max-payloads-per-payloads-page=1000
+                    max-working-memory-in-bytes-for-id-pages=104857600
+                }
                 api-stream-shutdown-timeout="5s"
                 buffered-streams-page-size=100
                 completions-page-size=1000
-                events-page-size=1000
                 events-processing-parallelism=8
                 global-max-event-id-queries=20
                 global-max-event-payload-queries=10


### PR DESCRIPTION
Changes:
1. Move acs config keys into into its own case class + config key renames.
2. Apply the global limit of parallel event id queries (shared with tx streams) to acs streams.
3. Replace the acs limit of parallel event payload queries with the global limit (shared with tx streams).
4. Assert on participant_meta_table in StorageBackendTestsInitializeIngestion test