### PR TITLE
Fix Timer resource teardown

### DIFF
--- a/libs-scala/resources/src/main/scala/com/digitalasset/resources/TimerResourceOwner.scala
+++ b/libs-scala/resources/src/main/scala/com/digitalasset/resources/TimerResourceOwner.scala
@@ -3,12 +3,29 @@
 
 package com.daml.resources
 
-import java.util.Timer
-
-import scala.concurrent.Future
+import java.util.{Timer, TimerTask}
+import scala.concurrent.{Future, Promise}
+import scala.util.Try
 
 class TimerResourceOwner[Context: HasExecutionContext](acquireTimer: () => Timer)
     extends AbstractResourceOwner[Context, Timer] {
   override def acquire()(implicit context: Context): Resource[Context, Timer] =
-    ReleasableResource(Future(acquireTimer()))(timer => Future(timer.cancel()))
+    ReleasableResource(Future(acquireTimer())) { timer =>
+      val timerCancelledPromise = Promise[Unit]()
+      Future(
+        // We are cancel()-ing the timer in a scheduled task to make sure no scheduled tasks are running
+        // as the Timer Resource is released. See Timer.cancel() method's Java Documentation for more information.
+        timer.schedule(
+          new TimerTask {
+            override def run(): Unit =
+              timerCancelledPromise.complete(
+                Try(timer.cancel())
+              )
+          },
+          0L,
+        )
+      )
+        // if timer.schedule fails, we do not want to wait for the timerCancelledPromise
+        .flatMap(_ => timerCancelledPromise.future)
+    }
 }


### PR DESCRIPTION
After this PR the TimerResourceOwner will make sure that none of the scheduled task are running, after the Resource finished releasing. Also adds asynchronous test as evidence.

[CHANGELOG_BEGIN]
[CHANGELOG_END]

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
