### PR TITLE
[metrics] Allow extension of no-op metrics factory

### DIFF
--- a/observability/metrics/src/main/scala/com/daml/metrics/api/noop/NoOpMetricsFactory.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/noop/NoOpMetricsFactory.scala
@@ -6,7 +6,7 @@ package com.daml.metrics.api.noop
 import com.daml.metrics.api.MetricHandle.LabeledMetricsFactory
 import com.daml.metrics.api.{MetricHandle, MetricName, MetricsContext}
 
-object NoOpMetricsFactory extends LabeledMetricsFactory {
+class NoOpMetricsFactory extends LabeledMetricsFactory {
 
   override def timer(
       name: MetricName,
@@ -50,3 +50,5 @@ object NoOpMetricsFactory extends LabeledMetricsFactory {
       context: MetricsContext
   ): MetricHandle.Histogram = NoOpHistogram(name)
 }
+
+object NoOpMetricsFactory extends NoOpMetricsFactory


### PR DESCRIPTION
This allows us to easily extend the no-op implementation for the canton metric factory

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
