### PR TITLE
more determinism in delete order

### DIFF
--- a/ledger-service/db-backend/BUILD.bazel
+++ b/ledger-service/db-backend/BUILD.bazel
@@ -42,6 +42,8 @@ da_scala_library(
         "//ledger/metrics",
         "//libs-scala/contextualized-logging",
         "//libs-scala/nonempty",
+        "//libs-scala/nonempty-cats",
+        "//libs-scala/scala-utils",
         "@maven//:io_dropwizard_metrics_metrics_core",
     ],
 )

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -294,6 +294,9 @@ sealed abstract class Queries(tablePrefix: String, tpIdCacheMaxEntries: Long)(im
   protected[this] type DBContractKey
   protected[this] def toDBContractKey[CK: JsonWriter](ck: CK): DBContractKey
 
+  /** Whether strict determinism can be avoided by the contracts-fetch process. */
+  def allowDamlTransactionBatching: Boolean
+
   final def insertContracts[F[_]: cats.Foldable: Functor, CK: JsonWriter, PL: JsonWriter](
       dbcs: F[DBContract[SurrogateTpId, CK, PL, Seq[String]]]
   )(implicit log: LogHandler): ConnectionIO[Int] =
@@ -723,6 +726,8 @@ private final class PostgresQueries(tablePrefix: String, tpIdCacheMaxEntries: Lo
 
   protected[this] override def toDBContractKey[CK: JsonWriter](x: CK) = x.toJson
 
+  override def allowDamlTransactionBatching = true
+
   protected[this] override def primInsertContracts[F[_]: cats.Foldable: Functor](
       dbcs: F[DBContract[SurrogateTpId, DBContractKey, JsValue, Array[String]]]
   )(implicit log: LogHandler): ConnectionIO[Int] = {
@@ -889,6 +894,8 @@ private final class OracleQueries(
 
   protected[this] override def toDBContractKey[CK: JsonWriter](x: CK): DBContractKey =
     JsObject(Map("key" -> x.toJson))
+
+  override def allowDamlTransactionBatching = true
 
   protected[this] override def primInsertContracts[F[_]: cats.Foldable: Functor](
       dbcs: F[DBContract[SurrogateTpId, DBContractKey, JsValue, Array[String]]]

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -258,7 +258,7 @@ sealed abstract class Queries(tablePrefix: String, tpIdCacheMaxEntries: Long)(im
   )(implicit log: LogHandler): ConnectionIO[Int] = {
     val (existingParties, newParties) = {
       import cats.syntax.foldable._
-      parties.toList.partition(p => lastOffsets.contains(p))
+      parties.toList.sorted.partition(p => lastOffsets.contains(p))
     }
     // If a concurrent transaction inserted an offset for a new party, the insert will fail.
     val insert =

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -11,7 +11,7 @@ import nonempty.NonEmptyReturningOps._
 import doobie._
 import doobie.implicits._
 import scala.annotation.nowarn
-import scala.collection.immutable.{Seq => ISeq, SortedMap}
+import scala.collection.immutable.{Seq => ISeq, SortedMap, SortedSet}
 import scalaz.{@@, Cord, Functor, OneAnd, Tag, \/, -\/, \/-}
 import scalaz.Digit._0
 import scalaz.syntax.foldable._
@@ -308,7 +308,7 @@ sealed abstract class Queries(tablePrefix: String, tpIdCacheMaxEntries: Long)(im
   )(implicit log: LogHandler): ConnectionIO[Int] = {
     import cats.instances.vector._
     import nonempty.catsinstances._
-    cids match {
+    cids to SortedSet match {
       case NonEmpty(cids) =>
         val del = fr"DELETE FROM $contractTableName WHERE " ++ {
           val chunks =

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
@@ -329,7 +329,7 @@ private class ContractsFetch(
 
         val transactInsertsDeletes = Flow
           .fromFunction(jsonifyInsertDeleteStep)
-          .via(conflation)
+          .via(if (sjd.q.queries.allowDamlTransactionBatching) conflation else Flow.apply)
           .map(insertAndDelete)
 
         idses.map(_.toInsertDelete) ~> transactInsertsDeletes ~> acsSink

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
@@ -291,68 +291,74 @@ private class ContractsFetch(
     import domain.Offset._, fetchContext.{jwt, ledgerId, parties}
     val startOffset = offsets.values.toList.minimum.cata(AbsoluteBookmark(_), LedgerBegin)
 
-    val graph = RunnableGraph.fromGraph(
-      GraphDSL.createGraph(
-        Sink.queue[ConnectionIO[Unit]](),
-        Sink.last[BeginBookmark[domain.Offset]],
-      )(Keep.both) { implicit builder => (acsSink, offsetSink) =>
-        import GraphDSL.Implicits._
+    // skip if *we don't use the acs* (which can read past absEnd) and current
+    // DB is already caught up to absEnd
+    if (startOffset == AbsoluteBookmark(absEnd.toDomain))
+      fconn.pure(startOffset)
+    else {
+      val graph = RunnableGraph.fromGraph(
+        GraphDSL.createGraph(
+          Sink.queue[ConnectionIO[Unit]](),
+          Sink.last[BeginBookmark[domain.Offset]],
+        )(Keep.both) { implicit builder => (acsSink, offsetSink) =>
+          import GraphDSL.Implicits._
 
-        val txnK = getCreatesAndArchivesSince(
-          jwt,
-          ledgerId,
-          transactionFilter(parties, List(templateId)),
-          _: lav1.ledger_offset.LedgerOffset,
-          absEnd,
-        )(lc)
+          val txnK = getCreatesAndArchivesSince(
+            jwt,
+            ledgerId,
+            transactionFilter(parties, List(templateId)),
+            _: lav1.ledger_offset.LedgerOffset,
+            absEnd,
+          )(lc)
 
-        // include ACS iff starting at LedgerBegin
-        val (idses, lastOff) = (startOffset, disableAcs) match {
-          case (LedgerBegin, false) =>
-            val stepsAndOffset = builder add acsFollowingAndBoundary(txnK)
-            stepsAndOffset.in <~ getActiveContracts(
-              jwt,
-              ledgerId,
-              transactionFilter(parties, List(templateId)),
-              true,
-            )(lc)
-            (stepsAndOffset.out0, stepsAndOffset.out1)
+          // include ACS iff starting at LedgerBegin
+          val (idses, lastOff) = (startOffset, disableAcs) match {
+            case (LedgerBegin, false) =>
+              val stepsAndOffset = builder add acsFollowingAndBoundary(txnK)
+              stepsAndOffset.in <~ getActiveContracts(
+                jwt,
+                ledgerId,
+                transactionFilter(parties, List(templateId)),
+                true,
+              )(lc)
+              (stepsAndOffset.out0, stepsAndOffset.out1)
 
-          case (AbsoluteBookmark(_), _) | (LedgerBegin, true) =>
-            val stepsAndOffset = builder add transactionsFollowingBoundary(txnK)
-            stepsAndOffset.in <~ Source.single(startOffset)
-            (
-              (stepsAndOffset: FanOutShape2[_, ContractStreamStep.LAV1, _]).out0,
-              stepsAndOffset.out1,
-            )
+            case (AbsoluteBookmark(_), _) | (LedgerBegin, true) =>
+              val stepsAndOffset = builder add transactionsFollowingBoundary(txnK)
+              stepsAndOffset.in <~ Source.single(startOffset)
+              (
+                (stepsAndOffset: FanOutShape2[_, ContractStreamStep.LAV1, _]).out0,
+                stepsAndOffset.out1,
+              )
+          }
+
+          val transactInsertsDeletes = Flow
+            .fromFunction(jsonifyInsertDeleteStep)
+            .via(if (sjd.q.queries.allowDamlTransactionBatching) conflation else Flow.apply)
+            .map(insertAndDelete)
+
+          idses.map(_.toInsertDelete) ~> transactInsertsDeletes ~> acsSink
+          lastOff ~> offsetSink
+
+          ClosedShape
         }
+      )
 
-        val transactInsertsDeletes = Flow
-          .fromFunction(jsonifyInsertDeleteStep)
-          .via(if (sjd.q.queries.allowDamlTransactionBatching) conflation else Flow.apply)
-          .map(insertAndDelete)
+      val (acsQueue, lastOffsetFuture) = graph.run()
 
-        idses.map(_.toInsertDelete) ~> transactInsertsDeletes ~> acsSink
-        lastOff ~> offsetSink
-
-        ClosedShape
-      }
-    )
-
-    val (acsQueue, lastOffsetFuture) = graph.run()
-
-    for {
-      _ <- sinkCioSequence_(acsQueue)
-      offset0 <- connectionIOFuture(lastOffsetFuture)
-      offsetOrError <- offset0 max AbsoluteBookmark(absEnd.toDomain) match {
-        case ab @ AbsoluteBookmark(newOffset) =>
-          ContractDao
-            .updateOffset(parties, templateId, newOffset, offsets)
-            .map(_ => ab)
-        case LedgerBegin =>
-          fconn.pure(LedgerBegin)
-      }
-    } yield offsetOrError
+      for {
+        _ <- sinkCioSequence_(acsQueue)
+        offset0 <- connectionIOFuture(lastOffsetFuture)
+        offsetOrError <- offset0 max AbsoluteBookmark(absEnd.toDomain) match {
+          case ab @ AbsoluteBookmark(newOffset) =>
+            ContractDao
+              .updateOffset(parties, templateId, newOffset, offsets)
+              .map(_ => ab)
+          case LedgerBegin =>
+            fconn.pure(LedgerBegin)
+        }
+      } yield offsetOrError
+    }
   }
 }
 


### PR DESCRIPTION
* [x] backport #15565
* [x] deterministic order for delete
* [x] avoid `in` for delete entirely on Oracle
* [x] deterministic order for update offset
* [x] remove backpressure batching for Oracle
* [x] small extra optimization: don't update offset if end = start
* [ ] forward-port to main
    * [ ] exclude 029f2b5895ff062c4c9e6e33e04d4e8d369af1dc as it is a mangled backport, and therefore does not need forward porting
    * [ ] the outer added layer in main, the tpid for deletes, should also be sorted

#16261 should also be merged.