### PR TITLE
[Engine] Check disclosed contract key during preprocessing

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
@@ -127,19 +127,33 @@ object Error {
 
     final case class RootNode(nodeId: NodeId, override val message: String) extends Error
 
-    final case class BadDisclosedContract(message: String) extends Error
-
-    final case class DuplicateDisclosedContractId(
+    final case class UnexpectedDisclosedContractKeyHash(
         contractId: Value.ContractId,
-        templateId: Ref.Identifier,
+        templateId: Ref.TypeConName,
+        hash: crypto.Hash,
     ) extends Error {
       override def message: String =
-        s"Preprocessor encountered a duplicate disclosed contract ID $contractId for template $templateId"
+        s"Unexpected contract key hash for the disclosed contract ${contractId.coid} ($templateId)"
+    }
+
+    final case class MissingDisclosedContractKeyHash(
+        contractId: Value.ContractId,
+        templateId: Ref.TypeConName,
+    ) extends Error {
+      override def message: String =
+        s"Missing contract key hash for the disclosed contract ${contractId.coid} ($templateId)"
+    }
+
+    final case class DuplicateDisclosedContractId(
+        contractId: Value.ContractId
+    ) extends Error {
+      override def message: String =
+        s"Duplicate disclosed contract ID ${contractId.coid}"
     }
 
     final case class DuplicateDisclosedContractKey(keyHash: crypto.Hash) extends Error {
       override def message: String =
-        s"Preprocessor encountered a duplicate disclosed contract key hash ${keyHash.toHexString}"
+        s"Duplicate disclosed contract key hash ${keyHash.toHexString}"
     }
   }
 

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/ExplicitDisclosureIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/ExplicitDisclosureIT.scala
@@ -566,16 +566,16 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
         )
 
         _ <- ownerParticipant.create(owner, WithKey(owner))
-        wihtKeyTxs <- ownerParticipant.flatTransactionsByTemplateId(WithKey.id, owner)
-        wihtKeyCreate = createdEvents(wihtKeyTxs(0)).head
-        wihtKeyDisclosedContract = createEventToDisclosedContract(wihtKeyCreate)
+        whitKeyTxs <- ownerParticipant.flatTransactionsByTemplateId(WithKey.id, owner)
+        whitKeyCreate = createdEvents(whitKeyTxs(0)).head
+        whitKeyDisclosedContract = createEventToDisclosedContract(whitKeyCreate)
 
         // Exercise a choice using invalid explicit disclosure (bad contract key)
         _ <- testContext
           .exerciseFetchDelegated(
             testContext.disclosedContract,
             // Provide a superfluous disclosed contract with mismatching key hash
-            wihtKeyDisclosedContract
+            whitKeyDisclosedContract
               .update(
                 _.metadata.contractKeyHash := ByteString.copyFromUtf8(
                   "BadKeyBadKeyBadKeyBadKeyBadKey00"
@@ -588,7 +588,7 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
           .exerciseFetchDelegated(
             testContext.disclosedContract,
             // Provide a superfluous disclosed contract with mismatching createdAt
-            wihtKeyDisclosedContract
+            whitKeyDisclosedContract
               .update(_.metadata.createdAt := com.google.protobuf.timestamp.Timestamp.of(1, 0)),
           )
 

--- a/ledger/ledger-api-tests/tool/BUILD.bazel
+++ b/ledger/ledger-api-tests/tool/BUILD.bazel
@@ -113,7 +113,7 @@ conformance_test(
         "--crt $$(rlocation $$TEST_WORKSPACE/$(rootpath //test-common/test-certificates:client.crt))",
         "--cacrt $$(rlocation $$TEST_WORKSPACE/$(rootpath //test-common/test-certificates:ca.crt))",
         "--pem $$(rlocation $$TEST_WORKSPACE/$(rootpath //test-common/test-certificates:client.pem))",
-        "--additional=TLSOnePointThreeIT",
+        "--include=ExplicitDisclosureIT",
     ],
 )
 

--- a/ledger/ledger-api-tests/tool/BUILD.bazel
+++ b/ledger/ledger-api-tests/tool/BUILD.bazel
@@ -113,7 +113,7 @@ conformance_test(
         "--crt $$(rlocation $$TEST_WORKSPACE/$(rootpath //test-common/test-certificates:client.crt))",
         "--cacrt $$(rlocation $$TEST_WORKSPACE/$(rootpath //test-common/test-certificates:ca.crt))",
         "--pem $$(rlocation $$TEST_WORKSPACE/$(rootpath //test-common/test-certificates:client.pem))",
-        "--include=ExplicitDisclosureIT",
+        "--additional=TLSOnePointThreeIT",
     ],
 )
 


### PR DESCRIPTION
The only think we do not check is the value of the as we need to run the engine to evaluate the key.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
