### PR TITLE
[engine] scoped authority change via SBWithAuthority primitive

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PhaseOne.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PhaseOne.scala
@@ -470,8 +470,10 @@ private[lf] final class PhaseOne(
           // List functions
           case BFoldl => SBFoldl
           case BFoldr => SBFoldr
-          case BWithAuthority => SBWithAuthority
           case BEqualList => SBEqualList
+
+          // Authority functions
+          case BWithAuthority => SBWithAuthority
 
           // Errors
           case BError => SBUserError

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -1733,6 +1733,15 @@ private[lf] object Speedy {
       }
   }
 
+  private[speedy] final case object KCloseWithAuthority extends Kont {
+
+    override def execute[Q](machine: Machine[Q], result: SValue): Control[Q] =
+      machine.asUpdateMachine(productPrefix) { machine =>
+        machine.ptx = machine.ptx.endWithAuthority
+        Control.Value(result)
+      }
+  }
+
   /** KTryCatchHandler marks the kont-stack to allow unwinding when throw is executed. If
     * the continuation is entered normally, the environment is restored but the handler is
     * not executed.  When a throw is executed, the kont-stack is unwound to the nearest

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
@@ -34,7 +34,7 @@ class RollbackTest extends AnyWordSpec with Matchers with TableDrivenPropertyChe
     val machine = Speedy.Machine.fromUpdateSExpr(pkgs1, transactionSeed, example, Set(party))
     SpeedyTestLib
       .buildTransaction(machine)
-      .fold(e => fail(Pretty.prettyError(e).toString()), identity)
+      .fold(e => fail(Pretty.prettyError(e).render(80)), identity)
   }
 
   val pkgs: PureCompiledPackages = SpeedyTestLib.typeAndCompile(p"""

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/WithAuthorityTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/WithAuthorityTest.scala
@@ -1,0 +1,75 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+
+import com.daml.lf.data.Ref.Party
+import com.daml.lf.language.Ast.Expr
+import com.daml.lf.speedy.SExpr._
+import com.daml.lf.speedy.SValue._
+import com.daml.lf.testing.parser.Implicits._
+import com.daml.lf.transaction.SubmittedTransaction
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.Inside
+
+import com.daml.lf.speedy.SError._
+
+class WithAuthorityTest
+    extends AnyFreeSpec
+    with Matchers
+    with TableDrivenPropertyChecks
+    with Inside {
+
+  import SpeedyTestLib.loggingContext
+
+  private[this] val transactionSeed = crypto.Hash.hashPrivateKey("WithAuthorityTest.scala")
+
+  val pkgs: PureCompiledPackages = SpeedyTestLib.typeAndCompile(p"""
+      module M {
+
+        record @serializable T1 = { party: Party, info: Int64 } ;
+        template (record : T1) = {
+          precondition True;
+          signatories Cons @Party [M:T1 {party} record] (Nil @Party);
+          observers Nil @Party;
+          agreement "Agreement";
+        };
+
+        val entryPoint : Party-> Party -> Party -> Update Unit =
+          \(a: Party) -> \(b: Party) -> \(c: Party) ->
+
+           // nested calls to WITH_AUTHORITY...
+           WITH_AUTHORITY @Unit (Cons @Party [b] Nil@Party)
+           (WITH_AUTHORITY @Unit (Cons @Party [c] Nil@Party)
+            (ubind
+              x1: ContractId M:T1 <- create @M:T1 M:T1 { party = c, info = 100 }
+            in upure @Unit ()));
+       }
+      """)
+
+  "NEW" - {
+    "new test" in {
+      val alice = Party.assertFromString("Alice")
+      val bob = Party.assertFromString("Bob")
+      val charlie = Party.assertFromString("Charlie")
+      val exp: Expr = e"M:entryPoint"
+      val se: SExpr = pkgs.compiler.unsafeCompile(exp)
+      val example: SExpr = SEApp(se, Array(SParty(alice), SParty(bob), SParty(charlie)))
+      val committers: Set[Party] = Set(alice)
+      val machine: Speedy.UpdateMachine =
+        Speedy.Machine.fromUpdateSExpr(pkgs, transactionSeed, example, committers)
+      val either: Either[SError, SubmittedTransaction] = SpeedyTestLib.buildTransaction(machine)
+      either match {
+        case Right(tx) =>
+          println(s"TX=$tx")
+        case Left(e) =>
+          fail(Pretty.prettyError(e).render(80))
+      }
+
+    }
+  }
+
+}


### PR DESCRIPTION
Support scoped authority change via `SBWithAuthority` primitive:
- drive with small Daml-LF example constructed using remy-parser
- correct evaluation order achieved by having primitive wait for `SToken`
- `partialTransaction`: `beginWithAuthority`, `endWithAuthority`, `WithAuthorityContextInfo`
- primitive calls `beginWithAuthority`
- primitive pushes continuation `KCloseWithAuthority` to call `endWithAuthority`

TODO (in later PRs)
- determine if new authority is required, or if this is just an authority restriction
- ask ledger if required new authority is allowed
- construct TX node to record the authority change

Advances #15882
