### PR TITLE
Migrate DatabaseMetrics to use a labeled metrics factory [PLEN-164]

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/DatabaseMetricsFactory.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/DatabaseMetricsFactory.scala
@@ -3,12 +3,12 @@
 
 package com.daml.metrics
 
-import com.daml.metrics.api.MetricHandle.MetricsFactory
+import com.daml.metrics.api.MetricHandle.LabeledMetricsFactory
 import com.daml.metrics.api.MetricName
 
-abstract class DatabaseMetricsFactory(prefix: MetricName, factory: MetricsFactory) {
+abstract class DatabaseMetricsFactory(prefix: MetricName, factory: LabeledMetricsFactory) {
 
   protected def createDbMetrics(name: String): DatabaseMetrics = {
-    new DatabaseMetrics(prefix, name, factory)
+    new DatabaseMetrics(prefix :+ name, factory)
   }
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/IdentityProviderConfigStoreMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IdentityProviderConfigStoreMetrics.scala
@@ -3,17 +3,14 @@
 
 package com.daml.metrics
 
-import com.daml.metrics.api.MetricHandle.MetricsFactory
-import com.daml.metrics.api.{MetricDoc, MetricName}
+import com.daml.metrics.api.MetricHandle.{LabeledMetricsFactory, MetricsFactory}
+import com.daml.metrics.api.MetricName
 
-@MetricDoc.GroupTag(
-  representative = "daml.identity_provider_config_store.<operation>",
-  groupableClass = classOf[DatabaseMetrics],
-)
 class IdentityProviderConfigStoreMetrics(
     prefix: MetricName,
     factory: MetricsFactory,
-) extends DatabaseMetricsFactory(prefix, factory) {
+    labeledMetricsFactory: LabeledMetricsFactory,
+) extends DatabaseMetricsFactory(prefix, labeledMetricsFactory) {
 
   val idpConfigCache = new CacheMetrics(prefix :+ "idp_config_cache", factory)
   val verifierCache = new CacheMetrics(prefix :+ "verifier_cache", factory)

--- a/ledger/metrics/src/main/scala/com/daml/metrics/IndexDBMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IndexDBMetrics.scala
@@ -4,11 +4,14 @@
 package com.daml.metrics
 
 import com.daml.metrics.api.MetricDoc.MetricQualification.Debug
-import com.daml.metrics.api.MetricHandle.{MetricsFactory, Histogram, Timer}
+import com.daml.metrics.api.MetricHandle.{Histogram, LabeledMetricsFactory, MetricsFactory, Timer}
 import com.daml.metrics.api.{MetricDoc, MetricName}
 
-class IndexDBMetrics(val prefix: MetricName, val factory: MetricsFactory)
-    extends MainIndexDBMetrics(prefix, factory)
+class IndexDBMetrics(
+    val prefix: MetricName,
+    val factory: MetricsFactory,
+    labeledMetricsFactory: LabeledMetricsFactory,
+) extends MainIndexDBMetrics(prefix, factory, labeledMetricsFactory)
     with TransactionStreamsDbMetrics {
   self =>
 }
@@ -18,10 +21,6 @@ trait TransactionStreamsDbMetrics {
   val prefix: MetricName
   val factory: MetricsFactory
 
-  @MetricDoc.GroupTag(
-    representative = "daml.index.db.flat_transactions_stream.<operation>",
-    groupableClass = classOf[DatabaseMetrics],
-  )
   object flatTxStream {
     val prefix: MetricName = self.prefix :+ "flat_transactions_stream"
 
@@ -45,10 +44,6 @@ trait TransactionStreamsDbMetrics {
     val translationTimer: Timer = factory.timer(prefix :+ "translation")
   }
 
-  @MetricDoc.GroupTag(
-    representative = "daml.index.db.tree_transactions_stream.<operation>",
-    groupableClass = classOf[DatabaseMetrics],
-  )
   object treeTxStream {
     val prefix: MetricName = self.prefix :+ "tree_transactions_stream"
 
@@ -86,12 +81,11 @@ trait TransactionStreamsDbMetrics {
 
 }
 
-@MetricDoc.GroupTag(
-  representative = "daml.index.db.<operation>",
-  groupableClass = classOf[DatabaseMetrics],
-)
-class MainIndexDBMetrics(prefix: MetricName, factory: MetricsFactory)
-    extends DatabaseMetricsFactory(prefix, factory) { self =>
+class MainIndexDBMetrics(
+    prefix: MetricName,
+    factory: MetricsFactory,
+    labeledMetricsFactory: LabeledMetricsFactory,
+) extends DatabaseMetricsFactory(prefix, labeledMetricsFactory) { self =>
 
   @MetricDoc.Tag(
     summary = "The time spent looking up a contract using its key.",

--- a/ledger/metrics/src/main/scala/com/daml/metrics/IndexMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IndexMetrics.scala
@@ -4,10 +4,20 @@
 package com.daml.metrics
 
 import com.daml.metrics.api.MetricDoc.MetricQualification.{Debug, Saturation}
-import com.daml.metrics.api.MetricHandle.{Counter, MetricsFactory, Gauge, Timer}
+import com.daml.metrics.api.MetricHandle.{
+  Counter,
+  Gauge,
+  LabeledMetricsFactory,
+  MetricsFactory,
+  Timer,
+}
 import com.daml.metrics.api.{MetricDoc, MetricName, MetricsContext}
 
-class IndexMetrics(prefix: MetricName, factory: MetricsFactory) {
+class IndexMetrics(
+    prefix: MetricName,
+    factory: MetricsFactory,
+    labeledMetricsFactory: LabeledMetricsFactory,
+) {
 
   @MetricDoc.Tag(
     summary = "The buffer size for transaction trees requests.",
@@ -56,7 +66,7 @@ class IndexMetrics(prefix: MetricName, factory: MetricsFactory) {
   val completionsBufferSize: Counter =
     factory.counter(prefix :+ "completions_buffer_size")
 
-  object db extends IndexDBMetrics(prefix :+ "db", factory)
+  object db extends IndexDBMetrics(prefix :+ "db", factory, labeledMetricsFactory)
 
   @MetricDoc.Tag(
     summary = "The sequential id of the current ledger end kept in memory.",

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -39,12 +39,6 @@ final class Metrics(
 
   val executorServiceMetrics = new ExecutorServiceMetrics(labeledMetricsFactory)
 
-  object test {
-    private val prefix: MetricName = MetricName("test")
-
-    val db: DatabaseMetrics = new DatabaseMetrics(prefix, "db", defaultMetricsFactory)
-  }
-
   object daml {
     val prefix: MetricName = MetricName.Daml
 
@@ -55,25 +49,38 @@ final class Metrics(
     object lapi extends LAPIMetrics(prefix :+ "lapi", defaultMetricsFactory)
 
     object userManagement
-        extends UserManagementMetrics(prefix :+ "user_management", defaultMetricsFactory)
+        extends UserManagementMetrics(
+          prefix :+ "user_management",
+          defaultMetricsFactory,
+          labeledMetricsFactory,
+        )
 
     object partyRecordStore
-        extends PartyRecordStoreMetrics(prefix :+ "party_record_store", defaultMetricsFactory)
+        extends PartyRecordStoreMetrics(
+          prefix :+ "party_record_store",
+          labeledMetricsFactory,
+        )
 
     object identityProviderConfigStore
         extends IdentityProviderConfigStoreMetrics(
           prefix :+ "identity_provider_config_store",
           defaultMetricsFactory,
+          labeledMetricsFactory,
         )
 
-    object index extends IndexMetrics(prefix :+ "index", defaultMetricsFactory)
+    object index
+        extends IndexMetrics(prefix :+ "index", defaultMetricsFactory, labeledMetricsFactory)
 
     object indexer extends IndexerMetrics(prefix :+ "indexer", defaultMetricsFactory)
 
     object indexerEvents extends IndexedUpdatesMetrics(prefix :+ "indexer", labeledMetricsFactory)
 
     object parallelIndexer
-        extends ParallelIndexerMetrics(prefix :+ "parallel_indexer", defaultMetricsFactory)
+        extends ParallelIndexerMetrics(
+          prefix :+ "parallel_indexer",
+          defaultMetricsFactory,
+          labeledMetricsFactory,
+        )
 
     object services
         extends ServicesMetrics(prefix :+ "services", defaultMetricsFactory, labeledMetricsFactory)

--- a/ledger/metrics/src/main/scala/com/daml/metrics/ParallelIndexerMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/ParallelIndexerMetrics.scala
@@ -4,16 +4,22 @@
 package com.daml.metrics
 
 import com.daml.metrics.api.MetricDoc.MetricQualification.{Debug, Latency, Saturation, Traffic}
-import com.daml.metrics.api.MetricHandle.{Counter, MetricsFactory, Histogram, Timer}
+import com.daml.metrics.api.MetricHandle.{
+  Counter,
+  Histogram,
+  LabeledMetricsFactory,
+  MetricsFactory,
+  Timer,
+}
 import com.daml.metrics.api.dropwizard.DropwizardTimer
 import com.daml.metrics.api.{MetricDoc, MetricName}
 
-@MetricDoc.GroupTag(
-  representative = "daml.parallel_indexer.<stage>",
-  groupableClass = classOf[DatabaseMetrics],
-)
-class ParallelIndexerMetrics(prefix: MetricName, factory: MetricsFactory) {
-  val initialization = new DatabaseMetrics(prefix, "initialization", factory)
+class ParallelIndexerMetrics(
+    prefix: MetricName,
+    factory: MetricsFactory,
+    labeledMetricsFactory: LabeledMetricsFactory,
+) {
+  val initialization = new DatabaseMetrics(prefix :+ "initialization", labeledMetricsFactory)
 
   // Number of state updates persisted to the database
   // (after the effect of the corresponding Update is persisted into the database,
@@ -94,9 +100,9 @@ class ParallelIndexerMetrics(prefix: MetricName, factory: MetricsFactory) {
 
   // Ingestion stage
   // Parallel ingestion of prepared data into the database
-  val ingestion = new DatabaseMetrics(prefix, "ingestion", factory)
+  val ingestion = new DatabaseMetrics(prefix :+ "ingestion", labeledMetricsFactory)
 
   // Tail ingestion stage
   // The throttled update of ledger end parameters
-  val tailIngestion = new DatabaseMetrics(prefix, "tail_ingestion", factory)
+  val tailIngestion = new DatabaseMetrics(prefix :+ "tail_ingestion", labeledMetricsFactory)
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/PartyRecordStoreMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/PartyRecordStoreMetrics.scala
@@ -3,17 +3,13 @@
 
 package com.daml.metrics
 
-import com.daml.metrics.api.MetricHandle.MetricsFactory
-import com.daml.metrics.api.{MetricDoc, MetricName}
+import com.daml.metrics.api.MetricHandle.LabeledMetricsFactory
+import com.daml.metrics.api.MetricName
 
-@MetricDoc.GroupTag(
-  representative = "daml.party_record_store.<operation>",
-  groupableClass = classOf[DatabaseMetrics],
-)
 class PartyRecordStoreMetrics(
     prefix: MetricName,
-    factory: MetricsFactory,
-) extends DatabaseMetricsFactory(prefix, factory) {
+    labeledMetricsFactory: LabeledMetricsFactory,
+) extends DatabaseMetricsFactory(prefix, labeledMetricsFactory) {
 
   val getPartyRecord: DatabaseMetrics = createDbMetrics("get_party_record")
   val partiesExist: DatabaseMetrics = createDbMetrics("parties_exist")

--- a/ledger/metrics/src/main/scala/com/daml/metrics/UserManagementMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/UserManagementMetrics.scala
@@ -3,15 +3,14 @@
 
 package com.daml.metrics
 
-import com.daml.metrics.api.MetricHandle.MetricsFactory
-import com.daml.metrics.api.{MetricDoc, MetricName}
+import com.daml.metrics.api.MetricHandle.{LabeledMetricsFactory, MetricsFactory}
+import com.daml.metrics.api.MetricName
 
-@MetricDoc.GroupTag(
-  representative = "daml.user_management.<operation>",
-  groupableClass = classOf[DatabaseMetrics],
-)
-class UserManagementMetrics(val prefix: MetricName, val factory: MetricsFactory)
-    extends DatabaseMetricsFactory(prefix, factory) {
+class UserManagementMetrics(
+    val prefix: MetricName,
+    val factory: MetricsFactory,
+    labeledFactory: LabeledMetricsFactory,
+) extends DatabaseMetricsFactory(prefix, labeledFactory) {
 
   val cache = new CacheMetrics(prefix :+ "cache", factory)
 

--- a/observability/metrics/src/main/scala/com/daml/metrics/DatabaseMetrics.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/DatabaseMetrics.scala
@@ -64,8 +64,8 @@ class DatabaseMetrics private[metrics] (
   @MetricDoc.Tag(
     summary = "The time needed to run the SQL query.",
     description = """This metric measures the time it takes to execute a block of code (on a
-                    |decidated executor) related to the <operation> that can issue multiple SQL
-                    |statements such that all run in a single DB transaction (either commtted or
+                    |dedicated executor) related to the <operation> that can issue multiple SQL
+                    |statements such that all run in a single DB transaction (either committed or
                     |aborted).""",
     qualification = Debug,
   )

--- a/observability/metrics/src/main/scala/com/daml/metrics/DatabaseMetrics.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/DatabaseMetrics.scala
@@ -22,6 +22,9 @@ class DatabaseMetrics private[metrics] (
                     |it takes between creating the SQL statement corresponding to the <operation>
                     |and the point when it starts running on the dedicated executor.""",
     qualification = Debug,
+    labelsWithDescription = Map(
+      "name" -> "The operation/pool for which the metric is registered."
+    ),
   )
   val waitTimer: Timer = factory.timer(dbPrefix :+ "wait")
 
@@ -31,6 +34,9 @@ class DatabaseMetrics private[metrics] (
                     |Additionally it includes the time needed to obtain the DB connection,
                     |optionally roll it back and close the connection at the end.""",
     qualification = Debug,
+    labelsWithDescription = Map(
+      "name" -> "The operation/pool for which the metric is registered."
+    ),
   )
   val executionTimer: Timer = factory.timer(dbPrefix :+ "exec")
 
@@ -40,6 +46,9 @@ class DatabaseMetrics private[metrics] (
                     |Daml-LF translation step. For such queries this metric stands for the time it
                     |takes to turn the serialized Daml-LF values into in-memory representation.""",
     qualification = Debug,
+    labelsWithDescription = Map(
+      "name" -> "The operation/pool for which the metric is registered."
+    ),
   )
   val translationTimer: Timer = factory.timer(dbPrefix :+ "translation")
 
@@ -49,6 +58,9 @@ class DatabaseMetrics private[metrics] (
                     |step. For such queries this metric represents the time it takes to decompress
                     |contract arguments retrieved from the database.""",
     qualification = Debug,
+    labelsWithDescription = Map(
+      "name" -> "The operation/pool for which the metric is registered."
+    ),
   )
   val compressionTimer: Timer = factory.timer(dbPrefix :+ "compression")
 
@@ -58,6 +70,9 @@ class DatabaseMetrics private[metrics] (
                     |to the <operation>. It roughly corresponds to calling `commit()` on a DB
                     |connection.""",
     qualification = Debug,
+    labelsWithDescription = Map(
+      "name" -> "The operation/pool for which the metric is registered."
+    ),
   )
   val commitTimer: Timer = factory.timer(dbPrefix :+ "commit")
 
@@ -68,6 +83,9 @@ class DatabaseMetrics private[metrics] (
                     |statements such that all run in a single DB transaction (either committed or
                     |aborted).""",
     qualification = Debug,
+    labelsWithDescription = Map(
+      "name" -> "The operation/pool for which the metric is registered."
+    ),
   )
   val queryTimer: Timer = factory.timer(dbPrefix :+ "query")
 }

--- a/observability/metrics/src/main/scala/com/daml/metrics/DatabaseMetrics.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/DatabaseMetrics.scala
@@ -3,18 +3,18 @@
 
 package com.daml.metrics
 
-import com.codahale.metrics.MetricRegistry
 import com.daml.metrics.api.MetricDoc.MetricQualification.Debug
-import com.daml.metrics.api.MetricHandle.{MetricsFactory, Timer}
-import com.daml.metrics.api.dropwizard.DropwizardMetricsFactory
-import com.daml.metrics.api.{MetricDoc, MetricName}
+import com.daml.metrics.api.MetricHandle.{LabeledMetricsFactory, Timer}
+import com.daml.metrics.api.noop.NoOpMetricsFactory
+import com.daml.metrics.api.{MetricDoc, MetricName, MetricsContext}
 
 class DatabaseMetrics private[metrics] (
-    val prefix: MetricName,
     val name: String,
-    val factory: MetricsFactory,
+    val factory: LabeledMetricsFactory,
 ) {
-  protected val dbPrefix: MetricName = prefix :+ name
+
+  private val dbPrefix: MetricName = MetricName.Daml :+ "db"
+  private implicit val mc: MetricsContext = MetricsContext("name" -> name)
 
   @MetricDoc.Tag(
     summary = "The time needed to acquire a connection to the database.",
@@ -76,8 +76,7 @@ object DatabaseMetrics {
 
   def ForTesting(metricsName: String): DatabaseMetrics =
     new DatabaseMetrics(
-      prefix = MetricName("ForTesting"),
       name = metricsName,
-      new DropwizardMetricsFactory(new MetricRegistry),
+      NoOpMetricsFactory,
     )
 }


### PR DESCRIPTION
This will simplify the db metrics and make them available only when using the prometheus exporter

Metrics being replaced:

<table>
<tr>
	<td> Old metric
	<td> New Metric
<tr>
	<td> daml.{{prefix}}.{{operation}}.wait
	<td> daml.db.wait {name = "daml.{{prefix}}.{{operation}}"}
<tr>
	<td> daml.{{prefix}}.{{operation}}.exec
	<td>daml.db.exec {name = "daml.{{prefix}}.{{operation}}"}
<tr>
	<td> daml.{{prefix}}.{{operation}}.translation
	<td>daml.db.translation {name = "daml.{{prefix}}.{{operation}}"}
<tr>
	<td> daml.{{prefix}}.{{operation}}.compression
	<td>daml.db.compression {name = "daml.{{prefix}}.{{operation}}"}
<tr>
	<td> daml.{{prefix}}.{{operation}}.commit
	<td>daml.db.commit {name = "daml.{{prefix}}.{{operation}}"}
<tr>
	<td> daml.{{prefix}}.{{operation}}.query
	<td>daml.db.query {name = "daml.{{prefix}}.{{operation}}"}
</table>

All the metrics are timers therefore the old type of `Summary` is being replaced with a `Histogram`

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
