### PR TITLE
[DPP-1400] Refactor and simplify the pruning backend tests

### DIFF
--- a/ledger/participant-integration-api/BUILD.bazel
+++ b/ledger/participant-integration-api/BUILD.bazel
@@ -161,6 +161,7 @@ da_scala_library(
         "@maven//:org_scalatest_scalatest_flatspec",
         "@maven//:org_scalatest_scalatest_matchers_core",
         "@maven//:org_scalatest_scalatest_shouldmatchers",
+        "@maven//:org_playframework_anorm_anorm",
     ],
     scala_runtime_deps = [
         "@maven//:com_typesafe_akka_akka_slf4j",

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/PruningDtoQueries.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/PruningDtoQueries.scala
@@ -1,0 +1,74 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.backend
+
+import java.sql.Connection
+
+import anorm.RowParser
+import anorm.SqlParser.{long, str}
+import anorm.~
+import com.daml.platform.store.backend.common.ComposableQuery.SqlStringInterpolation
+import com.daml.platform.store.backend.common.SimpleSqlAsVectorOf._
+
+object PruningDto {
+
+  case class Create(seqId: Long)
+  case class Consuming(seqId: Long)
+  case class NonConsuming(seqId: Long)
+  case class Divulgence(seqId: Long)
+
+  case class CreateFilterStakeholder(seqId: Long, party: Long)
+  case class CreateFilterNonStakeholder(seqId: Long, party: Long)
+  case class ConsumingFilterStakeholder(seqId: Long, party: Long)
+  case class ConsumingFilterNonStakeholder(seqId: Long, party: Long)
+  case class NonConsumingFilter(seqId: Long, party: Long)
+
+  case class TxMeta(offset: String)
+  case class Completion(offset: String)
+
+}
+class PruningDtoQueries {
+  import PruningDto._
+  private def seqIdParser[T](f: Long => T): RowParser[T] = long("event_sequential_id").map(f)
+  private def idFilterParser[T](f: (Long, Long) => T): RowParser[T] =
+    long("event_sequential_id") ~ long("party_id") map { case seqId ~ partyId => f(seqId, partyId) }
+  private def offsetParser[T](f: String => T): RowParser[T] = str("offset") map (f)
+
+  def create(implicit c: Connection): Seq[Create] =
+    SQL"SELECT event_sequential_id FROM participant_events_create ORDER BY event_sequential_id"
+      .asVectorOf(seqIdParser(Create))(c)
+  def consuming(implicit c: Connection): Seq[Consuming] =
+    SQL"SELECT event_sequential_id FROM participant_events_consuming_exercise ORDER BY event_sequential_id"
+      .asVectorOf(seqIdParser(Consuming))(c)
+  def nonConsuming(implicit c: Connection): Seq[NonConsuming] =
+    SQL"SELECT event_sequential_id FROM participant_events_non_consuming_exercise ORDER BY event_sequential_id"
+      .asVectorOf(seqIdParser(NonConsuming))(c)
+  def divulgence(implicit c: Connection): Seq[Divulgence] =
+    SQL"SELECT event_sequential_id FROM participant_events_divulgence ORDER BY event_sequential_id"
+      .asVectorOf(seqIdParser(Divulgence))(c)
+
+  def createFilterStakeholder(implicit c: Connection): Seq[CreateFilterStakeholder] =
+    SQL"SELECT event_sequential_id, party_id FROM pe_create_id_filter_stakeholder ORDER BY event_sequential_id, party_id"
+      .asVectorOf(idFilterParser(CreateFilterStakeholder))(c)
+  def createFilterNonStakeholder(implicit c: Connection): Seq[CreateFilterNonStakeholder] =
+    SQL"SELECT event_sequential_id, party_id FROM pe_create_id_filter_non_stakeholder_informee ORDER BY event_sequential_id, party_id"
+      .asVectorOf(idFilterParser(CreateFilterNonStakeholder))(c)
+  def consumingFilterStakeholder(implicit c: Connection): Seq[ConsumingFilterStakeholder] =
+    SQL"SELECT event_sequential_id, party_id FROM pe_consuming_id_filter_stakeholder ORDER BY event_sequential_id, party_id"
+      .asVectorOf(idFilterParser(ConsumingFilterStakeholder))(c)
+  def consumingFilterNonStakeholder(implicit c: Connection): Seq[ConsumingFilterNonStakeholder] =
+    SQL"SELECT event_sequential_id, party_id FROM pe_consuming_id_filter_non_stakeholder_informee ORDER BY event_sequential_id, party_id"
+      .asVectorOf(idFilterParser(ConsumingFilterNonStakeholder))(c)
+  def nonConsumingFilter(implicit c: Connection): Seq[NonConsumingFilter] =
+    SQL"SELECT event_sequential_id, party_id FROM pe_non_consuming_id_filter_informee ORDER BY event_sequential_id, party_id"
+      .asVectorOf(idFilterParser(NonConsumingFilter))(c)
+
+  def txMeta(implicit c: Connection): Seq[TxMeta] =
+    SQL"SELECT event_offset AS offset FROM participant_transaction_meta ORDER BY event_offset"
+      .asVectorOf(offsetParser(TxMeta))(c)
+  def completions(implicit c: Connection): Seq[Completion] =
+    SQL"SELECT completion_offset AS offset FROM participant_command_completions ORDER BY completion_offset"
+      .asVectorOf(offsetParser(Completion))(c)
+
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/PruningDtoQueries.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/PruningDtoQueries.scala
@@ -11,6 +11,9 @@ import anorm.~
 import com.daml.platform.store.backend.common.ComposableQuery.SqlStringInterpolation
 import com.daml.platform.store.backend.common.SimpleSqlAsVectorOf._
 
+/** Contains dto classes each holding a minimal set of data sufficient
+  * to uniquely identify a row in the corresponding table.
+  */
 object PruningDto {
 
   case class Create(seqId: Long)

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/PruningDtoQueries.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/PruningDtoQueries.scala
@@ -16,16 +16,16 @@ import com.daml.platform.store.backend.common.SimpleSqlAsVectorOf._
   */
 object PruningDto {
 
-  case class Create(seqId: Long)
-  case class Consuming(seqId: Long)
-  case class NonConsuming(seqId: Long)
-  case class Divulgence(seqId: Long)
+  case class EventCreate(seqId: Long)
+  case class EventConsuming(seqId: Long)
+  case class EventNonConsuming(seqId: Long)
+  case class EventDivulgence(seqId: Long)
 
-  case class CreateFilterStakeholder(seqId: Long, party: Long)
-  case class CreateFilterNonStakeholder(seqId: Long, party: Long)
-  case class ConsumingFilterStakeholder(seqId: Long, party: Long)
-  case class ConsumingFilterNonStakeholder(seqId: Long, party: Long)
-  case class NonConsumingFilter(seqId: Long, party: Long)
+  case class FilterCreateStakeholder(seqId: Long, party: Long)
+  case class FilterCreateNonStakeholder(seqId: Long, party: Long)
+  case class FilterConsumingStakeholder(seqId: Long, party: Long)
+  case class FilterConsumingNonStakeholder(seqId: Long, party: Long)
+  case class FilterNonConsuming(seqId: Long, party: Long)
 
   case class TxMeta(offset: String)
   case class Completion(offset: String)
@@ -38,34 +38,34 @@ class PruningDtoQueries {
     long("event_sequential_id") ~ long("party_id") map { case seqId ~ partyId => f(seqId, partyId) }
   private def offsetParser[T](f: String => T): RowParser[T] = str("offset") map (f)
 
-  def create(implicit c: Connection): Seq[Create] =
+  def eventCreate(implicit c: Connection): Seq[EventCreate] =
     SQL"SELECT event_sequential_id FROM participant_events_create ORDER BY event_sequential_id"
-      .asVectorOf(seqIdParser(Create))(c)
-  def consuming(implicit c: Connection): Seq[Consuming] =
+      .asVectorOf(seqIdParser(EventCreate))(c)
+  def eventConsuming(implicit c: Connection): Seq[EventConsuming] =
     SQL"SELECT event_sequential_id FROM participant_events_consuming_exercise ORDER BY event_sequential_id"
-      .asVectorOf(seqIdParser(Consuming))(c)
-  def nonConsuming(implicit c: Connection): Seq[NonConsuming] =
+      .asVectorOf(seqIdParser(EventConsuming))(c)
+  def eventNonConsuming(implicit c: Connection): Seq[EventNonConsuming] =
     SQL"SELECT event_sequential_id FROM participant_events_non_consuming_exercise ORDER BY event_sequential_id"
-      .asVectorOf(seqIdParser(NonConsuming))(c)
-  def divulgence(implicit c: Connection): Seq[Divulgence] =
+      .asVectorOf(seqIdParser(EventNonConsuming))(c)
+  def eventDivulgence(implicit c: Connection): Seq[EventDivulgence] =
     SQL"SELECT event_sequential_id FROM participant_events_divulgence ORDER BY event_sequential_id"
-      .asVectorOf(seqIdParser(Divulgence))(c)
+      .asVectorOf(seqIdParser(EventDivulgence))(c)
 
-  def createFilterStakeholder(implicit c: Connection): Seq[CreateFilterStakeholder] =
+  def filterCreateStakeholder(implicit c: Connection): Seq[FilterCreateStakeholder] =
     SQL"SELECT event_sequential_id, party_id FROM pe_create_id_filter_stakeholder ORDER BY event_sequential_id, party_id"
-      .asVectorOf(idFilterParser(CreateFilterStakeholder))(c)
-  def createFilterNonStakeholder(implicit c: Connection): Seq[CreateFilterNonStakeholder] =
+      .asVectorOf(idFilterParser(FilterCreateStakeholder))(c)
+  def filterCreateNonStakeholder(implicit c: Connection): Seq[FilterCreateNonStakeholder] =
     SQL"SELECT event_sequential_id, party_id FROM pe_create_id_filter_non_stakeholder_informee ORDER BY event_sequential_id, party_id"
-      .asVectorOf(idFilterParser(CreateFilterNonStakeholder))(c)
-  def consumingFilterStakeholder(implicit c: Connection): Seq[ConsumingFilterStakeholder] =
+      .asVectorOf(idFilterParser(FilterCreateNonStakeholder))(c)
+  def filterConsumingStakeholder(implicit c: Connection): Seq[FilterConsumingStakeholder] =
     SQL"SELECT event_sequential_id, party_id FROM pe_consuming_id_filter_stakeholder ORDER BY event_sequential_id, party_id"
-      .asVectorOf(idFilterParser(ConsumingFilterStakeholder))(c)
-  def consumingFilterNonStakeholder(implicit c: Connection): Seq[ConsumingFilterNonStakeholder] =
+      .asVectorOf(idFilterParser(FilterConsumingStakeholder))(c)
+  def filterConsumingNonStakeholder(implicit c: Connection): Seq[FilterConsumingNonStakeholder] =
     SQL"SELECT event_sequential_id, party_id FROM pe_consuming_id_filter_non_stakeholder_informee ORDER BY event_sequential_id, party_id"
-      .asVectorOf(idFilterParser(ConsumingFilterNonStakeholder))(c)
-  def nonConsumingFilter(implicit c: Connection): Seq[NonConsumingFilter] =
+      .asVectorOf(idFilterParser(FilterConsumingNonStakeholder))(c)
+  def filterNonConsuming(implicit c: Connection): Seq[FilterNonConsuming] =
     SQL"SELECT event_sequential_id, party_id FROM pe_non_consuming_id_filter_informee ORDER BY event_sequential_id, party_id"
-      .asVectorOf(idFilterParser(NonConsumingFilter))(c)
+      .asVectorOf(idFilterParser(FilterNonConsuming))(c)
 
   def txMeta(implicit c: Connection): Seq[TxMeta] =
     SQL"SELECT event_offset AS offset FROM participant_transaction_meta ORDER BY event_offset"

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/PruningDtoQueries.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/PruningDtoQueries.scala
@@ -36,7 +36,7 @@ class PruningDtoQueries {
   private def seqIdParser[T](f: Long => T): RowParser[T] = long("event_sequential_id").map(f)
   private def idFilterParser[T](f: (Long, Long) => T): RowParser[T] =
     long("event_sequential_id") ~ long("party_id") map { case seqId ~ partyId => f(seqId, partyId) }
-  private def offsetParser[T](f: String => T): RowParser[T] = str("offset") map (f)
+  private def offsetParser[T](f: String => T): RowParser[T] = str("ledger_offset") map (f)
 
   def eventCreate(implicit c: Connection): Seq[EventCreate] =
     SQL"SELECT event_sequential_id FROM participant_events_create ORDER BY event_sequential_id"
@@ -68,10 +68,10 @@ class PruningDtoQueries {
       .asVectorOf(idFilterParser(FilterNonConsuming))(c)
 
   def txMeta(implicit c: Connection): Seq[TxMeta] =
-    SQL"SELECT event_offset AS offset FROM participant_transaction_meta ORDER BY event_offset"
+    SQL"SELECT event_offset AS ledger_offset FROM participant_transaction_meta ORDER BY event_offset"
       .asVectorOf(offsetParser(TxMeta))(c)
   def completions(implicit c: Connection): Seq[Completion] =
-    SQL"SELECT completion_offset AS offset FROM participant_command_completions ORDER BY completion_offset"
+    SQL"SELECT completion_offset AS ledger_offset FROM participant_command_completions ORDER BY completion_offset"
       .asVectorOf(offsetParser(Completion))(c)
 
 }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendProvider.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendProvider.scala
@@ -98,9 +98,8 @@ case class TestBackend(
     participantPartyStorageBackend: PartyRecordStorageBackend,
     metering: TestMeteringBackend,
     identityProviderStorageBackend: IdentityProviderStorageBackend,
-) {
-  val pruningDtoQeuries: PruningDtoQueries = new PruningDtoQueries
-}
+    pruningDtoQueries: PruningDtoQueries = new PruningDtoQueries,
+)
 
 case class TestMeteringBackend(
     read: MeteringStorageReadBackend,

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendProvider.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendProvider.scala
@@ -98,7 +98,9 @@ case class TestBackend(
     participantPartyStorageBackend: PartyRecordStorageBackend,
     metering: TestMeteringBackend,
     identityProviderStorageBackend: IdentityProviderStorageBackend,
-)
+) {
+  val pruningDtoQeuries: PruningDtoQueries = new PruningDtoQueries
+}
 
 case class TestMeteringBackend(
     read: MeteringStorageReadBackend,


### PR DESCRIPTION
A concern with the existing pruning backend tests is that they are relatively complex particularly because:
- in order to fetch data from the indexdb they use production sql queries which might have builtin knowledge of pruning offsets,
- production sql queries are not designed for ergonomic one-off usage.

This PR introduces a set of queries, one for each table subject to pruning, each returning a record for each row its table. This leads to more a concise and straightforward way assert what data has or hasn't been pruned.  