### PR TITLE
Ensure trigger service stops runners that throw trigger overflow exceptions

### DIFF
--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -961,7 +961,8 @@ private[lf] class Runner private (
                       "active" -> acs.length,
                       "pending" -> 0,
                     )
-                  )
+                  ),
+                  "in-flight" -> 0,
                 )
               ),
             )

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -137,11 +137,15 @@ private[lf] final case class Trigger(
   }
 }
 
+/** Throwing an instance of this exception will cause the trigger service to stop the runner
+  */
+private sealed abstract class TriggerOverflowException extends Exception
+
 private final case class InFlightCommandOverflowException(inFlightCommands: Int, crashCount: Int)
-    extends Exception
+    extends TriggerOverflowException
 
 private final case class ACSOverflowException(activeContracts: Int, crashCount: Long)
-    extends Exception
+    extends TriggerOverflowException
 
 // Utilities for interacting with the speedy machine.
 private[lf] object Machine {

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -317,6 +317,7 @@ da_scala_test_suite(
         "//libs-scala/ports",
         "//libs-scala/resources",
         "//libs-scala/test-evidence/tag:test-evidence-tag",
+        "//triggers/runner:trigger-runner-lib",
         "//triggers/service/auth:oauth2-test-server",
         "@maven//:eu_rekawek_toxiproxy_toxiproxy_java_2_1_7",
         "@maven//:org_scalatest_scalatest_compatible",

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -341,6 +341,7 @@ da_scala_test_suite(
           cp -L $(location :test-model/ErrorTrigger.daml) $$TMP_DIR/daml
           cp -L $(location :test-model/LowLevelErrorTrigger.daml) $$TMP_DIR/daml
           cp -L $(location :test-model/ReadAs.daml) $$TMP_DIR/daml
+          cp -L $(location :test-model/Cats.daml) $$TMP_DIR/daml
           cp -L $(location {daml_trigger}) $$TMP_DIR/daml-trigger.dar
           cp -L $(location {daml_script}) $$TMP_DIR/daml-script.dar
           cat << EOF > $$TMP_DIR/daml.yaml

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
@@ -60,10 +60,14 @@ object TriggerRunner {
                 Behaviors
                   .supervise(
                     Behaviors
-                      .supervise(TriggerRunnerImpl(config))
-                      .onFailure[InitializationHalted](stop)
+                      .supervise(
+                        Behaviors
+                          .supervise(TriggerRunnerImpl(config))
+                          .onFailure[InitializationHalted](stop)
+                      )
+                      .onFailure[UnauthenticatedException](stop)
                   )
-                  .onFailure[UnauthenticatedException](stop)
+                  .onFailure[TriggerOverflowException](stop)
               )
               .onFailure(
                 restartWithBackoff(

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
@@ -51,8 +51,8 @@ object TriggerRunner {
     config.withTriggerLogContext { implicit triggerContext =>
       Behaviors.setup { ctx =>
         // Spawn a trigger runner impl. Supervise it. Stop immediately on
-        // initialization halted exceptions, retry any initialization or
-        // execution failure exceptions.
+        // initialization halted and trigger overflow exceptions, retry
+        // any other initialization or execution failure exceptions.
         val runner =
           ctx.spawn(
             Behaviors
@@ -60,10 +60,14 @@ object TriggerRunner {
                 Behaviors
                   .supervise(
                     Behaviors
-                      .supervise(TriggerRunnerImpl(config))
-                      .onFailure[InitializationHalted](stop)
+                      .supervise(
+                        Behaviors
+                          .supervise(TriggerRunnerImpl(config))
+                          .onFailure[InitializationHalted](stop)
+                      )
+                      .onFailure[UnauthenticatedException](stop)
                   )
-                  .onFailure[UnauthenticatedException](stop)
+                  .onFailure[TriggerOverflowException](stop)
               )
               .onFailure(
                 restartWithBackoff(

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
@@ -60,14 +60,10 @@ object TriggerRunner {
                 Behaviors
                   .supervise(
                     Behaviors
-                      .supervise(
-                        Behaviors
-                          .supervise(TriggerRunnerImpl(config))
-                          .onFailure[InitializationHalted](stop)
-                      )
-                      .onFailure[UnauthenticatedException](stop)
+                      .supervise(TriggerRunnerImpl(config))
+                      .onFailure[InitializationHalted](stop)
                   )
-                  .onFailure[TriggerOverflowException](stop)
+                  .onFailure[UnauthenticatedException](stop)
               )
               .onFailure(
                 restartWithBackoff(

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -652,7 +652,9 @@ trait AbstractTriggerServiceTest extends AbstractTriggerServiceTestHelper {
         ApiTypes.ApplicationId("exp-app-id"),
         actAs = List(ApiTypes.Party(aliceExp.unwrap)),
       )
-      _ <- Future.sequence((1 until 100).map(id => submitCmd(client, aliceExp.unwrap, cat(id))))
+      _ <- Future.sequence(
+        (1 until 100).map(id => submitCmd(client, aliceExp.unwrap, cat(id.toLong)))
+      )
       resp <- startTrigger(uri, s"$testPkgId:Cats:breedingTrigger", alice)
       catsTrigger <- parseTriggerId(resp)
       _ <- assertTriggerIds(uri, alice, Vector(catsTrigger))

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -646,7 +646,7 @@ trait AbstractTriggerServiceTest extends AbstractTriggerServiceTestHelper {
     )
   }
 
-  val catsAppId = ApiTypes.ApplicationId("cats-app-id")
+  val catsAppId: ApplicationId = ApiTypes.ApplicationId("cats-app-id")
 
   it should "stop the trigger if the ACS is too large at initialization time" inClaims withTriggerService(
     List(dar),

--- a/triggers/service/test-model/Cats.daml
+++ b/triggers/service/test-model/Cats.daml
@@ -1,0 +1,47 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Cats where
+
+import Daml.Trigger
+import DA.Foldable (forA_)
+import DA.Time (seconds)
+import DA.Functor (void)
+
+
+template Cat
+  with
+    owner : Party
+    id : Int
+  where
+    signatory owner
+
+template TestComplete
+  with
+    owner : Party
+  where
+    signatory owner
+
+populationSize : Int
+populationSize = 100
+
+breedingTrigger : Trigger Int
+breedingTrigger = Trigger
+  { initialize = pure populationSize
+  , updateState = \msg -> case msg of
+       MTransaction (Transaction _ _ [CreatedEvent (fromCreated @Cat -> Some catId)]) -> do
+         modify (subtract 1)
+       _ -> pure ()
+  , rule = breedTheCats
+  , registeredTemplates = RegisteredTemplates [ registeredTemplate @TestComplete, registeredTemplate @Cat ]
+  , heartbeat = Some(seconds 1)
+  }
+
+breedTheCats: Party -> TriggerA Int ()
+breedTheCats party = do
+  breedCount <- get
+  if breedCount == 0 then
+    void $ emitCommands [createCmd (TestComplete party)] []
+  else
+    forA_ [1..breedCount] \id -> do
+      void $ emitCommands [createCmd (Cat party id)] []


### PR DESCRIPTION
Fixes #16224 

- [x] add in supervisor behaviours to trap (and so stop) when the runner throws these overflow exceptions - whilst testing shows this may not be required, supervisor code to do this has been added (that way restart config/policy can not control this behaviour)
- [x] add in trigger service tests to validate that the runner does stop when overflows occur

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
