### PR TITLE
Remove @stefanobaghino-da from the `CODEOWNERS` for `/docs`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -79,7 +79,7 @@ NOTICES     @garyverhaegen-da @dasormeter
 /triggers/service/     @ray-roestenburg-da
 
 # Misc
-/docs/              @stefanobaghino-da @digital-asset/daml-docs @hrischuk-da
+/docs/              @digital-asset/daml-docs @hrischuk-da
 /libs-scala/nonempty-cats/src/    @S11001001
 /libs-scala/scala-utils/src/    @S11001001
 /libs-scala/scalatest-utils/src/    @S11001001


### PR DESCRIPTION
Now that the @digital-asset/daml-docs team is in charge (and that I am rolling back to engineering) there is no need for me to keep constantly an eye on this specific directory.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
