### PR TITLE
Flaky test fix of TransactionServiceVisibilityIT

### DIFF
--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceVisibilityIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceVisibilityIT.scala
@@ -29,18 +29,18 @@ import com.daml.test.evidence.tag.Security.SecurityTest.Property.Privacy
 import scala.collection.immutable.Seq
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration.DurationInt
 
 class TransactionServiceVisibilityIT extends LedgerTestSuite {
 
-  // triple eventually wait duration compared to default to avoid database timeouts
+  // quadruple the eventually wait duration compared to default to avoid database timeouts
   // when running against Oracle in enterprise mode
   def eventually[A](
       assertionName: String
   )(runAssertion: => Future[A])(implicit ec: ExecutionContext): Future[A] =
     Eventually.eventually(
       assertionName,
-      firstWaitTime = 30.millis, // compared to default of 10.millis
+      attempts =
+        12, // compared to the default of 10; 4x comes from exponential 2x backoff on each attempt
     )(runAssertion)
 
   def privacyHappyCase(asset: String, happyCase: String)(implicit

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceVisibilityIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceVisibilityIT.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.api.testtool.suites.v1_8
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
-import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
+import com.daml.ledger.api.testtool.infrastructure.Eventually
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
 import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
@@ -28,8 +28,20 @@ import com.daml.test.evidence.tag.Security.SecurityTest.Property.Privacy
 
 import scala.collection.immutable.Seq
 import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.DurationInt
 
 class TransactionServiceVisibilityIT extends LedgerTestSuite {
+
+  // triple eventually wait duration compared to default to avoid database timeouts
+  // when running against Oracle in enterprise mode
+  def eventually[A](
+      assertionName: String
+  )(runAssertion: => Future[A])(implicit ec: ExecutionContext): Future[A] =
+    Eventually.eventually(
+      assertionName,
+      firstWaitTime = 30.millis, // compared to default of 10.millis
+    )(runAssertion)
 
   def privacyHappyCase(asset: String, happyCase: String)(implicit
       lineNo: sourcecode.Line,


### PR DESCRIPTION
when running against OracleDb.

For example we have seen `TransactionServiceVisibilityIT:TXTreeBlinding` time out waiting for one of the three participants to write to oracle db.

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
