### PR TITLE
Fix warning about unused `this` in exception messages

### DIFF
--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "5e6fd139c43d380ac0df7fc36b73899b47d63a22"
+GHC_REV = "d926f299680012b07270e11744d6e61ca4ff148b"
 GHC_PATCHES = [
 ]
 

--- a/compiler/damlc/tests/daml-test-files/ExceptionUnusedWarning.daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionUnusedWarning.daml
@@ -1,0 +1,14 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @SINCE-LF-FEATURE DAML_EXCEPTIONS
+
+{-# OPTIONS_GHC -fwarn-unused-matches #-}
+
+module ExceptionUnusedWarning where
+
+exception MyException
+    with
+        m : Text
+    where
+        message m


### PR DESCRIPTION
Resolves #11004 
Relevant ghc changes: https://github.com/digital-asset/ghc/pull/160
- Adds a `let _ = this in` before the method body in exception HasMessage
