### PR TITLE
[DPP-1363] Use largest smaller power of two for Akka async input buffers for ETQ streams

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/configuration/IndexServiceConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/configuration/IndexServiceConfig.scala
@@ -67,9 +67,7 @@ case class TransactionFlatStreamsConfig(
     maxPayloadsPerPayloadsPage: Int = 1000,
     maxParallelIdCreateQueries: Int = 4,
     maxParallelIdConsumingQueries: Int = 4,
-    // Must be a power of 2
     maxParallelPayloadCreateQueries: Int = 2,
-    // Must be a power of 2
     maxParallelPayloadConsumingQueries: Int = 2,
     maxParallelPayloadQueries: Int = 2,
     transactionsProcessingParallelism: Int = 8,
@@ -86,11 +84,8 @@ case class TransactionTreeStreamsConfig(
     maxParallelIdCreateQueries: Int = 8,
     maxParallelIdConsumingQueries: Int = 8,
     maxParallelIdNonConsumingQueries: Int = 4,
-    // Must be a power of 2
     maxParallelPayloadCreateQueries: Int = 2,
-    // Must be a power of 2
     maxParallelPayloadConsumingQueries: Int = 2,
-    // Must be a power of 2
     maxParallelPayloadNonConsumingQueries: Int = 2,
     maxParallelPayloadQueries: Int = 2,
     transactionsProcessingParallelism: Int = 8,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ACSReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ACSReader.scala
@@ -116,6 +116,8 @@ class ACSReader(
         }
       )
 
+    // Akka requires for this buffer's size to be a power of two.
+    val inputBufferSize = Utils.largestSmallerPowerOfTwo(config.maxParallelPayloadCreateQueries)
     decomposedFilters
       .map(fetchIds)
       .pipe(EventIdsUtils.sortAndDeduplicateIds)
@@ -126,12 +128,7 @@ class ACSReader(
         )
       )
       .async
-      .addAttributes(
-        Attributes.inputBuffer(
-          initial = config.maxParallelPayloadCreateQueries,
-          max = config.maxParallelPayloadCreateQueries,
-        )
-      )
+      .addAttributes(Attributes.inputBuffer(initial = inputBufferSize, max = inputBufferSize))
       .mapAsync(config.maxParallelPayloadCreateQueries)(fetchPayloads)
   }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ACSReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ACSReader.scala
@@ -117,7 +117,8 @@ class ACSReader(
       )
 
     // Akka requires for this buffer's size to be a power of two.
-    val inputBufferSize = Utils.largestSmallerPowerOfTwo(config.maxParallelPayloadCreateQueries)
+    val inputBufferSize =
+      Utils.largestSmallerOrEqualPowerOfTwo(config.maxParallelPayloadCreateQueries)
     decomposedFilters
       .map(fetchIds)
       .pipe(EventIdsUtils.sortAndDeduplicateIds)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsFlatStreamReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsFlatStreamReader.scala
@@ -153,15 +153,10 @@ class TransactionsFlatStreamReader(
         maxParallelPayloadQueries: Int,
         dbMetric: DatabaseMetrics,
     ): Source[EventStorageBackend.Entry[Raw.FlatEvent], NotUsed] = {
+      // Akka requires for this buffer's size to be a power of two.
+      val inputBufferSize = Utils.largestSmallerPowerOfTwo(maxParallelPayloadQueries)
       ids.async
-        .addAttributes(
-          Attributes.inputBuffer(
-            // TODO etq: Consider use the nearest greater or equal power of two instead to prevent stream creation failures
-            // TODO etq: Consider removing this buffer completely
-            initial = maxParallelPayloadQueries,
-            max = maxParallelPayloadQueries,
-          )
-        )
+        .addAttributes(Attributes.inputBuffer(initial = inputBufferSize, max = inputBufferSize))
         .mapAsync(maxParallelPayloadQueries)(ids =>
           payloadQueriesLimiter.execute {
             globalPayloadQueriesLimiter.execute {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsFlatStreamReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsFlatStreamReader.scala
@@ -154,7 +154,7 @@ class TransactionsFlatStreamReader(
         dbMetric: DatabaseMetrics,
     ): Source[EventStorageBackend.Entry[Raw.FlatEvent], NotUsed] = {
       // Akka requires for this buffer's size to be a power of two.
-      val inputBufferSize = Utils.largestSmallerPowerOfTwo(maxParallelPayloadQueries)
+      val inputBufferSize = Utils.largestSmallerOrEqualPowerOfTwo(maxParallelPayloadQueries)
       ids.async
         .addAttributes(Attributes.inputBuffer(initial = inputBufferSize, max = inputBufferSize))
         .mapAsync(maxParallelPayloadQueries)(ids =>

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsTreeStreamReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsTreeStreamReader.scala
@@ -151,7 +151,7 @@ class TransactionsTreeStreamReader(
         metric: DatabaseMetrics,
     ): Source[EventStorageBackend.Entry[Raw.TreeEvent], NotUsed] = {
       // Akka requires for this buffer's size to be a power of two.
-      val inputBufferSize = Utils.largestSmallerPowerOfTwo(maxParallelPayloadQueries)
+      val inputBufferSize = Utils.largestSmallerOrEqualPowerOfTwo(maxParallelPayloadQueries)
       ids.async
         .addAttributes(Attributes.inputBuffer(initial = inputBufferSize, max = inputBufferSize))
         .mapAsync(maxParallelPayloadQueries)(ids =>

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsTreeStreamReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsTreeStreamReader.scala
@@ -150,11 +150,10 @@ class TransactionsTreeStreamReader(
         maxParallelPayloadQueries: Int,
         metric: DatabaseMetrics,
     ): Source[EventStorageBackend.Entry[Raw.TreeEvent], NotUsed] = {
+      // Akka requires for this buffer's size to be a power of two.
+      val inputBufferSize = Utils.largestSmallerPowerOfTwo(maxParallelPayloadQueries)
       ids.async
-        .addAttributes(
-          Attributes
-            .inputBuffer(initial = maxParallelPayloadQueries, max = maxParallelPayloadQueries)
-        )
+        .addAttributes(Attributes.inputBuffer(initial = inputBufferSize, max = inputBufferSize))
         .mapAsync(maxParallelPayloadQueries)(ids =>
           payloadQueriesLimiter.execute {
             globalPayloadQueriesLimiter.execute {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/Utils.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/Utils.scala
@@ -7,7 +7,7 @@ object Utils {
 
   /** @param n needs to be positive
     */
-  def largestSmallerPowerOfTwo(n: Int): Int =
+  def largestSmallerOrEqualPowerOfTwo(n: Int): Int =
     Integer.highestOneBit(n)
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/Utils.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/Utils.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.dao.events
+
+object Utils {
+
+  /** @param n needs to be positive
+    */
+  def largestSmallerPowerOfTwo(n: Int): Int =
+    Integer.highestOneBit(n)
+
+}

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/UtilsSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/UtilsSpec.scala
@@ -9,14 +9,14 @@ import org.scalatest.matchers.should.Matchers
 class UtilsSpec extends AnyFlatSpec with Matchers {
 
   it should "compute largest smaller power of two" in {
-    Utils.largestSmallerPowerOfTwo(31) shouldBe 16
-    Utils.largestSmallerPowerOfTwo(16) shouldBe 16
-    Utils.largestSmallerPowerOfTwo(9) shouldBe 8
-    Utils.largestSmallerPowerOfTwo(8) shouldBe 8
-    Utils.largestSmallerPowerOfTwo(7) shouldBe 4
-    Utils.largestSmallerPowerOfTwo(5) shouldBe 4
-    Utils.largestSmallerPowerOfTwo(3) shouldBe 2
-    Utils.largestSmallerPowerOfTwo(2) shouldBe 2
-    Utils.largestSmallerPowerOfTwo(1) shouldBe 1
+    Utils.largestSmallerOrEqualPowerOfTwo(31) shouldBe 16
+    Utils.largestSmallerOrEqualPowerOfTwo(16) shouldBe 16
+    Utils.largestSmallerOrEqualPowerOfTwo(9) shouldBe 8
+    Utils.largestSmallerOrEqualPowerOfTwo(8) shouldBe 8
+    Utils.largestSmallerOrEqualPowerOfTwo(7) shouldBe 4
+    Utils.largestSmallerOrEqualPowerOfTwo(5) shouldBe 4
+    Utils.largestSmallerOrEqualPowerOfTwo(3) shouldBe 2
+    Utils.largestSmallerOrEqualPowerOfTwo(2) shouldBe 2
+    Utils.largestSmallerOrEqualPowerOfTwo(1) shouldBe 1
   }
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/UtilsSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/UtilsSpec.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.dao.events
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class UtilsSpec extends AnyFlatSpec with Matchers {
+
+  it should "compute largest smaller power of two" in {
+    Utils.largestSmallerPowerOfTwo(31) shouldBe 16
+    Utils.largestSmallerPowerOfTwo(16) shouldBe 16
+    Utils.largestSmallerPowerOfTwo(9) shouldBe 8
+    Utils.largestSmallerPowerOfTwo(8) shouldBe 8
+    Utils.largestSmallerPowerOfTwo(7) shouldBe 4
+    Utils.largestSmallerPowerOfTwo(5) shouldBe 4
+    Utils.largestSmallerPowerOfTwo(3) shouldBe 2
+    Utils.largestSmallerPowerOfTwo(2) shouldBe 2
+    Utils.largestSmallerPowerOfTwo(1) shouldBe 1
+  }
+}


### PR DESCRIPTION
Thanks to that a number of payload processing parallelism config keys can be now any (reasonably small) positive integers. Previously they had to be powers of two.