### PR TITLE
Remove latest offset gauge [PLEN-103]

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/IndexerMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IndexerMetrics.scala
@@ -23,15 +23,6 @@ class IndexerMetrics(prefix: MetricName, factory: MetricsFactory) {
     factory.gauge(prefix :+ "last_received_record_time", 0L)(MetricsContext.Empty)
 
   @MetricDoc.Tag(
-    summary = "A string value representing the last ledger offset ingested by the index db.",
-    description = """It is only available on metrics backends that support strings. In particular,
-                    |it is not available in Prometheus.""",
-    qualification = Debug,
-  )
-  val lastReceivedOffset: Gauge[String] =
-    factory.gauge(prefix :+ "last_received_offset", "<none>")(MetricsContext.Empty)
-
-  @MetricDoc.Tag(
     summary = "The sequential id of the current ledger end kept in the database.",
     description = """The ledger end's sequential id is a monotonically increasing integer value
                     |representing the sequential id ascribed to the most recent ledger event

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerSubscription.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerSubscription.scala
@@ -291,8 +291,6 @@ object ParallelIndexerSubscription {
                 .updateValue(lastBatch.lastSeqEventId)
               metrics.daml.indexer.lastReceivedRecordTime
                 .updateValue(lastBatch.lastRecordTime)
-              metrics.daml.indexer.lastReceivedOffset
-                .updateValue(lastBatch.lastOffset.toHexString)
               logger.info("Ledger end updated in IndexDB")
               batchOfBatches
             }


### PR DESCRIPTION
Prometheus supports only numeric values, therefore this gauges gets dropped and cannot be used with our metrics system
This will also allow us to tighten our API in the future by enforcing numeric only values.

Metric name that is removed: `daml_indexer_last_received_offset`
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
