### PR TITLE
Add flag to automatically run scenarios for Studio

### DIFF
--- a/compiler/daml-extension/package.json
+++ b/compiler/daml-extension/package.json
@@ -107,6 +107,11 @@
                     "default": "From consent popup",
                     "description": "Controls whether you send Daml usage data to Digital Asset"
                 },
+                "daml.autorunAllTests": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Run all tests in a file once it's opened, instead of waiting for the user to select individual tests."
+                },
                 "daml.extraArguments": {
                     "type": "string",
                     "default": "",

--- a/compiler/daml-extension/src/extension.ts
+++ b/compiler/daml-extension/src/extension.ts
@@ -304,6 +304,7 @@ export function createLanguageClient(
     ["debug", ["--debug"]],
     ["experimental", ["--experimental"]],
     ["profile", ["+RTS", "-h", "-RTS"]],
+    ["autorunAllTests", ["--studio-auto-run-all-scenarios=yes"]],
   ]);
 
   if (config.get("experimental")) {

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/IdeState/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/IdeState/Daml.hs
@@ -24,15 +24,16 @@ import qualified Language.LSP.Types as LSP
 
 getDamlIdeState
     :: Options
+    -> StudioAutorunAllScenarios
     -> Maybe Scenario.Handle
     -> Logger.Handle IO
     -> Debouncer LSP.NormalizedUri
     -> ShakeLspEnv
     -> VFSHandle
     -> IO IdeState
-getDamlIdeState compilerOpts mbScenarioService loggerH debouncer lspEnv vfs = do
+getDamlIdeState compilerOpts autorunAllScenarios mbScenarioService loggerH debouncer lspEnv vfs = do
     let rule = mainRule compilerOpts <> pluginRules enabledPlugins
-    damlEnv <- mkDamlEnv compilerOpts mbScenarioService
+    damlEnv <- mkDamlEnv compilerOpts autorunAllScenarios mbScenarioService
     initialise rule lspEnv (toIdeLogger loggerH) debouncer damlEnv (toCompileOpts compilerOpts) vfs
 
 enabledPlugins :: Plugin a
@@ -53,7 +54,7 @@ withDamlIdeState opts@Options{..} loggerH eventHandler f = do
     Scenario.withScenarioService' optScenarioService optEnableScenarios optDamlLfVersion loggerH scenarioServiceConfig $ \mbScenarioService -> do
         vfs <- makeVFSHandle
         bracket
-            (getDamlIdeState opts mbScenarioService loggerH noopDebouncer (DummyLspEnv eventHandler) vfs)
+            (getDamlIdeState opts (StudioAutorunAllScenarios True) mbScenarioService loggerH noopDebouncer (DummyLspEnv eventHandler) vfs)
             shutdown
             f
 

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
@@ -56,13 +56,14 @@ data DamlEnv = DamlEnv
   , envSkipScenarioValidation :: SkipScenarioValidation
   , envEnableScenarios :: EnableScenarios
   , envAllowLargeTuples :: AllowLargeTuples
+  , envStudioAutorunAllScenarios :: StudioAutorunAllScenarios
   , envTestFilter :: T.Text -> Bool
   }
 
 instance IsIdeGlobal DamlEnv
 
-mkDamlEnv :: Options -> Maybe SS.Handle -> IO DamlEnv
-mkDamlEnv opts scenarioService = do
+mkDamlEnv :: Options -> StudioAutorunAllScenarios -> Maybe SS.Handle -> IO DamlEnv
+mkDamlEnv opts autorunAllScenarios scenarioService = do
     openVRsVar <- newVar HashSet.empty
     scenarioContextsVar <- newMVar HashMap.empty
     previousScenarioContextsVar <- newMVar []
@@ -75,6 +76,7 @@ mkDamlEnv opts scenarioService = do
         , envSkipScenarioValidation = optSkipScenarioValidation opts
         , envEnableScenarios = optEnableScenarios opts
         , envAllowLargeTuples = optAllowLargeTuples opts
+        , envStudioAutorunAllScenarios = autorunAllScenarios
         , envTestFilter = optTestFilter opts
         }
 

--- a/compiler/damlc/daml-ide-core/test/Development/IDE/Core/API/Testing.hs
+++ b/compiler/damlc/daml-ide-core/test/Development/IDE/Core/API/Testing.hs
@@ -169,7 +169,7 @@ runShakeTestOpts fOpts mbScenarioService (ShakeTest m) = do
             atomically $ modifyTVar' virtualResourcesNotes (Map.insert vr note)
         eventLogger _ _ = pure ()
     vfs <- API.makeVFSHandle
-    damlEnv <- mkDamlEnv options mbScenarioService
+    damlEnv <- mkDamlEnv options (StudioAutorunAllScenarios True) mbScenarioService
     service <- API.initialise (mainRule options) (DummyLspEnv $ NotificationHandler eventLogger) noLogging noopDebouncer damlEnv (toCompileOpts options) vfs
     result <- withSystemTempDirectory "shake-api-test" $ \testDirPath -> do
         let ste = ShakeTestEnv

--- a/compiler/damlc/daml-ide-core/test/Development/IDE/Core/API/Testing.hs
+++ b/compiler/damlc/daml-ide-core/test/Development/IDE/Core/API/Testing.hs
@@ -169,7 +169,7 @@ runShakeTestOpts fOpts mbScenarioService (ShakeTest m) = do
             atomically $ modifyTVar' virtualResourcesNotes (Map.insert vr note)
         eventLogger _ _ = pure ()
     vfs <- API.makeVFSHandle
-    damlEnv <- mkDamlEnv options (StudioAutorunAllScenarios True) mbScenarioService
+    damlEnv <- mkDamlEnv options (StudioAutorunAllScenarios False) mbScenarioService
     service <- API.initialise (mainRule options) (DummyLspEnv $ NotificationHandler eventLogger) noLogging noopDebouncer damlEnv (toCompileOpts options) vfs
     result <- withSystemTempDirectory "shake-api-test" $ \testDirPath -> do
         let ste = ShakeTestEnv

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -9,6 +9,7 @@ module DA.Daml.Options.Types
     , EnableScenarioService(..)
     , EnableScenarios(..)
     , AllowLargeTuples(..)
+    , StudioAutorunAllScenarios(..)
     , SkipScenarioValidation(..)
     , DlintRulesFile(..)
     , DlintHintFiles(.., NoDlintHintFiles)
@@ -179,6 +180,9 @@ newtype EnableScenarios = EnableScenarios { getEnableScenarios :: Bool }
     deriving Show
 
 newtype AllowLargeTuples = AllowLargeTuples { getAllowLargeTuples :: Bool }
+    deriving Show
+
+newtype StudioAutorunAllScenarios = StudioAutorunAllScenarios { getStudioAutorunAllScenarios :: Bool }
     deriving Show
 
 damlArtifactDir :: FilePath

--- a/compiler/damlc/daml-rule-types/src/Development/IDE/Core/RuleTypes/Daml.hs
+++ b/compiler/damlc/daml-rule-types/src/Development/IDE/Core/RuleTypes/Daml.hs
@@ -99,9 +99,13 @@ type instance RuleResult RunScenarios = [(VirtualResource, Either SS.Error SS.Sc
 -- be no test with that name
 type instance RuleResult RunSingleScenario = [(VirtualResource, Either SS.Error SS.ScenarioResult)]
 
+type instance RuleResult GetScenarios = [VirtualResource]
+
 type instance RuleResult RunScripts = [(VirtualResource, Either SS.Error SS.ScenarioResult)]
 
 type instance RuleResult RunSingleScript = [(VirtualResource, Either SS.Error SS.ScenarioResult)]
+
+type instance RuleResult GetScripts = [VirtualResource]
 
 -- | Encode a module and produce a hash of the module and all its transitive dependencies.
 -- The hash is used to decide if a module needs to be reloaded in the scenario service.
@@ -217,6 +221,12 @@ instance Binary   RunSingleScenario
 instance Hashable RunSingleScenario
 instance NFData   RunSingleScenario
 
+data GetScenarios = GetScenarios
+    deriving (Eq, Show, Typeable, Generic)
+instance Binary   GetScenarios
+instance Hashable GetScenarios
+instance NFData   GetScenarios
+
 data RunScripts = RunScripts
     deriving (Eq, Show, Typeable, Generic)
 instance Binary   RunScripts
@@ -228,6 +238,12 @@ data RunSingleScript = RunSingleScript T.Text
 instance Binary   RunSingleScript
 instance Hashable RunSingleScript
 instance NFData   RunSingleScript
+
+data GetScripts = GetScripts
+    deriving (Eq, Show, Typeable, Generic)
+instance Binary   GetScripts
+instance Hashable GetScripts
+instance NFData   GetScripts
 
 data EncodeModule = EncodeModule
     deriving (Eq, Show, Typeable, Generic)

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -139,6 +139,7 @@ cmdIde numProcessors =
         <$> telemetryOpt
         <*> debugOpt
         <*> enableScenarioServiceOpt
+        <*> studioAutorunAllScenariosOpt
         <*> optionsParser
               numProcessors
               (EnableScenarioService True)
@@ -525,9 +526,10 @@ execLicense =
 execIde :: Telemetry
         -> Debug
         -> EnableScenarioService
+        -> StudioAutorunAllScenarios
         -> Options
         -> Command
-execIde telemetry (Debug debug) enableScenarioService options =
+execIde telemetry (Debug debug) enableScenarioService autorunAllScenarios options =
     Command Ide Nothing effect
   where effect = NS.withSocketsDo $ do
           let threshold =
@@ -580,7 +582,7 @@ execIde telemetry (Debug debug) enableScenarioService options =
                   Logger.logInfo loggerH (T.pack $ "SDK version: " <> sdkVersion)
                   debouncer <- newAsyncDebouncer
                   runLanguageServer loggerH enabledPlugins Config $ \lspEnv vfs _ ->
-                      getDamlIdeState options mbScenarioService loggerH debouncer (RealLspEnv lspEnv) vfs
+                      getDamlIdeState options autorunAllScenarios mbScenarioService loggerH debouncer (RealLspEnv lspEnv) vfs
 
 
 -- | Whether we should write interface files during `damlc compile`.

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -216,6 +216,13 @@ enableScenarioServiceOpt = fmap EnableScenarioService $
             "Control whether to start the Scenario Service, \
             \enabling/disabling support for running Daml Scripts and scenarios"
 
+studioAutorunAllScenariosOpt :: Parser StudioAutorunAllScenarios
+studioAutorunAllScenariosOpt = fmap StudioAutorunAllScenarios $
+    flagYesNoAuto "studio-auto-run-all-scenarios" False desc idm
+    where
+        desc =
+            "Control whether Scenarios should automatically run on opening a file in Daml Studio."
+
 enableScenariosOpt :: Parser EnableScenarios
 enableScenariosOpt = EnableScenarios <$>
     flagYesNoAuto "enable-scenarios" False desc internal

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -252,7 +252,7 @@ getIntegrationTests registerTODO scenarioService (packageDbPath, packageFlag) = 
                 }
 
               mkIde options = do
-                damlEnv <- mkDamlEnv options (Just scenarioService)
+                damlEnv <- mkDamlEnv options (StudioAutorunAllScenarios True) (Just scenarioService)
                 initialise
                   (mainRule options)
                   (DummyLspEnv $ NotificationHandler $ \_ _ -> pure ())

--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -1227,6 +1227,7 @@ runScripts service fileContent = bracket getIdeState shutdown $ \ideState -> do
       logger <- Logger.newStderrLogger Logger.Error "script-service"
       getDamlIdeState
         options
+        (StudioAutorunAllScenarios True)
         (Just service)
         logger
         noopDebouncer

--- a/compiler/damlc/tests/src/DA/Test/ScriptService_1_15.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService_1_15.hs
@@ -262,6 +262,7 @@ runScripts service fileContent = bracket getIdeState shutdown $ \ideState -> do
       logger <- Logger.newStderrLogger Logger.Error "script-service"
       getDamlIdeState
         options
+        (StudioAutorunAllScenarios True)
         (Just service)
         logger
         noopDebouncer


### PR DESCRIPTION
This makes the old behaviour before https://github.com/digital-asset/daml/pull/16211 available via a flag, as per https://github.com/digital-asset/daml/issues/16399

Usage: add `--studio-auto-run-all-scenarios` under `extraArguments` in the Daml extension's configuration

![image](https://user-images.githubusercontent.com/106664681/221618254-874463c8-62c5-43e5-817c-f2359ed4629f.png)