### PR TITLE
Trigger should always perform message batching

### DIFF
--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -25,7 +25,7 @@ import com.daml.ledger.api.v1.{value => api}
 import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.services.commands.CompletionStreamElement._
 import com.daml.lf.archive.Dar
-import com.daml.lf.data.{BackStack, FrontStack, ImmArray, Ref}
+import com.daml.lf.data.{FrontStack, ImmArray, Ref}
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.ScalazEqual._
 import com.daml.lf.data.Time.Timestamp

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerConfig.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerConfig.scala
@@ -18,8 +18,8 @@ import scala.concurrent.duration._
   *                                  kill the trigger instance by throwing an InFlightCommandOverflowException.
   * @param allowInFlightCommandOverflows flag to control whether we allow in-flight command overflows or not.
   * @param submissionFailureQueueSize Size of the queue holding ledger API command submission failures.
-  * @param maximumBatchSize Maximum number of messages triggers will batch (for rule evaluation/processing) before
-  *                         backpressure is applied.
+  * @param maximumBatchSize Maximum number of messages triggers will batch (for rule evaluation/processing).
+  * @param batchingDuration Period of time we will wait before emitting a message batch (for rule evaluation/processing).
   */
 final case class TriggerRunnerConfig(
     parallelism: Int,
@@ -31,6 +31,7 @@ final case class TriggerRunnerConfig(
     allowInFlightCommandOverflows: Boolean,
     submissionFailureQueueSize: Int,
     maximumBatchSize: Long,
+    batchingDuration: FiniteDuration,
 )
 
 object TriggerRunnerConfig {
@@ -48,6 +49,7 @@ object TriggerRunnerConfig {
       // 256 here comes from the default ExecutionContext.
       submissionFailureQueueSize = 256 + parallelism,
       maximumBatchSize = 1000,
+      batchingDuration = 250.milliseconds,
     )
   }
 }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Cli.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Cli.scala
@@ -329,11 +329,20 @@ private[trigger] object Cli {
     opt[Long]("max-batch-size")
       .optional()
       .text(
-        s"maximum number of messages processed between two high-level rule triggers. Defaults to ${DefaultTriggerRunnerConfig.maximumBatchSize}"
+        s"Maximum number of messages triggers will batch (for rule evaluation/processing). Defaults to ${DefaultTriggerRunnerConfig.maximumBatchSize}"
       )
       .action((size, cli) =>
         if (size > 0) cli.copy(triggerConfig = cli.triggerConfig.copy(maximumBatchSize = size))
         else throw new IllegalArgumentException("batch size must be strictly positive")
+      )
+
+    opt[FiniteDuration]("batch-duration")
+      .optional()
+      .text(
+        s"Period of time we will wait before emitting a message batch (for rule evaluation/processing). Defaults to ${DefaultTriggerRunnerConfig.batchingDuration}"
+      )
+      .action((period, cli) =>
+        cli.copy(triggerConfig = cli.triggerConfig.copy(batchingDuration = period))
       )
 
     opt[Int]("overflow-size")


### PR DESCRIPTION
Previously, triggers would only batch messages when rule evaluation started to back pressure. This PR introduces an optimisation whereby we always batch trigger messages.

Trigger context logging refactored to better manage message batching based contexts.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
