### PR TITLE
[engine] construct `ResultNeedAuthority`

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -113,6 +113,7 @@ final class Conversions(
           case SError.SErrorDamlException(interpretationError) =>
             import interpretation.Error._
             interpretationError match {
+              case RejectedAuthorityRequest(_, _) => ??? // TODO #15882
               case UnhandledException(_, value) =>
                 builder.setUnhandledException(convertValue(value))
               case UserError(msg) =>

--- a/daml-lf/engine/BUILD.bazel
+++ b/daml-lf/engine/BUILD.bazel
@@ -56,6 +56,7 @@ da_scala_test_suite(
         "//daml-lf/tests:MultiKeys.dar",
         "//daml-lf/tests:Optional.dar",
         "//daml-lf/tests:ReinterpretTests.dar",
+        "//daml-lf/tests:WithAuthority.dar",
     ],
     scala_deps = [
         "@maven//:com_storm_enroute_scalameter_core",

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -67,6 +67,10 @@ private[lf] object Pretty {
           "Update failed due to fetch-by-key or exercise-by-key which did not find a contract with key"
         ) &
           prettyValue(false)(gk.key) & char('(') + prettyIdentifier(gk.templateId) + char(')')
+      case RejectedAuthorityRequest(holding, requesting) =>
+        text("Update failed due to rejected authority request") &
+          text("holding:") & intercalate(comma + space, holding.map(prettyParty)) &
+          text("requesting:") & intercalate(comma + space, requesting.map(prettyParty))
       case ContractKeyNotVisible(coid, gk, actAs, readAs, stakeholders) =>
         text(
           "Update failed due to a fetch, lookup or exercise by key of contract not visible to the reading parties"

--- a/daml-lf/tests/BUILD.bazel
+++ b/daml-lf/tests/BUILD.bazel
@@ -53,6 +53,13 @@ daml_compile(
 )
 
 daml_compile(
+    name = "WithAuthority",
+    srcs = ["WithAuthority.daml"],
+    target = "1.dev",
+    visibility = ["//daml-lf:__subpackages__"],
+)
+
+daml_compile(
     name = "Interfaces",
     srcs = ["Interfaces.daml"],
     target = "1.dev",

--- a/daml-lf/tests/WithAuthority.daml
+++ b/daml-lf/tests/WithAuthority.daml
@@ -1,0 +1,24 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module WithAuthority where
+
+template HaveAuthority
+  with
+    p : Party
+  where
+    signatory p
+
+template T
+  with
+    party1 : Party
+  where
+    signatory party1
+
+    nonconsuming choice GainAuthority: ()
+      with party2 : Party
+      controller party1
+      do
+        withAuthorityOf [party2] $ do
+          create (HaveAuthority party2)
+          pure ()

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -26,6 +26,11 @@ object Error {
 
   final case class ContractNotFound(cid: Value.ContractId) extends Error
 
+  final case class RejectedAuthorityRequest(
+      holding: Set[Party],
+      requesting: Set[Party],
+  ) extends Error
+
   /** Template pre-condition (ensure) evaluated to false and the transaction
     * was aborted. Note that the compiler will throw instead of returning False
     * for code in LF >= 1.14 so this will never be thrown for newer versions.

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -231,7 +231,14 @@ private[apiserver] final class StoreBackedCommandExecutor(
             )
           )
 
-        case ResultNeedAuthority(holding @ _, requesting @ _, resume @ _) => ??? // TODO #15882
+        case ResultNeedAuthority(holding @ _, requesting @ _, resume) =>
+          val granted = true // TODO #15882
+          resolveStep(
+            Tracked.value(
+              metrics.daml.execution.engineRunning,
+              trackSyncExecution(interpretationTimeNanos)(resume(granted)),
+            )
+          )
 
       }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/RejectionGenerators.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/RejectionGenerators.scala
@@ -58,6 +58,7 @@ object RejectionGenerators {
       // detailMessage is only suitable for server side debugging but not for the user, so don't pass except on internal errors
 
       err match {
+        case LfInterpretationError.RejectedAuthorityRequest(_, _) => ??? // TODO #15882
         case LfInterpretationError.ContractNotFound(cid) =>
           LedgerApiErrors.ConsistencyErrors.ContractNotFound
             .Reject(renderedMessage, cid)


### PR DESCRIPTION
Advances: #15882

- make link in engine from `SResult.NeedAuthority` --> `ResultNeedAuthority`
- convert rejected authority requests into new error: `RejectedAuthorityRequest`

I think this change represents the _last piece of the puzzle_ on the compiler/engine side, to expose `withAuthorityOf` all the way from the new Daml primitive into Canton.
