### PR TITLE
cron: fix sgnature key

### DIFF
--- a/ci/bash-lib.yml
+++ b/ci/bash-lib.yml
@@ -210,7 +210,7 @@ steps:
     PUB_KEY
         gpg_dir=$(mktemp -d)
         GNUPGHOME=$gpg_dir gpg --no-tty --quiet --import $key
-        GNUPGHOME=$gpg_dir gpg --no-tty --quiet --command-fd 0 --edit-key 4911A8DFE976ACDFA07130DBE8372C0C1C734C51 << CMD
+        GNUPGHOME=$gpg_dir gpg --no-tty --quiet --command-fd 0 --edit-key F26D8A0AADF666CCB28F2AB1650EC3253B6A8FF5 << CMD
     trust
     4
     quit


### PR DESCRIPTION
I _believe_ this is what has been tripping up the check-releses job for the past few days: while updating the signing key, I did not update the key fingerprint to match, and therefore trying to check any signature fails.

The failure mode of the existing script is still pretty bad, regadless: looping on the same release until the hard drive is full is definitely not expected. Our retry policies are supposed to have time bounds, and failure should result in cleaning up the workdir.

run-full-compat: true