### PR TITLE
Common metrics reporter config format [PLEN-91]

### DIFF
--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/Config.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/Config.scala
@@ -20,6 +20,7 @@ import ch.qos.logback.classic.{Level => LogLevel}
 import com.daml.cliopts.Logging.LogEncoder
 import com.daml.http.{WebsocketConfig => WSC}
 import com.daml.http.dbbackend.JdbcConfig
+import com.daml.metrics.MetricsConfig
 import com.daml.metrics.api.reporters.MetricsReporter
 
 // The internal transient scopt structure *and* StartSettings; external `start`
@@ -43,7 +44,7 @@ private[http] final case class Config(
     logLevel: Option[LogLevel] = None, // the default is in logback.xml
     logEncoder: LogEncoder = LogEncoder.Plain,
     metricsReporter: Option[MetricsReporter] = None,
-    metricsReportingInterval: FiniteDuration = StartSettings.DefaultMetricsReportingInterval,
+    metricsReportingInterval: FiniteDuration = MetricsConfig.DefaultMetricsReportingInterval,
     surrogateTpIdCacheMaxEntries: Option[Long] = None,
 ) extends StartSettings
 

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/FileBasedConfig.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/FileBasedConfig.scala
@@ -7,7 +7,8 @@ import akka.stream.ThrottleMode
 import com.daml.cliopts
 import com.daml.cliopts.Logging.LogEncoder
 import com.daml.http.dbbackend.{DbStartupMode, JdbcConfig}
-import com.daml.pureconfigutils.{HttpServerConfig, LedgerApiConfig, MetricsConfig}
+import com.daml.metrics.MetricsConfig
+import com.daml.pureconfigutils.{HttpServerConfig, LedgerApiConfig}
 import com.daml.pureconfigutils.SharedConfigReaders._
 import pureconfig.ConfigReader
 import pureconfig.generic.semiauto._
@@ -87,7 +88,7 @@ private[http] final case class FileBasedConfig(
       logEncoder = logEncoder,
       metricsReporter = metrics.map(_.reporter),
       metricsReportingInterval =
-        metrics.map(_.reportingInterval).getOrElse(StartSettings.DefaultMetricsReportingInterval),
+        metrics.map(_.reportingInterval).getOrElse(MetricsConfig.DefaultMetricsReportingInterval),
       surrogateTpIdCacheMaxEntries = maxTemplateIdCacheEntries,
     )
   }

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/StartSettings.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/StartSettings.scala
@@ -42,7 +42,6 @@ object StartSettings {
   val DefaultPackageReloadInterval: FiniteDuration = 5.seconds
   val DefaultMaxInboundMessageSize: Int = 4194304
   val DefaultHealthTimeoutSeconds: Int = 5
-  val DefaultMetricsReportingInterval: FiniteDuration = 10.seconds
 
   trait Default extends StartSettings {
     override val staticContentConfig: Option[StaticContentConfig] = None

--- a/ledger-service/pureconfig-utils/src/main/scala/com/daml/pureconfigutils/SharedConfigReaders.scala
+++ b/ledger-service/pureconfig-utils/src/main/scala/com/daml/pureconfigutils/SharedConfigReaders.scala
@@ -19,7 +19,6 @@ import scalaz.syntax.std.option._
 import java.nio.file.Path
 import java.io.File
 import com.daml.metrics.api.reporters.MetricsReporter
-import scala.concurrent.duration.FiniteDuration
 
 final case class HttpServerConfig(address: String, port: Int, portFile: Option[Path] = None)
 final case class LedgerTlsConfig(
@@ -36,7 +35,6 @@ final case class LedgerApiConfig(
     port: Int,
     tls: LedgerTlsConfig = LedgerTlsConfig(),
 )
-final case class MetricsConfig(reporter: MetricsReporter, reportingInterval: FiniteDuration)
 
 object TokenVerifierConfig {
   private val knownTokenVerifiers: Map[String, String => JwtError \/ JwtVerifierBase] =
@@ -125,5 +123,4 @@ object SharedConfigReaders {
     deriveReader[LedgerTlsConfig]
   implicit val ledgerApiConfReader: ConfigReader[LedgerApiConfig] =
     deriveReader[LedgerApiConfig]
-  implicit val metricsConfigReader: ConfigReader[MetricsConfig] = deriveReader[MetricsConfig]
 }

--- a/ledger-service/pureconfig-utils/src/test/scala/com/daml/pureconfigutils/SharedConfigReadersTest.scala
+++ b/ledger-service/pureconfig-utils/src/test/scala/com/daml/pureconfigutils/SharedConfigReadersTest.scala
@@ -4,6 +4,7 @@
 package com.daml.pureconfigutils
 
 import com.daml.jwt.JwtVerifierBase
+import com.daml.metrics.MetricsConfig
 import org.scalatest.Inside.inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec

--- a/observability/metrics/BUILD.bazel
+++ b/observability/metrics/BUILD.bazel
@@ -12,11 +12,14 @@ da_scala_library(
     srcs = glob(["src/main/scala/**/*.scala"]),
     resources = glob(["src/main/resources/**/*"]),
     scala_deps = [
+        "@maven//:com_chuusai_shapeless",
+        "@maven//:com_github_pureconfig_pureconfig_core",
+        "@maven//:com_github_pureconfig_pureconfig_generic",
+        "@maven//:com_github_scopt_scopt",
         "@maven//:com_thesamet_scalapb_scalapb_runtime",
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:org_scalaz_scalaz_core",
-        "@maven//:com_github_scopt_scopt",
     ],
     tags = ["maven_coordinates=com.daml:metrics:__VERSION__"],
     visibility = [

--- a/observability/metrics/src/main/scala/com/daml/metrics/MetricsConfig.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/MetricsConfig.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.metrics
+
+import com.daml.metrics.api.reporters.MetricsReporter
+import pureconfig.{ConfigReader, ConvertHelpers}
+import pureconfig.generic.semiauto.deriveReader
+import scala.concurrent.duration._
+
+final case class MetricsConfig(reporter: MetricsReporter, reportingInterval: FiniteDuration)
+
+object MetricsConfig {
+
+  val DefaultMetricsReportingInterval: FiniteDuration = 10.seconds
+
+  implicit val metricReporterReader: ConfigReader[MetricsReporter] = {
+    ConfigReader.fromString[MetricsReporter](ConvertHelpers.catchReadError { s =>
+      MetricsReporter.parseMetricsReporter(s.toLowerCase())
+    })
+  }
+
+  implicit val metricsConfigReader: ConfigReader[MetricsConfig] = deriveReader[MetricsConfig]
+}

--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -224,6 +224,7 @@ da_scala_test(
         "//libs-scala/scala-utils",
         "//libs-scala/test-evidence/scalatest:test-evidence-scalatest",
         "//libs-scala/test-evidence/tag:test-evidence-tag",
+        "//observability/metrics",
         "@maven//:com_auth0_java_jwt",
         "@maven//:com_typesafe_config",
     ],

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Cli.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Cli.scala
@@ -53,8 +53,8 @@ private[oauth2] final case class Cli(
     metricsReportingInterval: FiniteDuration = FiniteDuration(10, duration.SECONDS),
 ) extends StrictLogging {
 
-  def loadFromConfigFile: Option[Either[ConfigReaderFailures, Config]] = {
-    configFile.map(cf => ConfigSource.file(cf).load[Config])
+  def loadFromConfigFile: Option[Either[ConfigReaderFailures, FileConfig]] = {
+    configFile.map(cf => ConfigSource.file(cf).load[FileConfig])
   }
 
   def loadFromCliArgs: Config = {
@@ -84,7 +84,7 @@ private[oauth2] final case class Cli(
   def loadConfig: Option[Config] = {
     loadFromConfigFile.cata(
       {
-        case Right(cfg) => Some(cfg)
+        case Right(cfg) => Some(cfg.toConfig())
         case Left(ex) =>
           logger.error(
             s"Error loading oauth2-middleware config from file $configFile",

--- a/triggers/service/auth/src/test/resources/oauth2-middleware.conf
+++ b/triggers/service/auth/src/test/resources/oauth2-middleware.conf
@@ -24,4 +24,8 @@
     type = "rs256-jwks"
     uri = "https://example.com/.well-known/jwks.json"
   }
+  metrics {
+    reporter = "prometheus://0.0.0.0:5104"
+    reporting-interval = 30s
+  }
 }

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/CliSpec.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/CliSpec.scala
@@ -8,14 +8,17 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 import com.daml.bazeltools.BazelRunfiles.requiredResource
 import com.daml.jwt.JwksVerifier
+import com.daml.metrics.MetricsConfig
+import com.daml.metrics.api.reporters.MetricsReporter
 import org.scalatest.Inside.inside
 import pureconfig.error.{CannotReadFile, ConfigReaderFailures}
 
 import java.nio.file.Paths
+import java.net.InetSocketAddress
 import scala.concurrent.duration._
 
 class CliSpec extends AsyncWordSpec with Matchers {
-  val minimalCfg = Config(
+  val minimalCfg = FileConfig(
     oauthAuth = Uri("https://oauth2/uri"),
     oauthToken = Uri("https://oauth2/token"),
     callbackUri = Some(Uri("https://example.com/auth/cb")),
@@ -61,6 +64,12 @@ class CliSpec extends AsyncWordSpec with Matchers {
         oauthAuthTemplate = Some(Paths.get("auth_template")),
         oauthTokenTemplate = Some(Paths.get("token_template")),
         oauthRefreshTemplate = Some(Paths.get("refresh_template")),
+        metrics = Some(
+          MetricsConfig(
+            MetricsReporter.Prometheus(new InetSocketAddress("0.0.0.0", 5104)),
+            30.seconds,
+          )
+        ),
       )
       // token verifier needs to be set.
       c.tokenVerifier shouldBe a[JwksVerifier]

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceAppConf.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceAppConf.scala
@@ -11,6 +11,7 @@ import com.daml.platform.services.time.TimeProviderType
 import pureconfig.{ConfigReader, ConvertHelpers}
 import com.daml.auth.middleware.api.{Client => AuthClient}
 import com.daml.lf.engine.trigger.TriggerRunnerConfig.DefaultTriggerRunnerConfig
+import com.daml.metrics.MetricsConfig
 import com.daml.pureconfigutils.LedgerApiConfig
 import com.daml.pureconfigutils.SharedConfigReaders._
 import pureconfig.error.FailureReason
@@ -110,6 +111,7 @@ private[trigger] final case class TriggerServiceAppConf(
     triggerConfig: TriggerRunnerConfig = DefaultTriggerRunnerConfig,
     rootLoggingLevel: Option[Level] = None,
     logEncoder: LogEncoder = LogEncoder.Plain,
+    metrics: Option[MetricsConfig] = None,
 ) {
   def toServiceConfig: ServiceConfig = {
     ServiceConfig(
@@ -141,6 +143,9 @@ private[trigger] final case class TriggerServiceAppConf(
       triggerConfig = triggerConfig,
       rootLoggingLevel = rootLoggingLevel,
       logEncoder = logEncoder,
+      metricsReporter = metrics.map(_.reporter),
+      metricsReportingInterval =
+        metrics.map(_.reportingInterval).getOrElse(MetricsConfig.DefaultMetricsReportingInterval),
     )
   }
 }


### PR DESCRIPTION
Fixed the config for metrics reporter for trigger service and oauth middleware.
They are using a common config definition, as well as the JSON API service.
The format matches the one used in canton configs.

CHANGELOG_BEGIN
CHANGELOG_END

