### PR TITLE
Bug fix for trigger backwards compatibility issues

### DIFF
--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -983,8 +983,16 @@ private[lf] class Runner private (
                 LoggingEntries(
                   "acs" -> LoggingValue.Nested(
                     LoggingEntries(
-                      "active" -> numberOfActiveContracts(state, trigger.defn.level),
-                      "pending" -> numberOfPendingContracts(state, trigger.defn.level),
+                      "active" -> numberOfActiveContracts(
+                        state,
+                        trigger.defn.level,
+                        trigger.defn.version,
+                      ),
+                      "pending" -> numberOfPendingContracts(
+                        state,
+                        trigger.defn.level,
+                        trigger.defn.version,
+                      ),
                     )
                   ),
                   "in-flight" -> numberOfInFlightCommands(
@@ -1020,8 +1028,16 @@ private[lf] class Runner private (
                 ),
                 "acs" -> LoggingValue.Nested(
                   LoggingEntries(
-                    "active" -> numberOfActiveContracts(state, trigger.defn.level),
-                    "pending" -> numberOfPendingContracts(state, trigger.defn.level),
+                    "active" -> numberOfActiveContracts(
+                      state,
+                      trigger.defn.level,
+                      trigger.defn.version,
+                    ),
+                    "pending" -> numberOfPendingContracts(
+                      state,
+                      trigger.defn.level,
+                      trigger.defn.version,
+                    ),
                   )
                 ),
               )
@@ -1065,8 +1081,16 @@ private[lf] class Runner private (
                         ),
                         "acs" -> LoggingValue.Nested(
                           LoggingEntries(
-                            "active" -> numberOfActiveContracts(newState, trigger.defn.level),
-                            "pending" -> numberOfPendingContracts(newState, trigger.defn.level),
+                            "active" -> numberOfActiveContracts(
+                              newState,
+                              trigger.defn.level,
+                              trigger.defn.version,
+                            ),
+                            "pending" -> numberOfPendingContracts(
+                              newState,
+                              trigger.defn.level,
+                              trigger.defn.version,
+                            ),
                           )
                         ),
                       )
@@ -1074,7 +1098,7 @@ private[lf] class Runner private (
                   )
                 }
 
-                numberOfActiveContracts(newState, trigger.defn.level) match {
+                numberOfActiveContracts(newState, trigger.defn.level, trigger.defn.version) match {
                   case Some(activeContracts)
                       if activeContracts > triggerConfig.maximumActiveContracts =>
                     triggerContext.logError(
@@ -1324,8 +1348,16 @@ object Runner {
     smap.expect("SMap", { case SMap(_, values) => values.size }).orConverterException
   }
 
-  private def numberOfActiveContracts(svalue: SValue, level: Trigger.Level): Option[Int] = {
+  private def numberOfActiveContracts(
+      svalue: SValue,
+      level: Trigger.Level,
+      version: Trigger.Version,
+  ): Option[Int] = {
     level match {
+      case Trigger.Level.High if version <= Trigger.Version.`2.0.0` =>
+        // For older trigger code, we do not support extracting active contracts from the ACS
+        None
+
       case Trigger.Level.High =>
         // The following code should be kept in sync with the ACS variant type in Internal.daml
         // svalue: TriggerState s
@@ -1345,8 +1377,16 @@ object Runner {
     }
   }
 
-  private def numberOfPendingContracts(svalue: SValue, level: Trigger.Level): Option[Int] = {
+  private def numberOfPendingContracts(
+      svalue: SValue,
+      level: Trigger.Level,
+      version: Trigger.Version,
+  ): Option[Int] = {
     level match {
+      case Trigger.Level.High if version <= Trigger.Version.`2.0.0` =>
+        // For older trigger code, we do not support extracting pending contracts from the ACS
+        None
+
       case Trigger.Level.High =>
         // The following code should be kept in sync with the ACS variant type in Internal.daml
         // svalue: TriggerState s


### PR DESCRIPTION
For SDK versions 1.10.2, 1.11.3, 1.7.0, 1.8.1 and 1.9.0, recent metrics changes failed backwards compatibility checks.

Compatibility fixes verified in a local dev environment for:
- [x] `bazel test //:daml-trigger-test-compiler-1.10.2-runner-0.0.0`
- [x] `bazel test //:daml-trigger-test-compiler-1.11.3-runner-0.0.0`
- [x] `bazel test //:daml-trigger-test-compiler-1.7.0-runner-0.0.0`
- [x] `bazel test //:daml-trigger-test-compiler-1.8.1-runner-0.0.0`
- [x] `bazel test //:daml-trigger-test-compiler-1.9.0-runner-0.0.0`

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
