### PR TITLE
[engine] Create Node.Authority only when authority is to be gained

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1827,18 +1827,34 @@ private[lf] object SBuiltin {
       val required = extractParties(NameOf.qualifiedNameOfCurrentFunc, args.get(0))
       val action = args.get(1)
       checkToken(args, 2)
-      // TODO #15882: check with ledger if required authority is allowed
-      val gaining = required.diff(machine.ptx.context.info.authorizers)
-      if (gaining.isEmpty) {
+      val current = machine.ptx.context.info.authorizers
+      if (required == current) {
+        // just run the body action
         machine.enterApplication(action, Array(SEValue(SToken)))
       } else {
-        machine.ptx.beginGainAuthority(
-          required = required
-        ) match {
-          case ptx =>
-            machine.ptx = ptx
-            machine.pushKont(KCloseGainAuthority)
-            machine.enterApplication(action, Array(SEValue(SToken)))
+        val gaining = required.diff(machine.ptx.context.info.authorizers)
+        if (gaining.isEmpty) {
+          // do scoped authority restriction; (TX) Node.Authority is *NOT* created
+          machine.ptx.beginRestrictAuthority(
+            required = required
+          ) match {
+            case ptx =>
+              machine.ptx = ptx
+              machine.pushKont(KCloseRestrictAuthority)
+              machine.enterApplication(action, Array(SEValue(SToken)))
+          }
+        } else {
+          // TODO #15882: check with ledger that required authority change is allowed
+
+          // do scoped authority change; (TX) Node.Authority *IS* created
+          machine.ptx.beginGainAuthority(
+            required = required
+          ) match {
+            case ptx =>
+              machine.ptx = ptx
+              machine.pushKont(KCloseGainAuthority)
+              machine.enterApplication(action, Array(SEValue(SToken)))
+          }
         }
       }
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1832,12 +1832,12 @@ private[lf] object SBuiltin {
       if (gaining.isEmpty) {
         machine.enterApplication(action, Array(SEValue(SToken)))
       } else {
-        machine.ptx.beginWithAuthority(
+        machine.ptx.beginGainAuthority(
           required = required
         ) match {
           case ptx =>
             machine.ptx = ptx
-            machine.pushKont(KCloseWithAuthority)
+            machine.pushKont(KCloseGainAuthority)
             machine.enterApplication(action, Array(SEValue(SToken)))
         }
       }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1828,13 +1828,18 @@ private[lf] object SBuiltin {
       val action = args.get(1)
       checkToken(args, 2)
       // TODO #15882: check with ledger if required authority is allowed
-      machine.ptx.beginWithAuthority(
-        required = required
-      ) match {
-        case ptx =>
-          machine.ptx = ptx
-          machine.pushKont(KCloseWithAuthority)
-          machine.enterApplication(action, Array(SEValue(SToken)))
+      val gaining = required.diff(machine.ptx.context.info.authorizers)
+      if (gaining.isEmpty) {
+        machine.enterApplication(action, Array(SEValue(SToken)))
+      } else {
+        machine.ptx.beginWithAuthority(
+          required = required
+        ) match {
+          case ptx =>
+            machine.ptx = ptx
+            machine.pushKont(KCloseWithAuthority)
+            machine.enterApplication(action, Array(SEValue(SToken)))
+        }
       }
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -1739,11 +1739,11 @@ private[lf] object Speedy {
       }
   }
 
-  private[speedy] final case object KCloseWithAuthority extends Kont {
+  private[speedy] final case object KCloseGainAuthority extends Kont {
 
     override def execute[Q](machine: Machine[Q], result: SValue): Control[Q] =
       machine.asUpdateMachine(productPrefix) { machine =>
-        machine.ptx = machine.ptx.endWithAuthority
+        machine.ptx = machine.ptx.endGainAuthority
         Control.Value(result)
       }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -1748,6 +1748,15 @@ private[lf] object Speedy {
       }
   }
 
+  private[speedy] final case object KCloseRestrictAuthority extends Kont {
+
+    override def execute[Q](machine: Machine[Q], result: SValue): Control[Q] =
+      machine.asUpdateMachine(productPrefix) { machine =>
+        machine.ptx = machine.ptx.endRestrictAuthority
+        Control.Value(result)
+      }
+  }
+
   /** KTryCatchHandler marks the kont-stack to allow unwinding when throw is executed. If
     * the continuation is entered normally, the environment is restored but the handler is
     * not executed.  When a throw is executed, the kont-stack is unwound to the nearest

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -39,7 +39,7 @@ private[lf] object PartialTransaction {
 
   sealed abstract class ContextInfo {
     val actionChildSeed: Int => crypto.Hash
-    private[PartialTransaction] def authorizers: Set[Party]
+    private[lf] def authorizers: Set[Party]
   }
 
   sealed abstract class RootContextInfo extends ContextInfo {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/WithAuthorityTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/WithAuthorityTest.scala
@@ -38,8 +38,7 @@ class WithAuthorityTest extends AnyFreeSpec with Inside {
     "single (auth unchanged; no auth node) A->{A}->A" in {
       inside(makeSingleCall(required = Set(aa), signed = aa)) { case Right(tx) =>
         val shape = shapeOfTransaction(tx)
-        val expected = List(Authority(Set(aa), List(Create(aa)))) // NICK: wrong!
-        // val expected = List(Create(aa)) // NICK: want this!
+        val expected = List(Create(aa))
         shape shouldBe expected
       }
     }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/WithAuthorityTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/WithAuthorityTest.scala
@@ -38,12 +38,31 @@ class WithAuthorityTest extends AnyFreeSpec with Inside {
       }
     }
 
+    "single (auth restricted/extended) {A,B}->{B,C}->B" in {
+      inside(makeSingleCall(committers = Set(a, b), required = Set(b, c), signed = b)) {
+        case Right(tx) =>
+          val shape = shapeOfTransaction(tx)
+          val expected = List(Authority(Set(b, c), List(Create(b))))
+          shape shouldBe expected
+      }
+    }
+
     "single (auth unchanged; no auth node) A->{A}->A" in {
       inside(makeSingleCall(committers = Set(a), required = Set(a), signed = a)) { case Right(tx) =>
         val shape = shapeOfTransaction(tx)
         val expected = List(Create(a))
         shape shouldBe expected
       }
+    }
+
+    "single (auth restricted; no auth node) {A,B}->{A}->A" in {
+      inside(makeSingleCall(committers = Set(a, b), required = Set(b), signed = b)) {
+        case Right(tx) =>
+          val shape = shapeOfTransaction(tx)
+          val expected = List(Create(b))
+          shape shouldBe expected
+      }
+      // TODO #15882 -- check auth failure if we attempt sign by party removed from auth context
     }
   }
 


### PR DESCRIPTION
Support authority restriction properly... Advance #15882
- When authority is only restricted, we must not create a (TX) `Node.Authority`.
- But the operation must still be properly scoped.
- We do this by distinguishing `GainAuthority` from `RestrictAuthority`, in ptx begin/end ops, and the speedy `Kont`
- Add more tests, including negative tests (expected `CreateMissingAuthorization` failure)
