### PR TITLE
[engine] new Result type: `ResultNeedAuthority`

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
@@ -50,6 +50,7 @@ sealed trait Result[+A] extends Product with Serializable {
       pcs: ContractId => Option[VersionedContractInstance],
       packages: PackageId => Option[Package],
       keys: GlobalKeyWithMaintainers => Option[ContractId],
+      grantNeedAuthority: Boolean = false,
   ): Either[Error, A] = {
     @tailrec
     def go(res: Result[A]): Either[Error, A] =
@@ -60,7 +61,7 @@ sealed trait Result[+A] extends Product with Serializable {
         case ResultNeedContract(acoid, resume) => go(resume(pcs(acoid)))
         case ResultNeedPackage(pkgId, resume) => go(resume(packages(pkgId)))
         case ResultNeedKey(key, resume) => go(resume(keys(key)))
-        case ResultNeedAuthority(_, _, resume) => go(resume(true)) // grant every request
+        case ResultNeedAuthority(_, _, resume) => go(resume(grantNeedAuthority))
       }
     go(this)
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -15,6 +15,7 @@ import com.daml.lf.engine.{
   ResultDone,
   ResultError,
   ResultInterruption,
+  ResultNeedAuthority,
   ResultNeedContract,
   ResultNeedKey,
   ResultNeedPackage,
@@ -229,6 +230,9 @@ private[apiserver] final class StoreBackedCommandExecutor(
               trackSyncExecution(interpretationTimeNanos)(continue()),
             )
           )
+
+        case ResultNeedAuthority(holding @ _, requesting @ _, resume @ _) => ??? // TODO #15882
+
       }
 
     resolveStep(result).andThen { case _ =>

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/LfValueTranslation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/LfValueTranslation.scala
@@ -472,6 +472,10 @@ final class LfValueTranslation(
 
           case LfEngine.ResultInterruption(continue) =>
             goAsync(continue())
+
+          case LfEngine.ResultNeedAuthority(_, _, _) =>
+            Future.failed(new IllegalStateException("View computation must be a pure function"))
+
         }
 
       Future(engine.computeInterfaceView(templateId, value, interfaceId))


### PR DESCRIPTION
Advances #15882

- add `ResultNeedAuthority` -- new variant of `Result`
- This is an API change, so we should expect build failures in Canton