### PR TITLE
Added in missing metrics for trigger initialization

### DIFF
--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -945,7 +945,7 @@ private[lf] class Runner private (
               "state" -> triggerUserState(state, trigger.defn.level, trigger.defn.version),
             )
             triggerContext.logInfo(
-              "Trigger rule initialization",
+              "Trigger rule initialization start",
               "metrics" -> LoggingValue.Nested(
                 LoggingEntries(
                   "acs" -> LoggingValue.Nested(
@@ -967,6 +967,21 @@ private[lf] class Runner private (
               )
               throw ACSOverflowException(activeContracts, triggerConfig.maximumActiveContracts)
             }
+
+            triggerContext.logInfo(
+              "Trigger rule initialization end",
+              "metrics" -> LoggingValue.Nested(
+                LoggingEntries(
+                  "acs" -> LoggingValue.Nested(
+                    LoggingEntries(
+                      "active" -> numberOfActiveContracts(state, trigger.defn.level),
+                      "pending" -> numberOfPendingContracts(state, trigger.defn.level),
+                    )
+                  ),
+                  "in-flight" -> numberOfInFlightCommands(state, trigger.defn.level),
+                )
+              ),
+            )
 
             state
           }

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -978,7 +978,11 @@ private[lf] class Runner private (
                       "pending" -> numberOfPendingContracts(state, trigger.defn.level),
                     )
                   ),
-                  "in-flight" -> numberOfInFlightCommands(state, trigger.defn.level),
+                  "in-flight" -> numberOfInFlightCommands(
+                    state,
+                    trigger.defn.level,
+                    trigger.defn.version,
+                  ),
                 )
               ),
             )


### PR DESCRIPTION
Currently we log metrics for the starting ACS and in-flight states, but not information for these data structures at the end of trigger initialisation.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
