### PR TITLE
[DPP-1367] Make the ACS pruning tests work for Canton

### DIFF
--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
@@ -727,7 +727,7 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
       ) {
         // We are retrying a command submission + pruning to make this test compatible with Canton.
         // That's because in Canton pruning will fail unless ACS commitments have been exchanged between participants.
-        // To this end, submitting a command is prompting Canton to exchange ACS commitments
+        // To this end, repeatedly submitting commands is prompting Canton to exchange ACS commitments
         // and allows the pruning call to eventually succeed.
         for {
           _ <- ledger.submitAndWait(ledger.submitAndWaitRequest(party, Dummy(party).create.command))

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
@@ -684,7 +684,7 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
         ledger.delayMechanism,
         "Pruning",
       ) {
-        ledger.prune(pruneUpTo = anOffset)
+        ledger.prune(pruneUpTo = anOffset, attempts = 1)
       }
       (acsOffset, acs) <- ledger
         .activeContractsIds(
@@ -718,7 +718,7 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
         ledger.delayMechanism,
         "Pruning",
       ) {
-        ledger.prune(pruneUpTo = offset2)
+        ledger.prune(pruneUpTo = offset2, attempts = 1)
       }
       _ <- ledger
         .activeContractsIds(

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
@@ -679,12 +679,15 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
       anOffset <- ledger.currentEnd()
       _ <- ledger.create(party, Dummy(party))
       _ <- FutureAssertions.succeedsEventually(
-        retryDelay = 10.millis,
+        retryDelay = 100.millis,
         maxRetryDuration = 10.seconds,
         ledger.delayMechanism,
         "Pruning",
       ) {
-        ledger.prune(pruneUpTo = anOffset, attempts = 1)
+        for {
+          _ <- ledger.submitAndWait(ledger.submitAndWaitRequest(party, Dummy(party).create.command))
+          _ <- ledger.prune(pruneUpTo = anOffset, attempts = 1)
+        } yield ()
       }
       (acsOffset, acs) <- ledger
         .activeContractsIds(
@@ -713,12 +716,15 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
       offset2 <- ledger.currentEnd()
       _ <- ledger.create(party, Dummy(party))
       _ <- FutureAssertions.succeedsEventually(
-        retryDelay = 10.millis,
+        retryDelay = 100.millis,
         maxRetryDuration = 10.seconds,
         ledger.delayMechanism,
         "Pruning",
       ) {
-        ledger.prune(pruneUpTo = offset2, attempts = 1)
+        for {
+          _ <- ledger.submitAndWait(ledger.submitAndWaitRequest(party, Dummy(party).create.command))
+          _ <- ledger.prune(pruneUpTo = offset2, attempts = 1)
+        } yield ()
       }
       _ <- ledger
         .activeContractsIds(

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
@@ -684,6 +684,10 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
         ledger.delayMechanism,
         "Pruning",
       ) {
+        // We are retrying a command submission + pruning to make this test compatible with Canton.
+        // That's because in Canton pruning will fail unless ACS commitments have been exchanged between participants.
+        // To this end, submitting a command is prompting Canton to exchange ACS commitments
+        // and allows the pruning call to eventually succeed.
         for {
           _ <- ledger.submitAndWait(ledger.submitAndWaitRequest(party, Dummy(party).create.command))
           _ <- ledger.prune(pruneUpTo = anOffset, attempts = 1)
@@ -721,6 +725,10 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
         ledger.delayMechanism,
         "Pruning",
       ) {
+        // We are retrying a command submission + pruning to make this test compatible with Canton.
+        // That's because in Canton pruning will fail unless ACS commitments have been exchanged between participants.
+        // To this end, submitting a command is prompting Canton to exchange ACS commitments
+        // and allows the pruning call to eventually succeed.
         for {
           _ <- ledger.submitAndWait(ledger.submitAndWaitRequest(party, Dummy(party).create.command))
           _ <- ledger.prune(pruneUpTo = offset2, attempts = 1)


### PR DESCRIPTION
This is based on the prior art: https://github.com/digital-asset/daml/blob/main/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/CommandDeduplicationPeriodValidationIT.scala#L182-L193