### PR TITLE
Remove ledger dependency on script

### DIFF
--- a/ledger/ledger-api-bench-tool/BUILD.bazel
+++ b/ledger/ledger-api-bench-tool/BUILD.bazel
@@ -143,7 +143,6 @@ da_scala_test_suite(
         "//libs-scala/timer-utils",
         "//ledger/test-common:benchtool-tests-%s.scala" % "1.15",
         "//ledger/test-common:dar-files-%s-lib" % "1.15",
-        "//daml-script/runner:script-runner-lib",
         "//language-support/scala/bindings",
         "//ledger-api/rs-grpc-bridge",
         "//ledger-api/testing-utils",


### PR DESCRIPTION
Before:
```
$ bazel query 'allpaths(//ledger/..., //daml-script/...)' --output graph
Starting local Bazel server and connecting to it...
digraph mygraph {
  node [shape=box];
  "//ledger/ledger-api-bench-tool:ledger-api-bench-tool-tests"
  "//ledger/ledger-api-bench-tool:ledger-api-bench-tool-tests" -> "//ledger/ledger-api-bench-tool:ledger-api-bench-tool-tests_test_suite_src_test_suite_scala_com_daml_ledger_api_benchtool_metrics_ConsumptionSpeedMetricSpec.scala\n//ledger/ledger-api-bench-tool:ledger-api-bench-tool-tests_test_suite_src_test_suite_scala_com_daml_ledger_api_benchtool_ConfigEnricherSpec.scala\n//ledger/ledger-api-bench-tool:ledger-api-bench-tool-tests_test_suite_src_test_suite_scala_com_daml_ledger_api_benchtool_submission_DistributionSpec.scala\n...and 26 more items"
  "//ledger/ledger-api-bench-tool:ledger-api-bench-tool-tests_test_suite_src_test_suite_scala_com_daml_ledger_api_benchtool_metrics_ConsumptionSpeedMetricSpec.scala\n//ledger/ledger-api-bench-tool:ledger-api-bench-tool-tests_test_suite_src_test_suite_scala_com_daml_ledger_api_benchtool_ConfigEnricherSpec.scala\n//ledger/ledger-api-bench-tool:ledger-api-bench-tool-tests_test_suite_src_test_suite_scala_com_daml_ledger_api_benchtool_submission_DistributionSpec.scala\n...and 26 more items"
  "//ledger/ledger-api-bench-tool:ledger-api-bench-tool-tests_test_suite_src_test_suite_scala_com_daml_ledger_api_benchtool_metrics_ConsumptionSpeedMetricSpec.scala\n//ledger/ledger-api-bench-tool:ledger-api-bench-tool-tests_test_suite_src_test_suite_scala_com_daml_ledger_api_benchtool_ConfigEnricherSpec.scala\n//ledger/ledger-api-bench-tool:ledger-api-bench-tool-tests_test_suite_src_test_suite_scala_com_daml_ledger_api_benchtool_submission_DistributionSpec.scala\n...and 26 more items" -> "//daml-script/runner:script-runner-lib"
  "//daml-script/runner:script-runner-lib"
  "//daml-script/runner:script-runner-lib" -> "//daml-script/converter:converter"
  "//daml-script/converter:converter"
}
Loading: 670 packages loaded
```

After:
```
$ bazel query 'allpaths(//ledger/..., //daml-script/...)' --output graph
digraph mygraph {
  node [shape=box];
}
INFO: Empty results
Loading: 161 packages loaded
```

