### PR TITLE
Add ability to document async gauges [PLEN-176]

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/IndexerMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IndexerMetrics.scala
@@ -7,7 +7,6 @@ import java.time.Instant
 
 import com.daml.metrics.api.MetricDoc.MetricQualification.Debug
 import com.daml.metrics.api.MetricHandle.{Gauge, MetricsFactory}
-import com.daml.metrics.api.noop.NoOpGauge
 import com.daml.metrics.api.{MetricDoc, MetricName, MetricsContext}
 
 class IndexerMetrics(prefix: MetricName, factory: MetricsFactory) {
@@ -44,10 +43,7 @@ class IndexerMetrics(prefix: MetricName, factory: MetricsFactory) {
                     |can be negative.""",
     qualification = Debug,
   )
-  val currentRecordTimeLagForDocs: Gauge[Long] =
-    NoOpGauge(prefix :+ "current_record_time_lag", 0)
-
-  factory.gaugeWithSupplier(
+  val _: Gauge.CloseableGauge = factory.gaugeWithSupplier(
     prefix :+ "current_record_time_lag",
     () => Instant.now().toEpochMilli - lastReceivedRecordTime.getValue,
   )(MetricsContext.Empty)

--- a/ledger/metrics/src/main/scala/com/daml/metrics/IndexerMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IndexerMetrics.scala
@@ -43,7 +43,7 @@ class IndexerMetrics(prefix: MetricName, factory: MetricsFactory) {
                     |can be negative.""",
     qualification = Debug,
   )
-  val _: Gauge.CloseableGauge = factory.gaugeWithSupplier(
+  val currentRecordTimeLag: Gauge.CloseableGauge = factory.gaugeWithSupplier(
     prefix :+ "current_record_time_lag",
     () => Instant.now().toEpochMilli - lastReceivedRecordTime.getValue,
   )(MetricsContext.Empty)

--- a/ledger/metrics/src/main/scala/com/daml/metrics/ParallelIndexerMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/ParallelIndexerMetrics.scala
@@ -3,7 +3,7 @@
 
 package com.daml.metrics
 
-import com.daml.metrics.api.MetricDoc.MetricQualification.{Debug, Latency, Saturation, Traffic}
+import com.daml.metrics.api.MetricDoc.MetricQualification.{Debug, Saturation, Traffic}
 import com.daml.metrics.api.MetricHandle.{
   Counter,
   Histogram,
@@ -11,7 +11,6 @@ import com.daml.metrics.api.MetricHandle.{
   MetricsFactory,
   Timer,
 }
-import com.daml.metrics.api.dropwizard.DropwizardTimer
 import com.daml.metrics.api.{MetricDoc, MetricName}
 
 class ParallelIndexerMetrics(
@@ -88,15 +87,6 @@ class ParallelIndexerMetrics(
     )
     val duration: Timer = factory.timer(prefix :+ "duration")
   }
-
-  @MetricDoc.Tag(
-    summary = "The time needed to run the SQL query and read the result.",
-    description = """This metric encompasses the time measured by `query` and `commit` metrics.
-                    |Additionally it includes the time needed to obtain the DB connection,
-                    |optionally roll it back and close the connection at the end.""",
-    qualification = Latency,
-  )
-  val ingestionExecForDocs: Timer = DropwizardTimer(prefix :+ "ingestion" :+ "exec", null)
 
   // Ingestion stage
   // Parallel ingestion of prepared data into the database

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/MetricHandle.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/MetricHandle.scala
@@ -131,9 +131,10 @@ object MetricHandle {
       * longer being updated vs. the value no longer existing (contrary to how meters, histograms work). Because of this reasoning
       * gauges have to be closed after usage.
       */
-    trait CloseableGauge extends AutoCloseable
+    trait CloseableGauge extends AutoCloseable with MetricHandle
 
-    case class SimpleCloseableGauge(delegate: AutoCloseable) extends CloseableGauge {
+    case class SimpleCloseableGauge(name: String, delegate: AutoCloseable) extends CloseableGauge {
+      override def metricType: String = "Gauge"
       override def close(): Unit = delegate.close()
     }
   }

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/dropwizard/DropwizardMetricsFactory.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/dropwizard/DropwizardMetricsFactory.scala
@@ -36,7 +36,7 @@ class DropwizardMetricsFactory(val registry: codahale.MetricRegistry) extends Me
       name,
       AsyncGauge(gaugeSupplier),
     )
-    SimpleCloseableGauge(() => discard(registry.remove(name)))
+    SimpleCloseableGauge(name, () => discard(registry.remove(name)))
   }
 
   override def meter(name: MetricName, description: String = "")(implicit

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/noop/NoOpMetricsFactory.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/noop/NoOpMetricsFactory.scala
@@ -3,7 +3,7 @@
 
 package com.daml.metrics.api.noop
 
-import com.daml.metrics.api.MetricHandle.Gauge.CloseableGauge
+import com.daml.metrics.api.MetricHandle.Gauge.{CloseableGauge, SimpleCloseableGauge}
 import com.daml.metrics.api.MetricHandle.LabeledMetricsFactory
 import com.daml.metrics.api.{MetricHandle, MetricName, MetricsContext}
 
@@ -28,7 +28,7 @@ class NoOpMetricsFactory extends LabeledMetricsFactory {
       name: MetricName,
       gaugeSupplier: () => T,
       description: String,
-  )(implicit context: MetricsContext): CloseableGauge = () => ()
+  )(implicit context: MetricsContext): CloseableGauge = SimpleCloseableGauge(name, () => ())
 
   override def meter(
       name: MetricName,

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryMetricsFactory.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryMetricsFactory.scala
@@ -108,7 +108,7 @@ class OpenTelemetryMetricsFactory(
             val value = valueSupplier()
             consumer.record(value.asInstanceOf[Int].toLong, attributes)
           }
-        SimpleCloseableGauge(gaugeHandle)
+        SimpleCloseableGauge(name, gaugeHandle)
       case _: Long =>
         val gaugeHandle = otelMeter
           .gaugeBuilder(name)
@@ -118,7 +118,7 @@ class OpenTelemetryMetricsFactory(
             val value = valueSupplier()
             consumer.record(value.asInstanceOf[Long], attributes)
           }
-        SimpleCloseableGauge(gaugeHandle)
+        SimpleCloseableGauge(name, gaugeHandle)
       case _: Double =>
         val gaugeHandle = otelMeter
           .gaugeBuilder(name)
@@ -127,7 +127,7 @@ class OpenTelemetryMetricsFactory(
             val value = valueSupplier()
             consumer.record(value.asInstanceOf[Double], attributes)
           }
-        SimpleCloseableGauge(gaugeHandle)
+        SimpleCloseableGauge(name, gaugeHandle)
       case _ =>
         throw new IllegalArgumentException("Gauges support only numeric values.")
     }
@@ -212,7 +212,7 @@ object OpenTelemetryTimer {
 
   private val NanosecondsInASecond = 1_000_000_000
 
-  private def convertNanosecondsToSeconds[T](nanoseconds: Long): Double = {
+  private def convertNanosecondsToSeconds(nanoseconds: Long): Double = {
     nanoseconds.toDouble / NanosecondsInASecond
   }
 }

--- a/observability/metrics/src/test/lib/scala/com/daml/metrics/api/testing/InMemoryMetricsFactory.scala
+++ b/observability/metrics/src/test/lib/scala/com/daml/metrics/api/testing/InMemoryMetricsFactory.scala
@@ -7,7 +7,7 @@ import java.time.Duration
 import java.util.concurrent.{ConcurrentLinkedQueue, TimeUnit}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong, AtomicReference}
 
-import com.daml.metrics.api.MetricHandle.Gauge.CloseableGauge
+import com.daml.metrics.api.MetricHandle.Gauge.{CloseableGauge, SimpleCloseableGauge}
 import com.daml.metrics.api.MetricHandle.{
   Counter,
   Gauge,
@@ -56,7 +56,10 @@ class InMemoryMetricsFactory extends LabeledMetricsFactory {
       description: String,
   )(implicit context: MetricsContext): CloseableGauge = {
     metrics.addAsyncGauge(name, context, gaugeSupplier)
-    () => discard { metrics.asyncGauges.get(name).foreach(_.remove(context)) }
+    SimpleCloseableGauge(
+      name,
+      () => discard { metrics.asyncGauges.get(name).foreach(_.remove(context)) },
+    )
   }
 
   override def meter(name: MetricName, description: String)(implicit

--- a/observability/metrics/src/test/lib/scala/com/daml/metrics/api/testing/ProxyMetricsFactory.scala
+++ b/observability/metrics/src/test/lib/scala/com/daml/metrics/api/testing/ProxyMetricsFactory.scala
@@ -51,7 +51,7 @@ class ProxyMetricsFactory(firstTarget: MetricsFactory, secondTarget: MetricsFact
       description: String,
   )(implicit context: MetricsContext): CloseableGauge = {
     val closingTargets = targets.map(_.gaugeWithSupplier(name, gaugeSupplier, description))
-    SimpleCloseableGauge(() => closingTargets.foreach(_.close()))
+    SimpleCloseableGauge(name, () => closingTargets.foreach(_.close()))
   }
 
   override def meter(


### PR DESCRIPTION
By making CloseableGauge a MetricHandle we can now use the annotations to document the async gauges directly
This mostly removes the need to add a special NoOpGauge that is used for documentation only.
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
