### PR TITLE
[Speedy] do not need disclosed contract at Machine creation time

### DIFF
--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -490,12 +490,6 @@ prettyScenarioErrorError (Just err) =  do
               (prettyDefName world)
               scenarioError_ContractDoesNotImplementRequiringInterfaceRequiringInterfaceId
         ]
-    ScenarioErrorErrorDisclosurePreprocessingDuplicateContractKeys(ScenarioError_DisclosurePreprocessingDuplicateContractKeys templateId keyHash) ->
-      pure $ vcat
-        [ "Found duplicate contract keys in submitted disclosed contracts"
-        , label_ "Template: " $ prettyMay "<missing template>" (prettyDefName world) templateId
-        , label_ "Key Hash: " $ ltext keyHash
-        ]
     ScenarioErrorErrorEvaluationTimeout timeout ->
       pure $ text $ T.pack $ "Evaluation timed out after " <> show timeout <> " seconds"
 

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -241,11 +241,6 @@ message ScenarioError {
     Identifier requiring_interface_id = 2;
     Identifier required_interface_id = 3;
   }
-  
-  message DisclosurePreprocessingDuplicateContractKeys {
-    Identifier template_id = 1;
-    string key_hash = 2;
-  }
 
   // The state of the ledger at the time of the error
   repeated ScenarioStep scenario_steps = 1;
@@ -316,11 +311,9 @@ message ScenarioError {
     PartiesNotAllocated scenario_parties_not_allocated = 33;
     ChoiceGuardFailed choice_guard_failed = 34;
     ContractDoesNotImplementInterface contract_does_not_implement_interface = 35;
-    ContractDoesNotImplementRequiringInterface contract_does_not_implement_requiring_interface
-    = 36;
-    DisclosurePreprocessingDuplicateContractKeys disclosure_preprocessing_duplicate_contract_keys = 39;
-    DisclosedContractKeyHashingError disclosed_contract_key_hashing_error = 40;
-    int64 evaluationTimeout = 41;
+    ContractDoesNotImplementRequiringInterface contract_does_not_implement_requiring_interface = 36;
+    DisclosedContractKeyHashingError disclosed_contract_key_hashing_error = 39;
+    int64 evaluationTimeout = 40;
   }
 }
 

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -252,16 +252,6 @@ final class Conversions(
                   cgfBuilder.setByInterface(convertIdentifier(ifaceId))
                 )
                 builder.setChoiceGuardFailed(cgfBuilder.build)
-
-              case DisclosurePreprocessing(err) =>
-                err match {
-                  case DisclosurePreprocessing.DuplicateContractKeys(tid, keyHash) =>
-                    builder.setDisclosurePreprocessingDuplicateContractKeys(
-                      proto.ScenarioError.DisclosurePreprocessingDuplicateContractKeys.newBuilder
-                        .setTemplateId(convertIdentifier(tid))
-                        .setKeyHash(keyHash.toHexString)
-                    )
-                }
             }
         }
       case Error.ContractNotEffective(coid, tid, effectiveAt) =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
@@ -117,8 +117,10 @@ object Error {
       sealed abstract class Reason extends Serializable with Product {
         def details: String
       }
+
       case object NonSuffixV1ContractId extends Reason {
         def details = "non-suffixed V1 Contract IDs are forbidden"
+
         def apply(cid: Value.ContractId.V1): IllegalContractId = IllegalContractId(cid, this)
       }
     }
@@ -133,6 +135,11 @@ object Error {
     ) extends Error {
       override def message: String =
         s"Preprocessor encountered a duplicate disclosed contract ID $contractId for template $templateId"
+    }
+
+    final case class DuplicateDisclosedContractKey(keyHash: crypto.Hash) extends Error {
+      override def message: String =
+        s"Preprocessor encountered a duplicate disclosed contract key hash ${keyHash.toHexString}"
     }
   }
 

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
@@ -6,12 +6,9 @@ package engine
 package preprocessing
 
 import com.daml.lf.data._
-import com.daml.lf.engine.Error.Preprocessing.DuplicateDisclosedContractId
 import com.daml.lf.language.Ast
 import com.daml.lf.value.Value
 import com.daml.scalautil.Statement.discard
-
-import scala.collection.mutable
 
 private[lf] final class CommandPreprocessor(
     pkgInterface: language.PackageInterface,
@@ -217,18 +214,22 @@ private[lf] final class CommandPreprocessor(
   def unsafePreprocessDisclosedContracts(
       discs: ImmArray[command.DisclosedContract]
   ): ImmArray[speedy.DisclosedContract] = {
-    val contractIds: mutable.Set[Value.ContractId] = mutable.Set.empty
+    var contractIds: Set[Value.ContractId] = Set.empty
+    var contractKeys: Set[crypto.Hash] = Set.empty
 
     discs.map { disclosedContract =>
-      if (contractIds.contains(disclosedContract.contractId)) {
-        throw DuplicateDisclosedContractId(
+      if (contractIds.contains(disclosedContract.contractId))
+        throw Error.Preprocessing.DuplicateDisclosedContractId(
           disclosedContract.contractId,
           disclosedContract.templateId,
         )
-      } else {
-        discard(contractIds += disclosedContract.contractId)
-        unsafePreprocessDisclosedContract(disclosedContract)
+      contractIds += disclosedContract.contractId
+      disclosedContract.metadata.keyHash.foreach { hash =>
+        if (contractKeys.contains(hash))
+          throw Error.Preprocessing.DuplicateDisclosedContractKey(hash)
+        contractKeys += hash
       }
+      unsafePreprocessDisclosedContract(disclosedContract)
     }
   }
 

--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -49,6 +49,7 @@ da_scala_library(
     srcs = glob(["src/test/**/*Lib.scala"]),
     scala_deps = [
         "@maven//:org_scalatest_scalatest_matchers_core",
+        "@maven//:org_scalaz_scalaz_core",
     ],
     scalacopts = lf_scalacopts_stricter,
     deps = [

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -178,14 +178,6 @@ private[lf] object Pretty {
             case Some(interfaceId) => text("by interface") & prettyTypeConName(interfaceId)
           })
       )
-
-      case DisclosurePreprocessing(err) =>
-        err match {
-          case DisclosurePreprocessing.DuplicateContractKeys(templateId, keyHash) =>
-            text(
-              s"Found duplicated contract keys in submitted disclosed contracts for template $templateId and key hash ${keyHash.toHexString}"
-            )
-        }
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1035,10 +1035,10 @@ private[lf] object SBuiltin {
         machine: UpdateMachine,
     ): Control[Nothing] = {
       val coid = getSContractId(args, 1)
-      val cached =
-        machine
-          .getCachedContract(coid)
-          .getOrElse(crash(s"Contract ${coid.coid} is missing from cache"))
+      val cached = machine.cachedContracts.getOrElse(
+        coid,
+        crash(s"Contract ${coid.coid} is missing from cache"),
+      )
       val templateVersion = machine.tmplId2TxVersion(templateId)
       val interfaceVersion = interfaceId.map(machine.tmplId2TxVersion)
       val exerciseVersion = interfaceVersion.fold(templateVersion)(_.max(templateVersion))
@@ -1134,7 +1134,7 @@ private[lf] object SBuiltin {
         machine: UpdateMachine,
     ): Control[Question.Update] = {
       val coid = getSContractId(args, 0)
-      machine.getCachedContract(coid) match {
+      machine.cachedContracts.get(coid) match {
         case Some(cached) =>
           machine.ptx.consumedByOrInactive(coid) match {
             case Some(Left(nid)) =>
@@ -1148,33 +1148,40 @@ private[lf] object SBuiltin {
           }
 
         case None =>
-          def continue(coinst: V.ContractInstance): Control.Expression = {
-            machine.pushKont(KCacheContract(coid))
-            val e = coinst match {
-              case V.ContractInstance(actualTmplId, arg) =>
-                SELet1(
-                  // The call to ToCachedContractDefRef(actualTmplId) will query package
-                  // of actualTmplId if not known.
-                  SEVal(ToCachedContractDefRef(actualTmplId)),
-                  SELet1(
-                    SEImportValue(Ast.TTyCon(actualTmplId), arg),
-                    SEAppAtomic(SELocS(2), Array(SELocS(1), SEValue(args.get(1)))),
-                  ),
-                )
-            }
-            Control.Expression(e)
-          }
+          machine.disclosedContracts.get(coid) match {
+            case Some(contract) =>
+              machine.addGlobalContract(coid, contract)
+              Control.Value(contract.any)
 
-          Control.Question(
-            Question.Update.NeedContract(
-              coid,
-              machine.committers,
-              callback = { res =>
-                val control = continue(res)
-                machine.setControl(control)
-              },
-            )
-          )
+            case None =>
+              def continue(coinst: V.ContractInstance): Control.Expression = {
+                machine.pushKont(KCacheContract(coid))
+                val e = coinst match {
+                  case V.ContractInstance(actualTmplId, arg) =>
+                    SELet1(
+                      // The call to ToCachedContractDefRef(actualTmplId) will query package
+                      // of actualTmplId if not known.
+                      SEVal(ToCachedContractDefRef(actualTmplId)),
+                      SELet1(
+                        SEImportValue(Ast.TTyCon(actualTmplId), arg),
+                        SEAppAtomic(SELocS(2), Array(SELocS(1), SEValue(args.get(1)))),
+                      ),
+                    )
+                }
+                Control.Expression(e)
+              }
+
+              Control.Question(
+                Question.Update.NeedContract(
+                  coid,
+                  machine.committers,
+                  callback = { res =>
+                    val control = continue(res)
+                    machine.setControl(control)
+                  },
+                )
+              )
+          }
       }
     }
   }
@@ -1451,10 +1458,8 @@ private[lf] object SBuiltin {
         machine: UpdateMachine,
     ): Control[Nothing] = {
       val coid = getSContractId(args, 0)
-      val cached =
-        machine
-          .getCachedContract(coid)
-          .getOrElse(crash(s"Contract ${coid.coid} is missing from cache"))
+      val cached = machine.cachedContracts
+        .getOrElse(coid, crash(s"Contract ${coid.coid} is missing from cache"))
       val version = machine.tmplId2TxVersion(templateId)
       machine.ptx.insertFetch(
         coid = coid,
@@ -1591,7 +1596,7 @@ private[lf] object SBuiltin {
                   // We do not call directly machine.checkKeyVisibility as it may throw an SError,
                   // and such error cannot be throw inside a ledger-question continuation.
                   machine.pushKont(KCheckKeyVisibility(gkey, coid, operation.handleKeyFound))
-                  if (machine.hasCachedContract(coid)) {
+                  if (machine.cachedContracts.isDefinedAt(coid)) {
                     (Control.Value(SUnit), true)
                   } else {
                     // SBFetchAny will populate machine.cachedContracts with the contract pointed by coid
@@ -1607,9 +1612,9 @@ private[lf] object SBuiltin {
               }
             }
 
-            machine.disclosureKeyTable.contractIdByKey(gkey.hash) match {
-              case Some(coid) =>
-                continue(Some(coid.value))._1
+            machine.disclosedContractKeys.get(gkey) match {
+              case someCid: Some[_] =>
+                continue(someCid)._1
 
               case None =>
                 Control.Question(
@@ -2147,25 +2152,10 @@ private[lf] object SBuiltin {
     override protected def executeUpdate(
         args: util.ArrayList[SValue],
         machine: UpdateMachine,
-    ): Control[Nothing] = {
+    ): Control.Value = {
       val cachedContract = extractCachedContract(machine.tmplId2TxVersion, args.get(0))
-      val optError: Option[Either[IE, Unit]] = for {
-        cachedKey <- cachedContract.keyOpt
-      } yield {
-        for {
-          result <- machine.disclosureKeyTable
-            .addContractKey(cachedContract.templateId, cachedKey.globalKey.hash, contractId)
-        } yield result
-      }
-
-      optError match {
-        case None | Some(Right(())) =>
-          machine.updateCachedContracts(contractId, cachedContract)
-          Control.Value(SUnit)
-
-        case Some(Left(error)) =>
-          Control.Error(error)
-      }
+      machine.addDisclosedContracts(contractId, cachedContract)
+      Control.Value(SUnit)
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -22,7 +22,6 @@ import com.daml.lf.transaction.{
   SubmittedTransaction,
   Node,
   ContractKeyUniquenessMode,
-  ProcessedDisclosedContract,
   NodeId,
   GlobalKey,
   IncompleteTransaction => IncompleteTx,
@@ -33,8 +32,7 @@ import com.daml.nameof.NameOf
 import com.daml.scalautil.Statement.discard
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 
-import scala.annotation.{tailrec, nowarn}
-import scala.collection.mutable
+import scala.annotation.{nowarn, tailrec}
 
 private[lf] object Speedy {
 
@@ -140,7 +138,7 @@ private[lf] object Speedy {
       Node.Create(
         coid = coid,
         templateId = templateId,
-        arg = value.toNormalizedValue(version),
+        arg = arg,
         agreementText = agreementText,
         signatories = signatories,
         stakeholders = stakeholders,
@@ -172,7 +170,6 @@ private[lf] object Speedy {
       /* Commit location, if a scenario commit is in progress. */
       val commitLocation: Option[Location],
       val limits: interpretation.Limits,
-      val disclosureKeyTable: DisclosedContractKeyTable,
   )(implicit loggingContext: LoggingContext)
       extends Machine[Question.Update] {
 
@@ -234,8 +231,27 @@ private[lf] object Speedy {
     /* Flag to trace usage of get_time builtins */
     private[this] var dependsOnTime: Boolean = false
     // global contract discriminators, that are discriminators from contract created in previous transactions
-    private[this] var cachedContracts: Map[V.ContractId, CachedContract] = Map.empty
+    private[this] var cachedContracts_ : Map[V.ContractId, CachedContract] = Map.empty
     private[this] var numInputContracts: Int = 0
+
+    private[this] var disclosedContracts_ = Map.empty[V.ContractId, CachedContract]
+    private[speedy] def disclosedContracts: Map[V.ContractId, CachedContract] = disclosedContracts_
+
+    private[this] var disclosedContractKeys_ = Map.empty[GlobalKey, V.ContractId]
+    private[speedy] def disclosedContractKeys: Map[GlobalKey, V.ContractId] = disclosedContractKeys_
+
+    private[speedy] def addDisclosedContracts(
+        contractId: V.ContractId,
+        contract: CachedContract,
+    ): Unit = {
+      disclosedContracts_ = disclosedContracts.updated(contractId, contract)
+      contract.keyOpt.foreach(key =>
+        disclosedContractKeys_ = disclosedContractKeys.updated(key.globalKey, contractId)
+      )
+    }
+
+    private[speedy] def isDisclosedContract(contractId: V.ContractId): Boolean =
+      disclosedContracts.isDefinedAt(contractId)
 
     private[speedy] def setDependsOnTime(): Unit =
       dependsOnTime = true
@@ -243,14 +259,8 @@ private[lf] object Speedy {
     def getDependsOnTime: Boolean =
       dependsOnTime
 
-    private[speedy] def getCachedContracts: Map[V.ContractId, CachedContract] =
-      cachedContracts
-
-    private[speedy] def getCachedContract(contractId: V.ContractId): Option[CachedContract] =
-      cachedContracts.get(contractId)
-
-    private[speedy] def hasCachedContract(contractId: V.ContractId): Boolean =
-      cachedContracts.contains(contractId)
+    private[speedy] def cachedContracts: Map[V.ContractId, CachedContract] =
+      cachedContracts_
 
     val visibleToStakeholders: Set[Party] => SVisibleToStakeholders =
       if (validating) { _ => SVisibleToStakeholders.Visible }
@@ -264,9 +274,6 @@ private[lf] object Speedy {
       ptx.contractState.locallyCreated.contains(contractId)
     }
 
-    private[speedy] def isDisclosedContract(contractId: V.ContractId): Boolean =
-      ptx.disclosedContractIds.contains(contractId)
-
     private[speedy] def updateCachedContracts(cid: V.ContractId, contract: CachedContract): Unit = {
       enforceLimit(
         contract.signatories.size,
@@ -275,7 +282,7 @@ private[lf] object Speedy {
           .ContractSignatories(
             cid,
             contract.templateId,
-            contract.value.toUnnormalizedValue,
+            contract.arg,
             contract.signatories,
             _,
           ),
@@ -287,12 +294,12 @@ private[lf] object Speedy {
           .ContractObservers(
             cid,
             contract.templateId,
-            contract.value.toUnnormalizedValue,
+            contract.arg,
             contract.observers,
             _,
           ),
       )
-      cachedContracts = cachedContracts.updated(cid, contract)
+      cachedContracts_ = cachedContracts_.updated(cid, contract)
     }
 
     private[speedy] def addGlobalContract(coid: V.ContractId, contract: CachedContract): Unit = {
@@ -331,30 +338,21 @@ private[lf] object Speedy {
         IError.Limit.ChoiceObservers(cid, templateId, choiceName, arg, observers, _),
       )
 
+    // The set of create events for the disclosed contracts that are used by the generated transaction.
+    def disclosedCreateEvents: ImmArray[Node.Create] =
+      disclosedContracts.iterator
+        .collect {
+          case (coid, contract) if cachedContracts_.isDefinedAt(coid) => contract.toCreateNode(coid)
+        }
+        .to(ImmArray)
+
     def finish: Either[SErrorCrash, UpdateMachine.Result] = ptx.finish.map { case (tx, seeds) =>
-      val inputContracts = tx.inputContracts
       UpdateMachine.Result(
         tx,
         ptx.locationInfo(),
         seeds zip ptx.actionNodeSeeds.toImmArray,
         ptx.contractState.globalKeyInputs.transform((_, v) => v.toKeyMapping),
-        // TODO(#15745) Improve test coverage for disclosed contracts with metadata extraction
-        ptx.disclosedContracts
-          .collect {
-            case disclosedContract if inputContracts(disclosedContract.contractId.value) =>
-              val lfContractId = disclosedContract.contractId.value
-              val cachedContract = getCachedContract(lfContractId).getOrElse(
-                throw SErrorCrash(
-                  NameOf.qualifiedNameOfCurrentFunc,
-                  s"contract ${lfContractId.coid} not in cachedContracts",
-                )
-              )
-              ProcessedDisclosedContract(
-                cachedContract.toCreateNode(disclosedContract.contractId.value),
-                createdAt = disclosedContract.metadata.createdAt,
-                driverMetadata = disclosedContract.metadata.driverMetadata,
-              )
-          },
+        disclosedCreateEvents,
       )
     }
 
@@ -396,7 +394,7 @@ private[lf] object Speedy {
       if (isLocalContract(coid) || isDisclosedContract(coid)) {
         handleKeyFound(coid)
       } else {
-        getCachedContract(coid) match {
+        cachedContracts.get(coid) match {
           case Some(cachedContract) =>
             val stakeholders = cachedContract.signatories union cachedContract.observers
             visibleToStakeholders(stakeholders) match {
@@ -454,7 +452,6 @@ private[lf] object Speedy {
             contractKeyUniqueness,
             initialSeeding,
             committers,
-            disclosedContracts,
             authorizationChecker,
           ),
         committers = committers,
@@ -462,7 +459,6 @@ private[lf] object Speedy {
         commitLocation = commitLocation,
         contractKeyUniqueness = contractKeyUniqueness,
         limits = limits,
-        disclosureKeyTable = new DisclosedContractKeyTable,
         traceLog = traceLog,
         warningLog = warningLog,
         profile = new Profile(),
@@ -476,45 +472,8 @@ private[lf] object Speedy {
         locationInfo: Map[NodeId, Location],
         seeds: NodeSeeds,
         globalKeyMapping: Map[GlobalKey, KeyMapping],
-        processedDisclosedContracts: ImmArray[ProcessedDisclosedContract],
+        disclosedCreateEvent: ImmArray[Node.Create],
     )
-  }
-
-  private[speedy] class DisclosedContractKeyTable {
-
-    private[this] val keyMap: mutable.Map[crypto.Hash, SValue.SContractId] = mutable.Map.empty
-
-    private[speedy] def addContractKey(
-        templateId: TypeConName,
-        keyHash: crypto.Hash,
-        contractId: V.ContractId,
-    ): Either[IError, Unit] = {
-      if (keyMap.contains(keyHash)) {
-        Left(
-          IError.DisclosurePreprocessing(
-            IError.DisclosurePreprocessing.DuplicateContractKeys(
-              templateId,
-              keyHash,
-            )
-          )
-        )
-      } else {
-        keyMap.update(keyHash, SValue.SContractId(contractId))
-        Right(())
-      }
-    }
-
-    private[speedy] def contractIdByKey(keyHash: crypto.Hash): Option[SValue.SContractId] =
-      keyMap.get(keyHash)
-
-    private[speedy] def isValidDisclosedContractKeyEntry(
-        key: GlobalKey,
-        contractId: V.ContractId,
-    ): Boolean = {
-      contractIdByKey(key.hash).map(_.value).contains(contractId)
-    }
-
-    private[speedy] def toMap: Map[crypto.Hash, SValue.SContractId] = keyMap.toMap
   }
 
   final class ScenarioMachine(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -190,7 +190,6 @@ private[lf] object PartialTransaction {
       contractKeyUniqueness: ContractKeyUniquenessMode,
       initialSeeds: InitialSeeding,
       committers: Set[Party],
-      disclosedContracts: ImmArray[DisclosedContract],
       authorizationChecker: AuthorizationChecker = DefaultAuthorizationChecker,
   ) = PartialTransaction(
     nextNodeIdx = 0,
@@ -199,7 +198,6 @@ private[lf] object PartialTransaction {
     context = Context(initialSeeds, committers),
     contractState = new ContractStateMachine[NodeId](contractKeyUniqueness).initial,
     actionNodeLocations = BackStack.empty,
-    disclosedContracts = disclosedContracts,
     authorizationChecker = authorizationChecker,
   )
 
@@ -234,14 +232,10 @@ private[speedy] case class PartialTransaction(
     context: PartialTransaction.Context,
     contractState: ContractStateMachine[NodeId]#State,
     actionNodeLocations: BackStack[Option[Location]],
-    disclosedContracts: ImmArray[DisclosedContract],
     authorizationChecker: AuthorizationChecker,
 ) {
 
   import PartialTransaction._
-
-  val disclosedContractIds: Set[Value.ContractId] =
-    disclosedContracts.map(_.contractId.value).toSeq.toSet
 
   def consumedByOrInactive(cid: Value.ContractId): Option[Either[NodeId, Unit]] = {
     contractState.consumedByOrInactive(cid)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureLib.scala
@@ -338,10 +338,14 @@ object ExplicitDisclosureLib {
     machine =>
       val expectedResult = contractIds.toSet
       val actualResult = machine.ptx.contractState.activeState.consumedBy.keySet
-      val debugMessage = Seq(
-        s"expected but missing contract IDs: ${expectedResult.filter(!actualResult.toSeq.contains(_))}",
-        s"unexpected but found contract IDs: ${actualResult.filter(!expectedResult.toSeq.contains(_))}",
-      ).mkString("\n  ", "\n  ", "")
+      val debugMessage = {
+        val diff1 = expectedResult -- actualResult
+        val diff2 = actualResult -- expectedResult
+        if (diff1.nonEmpty)
+          s"expected but missing contract IDs: $diff1"
+        else
+          s"unexpected but found contract IDs: $diff2"
+      }
 
       MatchResult(
         expectedResult == actualResult,
@@ -351,18 +355,26 @@ object ExplicitDisclosureLib {
   }
 
   def haveDisclosedContracts(
-      disclosedContracts: (ContractId, CachedContract)*
+      disclosedContracts: DisclosedContract*
   ): Matcher[Speedy.UpdateMachine] =
     Matcher { machine =>
-      val expectedResult = disclosedContracts.map { case (coid, contract) =>
-        contract.toCreateNode(coid)
-      }
-      val actualResult = machine.disclosedCreateEvents.toSeq
+      val expectedResult = disclosedContracts.iterator
+        .map(c =>
+          c.contractId.value -> c.argument.toNormalizedValue(machine.tmplId2TxVersion(c.templateId))
+        )
+        .toMap
+      val actualResult = machine.disclosedContracts.transform((_, c) => c.arg)
 
-      val debugMessage = Seq(
-        s"expected but missing contract IDs: ${expectedResult.filter(!actualResult.contains(_)).map(_.coid)}",
-        s"unexpected but found contract IDs: ${actualResult.filter(!expectedResult.contains(_)).map(_.coid)}",
-      ).mkString("\n  ", "\n  ", "")
+      val debugMessage = {
+        val diff1 = expectedResult.keySet -- actualResult.keySet
+        val diff2 = actualResult.keySet -- expectedResult.keySet
+        if (diff1.nonEmpty)
+          s"expected but missing contract IDs: $diff1"
+        else if (diff2.nonEmpty)
+          s"unexpected but found contract IDs: $diff2"
+        else
+          ""
+      }
 
       MatchResult(
         expectedResult == actualResult,

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureTest.scala
@@ -424,7 +424,8 @@ private[lf] trait ExplicitDisclosureTestMethods extends AnyFreeSpec with Inside 
       )
 
     assertResult(result)
-    ledger should haveDisclosedContracts(disclosedContract)
+    remy.blackHole(disclosedContract)
+    // ledger should haveDisclosedContracts(disclosedContract)
     ledger should haveInactiveContractIds()
   }
 
@@ -483,7 +484,8 @@ private[lf] trait ExplicitDisclosureTestMethods extends AnyFreeSpec with Inside 
       )
 
     assertResult(result)
-    ledger should haveDisclosedContracts(disclosedContract)
+    remy.blackHole(disclosedContract)
+//    ledger should haveDisclosedContracts(disclosedContract)
     ledger should haveInactiveContractIds(contractToDestroy)
   }
 
@@ -514,7 +516,7 @@ private[lf] trait ExplicitDisclosureTestMethods extends AnyFreeSpec with Inside 
       )
 
     assertResult(result)
-    ledger should haveDisclosedContracts(malformedDisclosedContract)
+    //  ledger should haveDisclosedContracts(malformedDisclosedContract)
     ledger should haveInactiveContractIds()
   }
 }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureTest.scala
@@ -6,7 +6,7 @@ package speedy
 
 import com.daml.lf.command.ContractMetadata
 import com.daml.lf.data.Ref.Party
-import com.daml.lf.data.{Bytes, ImmArray, Ref, Time}
+import com.daml.lf.data.{Bytes, Ref, ImmArray, Time}
 import com.daml.lf.interpretation.Error.{ContractKeyNotFound, ContractNotActive}
 import com.daml.lf.speedy.SExpr.SEValue
 import com.daml.lf.value.Value
@@ -14,9 +14,9 @@ import com.daml.lf.value.Value.ContractId
 import org.scalatest.{Assertion, Inside}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
-import com.daml.lf.speedy.SBuiltin.{SBFetchAny, SBUFetchKey, SBULookupKey}
+import com.daml.lf.speedy.SBuiltin.{SBUFetchKey, SBFetchAny, SBULookupKey}
 import com.daml.lf.speedy.SValue.SContractId
-import com.daml.lf.transaction.{GlobalKey, GlobalKeyWithMaintainers}
+import com.daml.lf.transaction.{GlobalKeyWithMaintainers, GlobalKey}
 import com.daml.lf.testing.parser.Implicits._
 
 class ExplicitDisclosureTest extends ExplicitDisclosureTestMethods {
@@ -391,7 +391,7 @@ private[lf] trait ExplicitDisclosureTestMethods extends AnyFreeSpec with Inside 
         PartialFunction.empty,
       getKey: PartialFunction[GlobalKeyWithMaintainers, Value.ContractId] = PartialFunction.empty,
   )(assertResult: Either[SError.SError, SValue] => Assertion): Assertion = {
-    val (result, ledger) =
+    val (result, machine) =
       evaluateSExpr(
         sexpr,
         committers = committers,
@@ -401,8 +401,8 @@ private[lf] trait ExplicitDisclosureTestMethods extends AnyFreeSpec with Inside 
       )
 
     assertResult(result)
-    ledger should haveDisclosedContracts()
-    ledger should haveInactiveContractIds()
+    machine should haveDisclosedContracts()
+    machine should haveInactiveContractIds()
   }
 
   def disclosureTableQueriedWhenContractDisclosed(
@@ -414,7 +414,7 @@ private[lf] trait ExplicitDisclosureTestMethods extends AnyFreeSpec with Inside 
         PartialFunction.empty,
       getKey: PartialFunction[GlobalKeyWithMaintainers, Value.ContractId] = PartialFunction.empty,
   )(assertResult: Either[SError.SError, SValue] => Assertion): Assertion = {
-    val (result, ledger) =
+    val (result, machine) =
       evaluateSExpr(
         sexpr,
         committers = committers,
@@ -424,9 +424,8 @@ private[lf] trait ExplicitDisclosureTestMethods extends AnyFreeSpec with Inside 
       )
 
     assertResult(result)
-    remy.blackHole(disclosedContract)
-    // ledger should haveDisclosedContracts(disclosedContract)
-    ledger should haveInactiveContractIds()
+    machine should haveDisclosedContracts(disclosedContract)
+    machine should haveInactiveContractIds()
   }
 
   def ledgerQueryFailsWhenContractNotDisclosed(
@@ -439,7 +438,7 @@ private[lf] trait ExplicitDisclosureTestMethods extends AnyFreeSpec with Inside 
         PartialFunction.empty,
       getKey: PartialFunction[GlobalKeyWithMaintainers, Value.ContractId] = PartialFunction.empty,
   )(assertResult: Either[SError.SError, SValue] => Assertion): Assertion = {
-    val (result, ledger) =
+    val (result, machine) =
       evaluateSExprWithSetup(
         e"""\(contractId: ContractId TestMod:House) ->
                           $action contractId
@@ -454,8 +453,8 @@ private[lf] trait ExplicitDisclosureTestMethods extends AnyFreeSpec with Inside 
       )
 
     assertResult(result)
-    ledger should haveDisclosedContracts()
-    ledger should haveInactiveContractIds(contractId)
+    machine should haveDisclosedContracts()
+    machine should haveInactiveContractIds(contractId)
   }
 
   def disclosureTableQueryFailsWhenContractDisclosed(
@@ -469,7 +468,7 @@ private[lf] trait ExplicitDisclosureTestMethods extends AnyFreeSpec with Inside 
         PartialFunction.empty,
       getKey: PartialFunction[GlobalKeyWithMaintainers, Value.ContractId] = PartialFunction.empty,
   )(assertResult: Either[SError.SError, SValue] => Assertion): Assertion = {
-    val (result, ledger) =
+    val (result, machine) =
       evaluateSExprWithSetup(
         e"""\(contractId: ContractId TestMod:House) ->
                           $action contractId
@@ -484,9 +483,8 @@ private[lf] trait ExplicitDisclosureTestMethods extends AnyFreeSpec with Inside 
       )
 
     assertResult(result)
-    remy.blackHole(disclosedContract)
-//    ledger should haveDisclosedContracts(disclosedContract)
-    ledger should haveInactiveContractIds(contractToDestroy)
+    machine should haveDisclosedContracts(disclosedContract)
+    machine should haveInactiveContractIds(contractToDestroy)
   }
 
   def wronglyTypedDisclosedContractsRejected(
@@ -508,7 +506,7 @@ private[lf] trait ExplicitDisclosureTestMethods extends AnyFreeSpec with Inside 
         ),
         ContractMetadata(Time.Timestamp.now(), Some(houseContractKey.hash), Bytes.Empty),
       )
-    val (result, ledger) =
+    val (result, machine) =
       evaluateSExpr(
         sexpr,
         committers = Set(disclosureParty),
@@ -516,7 +514,7 @@ private[lf] trait ExplicitDisclosureTestMethods extends AnyFreeSpec with Inside 
       )
 
     assertResult(result)
-    //  ledger should haveDisclosedContracts(malformedDisclosedContract)
-    ledger should haveInactiveContractIds()
+    machine should haveDisclosedContracts(malformedDisclosedContract)
+    machine should haveInactiveContractIds()
   }
 }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -27,7 +27,6 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
     ContractKeyUniquenessMode.Strict,
     InitialSeeding.TransactionSeed(transactionSeed),
     committers,
-    ImmArray.Empty,
   )
 
   private[this] def contractIdsInOrder(ptx: PartialTransaction): List[Value.ContractId] = {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -639,12 +639,8 @@ object SpeedyTest {
       .withCachedContracts(
         localContractId -> localCachedContract,
         globalContractId -> globalCachedContract,
-        disclosedContractId -> disclosedCachedContract,
       )
       .withLocalContractKey(localContractId, localContractKey)
-      .withDisclosedContractKeys(
-        houseTemplateType,
-        disclosedContractKey.hash -> disclosedContractId,
-      )
+      .withDisclosedContractKeys(disclosedContractId -> disclosedCachedContract)
   }
 }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
@@ -5,7 +5,7 @@ package com.daml
 package lf
 package speedy
 
-import data.Ref.{PackageId, TypeConName}
+import data.Ref.PackageId
 import data.Time
 import SResult._
 import com.daml.lf.language.{Ast, PackageInterface}
@@ -163,7 +163,6 @@ private[speedy] object SpeedyTestLib {
           readAs = machine.readAs,
           commitLocation = machine.commitLocation,
           limits = machine.limits,
-          disclosureKeyTable = machine.disclosureKeyTable,
           iterationsBetweenInterruptions = machine.iterationsBetweenInterruptions,
         )
 
@@ -189,14 +188,11 @@ private[speedy] object SpeedyTestLib {
       }
 
       private[speedy] def withDisclosedContractKeys(
-          templateId: TypeConName,
-          disclosedContractKeys: (crypto.Hash, ContractId)*
+          disclosedContractKeys: (ContractId, CachedContract)*
       ): UpdateMachine = {
-        for {
-          entry <- disclosedContractKeys
-          (keyHash, contractId) = entry
-        } machine.disclosureKeyTable.addContractKey(templateId, keyHash, contractId)
-
+        disclosedContractKeys.foreach { case (contractId, contract) =>
+          machine.addDisclosedContracts(contractId, contract)
+        }
         machine
       }
     }

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -718,13 +718,13 @@ Then we can define our kinds, types, and expressions::
   Updates
     u ::= 'pure' @τ e                               -- UpdatePure
        |  'bind' x₁ : τ₁ ← e₁ 'in' e₂               -- UpdateBlock
-       |  'create' @Mod:T e                         -- UpdateCreate
+  x     |  'create' @Mod:T e                         -- UpdateCreate
        |  'create_interface' @Mod:I e               -- UpdateCreateInterface [Daml-LF ≥ 1.dev]
        |  'fetch' @Mod:T e                          -- UpdateFetch
        |  'fetch_interface' @Mod:I e                -- UpdateFetchInterface [Daml-LF ≥ 1.dev]
-       |  'exercise' @Mod:T Ch e₁ e₂                -- UpdateExercise
-       |  'exercise_by_key' @Mod:T Ch e₁ e₂         -- UpdateExerciseByKey [Daml-LF ≥ 1.11]
-       |  'exercise_interface' @Mod:I Ch e₁ e₂ e₃   -- UpdateExerciseInterface [Daml-LF ≥ 1.dev]
+  x     |  'exercise' @Mod:T Ch e₁ e₂                -- UpdateExercise
+  x     |  'exercise_by_key' @Mod:T Ch e₁ e₂         -- UpdateExerciseByKey [Daml-LF ≥ 1.11]
+  x     |  'exercise_interface' @Mod:I Ch e₁ e₂ e₃   -- UpdateExerciseInterface [Daml-LF ≥ 1.dev]
        |  'get_time'                                -- UpdateGetTime
        |  'fetch_by_key' @τ e                       -- UpdateFecthByKey
        |  'lookup_by_key' @τ e                      -- UpdateLookUpByKey

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -4,7 +4,6 @@
 package com.daml.lf
 package interpretation
 
-import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Ref.{ChoiceName, Location, Party, TypeConName}
 import com.daml.lf.transaction.{GlobalKey, NodeId}
 import com.daml.lf.language.Ast
@@ -152,12 +151,6 @@ object Error {
       choiceName: ChoiceName,
       byInterface: Option[TypeConName],
   ) extends Error
-
-  final case class DisclosurePreprocessing(error: DisclosurePreprocessing.Error) extends Error
-  object DisclosurePreprocessing {
-    sealed abstract class Error extends Serializable with Product
-    final case class DuplicateContractKeys(templateId: TypeConName, keyHash: Hash) extends Error
-  }
 
   final case class Limit(error: Limit.Error) extends Error
 

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/ExplicitDisclosureIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/ExplicitDisclosureIT.scala
@@ -603,10 +603,10 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
         }
         assertGrpcErrorRegex(
           errorDuplicateKey,
-          LedgerApiErrors.CommandExecution.Interpreter.InvalidArgumentInterpretationError,
+          LedgerApiErrors.CommandExecution.Preprocessing.PreprocessingFailed,
           Some(
             Pattern.compile(
-              s"Found duplicated contract keys in submitted disclosed contracts .* $expectedKeyHashString"
+              s"Preprocessor encountered a duplicate disclosed contract key hash $expectedKeyHashString"
             )
           ),
           checkDefiniteAnswerMetadata = true,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/RejectionGenerators.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/RejectionGenerators.scala
@@ -142,11 +142,6 @@ object RejectionGenerators {
             .Error(
               renderedMessage
             )
-        case _: LfInterpretationError.DisclosurePreprocessing =>
-          LedgerApiErrors.CommandExecution.Interpreter.InvalidArgumentInterpretationError
-            .Error(
-              renderedMessage
-            )
       }
     }
 


### PR DESCRIPTION
This PR makes several changes on how the disclosed contract are handle by the speedy machine.

(1) disclosed contract at not anymore pass a builtin time. They are anyway passed latter using `SBCacheDisclosedContract`.

(2) disclosed contracts are first keep in their own cache, `disclosedContracts: Map[V.ContractId, CachedContract]`. They are moved to the cached for used contract only if used.  In fact we need to be sure the disclosed contracts pass through the `Speedy#addGlobalContract` to verify the transaction limits are not exceeded iff they are used. 

(3) duplicate key for disclosed contracts is check during preprocessing.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
