### PR TITLE
Add GetLatestPrunedOffsets to TransactionService [DPP-1394]

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -917,6 +917,18 @@ excluded_test_tool_tests = [
             },
         ],
     },
+    {
+        "start": "2.6.0-snapshot.20230123.11292.1",
+        "platform_ranges": [
+            {
+                "end": "2.6.0-snapshot.20230123.11292.0.b3f84bfc",
+                "exclusions": [
+                    # This test relies on a new Ledger API endpoint. Disable it for prior platforms
+                    "ParticipantPruningIT:PRQueryLatestPrunedOffsets",
+                ],
+            },
+        ],
+    },
 ]
 
 def in_range(version, range):

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionsServiceImpl.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionsServiceImpl.scala
@@ -42,6 +42,7 @@ final class TransactionsServiceImpl(ledgerContent: Observable[LedgerItem])
   val lastFlatTransactionByEventIdRequest = new AtomicReference[GetTransactionByEventIdRequest]()
   val lastFlatTransactionByIdRequest = new AtomicReference[GetTransactionByIdRequest]()
   val lastLedgerEndRequest = new AtomicReference[GetLedgerEndRequest]()
+  val lastLatestPrunedOffsetsRequest = new AtomicReference[GetLatestPrunedOffsetsRequest]
 
   override def getTransactions(
       request: GetTransactionsRequest,
@@ -118,6 +119,15 @@ final class TransactionsServiceImpl(ledgerContent: Observable[LedgerItem])
         .last(GetLedgerEndResponse(Option(LedgerOffset(Boundary(LEDGER_BEGIN)))))
     result.subscribe(promise.success _, promise.failure _)
     promise.future
+  }
+
+  override def getLatestPrunedOffsets(
+      request: GetLatestPrunedOffsetsRequest
+  ): Future[GetLatestPrunedOffsetsResponse] = {
+    lastLatestPrunedOffsetsRequest.set(request)
+    Future.successful(
+      new GetLatestPrunedOffsetsResponse(None)
+    ) // just a mock, not intended for consumption
   }
 
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
@@ -43,6 +43,9 @@ service TransactionService {
   // Subscriptions started with the returned offset will serve transactions created after this RPC was called.
   rpc GetLedgerEnd (GetLedgerEndRequest) returns (GetLedgerEndResponse);
 
+  // Get the latest successfully pruned ledger offsets
+  rpc GetLatestPrunedOffsets (GetLatestPrunedOffsetsRequest) returns (GetLatestPrunedOffsetsResponse);
+
 }
 
 message GetTransactionsRequest {
@@ -140,3 +143,16 @@ message GetLedgerEndResponse {
   LedgerOffset offset = 1;
 }
 
+message GetLatestPrunedOffsetsRequest {
+  // Empty for now, but may contain fields in the future
+}
+
+message GetLatestPrunedOffsetsResponse {
+  // The offset up until the ledger has been pruned, excluding divulgence events
+  // (when the PruneRequest was issued with prune_all_divulged_contracts=false)
+  LedgerOffset participant_pruned_up_to_inclusive = 1;
+
+  // The offset up until the ledger has been pruned including all divulgence events
+  // (when the PruneRequest was issued with prune_all_divulged_contracts=true)
+  LedgerOffset all_divulged_contracts_pruned_up_to_inclusive = 2;
+}

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
@@ -144,15 +144,15 @@ message GetLedgerEndResponse {
 }
 
 message GetLatestPrunedOffsetsRequest {
-  // Empty for now, but may contain fields in the future
+  // Empty for now, but may contain fields in the future.
 }
 
 message GetLatestPrunedOffsetsResponse {
-  // The offset up until the ledger has been pruned, excluding divulgence events
-  // (when the PruneRequest was issued with prune_all_divulged_contracts=false)
+  // The offset up until the ledger has been pruned, without pruning divulgence events.
   LedgerOffset participant_pruned_up_to_inclusive = 1;
 
-  // The offset up until the ledger has been pruned including all divulgence events
-  // (when the PruneRequest was issued with prune_all_divulged_contracts=true)
+  // The offset up until the ledger has been pruned including pruning all divulgence events.
+  // For more details about all divulgence events pruning,
+  // see PruneRequest.prune_all_divulged_contracts in ``participant_pruning_service.proto``.
   LedgerOffset all_divulged_contracts_pruned_up_to_inclusive = 2;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
@@ -148,11 +148,12 @@ message GetLatestPrunedOffsetsRequest {
 }
 
 message GetLatestPrunedOffsetsResponse {
-  // The offset up until the ledger has been pruned, without pruning all divulgence events.
+  // The offset up to which the ledger has been pruned, disregarding the state of all divulged contracts pruning.
   LedgerOffset participant_pruned_up_to_inclusive = 1;
 
-  // The offset up until the ledger has been pruned including pruning all divulgence events.
-  // For more details about all divulgence events pruning,
-  // see PruneRequest.prune_all_divulged_contracts in ``participant_pruning_service.proto``.
+  // The offset up to which all divulged events have been pruned on the ledger. It can be at or before the
+  // ``participant_pruned_up_to_inclusive`` offset.
+  // For more details about all divulged events pruning,
+  // see ``PruneRequest.prune_all_divulged_contracts`` in ``participant_pruning_service.proto``.
   LedgerOffset all_divulged_contracts_pruned_up_to_inclusive = 2;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
@@ -148,7 +148,7 @@ message GetLatestPrunedOffsetsRequest {
 }
 
 message GetLatestPrunedOffsetsResponse {
-  // The offset up until the ledger has been pruned, without pruning divulgence events.
+  // The offset up until the ledger has been pruned, without pruning all divulgence events.
   LedgerOffset participant_pruned_up_to_inclusive = 1;
 
   // The offset up until the ledger has been pruned including pruning all divulgence events.

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/TransactionServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/TransactionServiceAuthorization.scala
@@ -75,6 +75,11 @@ private[daml] final class TransactionServiceAuthorization(
   override def getLedgerEnd(request: GetLedgerEndRequest): Future[GetLedgerEndResponse] =
     authorizer.requirePublicClaims(service.getLedgerEnd)(request)
 
+  override def getLatestPrunedOffsets(
+      request: GetLatestPrunedOffsetsRequest
+  ): Future[GetLatestPrunedOffsetsResponse] =
+    authorizer.requirePublicClaims(service.getLatestPrunedOffsets)(request)
+
   override def bindService(): ServerServiceDefinition =
     TransactionServiceGrpc.bindService(this, executionContext)
 

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/TransactionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/TransactionService.scala
@@ -14,6 +14,7 @@ import com.daml.ledger.api.messages.transaction.{
 }
 import com.daml.ledger.api.v1.transaction_service.{
   GetFlatTransactionResponse,
+  GetLatestPrunedOffsetsResponse,
   GetTransactionResponse,
   GetTransactionTreesResponse,
   GetTransactionsResponse,
@@ -51,4 +52,6 @@ trait TransactionService {
   def getFlatTransactionByEventId(
       req: GetTransactionByEventIdRequest
   )(implicit loggingContext: LoggingContext): Future[GetFlatTransactionResponse]
+
+  def getLatestPrunedOffsets: Future[GetLatestPrunedOffsetsResponse]
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcTransactionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcTransactionService.scala
@@ -96,7 +96,7 @@ final class GrpcTransactionService(
 
   override def getTransactionByEventId(
       request: GetTransactionByEventIdRequest
-  ): Future[GetTransactionResponse] = {
+  ): Future[GetTransactionResponse] =
     withEnrichedLoggingContext(traceId(telemetry.traceIdFromGrpcContext)) {
       implicit loggingContext =>
         getSingleTransaction(
@@ -105,11 +105,10 @@ final class GrpcTransactionService(
           service.getTransactionByEventId,
         )
     }
-  }
 
   override def getTransactionById(
       request: GetTransactionByIdRequest
-  ): Future[GetTransactionResponse] = {
+  ): Future[GetTransactionResponse] =
     withEnrichedLoggingContext(traceId(telemetry.traceIdFromGrpcContext)) {
       implicit loggingContext =>
         getSingleTransaction(
@@ -118,11 +117,10 @@ final class GrpcTransactionService(
           service.getTransactionById,
         )
     }
-  }
 
   override def getFlatTransactionByEventId(
       request: GetTransactionByEventIdRequest
-  ): Future[GetFlatTransactionResponse] = {
+  ): Future[GetFlatTransactionResponse] =
     withEnrichedLoggingContext(traceId(telemetry.traceIdFromGrpcContext)) {
       implicit loggingContext =>
         getSingleTransaction(
@@ -131,11 +129,10 @@ final class GrpcTransactionService(
           service.getFlatTransactionByEventId,
         )
     }
-  }
 
   override def getFlatTransactionById(
       request: GetTransactionByIdRequest
-  ): Future[GetFlatTransactionResponse] = {
+  ): Future[GetFlatTransactionResponse] =
     withEnrichedLoggingContext(traceId(telemetry.traceIdFromGrpcContext)) {
       implicit loggingContext =>
         getSingleTransaction(
@@ -144,7 +141,6 @@ final class GrpcTransactionService(
           service.getFlatTransactionById,
         )
     }
-  }
 
   override def getLedgerEnd(request: GetLedgerEndRequest): Future[GetLedgerEndResponse] = {
     val validation = validator.validateLedgerEnd(request)
@@ -163,4 +159,7 @@ final class GrpcTransactionService(
   override def bindService(): ServerServiceDefinition =
     TransactionServiceGrpc.bindService(this, executionContext)
 
+  override def getLatestPrunedOffsets(
+      request: GetLatestPrunedOffsetsRequest
+  ): Future[GetLatestPrunedOffsetsResponse] = service.getLatestPrunedOffsets
 }

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -80,6 +80,8 @@ conformance_test_tool_args = [
         "CommandDeduplicationPeriodValidationIT:OffsetPruned",  # requires pruning not available in canton community
         "ActiveContractsServiceIT:AcsBeforePruningOffsetIsDisallowed",  # requires pruning not available in canton community
         "ActiveContractsServiceIT:AcsAtPruningOffsetIsAllowed",  # requires pruning not available in canton community
+        # TODO pruning: Disable this exclusion once the round-trip is finished
+        "ParticipantPruningIT:PRQueryLatestPrunedOffsets",
     ]),
 ]
 

--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContexts.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContexts.scala
@@ -422,6 +422,7 @@ trait ParticipantTestContext extends UserManagementTestContext {
       pruneAllDivulgedContracts: Boolean = false,
   ): Future[PruneResponse]
 
+  def latestPrunedOffsets(): Future[(LedgerOffset, LedgerOffset)]
 }
 
 object ParticipantTestContext {

--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/SingleParticipantTestContext.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/SingleParticipantTestContext.scala
@@ -88,6 +88,7 @@ import com.daml.ledger.api.v1.transaction_filter.{
   TransactionFilter,
 }
 import com.daml.ledger.api.v1.transaction_service.{
+  GetLatestPrunedOffsetsRequest,
   GetLedgerEndRequest,
   GetTransactionByEventIdRequest,
   GetTransactionByIdRequest,
@@ -169,6 +170,13 @@ final class SingleParticipantTestContext private[participant] (
     services.transaction
       .getLedgerEnd(new GetLedgerEndRequest(overrideLedgerId))
       .map(_.getOffset)
+
+  override def latestPrunedOffsets(): Future[(LedgerOffset, LedgerOffset)] =
+    services.transaction
+      .getLatestPrunedOffsets(GetLatestPrunedOffsetsRequest())
+      .map(response =>
+        response.getParticipantPrunedUpToInclusive -> response.getAllDivulgedContractsPrunedUpToInclusive
+      )
 
   override def offsetBeyondLedgerEnd(): Future[LedgerOffset] =
     currentEnd().map(end => LedgerOffset(LedgerOffset.Value.Absolute("ffff" + end.getAbsolute)))

--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/TimeoutParticipantTestContext.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/TimeoutParticipantTestContext.scala
@@ -549,4 +549,9 @@ class TimeoutParticipantTestContext(timeoutScaleFactor: Double, delegate: Partic
       templateIds: Seq[TemplateId],
       interfaceFilters: Seq[(TemplateId, IncludeInterfaceView)],
   ): Filters = delegate.filters(templateIds, interfaceFilters)
+
+  override def latestPrunedOffsets(): Future[(LedgerOffset, LedgerOffset)] = withTimeout(
+    "Requesting the latest pruned offsets",
+    delegate.latestPrunedOffsets(),
+  )
 }

--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/TimeoutParticipantTestContext.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/TimeoutParticipantTestContext.scala
@@ -532,6 +532,14 @@ class TimeoutParticipantTestContext(timeoutScaleFactor: Double, delegate: Partic
     delegate.prune(pruneUpTo, attempts, pruneAllDivulgedContracts),
   )
 
+  override def pruneCantonSafe(
+      pruneUpTo: LedgerOffset,
+      party: Primitive.Party,
+      dummyCommand: Primitive.Party => Command,
+      pruneAllDivulgedContracts: Boolean = false,
+  )(implicit ec: ExecutionContext): Future[Unit] =
+    delegate.pruneCantonSafe(pruneUpTo, party, dummyCommand, pruneAllDivulgedContracts)
+
   private def withTimeout[T](hint: String, future: => Future[T]): Future[T] = {
     Future.firstCompletedOf(
       Seq(

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
@@ -29,19 +29,13 @@ import com.daml.ledger.test.model.Test.{
   WithObservers,
   Witnesses => TestWitnesses,
 }
-import com.daml.ledger.api.testtool.infrastructure.FutureAssertions
-import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
-import com.daml.logging.LoggingContext
 import scalaz.syntax.tag._
 
-import scala.concurrent.duration._
 import scala.collection.immutable.Seq
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Random
 
 class ActiveContractsServiceIT extends LedgerTestSuite {
-
-  private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
 
   test(
     "ACSinvalidLedgerId",
@@ -679,7 +673,11 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
       c1 <- ledger.create(party, Dummy(party))
       anOffset <- ledger.currentEnd()
       _ <- ledger.create(party, Dummy(party))
-      _ <- pruneCantonSafe(ledger = ledger, pruneUpTo = anOffset, party = party)
+      _ <- ledger.pruneCantonSafe(
+        pruneUpTo = anOffset,
+        party = party,
+        dummyCommand = Dummy(_).create.command,
+      )
       (acsOffset, acs) <- ledger
         .activeContractsIds(
           GetActiveContractsRequest(
@@ -706,7 +704,7 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
       _ <- ledger.create(party, Dummy(party))
       offset2 <- ledger.currentEnd()
       _ <- ledger.create(party, Dummy(party))
-      _ <- pruneCantonSafe(ledger = ledger, pruneUpTo = offset2, party = party)
+      _ <- ledger.pruneCantonSafe(pruneUpTo = offset2, party = party, Dummy(_).create.command)
       _ <- ledger
         .activeContractsIds(
           GetActiveContractsRequest(
@@ -797,27 +795,4 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
       s"${party.mkString(" and ")} expected $count $templateId events, but received $templateEvents.",
     )
   }
-
-  /** We are retrying a command submission + pruning to make this test compatible with Canton.
-    * That's because in Canton pruning will fail unless ACS commitments have been exchanged between participants.
-    * To this end, repeatedly submitting commands is prompting Canton to exchange ACS commitments
-    * and allows the pruning call to eventually succeed.
-    */
-  private def pruneCantonSafe(
-      ledger: ParticipantTestContext,
-      pruneUpTo: LedgerOffset,
-      party: Party,
-  )(implicit ec: ExecutionContext): Future[Unit] =
-    FutureAssertions.succeedsEventually(
-      retryDelay = 100.millis,
-      maxRetryDuration = 10.seconds,
-      ledger.delayMechanism,
-      "Pruning",
-    ) {
-      for {
-        _ <- ledger.submitAndWait(ledger.submitAndWaitRequest(party, Dummy(party).create.command))
-        _ <- ledger.prune(pruneUpTo = pruneUpTo, attempts = 1)
-      } yield ()
-    }
-
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/IndexDBMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IndexDBMetrics.scala
@@ -146,6 +146,7 @@ class MainIndexDBMetrics(prefix: MetricName, factory: MetricsFactory)
   val storePackageEntryDbMetrics: DatabaseMetrics = createDbMetrics("store_package_entry")
   val loadPackageEntries: DatabaseMetrics = createDbMetrics("load_package_entries")
   val pruneDbMetrics: DatabaseMetrics = createDbMetrics("prune")
+  val fetchPruningOffsetsMetrics: DatabaseMetrics = createDbMetrics("fetch_pruning_offsets")
   val lookupActiveContractDbMetrics: DatabaseMetrics = createDbMetrics("lookup_active_contract")
   val lookupContractByKeyDbMetrics: DatabaseMetrics = createDbMetrics(
     "lookup_contract_by_key"

--- a/ledger/metrics/src/main/scala/com/daml/metrics/ServicesMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/ServicesMetrics.scala
@@ -43,6 +43,8 @@ class ServicesMetrics(
     @MetricDoc.FanInstanceTag
     val currentLedgerEnd: Timer = factory.timer(prefix :+ "current_ledger_end")
     @MetricDoc.FanInstanceTag
+    val latestPrunedOffsets: Timer = factory.timer(prefix :+ "latest_pruned_offsets")
+    @MetricDoc.FanInstanceTag
     val getCompletions: Timer = factory.timer(prefix :+ "get_completions")
     @MetricDoc.FanInstanceTag
     val getCompletionsLimited: Timer = factory.timer(prefix :+ "get_completions_limited")

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
@@ -238,4 +238,9 @@ private[daml] final class TimedIndexService(delegate: IndexService, metrics: Met
       metrics.daml.services.index.lookupContractStateWithoutDivulgence,
       delegate.lookupContractStateWithoutDivulgence(contractId),
     )
+
+  override def latestPrunedOffsets()(implicit
+      loggingContext: LoggingContext
+  ): Future[(LedgerOffset.Absolute, LedgerOffset.Absolute)] =
+    Timed.future(metrics.daml.services.index.latestPrunedOffsets, delegate.latestPrunedOffsets())
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -269,9 +269,9 @@ private[apiserver] final class ApiTransactionService private (
       case (prunedUpToInclusive, divulgencePrunedUpTo) =>
         GetLatestPrunedOffsetsResponse(
           participantPrunedUpToInclusive =
-            Some(LedgerOffset(LedgerOffset.Value.Absolute(divulgencePrunedUpTo.value))),
-          allDivulgedContractsPrunedUpToInclusive =
             Some(LedgerOffset(LedgerOffset.Value.Absolute(prunedUpToInclusive.value))),
+          allDivulgedContractsPrunedUpToInclusive =
+            Some(LedgerOffset(LedgerOffset.Value.Absolute(divulgencePrunedUpTo.value))),
         )
     }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
@@ -406,10 +406,16 @@ private[index] class IndexServiceImpl(
   override def currentLedgerEnd()(implicit
       loggingContext: LoggingContext
   ): Future[LedgerOffset.Absolute] = {
+    val absoluteApiOffset = toApiOffset(ledgerEnd())
+    Future.successful(absoluteApiOffset)
+  }
+
+  private def toApiOffset(ledgerDomainOffset: Offset): LedgerOffset.Absolute = {
     val offset =
-      if (ledgerEnd() == Offset.beforeBegin) ApiOffset.begin
-      else ledgerEnd()
-    Future.successful(toAbsolute(offset))
+      if (ledgerDomainOffset == Offset.beforeBegin) ApiOffset.begin
+      else ledgerDomainOffset
+
+    toAbsolute(offset)
   }
 
   private def ledgerEnd(): Offset = dispatcher().getHead()
@@ -479,6 +485,16 @@ private[index] class IndexServiceImpl(
       loggingContext: LoggingContext
   ): Future[MaximumLedgerTime] =
     maximumLedgerTimeService.lookupMaximumLedgerTimeAfterInterpretation(ids)
+
+  override def latestPrunedOffsets()(implicit
+      loggingContext: LoggingContext
+  ): Future[(LedgerOffset.Absolute, LedgerOffset.Absolute)] =
+    ledgerDao.pruningOffsets
+      .map { case (prunedUpToInclusiveO, divulgencePrunedUpToO) =>
+        toApiOffset(divulgencePrunedUpToO.getOrElse(Offset.beforeBegin)) -> toApiOffset(
+          prunedUpToInclusiveO.getOrElse(Offset.beforeBegin)
+        )
+      }(ExecutionContext.parasitic)
 }
 
 object IndexServiceImpl {

--- a/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
@@ -490,8 +490,8 @@ private[index] class IndexServiceImpl(
   ): Future[(LedgerOffset.Absolute, LedgerOffset.Absolute)] =
     ledgerDao.pruningOffsets
       .map { case (prunedUpToInclusiveO, divulgencePrunedUpToO) =>
-        toApiOffset(divulgencePrunedUpToO.getOrElse(Offset.beforeBegin)) -> toApiOffset(
-          prunedUpToInclusiveO.getOrElse(Offset.beforeBegin)
+        toApiOffset(prunedUpToInclusiveO.getOrElse(Offset.beforeBegin)) -> toApiOffset(
+          divulgencePrunedUpToO.getOrElse(Offset.beforeBegin)
         )
       }(ExecutionContext.parasitic)
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
@@ -414,7 +414,6 @@ private[index] class IndexServiceImpl(
     val offset =
       if (ledgerDomainOffset == Offset.beforeBegin) ApiOffset.begin
       else ledgerDomainOffset
-
     toAbsolute(offset)
   }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -448,6 +448,14 @@ private class JdbcLedgerDao(
       }(servicesExecutionContext)
   }
 
+  override def pruningOffsets(implicit
+      loggingContext: LoggingContext
+  ): Future[(Option[Offset], Option[Offset])] =
+    dbDispatcher.executeSql(metrics.daml.index.db.fetchPruningOffsetsMetrics) { conn =>
+      parameterStorageBackend.prunedUpToInclusive(conn) -> parameterStorageBackend
+        .participantAllDivulgedContractsPrunedUpToInclusive(conn)
+    }
+
   private val translation: LfValueTranslation =
     new LfValueTranslation(
       metrics = metrics,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -144,6 +144,13 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
       loggingContext: LoggingContext
   ): Future[Unit]
 
+  /** Return the pruned offsets from the parameters table (if defined)
+    * as a tuple of (participant_all_divulged_contracts_pruned_up_to_inclusive, participant_pruned_up_to_inclusive)
+    */
+  def pruningOffsets(implicit
+      loggingContext: LoggingContext
+  ): Future[(Option[Offset], Option[Offset])]
+
   /** Returns all TransactionMetering records matching given criteria */
   def meteringReportData(
       from: Timestamp,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsReader.scala
@@ -151,9 +151,9 @@ private[dao] final class TransactionsReader(
     dispatcher
       .executeSql(dbMetrics.getAcsEventSeqIdRange)(implicit connection =>
         queryNonPruned.executeSql(
-          eventSeqIdReader.readEventSeqIdRange(activeAt)(connection),
-          activeAt,
-          pruned =>
+          query = eventSeqIdReader.readEventSeqIdRange(activeAt)(connection),
+          minOffsetExclusive = activeAt,
+          error = pruned =>
             ACSReader.acsBeforePruningErrorReason(
               acsOffset = activeAt.toHexString,
               prunedUpToOffset = pruned.toHexString,

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexTransactionsService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexTransactionsService.scala
@@ -44,4 +44,8 @@ trait IndexTransactionsService extends LedgerEndService {
       transactionId: TransactionId,
       requestingParties: Set[Ref.Party],
   )(implicit loggingContext: LoggingContext): Future[Option[GetTransactionResponse]]
+
+  def latestPrunedOffsets()(implicit
+      loggingContext: LoggingContext
+  ): Future[(LedgerOffset.Absolute, LedgerOffset.Absolute)]
 }

--- a/ledger/sandbox-on-x/src/test/it/scala/com/daml/ledger/platform/sandbox/auth/GetLatestPrunedOffsetsAuthIT.scala
+++ b/ledger/sandbox-on-x/src/test/it/scala/com/daml/ledger/platform/sandbox/auth/GetLatestPrunedOffsetsAuthIT.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox.auth
+
+import com.daml.ledger.api.v1.transaction_service.{
+  GetLatestPrunedOffsetsRequest,
+  TransactionServiceGrpc,
+}
+
+import scala.concurrent.Future
+
+class GetLatestPrunedOffsetsAuthIT extends PublicServiceCallAuthTests {
+  override def serviceCallName: String = "TransactionService#GetLatestPrunedOffsets"
+
+  private lazy val request = new GetLatestPrunedOffsetsRequest()
+
+  override def serviceCall(context: ServiceCallContext): Future[Any] =
+    stub(TransactionServiceGrpc.stub(channel), context.token).getLatestPrunedOffsets(request)
+
+}


### PR DESCRIPTION
This PR adds the ability to query the latest pruned ledger offsets by any public party by querying TransactionService.GetLatestPrunedOffsets

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
