### PR TITLE
Fix list pattern match warnings to use ::

### DIFF
--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "9a39d60b408183b1993df34f3bdbd327c4babcf1"
+GHC_REV = "b88d315c8e07fd3174ba3944a916e61cdbed4ab5"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "7be2c87f191abb4a13d77171968dcdbe9a25b40e"
+GHC_REV = "9a39d60b408183b1993df34f3bdbd327c4babcf1"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "b88d315c8e07fd3174ba3944a916e61cdbed4ab5"
+GHC_REV = "fff6c81077edbcae1b5fe00334fec0a779ae8a2c"
 GHC_PATCHES = [
 ]
 

--- a/compiler/damlc/tests/daml-test-files/ListNonExhaustivePatternError.daml
+++ b/compiler/damlc/tests/daml-test-files/ListNonExhaustivePatternError.daml
@@ -1,0 +1,10 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+
+module ListNonExhaustivePatternError where
+
+-- @WARN range=10:1-10:11;warning: Pattern match(es) are non-exhaustive In an equation for ‘f’: Patterns not matched: [] (_::_::_)
+
+f : [a] -> ()
+f [_] = ()


### PR DESCRIPTION
Resolves #8947
Relevant ghc changes https://github.com/digital-asset/ghc/pull/158
- Switch list pretty printing logic to use `dcolon` over `colon`

CHANGELOG_BEGIN

- [Daml Studio] Include signatories in transaction tree view for create and fetch nodes.
  See `#8947 <https://github.com/digital-asset/daml/issues/8947>`__.

CHANGELOG_END