### PR TITLE
Parse multi-value audiences for the JWT tokens [PLEN-138]

### DIFF
--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceJWTPayload.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceJWTPayload.scala
@@ -189,11 +189,14 @@ object AuthServiceJWTCodec {
       // We're using this rather restrictive test to ensure we continue parsing all legacy sandbox tokens that
       // are in use before the 2.0 release; and thereby maintain full backwards compatibility.
       val audienceValue = readOptionalStringOrArray(propAud, fields)
-      if (audienceValue.exists(_.startsWith(audPrefix))) {
-        // Tokens with audience which starts with `https://daml.com/participant/jwt/aud/participant/${participantId}`
-        // where `${participantId}` is non-empty string are supported.
-        // As required for JWTs, additional fields can be in a token but will be ignored (including scope)
-        audienceValue.map(_.substring(audPrefix.length)).filter(_.nonEmpty) match {
+      // Tokens with audience which starts with `https://daml.com/participant/jwt/aud/participant/${participantId}`
+      // where `${participantId}` is non-empty string are supported.
+      // As required for JWTs, additional fields can be in a token but will be ignored (including scope)
+      val participantAudiences = audienceValue.filter(_.startsWith(audPrefix))
+      if (participantAudiences.nonEmpty) {
+        participantAudiences
+          .map(_.substring(audPrefix.length))
+          .filter(_.nonEmpty) match {
           case participantId :: Nil =>
             StandardJWTPayload(
               issuer = readOptionalString("iss", fields),


### PR DESCRIPTION
Some token providers can add their own audiences to the JWT token (Auth0 for example) alongside the daml audience. So for tokens with audiences we actually can process lists with multiple values but we expect only one daml audience.

The current changes will fix multi audience tokens only for `participant based audiences`, we will still not support multi audiences for the `daml_ledger_api` scope. The reasoning behind is that for scope based tokens we expect the audience to be the participant id and there is no easy way to determine what audience represents the participant id without making some assumptions. 

- [x] Add tests
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
