### PR TITLE
Remove custom Akka async buffer sizings for event streams - constant 16 (Akka default)

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/configuration/IndexServiceConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/configuration/IndexServiceConfig.scala
@@ -53,9 +53,9 @@ object AcsStreamsConfig {
   val DefaultAcsIdPageSize: Int = 20000
   val DefaultAcsIdPageBufferSize: Int = 1
   val DefaultAcsIdPageWorkingMemoryBytes: Int = 100 * 1024 * 1024
-  val DefaultAcsIdFetchingParallelism: Int = 2
+  val DefaultAcsIdFetchingParallelism: Int = 16
   // Must be a power of 2
-  val DefaultAcsContractFetchingParallelism: Int = 2
+  val DefaultAcsContractFetchingParallelism: Int = 16
 
   val default: AcsStreamsConfig = AcsStreamsConfig()
 }
@@ -68,10 +68,10 @@ case class TransactionFlatStreamsConfig(
     maxParallelIdCreateQueries: Int = 4,
     maxParallelIdConsumingQueries: Int = 4,
     // Must be a power of 2
-    maxParallelPayloadCreateQueries: Int = 2,
+    maxParallelPayloadCreateQueries: Int = 16,
     // Must be a power of 2
-    maxParallelPayloadConsumingQueries: Int = 2,
-    maxParallelPayloadQueries: Int = 2,
+    maxParallelPayloadConsumingQueries: Int = 16,
+    maxParallelPayloadQueries: Int = 16,
     transactionsProcessingParallelism: Int = 8,
 )
 object TransactionFlatStreamsConfig {
@@ -87,12 +87,12 @@ case class TransactionTreeStreamsConfig(
     maxParallelIdConsumingQueries: Int = 8,
     maxParallelIdNonConsumingQueries: Int = 4,
     // Must be a power of 2
-    maxParallelPayloadCreateQueries: Int = 2,
+    maxParallelPayloadCreateQueries: Int = 16,
     // Must be a power of 2
-    maxParallelPayloadConsumingQueries: Int = 2,
+    maxParallelPayloadConsumingQueries: Int = 16,
     // Must be a power of 2
-    maxParallelPayloadNonConsumingQueries: Int = 2,
-    maxParallelPayloadQueries: Int = 2,
+    maxParallelPayloadNonConsumingQueries: Int = 16,
+    maxParallelPayloadQueries: Int = 16,
     transactionsProcessingParallelism: Int = 8,
 )
 object TransactionTreeStreamsConfig {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ACSReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ACSReader.scala
@@ -128,8 +128,8 @@ class ACSReader(
       .async
       .addAttributes(
         Attributes.inputBuffer(
-          initial = config.maxParallelPayloadCreateQueries,
-          max = config.maxParallelPayloadCreateQueries,
+          initial = 16,
+          max = 16,
         )
       )
       .mapAsync(config.maxParallelPayloadCreateQueries)(fetchPayloads)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsFlatStreamReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsFlatStreamReader.scala
@@ -156,10 +156,8 @@ class TransactionsFlatStreamReader(
       ids.async
         .addAttributes(
           Attributes.inputBuffer(
-            // TODO etq: Consider use the nearest greater or equal power of two instead to prevent stream creation failures
-            // TODO etq: Consider removing this buffer completely
-            initial = maxParallelPayloadQueries,
-            max = maxParallelPayloadQueries,
+            initial = 16,
+            max = 16,
           )
         )
         .mapAsync(maxParallelPayloadQueries)(ids =>

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsTreeStreamReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsTreeStreamReader.scala
@@ -153,7 +153,7 @@ class TransactionsTreeStreamReader(
       ids.async
         .addAttributes(
           Attributes
-            .inputBuffer(initial = maxParallelPayloadQueries, max = maxParallelPayloadQueries)
+            .inputBuffer(initial = 16, max = 16)
         )
         .mapAsync(maxParallelPayloadQueries)(ids =>
           payloadQueriesLimiter.execute {

--- a/ledger/sandbox-on-x/reference.conf
+++ b/ledger/sandbox-on-x/reference.conf
@@ -389,7 +389,7 @@ ledger {
           max-pages-per-id-pages-buffer=1
           # Number of contract id pages fetched in parallel when serving ACS calls.
           max-parallel-id-create-queries=2
-          # Number of event pages fetched in parallel when serving ACS calls. Must be a power of 2.
+          # Number of event pages fetched in parallel when serving ACS calls.
           max-parallel-payload-create-queries=2
           # Number of events fetched from the index for every round trip when serving ACS streaming calls.
           # When streaming, the API server will query the database for events in pages
@@ -447,9 +447,9 @@ ledger {
             max-parallel-id-consuming-queries=4
             # Upper bound on the number of per-stream parallel id fetching queries for create events.
             max-parallel-id-create-queries=4
-            # Upper bound on the number of per-stream parallel payload fetching queries for consuming events. Must be a power of 2.
+            # Upper bound on the number of per-stream parallel payload fetching queries for consuming events.
             max-parallel-payload-consuming-queries=2
-            # Upper bound on the number of per-stream parallel payload fetching queries for create events. Must be a power of 2.
+            # Upper bound on the number of per-stream parallel payload fetching queries for create events.
             max-parallel-payload-create-queries=2
             # Upper bound on the number of per-stream parallel payload fetching queries (sum of payload fetching queries for consuming and create events).
             max-parallel-payload-queries=2
@@ -481,11 +481,11 @@ ledger {
             max-parallel-id-create-queries=8
             # Upper bound on the number of per-stream parallel id fetching queries for non-consuming events.
             max-parallel-id-non-consuming-queries=4
-            # Upper bound on the number of per-stream parallel payload fetching queries for consuming events. Must be a power of 2.
+            # Upper bound on the number of per-stream parallel payload fetching queries for consuming events.
             max-parallel-payload-consuming-queries=2
-            # Upper bound on the number of per-stream parallel payload fetching queries for create events. Must be a power of 2.
+            # Upper bound on the number of per-stream parallel payload fetching queries for create events.
             max-parallel-payload-create-queries=2
-            # Upper bound on the number of per-stream parallel payload fetching queries for non-consuming events. Must be a power of 2.
+            # Upper bound on the number of per-stream parallel payload fetching queries for non-consuming events.
             max-parallel-payload-non-consuming-queries=2
             # Upper bound on the number of per-stream parallel payload fetching queries (sum of payload fetching queries for consuming, non-consuming and create events)
             max-parallel-payload-queries=2

--- a/ledger/sandbox-on-x/resources/generated-default.conf
+++ b/ledger/sandbox-on-x/resources/generated-default.conf
@@ -86,8 +86,8 @@ ledger {
                 acs-streams {
                     max-ids-per-id-page=20000
                     max-pages-per-id-pages-buffer=1
-                    max-parallel-id-create-queries=2
-                    max-parallel-payload-create-queries=2
+                    max-parallel-id-create-queries=16
+                    max-parallel-payload-create-queries=16
                     max-payloads-per-payloads-page=1000
                     max-working-memory-in-bytes-for-id-pages=104857600
                 }
@@ -108,9 +108,9 @@ ledger {
                     max-pages-per-id-pages-buffer=1
                     max-parallel-id-consuming-queries=4
                     max-parallel-id-create-queries=4
-                    max-parallel-payload-consuming-queries=2
-                    max-parallel-payload-create-queries=2
-                    max-parallel-payload-queries=2
+                    max-parallel-payload-consuming-queries=16
+                    max-parallel-payload-create-queries=16
+                    max-parallel-payload-queries=16
                     max-payloads-per-payloads-page=1000
                     max-working-memory-in-bytes-for-id-pages=104857600
                     transactions-processing-parallelism=8
@@ -121,10 +121,10 @@ ledger {
                     max-parallel-id-consuming-queries=8
                     max-parallel-id-create-queries=8
                     max-parallel-id-non-consuming-queries=4
-                    max-parallel-payload-consuming-queries=2
-                    max-parallel-payload-create-queries=2
-                    max-parallel-payload-non-consuming-queries=2
-                    max-parallel-payload-queries=2
+                    max-parallel-payload-consuming-queries=16
+                    max-parallel-payload-create-queries=16
+                    max-parallel-payload-non-consuming-queries=16
+                    max-parallel-payload-queries=16
                     max-payloads-per-payloads-page=1000
                     max-working-memory-in-bytes-for-id-pages=104857600
                     transactions-processing-parallelism=8


### PR DESCRIPTION
TODO: This needs to be benchmarked