### PR TITLE
In memory metrics: Keep track of created metrics [PLEN-98]

### DIFF
--- a/observability/metrics/src/test/lib/scala/com/daml/metrics/api/testing/InMemoryMetricsFactory.scala
+++ b/observability/metrics/src/test/lib/scala/com/daml/metrics/api/testing/InMemoryMetricsFactory.scala
@@ -27,18 +27,17 @@ import com.daml.metrics.api.{MetricHandle, MetricName, MetricsContext}
 import com.daml.scalautil.Statement.discard
 
 import scala.collection.concurrent.{TrieMap, Map => ConcurrentMap}
-import scala.collection.mutable
 
 class InMemoryMetricsFactory extends LabeledMetricsFactory {
 
   val metrics: MetricsState =
     MetricsState(
-      timers = mutable.Map.empty,
-      gauges = mutable.Map.empty,
-      meters = mutable.Map.empty,
-      counters = mutable.Map.empty,
-      histograms = mutable.Map.empty,
-      asyncGauges = TrieMap[(MetricName, MetricsContext), () => Any](),
+      timers = TrieMap.empty,
+      gauges = TrieMap.empty,
+      meters = TrieMap.empty,
+      counters = TrieMap.empty,
+      histograms = TrieMap.empty,
+      asyncGauges = TrieMap.empty,
     )
 
   override def timer(name: MetricName, description: String)(implicit
@@ -74,11 +73,11 @@ object InMemoryMetricsFactory extends InMemoryMetricsFactory {
 
   type MetricIdentifier = (MetricName, MetricsContext)
   case class MetricsState(
-      timers: mutable.Map[MetricIdentifier, InMemoryTimer],
-      gauges: mutable.Map[MetricIdentifier, InMemoryGauge[_]],
-      meters: mutable.Map[MetricIdentifier, InMemoryMeter],
-      counters: mutable.Map[MetricIdentifier, InMemoryCounter],
-      histograms: mutable.Map[MetricIdentifier, InMemoryHistogram],
+      timers: ConcurrentMap[MetricIdentifier, InMemoryTimer],
+      gauges: ConcurrentMap[MetricIdentifier, InMemoryGauge[_]],
+      meters: ConcurrentMap[MetricIdentifier, InMemoryMeter],
+      counters: ConcurrentMap[MetricIdentifier, InMemoryCounter],
+      histograms: ConcurrentMap[MetricIdentifier, InMemoryHistogram],
       asyncGauges: ConcurrentMap[MetricIdentifier, () => Any],
   ) {
 

--- a/observability/metrics/src/test/lib/scala/com/daml/metrics/api/testing/MetricValues.scala
+++ b/observability/metrics/src/test/lib/scala/com/daml/metrics/api/testing/MetricValues.scala
@@ -50,7 +50,7 @@ trait MetricValues {
   class InMemoryMetricFactoryValues(factory: InMemoryMetricsFactory) {
 
     def asyncGaugeValues(labelFilter: LabelFilter*): Map[MetricName, Any] = {
-      factory.asyncGauges
+      factory.metrics.asyncGauges
         .filter { case ((_, metricContext), _) =>
           labelFilter.forall(filter => metricContext.labels.get(filter.name).contains(filter.value))
         }


### PR DESCRIPTION
This allows us in test to read all the created metrics and find metrics for which we don't have a reference (or that are created by third parties)

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
