### PR TITLE
[DPP-1395] Use one randomness provider in the benchtool

### DIFF
--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/LedgerApiBenchTool.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/LedgerApiBenchTool.scala
@@ -252,11 +252,7 @@ class LedgerApiBenchTool(
             allocatedParties = allocatedParties,
             randomnessProvider = RandomnessProvider.Default,
           ),
-          contractDescriptionRandomnessProvider = RandomnessProvider.Default,
-          payloadRandomnessProvider = RandomnessProvider.Default,
-          consumingEventsRandomnessProvider = RandomnessProvider.Default,
-          nonConsumingEventsRandomnessProvider = RandomnessProvider.Default,
-          applicationIdRandomnessProvider = RandomnessProvider.Default,
+          randomnessProvider = RandomnessProvider.Default,
         )
         for {
           metricsManager <- MetricsManager(
@@ -339,12 +335,7 @@ class LedgerApiBenchTool(
               submissionConfig = submissionConfig,
               allocatedParties = allocatedParties,
               names = names,
-              partySelectingRandomnessProvider = RandomnessProvider.Default,
-              payloadRandomnessProvider = RandomnessProvider.Default,
-              consumingEventsRandomnessProvider = RandomnessProvider.Default,
-              nonConsumingEventsRandomnessProvider = RandomnessProvider.Default,
-              applicationIdRandomnessProvider = RandomnessProvider.Default,
-              contractDescriptionRandomnessProvider = RandomnessProvider.Default,
+              randomnessProvider = RandomnessProvider.Default,
             ).performSubmission()
           case submissionConfig: FibonacciSubmissionConfig =>
             val generator: CommandGenerator = new FibonacciCommandGenerator(

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/FooCommandGenerator.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/FooCommandGenerator.scala
@@ -24,11 +24,7 @@ final class FooCommandGenerator(
     divulgeesToDivulgerKeyMap: Map[Set[Primitive.Party], Value],
     names: Names,
     partySelecting: RandomPartySelecting,
-    contractDescriptionRandomnessProvider: RandomnessProvider,
-    payloadRandomnessProvider: RandomnessProvider,
-    consumingEventsRandomnessProvider: RandomnessProvider,
-    nonConsumingEventsRandomnessProvider: RandomnessProvider,
-    applicationIdRandomnessProvider: RandomnessProvider,
+    randomnessProvider: RandomnessProvider,
 ) extends CommandGenerator {
   private val contractDescriptions = new Distribution[FooSubmissionConfig.ContractDescription](
     weights = config.instanceDistribution.map(_.weight),
@@ -75,7 +71,7 @@ final class FooCommandGenerator(
       names.benchtoolApplicationId
     )(applicationIdsDistribution =>
       applicationIdsDistribution
-        .choose(applicationIdRandomnessProvider.randomDouble())
+        .choose(randomnessProvider.randomDouble())
         .applicationId
     )
   }
@@ -85,7 +81,7 @@ final class FooCommandGenerator(
   }
 
   private def pickContractDescription(): FooSubmissionConfig.ContractDescription =
-    contractDescriptions.choose(contractDescriptionRandomnessProvider.randomDouble())
+    contractDescriptions.choose(randomnessProvider.randomDouble())
 
   private def createCommands(
       templateDescriptor: FooTemplateDescriptor,
@@ -122,7 +118,7 @@ final class FooCommandGenerator(
     // Consuming events
     val consumingPayloadO: Option[String] = config.consumingExercises
       .flatMap(config =>
-        if (consumingEventsRandomnessProvider.randomDouble() <= config.probability) {
+        if (randomnessProvider.randomDouble() <= config.probability) {
           Some(randomPayload(config.payloadSizeBytes))
         } else None
       )
@@ -185,7 +181,7 @@ final class FooCommandGenerator(
     val nonconsumingExercisePayloads: Seq[String] =
       config.nonConsumingExercises.fold(Seq.empty[String]) { config =>
         var f = config.probability.toInt
-        if (nonConsumingEventsRandomnessProvider.randomDouble() <= config.probability - f) {
+        if (randomnessProvider.randomDouble() <= config.probability - f) {
           f += 1
         }
         Seq.fill[String](f)(randomPayload(config.payloadSizeBytes))
@@ -271,7 +267,7 @@ final class FooCommandGenerator(
   }
 
   private def randomPayload(sizeBytes: Int): String =
-    FooCommandGenerator.randomPayload(payloadRandomnessProvider, sizeBytes)
+    FooCommandGenerator.randomPayload(randomnessProvider, sizeBytes)
 
 }
 

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/FooSubmission.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/FooSubmission.scala
@@ -15,12 +15,7 @@ class FooSubmission(
     submissionConfig: FooSubmissionConfig,
     allocatedParties: AllocatedParties,
     names: Names,
-    partySelectingRandomnessProvider: RandomnessProvider,
-    payloadRandomnessProvider: RandomnessProvider,
-    consumingEventsRandomnessProvider: RandomnessProvider,
-    nonConsumingEventsRandomnessProvider: RandomnessProvider,
-    applicationIdRandomnessProvider: RandomnessProvider,
-    contractDescriptionRandomnessProvider: RandomnessProvider,
+    randomnessProvider: RandomnessProvider,
 ) {
 
   def performSubmission()(implicit
@@ -35,7 +30,7 @@ class FooSubmission(
       new RandomPartySelecting(
         config = submissionConfig,
         allocatedParties = allocatedParties,
-        randomnessProvider = partySelectingRandomnessProvider,
+        randomnessProvider = randomnessProvider,
       )
     for {
       _ <-
@@ -58,11 +53,7 @@ class FooSubmission(
         names = names,
         allocatedParties = allocatedParties,
         partySelecting = partySelecting,
-        contractDescriptionRandomnessProvider = contractDescriptionRandomnessProvider,
-        payloadRandomnessProvider = payloadRandomnessProvider,
-        consumingEventsRandomnessProvider = consumingEventsRandomnessProvider,
-        nonConsumingEventsRandomnessProvider = nonConsumingEventsRandomnessProvider,
-        applicationIdRandomnessProvider = applicationIdRandomnessProvider,
+        randomnessProvider = randomnessProvider,
       )
       _ <- submitter
         .generateAndSubmit(

--- a/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/BenchtoolSandboxFixture.scala
+++ b/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/BenchtoolSandboxFixture.scala
@@ -6,9 +6,17 @@ package com.daml.ledger.api.benchtool
 import java.io.File
 import com.codahale.metrics.MetricRegistry
 import com.daml.bazeltools.BazelRunfiles.rlocation
+import com.daml.ledger.api.benchtool.config.WorkflowConfig
 import com.daml.ledger.api.benchtool.metrics.MetricsManager.NoOpMetricsManager
 import com.daml.ledger.api.benchtool.services.LedgerApiServices
-import com.daml.ledger.api.benchtool.submission.{CommandSubmitter, Names, PartyAllocating}
+import com.daml.ledger.api.benchtool.submission.{
+  AllocatedParties,
+  CommandSubmitter,
+  FooSubmission,
+  Names,
+  PartyAllocating,
+  RandomnessProvider,
+}
 import com.daml.ledger.test.BenchtoolTestDar
 import com.daml.lf.language.LanguageVersion
 import com.daml.platform.sandbox.fixture.SandboxFixture
@@ -58,6 +66,24 @@ trait BenchtoolSandboxFixture extends SandboxFixture {
       names,
       submitter,
     )
+  }
+
+  def benchtoolFooSubmissionFixture(
+      submissionConfig: WorkflowConfig.FooSubmissionConfig
+  )(implicit ec: ExecutionContext): Future[(LedgerApiServices, AllocatedParties, FooSubmission)] = {
+    for {
+      (apiServices, _, submitter) <- benchtoolFixture()
+      allocatedParties <- submitter.prepare(submissionConfig)
+      foo = new FooSubmission(
+        submitter = submitter,
+        maxInFlightCommands = 1,
+        submissionBatchSize = 1,
+        allocatedParties = allocatedParties,
+        names = new Names(),
+        randomnessProvider = RandomnessProvider.forSeed(seed = 0),
+        submissionConfig = submissionConfig,
+      )
+    } yield (apiServices, allocatedParties, foo)
   }
 
 }

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/FooCommandSubmitterITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/FooCommandSubmitterITSpec.scala
@@ -64,24 +64,9 @@ class FooCommandSubmitterITSpec
     )
 
     for {
-      (apiServices, names, submitter) <- benchtoolFixture()
-      allocatedParties <- submitter.prepare(config)
+      (apiServices, allocatedParties, fooSubmission) <- benchtoolFooSubmissionFixture(config)
       _ = allocatedParties.divulgees shouldBe empty
-      tested = new FooSubmission(
-        submitter = submitter,
-        maxInFlightCommands = 1,
-        submissionBatchSize = 5,
-        submissionConfig = config,
-        allocatedParties = allocatedParties,
-        names = names,
-        partySelectingRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        payloadRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        consumingEventsRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        nonConsumingEventsRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        applicationIdRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        contractDescriptionRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-      )
-      _ <- tested.performSubmission()
+      _ <- fooSubmission.performSubmission()
       observerResult_signatory: ObservedEvents <- treeEventsObserver(
         apiServices = apiServices,
         party = allocatedParties.signatory,
@@ -146,7 +131,7 @@ class FooCommandSubmitterITSpec
       // Second observer can see ~10% of all non-consuming events
       cp(
         discard(
-          observerResult_observer1.nonConsumingExercises.size shouldBe 32 withClue ("number of non consuming exercises visible to Obs-1")
+          observerResult_observer1.nonConsumingExercises.size shouldBe 14 withClue ("number of non consuming exercises visible to Obs-1")
         )
       )
       cp.reportAll()

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/InterfaceSubscriptionITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/InterfaceSubscriptionITSpec.scala
@@ -56,27 +56,12 @@ class InterfaceSubscriptionITSpec
     )
 
     for {
-      (apiServices, names, submitter) <- benchtoolFixture()
-      allocatedParties <- submitter.prepare(config)
+      (apiServices, allocatedParties, fooSubmission) <- benchtoolFooSubmissionFixture(config)
       configDesugaring = new ConfigEnricher(
         allocatedParties,
         BenchtoolTestsPackageInfo.StaticDefault,
       )
-      tested = new FooSubmission(
-        submitter = submitter,
-        maxInFlightCommands = 1,
-        submissionBatchSize = 5,
-        submissionConfig = config,
-        allocatedParties = allocatedParties,
-        names = names,
-        partySelectingRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        payloadRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        consumingEventsRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        nonConsumingEventsRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        applicationIdRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        contractDescriptionRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-      )
-      _ <- tested.performSubmission()
+      _ <- fooSubmission.performSubmission()
       observedEvents <- observer(
         configDesugaring = configDesugaring,
         apiServices = apiServices,

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/NonStakeholderInformeesITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/NonStakeholderInformeesITSpec.scala
@@ -51,23 +51,10 @@ class NonStakeholderInformeesITSpec
       applicationIds = List.empty,
     )
     for {
-      (apiServices, names, submitter) <- benchtoolFixture()
-      allocatedParties <- submitter.prepare(submissionConfig)
-      tested = new FooSubmission(
-        submitter = submitter,
-        maxInFlightCommands = 1,
-        submissionBatchSize = 5,
-        submissionConfig = submissionConfig,
-        allocatedParties = allocatedParties,
-        names = names,
-        partySelectingRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        payloadRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        consumingEventsRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        nonConsumingEventsRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        applicationIdRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        contractDescriptionRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
+      (apiServices, allocatedParties, fooSubmission) <- benchtoolFooSubmissionFixture(
+        submissionConfig
       )
-      _ <- tested.performSubmission()
+      _ <- fooSubmission.performSubmission()
       (treeResults_divulgee0, flatResults_divulgee0) <- observeAllTemplatesForParty(
         party = allocatedParties.divulgees(0),
         apiServices = apiServices,
@@ -123,7 +110,7 @@ class NonStakeholderInformeesITSpec
           val flatFoo1 = flatResults_divulgee0.numberOfConsumingExercisesPerTemplateName("Foo1")
           cp(
             discard(
-              treeFoo1 shouldBe 14 withClue ("number of Foo1 consuming events visible to divulgee0 on tree transactions stream")
+              treeFoo1 shouldBe 13 withClue ("number of Foo1 consuming events visible to divulgee0 on tree transactions stream")
             )
           )
           cp(
@@ -139,7 +126,7 @@ class NonStakeholderInformeesITSpec
         val flatFoo1 = flatResults_divulgee1.numberOfCreatesPerTemplateName("Foo1")
         // This assertion will fail once in ~37k test executions with number of observed items being 0
         // because for 100 instances and 10% chance of divulging to divulgee1, divulgee1 won't be disclosed any contracts once in 1/(0.9**100) ~= 37649
-        cp(discard(treeFoo1 shouldBe 12))
+        cp(discard(treeFoo1 shouldBe 9))
         cp(discard(flatFoo1 shouldBe 0))
         val divulger = treeResults_divulgee1.numberOfCreatesPerTemplateName("Divulger")
         cp(discard(divulger shouldBe 4))
@@ -150,7 +137,7 @@ class NonStakeholderInformeesITSpec
         val flatFoo1 = flatResults_observer0.numberOfCreatesPerTemplateName("Foo1")
         cp(discard(treeFoo1 shouldBe 100))
         // Approximately 10% of contracts is created and archived in the same transaction and thus omitted from the flat transactions stream
-        cp(discard(flatFoo1 shouldBe 86))
+        cp(discard(flatFoo1 shouldBe 87))
         val divulger = treeResults_observer0.numberOfCreatesPerTemplateName("Divulger")
         cp(discard(divulger shouldBe 0))
       }

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/PartySetsITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/PartySetsITSpec.scala
@@ -71,27 +71,14 @@ class PartySetsITSpec
       ),
     )
     for {
-      (apiServices, names, submitter) <- benchtoolFixture()
-      allocatedParties <- submitter.prepare(submissionConfig)
+      (apiServices, allocatedParties, fooSubmission) <- benchtoolFooSubmissionFixture(
+        submissionConfig
+      )
       configDesugaring = new ConfigEnricher(
         allocatedParties,
         BenchtoolTestsPackageInfo.StaticDefault,
       )
-      tested = new FooSubmission(
-        submitter = submitter,
-        maxInFlightCommands = 1,
-        submissionBatchSize = 1,
-        submissionConfig = submissionConfig,
-        allocatedParties = allocatedParties,
-        names = names,
-        partySelectingRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        payloadRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        consumingEventsRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        nonConsumingEventsRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        applicationIdRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        contractDescriptionRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-      )
-      _ <- tested.performSubmission()
+      _ <- fooSubmission.performSubmission()
       _ = allocatedParties.observerPartySets
         .find(_.mainPartyNamePrefix == "FooParty")
         .value
@@ -134,10 +121,10 @@ class PartySetsITSpec
       val cp = new Checkpoint
 
       { // Party from party set
-        cp(discard(treeResults_fooParty87.numberOfCreatesPerTemplateName("Foo1") shouldBe 6))
+        cp(discard(treeResults_fooParty87.numberOfCreatesPerTemplateName("Foo1") shouldBe 4))
         cp(
           discard(
-            treeResults_fooParty87.numberOfNonConsumingExercisesPerTemplateName("Foo1") shouldBe 12
+            treeResults_fooParty87.numberOfNonConsumingExercisesPerTemplateName("Foo1") shouldBe 8
           )
         )
         cp(
@@ -155,7 +142,7 @@ class PartySetsITSpec
         )
         cp(
           discard(
-            treeResults_fooPartySet.numberOfConsumingExercisesPerTemplateName("Foo1") shouldBe 1
+            treeResults_fooPartySet.numberOfConsumingExercisesPerTemplateName("Foo1") shouldBe 4
           )
         )
       }
@@ -174,20 +161,20 @@ class PartySetsITSpec
           discard(
             treeResults_fooPartyNamePrefix.numberOfConsumingExercisesPerTemplateName(
               "Foo1"
-            ) shouldBe 1
+            ) shouldBe 4
           )
         )
       }
       { // Bar party set
-        cp(discard(treeResults_barPartySet.numberOfCreatesPerTemplateName("Foo1") shouldBe 7))
+        cp(discard(treeResults_barPartySet.numberOfCreatesPerTemplateName("Foo1") shouldBe 5))
         cp(
           discard(
-            treeResults_barPartySet.numberOfNonConsumingExercisesPerTemplateName("Foo1") shouldBe 14
+            treeResults_barPartySet.numberOfNonConsumingExercisesPerTemplateName("Foo1") shouldBe 10
           )
         )
         cp(
           discard(
-            treeResults_barPartySet.numberOfConsumingExercisesPerTemplateName("Foo1") shouldBe 1
+            treeResults_barPartySet.numberOfConsumingExercisesPerTemplateName("Foo1") shouldBe 2
           )
         )
       }
@@ -206,7 +193,7 @@ class PartySetsITSpec
           discard(
             treeResults_barPartyNamePrefix.numberOfConsumingExercisesPerTemplateName(
               "Foo1"
-            ) shouldBe 1
+            ) shouldBe 2
           )
         )
       }

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/WeightedApplicationIdsAndSubmittersITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/WeightedApplicationIdsAndSubmittersITSpec.scala
@@ -58,23 +58,10 @@ class WeightedApplicationIdsAndSubmittersITSpec
       ),
     )
     for {
-      (apiServices, names, submitter) <- benchtoolFixture()
-      allocatedParties <- submitter.prepare(submissionConfig)
-      tested = new FooSubmission(
-        submitter = submitter,
-        maxInFlightCommands = 1,
-        submissionBatchSize = 1,
-        submissionConfig = submissionConfig,
-        names = names,
-        allocatedParties = allocatedParties,
-        partySelectingRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        payloadRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        consumingEventsRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        nonConsumingEventsRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        applicationIdRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
-        contractDescriptionRandomnessProvider = RandomnessProvider.forSeed(seed = 0),
+      (apiServices, allocatedParties, fooSubmission) <- benchtoolFooSubmissionFixture(
+        submissionConfig
       )
-      _ <- tested.performSubmission()
+      _ <- fooSubmission.performSubmission()
       completionsApp1 <- observeCompletions(
         parties = List(allocatedParties.signatory),
         apiServices = apiServices,
@@ -98,16 +85,16 @@ class WeightedApplicationIdsAndSubmittersITSpec
     } yield {
       val cp = new Checkpoint
       // App only filters
-      cp(discard(completionsApp1.completions.size shouldBe 85))
-      cp(discard(completionsApp2.completions.size shouldBe 15))
+      cp(discard(completionsApp1.completions.size shouldBe 91))
+      cp(discard(completionsApp2.completions.size shouldBe 9))
       // App and party filters
       cp(
         discard(
           completionsApp1Submitter0.completions.size shouldBe completionsApp1.completions.size
         )
       )
-      cp(discard(completionsApp1Submitter0.completions.size shouldBe 85))
-      cp(discard(completionsApp1Submitter1.completions.size shouldBe 12))
+      cp(discard(completionsApp1Submitter0.completions.size shouldBe 91))
+      cp(discard(completionsApp1Submitter1.completions.size shouldBe 9))
       cp.reportAll()
       succeed
     }


### PR DESCRIPTION
Using multiple separate ones with the same seed (in tests) leads to each of the producing the same values.
Fixing it now by using just one randomness provider