### PR TITLE
[engine] remove clunky suffix from with-authority internal names

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -302,7 +302,7 @@ data BuiltinExpr
   | BEEqualList                  -- :: ∀a. (a -> a -> Bool) -> List a -> List a -> Bool
 
   -- Authority operations
-  | BEWithAuthorityOf            -- :: ∀ a. List Party -> Update a -> Update a
+  | BEWithAuthority              -- :: ∀ a. List Party -> Update a -> Update a
 
   -- Map operations
   | BETextMapEmpty               -- :: ∀ a. TextMap a

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -267,7 +267,7 @@ instance Pretty BuiltinExpr where
     BEExpInt64 -> "EXP_INT64"
     BEFoldl -> "FOLDL"
     BEFoldr -> "FOLDR"
-    BEWithAuthorityOf -> "WITH_AUTHORITY_OF"
+    BEWithAuthority -> "WITH_AUTHORITY"
     BETextMapEmpty -> "TEXTMAP_EMPTY"
     BETextMapInsert -> "TEXTMAP_INSERT"
     BETextMapLookup -> "TEXTMAP_LOOKUP"

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -101,7 +101,7 @@ featureUnstable = Feature
 
 featureWithAuthority :: Feature
 featureWithAuthority = Feature
-    { featureName = "withAuthorityOf primitive"
+    { featureName = "withAuthority primitive"
     , featureMinVersion = versionDev
     , featureCppFlag = Just "DAML_WITH_AUTHORITY"
     }

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -473,7 +473,7 @@ decodeBuiltinFunction = \case
 
   LF1.BuiltinFunctionFOLDL          -> pure BEFoldl
   LF1.BuiltinFunctionFOLDR          -> pure BEFoldr
-  LF1.BuiltinFunctionWITH_AUTHORITY_OF -> pure BEWithAuthorityOf
+  LF1.BuiltinFunctionWITH_AUTHORITY -> pure BEWithAuthority
   LF1.BuiltinFunctionEQUAL_LIST     -> pure BEEqualList
   LF1.BuiltinFunctionAPPEND_TEXT    -> pure BEAppendText
 

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -516,7 +516,7 @@ encodeBuiltinExpr = \case
 
     BEFoldl -> builtin P.BuiltinFunctionFOLDL
     BEFoldr -> builtin P.BuiltinFunctionFOLDR
-    BEWithAuthorityOf -> builtin P.BuiltinFunctionWITH_AUTHORITY_OF
+    BEWithAuthority -> builtin P.BuiltinFunctionWITH_AUTHORITY
     BEEqualList -> builtin P.BuiltinFunctionEQUAL_LIST
     BEExplodeText -> builtin P.BuiltinFunctionEXPLODE_TEXT
     BEAppendText -> builtin P.BuiltinFunctionAPPEND_TEXT

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -137,7 +137,7 @@ safetyStep = \case
       BEExpInt64          -> Safe 1
       BEFoldl             -> Safe 2
       BEFoldr             -> Safe 2
-      BEWithAuthorityOf   -> undefined -- TODO https://github.com/digital-asset/daml/issues/15882
+      BEWithAuthority     -> undefined -- TODO https://github.com/digital-asset/daml/issues/15882
       BETextMapEmpty      -> Safe 0
       BETextMapInsert     -> Safe 3
       BETextMapLookup     -> Safe 2

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -278,7 +278,7 @@ typeOfBuiltin = \case
   BEFoldr -> pure $ TForall (alpha, KStar) $ TForall (beta, KStar) $
              (tAlpha :-> tBeta :-> tBeta) :-> tBeta :-> TList tAlpha :-> tBeta
 
-  BEWithAuthorityOf ->
+  BEWithAuthority ->
     pure $ TForall (alpha, KStar) $
     TList TParty :->
     TUpdate tAlpha :->

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -89,8 +89,8 @@ convertPrim _ "BEFoldr" ((a1 :-> b1 :-> b2) :-> b3 :-> TList a2 :-> b4) | a1 == 
     pure $ EBuiltin BEFoldr `ETyApp` a1 `ETyApp` b1
 
 -- Authority operations
-convertPrim _ "BEWithAuthorityOf" (TList TParty :-> TUpdate a1 :-> TUpdate a2) | a1 == a2 =
-    pure $ EBuiltin BEWithAuthorityOf `ETyApp` a1
+convertPrim _ "BEWithAuthority" (TList TParty :-> TUpdate a1 :-> TUpdate a2) | a1 == a2 =
+    pure $ EBuiltin BEWithAuthority `ETyApp` a1
 
 -- Error
 convertPrim _ "BEError" (TText :-> t2) =

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -280,6 +280,6 @@ data AnyException = AnyException Opaque
 
 -- | Authority operations.
 withAuthorityOf : [Party] -> Update a -> Update a
-withAuthorityOf = primitive @"BEWithAuthorityOf"
+withAuthorityOf = primitive @"BEWithAuthority"
 
 #endif

--- a/compiler/damlc/tests/daml-test-files/WithAuthority.daml
+++ b/compiler/damlc/tests/daml-test-files/WithAuthority.daml
@@ -1,7 +1,7 @@
 
 -- @SINCE-LF-FEATURE DAML_WITH_AUTHORITY
 
-module WithAuthorityOf where
+module WithAuthority where
 
 template HasConsortiumAutority
   with

--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -450,7 +450,7 @@ enum BuiltinFunction {
 
   FOLDL = 20;
   FOLDR = 21;
-  WITH_AUTHORITY_OF = 149;
+  WITH_AUTHORITY = 149;
 
   TEXTMAP_EMPTY = 96;
   TEXTMAP_INSERT = 97;

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -2076,7 +2076,7 @@ private[archive] object DecodeV1 {
       BuiltinFunctionInfo(NUMERIC_TO_INT64, BNumericToInt64, minVersion = numeric),
       BuiltinFunctionInfo(FOLDL, BFoldl),
       BuiltinFunctionInfo(FOLDR, BFoldr),
-      BuiltinFunctionInfo(WITH_AUTHORITY_OF, BWithAuthorityOf),
+      BuiltinFunctionInfo(WITH_AUTHORITY, BWithAuthority),
       BuiltinFunctionInfo(TEXTMAP_EMPTY, BTextMapEmpty),
       BuiltinFunctionInfo(TEXTMAP_INSERT, BTextMapInsert),
       BuiltinFunctionInfo(TEXTMAP_LOOKUP, BTextMapLookup),

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PhaseOne.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PhaseOne.scala
@@ -470,7 +470,7 @@ private[lf] final class PhaseOne(
           // List functions
           case BFoldl => SBFoldl
           case BFoldr => SBFoldr
-          case BWithAuthorityOf => SBWithAuthorityOf
+          case BWithAuthority => SBWithAuthority
           case BEqualList => SBEqualList
 
           // Errors

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -655,7 +655,7 @@ private[lf] object SBuiltin {
     }
   }
 
-  final case object SBWithAuthorityOf extends SBuiltin(2) {
+  final case object SBWithAuthority extends SBuiltin(2) {
     override private[speedy] def execute[Q](
         args: util.ArrayList[SValue],
         machine: Machine[Q],
@@ -663,7 +663,7 @@ private[lf] object SBuiltin {
       // TODO https://github.com/digital-asset/daml/issues/15882
       // For development, implement this primitive as the identity operation. No authority is gained.
       // val parties = args.get(0)
-      // println(s"**SBWithAuthorityOf/execute, parties=$parties")
+      // println(s"**SBWithAuthority/execute, parties=$parties")
       val action = args.get(1)
       Control.Value(action)
     }

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -458,7 +458,7 @@ object Ast {
   final case object BFoldr extends BuiltinFunction // : ∀a b. (a → b → b) → b → List a → b
 
   // Authority
-  final case object BWithAuthorityOf
+  final case object BWithAuthority
       extends BuiltinFunction // : ∀ a. List Party → Update a → Update a
 
   // Maps

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -338,7 +338,7 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
     "UNIX_MICROSECONDS_TO_TIMESTAMP" -> BUnixMicrosecondsToTimestamp,
     "FOLDL" -> BFoldl,
     "FOLDR" -> BFoldr,
-    "WITH_AUTHORITY_OF" -> BWithAuthorityOf,
+    "WITH_AUTHORITY" -> BWithAuthority,
     "TEXTMAP_EMPTY" -> BTextMapEmpty,
     "TEXTMAP_INSERT" -> BTextMapInsert,
     "TEXTMAP_LOOKUP" -> BTextMapLookup,

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -209,7 +209,7 @@ class ParsersSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matcher
         "UNIX_MICROSECONDS_TO_TIMESTAMP" -> BUnixMicrosecondsToTimestamp,
         "FOLDL" -> BFoldl,
         "FOLDR" -> BFoldr,
-        "WITH_AUTHORITY_OF" -> BWithAuthorityOf,
+        "WITH_AUTHORITY" -> BWithAuthority,
         "EXPLODE_TEXT" -> BExplodeText,
         "IMPLODE_TEXT" -> BImplodeText,
         "APPEND_TEXT" -> BAppendText,

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -4560,7 +4560,7 @@ List functions
 Authority functions
 ~~~~~~~~~~~~~~~~~~~
 
-* ``WITH_AUTHORITY_OF : ∀ (α : ⋆) . 'List' 'Party' → 'Update' α → 'Update' α``
+* ``WITH_AUTHORITY : ∀ (α : ⋆) . 'List' 'Party' → 'Update' α → 'Update' α``
 
   Request authorization from the ledger for the scope of an update operation.
 

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -138,7 +138,7 @@ private[validation] object Typing {
           TForall(beta.name -> KStar, (alpha ->: beta ->: beta) ->: beta ->: TList(alpha) ->: beta),
         ),
       // Authority
-      BWithAuthorityOf ->
+      BWithAuthority ->
         TForall(
           alpha.name -> KStar,
           TList(TParty) ->: TUpdate(alpha) ->: TUpdate(alpha),

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -69,7 +69,7 @@ genrule(
       cp -L $(location :daml/TestContractId.daml) $$TMP_DIR/daml
       cp -L $(location :daml/TestExceptions.daml) $$TMP_DIR/daml
       cp -L $(location :daml/TestInterfaces.daml) $$TMP_DIR/daml
-      cp -L $(location :daml/TestWithAuthorityOf.daml) $$TMP_DIR/daml
+      cp -L $(location :daml/TestWithAuthority.daml) $$TMP_DIR/daml
       cp -L $(location //daml-script/daml:daml-script-1.dev.dar) $$TMP_DIR/
       cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: {sdk}

--- a/daml-script/test/daml/TestWithAuthority.daml
+++ b/daml-script/test/daml/TestWithAuthority.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module TestWithAuthorityOf where
+module TestWithAuthority where
 
 import Daml.Script
 

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
@@ -359,13 +359,13 @@ abstract class AbstractFuncIT
         }
       }
     }
-    "WithAuthorityOf:test" should {
+    "WithAuthority:test" should {
       "succeed" in {
         for {
           clients <- participantClients()
           v <- run(
             clients,
-            QualifiedName.assertFromString("TestWithAuthorityOf:test"),
+            QualifiedName.assertFromString("TestWithAuthority:test"),
             dar = devDar,
           )
         } yield {


### PR DESCRIPTION
Remove clunky/unnecessary `Of`  /  `_OF` suffixes from (internal) _WithAuthority_ names:
- proto
- Daml-LF Ast
- other internal data-structure
- test file names and modules

The suffix wasn't being used consistently. And the names are easier to process without it.

The `Of` suffix is kept only in the name of the user-facing Daml fuction:
(I think the suffix is clunky here also, but removing this is a decision for product.)
```
withAuthorityOf : [Party] -> Update a -> Update a
```