### PR TITLE
Remove duplicate HTTP metrics replaced by the golden signal metrics [PLEN-117]

### DIFF
--- a/docs/source/json-api/production-setup/metrics.rst
+++ b/docs/source/json-api/production-setup/metrics.rst
@@ -73,8 +73,7 @@ Metrics Reference
 *****************
 
 The HTTP JSON API Service supports :doc:`common HTTP metrics </ops/common-metrics>`.
-In addition, see the following list of selected metrics that can be particularly
-important to track.
+In addition, see the following list of important metrics:
 
 ``daml.http_json_api.incoming_json_parsing_and_validation_timing``
 ==================================================================

--- a/docs/source/json-api/production-setup/metrics.rst
+++ b/docs/source/json-api/production-setup/metrics.rst
@@ -76,46 +76,6 @@ The HTTP JSON API Service supports :doc:`common HTTP metrics </ops/common-metric
 In addition, see the following list of selected metrics that can be particularly
 important to track.
 
-``daml.http_json_api.command_submission_timing``
-================================================
-
-A timer. Measures latency (in milliseconds) for processing of a command submission request.
-
-``daml.http_json_api.query_all_timing``
-=======================================
-
-A timer. Measures latency (in milliseconds) for processing of a query GET request.
-
-``daml.http_json_api.query_matching_timing``
-============================================
-
-A timer. Measures latency (in milliseconds) for processing of a query POST request.
-
-``daml.http_json_api.fetch_timing``
-===================================
-
-A timer. Measures latency (in milliseconds) for processing of a fetch request.
-
-``daml.http_json_api.get_party_timing``
-=======================================
-
-A timer. Measures latency (in milliseconds) for processing of a get party/parties request.
-
-``daml.http_json_api.allocate_party_timing``
-============================================
-
-A timer. Measures latency (in milliseconds) for processing of a party management request.
-
-``daml.http_json_api.download_package_timing``
-==============================================
-
-A timer. Measures latency (in milliseconds) for processing of a package download request.
-
-``daml.http_json_api.upload_package_timing``
-============================================
-
-A timer. Measures latency (in milliseconds) for processing of a package upload request.
-
 ``daml.http_json_api.incoming_json_parsing_and_validation_timing``
 ==================================================================
 
@@ -141,27 +101,7 @@ A timer. Measures latency (in milliseconds) of the find by contract id database 
 
 A timer. Measures latency (in milliseconds) for processing the command submission requests on the ledger.
 
-``daml.http_json_api.http_request_throughput``
-==============================================
-
-A meter. Number of http requests
-
 ``daml.http_json_api.websocket_request_count``
 ==============================================
 
 A Counter. Count of active websocket connections
-
-``daml.http_json_api.command_submission_throughput``
-====================================================
-
-A meter. Number of command submissions
-
-``daml.http_json_api.upload_packages_throughput``
-=================================================
-
-A meter. Number of package uploads
-
-``daml.http_json_api.allocation_party_throughput``
-==================================================
-
-A meter. Number of party allocations

--- a/docs/source/json-api/production-setup/metrics.rst
+++ b/docs/source/json-api/production-setup/metrics.rst
@@ -103,4 +103,4 @@ A timer. Measures latency (in milliseconds) for processing the command submissio
 ``daml.http_json_api.websocket_request_count``
 ==============================================
 
-A Counter. Count of active websocket connections
+A Counter. Counts active websocket connections.

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -318,7 +318,6 @@ class Endpoints(
       extendWithRequestIdLogCtx(identity)(lc0)
     val markThroughputAndLogProcessingTime: Directive0 = Directive { (fn: Unit => Route) =>
       val t0 = System.nanoTime
-      metrics.httpRequestThroughput.mark()
       fn(()).andThen { res =>
         res.onComplete(_ => logger.trace(s"Processed request after ${System.nanoTime() - t0}ns"))
         res

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -37,7 +37,6 @@ import com.daml.jwt.domain.Jwt
 import com.daml.ledger.api.{domain => LedgerApiDomain}
 import com.daml.ledger.client.services.admin.UserManagementClient
 import com.daml.ledger.client.services.identity.LedgerIdentityClient
-import com.daml.metrics.api.MetricHandle.Timer
 import scalaz.EitherT.eitherT
 
 import scala.util.control.NonFatal
@@ -130,7 +129,7 @@ class Endpoints(
 
   private def toGetRoute[Res](
       httpRequest: HttpRequest,
-      fn: (Jwt) => ET[domain.SyncResponse[Res]],
+      fn: Jwt => ET[domain.SyncResponse[Res]],
   )(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID],
       mkHttpResponse: MkHttpResponse[ET[domain.SyncResponse[Res]]],
@@ -162,7 +161,7 @@ class Endpoints(
     responseToRoute(httpResponse(res))
   }
 
-  private def toDownloadPackageRoute[Res](
+  private def toDownloadPackageRoute(
       httpRequest: HttpRequest,
       packageId: String,
       fn: (Jwt, LedgerApiDomain.LedgerId, String) => Future[HttpResponse],
@@ -317,7 +316,6 @@ class Endpoints(
   ): Route = extractRequest apply { req =>
     implicit val lc: LoggingContextOf[InstanceUUID with RequestID] =
       extendWithRequestIdLogCtx(identity)(lc0)
-    import metrics._
     val markThroughputAndLogProcessingTime: Directive0 = Directive { (fn: Unit => Route) =>
       val t0 = System.nanoTime
       metrics.httpRequestThroughput.mark()
@@ -326,34 +324,26 @@ class Endpoints(
         res
       }
     }
-    // As futures are eager it is best to start the timer rather sooner than later
-    // to get accurate timings. This also consistent with the implementation above which
-    // logs the processing time.
-    def withTimer(timer: Timer) = Directive { (fn: Unit => Route) => ctx =>
-      Timed.future(timer, fn(())(ctx))
-    }
     def path[L](pm: PathMatcher[L]) =
       server.Directives.path(pm) & markThroughputAndLogProcessingTime & logRequestAndResult
-    val withCmdSubmitTimer: Directive0 = withTimer(commandSubmissionTimer)
-    val withFetchTimer: Directive0 = withTimer(fetchTimer)
     concat(
       pathPrefix("v1") apply concat(
         post apply concat(
-          path("create") & withCmdSubmitTimer apply toRoute(create(req)),
-          path("exercise") & withCmdSubmitTimer apply toRoute(exercise(req)),
-          path("create-and-exercise") & withCmdSubmitTimer apply toRoute(
+          path("create") apply toRoute(create(req)),
+          path("exercise") apply toRoute(exercise(req)),
+          path("create-and-exercise") apply toRoute(
             createAndExercise(req)
           ),
-          path("query") & withTimer(queryMatchingTimer) apply toRoute(query(req)),
-          path("fetch") & withFetchTimer apply toRoute(fetch(req)),
+          path("query") apply toRoute(query(req)),
+          path("fetch") apply toRoute(fetch(req)),
           path("user") apply toPostRoute(req, getUser),
           path("user" / "create") apply toPostRoute(req, createUser),
           path("user" / "delete") apply toPostRoute(req, deleteUser),
           path("user" / "rights") apply toPostRoute(req, listUserRights),
           path("user" / "rights" / "grant") apply toPostRoute(req, grantUserRights),
           path("user" / "rights" / "revoke") apply toPostRoute(req, revokeUserRights),
-          path("parties") & withFetchTimer apply toPostRoute(req, parties),
-          path("parties" / "allocate") & withTimer(allocatePartyTimer) apply toPostRoute(
+          path("parties") apply toPostRoute(req, parties),
+          path("parties" / "allocate") apply toPostRoute(
             req,
             allocateParty,
           ),
@@ -361,15 +351,14 @@ class Endpoints(
           path("metering-report") apply toPostRoute(req, meteringReportEndpoint.generateReport),
         ),
         get apply concat(
-          path("query") & withTimer(queryAllTimer) apply
-            toRoute(retrieveAll(req)),
+          path("query") apply toRoute(retrieveAll(req)),
           path("user") apply toGetRoute(req, getAuthenticatedUser),
           path("user" / "rights") apply toGetRoute(req, listAuthenticatedUserRights),
           path("users") apply toGetRoute(req, listUsers),
-          path("parties") & withTimer(getPartyTimer) apply toGetRoute(req, allParties),
+          path("parties") apply toGetRoute(req, allParties),
           path("packages") apply toGetRouteLedgerId(req, listPackages),
           path("packages" / ".+".r)(packageId =>
-            withTimer(downloadPackageTimer) & extractRequest apply (req =>
+            extractRequest apply (req =>
               toDownloadPackageRoute(req, packageId, downloadPackage)
             )
           ),

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -358,9 +358,7 @@ class Endpoints(
           path("parties") apply toGetRoute(req, allParties),
           path("packages") apply toGetRouteLedgerId(req, listPackages),
           path("packages" / ".+".r)(packageId =>
-            extractRequest apply (req =>
-              toDownloadPackageRoute(req, packageId, downloadPackage)
-            )
+            extractRequest apply (req => toDownloadPackageRoute(req, packageId, downloadPackage))
           ),
         ),
       ),

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/PackagesAndDars.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/PackagesAndDars.scala
@@ -29,7 +29,6 @@ class PackagesAndDars(routeSetup: RouteSetup, packageManagementService: PackageM
   ): ET[domain.SyncResponse[Unit]] = {
     for {
       parseAndDecodeTimer <- getParseAndDecodeTimerCtx()
-      _ <- EitherT.pure(metrics.uploadPackagesThroughput.mark())
       t2 <- eitherT(routeSetup.inputSource(httpRequest))
       (jwt, payload, source) = t2
       _ <- EitherT.pure(parseAndDecodeTimer.stop())

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/Parties.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/Parties.scala
@@ -10,10 +10,9 @@ import util.Collections.toNonEmptySet
 import util.FutureUtil.eitherT
 import util.Logging.{InstanceUUID, RequestID}
 import scalaz.std.scalaFuture._
-import scalaz.{EitherT, NonEmptyList}
+import scalaz.NonEmptyList
 
 import scala.concurrent.ExecutionContext
-import com.daml.http.metrics.HttpJsonApiMetrics
 import com.daml.logging.LoggingContextOf
 
 private[http] final class Parties(partiesService: PartiesService)(implicit ec: ExecutionContext) {
@@ -34,10 +33,8 @@ private[http] final class Parties(partiesService: PartiesService)(implicit ec: E
 
   def allocateParty(jwt: Jwt, request: domain.AllocatePartyRequest)(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID],
-      metrics: HttpJsonApiMetrics,
   ): ET[domain.SyncResponse[domain.PartyDetails]] =
     for {
-      _ <- EitherT.pure(metrics.allocatePartyThroughput.mark())
       res <- eitherT(partiesService.allocate(jwt, request))
     } yield domain.OkResponse(res)
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/Parties.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/Parties.scala
@@ -32,7 +32,7 @@ private[http] final class Parties(partiesService: PartiesService)(implicit ec: E
     } yield partiesResponse(parties = ps._1.toList, unknownParties = ps._2.toList)
 
   def allocateParty(jwt: Jwt, request: domain.AllocatePartyRequest)(implicit
-      lc: LoggingContextOf[InstanceUUID with RequestID],
+      lc: LoggingContextOf[InstanceUUID with RequestID]
   ): ET[domain.SyncResponse[domain.PartyDetails]] =
     for {
       res <- eitherT(partiesService.allocate(jwt, request))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/RouteSetup.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/RouteSetup.scala
@@ -69,7 +69,6 @@ private[http] final class RouteSetup(
   ): ET[domain.SyncResponse[JsValue]] =
     for {
       parseAndDecodeTimerCtx <- getParseAndDecodeTimerCtx()
-      _ <- EitherT.pure(metrics.commandSubmissionThroughput.mark())
       t3 <- inputJsValAndJwtPayload(req): ET[(Jwt, JwtWritePayload, JsValue)]
       (jwt, jwtPayload, reqBody) = t3
       resp <- withJwtPayloadLoggingContext(jwtPayload)(

--- a/ledger-service/metrics/src/main/scala/com/digitalasset/http/metrics/HttpJsonApiMetrics.scala
+++ b/ledger-service/metrics/src/main/scala/com/digitalasset/http/metrics/HttpJsonApiMetrics.scala
@@ -50,22 +50,6 @@ class HttpJsonApiMetrics(
   val surrogateTemplateIdCache =
     new CacheMetrics(prefix :+ "surrogate_tpid_cache", defaultMetricsFactory)
 
-  // Meters how long processing of a command submission request takes
-  val commandSubmissionTimer: Timer =
-    defaultMetricsFactory.timer(prefix :+ "command_submission_timing")
-  // Meters how long processing of a query GET request takes
-  val queryAllTimer: Timer = defaultMetricsFactory.timer(prefix :+ "query_all_timing")
-  // Meters how long processing of a query POST request takes
-  val queryMatchingTimer: Timer = defaultMetricsFactory.timer(prefix :+ "query_matching_timing")
-  // Meters how long processing of a fetch request takes
-  val fetchTimer: Timer = defaultMetricsFactory.timer(prefix :+ "fetch_timing")
-  // Meters how long processing of a get party/parties request takes
-  val getPartyTimer: Timer = defaultMetricsFactory.timer(prefix :+ "get_party_timing")
-  // Meters how long processing of a party management request takes
-  val allocatePartyTimer: Timer = defaultMetricsFactory.timer(prefix :+ "allocate_party_timing")
-  // Meters how long processing of a package download request takes
-  val downloadPackageTimer: Timer =
-    defaultMetricsFactory.timer(prefix :+ "download_package_timing")
   // Meters how long processing of a package upload request takes
   val uploadPackageTimer: Timer = defaultMetricsFactory.timer(prefix :+ "upload_package_timing")
   // Meters how long parsing and decoding of an incoming json payload takes

--- a/ledger-service/metrics/src/main/scala/com/digitalasset/http/metrics/HttpJsonApiMetrics.scala
+++ b/ledger-service/metrics/src/main/scala/com/digitalasset/http/metrics/HttpJsonApiMetrics.scala
@@ -8,7 +8,6 @@ import com.daml.metrics.{CacheMetrics, HealthMetrics}
 import com.daml.metrics.api.MetricHandle.{
   Counter,
   LabeledMetricsFactory,
-  Meter,
   MetricsFactory,
   Timer,
 }
@@ -50,8 +49,6 @@ class HttpJsonApiMetrics(
   val surrogateTemplateIdCache =
     new CacheMetrics(prefix :+ "surrogate_tpid_cache", defaultMetricsFactory)
 
-  // Meters how long processing of a package upload request takes
-  val uploadPackageTimer: Timer = defaultMetricsFactory.timer(prefix :+ "upload_package_timing")
   // Meters how long parsing and decoding of an incoming json payload takes
   val incomingJsonParsingAndValidationTimer: Timer =
     defaultMetricsFactory.timer(prefix :+ "incoming_json_parsing_and_validation_timing")
@@ -68,20 +65,9 @@ class HttpJsonApiMetrics(
   val commandSubmissionLedgerTimer: Timer =
     defaultMetricsFactory.timer(prefix :+ "command_submission_ledger_timing")
   // Meters http requests throughput
-  val httpRequestThroughput: Meter =
-    defaultMetricsFactory.meter(prefix :+ "http_request_throughput")
   // Meters how many websocket connections are currently active
   val websocketRequestCounter: Counter =
     defaultMetricsFactory.counter(prefix :+ "websocket_request_count")
-  // Meters command submissions throughput
-  val commandSubmissionThroughput: Meter =
-    defaultMetricsFactory.meter(prefix :+ "command_submission_throughput")
-  // Meters package uploads throughput
-  val uploadPackagesThroughput: Meter =
-    defaultMetricsFactory.meter(prefix :+ "upload_packages_throughput")
-  // Meters party allocation throughput
-  val allocatePartyThroughput: Meter =
-    defaultMetricsFactory.meter(prefix :+ "allocation_party_throughput")
 
   val http = new DamlHttpMetrics(labeledMetricsFactory, ComponentName)
   val websocket = new DamlWebSocketMetrics(labeledMetricsFactory, ComponentName)

--- a/ledger-service/metrics/src/main/scala/com/digitalasset/http/metrics/HttpJsonApiMetrics.scala
+++ b/ledger-service/metrics/src/main/scala/com/digitalasset/http/metrics/HttpJsonApiMetrics.scala
@@ -5,12 +5,7 @@ package com.daml.http.metrics
 
 import com.codahale.metrics.MetricRegistry
 import com.daml.metrics.{CacheMetrics, HealthMetrics}
-import com.daml.metrics.api.MetricHandle.{
-  Counter,
-  LabeledMetricsFactory,
-  MetricsFactory,
-  Timer,
-}
+import com.daml.metrics.api.MetricHandle.{Counter, LabeledMetricsFactory, MetricsFactory, Timer}
 import com.daml.metrics.api.MetricName
 import com.daml.metrics.api.dropwizard.DropwizardMetricsFactory
 import com.daml.metrics.api.opentelemetry.OpenTelemetryMetricsFactory


### PR DESCRIPTION
- Replaced by the golden signal metrics
Metrics removed:

```
``daml.http_json_api.command_submission_timing``
================================================

A timer. Measures latency (in milliseconds) for processing of a command submission request.

``daml.http_json_api.query_all_timing``
=======================================

A timer. Measures latency (in milliseconds) for processing of a query GET request.

``daml.http_json_api.query_matching_timing``
============================================

A timer. Measures latency (in milliseconds) for processing of a query POST request.

``daml.http_json_api.fetch_timing``
===================================

A timer. Measures latency (in milliseconds) for processing of a fetch request.

``daml.http_json_api.get_party_timing``
=======================================

A timer. Measures latency (in milliseconds) for processing of a get party/parties request.

``daml.http_json_api.allocate_party_timing``
============================================

A timer. Measures latency (in milliseconds) for processing of a party management request.

``daml.http_json_api.download_package_timing``
==============================================

A timer. Measures latency (in milliseconds) for processing of a package download request.

``daml.http_json_api.upload_package_timing``
============================================

A timer. Measures latency (in milliseconds) for processing of a package upload request.


``daml.http_json_api.http_request_throughput``
==============================================

A meter. Number of http requests


``daml.http_json_api.command_submission_throughput``
====================================================

A meter. Number of command submissions

``daml.http_json_api.upload_packages_throughput``
=================================================

A meter. Number of package uploads

``daml.http_json_api.allocation_party_throughput``
==================================================

A meter. Number of party allocations
```
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
