### PR TITLE
Allow name shadowing in choices

### DIFF
--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "1d75986d62e4d8e6bb7e3505e6c1b649a37e7458"
+GHC_REV = "5e6fd139c43d380ac0df7fc36b73899b47d63a22"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "fff6c81077edbcae1b5fe00334fec0a779ae8a2c"
+GHC_REV = "4d4174e4ca8efa89a7af74f0066cbe287002557e"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "4d4174e4ca8efa89a7af74f0066cbe287002557e"
+GHC_REV = "1d75986d62e4d8e6bb7e3505e6c1b649a37e7458"
 GHC_PATCHES = [
 ]
 

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1492,6 +1492,7 @@ internalFunctions = listToUFM $ map (bimap mkModuleNameFS mkUniqSet)
         [ "mkInterfaceInstance"
         , "mkMethod"
         , "mkInterfaceView"
+        , "bypassReduceLambda"
         ])
     , ("GHC.Tuple.Check",
         [ "userWrittenTuple"
@@ -1533,6 +1534,9 @@ convertExpr env0 e = do
             pure $ ETmLam (v, TStruct fields) $ ERecCon tupleType $ zipWithFrom mkFieldProj (1 :: Int) fields
     go env (VarIn GHC_Types "primitive") (LType (isStrLitTy -> Just y) : LType t : args)
         = fmap (, args) $ convertPrim (envLfVersion env) (unpackFS y) =<< convertType env t
+    -- erase bypassReduceLambda calls and leave only the body.
+    go env (VarIn DA_Internal_Desugar "bypassReduceLambda") (LType _t : LExpr body : args)
+        = go env body args
     -- erase mkMethod calls and leave only the body.
     go env (VarIn DA_Internal_Desugar "mkMethod") (LType _parent : LType _iface : LType _tpl : LType _methodName : LType _methodTy : LExpr _implDict : LExpr _hasMethodDic : LExpr body : args)
         = go env body args

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Desugar.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Desugar.daml
@@ -28,7 +28,8 @@ module DA.Internal.Desugar (
     mkMethod,
     InterfaceView,
     mkInterfaceView,
-    userWrittenTuple
+    userWrittenTuple,
+    bypassReduceLambda
 ) where
 
 import DA.Internal.Prelude
@@ -146,3 +147,6 @@ newtype InterfaceView p i t = InterfaceView ()
 -- it's extracted unmodified.
 mkInterfaceView : forall p i t v. (Implements t i, HasInterfaceView i v) => (t -> v) -> InterfaceView p i t
 mkInterfaceView = magic @"mkInterfaceView"
+
+bypassReduceLambda : forall a. a -> a
+bypassReduceLambda = magic @"bypassReduceLambda"

--- a/compiler/damlc/tests/daml-test-files/ChoiceShadowing.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/ChoiceShadowing.EXPECTED.desugared-daml
@@ -1,0 +1,119 @@
+module ChoiceShadowing where
+import (implicit) qualified DA.Internal.Record
+import (implicit) qualified GHC.Types
+import (implicit) qualified DA.Internal.Desugar
+import (implicit) DA.Internal.RebindableSyntax
+import DA.Assert
+data GHC.Types.DamlTemplate => T
+  = T {p : Party, p2 : Party}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+instance DA.Internal.Record.HasField "p" T Party where
+  getField = DA.Internal.Record.getFieldPrim @"p" @T @Party
+  setField = DA.Internal.Record.setFieldPrim @"p" @T @Party
+instance DA.Internal.Record.HasField "p2" T Party where
+  getField = DA.Internal.Record.getFieldPrim @"p2" @T @Party
+  setField = DA.Internal.Record.setFieldPrim @"p2" @T @Party
+data Call
+  = Call {p : Party}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+instance DA.Internal.Record.HasField "p" Call Party where
+  getField = DA.Internal.Record.getFieldPrim @"p" @Call @Party
+  setField = DA.Internal.Record.setFieldPrim @"p" @Call @Party
+instance DA.Internal.Desugar.HasSignatory T where
+  signatory this@T {..}
+    = DA.Internal.Desugar.toParties (p)
+    where
+        _ = this
+instance DA.Internal.Desugar.HasObserver T where
+  observer this@T {..}
+    = DA.Internal.Desugar.toParties ([p, p2])
+    where
+        _ = this
+instance DA.Internal.Desugar.HasEnsure T where
+  ensure this@T {..}
+    = DA.Internal.Desugar.True
+    where
+        _ = this
+instance DA.Internal.Desugar.HasAgreement T where
+  agreement this@T {..}
+    = ""
+    where
+        _ = this
+instance DA.Internal.Desugar.HasArchive T where
+  archive cid
+    = DA.Internal.Desugar.exercise cid DA.Internal.Desugar.Archive
+    where
+        _ = cid
+instance DA.Internal.Desugar.HasCreate T where
+  create = GHC.Types.primitive @"UCreate"
+instance DA.Internal.Desugar.HasFetch T where
+  fetch = GHC.Types.primitive @"UFetch"
+instance DA.Internal.Desugar.HasToAnyTemplate T where
+  _toAnyTemplate = GHC.Types.primitive @"EToAnyTemplate"
+instance DA.Internal.Desugar.HasFromAnyTemplate T where
+  _fromAnyTemplate = GHC.Types.primitive @"EFromAnyTemplate"
+instance DA.Internal.Desugar.HasTemplateTypeRep T where
+  _templateTypeRep = GHC.Types.primitive @"ETemplateTypeRep"
+instance DA.Internal.Desugar.HasIsInterfaceType T where
+  _isInterfaceType _ = DA.Internal.Desugar.False
+instance DA.Internal.Desugar.HasExercise T DA.Internal.Desugar.Archive (()) where
+  exercise = GHC.Types.primitive @"UExercise"
+instance DA.Internal.Desugar.HasToAnyChoice T DA.Internal.Desugar.Archive (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice T DA.Internal.Desugar.Archive (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasChoiceController T DA.Internal.Desugar.Archive where
+  _choiceController = GHC.Types.primitive @"EChoiceController"
+instance DA.Internal.Desugar.HasChoiceObserver T DA.Internal.Desugar.Archive where
+  _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
+instance DA.Internal.Desugar.HasExercise T Call (ContractId T) where
+  exercise = GHC.Types.primitive @"UExercise"
+instance DA.Internal.Desugar.HasToAnyChoice T Call (ContractId T) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice T Call (ContractId T) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasChoiceController T Call where
+  _choiceController = GHC.Types.primitive @"EChoiceController"
+instance DA.Internal.Desugar.HasChoiceObserver T Call where
+  _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
+_choice$_TArchive :
+  (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId T
+   -> T
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming T,
+   DA.Internal.Desugar.Optional (T
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+_choice$_TArchive
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
+     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
+     DA.Internal.Desugar.None)
+_choice$_TCall :
+  (T -> Call -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId T
+   -> T -> Call -> DA.Internal.Desugar.Update (ContractId T),
+   DA.Internal.Desugar.Consuming T,
+   DA.Internal.Desugar.Optional (T
+                                 -> Call -> [DA.Internal.Desugar.Party]))
+_choice$_TCall
+  = (\ this@T {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@Call {..}
+              -> let _ = this in
+                 let _ = arg in DA.Internal.Desugar.toParties (p2), 
+     \ self this@T {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@Call {..}
+              -> let _ = self in
+                 let _ = this in let _ = arg in do create T {p = p, p2 = p2}, 
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+test1
+  = scenario
+      do alice <- getParty "Alice"
+         bob <- getParty "Bob"
+         cid <- submit alice $ create (T alice bob)
+         submit
+           bob
+           do cid2 <- exercise cid (Call bob)
+              newT <- fetch cid2
+              newT === T bob bob

--- a/compiler/damlc/tests/daml-test-files/ChoiceShadowing.daml
+++ b/compiler/damlc/tests/daml-test-files/ChoiceShadowing.daml
@@ -1,0 +1,30 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- Check that name shadowing is allowed in choices, and that the argument takes precedence over the template
+
+module ChoiceShadowing where
+
+template T with
+    p : Party
+    p2 : Party
+  where
+    signatory p
+
+    choice Call : ContractId T with
+        p : Party
+      controller p2
+      do
+        create T with
+          p = p
+          p2 = p2
+
+test1 = scenario do
+    alice <- getParty "Alice"
+    bob <- getParty "Bob"
+    cid <- submit p do
+      createAndExercise
+        (T alice bob)
+        (Call bob)
+    newT <- queryContractId bob cid
+    newT === T bob bob

--- a/compiler/damlc/tests/daml-test-files/ChoiceShadowing.daml
+++ b/compiler/damlc/tests/daml-test-files/ChoiceShadowing.daml
@@ -3,13 +3,18 @@
 
 -- Check that name shadowing is allowed in choices, and that the argument takes precedence over the template
 
+{-# OPTIONS_GHC -Wno-ambiguous-fields #-}
+
 module ChoiceShadowing where
+
+import DA.Assert
 
 template T with
     p : Party
     p2 : Party
   where
     signatory p
+    observer [p, p2]
 
     choice Call : ContractId T with
         p : Party
@@ -22,9 +27,10 @@ template T with
 test1 = scenario do
     alice <- getParty "Alice"
     bob <- getParty "Bob"
-    cid <- submit p do
-      createAndExercise
-        (T alice bob)
-        (Call bob)
-    newT <- queryContractId bob cid
-    newT === T bob bob
+    cid <- submit alice $ create (T alice bob)
+    submit bob do
+      cid2 <- exercise cid (Call bob)
+      newT <- fetch cid2
+      newT === T bob bob
+
+-- @ENABLE-SCENARIOS

--- a/compiler/damlc/tests/daml-test-files/ExceptionSemantics.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionSemantics.EXPECTED.desugared-daml
@@ -415,20 +415,24 @@ _choice$_TUncatchableTry :
    DA.Internal.Desugar.Optional (T
                                  -> UncatchableTry -> [DA.Internal.Desugar.Party]))
 _choice$_TUncatchableTry
-  = (\ this@T {..} arg@UncatchableTry {..}
-       -> let _ = this in
-          let _ = arg in DA.Internal.Desugar.toParties (p), 
-     \ self this@T {..} arg@UncatchableTry {..}
-       -> let _ = self in
-          let _ = this in
-          let _ = arg
-          in
-            do DA.Internal.Desugar._tryCatch
-                 \ _ -> (() <$ fetch cid)
-                 \case
-                   (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
-                     -> DA.Internal.Desugar.Some pure ()
-                   _ -> DA.Internal.Desugar.None, 
+  = (\ this@T {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@UncatchableTry {..}
+              -> let _ = this in
+                 let _ = arg in DA.Internal.Desugar.toParties (p), 
+     \ self this@T {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@UncatchableTry {..}
+              -> let _ = self in
+                 let _ = this in
+                 let _ = arg
+                 in
+                   do DA.Internal.Desugar._tryCatch
+                        \ _ -> (() <$ fetch cid)
+                        \case
+                          (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
+                            -> DA.Internal.Desugar.Some pure ()
+                          _ -> DA.Internal.Desugar.None, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
 _choice$_TTransientDuplicate :
   (T -> TransientDuplicate -> [DA.Internal.Desugar.Party],
@@ -438,23 +442,27 @@ _choice$_TTransientDuplicate :
    DA.Internal.Desugar.Optional (T
                                  -> TransientDuplicate -> [DA.Internal.Desugar.Party]))
 _choice$_TTransientDuplicate
-  = (\ this@T {..} arg@TransientDuplicate {..}
-       -> let _ = this in
-          let _ = arg in DA.Internal.Desugar.toParties (p), 
-     \ self this@T {..} arg@TransientDuplicate {..}
-       -> let _ = self in
-          let _ = this in
-          let _ = arg
-          in
-            do DA.Internal.Desugar._tryCatch
-                 \ _
-                   -> do create (K p i)
-                         create (K p i)
-                         throw E
-                 \case
-                   (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
-                     -> DA.Internal.Desugar.Some pure ()
-                   _ -> DA.Internal.Desugar.None, 
+  = (\ this@T {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@TransientDuplicate {..}
+              -> let _ = this in
+                 let _ = arg in DA.Internal.Desugar.toParties (p), 
+     \ self this@T {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@TransientDuplicate {..}
+              -> let _ = self in
+                 let _ = this in
+                 let _ = arg
+                 in
+                   do DA.Internal.Desugar._tryCatch
+                        \ _
+                          -> do create (K p i)
+                                create (K p i)
+                                throw E
+                        \case
+                          (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
+                            -> DA.Internal.Desugar.Some pure ()
+                          _ -> DA.Internal.Desugar.None, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
 _choice$_TNonTransientDuplicate :
   (T -> NonTransientDuplicate -> [DA.Internal.Desugar.Party],
@@ -464,22 +472,26 @@ _choice$_TNonTransientDuplicate :
    DA.Internal.Desugar.Optional (T
                                  -> NonTransientDuplicate -> [DA.Internal.Desugar.Party]))
 _choice$_TNonTransientDuplicate
-  = (\ this@T {..} arg@NonTransientDuplicate {..}
-       -> let _ = this in
-          let _ = arg in DA.Internal.Desugar.toParties (p), 
-     \ self this@T {..} arg@NonTransientDuplicate {..}
-       -> let _ = self in
-          let _ = this in
-          let _ = arg
-          in
-            do DA.Internal.Desugar._tryCatch
-                 \ _
-                   -> do create (K p i)
-                         throw E
-                 \case
-                   (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
-                     -> DA.Internal.Desugar.Some pure ()
-                   _ -> DA.Internal.Desugar.None, 
+  = (\ this@T {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@NonTransientDuplicate {..}
+              -> let _ = this in
+                 let _ = arg in DA.Internal.Desugar.toParties (p), 
+     \ self this@T {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@NonTransientDuplicate {..}
+              -> let _ = self in
+                 let _ = this in
+                 let _ = arg
+                 in
+                   do DA.Internal.Desugar._tryCatch
+                        \ _
+                          -> do create (K p i)
+                                throw E
+                        \case
+                          (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
+                            -> DA.Internal.Desugar.Some pure ()
+                          _ -> DA.Internal.Desugar.None, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
 _choice$_TRollbackKey :
   (T -> RollbackKey -> [DA.Internal.Desugar.Party],
@@ -489,22 +501,26 @@ _choice$_TRollbackKey :
    DA.Internal.Desugar.Optional (T
                                  -> RollbackKey -> [DA.Internal.Desugar.Party]))
 _choice$_TRollbackKey
-  = (\ this@T {..} arg@RollbackKey {..}
-       -> let _ = this in
-          let _ = arg in DA.Internal.Desugar.toParties (p), 
-     \ self this@T {..} arg@RollbackKey {..}
-       -> let _ = self in
-          let _ = this in
-          let _ = arg
-          in
-            do DA.Internal.Desugar._tryCatch
-                 \ _
-                   -> do create (K p i)
-                         throw E
-                 \case
-                   (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
-                     -> DA.Internal.Desugar.Some create (K p i) >> pure ()
-                   _ -> DA.Internal.Desugar.None, 
+  = (\ this@T {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@RollbackKey {..}
+              -> let _ = this in
+                 let _ = arg in DA.Internal.Desugar.toParties (p), 
+     \ self this@T {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@RollbackKey {..}
+              -> let _ = self in
+                 let _ = this in
+                 let _ = arg
+                 in
+                   do DA.Internal.Desugar._tryCatch
+                        \ _
+                          -> do create (K p i)
+                                throw E
+                        \case
+                          (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
+                            -> DA.Internal.Desugar.Some create (K p i) >> pure ()
+                          _ -> DA.Internal.Desugar.None, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
 _choice$_TRollbackArchive :
   (T -> RollbackArchive -> [DA.Internal.Desugar.Party],
@@ -514,21 +530,25 @@ _choice$_TRollbackArchive :
    DA.Internal.Desugar.Optional (T
                                  -> RollbackArchive -> [DA.Internal.Desugar.Party]))
 _choice$_TRollbackArchive
-  = (\ this@T {..} arg@RollbackArchive {..}
-       -> let _ = this in
-          let _ = arg in DA.Internal.Desugar.toParties (p), 
-     \ self this@T {..} arg@RollbackArchive {..}
-       -> let _ = self in
-          let _ = this in
-          let _ = arg
-          in
-            do cid <- create (K p i)
-               DA.Internal.Desugar._tryCatch
-                 \ _ -> (archive cid >> throw E)
-                 \case
-                   (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
-                     -> DA.Internal.Desugar.Some archive cid
-                   _ -> DA.Internal.Desugar.None, 
+  = (\ this@T {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@RollbackArchive {..}
+              -> let _ = this in
+                 let _ = arg in DA.Internal.Desugar.toParties (p), 
+     \ self this@T {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@RollbackArchive {..}
+              -> let _ = self in
+                 let _ = this in
+                 let _ = arg
+                 in
+                   do cid <- create (K p i)
+                      DA.Internal.Desugar._tryCatch
+                        \ _ -> (archive cid >> throw E)
+                        \case
+                          (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
+                            -> DA.Internal.Desugar.Some archive cid
+                          _ -> DA.Internal.Desugar.None, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
 _choice$_TNonRollbackArchive :
   (T -> NonRollbackArchive -> [DA.Internal.Desugar.Party],
@@ -538,22 +558,26 @@ _choice$_TNonRollbackArchive :
    DA.Internal.Desugar.Optional (T
                                  -> NonRollbackArchive -> [DA.Internal.Desugar.Party]))
 _choice$_TNonRollbackArchive
-  = (\ this@T {..} arg@NonRollbackArchive {..}
-       -> let _ = this in
-          let _ = arg in DA.Internal.Desugar.toParties (p), 
-     \ self this@T {..} arg@NonRollbackArchive {..}
-       -> let _ = self in
-          let _ = this in
-          let _ = arg
-          in
-            do cid <- create (K p i)
-               DA.Internal.Desugar._tryCatch
-                 \ _ -> (archive cid)
-                 \case
-                   (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
-                     -> DA.Internal.Desugar.Some pure ()
-                   _ -> DA.Internal.Desugar.None
-               archive cid, 
+  = (\ this@T {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@NonRollbackArchive {..}
+              -> let _ = this in
+                 let _ = arg in DA.Internal.Desugar.toParties (p), 
+     \ self this@T {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@NonRollbackArchive {..}
+              -> let _ = self in
+                 let _ = this in
+                 let _ = arg
+                 in
+                   do cid <- create (K p i)
+                      DA.Internal.Desugar._tryCatch
+                        \ _ -> (archive cid)
+                        \case
+                          (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
+                            -> DA.Internal.Desugar.Some pure ()
+                          _ -> DA.Internal.Desugar.None
+                      archive cid, 
      DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
 data GHC.Types.DamlTemplate => Fetcher
   = Fetcher {sig : Party, obs : Party}
@@ -670,11 +694,15 @@ _choice$_FetcherFetch :
    DA.Internal.Desugar.Optional (Fetcher
                                  -> Fetch -> [DA.Internal.Desugar.Party]))
 _choice$_FetcherFetch
-  = (\ this@Fetcher {..} arg@Fetch {..}
-       -> let _ = this in
-          let _ = arg in DA.Internal.Desugar.toParties (obs), 
-     \ self this@Fetcher {..} arg@Fetch {..}
-       -> let _ = self in let _ = this in let _ = arg in do fetch cid, 
+  = (\ this@Fetcher {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@Fetch {..}
+              -> let _ = this in
+                 let _ = arg in DA.Internal.Desugar.toParties (obs), 
+     \ self this@Fetcher {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@Fetch {..}
+              -> let _ = self in let _ = this in let _ = arg in do fetch cid, 
      DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
 _choice$_FetcherRollbackFetch :
   (Fetcher -> RollbackFetch -> [DA.Internal.Desugar.Party],
@@ -684,20 +712,24 @@ _choice$_FetcherRollbackFetch :
    DA.Internal.Desugar.Optional (Fetcher
                                  -> RollbackFetch -> [DA.Internal.Desugar.Party]))
 _choice$_FetcherRollbackFetch
-  = (\ this@Fetcher {..} arg@RollbackFetch {..}
-       -> let _ = this in
-          let _ = arg in DA.Internal.Desugar.toParties (obs), 
-     \ self this@Fetcher {..} arg@RollbackFetch {..}
-       -> let _ = self in
-          let _ = this in
-          let _ = arg
-          in
-            do DA.Internal.Desugar._tryCatch
-                 \ _ -> (fetch cid >> throw E)
-                 \case
-                   (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
-                     -> DA.Internal.Desugar.Some pure ()
-                   _ -> DA.Internal.Desugar.None, 
+  = (\ this@Fetcher {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@RollbackFetch {..}
+              -> let _ = this in
+                 let _ = arg in DA.Internal.Desugar.toParties (obs), 
+     \ self this@Fetcher {..}
+       -> DA.Internal.Desugar.bypassReduceLambda
+            \ arg@RollbackFetch {..}
+              -> let _ = self in
+                 let _ = this in
+                 let _ = arg
+                 in
+                   do DA.Internal.Desugar._tryCatch
+                        \ _ -> (fetch cid >> throw E)
+                        \case
+                          (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
+                            -> DA.Internal.Desugar.Some pure ()
+                          _ -> DA.Internal.Desugar.None, 
      DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
 uncaughtUserException
   = scenario


### PR DESCRIPTION
Resolves #2186 
Relevant ghc changes: https://github.com/digital-asset/ghc/pull/159
- Switches desugaring for anything that uses `this` and `args` from `\ this@T{..} args@A{..} -> ...` to `\ this@T{..} -> bypassReduceLambda \args@A{..} -> ...`
  This allows for name shadowing, specifically supporting `this.someField` and `args.someField` in the same block. For ambiguous names, default behaviour is to take the arguments fields, as one would expect. We may wish to consider enabling the `-Wname-shadowing` warning by default, so users may specifically opt into this behaviour

CHANGELOG_BEGIN

- [Daml Compiler] Allow name shadowing in choice arguments over template arguments
See `#2186 <https://github.com/digital-asset/daml/issues/2186>`__.

CHANGELOG_END