### PR TITLE
Remove protobuf compatibility check silencer as 2.5 is released.

### DIFF
--- a/buf-ledger-api.yaml
+++ b/buf-ledger-api.yaml
@@ -16,10 +16,3 @@ breaking:
     - FILE
   except:
     - FILE_NO_DELETE # Avoids errors due to refactored `buf` modules.
-  ignore_only:
-    FIELD_SAME_ONEOF:
-      - com/daml/ledger/api/v1/commands.proto
-    FIELD_SAME_JSON_NAME:
-      - com/daml/ledger/api/v1/commands.proto
-    FIELD_SAME_NAME:
-      - com/daml/ledger/api/v1/commands.proto

--- a/buf-ledger-api.yaml
+++ b/buf-ledger-api.yaml
@@ -10,9 +10,10 @@ build:
 
 breaking:
   use:
-    # Note: FILE disallows field renaming, while WIRE does allow it.
-    # We rely in particular on fields not getting renamed in `UpdateXXX` calls that use a `FieldMask` 
-    # to select the fields to update, see https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/field_mask.proto
     - FILE
-  except:
-    - FILE_NO_DELETE # Avoids errors due to refactored `buf` modules.
+    # Generated source code breaking changes on a per-file basis, that is changes that would
+    # break the generated stubs where definitions cannot be moved across files.
+    # This category also verifies wire and JSON compatibility.
+    #
+    # We rely in particular on fields not getting renamed in `UpdateXXX` calls that use a `FieldMask`
+    # to select the fields to update, see https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/field_mask.proto


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
