### PR TITLE
[compatibility test] update to LF 1.15

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -40,8 +40,8 @@ jobs:
       matrix:
         linux:
           pool: ubuntu_20_04
-        macos:
-          pool: macOS-pool
+#        macos:
+#          pool: macOS-pool
     pool:
       name: $(pool)
       demands: assignment -equals default

--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -1146,8 +1146,11 @@ def daml_lf_compatible(sdk_version, platform_version):
         # any post 1.14.0 platform supports any pre 1.16 SDK
         in_range(platform_version, {"start": "1.14.0-snapshot"}) and not in_range(sdk_version, {"start": "1.16.0-snapshot"})
     ) or (
-        # any post 1.15.0 platform supports any SDK
-        in_range(platform_version, {"start": "1.15.0-snapshot"})
+        # any post 1.15.0 platform supports any pre 2.6 SDK
+        in_range(platform_version, {"start": "1.15.0-snapshot"}) and not in_range(sdk_version, {"start": "2.5.0-snapshot"})
+    ) or (
+        # any post 2.5.0 platform supports any SDK
+        in_range(platform_version, {"start": "2.5.0-snapshot"})
     )
 
 def sdk_platform_test(sdk_version, platform_version):


### PR DESCRIPTION
We disable conformance test for SDK older that 2.5.0 following usual workflow after updating the default output of the compiler. 

Additionally, we temporally disable compatibility tests on macos as the macos nodes are create with too little space (as of Feb 9th 2023). 

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
