### PR TITLE
[DPP-1395] Adding pruning benchmarking capability to the benchtool + non-transient contracts

### DIFF
--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/LedgerApiBenchTool.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/LedgerApiBenchTool.scala
@@ -181,6 +181,8 @@ class LedgerApiBenchTool(
               regularUserServices = regularUserServices,
               adminServices = adminServices,
               actorSystem = actorSystem,
+              signatory = allocatedParties.signatory,
+              names = names,
             )
           } else {
             benchmarkStreams(

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/LedgerApiBenchTool.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/LedgerApiBenchTool.scala
@@ -174,6 +174,14 @@ class LedgerApiBenchTool(
               actorSystem = actorSystem,
               maxLatencyObjectiveMillis = config.maxLatencyObjectiveMillis,
             )
+          } else if (config.workflow.pruning.isDefined) {
+            new PruningBenchmark(reportingPeriod = config.reportingPeriod).benchmarkPruning(
+              pruningConfig =
+                config.workflow.pruning.getOrElse(sys.error("Pruning config not defined!")),
+              regularUserServices = regularUserServices,
+              adminServices = adminServices,
+              actorSystem = actorSystem,
+            )
           } else {
             benchmarkStreams(
               regularUserServices = regularUserServices,
@@ -255,7 +263,7 @@ class LedgerApiBenchTool(
           randomnessProvider = RandomnessProvider.Default,
         )
         for {
-          metricsManager <- MetricsManager(
+          metricsManager <- MetricsManager.create(
             observedMetric = "submit-and-wait-latency",
             logInterval = config.reportingPeriod,
             metrics = List(LatencyMetric.empty(maxLatencyObjectiveMillis)),
@@ -332,11 +340,10 @@ class LedgerApiBenchTool(
               submitter = submitter,
               maxInFlightCommands = config.maxInFlightCommands,
               submissionBatchSize = config.submissionBatchSize,
-              submissionConfig = submissionConfig,
               allocatedParties = allocatedParties,
               names = names,
               randomnessProvider = RandomnessProvider.Default,
-            ).performSubmission()
+            ).performSubmission(submissionConfig)
           case submissionConfig: FibonacciSubmissionConfig =>
             val generator: CommandGenerator = new FibonacciCommandGenerator(
               signatory = allocatedParties.signatory,

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/PruningBenchmark.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/PruningBenchmark.scala
@@ -7,19 +7,34 @@ import akka.actor.typed.{ActorSystem, SpawnProtocol}
 import com.daml.ledger.api.benchtool.config.WorkflowConfig
 import com.daml.ledger.api.benchtool.metrics.{BenchmarkResult, MetricsManager, MetricsSet}
 import com.daml.ledger.api.benchtool.services.LedgerApiServices
+import com.daml.ledger.api.benchtool.submission.Names
 import com.daml.ledger.api.v1.admin.participant_pruning_service.PruneRequest
+import com.daml.ledger.client.binding.Primitive
+import com.daml.ledger.test.benchtool.Foo.Dummy
+import com.daml.ledger.api.v1.commands.Commands
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 
 class PruningBenchmark(reportingPeriod: FiniteDuration) {
   def benchmarkPruning(
+      signatory: Primitive.Party,
       pruningConfig: WorkflowConfig.PruningConfig,
       regularUserServices: LedgerApiServices,
       adminServices: LedgerApiServices,
       actorSystem: ActorSystem[SpawnProtocol.Command],
+      names: Names,
   )(implicit ec: ExecutionContext): Future[Either[String, Unit]] = for {
     endOffset <- regularUserServices.transactionService.getLedgerEnd()
+    // Submit on more command so that we're not pruning exactly at the ledger end offset
+    _ <- adminServices.commandService.submitAndWait(
+      Commands(
+        applicationId = names.benchtoolApplicationId,
+        commandId = "pruning-benchmarking-dummy-command",
+        commands = Seq(Dummy(signatory).create.command),
+        actAs = Seq(signatory.toString),
+      )
+    )
     durationMetric = MetricsSet.createTotalRuntimeMetric[Unit](pruningConfig.maxDurationObjective)
     metricsManager <- MetricsManager.create(
       observedMetric = "benchtool-pruning",

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/PruningBenchmark.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/PruningBenchmark.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.benchtool
+
+import akka.actor.typed.{ActorSystem, SpawnProtocol}
+import com.daml.ledger.api.benchtool.config.WorkflowConfig
+import com.daml.ledger.api.benchtool.metrics.{BenchmarkResult, MetricsManager, MetricsSet}
+import com.daml.ledger.api.benchtool.services.LedgerApiServices
+import com.daml.ledger.api.v1.admin.participant_pruning_service.PruneRequest
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
+
+class PruningBenchmark(reportingPeriod: FiniteDuration) {
+  def benchmarkPruning(
+      pruningConfig: WorkflowConfig.PruningConfig,
+      regularUserServices: LedgerApiServices,
+      adminServices: LedgerApiServices,
+      actorSystem: ActorSystem[SpawnProtocol.Command],
+  )(implicit ec: ExecutionContext): Future[Either[String, Unit]] = for {
+    endOffset <- regularUserServices.transactionService.getLedgerEnd()
+    durationMetric = MetricsSet.createTotalRuntimeMetric[Unit](pruningConfig.maxDurationObjective)
+    metricsManager <- MetricsManager.create(
+      observedMetric = "benchtool-pruning",
+      logInterval = reportingPeriod,
+      metrics = List(durationMetric),
+      exposedMetrics = None,
+    )(actorSystem, ec)
+    _ <- adminServices.pruningService
+      .prune(
+        new PruneRequest(
+          pruneUpTo = endOffset,
+          submissionId = "benchtool-pruning",
+          pruneAllDivulgedContracts = pruningConfig.pruneAllDivulgedContracts,
+        )
+      )
+      .map { _ =>
+        metricsManager.sendNewValue(())
+        metricsManager.result().map {
+          case BenchmarkResult.ObjectivesViolated => Left("Metrics objectives not met.")
+          case BenchmarkResult.Ok => Right(())
+        }
+      }
+  } yield Right(())
+
+}

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/config/WorkflowConfig.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/config/WorkflowConfig.scala
@@ -15,6 +15,7 @@ import scala.concurrent.duration.FiniteDuration
 case class WorkflowConfig(
     submission: Option[WorkflowConfig.SubmissionConfig] = None,
     streams: List[WorkflowConfig.StreamConfig] = Nil,
+    pruning: Option[WorkflowConfig.PruningConfig] = None,
 )
 
 object WorkflowConfig {
@@ -53,6 +54,7 @@ object WorkflowConfig {
       applicationIds: List[FooSubmissionConfig.ApplicationId] = List.empty,
       maybeWaitForSubmission: Option[Boolean] = None,
       observerPartySets: List[FooSubmissionConfig.PartySet] = List.empty,
+      allowNonTransientContracts: Boolean = false,
   ) extends SubmissionConfig {
     def waitForSubmission: Boolean = maybeWaitForSubmission.getOrElse(true)
   }
@@ -91,6 +93,12 @@ object WorkflowConfig {
     )
 
   }
+
+  case class PruningConfig(
+      name: String,
+      pruneAllDivulgedContracts: Boolean,
+      maxDurationObjective: FiniteDuration,
+  )
 
   sealed trait StreamConfig extends Product with Serializable {
     def name: String

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/MetricsManager.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/MetricsManager.scala
@@ -78,7 +78,7 @@ case class MetricsManagerImpl[T](
 }
 
 object MetricsManager {
-  def apply[StreamElem](
+  def create[StreamElem](
       observedMetric: String,
       logInterval: FiniteDuration,
       metrics: List[Metric[StreamElem]],

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/StreamMetrics.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/StreamMetrics.scala
@@ -23,7 +23,7 @@ object StreamMetrics {
       system: ActorSystem[SpawnProtocol.Command],
       ec: ExecutionContext,
   ): Future[MeteredStreamObserver[StreamElem]] =
-    MetricsManager(streamName, logInterval, metrics, exposedMetrics).map { manager =>
+    MetricsManager.create(streamName, logInterval, metrics, exposedMetrics).map { manager =>
       new MeteredStreamObserver[StreamElem](
         streamName = streamName,
         logger = logger,

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/metrics/TotalRuntimeMetric.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/metrics/TotalRuntimeMetric.scala
@@ -6,13 +6,13 @@ package com.daml.ledger.api.benchtool.metrics.metrics
 import java.time.{Clock, Duration, Instant}
 
 import com.daml.ledger.api.benchtool.metrics.{Metric, MetricValue, ServiceLevelObjective}
-import com.daml.ledger.api.benchtool.metrics.metrics.TotalStreamRuntimeMetric.{
+import com.daml.ledger.api.benchtool.metrics.metrics.TotalRuntimeMetric.{
   MaxDurationObjective,
   Value,
 }
 import com.daml.ledger.api.benchtool.util.TimeUtil
 
-object TotalStreamRuntimeMetric {
+object TotalRuntimeMetric {
 
   case class MaxDurationObjective(maxValue: Duration) extends ServiceLevelObjective[Value] {
     override def isViolatedBy(value: Value): Boolean = value.v.compareTo(maxValue) > 0
@@ -22,8 +22,8 @@ object TotalStreamRuntimeMetric {
       clock: Clock,
       startTime: Instant,
       objective: MaxDurationObjective,
-  ): TotalStreamRuntimeMetric[T] =
-    TotalStreamRuntimeMetric[T](
+  ): TotalRuntimeMetric[T] =
+    TotalRuntimeMetric[T](
       clock = clock,
       startTime = startTime,
       objective = objective,
@@ -34,7 +34,7 @@ object TotalStreamRuntimeMetric {
 
 /** Measures the total runtime since the set start time to the time of receiving the most recent item.
   */
-case class TotalStreamRuntimeMetric[T](
+case class TotalRuntimeMetric[T](
     clock: Clock,
     startTime: Instant,
     objective: MaxDurationObjective,

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/LedgerApiServices.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/LedgerApiServices.scala
@@ -32,6 +32,7 @@ class LedgerApiServices(
     )
   val packageManagementService =
     new PackageManagementService(channel, authorizationToken = authorizationToken)
+  val pruningService = new PruningService(channel, authorizationToken = authorizationToken)
   val packageService = new PackageService(channel, authorizationToken = authorizationToken)
   val partyManagementService =
     new PartyManagementService(channel, authorizationToken = authorizationToken)

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/PruningService.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/PruningService.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.benchtool.services
+
+import com.daml.ledger.api.benchtool.AuthorizationHelper
+import com.daml.ledger.api.v1.admin.participant_pruning_service.{
+  ParticipantPruningServiceGrpc,
+  PruneRequest,
+  PruneResponse,
+}
+import io.grpc.Channel
+
+import scala.concurrent.Future
+
+class PruningService(channel: Channel, authorizationToken: Option[String]) {
+  private val service: ParticipantPruningServiceGrpc.ParticipantPruningServiceStub =
+    AuthorizationHelper.maybeAuthedService(authorizationToken)(
+      ParticipantPruningServiceGrpc.stub(channel)
+    )
+
+  def prune(request: PruneRequest): Future[PruneResponse] = {
+    service.prune(request)
+  }
+}

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/ActiveContractKeysPool.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/ActiveContractKeysPool.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com
+package daml.ledger.api.benchtool.submission
+
+import daml.ledger.api.v1.value.Value
+
+import scala.collection.mutable
+
+/** Keeps track of contract keys of contracts that haven't been used up (archived) yet.
+  * Allows to select the next contract key to use up at random.
+  */
+final class ActiveContractKeysPool(randomnessProvider: RandomnessProvider) {
+
+  private val poolsPerTemplate = mutable.Map.empty[String, DepletingUniformRandomPool[Value]]
+
+  def getAndRemoveContractKey(templateName: String): Value = synchronized {
+    val pool = poolsPerTemplate(templateName)
+    pool.pop()
+  }
+
+  def addContractKey(templateName: String, key: Value): Unit = synchronized {
+    if (!poolsPerTemplate.contains(templateName)) {
+      poolsPerTemplate.put(templateName, new DepletingUniformRandomPool(randomnessProvider))
+    }
+    val pool = poolsPerTemplate(templateName)
+    pool.put(key)
+  }
+}
+
+/** A pool of elements supporting two operations:
+  * 1. pop() - select an element uniformly at random and remove it from the pool.
+  * 2. put() - add an element to the pool
+  */
+final class DepletingUniformRandomPool[V](randomnessProvider: RandomnessProvider) {
+  private val buffer = mutable.ArrayBuffer.empty[V]
+
+  def pop(): V = {
+    val v = buffer.last
+    buffer.remove(index = buffer.size - 1, count = 1)
+    v
+  }
+
+  def put(v: V): Unit = {
+    val i = randomnessProvider.randomNatural(buffer.size + 1)
+    buffer.insert(index = i, elem = v)
+  }
+}

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/FooSubmission.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/FooSubmission.scala
@@ -12,13 +12,12 @@ class FooSubmission(
     submitter: CommandSubmitter,
     maxInFlightCommands: Int,
     submissionBatchSize: Int,
-    submissionConfig: FooSubmissionConfig,
     allocatedParties: AllocatedParties,
     names: Names,
     randomnessProvider: RandomnessProvider,
 ) {
 
-  def performSubmission()(implicit
+  def performSubmission(submissionConfig: FooSubmissionConfig)(implicit
       ec: ExecutionContext
   ): Future[Unit] = {
     val (divulgerCmds, divulgeesToDivulgerKeyMap) = FooDivulgerCommandGenerator

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/util/ReportFormatter.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/util/ReportFormatter.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.api.benchtool.util
 
 import com.daml.ledger.api.benchtool.metrics.MetricsCollector.Response.{FinalReport, PeriodicReport}
 import com.daml.ledger.api.benchtool.metrics._
-import com.daml.ledger.api.benchtool.metrics.metrics.TotalStreamRuntimeMetric
+import com.daml.ledger.api.benchtool.metrics.metrics.TotalRuntimeMetric
 
 object ReportFormatter {
   def formatPeriodicReport(streamName: String, periodicReport: PeriodicReport): String = {
@@ -61,7 +61,7 @@ object ReportFormatter {
     case _: SizeMetric.Value => "Size rate [MB/s]"
     case _: TotalCountMetric.Value => "Total item count [item]"
     case _: LatencyMetric.Value => "Average latency (millis)"
-    case _: TotalStreamRuntimeMetric.Value => "Total stream runtime [ms]"
+    case _: TotalRuntimeMetric.Value => "Total runtime [ms]"
   }
 
   private def shortMetricReport(value: MetricValue): String =
@@ -74,7 +74,7 @@ object ReportFormatter {
     case _: SizeMetric.Value => "rate [MB/s]"
     case _: TotalCountMetric.Value => "count [item]"
     case _: LatencyMetric.Value => "Average latency (millis)"
-    case _: TotalStreamRuntimeMetric.Value => "Total stream runtime [ms]"
+    case _: TotalRuntimeMetric.Value => "Total runtime [ms]"
   }
 
   private def formattedValue(value: MetricValue): String = value match {
@@ -90,7 +90,7 @@ object ReportFormatter {
       s"${v.totalCount}"
     case v: LatencyMetric.Value =>
       s"${v.latencyNanos / 1000000.0d}"
-    case v: TotalStreamRuntimeMetric.Value =>
+    case v: TotalRuntimeMetric.Value =>
       v.v.toMillis.toString
   }
 
@@ -106,8 +106,8 @@ object ReportFormatter {
         s"Maximum item rate [item/s]"
       case _: LatencyMetric.MaxLatency =>
         "Maximum latency (millis)"
-      case _: TotalStreamRuntimeMetric.MaxDurationObjective =>
-        "Total stream runtime [ms]"
+      case _: TotalRuntimeMetric.MaxDurationObjective =>
+        "Total runtime [ms]"
     }
 
   private def formattedObjectiveValue(objective: ServiceLevelObjective[_]): String =
@@ -122,7 +122,7 @@ object ReportFormatter {
         obj.minAllowedRatePerSecond.toString
       case obj: LatencyMetric.MaxLatency =>
         obj.millis.toString
-      case obj: TotalStreamRuntimeMetric.MaxDurationObjective =>
+      case obj: TotalRuntimeMetric.MaxDurationObjective =>
         obj.maxValue.toMillis.toString
     }
 

--- a/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/BenchtoolSandboxFixture.scala
+++ b/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/BenchtoolSandboxFixture.scala
@@ -4,6 +4,7 @@
 package com.daml.ledger.api.benchtool
 
 import java.io.File
+
 import com.codahale.metrics.MetricRegistry
 import com.daml.bazeltools.BazelRunfiles.rlocation
 import com.daml.ledger.api.benchtool.config.WorkflowConfig
@@ -81,7 +82,6 @@ trait BenchtoolSandboxFixture extends SandboxFixture {
         allocatedParties = allocatedParties,
         names = new Names(),
         randomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        submissionConfig = submissionConfig,
       )
     } yield (apiServices, allocatedParties, foo)
   }

--- a/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/submission/ActiveContractsObserver.scala
+++ b/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/submission/ActiveContractsObserver.scala
@@ -30,7 +30,7 @@ class ActiveContractsObserver(logger: Logger, expectedTemplateNames: Set[String]
     for {
       created <- value.activeContracts
     } {
-      createEvents.addOne(ObservedCreateEvent(created))
+      createEvents.addOne(ObservedCreateEvent(created, offset = value.offset))
     }
 
   override def completeWith(): Future[ObservedEvents] = Future.successful(

--- a/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/submission/ObservedCreateEvent.scala
+++ b/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/submission/ObservedCreateEvent.scala
@@ -7,18 +7,24 @@ case class ObservedCreateEvent(
     templateName: String,
     createArgumentsSerializedSize: Int,
     interfaceViews: Seq[ObservedInterfaceView],
+    offset: String,
+    contractId: String,
 )
 
 object ObservedCreateEvent {
-  def apply(created: com.daml.ledger.api.v1.event.CreatedEvent): ObservedCreateEvent = {
+  def apply(
+      created: com.daml.ledger.api.v1.event.CreatedEvent,
+      offset: String,
+  ): ObservedCreateEvent = {
     val argsSize = created.createArguments.fold(0)(_.serializedSize)
     val templateName =
       created.templateId.getOrElse(sys.error(s"Expected templateId in $created")).entityName
-
     ObservedCreateEvent(
       templateName = templateName,
       createArgumentsSerializedSize = argsSize,
       interfaceViews = created.interfaceViews.map(ObservedInterfaceView.apply),
+      offset = offset,
+      contractId = created.contractId,
     )
   }
 }

--- a/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/submission/ObservedEvents.scala
+++ b/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/submission/ObservedEvents.scala
@@ -6,7 +6,7 @@ package com.daml.ledger.api.benchtool.submission
 case class ObservedEvents(
     expectedTemplateNames: Set[String],
     createEvents: Seq[ObservedCreateEvent],
-    exerciseEvents: Seq[ObservedExerciseEvent],
+    exerciseEvents: Seq[ObservedExerciseEvent] = List.empty,
 ) {
   private val _actualTemplateNames =
     (createEvents.map(_.templateName) ++ exerciseEvents.map(_.templateName)).toSet

--- a/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/submission/ObservedExerciseEvent.scala
+++ b/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/submission/ObservedExerciseEvent.scala
@@ -8,19 +8,27 @@ case class ObservedExerciseEvent(
     choiceName: String,
     choiceArgumentsSerializedSize: Int,
     consuming: Boolean,
+    offset: String,
+    contractId: String,
 )
 object ObservedExerciseEvent {
-  def apply(exercised: com.daml.ledger.api.v1.event.ExercisedEvent): ObservedExerciseEvent = {
+  def apply(
+      exercised: com.daml.ledger.api.v1.event.ExercisedEvent,
+      offset: String,
+  ): ObservedExerciseEvent = {
     val argsSize = exercised.choiceArgument.fold(0)(_.serializedSize)
     val templateName = exercised.templateId
       .getOrElse(sys.error(s"Expected templateId in $exercised"))
       .entityName
+    val contractId = exercised.contractId
     val choiceName = exercised.choice
     ObservedExerciseEvent(
       templateName = templateName,
       choiceName = choiceName,
       choiceArgumentsSerializedSize = argsSize,
       consuming = exercised.consuming,
+      offset = offset,
+      contractId = contractId,
     )
   }
 }

--- a/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/submission/TreeEventsObserver.scala
+++ b/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/submission/TreeEventsObserver.scala
@@ -34,9 +34,11 @@ class TreeEventsObserver(expectedTemplateNames: Set[String], logger: Logger)
       allEvents = transaction.eventsById.values
       event <- allEvents
     } {
-      event.kind.created.foreach(created => createEvents.addOne(ObservedCreateEvent(created)))
+      event.kind.created.foreach(created =>
+        createEvents.addOne(ObservedCreateEvent(created, offset = transaction.offset))
+      )
       event.kind.exercised.foreach(exercised =>
-        exerciseEvents.addOne(ObservedExerciseEvent(exercised))
+        exerciseEvents.addOne(ObservedExerciseEvent(exercised, offset = transaction.offset))
       )
     }
   }

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/config/WorkflowConfigParserSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/config/WorkflowConfigParserSpec.scala
@@ -6,13 +6,13 @@ package com.daml.ledger.api.benchtool.config
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
 import java.io.StringReader
-import com.daml.ledger.api.benchtool.config.WorkflowConfig.FooSubmissionConfig
+
+import com.daml.ledger.api.benchtool.config.WorkflowConfig.{FooSubmissionConfig, PruningConfig}
 import com.daml.ledger.api.benchtool.config.WorkflowConfig.FooSubmissionConfig.PartySet
 import com.daml.ledger.api.benchtool.config.WorkflowConfig.StreamConfig.PartyNamePrefixFilter
-
 import java.util.concurrent.TimeUnit
+
 import scala.concurrent.duration.Duration
 
 class WorkflowConfigParserSpec extends AnyWordSpec with Matchers {
@@ -32,6 +32,7 @@ class WorkflowConfigParserSpec extends AnyWordSpec with Matchers {
           |  num_divulgees: 5
           |  num_extra_submitters: 6
           |  unique_parties: true
+          |  allow_non_transient_contracts: true
           |  instance_distribution:
           |    - template: Foo1
           |      weight: 50
@@ -72,12 +73,19 @@ class WorkflowConfigParserSpec extends AnyWordSpec with Matchers {
           |    filters:
           |      - party: Obs-2
           |        templates:
-          |         - Foo1""".stripMargin
+          |         - Foo1
+          |unary:
+          | - type: pruning
+          |   name: pruning-123
+          |   prune_all_divulged_contracts: false
+          |   max_duration_objective: 56 ms
+          |""".stripMargin
 
       parseYaml(yaml) shouldBe Right(
         WorkflowConfig(
           submission = Some(
             WorkflowConfig.FooSubmissionConfig(
+              allowNonTransientContracts = true,
               numberOfInstances = 500,
               numberOfObservers = 4,
               numberOfDivulgees = 5,
@@ -147,6 +155,13 @@ class WorkflowConfigParserSpec extends AnyWordSpec with Matchers {
                 )
               ),
             ),
+          ),
+          pruning = Some(
+            PruningConfig(
+              name = "pruning-123",
+              pruneAllDivulgedContracts = false,
+              maxDurationObjective = Duration(56, TimeUnit.MILLISECONDS),
+            )
           ),
         )
       )

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/metrics/metrics/TotalRuntimeMetricSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/metrics/metrics/TotalRuntimeMetricSpec.scala
@@ -6,14 +6,14 @@ package com.daml.ledger.api.benchtool.metrics.metrics
 import java.time.{Clock, Duration, Instant, ZoneId}
 
 import com.daml.clock.AdjustableClock
-import com.daml.ledger.api.benchtool.metrics.metrics.TotalStreamRuntimeMetric.{
+import com.daml.ledger.api.benchtool.metrics.metrics.TotalRuntimeMetric.{
   MaxDurationObjective,
   Value,
 }
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class TotalStreamRuntimeMetricSpec extends AnyFlatSpec with Matchers {
+class TotalRuntimeMetricSpec extends AnyFlatSpec with Matchers {
 
   it should "keep track of total stream runtime" in {
     val startTime = Instant.EPOCH.plusMillis(1000)
@@ -21,7 +21,7 @@ class TotalStreamRuntimeMetricSpec extends AnyFlatSpec with Matchers {
     val objective = MaxDurationObjective(
       maxValue = Duration.ofMillis(103)
     )
-    val tested = TotalStreamRuntimeMetric[Any](
+    val tested = TotalRuntimeMetric[Any](
       clock = clock,
       startTime = clock.instant,
       objective = objective,

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/ActiveContractKeysPoolSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/ActiveContractKeysPoolSpec.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.benchtool.submission
+
+import com.daml.ledger.api.v1.value.Value
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ActiveContractKeysPoolSpec extends AnyFlatSpec with Matchers {
+
+  it should "put and pop from a pool" in {
+    val tested = new ActiveContractKeysPool(RandomnessProvider.forSeed(0))
+    intercept[NoSuchElementException](tested.getAndRemoveContractKey(templateName = "t1"))
+    tested.addContractKey(templateName = "t1", key = makeValue("1"))
+    intercept[NoSuchElementException](tested.getAndRemoveContractKey(templateName = "t2"))
+    tested.getAndRemoveContractKey("t1") shouldBe makeValue("1")
+    intercept[IndexOutOfBoundsException](tested.getAndRemoveContractKey(templateName = "t1"))
+    tested.addContractKey(templateName = "t1", key = makeValue("1"))
+    tested.addContractKey(templateName = "t1", key = makeValue("2"))
+    tested.addContractKey(templateName = "t1", key = makeValue("3"))
+    tested.addContractKey(templateName = "t2", key = makeValue("1"))
+    tested.getAndRemoveContractKey("t1") shouldBe makeValue("3")
+    tested.getAndRemoveContractKey("t1") shouldBe makeValue("1")
+    tested.getAndRemoveContractKey("t2") shouldBe makeValue("1")
+  }
+
+  private def makeValue(payload: String): Value = Value(Value.Sum.Text(payload))
+}

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/DepletingUniformRandomPoolSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/DepletingUniformRandomPoolSpec.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com
+package daml.ledger.api.benchtool.submission
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DepletingUniformRandomPoolSpec extends AnyFlatSpec with Matchers {
+
+  it should "put and pop from a pool" in {
+    val tested = new DepletingUniformRandomPool[Int](RandomnessProvider.forSeed(0))
+    intercept[IndexOutOfBoundsException](tested.pop())
+    tested.put(1)
+    tested.pop() shouldBe 1
+    tested.put(1)
+    tested.put(2)
+    tested.put(3)
+    tested.pop() shouldBe 3
+    tested.pop() shouldBe 1
+    tested.pop() shouldBe 2
+    intercept[IndexOutOfBoundsException](tested.pop())
+  }
+}

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/FooCommandSubmitterITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/FooCommandSubmitterITSpec.scala
@@ -66,7 +66,7 @@ class FooCommandSubmitterITSpec
     for {
       (apiServices, allocatedParties, fooSubmission) <- benchtoolFooSubmissionFixture(config)
       _ = allocatedParties.divulgees shouldBe empty
-      _ <- fooSubmission.performSubmission()
+      _ <- fooSubmission.performSubmission(submissionConfig = config)
       observerResult_signatory: ObservedEvents <- treeEventsObserver(
         apiServices = apiServices,
         party = allocatedParties.signatory,

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/InterfaceSubscriptionITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/InterfaceSubscriptionITSpec.scala
@@ -61,7 +61,7 @@ class InterfaceSubscriptionITSpec
         allocatedParties,
         BenchtoolTestsPackageInfo.StaticDefault,
       )
-      _ <- fooSubmission.performSubmission()
+      _ <- fooSubmission.performSubmission(submissionConfig = config)
       observedEvents <- observer(
         configDesugaring = configDesugaring,
         apiServices = apiServices,

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/NonStakeholderInformeesITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/NonStakeholderInformeesITSpec.scala
@@ -54,7 +54,7 @@ class NonStakeholderInformeesITSpec
       (apiServices, allocatedParties, fooSubmission) <- benchtoolFooSubmissionFixture(
         submissionConfig
       )
-      _ <- fooSubmission.performSubmission()
+      _ <- fooSubmission.performSubmission(submissionConfig = submissionConfig)
       (treeResults_divulgee0, flatResults_divulgee0) <- observeAllTemplatesForParty(
         party = allocatedParties.divulgees(0),
         apiServices = apiServices,

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/NonTransientContractsITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/NonTransientContractsITSpec.scala
@@ -1,0 +1,117 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.benchtool.submission
+
+import com.daml.ledger.api.benchtool.config.WorkflowConfig
+import com.daml.ledger.api.benchtool.services.LedgerApiServices
+import com.daml.ledger.api.benchtool.BenchtoolSandboxFixture
+import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
+import com.daml.ledger.client.binding
+import com.daml.scalautil.Statement.discard
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{AppendedClues, Checkpoints, EitherValues, OptionValues}
+
+import scala.concurrent.Future
+
+class NonTransientContractsITSpec
+    extends AsyncFlatSpec
+    with BenchtoolSandboxFixture
+    with SuiteResourceManagementAroundAll
+    with Matchers
+    with AppendedClues
+    with EitherValues
+    with OptionValues
+    with Checkpoints {
+
+  it should "submit non-transient contracts" in {
+    val totalContractsCount = 100
+    val submissionConfig = WorkflowConfig.FooSubmissionConfig(
+      numberOfInstances = totalContractsCount,
+      numberOfObservers = 1,
+      uniqueParties = false,
+      allowNonTransientContracts = true,
+      instanceDistribution = List(
+        WorkflowConfig.FooSubmissionConfig.ContractDescription(
+          template = "Foo1",
+          weight = 1,
+          payloadSizeBytes = 0,
+        ),
+        WorkflowConfig.FooSubmissionConfig.ContractDescription(
+          template = "Foo2",
+          weight = 1,
+          payloadSizeBytes = 0,
+        ),
+      ),
+      consumingExercises = Some(
+        WorkflowConfig.FooSubmissionConfig.ConsumingExercises(
+          probability = 0.7,
+          payloadSizeBytes = 0,
+        )
+      ),
+    )
+    for {
+      (apiServices, allocatedParties, submission) <- benchtoolFooSubmissionFixture(submissionConfig)
+      _ <- submission.performSubmission(submissionConfig)
+      txEvents: ObservedEvents <- txTreeObserver(
+        apiServices = apiServices,
+        party = allocatedParties.observers(0),
+      )
+    } yield {
+      val createAndConsumeOffsetPairs = for {
+        create <- txEvents.createEvents
+        consume <- txEvents.consumingExercises.find(_.contractId == create.contractId).toList
+      } yield create.offset -> consume.offset
+      val activeContracts = txEvents.createEvents.count(create =>
+        !txEvents.consumingExercises.exists(_.contractId == create.contractId)
+      )
+      val cp = new Checkpoint
+      val nonTransientContracts = createAndConsumeOffsetPairs.count {
+        case (createOffset, archiveOffset) => createOffset != archiveOffset
+      }
+      val transientContracts = createAndConsumeOffsetPairs.count {
+        case (createOffset, archiveOffset) => createOffset == archiveOffset
+      }
+      cp(discard(nonTransientContracts shouldBe 47))
+      cp(discard(transientContracts shouldBe 16))
+      // sanity check:
+      cp(
+        discard(
+          activeContracts + nonTransientContracts + transientContracts shouldBe totalContractsCount
+        )
+      )
+      cp.reportAll()
+      succeed
+    }
+  }
+
+  private def txTreeObserver(
+      apiServices: LedgerApiServices,
+      party: binding.Primitive.Party,
+      beginOffset: Option[LedgerOffset] = None,
+  ): Future[ObservedEvents] = {
+    val eventsObserver = TreeEventsObserver(expectedTemplateNames = Set("Foo1", "Foo2"))
+    val config = WorkflowConfig.StreamConfig.TransactionTreesStreamConfig(
+      name = "dummy-name",
+      filters = List(
+        WorkflowConfig.StreamConfig.PartyFilter(
+          party = party.toString,
+          templates = List.empty,
+          interfaces = List.empty,
+        )
+      ),
+      beginOffset = beginOffset,
+      endOffset = Some(LedgerOffset().withBoundary(LedgerOffset.LedgerBoundary.LEDGER_END)),
+      objectives = None,
+      maxItemCount = None,
+      timeoutO = None,
+    )
+    apiServices.transactionService.transactionTrees(
+      config = config,
+      observer = eventsObserver,
+    )
+  }
+
+}

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/PartySetsITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/PartySetsITSpec.scala
@@ -78,7 +78,7 @@ class PartySetsITSpec
         allocatedParties,
         BenchtoolTestsPackageInfo.StaticDefault,
       )
-      _ <- fooSubmission.performSubmission()
+      _ <- fooSubmission.performSubmission(submissionConfig = submissionConfig)
       _ = allocatedParties.observerPartySets
         .find(_.mainPartyNamePrefix == "FooParty")
         .value

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/PruningITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/PruningITSpec.scala
@@ -77,6 +77,8 @@ class PruningITSpec
         regularUserServices = apiServices,
         adminServices = apiServices,
         actorSystem = actorSystem,
+        signatory = allocatedParties.signatory,
+        names = new Names(),
       )
       acsPostPruning: ObservedEvents <- acsObserver(
         apiServices = apiServices,

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/PruningITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/PruningITSpec.scala
@@ -1,0 +1,146 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.benchtool.submission
+
+import akka.actor.typed.{ActorSystem, SpawnProtocol}
+import com.daml.ledger.api.benchtool.config.{Config, WorkflowConfig}
+import com.daml.ledger.api.benchtool.services.LedgerApiServices
+import com.daml.ledger.api.benchtool.util.TypedActorSystemResourceOwner.Creator
+import com.daml.ledger.api.benchtool.{BenchtoolSandboxFixture, PruningBenchmark}
+import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
+import com.daml.ledger.client.binding
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{AppendedClues, Checkpoints, EitherValues, OptionValues}
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class PruningITSpec
+    extends AsyncFlatSpec
+    with BenchtoolSandboxFixture
+    with SuiteResourceManagementAroundAll
+    with Matchers
+    with AppendedClues
+    with EitherValues
+    with OptionValues
+    with Checkpoints {
+
+  private var actorSystem: ActorSystem[SpawnProtocol.Command] = _
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    actorSystem = ActorSystem(Creator(), "Creator")
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    actorSystem.terminate()
+  }
+
+  it should "benchmark pruning" in {
+    val submissionConfig = WorkflowConfig.FooSubmissionConfig(
+      numberOfInstances = 100,
+      numberOfObservers = 1,
+      uniqueParties = false,
+      instanceDistribution = List(
+        WorkflowConfig.FooSubmissionConfig.ContractDescription(
+          template = "Foo1",
+          weight = 1,
+          payloadSizeBytes = 0,
+        )
+      ),
+      consumingExercises = Some(
+        WorkflowConfig.FooSubmissionConfig.ConsumingExercises(
+          probability = 0.5,
+          payloadSizeBytes = 0,
+        )
+      ),
+    )
+    val testedPruningBenchmark =
+      new PruningBenchmark(reportingPeriod = Config.Default.reportingPeriod)
+    for {
+      (apiServices, allocatedParties, submission) <- benchtoolFooSubmissionFixture(submissionConfig)
+      _ <- submission.performSubmission(submissionConfig)
+      txPrePruning: ObservedEvents <- txTreeObserver(
+        apiServices = apiServices,
+        party = allocatedParties.observers(0),
+      )
+      pruningBenchmarkResult <- testedPruningBenchmark.benchmarkPruning(
+        pruningConfig = WorkflowConfig.PruningConfig(
+          name = "pruning-benchmark-test",
+          pruneAllDivulgedContracts = true,
+          maxDurationObjective = 0.nano,
+        ),
+        regularUserServices = apiServices,
+        adminServices = apiServices,
+        actorSystem = actorSystem,
+      )
+      acsPostPruning: ObservedEvents <- acsObserver(
+        apiServices = apiServices,
+        party = allocatedParties.observers(0),
+      )
+    } yield {
+      pruningBenchmarkResult.value shouldBe ()
+      txPrePruning.createEvents.size shouldBe 100
+      txPrePruning.consumingExercises.size shouldBe 49
+      acsPostPruning.numberOfCreatesPerTemplateName("Foo1") shouldBe 51
+      acsPostPruning.numberOfConsumingExercisesPerTemplateName("Foo1") shouldBe 0
+      succeed
+    }
+  }
+
+  private def txTreeObserver(
+      apiServices: LedgerApiServices,
+      party: binding.Primitive.Party,
+      beginOffset: Option[LedgerOffset] = None,
+  ): Future[ObservedEvents] = {
+    val eventsObserver = TreeEventsObserver(expectedTemplateNames = Set("Foo1"))
+    val config = WorkflowConfig.StreamConfig.TransactionTreesStreamConfig(
+      name = "dummy-name",
+      filters = List(
+        WorkflowConfig.StreamConfig.PartyFilter(
+          party = party.toString,
+          templates = List.empty,
+          interfaces = List.empty,
+        )
+      ),
+      beginOffset = beginOffset,
+      endOffset = Some(LedgerOffset().withBoundary(LedgerOffset.LedgerBoundary.LEDGER_END)),
+      objectives = None,
+      maxItemCount = None,
+      timeoutO = None,
+    )
+    apiServices.transactionService.transactionTrees(
+      config = config,
+      observer = eventsObserver,
+    )
+  }
+
+  private def acsObserver(
+      apiServices: LedgerApiServices,
+      party: binding.Primitive.Party,
+  ): Future[ObservedEvents] = {
+    val eventsObserver = ActiveContractsObserver(expectedTemplateNames = Set("Foo1", "Foo2"))
+    val config = WorkflowConfig.StreamConfig.ActiveContractsStreamConfig(
+      name = "dummy-name",
+      filters = List(
+        WorkflowConfig.StreamConfig.PartyFilter(
+          party = party.toString,
+          templates = List.empty,
+          interfaces = List.empty,
+        )
+      ),
+      objectives = None,
+      maxItemCount = None,
+      timeoutO = None,
+    )
+    apiServices.activeContractsService.getActiveContracts(
+      config = config,
+      observer = eventsObserver,
+    )
+  }
+
+}

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/WeightedApplicationIdsAndSubmittersITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/WeightedApplicationIdsAndSubmittersITSpec.scala
@@ -61,7 +61,7 @@ class WeightedApplicationIdsAndSubmittersITSpec
       (apiServices, allocatedParties, fooSubmission) <- benchtoolFooSubmissionFixture(
         submissionConfig
       )
-      _ <- fooSubmission.performSubmission()
+      _ <- fooSubmission.performSubmission(submissionConfig = submissionConfig)
       completionsApp1 <- observeCompletions(
         parties = List(allocatedParties.signatory),
         apiServices = apiServices,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiParticipantPruningService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiParticipantPruningService.scala
@@ -185,7 +185,8 @@ final class ApiParticipantPruningService private (
     for {
       ledgerEnd <- readBackend.currentLedgerEnd()
       _ <-
-        if (pruneUpToString <= ledgerEnd.value) Future.successful(())
+        // NOTE: This constraint should be relaxed to (pruneUpToString <= ledgerEnd.value)
+        if (pruneUpToString < ledgerEnd.value) Future.successful(())
         else
           Future.failed(
             LedgerApiErrors.RequestValidation.OffsetOutOfRange

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiParticipantPruningService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiParticipantPruningService.scala
@@ -185,8 +185,7 @@ final class ApiParticipantPruningService private (
     for {
       ledgerEnd <- readBackend.currentLedgerEnd()
       _ <-
-        // NOTE: This constraint should be relaxed to (pruneUpToString <= ledgerEnd.value)
-        if (pruneUpToString < ledgerEnd.value) Future.successful(())
+        if (pruneUpToString <= ledgerEnd.value) Future.successful(())
         else
           Future.failed(
             LedgerApiErrors.RequestValidation.OffsetOutOfRange

--- a/ledger/test-common/src/main/daml/benchtool/Foo.daml
+++ b/ledger/test-common/src/main/daml/benchtool/Foo.daml
@@ -145,3 +145,9 @@ template Foo3
       controller signatory
       do
           return ()
+
+template Dummy
+  with
+    signatory: Party
+  where
+    signatory signatory


### PR DESCRIPTION
Changes:

1. Add support for defining pruning benchmarks.
Currently the new top-level `unary` section allow defining only a single `pruning` section.
Declaring both top sections `unary` and `streams` in a single workflow config is unsupported.
```
unary:
  - type: pruning
    name: pruning-or-101
    max_duration_objective: 600s
    prune_all_divulged_contracts: false
```

2. Add support for optionally submitting non-transient contracts.
```
submission:
  ...
  allow_non_transient_contracts: true
```  
