### PR TITLE
Change rate limiter stream check to use gauges [PLEN-95]

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/LAPIMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/LAPIMetrics.scala
@@ -6,7 +6,7 @@ package com.daml.metrics
 import com.daml.metrics.api.MetricDoc.MetricQualification.{Debug, Errors, Traffic}
 import com.daml.metrics.api.MetricHandle.{Counter, Factory, Timer}
 import com.daml.metrics.api.dropwizard.{DropwizardCounter, DropwizardTimer}
-import com.daml.metrics.api.{MetricDoc, MetricName}
+import com.daml.metrics.api.{MetricDoc, MetricHandle, MetricName, MetricsContext}
 
 class LAPIMetrics(val prefix: MetricName, val factory: Factory) {
 
@@ -89,11 +89,14 @@ class LAPIMetrics(val prefix: MetricName, val factory: Factory) {
 
     val activeName: MetricName = prefix :+ "active"
 
+    private val ActiveStreamsDescription =
+      "The number of ledger api streams currently being served to all clients."
     @MetricDoc.Tag(
-      summary = "The number of the actice streams served by the ledger api.",
-      description = "The number of ledger api streams currently being served to all clients.",
+      summary = "The number of the active streams served by the ledger api.",
+      description = ActiveStreamsDescription,
       qualification = Debug,
     )
-    val active: Counter = factory.counter(activeName)
+    val active: MetricHandle.Gauge[Int] =
+      factory.gauge(activeName, 0, ActiveStreamsDescription)(MetricsContext.Empty)
   }
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/ratelimiting/RateLimitingInterceptorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/ratelimiting/RateLimitingInterceptorSpec.scala
@@ -216,7 +216,7 @@ final class RateLimitingInterceptorSpec
         for {
           fStatus1 <- streamHello(channel) // Ok
           fStatus2 <- streamHello(channel) // Ok
-          activeStreams = metrics.daml.lapi.streams.active.getCount
+          activeStreams = metrics.daml.lapi.streams.active.getValue
           fStatus3 <- streamHello(channel) // Limited
           status3 <- fStatus3 // Closed as part of limiting
           _ = waitService.completeStream()
@@ -233,7 +233,7 @@ final class RateLimitingInterceptorSpec
           status3.getCode shouldBe Code.ABORTED
           status3.getDescription should include(metrics.daml.lapi.streams.activeName)
           status4.getCode shouldBe Code.OK
-          eventually { metrics.daml.lapi.streams.active.getCount shouldBe 0 }
+          eventually { metrics.daml.lapi.streams.active.getValue shouldBe 0 }
         }
       }
     }
@@ -255,7 +255,7 @@ final class RateLimitingInterceptorSpec
           fStatus2 <- streamHello(channel)
           fHelloStatus2 = singleHello(channel)
 
-          activeStreams = metrics.daml.lapi.streams.active.getCount
+          activeStreams = metrics.daml.lapi.streams.active.getValue
 
           _ = waitService.completeStream()
           _ = waitService.completeSingle()
@@ -273,7 +273,7 @@ final class RateLimitingInterceptorSpec
           helloStatus1.getCode shouldBe Code.OK
           status2.getCode shouldBe Code.OK
           helloStatus2.getCode shouldBe Code.OK
-          eventually { metrics.daml.lapi.streams.active.getCount shouldBe 0 }
+          eventually { metrics.daml.lapi.streams.active.getValue shouldBe 0 }
         }
       }
     }
@@ -323,7 +323,7 @@ final class RateLimitingInterceptorSpec
       } yield {
         status1.getCode shouldBe Code.CANCELLED
 
-        eventually { metrics.daml.lapi.streams.active.getCount shouldBe 0 }
+        eventually { metrics.daml.lapi.streams.active.getValue shouldBe 0 }
       }
     }
   }


### PR DESCRIPTION
With the update to opentelemetry we will not be able to read the value of a given counter anymore. This is still possible through the use of gauges (as in the actual implementation we store the value of the gauges in an atomic reference).

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
