### PR TITLE
[ScenarioService] add evaluation timeout

### DIFF
--- a/compiler/damlc/tests/daml-test-files/Loop.daml
+++ b/compiler/damlc/tests/daml-test-files/Loop.daml
@@ -8,7 +8,7 @@ module Loop where
 loop : Int -> ()
 loop x = loop (x + 1) 
 
--- @ERROR range=12:1-12:25; Evaluation times out after 5 seconds
+-- @ERROR range=12:1-12:25; Evaluation timed out after 5 seconds
 loop_in_scenario_machine = scenario do
   alice <- getParty "p"
   pure $ loop 1
@@ -23,7 +23,7 @@ template Helper
       do
         pure $ loop 1
 
--- @ERROR range=27:1-27:23; Evaluation times out after 5 seconds
+-- @ERROR range=27:1-27:23; Evaluation timed out after 5 seconds
 loop_in_ledger_machine = scenario do 
    alice <- getParty "p"
    alice `submit` createAndExercise (Helper alice) Go

--- a/compiler/damlc/tests/daml-test-files/Loop.daml
+++ b/compiler/damlc/tests/daml-test-files/Loop.daml
@@ -1,0 +1,30 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @ENABLE-SCENARIOS
+
+module Loop where
+
+loop : Int -> ()
+loop x = loop (x + 1) 
+
+-- @ERROR range=12:1-12:25; Evaluation times out after 5 seconds
+loop_in_scenario_machine = scenario do
+  alice <- getParty "p"
+  pure $ loop 1
+  
+template Helper
+  with
+    p : Party
+  where
+    signatory p
+    choice Go : ()
+      controller p
+      do
+        pure $ loop 1
+
+-- @ERROR range=27:1-27:23; Evaluation times out after 5 seconds
+loop_in_ledger_machine = scenario do 
+   alice <- getParty "p"
+   alice `submit` createAndExercise (Helper alice) Go
+  

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -104,7 +104,7 @@ instance IsOption SkipValidationOpt where
 
 main :: IO ()
 main = do
- let scenarioConf = SS.defaultScenarioServiceConfig { SS.cnfJvmOptions = ["-Xmx200M"] }
+ let scenarioConf = SS.defaultScenarioServiceConfig { SS.cnfJvmOptions = ["-Xmx200M"], SS.cnfEvaluationTimeout = Just 5 }
  -- This is a bit hacky, we want the LF version before we hand over to
  -- tasty. To achieve that we first pass with optparse-applicative ignoring
  -- everything apart from the LF version.

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -495,6 +495,8 @@ prettyScenarioErrorError (Just err) =  do
         , label_ "Template: " $ prettyMay "<missing template>" (prettyDefName world) templateId
         , label_ "Key Hash: " $ ltext keyHash
         ]
+    ScenarioErrorErrorEvaluationTimeout timeout ->
+      pure $ text $ T.pack $ "Evaluation times out after " <> show timeout <> " seconds"
 
 partyDifference :: V.Vector Party -> V.Vector Party -> Doc SyntaxClass
 partyDifference with without =

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -496,7 +496,7 @@ prettyScenarioErrorError (Just err) =  do
         , label_ "Key Hash: " $ ltext keyHash
         ]
     ScenarioErrorErrorEvaluationTimeout timeout ->
-      pure $ text $ T.pack $ "Evaluation times out after " <> show timeout <> " seconds"
+      pure $ text $ T.pack $ "Evaluation timed out after " <> show timeout <> " seconds"
 
 partyDifference :: V.Vector Party -> V.Vector Party -> Doc SyntaxClass
 partyDifference with without =

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
@@ -66,7 +66,8 @@ toLowLevelOpts :: LF.Version -> Options -> LowLevel.Options
 toLowLevelOpts optDamlLfVersion Options{..} =
     LowLevel.Options{..}
     where
-        optRequestTimeout = fromMaybe 60 $ cnfGrpcTimeout optScenarioServiceConfig
+        optGrpcTimeout = fromMaybe 70 $ cnfGrpcTimeout optScenarioServiceConfig
+        optEvaluationTimeout = fromMaybe 60 $ cnfEvaluationTimeout optScenarioServiceConfig
         optGrpcMaxMessageSize = cnfGrpcMaxMessageSize optScenarioServiceConfig
         optJvmOptions = cnfJvmOptions optScenarioServiceConfig
 
@@ -134,6 +135,7 @@ withScenarioService' (EnableScenarioService enable) enableScenarios ver loggerH 
 data ScenarioServiceConfig = ScenarioServiceConfig
     { cnfGrpcMaxMessageSize :: Maybe Int -- In bytes
     , cnfGrpcTimeout :: Maybe LowLevel.TimeoutSeconds
+    , cnfEvaluationTimeout :: Maybe LowLevel.TimeoutSeconds
     , cnfJvmOptions :: [String]
     } deriving Show
 
@@ -141,6 +143,7 @@ defaultScenarioServiceConfig :: ScenarioServiceConfig
 defaultScenarioServiceConfig = ScenarioServiceConfig
     { cnfGrpcMaxMessageSize = Nothing
     , cnfGrpcTimeout = Nothing
+    , cnfEvaluationTimeout = Nothing
     , cnfJvmOptions = []
     }
 
@@ -157,6 +160,7 @@ parseScenarioServiceConfig :: ProjectConfig -> Either ConfigError ScenarioServic
 parseScenarioServiceConfig conf = do
     cnfGrpcMaxMessageSize <- queryOpt "grpc-max-message-size"
     cnfGrpcTimeout <- queryOpt "grpc-timeout"
+    cnfEvaluationTimeout <- queryOpt "evaluation-timeout"
     cnfJvmOptions <- fromMaybe [] <$> queryOpt "jvm-options"
     pure ScenarioServiceConfig {..}
   where queryOpt opt = do

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -43,6 +43,7 @@ service ScenarioService {
 
 message NewContextRequest {
   string lf_minor = 1;
+  int64 evaluation_timeout = 2;
 }
 
 message NewContextResponse {
@@ -319,6 +320,7 @@ message ScenarioError {
     = 36;
     DisclosurePreprocessingDuplicateContractKeys disclosure_preprocessing_duplicate_contract_keys = 39;
     DisclosedContractKeyHashingError disclosed_contract_key_hashing_error = 40;
+    int64 evaluationTimeout = 41;
   }
 }
 

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
@@ -25,6 +25,7 @@ import io.grpc.netty.NettyServerBuilder
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Success, Failure}
 import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
@@ -37,6 +38,7 @@ private final case class ScenarioServiceConfig(
 private object ScenarioServiceConfig {
   // default to 128MB
   val DefaultMaxInboundMessageSize: Int = 128 * 1024 * 1024
+  val DefaultTimeout = 60.seconds
 
   val parser = new scopt.OptionParser[ScenarioServiceConfig]("scenario-service") {
     head("scenario-service")
@@ -234,7 +236,7 @@ class ScenarioService(
       LanguageVersion.Major.V1,
       LanguageVersion.Minor(req.getLfMinor),
     )
-    val ctx = Context.newContext(lfVersion)
+    val ctx = Context.newContext(lfVersion, req.getEvaluationTimeout.seconds)
     contexts += (ctx.contextId -> ctx)
     val response = NewContextResponse.newBuilder.setContextId(ctx.contextId).build
     respObs.onNext(response)

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
@@ -38,7 +38,6 @@ private final case class ScenarioServiceConfig(
 private object ScenarioServiceConfig {
   // default to 128MB
   val DefaultMaxInboundMessageSize: Int = 128 * 1024 * 1024
-  val DefaultTimeout = 60.seconds
 
   val parser = new scopt.OptionParser[ScenarioServiceConfig]("scenario-service") {
     head("scenario-service")

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -313,10 +313,8 @@ final class Conversions(
             .addAllParties(parties.map(convertParty).asJava)
             .build
         )
-      case Error.Timeout(_) =>
-        // TODO https://github.com/digital-asset/daml/issues/13954
-        //  add proper support for evaluation timeout
-        builder.setCrash("timeout")
+      case Error.Timeout(timeout) =>
+        builder.setEvaluationTimeout(timeout.toSeconds)
     }
     builder.build
   }

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -204,9 +204,9 @@ object Repl {
 
     def run(expr: Expr): ScenarioRunner.ScenarioResult =
       ScenarioRunner.run(
-        buildMachine = () => Speedy.Machine.fromScenarioExpr(compiledPackages, expr),
+        Speedy.Machine.fromScenarioExpr(compiledPackages, expr),
         initialSeed = seed,
-        timeout = timeout,
+        timeout,
       )
   }
 

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -40,18 +40,28 @@ final class ScenarioRunner private (
   var currentSubmission: Option[CurrentSubmission] = None
 
   private def runUnsafe(implicit loggingContext: LoggingContext): ScenarioSuccess = {
-    // NOTE(JM): Written with an imperative loop and exceptions for speed
-    // and so that we don't need to worry about stack usage.
+    val isOverdue = TimeBomb(timeout).start()
     val startTime = System.nanoTime()
-    val deadlineInNanos = startTime + timeout.toNanos
     var steps = 0
-    var finalValue: SValue = null
-    while (finalValue == null) {
-      // machine.print(steps)
-      steps += 1 // this counts the number of external `Need` interactions
 
-      if (System.nanoTime() > deadlineInNanos)
+    @tailrec
+    def innerLoop(
+        result: SubmissionResult[ScenarioLedger.CommitResult]
+    ): Either[SubmissionError, Commit[ScenarioLedger.CommitResult]] = {
+      if (isOverdue()) throw scenario.Error.Timeout(timeout)
+      result match {
+        case commit @ Commit(_, _, _) => Right(commit)
+        case err: SubmissionError => Left(err)
+        case Interruption(continue) => innerLoop(continue())
+      }
+    }
+
+    @tailrec
+    def outerloop(): SValue = {
+      if (isOverdue())
         throw scenario.Error.Timeout(timeout)
+
+      steps += 1
 
       machine.run() match {
 
@@ -68,51 +78,56 @@ final class ScenarioRunner private (
               getParty(partyText, callback)
 
             case Question.Scenario.Submit(committers, commands, location, mustFail, callback) =>
-              val submitResult = submit(
-                compiledPackages = machine.compiledPackages,
-                ledger = ScenarioLedgerApi(ledger),
-                committers = committers,
-                readAs = Set.empty,
-                commands = SEValue(commands),
-                location = location,
-                seed = nextSeed(),
-                traceLog = machine.traceLog,
-                warningLog = machine.warningLog,
-                timeout = timeout,
-                deadlineInNanos = deadlineInNanos,
+              val submitResult = innerLoop(
+                submit(
+                  compiledPackages = machine.compiledPackages,
+                  ledger = ScenarioLedgerApi(ledger),
+                  committers = committers,
+                  readAs = Set.empty,
+                  commands = SEValue(commands),
+                  location = location,
+                  seed = nextSeed(),
+                  traceLog = machine.traceLog,
+                  warningLog = machine.warningLog,
+                )
               )
+
               if (mustFail) {
                 submitResult match {
-                  case Commit(result, _, tx) =>
+                  case Right(Commit(result, _, tx)) =>
                     currentSubmission = Some(CurrentSubmission(location, tx))
                     throw scenario.Error.MustFailSucceeded(result.richTransaction.transaction)
-                  case _: SubmissionError =>
+                  case Left(_) =>
                     ledger = ledger.insertAssertMustFail(committers, Set.empty, location)
                     callback(SValue.SUnit)
                 }
               } else {
                 submitResult match {
-                  case Commit(result, value, _) =>
+                  case Right(Commit(result, value, _)) =>
                     currentSubmission = None
                     ledger = result.newLedger
                     callback(value)
-                  case SubmissionError(err, tx) =>
+                  case Left(SubmissionError(err, tx)) =>
                     currentSubmission = Some(CurrentSubmission(location, tx))
                     throw err
                 }
               }
           }
+          outerloop()
 
         case SResultFinal(v) =>
-          finalValue = v
+          v
 
         case SResultInterruption =>
+          outerloop()
 
         case SResultError(err) =>
           throw scenario.Error.RunnerException(err)
 
       }
     }
+
+    val finalValue = outerloop()
     val endTime = System.nanoTime()
     val diff = (endTime - startTime) / 1000.0 / 1000.0
     ScenarioSuccess(
@@ -141,11 +156,10 @@ final class ScenarioRunner private (
 private[lf] object ScenarioRunner {
 
   def run(
-      buildMachine: () => Speedy.ScenarioMachine,
+      machine: Speedy.ScenarioMachine,
       initialSeed: crypto.Hash,
       timeout: Duration,
   )(implicit loggingContext: LoggingContext): ScenarioResult = {
-    val machine = buildMachine()
     val runner = new ScenarioRunner(machine, initialSeed, timeout)
     handleUnsafe(runner.runUnsafe) match {
       case Left(err) =>
@@ -177,9 +191,18 @@ private[lf] object ScenarioRunner {
     }
   }
 
-  sealed trait SubmissionResult[+R]
+  sealed abstract class SubmissionResult[+R] {
+    @tailrec
+    private[lf] final def resolve(): Either[SubmissionError, Commit[R]] = {
+      this match {
+        case commit: Commit[R] => Right(commit)
+        case error: SubmissionError => Left(error)
+        case Interruption(continue) => continue().resolve()
+      }
+    }
+  }
 
-  final case class Commit[R](
+  final case class Commit[+R](
       result: R,
       value: SValue,
       tx: IncompleteTransaction,
@@ -187,6 +210,8 @@ private[lf] object ScenarioRunner {
 
   final case class SubmissionError(error: Error, tx: IncompleteTransaction)
       extends SubmissionResult[Nothing]
+
+  final case class Interruption[R](continue: () => SubmissionResult[R]) extends SubmissionResult[R]
 
   // The interface we need from a ledger during submission. We allow abstracting over this so we can play
   // tricks like caching all responses in some benchmarks.
@@ -401,8 +426,6 @@ private[lf] object ScenarioRunner {
       traceLog: TraceLog = Speedy.Machine.newTraceLog,
       warningLog: WarningLog = Speedy.Machine.newWarningLog,
       doEnrichment: Boolean = true,
-      timeout: Duration,
-      deadlineInNanos: Long,
   )(implicit loggingContext: LoggingContext): SubmissionResult[R] = {
     val ledgerMachine = Speedy.UpdateMachine(
       compiledPackages = compiledPackages,
@@ -421,6 +444,8 @@ private[lf] object ScenarioRunner {
     // https://github.com/digital-asset/daml/issues/14108
     val enricher = if (doEnrichment) new EnricherImpl(compiledPackages) else NoEnricher
     import enricher._
+
+    def continue = () => go()
 
     @tailrec
     def go(): SubmissionResult[R] = {
@@ -455,13 +480,7 @@ private[lf] object ScenarioRunner {
               throw Error.Internal(s"unexpected $res")
           }
         case SResultInterruption =>
-          if (deadlineInNanos < System.nanoTime())
-            SubmissionError(
-              Error.Timeout(timeout),
-              enrich(ledgerMachine.incompleteTransaction),
-            )
-          else
-            go()
+          Interruption(continue)
         case SResult.SResultFinal(resultValue) =>
           ledgerMachine.finish match {
             case Right(Speedy.UpdateMachine.Result(tx, locationInfo, _, _, _)) =>

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/TimeBomb.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/TimeBomb.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package scenario
+
+import java.util.{Timer, TimerTask}
+import scala.concurrent.duration._
+
+private[scenario] class TimeBomb(delayInMillis: Long) {
+  @volatile
+  private[this] var exploded: Boolean = false
+
+  def start(): () => Boolean = {
+    val task = new TimerTask { override def run(): Unit = exploded = true }
+    TimeBomb.timer.schedule(task, delayInMillis)
+    hasExploded
+  }
+
+  val hasExploded: () => Boolean = () => exploded
+}
+
+private[scenario] object TimeBomb {
+  private val timer = new Timer(true)
+  def apply(delayInMillis: Long): TimeBomb = new TimeBomb(delayInMillis)
+  def apply(duration: Duration): TimeBomb = apply(duration.toMillis)
+}


### PR DESCRIPTION
fixes #3643, 
fixes #13954

No measurable slow down:


-- before -- 
```
Result "com.daml.lf.speedy.perf.CollectAuthority.bench":
  11.859 ±(99.9%) 0.019 ms/op [Average]
  (min, avg, max) = (11.730, 11.859, 12.158), stdev = 0.079
  CI (99.9%): [11.841, 11.878] (assumes normal distribution)


# Run complete. Total time: 00:07:14

Benchmark                                                             (dar)             (scenario)  Mode  Cnt   Score   Error  Units
CollectAuthority.bench  //daml-lf/scenario-interpreter/CollectAuthority.dar  CollectAuthority:test  avgt  200  11.859 ± 0.019  ms/op
```

-- after --
```
Result "com.daml.lf.speedy.perf.CollectAuthority.bench":
  11.740 ±(99.9%) 0.026 ms/op [Average]
  (min, avg, max) = (11.542, 11.740, 12.098), stdev = 0.108
  CI (99.9%): [11.714, 11.765] (assumes normal distribution)


# Run complete. Total time: 00:07:15

Benchmark                                                             (dar)             (scenario)  Mode  Cnt   Score   Error  Units
CollectAuthority.bench  //daml-lf/scenario-interpreter/CollectAuthority.dar  CollectAuthority:test  avgt  200  11.740 ± 0.026  ms/op
``` 

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
