### PR TITLE
Expose opentelemetry jvm metrics alongside dropwizard metrics [PLEN-67]

### DIFF
--- a/ledger-service/metrics/src/main/scala/com/digitalasset/metrics/api/reporters/MetricsReporting.scala
+++ b/ledger-service/metrics/src/main/scala/com/digitalasset/metrics/api/reporters/MetricsReporting.scala
@@ -45,6 +45,11 @@ final class MetricsReporting[M](
     for {
       openTelemetry <- OpenTelemetryOwner(registerGlobalOpenTelemetry, extraMetricsReporter)
         .acquire()
+      _ = if (
+        registerGlobalOpenTelemetry
+      ) // if no global lib is registered there is no point in registering them
+        JvmMetricSet
+          .registerObservers() // has to be registered after opentelemetry is created as it uses the global lib
       slf4JReporter <- acquire(newSlf4jReporter(registry))
       _ <- acquire(newJmxReporter(registry))
         .map(_.start())

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/MetricsOwner.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/MetricsOwner.scala
@@ -33,6 +33,7 @@ case class MetricsOwner(meter: Meter, config: MetricsConfig, name: String)
     }
 
     metricRegistry.registerAll(new JvmMetricSet)
+    JvmMetricSet.registerObservers()
 
     Resource(
       Future(

--- a/observability/metrics/BUILD.bazel
+++ b/observability/metrics/BUILD.bazel
@@ -32,6 +32,7 @@ da_scala_library(
         "@maven//:io_dropwizard_metrics_metrics_graphite",
         "@maven//:io_dropwizard_metrics_metrics_jvm",
         "@maven//:io_grpc_grpc_api",
+        "@maven//:io_opentelemetry_instrumentation_opentelemetry_runtime_metrics",
         "@maven//:io_opentelemetry_opentelemetry_api",
         "@maven//:io_opentelemetry_opentelemetry_context",
         "@maven//:io_prometheus_simpleclient",

--- a/observability/metrics/src/main/scala/com/daml/metrics/JvmMetricSet.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/JvmMetricSet.scala
@@ -5,6 +5,7 @@ package com.daml.metrics
 
 import java.util
 
+import io.opentelemetry.instrumentation.runtimemetrics.{GarbageCollector, MemoryPools}
 import com.codahale.metrics.jvm.{
   ClassLoadingGaugeSet,
   GarbageCollectorMetricSet,
@@ -38,4 +39,13 @@ class JvmMetricSet extends MetricSet {
 
 object JvmMetricSet {
   private val Prefix = MetricName("jvm")
+
+  def registerObservers(): Unit = {
+//    BufferPools.registerObservers(openTelemetry)
+//    Classes.registerObservers(openTelemetry)
+//    Cpu.registerObservers(openTelemetry)
+//    Threads.registerObservers(openTelemetry)
+    MemoryPools.registerObservers()
+    GarbageCollector.registerObservers()
+  }
 }


### PR DESCRIPTION
- Minimal set of metrics supported by  opentelemetry at the current time
- With the latest opentelemetry library version we will have a more comprehensive set of metrics that will make the dropwizard ones redundant
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
