### PR TITLE
ci: fix Linux nodes

### DIFF
--- a/infra/vsts_agent_ubuntu_20_04_startup.sh
+++ b/infra/vsts_agent_ubuntu_20_04_startup.sh
@@ -72,9 +72,10 @@ apt-get install -qy \
     xdg-utils \
     wget
 
+## Currently broken, temporarily disabling as this prevents machine startup
 # Taken from https://cloud.google.com/logging/docs/agent/logging/installation
-curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-curl -sSL https://dl.google.com/cloudagents/add-logging-agent-repo.sh | bash -s -- --also-install
+#curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+#curl -sSL https://dl.google.com/cloudagents/add-logging-agent-repo.sh | bash -s -- --also-install
 
 #install docker
 # BEGIN Installing Docker per https://docs.docker.com/engine/install/ubuntu/


### PR DESCRIPTION
The URL `https://packages.cloud.google.com/apt/doc/apt-key.gpg` is currently returning a 500, so having this on our startup scripts prevents machines from starting.

Curiously, GCP logging does seem to collect logs anyway, so I'm unclear on what this was doing. Interestingly, the documentation link given does not seem to mention any kind of GPG key (i.e. no trace of the failing link), but the second link alone does indeed fail on a missing GPG key.