### PR TITLE
Source location plumbing

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -979,7 +979,6 @@ data InterfaceInstanceMethod = InterfaceInstanceMethod
 data InterfaceInstanceHead = InterfaceInstanceHead
   { iiInterface :: !(Qualified TypeConName)
   , iiTemplate :: !(Qualified TypeConName)
-  , iiLocation :: !(Maybe SourceLoc)
   }
   deriving (Eq, Ord, Data, Generic, NFData, Show)
 

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -953,6 +953,7 @@ data TemplateImplements = TemplateImplements
   { tpiInterface :: !(Qualified TypeConName)
     -- ^ Interface name for implementation.
   , tpiBody :: !InterfaceInstanceBody
+  , tpiLocation :: !(Maybe SourceLoc)
   }
   deriving (Eq, Data, Generic, NFData, Show)
 
@@ -978,6 +979,7 @@ data InterfaceInstanceMethod = InterfaceInstanceMethod
 data InterfaceInstanceHead = InterfaceInstanceHead
   { iiInterface :: !(Qualified TypeConName)
   , iiTemplate :: !(Qualified TypeConName)
+  , iiLocation :: !(Maybe SourceLoc)
   }
   deriving (Eq, Ord, Data, Generic, NFData, Show)
 
@@ -1012,6 +1014,7 @@ data InterfaceMethod = InterfaceMethod
 data InterfaceCoImplements = InterfaceCoImplements
   { iciTemplate :: !(Qualified TypeConName)
   , iciBody :: !InterfaceInstanceBody
+  , iciLocation :: !(Maybe SourceLoc)
   }
   deriving (Eq, Data, Generic, NFData, Show)
 

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
@@ -79,8 +79,8 @@ templateExpr f (Template loc tpl param precond signatories observers agreement c
   <*> (NM.traverse . templateImplementsExpr) f implements
 
 templateImplementsExpr :: Traversal' TemplateImplements Expr
-templateImplementsExpr f (TemplateImplements iface body) =
-  TemplateImplements iface
+templateImplementsExpr f (TemplateImplements iface body loc) =
+  flip (TemplateImplements iface) loc
     <$> interfaceInstanceBodyExpr f body
 
 interfaceInstanceBodyExpr :: Traversal' InterfaceInstanceBody Expr

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -645,8 +645,8 @@ pPrintTemplate lvl modName (Template mbLoc tpl param precond signatories observe
           , nest 2 (keyword_ "maintainers" <-> pPrintPrec lvl 0 (tplKeyMaintainers key))
           ]
       implementsDoc =
-        [ pPrintInterfaceInstance lvl (InterfaceInstanceHead interface qTpl) body
-        | TemplateImplements interface body <- NM.toList implements
+        [ pPrintInterfaceInstance lvl (InterfaceInstanceHead interface qTpl loc) body
+        | TemplateImplements interface body loc <- NM.toList implements
         ]
       qTpl = Qualified PRSelf modName tpl
 
@@ -722,8 +722,8 @@ pPrintDefInterface lvl modName defInterface =
     methodDocs = map (pPrintInterfaceMethod lvl) (NM.toList intMethods)
     choiceDocs = map (pPrintTemplateChoice lvl modName intName) (NM.toList intChoices)
     interfaceInstanceDocs =
-      [ pPrintInterfaceInstance lvl (InterfaceInstanceHead qIntName template) body
-      | InterfaceCoImplements template body <- NM.toList intCoImplements
+      [ pPrintInterfaceInstance lvl (InterfaceInstanceHead qIntName template loc) body
+      | InterfaceCoImplements template body loc <- NM.toList intCoImplements
       ]
     qIntName = Qualified PRSelf modName intName
 

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -645,17 +645,18 @@ pPrintTemplate lvl modName (Template mbLoc tpl param precond signatories observe
           , nest 2 (keyword_ "maintainers" <-> pPrintPrec lvl 0 (tplKeyMaintainers key))
           ]
       implementsDoc =
-        [ pPrintInterfaceInstance lvl (InterfaceInstanceHead interface qTpl loc) body
+        [ pPrintInterfaceInstance lvl (InterfaceInstanceHead interface qTpl) body loc
         | TemplateImplements interface body loc <- NM.toList implements
         ]
       qTpl = Qualified PRSelf modName tpl
 
-pPrintInterfaceInstance :: PrettyLevel -> InterfaceInstanceHead -> InterfaceInstanceBody -> Doc ann
-pPrintInterfaceInstance lvl head body =
-  hang
-    (pPrintInterfaceInstanceHead lvl head)
-    2
-    (pPrintInterfaceInstanceBody lvl body)
+pPrintInterfaceInstance :: PrettyLevel -> InterfaceInstanceHead -> InterfaceInstanceBody -> Maybe SourceLoc -> Doc ann
+pPrintInterfaceInstance lvl head body mLoc =
+  withSourceLoc lvl mLoc $
+    hang
+      (pPrintInterfaceInstanceHead lvl head)
+      2
+      (pPrintInterfaceInstanceBody lvl body)
 
 pPrintInterfaceInstanceBody :: PrettyLevel -> InterfaceInstanceBody -> Doc ann
 pPrintInterfaceInstanceBody lvl (InterfaceInstanceBody methods _view) =
@@ -722,7 +723,7 @@ pPrintDefInterface lvl modName defInterface =
     methodDocs = map (pPrintInterfaceMethod lvl) (NM.toList intMethods)
     choiceDocs = map (pPrintTemplateChoice lvl modName intName) (NM.toList intChoices)
     interfaceInstanceDocs =
-      [ pPrintInterfaceInstance lvl (InterfaceInstanceHead qIntName template loc) body
+      [ pPrintInterfaceInstance lvl (InterfaceInstanceHead qIntName template) body loc
       | InterfaceCoImplements template body loc <- NM.toList intCoImplements
       ]
     qIntName = Qualified PRSelf modName intName

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -257,6 +257,7 @@ decodeInterfaceCoImplements :: LF1.DefInterface_CoImplements -> Decode Interface
 decodeInterfaceCoImplements LF1.DefInterface_CoImplements {..} = InterfaceCoImplements
   <$> mayDecode "defInterface_CoImplementsTemplate" defInterface_CoImplementsTemplate decodeTypeConName
   <*> mayDecode "defInterface_CoImplementsBody" defInterface_CoImplementsBody decodeInterfaceInstanceBody
+  <*> traverse decodeLocation defInterface_CoImplementsLocation
 
 decodeFeatureFlags :: LF1.FeatureFlags -> Decode FeatureFlags
 decodeFeatureFlags LF1.FeatureFlags{..} =
@@ -337,6 +338,7 @@ decodeDefTemplateImplements :: LF1.DefTemplate_Implements -> Decode TemplateImpl
 decodeDefTemplateImplements LF1.DefTemplate_Implements{..} = TemplateImplements
   <$> mayDecode "defTemplate_ImplementsInterface" defTemplate_ImplementsInterface decodeTypeConName
   <*> mayDecode "defTemplate_ImplementsBody" defTemplate_ImplementsBody decodeInterfaceInstanceBody
+  <*> traverse decodeLocation defTemplate_ImplementsLocation
 
 decodeInterfaceInstanceBody :: LF1.InterfaceInstanceBody -> Decode InterfaceInstanceBody
 decodeInterfaceInstanceBody LF1.InterfaceInstanceBody{..} = InterfaceInstanceBody

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -969,6 +969,7 @@ encodeTemplateImplements :: TemplateImplements -> Encode P.DefTemplate_Implement
 encodeTemplateImplements TemplateImplements{..} = do
     defTemplate_ImplementsInterface <- encodeQualTypeConName tpiInterface
     defTemplate_ImplementsBody <- encodeInterfaceInstanceBody tpiBody
+    defTemplate_ImplementsLocation <- traverse encodeSourceLoc tpiLocation
     pure P.DefTemplate_Implements {..}
 
 encodeInterfaceInstanceBody :: InterfaceInstanceBody -> Encode (Just P.InterfaceInstanceBody)
@@ -1057,6 +1058,7 @@ encodeInterfaceCoImplements :: InterfaceCoImplements -> Encode P.DefInterface_Co
 encodeInterfaceCoImplements InterfaceCoImplements {..} = do
     defInterface_CoImplementsTemplate <- encodeQualTypeConName iciTemplate
     defInterface_CoImplementsBody <- encodeInterfaceInstanceBody iciBody
+    defInterface_CoImplementsLocation <- traverse encodeSourceLoc iciLocation
     pure P.DefInterface_CoImplements {..}
 
 encodePackageMetadata :: PackageMetadata -> Encode P.PackageMetadata

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -12,6 +12,7 @@ module DA.Daml.LF.TypeChecker.Error(
     toDiagnostic,
     ) where
 
+import Control.Applicative
 import DA.Pretty
 import qualified Data.Text as T
 import Development.IDE.Types.Diagnostics
@@ -167,10 +168,10 @@ contextLocation = \case
   ContextNone                -> Nothing
   ContextDefTypeSyn _ s      -> synLocation s
   ContextDefDataType _ d     -> dataLocation d
-  ContextTemplate _ t tp     -> templateLocation t tp
+  ContextTemplate _ t tp     -> templateLocation t tp <|> tplLocation t
   ContextDefValue _ v        -> dvalLocation v
   ContextDefException _ e    -> exnLocation e
-  ContextDefInterface _ i ip -> interfaceLocation i ip
+  ContextDefInterface _ i ip -> interfaceLocation i ip <|> intLocation i
 
 templateLocation :: Template -> TemplatePart -> Maybe SourceLoc
 templateLocation t = \case

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -184,9 +184,13 @@ templateLocation t = \case
   TPChoice tc -> chcLocation tc
   TPInterfaceInstance iih -> iiLocation iih
 
+-- This function is untested and difficult to test with current architecture. It is written as best effort, but any failure on its part simply falls back to
+-- template/interface header source location.
+-- This function isn't easily testable because GHC catches these errors before daml gets to them.
 extractExprSourceLoc :: Expr -> Maybe SourceLoc
-extractExprSourceLoc (ETmApp (ELocation loc _) _) = Just loc -- All 4 of the Expr values in Template are wrapped in ($ this)
-extractExprSourceLoc (ECase (ETmApp (ELocation loc _) _) _) = Just loc -- Precondition wraps the bool in a case when featureExceptions is supported
+extractExprSourceLoc (ELocation loc _) = Just loc
+extractExprSourceLoc (ETmApp f _) = extractExprSourceLoc f -- All 4 of the Expr values in Template are wrapped in ($ this), so we match this out
+extractExprSourceLoc (ECase c _) = extractExprSourceLoc c -- Precondition wraps the bool in a case when featureExceptions is supported
 extractExprSourceLoc _ = Nothing
 
 interfaceLocation :: DefInterface -> InterfacePart -> Maybe SourceLoc

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -164,13 +164,32 @@ data Error
 
 contextLocation :: Context -> Maybe SourceLoc
 contextLocation = \case
-  ContextNone            -> Nothing
-  ContextDefTypeSyn _ s  -> synLocation s
-  ContextDefDataType _ d -> dataLocation d
-  ContextTemplate _ t _  -> tplLocation t
-  ContextDefValue _ v    -> dvalLocation v
-  ContextDefException _ e -> exnLocation e
-  ContextDefInterface _ i _ -> intLocation i
+  ContextNone                -> Nothing
+  ContextDefTypeSyn _ s      -> synLocation s
+  ContextDefDataType _ d     -> dataLocation d
+  ContextTemplate _ t tp     -> templateLocation t tp
+  ContextDefValue _ v        -> dvalLocation v
+  ContextDefException _ e    -> exnLocation e
+  ContextDefInterface _ i ip -> interfaceLocation i ip
+
+templateLocation :: Template -> TemplatePart -> Maybe SourceLoc
+templateLocation t = \case
+  TPWhole -> tplLocation t
+  TPStakeholders -> Nothing
+  TPPrecondition -> Nothing
+  TPSignatories -> Nothing
+  TPObservers -> Nothing
+  TPAgreement -> Nothing
+  TPKey -> Nothing
+  TPChoice tc -> chcLocation tc
+  TPInterfaceInstance iih -> iiLocation iih
+
+interfaceLocation :: DefInterface -> InterfacePart -> Maybe SourceLoc
+interfaceLocation i = \case
+  IPWhole -> intLocation i
+  IPMethod im -> ifmLocation im
+  IPChoice tc -> chcLocation tc
+  IPInterfaceInstance iih -> iiLocation iih
 
 errorLocation :: Error -> Maybe SourceLoc
 errorLocation = \case

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -43,13 +43,13 @@ data TemplatePart
   | TPKey
   -- ^ Specifically the `key` keyword, not maintainers
   | TPChoice TemplateChoice
-  | TPInterfaceInstance InterfaceInstanceHead
+  | TPInterfaceInstance InterfaceInstanceHead (Maybe SourceLoc)
 
 data InterfacePart
   = IPWhole
   | IPMethod InterfaceMethod
   | IPChoice TemplateChoice
-  | IPInterfaceInstance InterfaceInstanceHead
+  | IPInterfaceInstance InterfaceInstanceHead (Maybe SourceLoc)
 
 data SerializabilityRequirement
   = SRTemplateArg
@@ -182,7 +182,7 @@ templateLocation t = \case
   TPAgreement -> extractExprSourceLoc $ tplAgreement t
   TPKey -> tplKey t >>= extractExprSourceLoc . tplKeyBody
   TPChoice tc -> chcLocation tc
-  TPInterfaceInstance iih -> iiLocation iih
+  TPInterfaceInstance _ loc -> loc
 
 -- This function is untested and difficult to test with current architecture. It is written as best effort, but any failure on its part simply falls back to
 -- template/interface header source location.
@@ -198,7 +198,7 @@ interfaceLocation i = \case
   IPWhole -> intLocation i
   IPMethod im -> ifmLocation im
   IPChoice tc -> chcLocation tc
-  IPInterfaceInstance iih -> iiLocation iih
+  IPInterfaceInstance _ loc -> loc
 
 errorLocation :: Error -> Maybe SourceLoc
 errorLocation = \case
@@ -230,14 +230,14 @@ instance Show TemplatePart where
     TPAgreement -> "agreement"
     TPKey -> "key"
     TPChoice choice -> "choice " <> T.unpack (unChoiceName $ chcName choice)
-    TPInterfaceInstance iiHead -> renderPretty iiHead
+    TPInterfaceInstance iiHead _ -> renderPretty iiHead
 
 instance Show InterfacePart where
   show = \case
     IPWhole -> ""
     IPMethod method -> "method " <> T.unpack (unMethodName $ ifmName method)
     IPChoice choice -> "choice " <> T.unpack (unChoiceName $ chcName choice)
-    IPInterfaceInstance iiHead -> renderPretty iiHead
+    IPInterfaceInstance iiHead _ -> renderPretty iiHead
 
 instance Pretty SerializabilityRequirement where
   pPrint = \case

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1169,7 +1169,7 @@ convertImplements env mc tpl = NM.fromList <$>
 
 convertInterfaceInstance ::
      TemplateOrInterface' TypeConName
-  -> (Qualified TypeConName -> Qualified TypeConName -> InterfaceInstanceBody -> (Maybe SourceLoc) -> r)
+  -> (Qualified TypeConName -> Qualified TypeConName -> InterfaceInstanceBody -> Maybe SourceLoc -> r)
   -> Env
   -> InterfaceInstanceBinds
   -> ConvertM r

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1169,7 +1169,7 @@ convertImplements env mc tpl = NM.fromList <$>
 
 convertInterfaceInstance ::
      TemplateOrInterface' TypeConName
-  -> (Qualified TypeConName -> Qualified TypeConName -> InterfaceInstanceBody -> r)
+  -> (Qualified TypeConName -> Qualified TypeConName -> InterfaceInstanceBody -> (Maybe SourceLoc) -> r)
   -> Env
   -> InterfaceInstanceBinds
   -> ConvertM r
@@ -1185,6 +1185,7 @@ convertInterfaceInstance parent mkR env iib = withRange (iibLoc iib) do
     interfaceQualTypeCon
     templateQualTypeCon
     (InterfaceInstanceBody methods view)
+    (iibLoc iib)
   where
     qualifyInterfaceCon =
       convertInterfaceTyCon env handleIsNotInterface

--- a/compiler/damlc/tests/daml-test-files/InterfaceMissingMethod.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceMissingMethod.daml
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SINCE-LF-FEATURE DAML_INTERFACE
--- @ERROR range=15:10-17:14;error type checking template InterfaceMissingMethod.T interface instance InterfaceMissingMethod:I for InterfaceMissingMethod:T: Interface instance lacks an implementation for method 'm'
+-- @ERROR range=20:5-21:32;error type checking template InterfaceMissingMethod.T interface instance InterfaceMissingMethod:I for InterfaceMissingMethod:T: Interface instance lacks an implementation for method 'm'
 
 module InterfaceMissingMethod where
 

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresError.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresError.daml
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SINCE-LF-FEATURE DAML_INTERFACE
--- @ERROR range=20:10-22:14;error type checking template InterfaceRequiresError.T interface instance InterfaceRequiresError:B for InterfaceRequiresError:T: Missing required 'interface instance InterfaceRequiresError:A for InterfaceRequiresError:T', required by interface 'InterfaceRequiresError:B'
+-- @ERROR range=25:5-26:32;error type checking template InterfaceRequiresError.T interface instance InterfaceRequiresError:B for InterfaceRequiresError:T: Missing required 'interface instance InterfaceRequiresError:A for InterfaceRequiresError:T', required by interface 'InterfaceRequiresError:B'
 
 -- | Check that interface hierarchy is enforced. So if interface B requires
 -- interface A, and template B has 'interface instance B for T', either A or T

--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -1592,6 +1592,7 @@ message DefTemplate {
   message Implements {
     TypeConName interface = 1;
     InterfaceInstanceBody body = 2;
+    Location location = 3;
   }
 
   // The type constructor for the template, acting as both
@@ -1664,6 +1665,7 @@ message DefInterface {
   message CoImplements {
     TypeConName template = 1;
     InterfaceInstanceBody body = 2;
+    Location location = 3;
   }
 
   Location location = 1;


### PR DESCRIPTION
Resolves #15572 
Includes changes to protobuf
Change to Scala not needed, as the scala decoders throw away source locations at the moment

CHANGELOG_BEGIN

- [Daml Compiler] Improve error source locations for Daml specific syntax
  See `#15572 <https://github.com/digital-asset/daml/issues/15572>`__.

CHANGELOG_END
