### PR TITLE
Add label support to the metrics tag [PLEN-102]

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/IndexedUpdatesMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IndexedUpdatesMetrics.scala
@@ -14,6 +14,10 @@ class IndexedUpdatesMetrics(prefix: MetricName, metricFactory: MetricsFactory) {
     description = """Represents the number of events that will be included in the metering report.
         |This is an estimate of the total number and not a substitute for the metering report.""",
     qualification = Debug,
+    labelsWithDescription = Map(
+      "participant_id" -> "The id of the participant.",
+      "application_id" -> "The application generating the events.",
+    ),
   )
   val meteredEventsMeter: MetricHandle.Meter = metricFactory.meter(
     prefix :+ "metered_events",
@@ -24,6 +28,12 @@ class IndexedUpdatesMetrics(prefix: MetricName, metricFactory: MetricsFactory) {
     summary = "Updates processed by the indexer",
     description = "Represents the total number of updates processed, that are sent for indexing.",
     qualification = Debug,
+    labelsWithDescription = Map(
+      "participant_id" -> "The id of the participant.",
+      "application_id" -> "The application generating the events.",
+      "event_type" -> "The type of ledger event processed (transaction, package upload, party allocation, configuration change).",
+      "status" -> "Indicates if the transaction was accepted or not. Possible values accepted|rejected.",
+    ),
   )
   val eventsMeter: MetricHandle.Meter =
     metricFactory.meter(prefix :+ "events", "Number of events ingested by the indexer.")

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/MetricDoc.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/MetricDoc.scala
@@ -23,10 +23,15 @@ object MetricDoc {
   // The Tag can be defined to document a single metric. Its summary, description and
   // qualification will be present as a separate documentation entry unless a GroupTag is defined
   // for the class that may belongs.
+  // labelsWithDescription must contains the labels that can be attached to the metrics.
+  //    It must be represented as literal strings, as the documentation is build based on static annotations.
+  //    Example: Map("label" -> "description"). Even if the label is a constant, it cannot be referenced, therefore
+  //    this is not an acceptable use: Map(SomeObject.SomeConstant -> "description")
   case class Tag(
       summary: String,
       description: String,
       qualification: MetricQualification,
+      labelsWithDescription: Map[String, String] = Map.empty,
   ) extends StaticAnnotation
 
   // The GroupTag can be defined for metrics that belong in the same class, are used in multiple


### PR DESCRIPTION
This allows us to include the labels that can be attached to a metrics. As the Tag class represents a static annotation, the label map must be formed from literal values and cannot reference other variables, not even constants.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
