### PR TITLE
Table and transaction view in daml test

### DIFF
--- a/compiler/daml-extension/BUILD.bazel
+++ b/compiler/daml-extension/BUILD.bazel
@@ -73,6 +73,15 @@ genrule(
     tools = ["//bazel_tools/sh:mktgz"],
 )
 
+genrule(
+    name = "webview-stylesheet.css",
+    srcs = ["src/webview.css"],
+    cmd = """
+    cp "$(location src/webview.css)" "$@"
+    """,
+    outs = ["webview-stylesheet.css"]
+)
+
 # This rule is not reproducible. `vsce package` generates a `.vsix` file which
 # is just a zip archive. The order of entries in that archive is
 # non-deterministic and the individual entries contain non-reproducible

--- a/compiler/daml-extension/BUILD.bazel
+++ b/compiler/daml-extension/BUILD.bazel
@@ -76,10 +76,10 @@ genrule(
 genrule(
     name = "webview-stylesheet.css",
     srcs = ["src/webview.css"],
+    outs = ["webview-stylesheet.css"],
     cmd = """
     cp "$(location src/webview.css)" "$@"
     """,
-    outs = ["webview-stylesheet.css"]
 )
 
 # This rule is not reproducible. `vsce package` generates a `.vsix` file which

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -95,7 +95,6 @@ package_app(
     resources = [
         ":daml-base-anchors.json",
         ":ghc-pkg-dist",
-        "//compiler/daml-extension:webview-stylesheet.css",
         "//compiler/damlc:ghcversion",
         "//compiler/damlc:hpp-dist",
         "//compiler/damlc/daml-ide-core:dlint.yaml",

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -95,6 +95,7 @@ package_app(
     resources = [
         ":daml-base-anchors.json",
         ":ghc-pkg-dist",
+        "//compiler/daml-extension:webview-stylesheet.css",
         "//compiler/damlc:ghcversion",
         "//compiler/damlc:hpp-dist",
         "//compiler/damlc/daml-ide-core:dlint.yaml",
@@ -102,7 +103,6 @@ package_app(
         "//compiler/damlc/stable-packages",
         "//compiler/repl-service/server:repl_service_jar",
         "//compiler/scenario-service/server:scenario_service_jar",
-        "//compiler/daml-extension:webview-stylesheet.css",
         "@static_asset_d3plus//:js/d3.min.js",
         "@static_asset_d3plus//:js/d3plus.min.js",
     ],

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -102,6 +102,7 @@ package_app(
         "//compiler/damlc/stable-packages",
         "//compiler/repl-service/server:repl_service_jar",
         "//compiler/scenario-service/server:scenario_service_jar",
+        "//compiler/daml-extension:webview-stylesheet.css",
         "@static_asset_d3plus//:js/d3.min.js",
         "@static_asset_d3plus//:js/d3plus.min.js",
     ],

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -159,6 +159,7 @@ da_haskell_library(
         "base",
         "base64",
         "base64-bytestring",
+        "blaze-html",
         "bytestring",
         "containers",
         "cryptonite",

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -234,7 +234,6 @@ cmdTest numProcessors =
       <*> filesOpt
       <*> fmap RunAllTests runAllTests
       <*> fmap ShowCoverage showCoverageOpt
-      <*> fmap ShowCoverage showCoverageOpt
       <*> fmap UseColor colorOutput
       <*> junitOutput
       <*> optionsParser

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -31,7 +31,6 @@ import Data.List.Extra
 import qualified Data.Map.Strict as M
 import Data.Maybe
 import qualified Data.NameMap as NM
-import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 import qualified Data.Text.Lazy as TL
@@ -60,8 +59,8 @@ import Text.Printf
 newtype UseColor = UseColor {getUseColor :: Bool}
 newtype ShowCoverage = ShowCoverage {getShowCoverage :: Bool}
 newtype RunAllTests = RunAllTests {getRunAllTests :: Bool}
-newtype TableOutputPath = TableOutputPath {getTableOutput :: Maybe String}
-newtype TransactionsOutputPath = TransactionsOutputPath {getTransactionsOutput :: Maybe String}
+newtype TableOutputPath = TableOutputPath (Maybe String)
+newtype TransactionsOutputPath = TransactionsOutputPath (Maybe String)
 
 -- | Test a Daml file.
 execTest :: [NormalizedFilePath] -> RunAllTests -> ShowCoverage -> UseColor -> Maybe FilePath -> Options -> TableOutputPath -> TransactionsOutputPath -> IO ()

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -9,6 +9,8 @@ module DA.Cli.Damlc.Test (
     , UseColor(..)
     , ShowCoverage(..)
     , RunAllTests(..)
+    , TableOutputPath(..)
+    , TransactionsOutputPath(..)
     -- , Summarize(..)
     ) where
 

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -11,6 +11,8 @@ module DA.Daml.LF.PrettyScenario
   , prettyWarningMessage
   , renderScenarioResult
   , renderScenarioError
+  , renderTableView
+  , renderTransactionView
   , lookupDefLocation
   , lookupLocationModule
   , scenarioNotInFileNote

--- a/release/util.bzl
+++ b/release/util.bzl
@@ -21,6 +21,7 @@ inputs = {
     "daml_helper_dist": "//daml-assistant/daml-helper:daml-helper-dist",
     "damlc_dist": "//compiler/damlc:damlc-dist",
     "daml_extension": "//compiler/daml-extension:vsix",
+    "daml_extension_stylesheet": "//compiler/daml-extension:webview-stylesheet.css",
     "daml2js_dist": "//language-support/ts/codegen:daml2js-dist",
     "templates": "//templates:templates-tarball.tar.gz",
     "trigger_dars": "//triggers/daml:daml-trigger-dars",
@@ -80,6 +81,7 @@ def sdk_tarball(name, version, config):
 
           mkdir -p $$OUT/studio
           cp $(location {daml_extension}) $$OUT/studio/daml-bundled.vsix
+          cp $(location {daml_extension_stylesheet}) $$OUT/studio/webview-stylesheet.css
 
           mkdir -p $$OUT/canton
           cp $(location {canton}) $$OUT/canton/canton.jar


### PR DESCRIPTION
Generate folders with test tables and test transaction traces in files inside them, using two new flags:
```
--table-output <table output dir>
--transactions-output <table output dir>
```