### PR TITLE
[engine] Speedy Machine should be invariant in its Question type

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -489,12 +489,11 @@ private[lf] object SBuiltin {
         args: util.ArrayList[SValue],
         machine: Machine[Q],
     ): Control.Value = {
-      val coid = getSContractId(args, 0).coid
-      machine match {
-        case _: PureMachine | _: ScenarioMachine =>
-          Control.Value(SOptional(Some(SText(coid))))
-        case _: UpdateMachine =>
-          Control.Value(SValue.SValue.None)
+      if (machine.isUpdateMachine) {
+        Control.Value(SValue.SValue.None)
+      } else {
+        val coid = getSContractId(args, 0).coid
+        Control.Value(SOptional(Some(SText(coid))))
       }
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -176,6 +176,8 @@ private[lf] object Speedy {
   )(implicit loggingContext: LoggingContext)
       extends Machine[Question.Update] {
 
+    private[speedy] override def isUpdateMachine: Boolean = true // for: SBContractIdToText
+
     private[speedy] override def asUpdateMachine(location: String)(
         f: UpdateMachine => Control[Question.Update]
     ): Control[Question.Update] =
@@ -582,7 +584,7 @@ private[lf] object Speedy {
   }
 
   /** The speedy CEK machine. */
-  private[lf] sealed abstract class Machine[+Q](implicit val loggingContext: LoggingContext) {
+  private[lf] sealed abstract class Machine[Q](implicit val loggingContext: LoggingContext) {
 
     val sexpr: SExpr
     /* The trace log. */
@@ -660,6 +662,8 @@ private[lf] object Speedy {
 
     @inline
     private[speedy] final def kontDepth(): Int = kontStack.size()
+
+    private[speedy] def isUpdateMachine: Boolean = false
 
     private[speedy] def asUpdateMachine(location: String)(
         f: UpdateMachine => Control[Question.Update]
@@ -796,7 +800,7 @@ private[lf] object Speedy {
       track.reset()
     }
 
-    final def setControl(x: Control[Nothing]): Unit = {
+    final def setControl(x: Control[Q]): Unit = {
       control = x
     }
 

--- a/daml-lf/interpreter/src/test/scala/com/daml/SBuiltinInterfaceTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/daml/SBuiltinInterfaceTest.scala
@@ -347,17 +347,19 @@ object SBuiltinInterfaceTest {
       getContract: PartialFunction[Value.ContractId, Value.VersionedContractInstance],
       getKey: PartialFunction[GlobalKeyWithMaintainers, Value.ContractId],
   ): Try[Either[SError, SValue]] = {
-    val machine =
-      if (onLedger)
+    if (onLedger) {
+      val machine =
         Speedy.Machine.fromUpdateSExpr(
           compiledBasePkgs,
           transactionSeed = crypto.Hash.hashPrivateKey("SBuiltinTest"),
           updateSE = SELet1(e, SEMakeClo(Array(SELocS(1)), 1, SELocF(0))),
           committers = Set(alice),
         )
-      else
-        Speedy.Machine.fromPureSExpr(compiledBasePkgs, e)
-    Try(SpeedyTestLib.run(machine, getPkg, getContract, getKey))
+      Try(SpeedyTestLib.run(machine, getPkg, getContract, getKey))
+    } else {
+      val machine = Speedy.Machine.fromPureSExpr(compiledBasePkgs, e)
+      Try(SpeedyTestLib.runPure(machine))
+    }
   }
 
 }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ComparisonSBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ComparisonSBuiltinTest.scala
@@ -687,7 +687,7 @@ class ComparisonSBuiltinTest extends AnyWordSpec with Matchers with TableDrivenP
         compiledPackages,
         SEApp(sexpr, (parties ++ contractIds).toArray),
       )
-    SpeedyTestLib.run(machine)
+    SpeedyTestLib.runPure(machine)
   }
 
 }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -580,7 +580,7 @@ object SpeedyTest {
 
   def evalSExpr(e: SExpr, packages: PureCompiledPackages): Either[SError, SValue] = {
     val machine = Speedy.Machine.fromPureSExpr(packages, e)
-    SpeedyTestLib.run(machine)
+    SpeedyTestLib.runPure(machine)
   }
 
   def evalApp(


### PR DESCRIPTION
Advances: #15882

Having the Speedy `Machine` covariant `[+Q]` in its question type plays very badly with the definition of its control field: `var control: Control[Q]` which is a contravariant instance. This is in fact only allowed by the scala type checker because it is declared `private[this]` (which seems somewhat of a nasty hack).

Better is to declare the speedy machine an invariant in `[Q]`, and fix the few places in the code which took advantage of the covariance. The _payoff_ is that we can get the _correct_ type for `setControl`.

This was: `final def setControl(x: Control[Nothing]): Unit`
But is now: `final def setControl(x: Control[Q]): Unit`

The improved type for `setControl` will be needed by the implementation of the new `Update` question: `NeedAuthority`
