### PR TITLE
Bug fix to avoid potential JVM OOM errors in the converter

### DIFF
--- a/daml-script/converter/src/main/scala/Converter.scala
+++ b/daml-script/converter/src/main/scala/Converter.scala
@@ -72,7 +72,7 @@ private[daml] object Converter {
         pf.lift(self) toRight orElse
 
       def expect[R](name: String, pf: A PartialFunction R): ErrorOr[R] =
-        self.intoOr(pf)(s"Expected $name but got $self")
+        self.intoOr(pf)(s"Expected $name but got ${self.getClass.getSimpleName}")
 
       def expectE[R](name: String, pf: A PartialFunction ErrorOr[R]): ErrorOr[R] =
         self.expect(name, pf).join


### PR DESCRIPTION
When using the converter, some `expect` expressions can pass large `SValue`'s to the converter. If pattern matching fails, then these large `SValue`s can cause the thread heap to OOM as the string is constructed. We resolve this issue here by simply printing out the class name rather than the whole `SValue`.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
