### PR TITLE
Support Script tests in integration suite

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -216,6 +216,7 @@ da_haskell_library(
             "//compiler/scenario-service/server:scenario_service_jar",
             "//daml-script/daml:daml-script-{version}.dar".format(version = version),
             "@jq_dev_env//:jq",
+            ghc_pkg,
         ],
         hackage_deps = [
             "base",

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -174,12 +174,15 @@ da_haskell_library(
     deps = [
         "//compiler/daml-lf-ast",
         "//compiler/daml-lf-proto:daml-lf-proto-encode",
+        "//compiler/damlc:damlc-lib",
         "//compiler/damlc/daml-compiler",
         "//compiler/damlc/daml-ide-core",
         "//compiler/damlc/daml-lf-util",
         "//compiler/damlc/daml-opts",
         "//compiler/damlc/daml-opts:daml-opts-types",
+        "//compiler/damlc/daml-package-config",
         "//compiler/scenario-service/client",
+        "//daml-assistant:daml-project-config",
         "//daml-lf/archive:daml_lf_dev_archive_haskell_proto",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
@@ -211,6 +214,7 @@ da_haskell_library(
             "//compiler/damlc/pkg-db",
             "//compiler/damlc/stable-packages",
             "//compiler/scenario-service/server:scenario_service_jar",
+            "//daml-script/daml:daml-script-{version}.dar".format(version = version),
             "@jq_dev_env//:jq",
         ],
         hackage_deps = [

--- a/compiler/damlc/tests/daml-test-files/ScriptEnabled.daml
+++ b/compiler/damlc/tests/daml-test-files/ScriptEnabled.daml
@@ -1,0 +1,20 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- This tests that Scripts do run by running a script that will fail, and ensuring the error is thrown
+-- -- @ERROR Scenarios are no longer supported.
+module ScriptEnabled where
+
+import Daml.Script
+
+template T with
+    p : Party
+  where
+    signatory p
+
+test : Script ()
+test = script do
+  alice <- allocateParty "alice"
+  bob <- allocateParty "bob"
+  alice `submit` createCmd (T bob)
+  pure ()

--- a/compiler/damlc/tests/daml-test-files/ScriptEnabled.daml
+++ b/compiler/damlc/tests/daml-test-files/ScriptEnabled.daml
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- This tests that Scripts do run by running a script that will fail, and ensuring the error is thrown
--- -- @ERROR Scenarios are no longer supported.
+-- @ERROR failed due to a missing authorization from 'bob'
 module ScriptEnabled where
 
 import Daml.Script


### PR DESCRIPTION
Adds support for running scripts in the integration test suite
Note, this does not currently use a flag to disable this behaviour, as the flag used for scenarios was only added as Scenarios have been disabled (and as such, threw a warning if not enabled). For ease of understanding, scripts will _always_ be run in accordance to the same predicates that the IDE allows scripts to be run (e.g., may not have arguments).

I've added a simple failing test that ensures the script is being run.

Resolves [#16331](https://github.com/digital-asset/daml/issues/16331)