### PR TITLE
Implement interface name synonyms in error prints

### DIFF
--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "9cf39eac7128b6653ab697d0ff438fbee5251e05"
+GHC_REV = "b3e59fc71837d529981a75466688e118b42bb004"
 GHC_PATCHES = [
 ]
 

--- a/compiler/damlc/tests/daml-test-files/InterfaceSynonymNonExistentMethod.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSynonymNonExistentMethod.daml
@@ -3,7 +3,7 @@
 
 module InterfaceSynonymNonExistentMethod where
 
--- @ERROR range=27:7-27:31; Possible Daml-specific reason for the following type error: Tried to implement method ‘getValueNonexistent’, but interface ‘I’ does not have a method with that name. Method ‘getValueNonexistent’ is only a method on the following interfaces: ‘J’
+-- @ERROR range=27:7-27:31; Possible Daml-specific reason for the following type error: Tried to implement method ‘getValueNonexistent’, but interface ‘I’ (Type synonym of ‘MyLongInterfaceNameI’) does not have a method with that name. Method ‘getValueNonexistent’ is only a method on the following interfaces: ‘J’
 
 type I = MyLongInterfaceNameI
 interface MyLongInterfaceNameI where

--- a/compiler/damlc/tests/daml-test-files/InterfaceSynonymTypeMismatchErrors.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSynonymTypeMismatchErrors.daml
@@ -3,7 +3,7 @@
 
 module InterfaceSynonymTypeMismatchErrors where
 
--- @ERROR range=23:7-23:24; Possible Daml-specific reason for the following type error: Implementation of method ‘getValueBad’ on interface ‘I’ should return ‘Int’ but instead returns ‘Text’
+-- @ERROR range=23:7-23:24; Possible Daml-specific reason for the following type error: Implementation of method ‘getValueBad’ on interface ‘I’ (Type synonym of ‘MyLongInterfaceNameI’) should return ‘Int’ but instead returns ‘Text’
 
 type I = MyLongInterfaceNameI
 interface MyLongInterfaceNameI where


### PR DESCRIPTION
Resolves #16011 
Corresponding ghc changes: https://github.com/digital-asset/ghc/pull/157
- Shows type synonyms of interfaces in error messages