### PR TITLE
[metrics] Improve the gauges API to allow closing a gauge [PLEN-107]

### DIFF
--- a/ledger/ledger-api-bench-tool/BUILD.bazel
+++ b/ledger/ledger-api-bench-tool/BUILD.bazel
@@ -65,6 +65,7 @@ da_scala_library(
         "//libs-scala/resources",
         "//libs-scala/resources-akka",
         "//libs-scala/resources-grpc",
+        "//libs-scala/scala-utils",
         "//libs-scala/timer-utils",
         "//ledger/test-common:benchtool-tests-%s.scala" % "1.15",  # TODO: make the LF version configurable
         "//ledger/test-common:dar-files-%s-lib" % "1.15",  # TODO: make the LF version configurable

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/ExposedMetrics.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/ExposedMetrics.scala
@@ -12,6 +12,7 @@ import com.daml.ledger.api.benchtool.util.TimeUtil
 import com.daml.metrics.api.MetricHandle.{Counter, Gauge, Histogram}
 import com.daml.metrics.api.dropwizard.{DropwizardCounter, DropwizardGauge, DropwizardHistogram}
 import com.daml.metrics.api.{Gauges, MetricName, MetricsContext}
+import com.daml.scalautil.Statement.discard
 import com.google.protobuf.timestamp.Timestamp
 
 final class ExposedMetrics[T](
@@ -92,14 +93,16 @@ object ExposedMetrics {
       )
     }
     val latestRecordTimeMetric = recordTimeFunction.map { f =>
+      val name = Prefix :+ "latest_record_time" :+ streamName
       LatestRecordTimeMetric[T](
         latestRecordTime = DropwizardGauge(
-          Prefix :+ "latest_record_time" :+ streamName,
+          name,
           registry
             .register(
-              Prefix :+ "latest_record_time" :+ streamName,
+              name,
               new Gauges.VarGauge[Long](0L),
             ),
+          () => discard(registry.remove(name)),
         ),
         recordTimeFunction = f,
       )

--- a/ledger/metrics/src/main/scala/com/daml/metrics/IndexerMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IndexerMetrics.scala
@@ -6,8 +6,8 @@ package com.daml.metrics
 import java.time.Instant
 
 import com.daml.metrics.api.MetricDoc.MetricQualification.Debug
-import com.daml.metrics.api.MetricHandle.{MetricsFactory, Gauge}
-import com.daml.metrics.api.dropwizard.DropwizardGauge
+import com.daml.metrics.api.MetricHandle.{Gauge, MetricsFactory}
+import com.daml.metrics.api.noop.NoOpGauge
 import com.daml.metrics.api.{MetricDoc, MetricName, MetricsContext}
 
 class IndexerMetrics(prefix: MetricName, factory: MetricsFactory) {
@@ -53,7 +53,8 @@ class IndexerMetrics(prefix: MetricName, factory: MetricsFactory) {
                     |can be negative.""",
     qualification = Debug,
   )
-  val currentRecordTimeLag: Gauge[Long] = DropwizardGauge(prefix :+ "current_record_time_lag", null)
+  val currentRecordTimeLagForDocs: Gauge[Long] =
+    NoOpGauge(prefix :+ "current_record_time_lag", 0)
 
   factory.gaugeWithSupplier(
     prefix :+ "current_record_time_lag",

--- a/observability/metrics/src/main/scala/com/daml/metrics/CacheMetrics.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/CacheMetrics.scala
@@ -6,6 +6,7 @@ package com.daml.metrics
 import com.daml.metrics.api.MetricDoc.MetricQualification.Debug
 import com.daml.metrics.api.MetricHandle.{Counter, MetricsFactory}
 import com.daml.metrics.api.{MetricDoc, MetricName, MetricsContext}
+import com.daml.scalautil.Statement.discard
 
 final class CacheMetrics(val prefix: MetricName, val factory: MetricsFactory) {
 
@@ -39,9 +40,11 @@ final class CacheMetrics(val prefix: MetricName, val factory: MetricsFactory) {
   )
   val evictionWeight: Counter = factory.counter(prefix :+ "evicted_weight")
 
-  def registerSizeGauge(sizeSupplier: () => Long): Unit =
+  def registerSizeGauge(sizeSupplier: () => Long): Unit = discard {
     factory.gaugeWithSupplier(prefix :+ "size", sizeSupplier)(MetricsContext.Empty)
-  def registerWeightGauge(weightSupplier: () => Long): Unit =
+  }
+  def registerWeightGauge(weightSupplier: () => Long): Unit = discard {
     factory.gaugeWithSupplier(prefix :+ "weight", weightSupplier)(MetricsContext.Empty)
+  }
 
 }

--- a/observability/metrics/src/main/scala/com/daml/metrics/ExecutorServiceMetrics.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/ExecutorServiceMetrics.scala
@@ -13,6 +13,7 @@ import com.daml.metrics.ExecutorServiceMetrics.{
 }
 import com.daml.metrics.api.MetricHandle.LabeledMetricsFactory
 import com.daml.metrics.api.{MetricName, MetricsContext}
+import com.daml.scalautil.Statement.discard
 import org.slf4j.LoggerFactory
 
 class ExecutorServiceMetrics(factory: LabeledMetricsFactory) {
@@ -89,15 +90,17 @@ class ExecutorServiceMetrics(factory: LabeledMetricsFactory) {
         "Approximate total number of tasks that have ever been scheduled for execution.",
       )
       queuedTasksGauge(() => executor.getQueue.size)
-      factory.gaugeWithSupplier(
-        ThreadPoolMetricsName.RemainingQueueCapacity,
-        () => executor.getQueue.remainingCapacity,
-        "Additional elements that this queue can ideally accept without blocking.",
-      )
+      discard {
+        factory.gaugeWithSupplier(
+          ThreadPoolMetricsName.RemainingQueueCapacity,
+          () => executor.getQueue.remainingCapacity,
+          "Additional elements that this queue can ideally accept without blocking.",
+        )
+      }
     }
   }
 
-  private def poolSizeGauge(size: () => Int)(implicit mc: MetricsContext): Unit = {
+  private def poolSizeGauge(size: () => Int)(implicit mc: MetricsContext): Unit = discard {
     factory.gaugeWithSupplier(
       CommonMetricsName.PoolSize,
       size,
@@ -105,15 +108,16 @@ class ExecutorServiceMetrics(factory: LabeledMetricsFactory) {
     )
   }
 
-  private def activeThreadsGauge(activeThreads: () => Int)(implicit mc: MetricsContext): Unit = {
-    factory.gaugeWithSupplier(
-      CommonMetricsName.ActiveThreads,
-      activeThreads,
-      "Estimate of the number of threads that executing tasks.",
-    )
-  }
+  private def activeThreadsGauge(activeThreads: () => Int)(implicit mc: MetricsContext): Unit =
+    discard {
+      factory.gaugeWithSupplier(
+        CommonMetricsName.ActiveThreads,
+        activeThreads,
+        "Estimate of the number of threads that executing tasks.",
+      )
+    }
 
-  private def queuedTasksGauge(queueSize: () => Int)(implicit mc: MetricsContext): Unit = {
+  private def queuedTasksGauge(queueSize: () => Int)(implicit mc: MetricsContext): Unit = discard {
     factory.gaugeWithSupplier(
       CommonMetricsName.QueuedTasks,
       queueSize,

--- a/observability/metrics/src/main/scala/com/daml/metrics/HealthMetrics.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/HealthMetrics.scala
@@ -5,6 +5,7 @@ package com.daml.metrics
 
 import java.util.concurrent.TimeoutException
 
+import com.daml.metrics.api.MetricHandle.Gauge.CloseableGauge
 import com.daml.metrics.api.MetricHandle.LabeledMetricsFactory
 import com.daml.metrics.api.{MetricsContext, MetricName => MN}
 
@@ -13,7 +14,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 class HealthMetrics(val factory: LabeledMetricsFactory) {
   import HealthMetrics._
 
-  def registerHealthGauge(componentName: String, supplier: () => Boolean): Unit = {
+  def registerHealthGauge(componentName: String, supplier: () => Boolean): CloseableGauge = {
     val asLong = () => if (supplier()) 1L else 0L
     factory.gaugeWithSupplier(MetricName, asLong, "The status of the Daml components")(
       MetricsContext((ComponentLabel, componentName))
@@ -22,7 +23,7 @@ class HealthMetrics(val factory: LabeledMetricsFactory) {
 
   def registerHealthGauge(componentName: String, supplier: () => Future[Boolean])(implicit
       executionContext: ExecutionContext
-  ): Unit = {
+  ): CloseableGauge = {
     registerHealthGauge(
       componentName,
       // gaugeWithSupplier underlying code requires the value to be provided in a finite amount of time

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/MetricHandle.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/MetricHandle.scala
@@ -127,8 +127,8 @@ object MetricHandle {
 
   object Gauge {
 
-    /** Because gauges represent a specific value at a given time there is a distinction between the value of a gauge no
-      * longer being updated vs the value no longer existing (contrary to how meters, histograms work). Because of this reasoning
+    /** Because gauges represent a specific value at a given time, there is a distinction between the value of a gauge no
+      * longer being updated vs. the value no longer existing (contrary to how meters, histograms work). Because of this reasoning
       * gauges have to be closed after usage.
       */
     trait CloseableGauge extends AutoCloseable

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/MetricHandle.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/MetricHandle.scala
@@ -6,6 +6,7 @@ package com.daml.metrics.api
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
+import com.daml.metrics.api.MetricHandle.Gauge.CloseableGauge
 import com.daml.metrics.api.MetricHandle.Timer.TimerHandle
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -43,7 +44,7 @@ object MetricHandle {
         description: String = "",
     )(implicit
         context: MetricsContext
-    ): Unit
+    ): CloseableGauge
 
     /** A meter represents a monotonically increasing value.
       * In Prometheus this is actually represented by a `Counter`.
@@ -114,7 +115,7 @@ object MetricHandle {
 
   }
 
-  trait Gauge[T] extends MetricHandle {
+  trait Gauge[T] extends MetricHandle with CloseableGauge {
     def metricType: String = "Gauge"
 
     def updateValue(newValue: T): Unit
@@ -122,6 +123,19 @@ object MetricHandle {
     def updateValue(f: T => T): Unit
 
     def getValue: T
+  }
+
+  object Gauge {
+
+    /** Because gauges represent a specific value at a given time there is a distinction between the value of a gauge no
+      * longer being updated vs the value no longer existing (contrary to how meters, histograms work). Because of this reasoning
+      * gauges have to be closed after usage.
+      */
+    trait CloseableGauge extends AutoCloseable
+
+    case class SimpleCloseableGauge(delegate: AutoCloseable) extends CloseableGauge {
+      override def close(): Unit = delegate.close()
+    }
   }
 
   trait Meter extends MetricHandle {

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/dropwizard/Metrics.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/dropwizard/Metrics.scala
@@ -66,11 +66,14 @@ sealed case class DropwizardCounter(name: String, metric: codahale.Counter) exte
 
 }
 
-sealed case class DropwizardGauge[T](name: String, metric: Gauges.VarGauge[T]) extends Gauge[T] {
+sealed case class DropwizardGauge[T](name: String, metric: Gauges.VarGauge[T], cleanUp: () => Unit)
+    extends Gauge[T] {
   def updateValue(newValue: T): Unit = metric.updateValue(newValue)
   override def getValue: T = metric.getValue
 
   override def updateValue(f: T => T): Unit = metric.updateValue(f)
+
+  override def close(): Unit = cleanUp()
 }
 
 sealed case class DropwizardHistogram(name: String, metric: codahale.Histogram)

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/noop/Metrics.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/noop/Metrics.scala
@@ -36,6 +36,8 @@ case class NoOpGauge[T](name: String, value: T) extends Gauge[T] {
   override def getValue: T = value
 
   override def updateValue(f: T => T): Unit = ()
+
+  override def close(): Unit = ()
 }
 
 case class NoOpMeter(name: String) extends Meter {

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/noop/NoOpMetricsFactory.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/noop/NoOpMetricsFactory.scala
@@ -3,6 +3,7 @@
 
 package com.daml.metrics.api.noop
 
+import com.daml.metrics.api.MetricHandle.Gauge.CloseableGauge
 import com.daml.metrics.api.MetricHandle.LabeledMetricsFactory
 import com.daml.metrics.api.{MetricHandle, MetricName, MetricsContext}
 
@@ -27,7 +28,7 @@ class NoOpMetricsFactory extends LabeledMetricsFactory {
       name: MetricName,
       gaugeSupplier: () => T,
       description: String,
-  )(implicit context: MetricsContext): Unit = ()
+  )(implicit context: MetricsContext): CloseableGauge = () => ()
 
   override def meter(
       name: MetricName,

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryMetricsFactory.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryMetricsFactory.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit
 
 import com.daml.buildinfo.BuildInfo
 import com.daml.metrics.api.Gauges.VarGauge
+import com.daml.metrics.api.MetricHandle.Gauge.{CloseableGauge, SimpleCloseableGauge}
 import com.daml.metrics.api.MetricHandle.Timer.TimerHandle
 import com.daml.metrics.api.MetricHandle.{
   Counter,
@@ -60,27 +61,29 @@ class OpenTelemetryMetricsFactory(
     initial match {
       case longInitial: Int =>
         val varGauge = new VarGauge[Int](longInitial)
-        otelMeter.gaugeBuilder(name).ofLongs().setDescription(description).buildWithCallback {
-          consumer =>
-            consumer.record(varGauge.getValue.toLong, attributes)
-        }
-        OpenTelemetryGauge(name, varGauge.asInstanceOf[VarGauge[T]])
+        val registeredGauge =
+          otelMeter.gaugeBuilder(name).ofLongs().setDescription(description).buildWithCallback {
+            consumer =>
+              consumer.record(varGauge.getValue.toLong, attributes)
+          }
+        OpenTelemetryGauge(name, varGauge.asInstanceOf[VarGauge[T]], registeredGauge)
       case longInitial: Long =>
         val varGauge = new VarGauge[Long](longInitial)
-        otelMeter.gaugeBuilder(name).ofLongs().setDescription(description).buildWithCallback {
-          consumer =>
-            consumer.record(varGauge.getValue, attributes)
-        }
-        OpenTelemetryGauge(name, varGauge.asInstanceOf[VarGauge[T]])
+        val registeredGauge =
+          otelMeter.gaugeBuilder(name).ofLongs().setDescription(description).buildWithCallback {
+            consumer =>
+              consumer.record(varGauge.getValue, attributes)
+          }
+        OpenTelemetryGauge(name, varGauge.asInstanceOf[VarGauge[T]], registeredGauge)
       case doubleInitial: Double =>
         val varGauge = new VarGauge[Double](doubleInitial)
-        otelMeter.gaugeBuilder(name).setDescription(description).buildWithCallback { consumer =>
-          consumer.record(varGauge.getValue, attributes)
-        }
-        OpenTelemetryGauge(name, varGauge.asInstanceOf[VarGauge[T]])
+        val registeredGauge =
+          otelMeter.gaugeBuilder(name).setDescription(description).buildWithCallback { consumer =>
+            consumer.record(varGauge.getValue, attributes)
+          }
+        OpenTelemetryGauge(name, varGauge.asInstanceOf[VarGauge[T]], registeredGauge)
       case _ =>
-        // A NoOp gauge as OpenTelemetry only supports longs and doubles
-        OpenTelemetryGauge(name, VarGauge(initial))
+        throw new IllegalArgumentException("Gauges support only numeric values.")
     }
   }
 
@@ -90,12 +93,12 @@ class OpenTelemetryMetricsFactory(
       description: String,
   )(implicit
       context: MetricsContext = MetricsContext.Empty
-  ): Unit = {
+  ): CloseableGauge = {
     val value = valueSupplier()
     val attributes = globalMetricsContext.merge(context).asAttributes
     value match {
       case _: Int =>
-        otelMeter
+        val gaugeHandle = otelMeter
           .gaugeBuilder(name)
           .ofLongs()
           .setDescription(description)
@@ -103,9 +106,9 @@ class OpenTelemetryMetricsFactory(
             val value = valueSupplier()
             consumer.record(value.asInstanceOf[Int].toLong, attributes)
           }
-        ()
+        SimpleCloseableGauge(gaugeHandle)
       case _: Long =>
-        otelMeter
+        val gaugeHandle = otelMeter
           .gaugeBuilder(name)
           .ofLongs()
           .setDescription(description)
@@ -113,18 +116,18 @@ class OpenTelemetryMetricsFactory(
             val value = valueSupplier()
             consumer.record(value.asInstanceOf[Long], attributes)
           }
-        ()
+        SimpleCloseableGauge(gaugeHandle)
       case _: Double =>
-        otelMeter
+        val gaugeHandle = otelMeter
           .gaugeBuilder(name)
           .setDescription(description)
           .buildWithCallback { consumer =>
             val value = valueSupplier()
             consumer.record(value.asInstanceOf[Double], attributes)
           }
-        ()
+        SimpleCloseableGauge(gaugeHandle)
       case _ =>
-      // NoOp as opentelemetry only supports longs and doubles
+        throw new IllegalArgumentException("Gauges support only numeric values.")
     }
   }
 
@@ -207,11 +210,14 @@ object OpenTelemetryTimer {
   }
 }
 
-case class OpenTelemetryGauge[T](name: String, varGauge: VarGauge[T]) extends Gauge[T] {
+case class OpenTelemetryGauge[T](name: String, varGauge: VarGauge[T], reference: AutoCloseable)
+    extends Gauge[T] {
 
   override def updateValue(newValue: T): Unit = varGauge.updateValue(newValue)
 
   override def getValue: T = varGauge.getValue
+
+  override def close(): Unit = reference.close()
 
   override def updateValue(f: T => T): Unit = varGauge.updateValue(f)
 }

--- a/observability/metrics/src/test/lib/scala/com/daml/metrics/api/testing/InMemoryMetricsFactory.scala
+++ b/observability/metrics/src/test/lib/scala/com/daml/metrics/api/testing/InMemoryMetricsFactory.scala
@@ -190,7 +190,7 @@ object InMemoryMetricsFactory extends InMemoryMetricsFactory {
     override def close(): Unit = closed.set(true)
 
     private def checkClosed(): Unit =
-      if (closed.get()) throw new IllegalStateException()("Already closed")
+      if (closed.get()) throw new IllegalStateException("Already closed")
   }
 
   case class InMemoryMeter(initialContext: MetricsContext) extends Meter {

--- a/observability/metrics/src/test/lib/scala/com/daml/metrics/api/testing/InMemoryMetricsFactory.scala
+++ b/observability/metrics/src/test/lib/scala/com/daml/metrics/api/testing/InMemoryMetricsFactory.scala
@@ -190,7 +190,7 @@ object InMemoryMetricsFactory extends InMemoryMetricsFactory {
     override def close(): Unit = closed.set(true)
 
     private def checkClosed(): Unit =
-      if (closed.get()) throw new IllegalArgumentException("Already closed")
+      if (closed.get()) throw new IllegalStateException()("Already closed")
   }
 
   case class InMemoryMeter(initialContext: MetricsContext) extends Meter {


### PR DESCRIPTION
This ensures gauges can be removed once they are no longer needed/used.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
