### PR TITLE
[engine] use `SResult.NeedAuthority` in speedy evaluation

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -408,7 +408,10 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
 
         case SResultQuestion(question) =>
           question match {
-            case _: Question.Update.NeedAuthority => ??? // TODO #15882
+            case Question.Update.NeedAuthority(holding @ _, requesting @ _, callback) =>
+              // TODO #15882 -- ask ledger using ResultNeedAuthority
+              callback()
+              loop()
 
             case Question.Update.NeedTime(callback) =>
               callback(time)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -48,10 +48,10 @@ object Question {
     ) extends Update
 
     final case class NeedAuthority(
-        using: Set[Party],
+        holding: Set[Party],
         requesting: Set[Party],
-        // Callback: the request is granted
-        callback: Boolean => Unit,
+        // Callback only when the request is granted
+        callback: () => Unit,
     ) extends Update
   }
 


### PR DESCRIPTION
Advances: #15882

- Change to unit callback in `SResult.NeedAuthority` (*)
- Speedy builtin evaluation calls `SResult.NeedAuthority`.
- Extend `SpeedyTestLib` helpers to collect `NeedAuthority` requests.
- Assert expected authority requests in `WithAuthorityTest` tests.

(*) We shall have a `Boolean` callback in `ResultNeedAuthority` (separate PR #16347) and translate to the unit callback in `Engine.interpretLoop`, checking/erring when authority is refused. This will mirror the handling for `NeedPackage` and `NeedContract` which gets translated similarly at the this point.
