### PR TITLE
add tip about blank line before lists

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,7 @@ If you’re not familiar, it’s really worth reading the [primer](http://www.sp
   """"""
   ```
 - For internal links, use the `doc` directive where you can. 
+- Before any lists in an .rst file, be sure to add an extra blank line. There should be two carriage returns between the text that comes before a list and the list itself. Otherwise, the list items will all be merged into a single paragraph.
 - For bullet points (unordered lists), use `-` (dashes).
 - For code blocks, use the `literalinclude` directive if you can: it's best to source code from files that we test whether they compile.
 


### PR DESCRIPTION
Add information to docs README to make sure there are two carriage returns before lists.

[CHANGELOG_BEGIN]
[CHANGELOG_END]

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
