### PR TITLE
Move Enum section in Understand the Generated Java

### DIFF
--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -312,42 +312,6 @@ The Java code generated for this variant is:
     public Variant toValue() { /* ... */ }
   }
 
-Parameterized Types
-^^^^^^^^^^^^^^^^^^^
-
-.. note::
-
-   This section is only included for completeness: we don't expect users to make use of the ``fromValue`` and ``toValue`` methods, because they would typically come from a template that doesn't have any unbound type parameters.
-
-The Java codegen uses Java Generic types to represent :ref:`Daml parameterized types <daml-ref-parameterized-types>`.
-
-This Daml fragment defines the parameterized type ``Attribute``, used by the ``BookAttribute`` type for modeling the characteristics of the book:
-
-.. literalinclude:: ./code-snippets/Com/Acme/ParameterizedTypes.daml
-   :language: daml
-   :start-after: -- start snippet: parameterized types example
-   :end-before: -- end snippet: parameterized types example
-   :caption: Com/Acme/ParametrizedTypes.daml
-
-The Java codegen generates a Java file with a generic class for  the ``Attribute a`` data type:
-
-.. code-block:: java
-  :caption: com/acme/parametrizedtypes/Attribute.java
-  :emphasize-lines: 3,8,10
-
-  package com.acme.parametrizedtypes;
-
-  public class Attribute<a> {
-    public final a value;
-
-    public Attribute(a value) { /* ... */  }
-
-    public DamlRecord toValue(Function<a, Value> toValuea) { /* ... */ }
-
-    public static <a> Attribute<a> fromValue(Value value$, Function<Value, a> fromValuea) { /* ... */ }
-  }
-
-
 Enums
 ^^^^^
 
@@ -383,6 +347,42 @@ The Java code generated for this variant is:
 
     public final DamlEnum toValue() { /* ... */ }
   }
+
+Parameterized Types
+^^^^^^^^^^^^^^^^^^^
+
+.. note::
+
+   This section is only included for completeness: we don't expect users to make use of the ``fromValue`` and ``toValue`` methods, because they would typically come from a template that doesn't have any unbound type parameters.
+
+The Java codegen uses Java Generic types to represent :ref:`Daml parameterized types <daml-ref-parameterized-types>`.
+
+This Daml fragment defines the parameterized type ``Attribute``, used by the ``BookAttribute`` type for modeling the characteristics of the book:
+
+.. literalinclude:: ./code-snippets/Com/Acme/ParameterizedTypes.daml
+   :language: daml
+   :start-after: -- start snippet: parameterized types example
+   :end-before: -- end snippet: parameterized types example
+   :caption: Com/Acme/ParametrizedTypes.daml
+
+The Java codegen generates a Java file with a generic class for  the ``Attribute a`` data type:
+
+.. code-block:: java
+  :caption: com/acme/parametrizedtypes/Attribute.java
+  :emphasize-lines: 3,8,10
+
+  package com.acme.parametrizedtypes;
+
+  public class Attribute<a> {
+    public final a value;
+
+    public Attribute(a value) { /* ... */  }
+
+    public DamlRecord toValue(Function<a, Value> toValuea) { /* ... */ }
+
+    public static <a> Attribute<a> fromValue(Value value$, Function<Value, a> fromValuea) { /* ... */ }
+  }
+
 
 Convert a Value of a Generated Type to a Java Bindings Value
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -333,18 +333,13 @@ The Java code generated for this variant is:
 
   package com.acme.enum;
 
-
   public enum Color implements DamlEnum<Color> {
     RED,
-
     GREEN,
-
     BLUE;
 
     /* ... */
-
     public static final Color fromValue(Value value$) { /* ... */ }
-
     public final DamlEnum toValue() { /* ... */ }
   }
 

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -384,24 +384,6 @@ The Java code generated for this variant is:
     public final DamlEnum toValue() { /* ... */ }
   }
 
-
-
-.. code-block:: java
-  :caption: com/acme/enum/bookattribute/Authors.java
-
-  package com.acme.enum.bookattribute;
-
-  public class Authors extends BookAttribute {
-    public final List<String> listValue;
-
-    public static Authors fromValue(Value value) { /* ... */ }
-
-    public Author(List<String> listValue) { /* ... */ }
-    public Value toValue() { /* ... */ }
-
-  }
-
-
 Convert a Value of a Generated Type to a Java Bindings Value
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -348,7 +348,7 @@ Parameterized Types
 
 .. note::
 
-   This section is only included for completeness: we don't expect users to make use of the ``fromValue`` and ``toValue`` methods, because they would typically come from a template that doesn't have any unbound type parameters.
+   This section is only included for completeness. The ``fromValue`` and ``toValue`` methods would typically come from a template that doesn't have any unbound type parameters.
 
 The Java codegen uses Java Generic types to represent :ref:`Daml parameterized types <daml-ref-parameterized-types>`.
 

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -358,7 +358,7 @@ This Daml fragment defines the parameterized type ``Attribute``, used by the ``B
    :language: daml
    :start-after: -- start snippet: parameterized types example
    :end-before: -- end snippet: parameterized types example
-   :caption: Com/Acme/ParametrizedTypes.daml
+   :caption: Com/Acme/ParameterizedTypes.daml
 
 The Java codegen generates a Java file with a generic class for  the ``Attribute a`` data type:
 

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -363,10 +363,10 @@ This Daml fragment defines the parameterized type ``Attribute``, used by the ``B
 The Java codegen generates a Java file with a generic class for  the ``Attribute a`` data type:
 
 .. code-block:: java
-  :caption: com/acme/parametrizedtypes/Attribute.java
+  :caption: com/acme/parameterizedtypes/Attribute.java
   :emphasize-lines: 3,8,10
 
-  package com.acme.parametrizedtypes;
+  package com.acme.parameterizedtypes;
 
   public class Attribute<a> {
     public final a value;


### PR DESCRIPTION
There appear to be two copy-and-paste issues on the [Generate Java Code from Daml page](https://docs.daml.com/app-dev/bindings-java/codegen.html#enums).

* The `Authors.java` code sample appears on the page twice.
* The **Enums** section appears to have been copy-and-pasted into the wrong location. It is *right in the middle of* the **Parameterized Types** section.
* The **Enums** sample code has extra empty lines.

This PR does this (see the commit history):

* Deletes the old, spurious copy of the `Authors.java` code sample from this page.
* Moves the **Enum** section up several lines to be *before* the  **Parameterized Types** section.
* Removes extra empty lines in the Enum's `Color.java` sample.