### PR TITLE
[engine] create TX authority nodes from PTX

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
@@ -98,7 +98,19 @@ object BlindingTransaction {
               }
           }
 
-        case Some(_: Node.Authority) => ??? // TODO #15882 -- we unsure what to do here
+        case Some(authNode: Node.Authority) =>
+          // TODO #15882 -- should an authNode have informees?
+          // TODO #15882 -- should an authNode be a kind of actionNode?
+          // val witnesses = parentExerciseWitnesses
+          val witnesses = parentExerciseWitnesses // TODO #15882 -- union authNode.informeesOfNode
+          val state = state0.discloseNode(witnesses, nodeId)
+          authNode.children.foldLeft(state) { (s, childNodeId) =>
+            processNode(
+              s,
+              witnesses,
+              childNodeId,
+            )
+          }
 
         case Some(rollback: Node.Rollback) =>
           // Rollback nodes are disclosed to the witnesses of the parent exercise.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -647,9 +647,6 @@ private[speedy] case class PartialTransaction(
   def beginWithAuthority(
       required: Set[Party]
   ): PartialTransaction = {
-    val was = context.info.authorizers
-    val now = required
-    println(s"**beginWithAuthority\n- Was=$was\n- Now=$now") // TODO #15882: remove debug
     val nid = NodeId(nextNodeIdx)
     val info = WithAuthorityContextInfo(nid, context, authorizers = required)
     copy(
@@ -661,18 +658,14 @@ private[speedy] case class PartialTransaction(
   def endWithAuthority: PartialTransaction = {
     context.info match {
       case info: WithAuthorityContextInfo =>
-        val was = info.authorizers
-        val now = info.parent.info.authorizers
-        println(s"**endWithAuthority\n- was=$was\n- now=$now") // TODO #15882: remove debug
         val authNode = Node.Authority(
-          obtained = info.authorizers, // NICK: change to now for a bug!
+          obtained = info.authorizers,
           children = context.children.toImmArray,
         )
         copy(
           context = info.parent.addActionChild(info.nodeId, context.minChildVersion),
           nodes = nodes.updated(info.nodeId, authNode),
         )
-
       case _ =>
         InternalError.runtimeException(
           NameOf.qualifiedNameOfCurrentFunc,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -664,12 +664,15 @@ private[speedy] case class PartialTransaction(
         val was = info.authorizers
         val now = info.parent.info.authorizers
         println(s"**endWithAuthority\n- was=$was\n- now=$now") // TODO #15882: remove debug
-        copy(
-          context = info.parent.copy(
-            children = info.parent.children :++ context.children.toImmArray,
-            nextActionChildIdx = context.nextActionChildIdx,
-          )
+        val authNode = Node.Authority(
+          obtained = info.authorizers, // NICK: change to now for a bug!
+          children = context.children.toImmArray,
         )
+        copy(
+          context = info.parent.addActionChild(info.nodeId, context.minChildVersion),
+          nodes = nodes.updated(info.nodeId, authNode),
+        )
+
       case _ =>
         InternalError.runtimeException(
           NameOf.qualifiedNameOfCurrentFunc,

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/WithAuthorityTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/WithAuthorityTest.scala
@@ -4,25 +4,23 @@
 package com.daml.lf
 package speedy
 
+import com.daml.lf.data.ImmArray
 import com.daml.lf.data.Ref.Party
-import com.daml.lf.language.Ast.Expr
-import com.daml.lf.speedy.SExpr._
-import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.SExpr.{SExpr, SEApp}
+import com.daml.lf.speedy.SValue.SParty
 import com.daml.lf.testing.parser.Implicits._
+import com.daml.lf.transaction.Node
+import com.daml.lf.transaction.NodeId
 import com.daml.lf.transaction.SubmittedTransaction
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.freespec.AnyFreeSpec
+import com.daml.lf.value.Value.{ValueInt64, ValueRecord}
+
 import org.scalatest.Inside
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-import com.daml.lf.speedy.SError._
+class WithAuthorityTest extends AnyFreeSpec with Matchers with Inside {
 
-class WithAuthorityTest
-    extends AnyFreeSpec
-    with Matchers
-    with TableDrivenPropertyChecks
-    with Inside {
-
+  import WithAuthorityTest._
   import SpeedyTestLib.loggingContext
 
   private[this] val transactionSeed = crypto.Hash.hashPrivateKey("WithAuthorityTest.scala")
@@ -40,36 +38,66 @@ class WithAuthorityTest
 
         val entryPoint : Party-> Party -> Party -> Update Unit =
           \(a: Party) -> \(b: Party) -> \(c: Party) ->
-
-           // nested calls to WITH_AUTHORITY...
-           WITH_AUTHORITY @Unit (Cons @Party [b] Nil@Party)
-           (WITH_AUTHORITY @Unit (Cons @Party [c] Nil@Party)
+           WITH_AUTHORITY @Unit (Cons @Party [a,b] Nil@Party)
+           (WITH_AUTHORITY @Unit (Cons @Party [b,c] Nil@Party)
             (ubind
               x1: ContractId M:T1 <- create @M:T1 M:T1 { party = c, info = 100 }
             in upure @Unit ()));
        }
       """)
 
-  "NEW" - {
-    "new test" in {
-      val alice = Party.assertFromString("Alice")
-      val bob = Party.assertFromString("Bob")
-      val charlie = Party.assertFromString("Charlie")
-      val exp: Expr = e"M:entryPoint"
-      val se: SExpr = pkgs.compiler.unsafeCompile(exp)
-      val example: SExpr = SEApp(se, Array(SParty(alice), SParty(bob), SParty(charlie)))
-      val committers: Set[Party] = Set(alice)
-      val machine: Speedy.UpdateMachine =
-        Speedy.Machine.fromUpdateSExpr(pkgs, transactionSeed, example, committers)
-      val either: Either[SError, SubmittedTransaction] = SpeedyTestLib.buildTransaction(machine)
-      either match {
-        case Right(tx) =>
-          println(s"TX=$tx") // NICK: assert the tx has expected shape, with correct auth nodes.
-        case Left(e) =>
-          fail(Pretty.prettyError(e).render(80))
+  "WithAuthorityTest" - {
+    val a = Party.assertFromString("Alice")
+    val b = Party.assertFromString("Bob")
+    val c = Party.assertFromString("Charlie")
+
+    val committers = Set(a)
+
+    "{A}->{A,B}->{B,C}->{C}" in {
+      val se: SExpr = pkgs.compiler.unsafeCompile(e"M:entryPoint")
+      val example: SExpr = SEApp(se, Array(SParty(a), SParty(b), SParty(c)))
+      val machine = Speedy.Machine.fromUpdateSExpr(pkgs, transactionSeed, example, committers)
+      val either = SpeedyTestLib.buildTransaction(machine)
+      inside(either) { case Right(tx) =>
+        val shape = shapeOfTransaction(tx)
+        val expected = List(Authority(Set(a, b), List(Authority(Set(b, c), List(Create(100))))))
+        shape shouldBe expected
       }
-
     }
-  }
 
+  }
+}
+
+object WithAuthorityTest {
+
+  // TODO #15882 -- test interaction between Authority and Exercise/Rollback nodes
+
+  sealed trait Shape // minimal transaction tree, for purposes of writing test expectation
+  final case class Create(x: Long) extends Shape
+  final case class Exercise(x: List[Shape]) extends Shape
+  final case class Rollback(x: List[Shape]) extends Shape
+  final case class Authority(obtained: Set[Party], x: List[Shape]) extends Shape
+
+  private def shapeOfTransaction(tx: SubmittedTransaction): List[Shape] = {
+    def trees(nid: NodeId): List[Shape] = {
+      tx.nodes(nid) match {
+        case create: Node.Create =>
+          create.arg match {
+            case ValueRecord(_, ImmArray(_, (None, ValueInt64(n)))) =>
+              List(Create(n))
+            case _ =>
+              sys.error(s"unexpected create.arg: ${create.arg}")
+          }
+        case _: Node.LeafOnlyAction =>
+          Nil
+        case node: Node.Exercise =>
+          List(Exercise(node.children.toList.flatMap(nid => trees(nid))))
+        case node: Node.Rollback =>
+          List(Rollback(node.children.toList.flatMap(nid => trees(nid))))
+        case node: Node.Authority =>
+          List(Authority(node.obtained, node.children.toList.flatMap(nid => trees(nid))))
+      }
+    }
+    tx.roots.toList.flatMap(nid => trees(nid))
+  }
 }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/WithAuthorityTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/WithAuthorityTest.scala
@@ -64,7 +64,7 @@ class WithAuthorityTest
       val either: Either[SError, SubmittedTransaction] = SpeedyTestLib.buildTransaction(machine)
       either match {
         case Right(tx) =>
-          println(s"TX=$tx")
+          println(s"TX=$tx") // NICK: assert the tx has expected shape, with correct auth nodes.
         case Left(e) =>
           fail(Pretty.prettyError(e).render(80))
       }

--- a/daml-lf/kv-support/src/main/scala/com/daml/lf/kv/transactions/TransactionNormalizer.scala
+++ b/daml-lf/kv-support/src/main/scala/com/daml/lf/kv/transactions/TransactionNormalizer.scala
@@ -11,30 +11,25 @@ object TransactionNormalizer {
   // KV specific normalization.
   // Drop Fetch, Lookup and Rollback nodes from a transaction, keeping Create and Exercise.
   // Also drop everything contained with a rollback node
+  // Ignore Authority node, but traverse them
   def normalize(
       tx: CommittedTransaction
   ): CommittedTransaction = {
 
     val keepNids: Set[NodeId] =
       tx.foldInExecutionOrder[Set[NodeId]](Set.empty)(
-        (acc, nid, _) => (acc + nid, ChildrenRecursion.DoRecurse),
-        (acc, _, _) => (acc, ChildrenRecursion.DoNotRecurse),
-        (acc, nid, node) =>
+        exerciseBegin = (acc, nid, _) => (acc + nid, ChildrenRecursion.DoRecurse),
+        rollbackBegin = (acc, _, _) => (acc, ChildrenRecursion.DoNotRecurse),
+        authorityBegin = (acc, _, _) => (acc, ChildrenRecursion.DoRecurse),
+        leaf = (acc, nid, node) =>
           node match {
             case _: Node.Create => acc + nid
             case _: Node.Fetch => acc
             case _: Node.LookupByKey => acc
           },
-        (acc, _, _) => acc,
-        (acc, _, _) => acc,
-        authorityBegin = (acc, nid, node) => {
-          val _ = (acc, nid, node) // NICK
-          ??? // NICK
-        },
-        authorityEnd = (acc, nid, node) => {
-          val _ = (acc, nid, node) // NICK
-          ??? // NICK
-        },
+        exerciseEnd = (acc, _, _) => acc,
+        rollbackEnd = (acc, _, _) => acc,
+        authorityEnd = (acc, _, _) => acc,
       )
     val filteredNodes =
       tx.nodes

--- a/daml-lf/kv-support/src/main/scala/com/daml/lf/kv/transactions/TransactionNormalizer.scala
+++ b/daml-lf/kv-support/src/main/scala/com/daml/lf/kv/transactions/TransactionNormalizer.scala
@@ -27,6 +27,14 @@ object TransactionNormalizer {
           },
         (acc, _, _) => acc,
         (acc, _, _) => acc,
+        authorityBegin = (acc, nid, node) => {
+          val _ = (acc, nid, node) // NICK
+          ??? // NICK
+        },
+        authorityEnd = (acc, nid, node) => {
+          val _ = (acc, nid, node) // NICK
+          ??? // NICK
+        },
       )
     val filteredNodes =
       tx.nodes

--- a/daml-lf/snapshot/src/main/scala/com/daml/TransactionSnapshot.scala
+++ b/daml-lf/snapshot/src/main/scala/com/daml/TransactionSnapshot.scala
@@ -154,6 +154,12 @@ private[snapshot] object TransactionSnapshot {
         },
         exerciseEnd = (_, _) => (),
         rollbackEnd = (_, _) => (),
+        authorityBegin = (_, _) => {
+          ??? // NICK
+        },
+        authorityEnd = (_, _) => {
+          ??? // NICK
+        },
       )
 
     def updateWithArchive(archive: ByteString) =

--- a/daml-lf/snapshot/src/main/scala/com/daml/TransactionSnapshot.scala
+++ b/daml-lf/snapshot/src/main/scala/com/daml/TransactionSnapshot.scala
@@ -148,18 +148,14 @@ private[snapshot] object TransactionSnapshot {
           ChildrenRecursion.DoRecurse
         },
         rollbackBegin = (_, _) => ChildrenRecursion.DoNotRecurse,
+        authorityBegin = (_, _) => ChildrenRecursion.DoRecurse,
         leaf = {
           case (_, create: Node.Create) => activeCreates += (create.coid -> create)
           case (_, _) =>
         },
         exerciseEnd = (_, _) => (),
         rollbackEnd = (_, _) => (),
-        authorityBegin = (_, _) => {
-          ??? // NICK
-        },
-        authorityEnd = (_, _) => {
-          ??? // NICK
-        },
+        authorityEnd = (_, _) => (),
       )
 
     def updateWithArchive(archive: ByteString) =

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/TransactionNodeStatistics.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/TransactionNodeStatistics.scala
@@ -143,6 +143,9 @@ object TransactionNodeStatistics {
         rollbackDepth += 1
         Transaction.ChildrenRecursion.DoRecurse
       },
+      authorityBegin = { (_, _) =>
+        Transaction.ChildrenRecursion.DoRecurse
+      },
       leaf = { (_, node) =>
         val idx = node match {
           case _: Node.Create =>
@@ -159,12 +162,7 @@ object TransactionNodeStatistics {
       },
       exerciseEnd = (_, _) => (),
       rollbackEnd = (_, _) => rollbackDepth -= 1,
-      authorityBegin = (_, _) => {
-        ??? // NICK
-      },
-      authorityEnd = (_, _) => {
-        ??? // NICK
-      },
+      authorityEnd = (_, _) => (),
     )
 
     TransactionNodeStatistics(build(committed), build(rolledBack))

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/TransactionNodeStatistics.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/TransactionNodeStatistics.scala
@@ -159,6 +159,12 @@ object TransactionNodeStatistics {
       },
       exerciseEnd = (_, _) => (),
       rollbackEnd = (_, _) => rollbackDepth -= 1,
+      authorityBegin = (_, _) => {
+        ??? // NICK
+      },
+      authorityEnd = (_, _) => {
+        ??? // NICK
+      },
     )
 
     TransactionNodeStatistics(build(committed), build(rolledBack))

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -599,7 +599,10 @@ sealed abstract class HasTxNodes {
       leaf: (NodeId, Node.LeafOnlyAction) => Unit,
       exerciseEnd: (NodeId, Node.Exercise) => Unit,
       rollbackEnd: (NodeId, Node.Rollback) => Unit,
+      authorityBegin: (NodeId, Node.Authority) => ChildrenRecursion, // NICK: with default
+      authorityEnd: (NodeId, Node.Authority) => ChildrenRecursion, // NICK: with default
   ): Unit = {
+    val _ = (authorityBegin, authorityEnd) // NICK: use them! must extend fix the Either type
     @tailrec
     def loop(
         currNodes: FrontStack[NodeId],
@@ -610,7 +613,8 @@ sealed abstract class HasTxNodes {
       currNodes.pop match {
         case Some((nid, rest)) =>
           nodes(nid) match {
-            case _: Node.Authority => ??? // TODO #15882 -- need authority{Begin,End} callbacks
+            // case _: Node.Authority => ??? // TODO #15882 -- need authority{Begin,End} callbacks
+            case _: Node.Authority => () // NICK: temp avoid crash!
             case rb: Node.Rollback =>
               rollbackBegin(nid, rb) match {
                 case ChildrenRecursion.DoRecurse =>
@@ -671,6 +675,15 @@ sealed abstract class HasTxNodes {
       (nid, node) => acc = leaf(acc, nid, node),
       (nid, node) => acc = exerciseEnd(acc, nid, node),
       (nid, node) => acc = rollbackEnd(acc, nid, node),
+      // NICK: also add begin/End auth callbacks to fold; fixup callers; and delegate here
+      authorityBegin = (nid, node) => {
+        val _ = (nid, node) // NICK
+        ??? // NICK
+      },
+      authorityEnd = (nid, node) => {
+        val _ = (nid, node) // NICK
+        ??? // NICK
+      },
     )
     acc
   }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -467,14 +467,10 @@ sealed abstract class HasTxNodes {
           case c: Node.Create => acc.create(c.coid)
           case _ => acc
         },
-      authorityBegin = (acc, nid, node) => {
-        val _ = (acc, nid, node) // NICK
-        ??? // NICK
+      authorityBegin = (acc, _, _) => {
+        (acc, ChildrenRecursion.DoRecurse)
       },
-      authorityEnd = (acc, nid, node) => {
-        val _ = (acc, nid, node) // NICK
-        ??? // NICK
-      },
+      authorityEnd = (acc, _, _) => acc,
     ).currentState.inactiveCids
   }
 
@@ -529,17 +525,13 @@ sealed abstract class HasTxNodes {
       rollbackBegin = (consumedByMap, _, _) => {
         (consumedByMap, ChildrenRecursion.DoNotRecurse)
       },
+      authorityBegin = (consumedByMap, _, _) => {
+        (consumedByMap, ChildrenRecursion.DoRecurse)
+      },
       leaf = (consumedByMap, _, _) => consumedByMap,
       exerciseEnd = (consumedByMap, _, _) => consumedByMap,
       rollbackEnd = (consumedByMap, _, _) => consumedByMap,
-      authorityBegin = (acc, nid, node) => {
-        val _ = (acc, nid, node) // NICK
-        ??? // NICK
-      },
-      authorityEnd = (acc, nid, node) => {
-        val _ = (acc, nid, node) // NICK
-        ??? // NICK
-      },
+      authorityEnd = (consumedByMap, _, _) => consumedByMap,
     )
 
   /** Return the expected contract key inputs (i.e. the state before the transaction)
@@ -723,19 +715,13 @@ sealed abstract class HasTxNodes {
   // This method returns all node-ids reachable from the roots of a transaction.
   final def reachableNodeIds: Set[NodeId] = {
     foldInExecutionOrder[Set[NodeId]](Set.empty)(
-      (acc, nid, _) => (acc + nid, ChildrenRecursion.DoRecurse),
-      (acc, nid, _) => (acc + nid, ChildrenRecursion.DoRecurse),
-      authorityBegin = (acc, nid, node) => {
-        val _ = (acc, nid, node) // NICK
-        ??? // NICK
-      },
-      (acc, nid, _) => acc + nid,
-      (acc, _, _) => acc,
-      (acc, _, _) => acc,
-      authorityEnd = (acc, nid, node) => {
-        val _ = (acc, nid, node) // NICK
-        ??? // NICK
-      },
+      exerciseBegin = (acc, nid, _) => (acc + nid, ChildrenRecursion.DoRecurse),
+      rollbackBegin = (acc, nid, _) => (acc + nid, ChildrenRecursion.DoRecurse),
+      authorityBegin = (acc, nid, _) => (acc + nid, ChildrenRecursion.DoRecurse),
+      leaf = (acc, nid, _) => acc + nid,
+      exerciseEnd = (acc, _, _) => acc,
+      rollbackEnd = (acc, _, _) => acc,
+      authorityEnd = (acc, _, _) => acc,
     )
   }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/ContractStateMachineSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/ContractStateMachineSpec.scala
@@ -758,6 +758,14 @@ object ContractStateMachineSpec {
         },
       rollbackBegin = (s, _, _) => s -> ChildrenRecursion.DoRecurse,
       rollbackEnd = (s, _, _) => s,
+      authorityBegin = (acc, nid, node) => {
+        val _ = (acc, nid, node) // NICK
+        ??? // NICK
+      },
+      authorityEnd = (acc, nid, node) => {
+        val _ = (acc, nid, node) // NICK
+        ??? // NICK
+      },
     )
   }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/ContractStateMachineSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/ContractStateMachineSpec.scala
@@ -758,14 +758,8 @@ object ContractStateMachineSpec {
         },
       rollbackBegin = (s, _, _) => s -> ChildrenRecursion.DoRecurse,
       rollbackEnd = (s, _, _) => s,
-      authorityBegin = (acc, nid, node) => {
-        val _ = (acc, nid, node) // NICK
-        ??? // NICK
-      },
-      authorityEnd = (acc, nid, node) => {
-        val _ = (acc, nid, node) // NICK
-        ??? // NICK
-      },
+      authorityBegin = (s, _, _) => s -> ChildrenRecursion.DoRecurse,
+      authorityEnd = (s, _, _) => s,
     )
   }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -103,7 +103,7 @@ class TransactionSpec
 
   }
 
-  "foldInExecutionOrder" - { // TODO 15882 -- extend test for Node.Authority -- NICK
+  "foldInExecutionOrder" - { // TODO #15882 -- extend test for Node.Authority
     "should traverse the transaction in execution order" in {
 
       val tx = mkTransaction(

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -103,7 +103,7 @@ class TransactionSpec
 
   }
 
-  "foldInExecutionOrder" - {
+  "foldInExecutionOrder" - { // TODO 15882 -- extend test for Node.Authority -- NICK
     "should traverse the transaction in execution order" in {
 
       val tx = mkTransaction(
@@ -119,19 +119,16 @@ class TransactionSpec
       )
 
       val result = tx.foldInExecutionOrder(List.empty[String])(
-        (acc, nid, _) => (s"exerciseBegin(${nid.index})" :: acc, ChildrenRecursion.DoRecurse),
-        (acc, nid, _) => (s"rollbackBegin(${nid.index})" :: acc, ChildrenRecursion.DoRecurse),
-        (acc, nid, _) => s"leaf(${nid.index})" :: acc,
-        (acc, nid, _) => s"exerciseEnd(${nid.index})" :: acc,
-        (acc, nid, _) => s"rollbackEnd(${nid.index})" :: acc,
-        authorityBegin = (acc, nid, node) => {
-          val _ = (acc, nid, node) // NICK
-          ??? // NICK
-        },
-        authorityEnd = (acc, nid, node) => {
-          val _ = (acc, nid, node) // NICK
-          ??? // NICK
-        },
+        exerciseBegin =
+          (acc, nid, _) => (s"exerciseBegin(${nid.index})" :: acc, ChildrenRecursion.DoRecurse),
+        rollbackBegin =
+          (acc, nid, _) => (s"rollbackBegin(${nid.index})" :: acc, ChildrenRecursion.DoRecurse),
+        authorityBegin =
+          (acc, nid, _) => (s"authorityBegin(${nid.index})" :: acc, ChildrenRecursion.DoRecurse),
+        leaf = (acc, nid, _) => s"leaf(${nid.index})" :: acc,
+        exerciseEnd = (acc, nid, _) => s"exerciseEnd(${nid.index})" :: acc,
+        rollbackEnd = (acc, nid, _) => s"rollbackEnd(${nid.index})" :: acc,
+        authorityEnd = (acc, nid, _) => s"authorityEnd(${nid.index})" :: acc,
       )
 
       result.reverse.mkString(", ") shouldBe

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -124,6 +124,14 @@ class TransactionSpec
         (acc, nid, _) => s"leaf(${nid.index})" :: acc,
         (acc, nid, _) => s"exerciseEnd(${nid.index})" :: acc,
         (acc, nid, _) => s"rollbackEnd(${nid.index})" :: acc,
+        authorityBegin = (acc, nid, node) => {
+          val _ = (acc, nid, node) // NICK
+          ??? // NICK
+        },
+        authorityEnd = (acc, nid, node) => {
+          val _ = (acc, nid, node) // NICK
+          ??? // NICK
+        },
       )
 
       result.reverse.mkString(", ") shouldBe

--- a/ledger/participant-integration-api/src/main/scala/platform/index/InMemoryStateUpdater.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/InMemoryStateUpdater.scala
@@ -227,9 +227,11 @@ private[platform] object InMemoryStateUpdater {
         exerciseBegin = (acc, nid, node) => ((nid -> node) :: acc, ChildrenRecursion.DoRecurse),
         // Rollback nodes are not indexed
         rollbackBegin = (acc, _, _) => (acc, ChildrenRecursion.DoNotRecurse),
+        authorityBegin = (acc, _, _) => (acc, ChildrenRecursion.DoRecurse),
         leaf = (acc, nid, node) => (nid -> node) :: acc,
         exerciseEnd = (acc, _, _) => acc,
         rollbackEnd = (acc, _, _) => acc,
+        authorityEnd = (acc, _, _) => acc,
       )
       .reverseIterator
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/UpdateToDbDto.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/UpdateToDbDto.scala
@@ -190,9 +190,11 @@ object UpdateToDbDto {
             exerciseBegin = (acc, nid, node) => ((nid -> node) :: acc, ChildrenRecursion.DoRecurse),
             // Rollback nodes are not included in the indexer
             rollbackBegin = (acc, _, _) => (acc, ChildrenRecursion.DoNotRecurse),
+            authorityBegin = (acc, _, _) => (acc, ChildrenRecursion.DoRecurse),
             leaf = (acc, nid, node) => (nid -> node) :: acc,
             exerciseEnd = (acc, _, _) => acc,
             rollbackEnd = (acc, _, _) => acc,
+            authorityEnd = (acc, _, _) => acc,
           )
           .reverse
 


### PR DESCRIPTION
Advances: #15882
- Create tx `Node.Authority` nodes in `endWithAuthority: PartialTransaction`,
- extend `foreachInExecutionOrder` and `foldInExecutionOrder` with new callbacks: `authorityBegin` `authorityEnd`, and fix up all callers
- Extend `calculateBlindingInfo`
- Improve testing in `WithAuthorityTest.scala` to check the constructed TXs have the expected shape.

Question: Should the new node type be regarded as an _Action_ node, and have `informeesOfNode: Set[Party]` ?
