### PR TITLE
Support importing Script.Daml to determinism & memory test file

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -743,6 +743,7 @@ damlc_compile_test(
     name = "memory-examples",
     srcs = [":daml-test-files"],
     enable_scenarios = True,  # TODO: https://github.com/digital-asset/daml/issues/11316
+    enable_scripts = True,
     heap_limit = "200M",
     main = "daml-test-files/Examples.daml",
     stack_limit = "230K",
@@ -752,6 +753,7 @@ damlc_compile_test(
     name = "memory-bond-trading",
     srcs = [":bond-trading"],
     enable_scenarios = True,  # TODO: https://github.com/digital-asset/daml/issues/11316
+    enable_scripts = True,
     heap_limit = "200M" if is_windows else "100M",
     main = "bond-trading/Test.daml",
     stack_limit = "100K" if is_windows else "70K",

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -5,7 +5,7 @@ load("//bazel_tools:haskell.bzl", "da_haskell_binary", "da_haskell_library", "da
 load("@os_info//:os_info.bzl", "is_windows")
 load(":util.bzl", "damlc_compile_test")
 load("//rules_daml:daml.bzl", "daml_build_test", "daml_compile", "daml_compile_with_dalf", "daml_test")
-load("@build_environment//:configuration.bzl", "sdk_version")
+load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
 load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS", "lf_version_configuration")
 load("//compiler/damlc:util.bzl", "ghc_pkg")
 
@@ -834,11 +834,15 @@ sh_test(
         "$(location //compiler/damlc)",
         "$(location @com_google_protobuf//:protoc)",
         "$(POSIX_DIFF)",
+        "$(location //daml-script/daml:daml-script.dar)",
+        sdk_version,
+        ghc_version,
     ],
     data = [
         ":daml-test-files",
         "//compiler/damlc",
         "//compiler/damlc/pkg-db",
+        "//daml-script/daml:daml-script.dar",
         "@com_google_protobuf//:protoc",
     ],
     toolchains = [

--- a/compiler/damlc/tests/daml-test-files/Examples.daml
+++ b/compiler/damlc/tests/daml-test-files/Examples.daml
@@ -42,3 +42,5 @@ import List()
 import Either()
 import Tuple()
 import Self2()
+
+import ScriptEnabled()

--- a/compiler/damlc/tests/src/daml-ghc-deterministic.sh
+++ b/compiler/damlc/tests/src/daml-ghc-deterministic.sh
@@ -65,7 +65,7 @@ cp -a $TESTS_DIR/. "$TMP_SRC1"
 cp -a $TMP_SRC1/. "$TMP_SRC2"
 
 (cd "$TMP_SRC1" && DAML_PROJECT="$TMP_SRC1" $damlc compile $scenarios "Examples.daml" -o "$TMP_OUT/out_1" $importargs)
-(cd "$TMP_SRC2" && DAML_PROJECT="$TMP_SRC1" $damlc compile $scenarios "Examples.daml" -o "$TMP_OUT/out_2" $importargs)
+(cd "$TMP_SRC2" && DAML_PROJECT="$TMP_SRC2" $damlc compile $scenarios "Examples.daml" -o "$TMP_OUT/out_2" $importargs)
 
 # When invoked with a project root (as set by the Daml assistant)
 # we should produce the same output regardless of the path with which we are invoked.

--- a/compiler/damlc/tests/util.bzl
+++ b/compiler/damlc/tests/util.bzl
@@ -3,6 +3,21 @@
 
 load("//bazel_tools:haskell.bzl", "da_haskell_test")
 load("//bazel_tools/sh:sh.bzl", "sh_inline_test")
+load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
+
+script_installer = """\
+SCRIPTDAR=$$(canonicalize_rlocation $(rootpath //daml-script/daml:daml-script.dar))
+cat <<EOF > "$$TMP/daml.yaml"
+sdk-version: {sdk_version}
+name: proj
+version: 0.0.1
+source: .
+dependencies: [daml-prim, daml-stdlib, "$$SCRIPTDAR"]
+EOF
+
+importargs="--package-db=./.daml/package-database --package=daml-script-{ghc_version}"
+(cd "$$TMP" && $$DAMLC build)
+"""
 
 def damlc_compile_test(
         name,
@@ -12,12 +27,13 @@ def damlc_compile_test(
         stack_limit = "",
         heap_limit = "",
         enable_scenarios = False,
+        enable_scripts = False,
         **kwargs):
     stack_opt = "-K" + stack_limit if stack_limit else ""
     heap_opt = "-M" + heap_limit if heap_limit else ""
     sh_inline_test(
         name = name,
-        data = [damlc, main] + srcs,
+        data = [damlc, main, "//daml-script/daml:daml-script.dar"] + srcs,
         cmd = """\
 DAMLC=$$(canonicalize_rlocation $(rootpath {damlc}))
 MAIN=$$(canonicalize_rlocation $(rootpath {main}))
@@ -28,13 +44,21 @@ function cleanup() {{
 }}
 trap cleanup EXIT
 
-$$DAMLC compile {scenarios} $$MAIN -o $$TMP/out +RTS -s {stack_opt} {heap_opt}
+importargs=""
+{install_script}
+
+DAML_PROJECT="$$TMP" $$DAMLC compile {scenarios} $$MAIN -o $$TMP/out $$importargs +RTS -s {stack_opt} {heap_opt}
 """.format(
             damlc = damlc,
             main = main,
             stack_opt = stack_opt,
             heap_opt = heap_opt,
             scenarios = "--enable-scenarios=yes" if enable_scenarios else "",
+            install_script =
+                script_installer.format(
+                    sdk_version = sdk_version,
+                    ghc_version = ghc_version,
+                ) if enable_scripts else "",
         ),
         **kwargs
     )


### PR DESCRIPTION
Resolves #16391
Allows importing Daml.Script in determinism tests

Tested with `DAML_SDK_RELEASE_VERSION` of `0.0.0` and `2.6.0-snapshot.20230220.11461.0.5deb4ea7`