### PR TITLE
[DPP-954] Allow pruning up to the ledger end offset

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -896,7 +896,7 @@ excluded_test_tool_tests = [
                 "start": "2.6.0-snapshot.20230123.11292.0.b3f84bfc.1",
                 "exclusions": [
                     # This test expected pruning at the ledger end to fail. In the current platform such pruning succeeds.
-                    "PRFailPruneByOutOfBoundsOffset:PRFailPruneByOutOfBoundsOffset",
+                    "ParticipantPruningIT:PRFailPruneByOutOfBoundsOffset",
                 ],
             },
         ],
@@ -908,7 +908,7 @@ excluded_test_tool_tests = [
                 "end": "2.6.0-snapshot.20230123.11292.0.b3f84bfc",
                 "exclusions": [
                     # This test expects pruning at the ledger end to succeed. In the previous platforms such pruning fails.
-                    "PRFailPruneByOutOfBoundsOffset:PRPruneAtLedgerEndOffset",
+                    "ParticipantPruningIT:PRPruneAtLedgerEndOffset",
                 ],
             },
         ],

--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -889,6 +889,30 @@ excluded_test_tool_tests = [
             },
         ],
     },
+    {
+        "end": "2.6.0-snapshot.20230123.11292.0.b3f84bfc",
+        "platform_ranges": [
+            {
+                "start": "2.6.0-snapshot.20230123.11292.0.b3f84bfc.1",
+                "exclusions": [
+                    # This test expected pruning at the ledger end to fail. In the current platform such pruning succeeds.
+                    "PRFailPruneByOutOfBoundsOffset:PRFailPruneByOutOfBoundsOffset",
+                ],
+            },
+        ],
+    },
+    {
+        "start": "2.6.0-snapshot.20230123.11292.0.b3f84bfc.1",
+        "platform_ranges": [
+            {
+                "end": "2.6.0-snapshot.20230123.11292.0.b3f84bfc",
+                "exclusions": [
+                    # This test expects pruning at the ledger end to succeed. In the previous platforms such pruning fails.
+                    "PRFailPruneByOutOfBoundsOffset:PRPruneAtLedgerEndOffset",
+                ],
+            },
+        ],
+    },
 ]
 
 def in_range(version, range):

--- a/docs/source/ops/pruning.rst
+++ b/docs/source/ops/pruning.rst
@@ -25,7 +25,7 @@ Still, Daml applications may be affected in the following ways:
 
 - Pruning is potentially a long-running operation and demanding one in terms of system resources; as such, it may significantly reduce Daml Ledger API throughput and increase latency while it is being performed. It is thus strongly recommended to plan pruning invocations, preferably, when the system is offline or at least when very low system utilization is expected.
 - Pruning may degrade the behavior of or abort in-progress requests if the pruning offset is too recent. In particular, the system might misbehave if command completions are pruned before the command trackers are able to process the completions.
-- Command deduplication and command tracker retention should always configured in such a way, that the associated windows don't overlap with the pruning window, so that their operation is unaffected by pruning.
+- Command deduplication and command tracker retention should always be configured in such a way, that the associated windows don't overlap with the pruning window, so that their operation is unaffected by pruning.
 - Pruning may affect the behavior of Ledger API calls that allow to read data from the ledger: see the next sub-section for more information about API impacts.
 - Pruning of all divulged contracts (see :ref:`Prune Request <com.daml.ledger.api.v1.admin.PruneRequest>`) does not preserve application visibility over contracts divulged up to the pruning offset, hence applications making use of pruned divulged contracts might start experiencing failed command submissions: see the section below for determining a suitable pruning offset.
 
@@ -73,11 +73,11 @@ Professional advice on database administration is strongly recommended that woul
 Determine a Suitable Pruning Offset
 -----------------------------------
 
-The :ref:`Transaction Service <transaction-service>` and the :ref:`Active Contract Service <active-contract-service>` provide offsets of the ledger end of the Transactions, and of Active Contracts snapshots respectively. Such offsets can be passed unchanged to `prune` calls, as long as they are lexicographically lower than the current ledger end.
+The :ref:`Transaction Service <transaction-service>` and the :ref:`Active Contract Service <active-contract-service>` provide offsets of the ledger end of the Transactions, and of Active Contracts snapshots respectively. Such offsets can be passed unchanged to `prune` calls.
 
 When pruning all divulged contracts, the participant operator can choose the pruning offset as follows:
 
-- Just before the ledger end, if no application hosted on the participant makes use of divulgence OR
+- At the ledger end, if no application hosted on the participant makes use of divulgence OR
 
 - An offset old enough (e.g. older than an arbitrary multi-day grace period) that it ensures that pruning does not affect any recently-divulged contract needed by the applications hosted on the participant.
 

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/participant_pruning_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/participant_pruning_service.proto
@@ -30,18 +30,17 @@ service ParticipantPruningService {
 message PruneRequest {
   // Inclusive offset up to which the ledger is to be pruned.
   // By default the following data is pruned:
-  //   1. All normal and divulged contracts that have been archived before
-  //   `prune_up_to`.
-  //   2. All transaction events and completions before `prune_up_to`
+  //   1. All normal and divulged contracts that have been archived before or at `prune_up_to` offset.
+  //   2. All transaction events and completions before or at `prune_up_to` offset.
   string prune_up_to = 1;
 
   // Unique submission identifier.
   // Optional, defaults to a random identifier, used for logging.
   string submission_id = 2;
 
-  // Prune all immediately and retroactively divulged contracts created before `prune_up_to`
-  // independent of whether they were archived before `prune_up_to`. Useful to avoid leaking
-  // storage on participant nodes that can see a divulged contract but not its archival.
+  // Prune all immediately and retroactively divulged contracts created before or at `prune_up_to` offset
+  // independent of whether they were archived before or at `prune_up_to` offset.
+  // Useful to avoid leaking storage on participant nodes that can see a divulged contract but not its archival.
   //
   // Application developers SHOULD write their Daml applications
   // such that they do not rely on divulged contracts; i.e., no warnings from

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
@@ -678,7 +678,6 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
     for {
       c1 <- ledger.create(party, Dummy(party))
       anOffset <- ledger.currentEnd()
-      _ <- ledger.create(party, Dummy(party))
       _ <- pruneCantonSafe(ledger = ledger, pruneUpTo = anOffset, party = party)
       (acsOffset, acs) <- ledger
         .activeContractsIds(
@@ -705,7 +704,6 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
       offset1 <- ledger.currentEnd()
       _ <- ledger.create(party, Dummy(party))
       offset2 <- ledger.currentEnd()
-      _ <- ledger.create(party, Dummy(party))
       _ <- pruneCantonSafe(ledger = ledger, pruneUpTo = offset2, party = party)
       _ <- ledger
         .activeContractsIds(

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/CommandDeduplicationPeriodValidationIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/CommandDeduplicationPeriodValidationIT.scala
@@ -175,10 +175,8 @@ class CommandDeduplicationPeriodValidationIT extends LedgerTestSuite {
       start <- ledger.currentEnd()
       firstCreate <- ledger.create(party, Dummy(party))
       _ <- ledger.exercise(party, firstCreate.exerciseDummyChoice1())
-      secondCreate <- ledger.create(party, Dummy(party))
       _ <- ledger.submitAndWait(ledger.submitAndWaitRequest(party, Dummy(party).create.command))
       end <- ledger.currentEnd()
-      _ <- ledger.exercise(party, secondCreate.exerciseDummyChoice1())
       _ <- FutureAssertions.succeedsEventually(
         retryDelay = 10.millis,
         maxRetryDuration = 10.seconds,

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ParticipantPruningIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ParticipantPruningIT.scala
@@ -72,16 +72,31 @@ class ParticipantPruningIT extends LedgerTestSuite {
   })
 
   test(
+    "PRFPruneAtLedgerEndOffset",
+    "Pruning a participant at the ledger end offset should succeed",
+    allocate(NoParties),
+    runConcurrently = false,
+  )(implicit ec => { case Participants(Participant(participant)) =>
+    for {
+      actualEndExclusive <- participant.currentEnd()
+      _ <- participant
+        .prune(actualEndExclusive, attempts = 1)
+    } yield {
+      // succeeding by not reporting any validation errors
+    }
+  })
+
+  test(
     "PRFailPruneByOutOfBoundsOffset",
-    "Pruning a participant specifying an offset after the ledger end should fail",
+    "Pruning a participant specifying an offset beyond the ledger end should fail",
     allocate(NoParties),
     runConcurrently =
       false, // in spite of being a negative test, cannot be run concurrently as otherwise ledger end grows
   )(implicit ec => { case Participants(Participant(participant)) =>
     for {
-      actualEndExclusive <- participant.currentEnd()
+      offsetBeyondLedgerEnd <- participant.offsetBeyondLedgerEnd()
       cannotPruneOffsetBeyondEnd <- participant
-        .prune(actualEndExclusive, attempts = 1)
+        .prune(offsetBeyondLedgerEnd, attempts = 1)
         .mustFail("pruning, specifying an offset after the ledger end")
     } yield {
       assertGrpcError(

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ParticipantPruningIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ParticipantPruningIT.scala
@@ -72,7 +72,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
   })
 
   test(
-    "PRFPruneAtLedgerEndOffset",
+    "PRPruneAtLedgerEndOffset",
     "Pruning a participant at the ledger end offset should succeed",
     allocate(NoParties),
     runConcurrently = false,

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ParticipantPruningIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ParticipantPruningIT.scala
@@ -840,9 +840,6 @@ class ParticipantPruningIT extends LedgerTestSuite {
 
       _ <- populateLedgerAndGetOffsets(participant, localParty)
 
-      // Dummy needed to prune at this offset
-      _ <- participant.create(localParty, Dummy(localParty))
-
       acsBeforePruning <- participant.activeContracts(localParty)
       _ <- participant.prune(offset, pruneAllDivulgedContracts = pruneAllDivulgedContracts)
       acsAfterPruning <- participant.activeContracts(localParty)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiParticipantPruningService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiParticipantPruningService.scala
@@ -185,8 +185,7 @@ final class ApiParticipantPruningService private (
     for {
       ledgerEnd <- readBackend.currentLedgerEnd()
       _ <-
-        // NOTE: This constraint should be relaxed to (pruneUpToString <= ledgerEnd.value)
-        if (pruneUpToString < ledgerEnd.value) Future.successful(())
+        if (pruneUpToString <= ledgerEnd.value) Future.successful(())
         else
           Future.failed(
             LedgerApiErrors.RequestValidation.OffsetOutOfRange


### PR DESCRIPTION
Before the pruning offset was required to be before the ledger end offset. Now the ledger end offset becomes a valid pruning offset