### PR TITLE
Use labeled metrics for the CacheMetrics [PLEN-163][PLEN-167]

### DIFF
--- a/ledger-service/http-json/src/itlib/scala/http/AbstractDatabaseIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractDatabaseIntegrationTest.scala
@@ -9,7 +9,7 @@ import com.daml.http.domain.ContractTypeId
 import com.daml.http.metrics.HttpJsonApiMetrics
 import com.daml.http.util.Logging.{InstanceUUID, instanceUUIDLogCtx}
 import com.daml.logging.LoggingContextOf
-import com.daml.metrics.api.testing.MetricValues
+import com.daml.metrics.api.testing.{InMemoryMetricsFactory, MetricValues}
 import doobie.util.log.LogHandler
 import doobie.free.{connection => fconn}
 import org.scalatest.freespec.AsyncFreeSpecLike
@@ -26,7 +26,8 @@ abstract class AbstractDatabaseIntegrationTest
   this: AsyncTestSuite with Matchers with Inside =>
 
   protected def jdbcConfig: JdbcConfig
-  protected implicit val metrics: HttpJsonApiMetrics = HttpJsonApiMetrics.ForTesting
+  protected implicit val metrics: HttpJsonApiMetrics =
+    new HttpJsonApiMetrics(new InMemoryMetricsFactory, new InMemoryMetricsFactory)
 
   // has to be lazy because jdbcConfig is NOT initialized yet
   protected lazy val dao = dbbackend.ContractDao(

--- a/ledger-service/metrics/src/main/scala/com/digitalasset/http/metrics/HttpJsonApiMetrics.scala
+++ b/ledger-service/metrics/src/main/scala/com/digitalasset/http/metrics/HttpJsonApiMetrics.scala
@@ -42,7 +42,7 @@ class HttpJsonApiMetrics(
   }
 
   val surrogateTemplateIdCache =
-    new CacheMetrics(prefix :+ "surrogate_tpid_cache", defaultMetricsFactory)
+    new CacheMetrics(prefix :+ "surrogate_tpid_cache", labeledMetricsFactory)
 
   // Meters how long parsing and decoding of an incoming json payload takes
   val incomingJsonParsingAndValidationTimer: Timer =

--- a/ledger/metrics/src/main/scala/com/daml/metrics/ExecutionMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/ExecutionMetrics.scala
@@ -4,10 +4,21 @@
 package com.daml.metrics
 
 import com.daml.metrics.api.MetricDoc.MetricQualification.Debug
-import com.daml.metrics.api.MetricHandle.{Counter, MetricsFactory, Histogram, Meter, Timer}
+import com.daml.metrics.api.MetricHandle.{
+  Counter,
+  Histogram,
+  LabeledMetricsFactory,
+  Meter,
+  MetricsFactory,
+  Timer,
+}
 import com.daml.metrics.api.{MetricDoc, MetricName}
 
-class ExecutionMetrics(val prefix: MetricName, val factory: MetricsFactory) {
+class ExecutionMetrics(
+    prefix: MetricName,
+    factory: MetricsFactory,
+    labeledMetricsFactory: LabeledMetricsFactory,
+) {
 
   @MetricDoc.Tag(
     summary = "The time to lookup individual active contracts during interpretation.",
@@ -116,15 +127,11 @@ class ExecutionMetrics(val prefix: MetricName, val factory: MetricsFactory) {
   )
   val engineRunning: Counter = factory.counter(prefix :+ "engine_running")
 
-  @MetricDoc.GroupTag(
-    representative = "daml.execution.cache.<state_cache>",
-    groupableClass = classOf[CacheMetrics],
-  )
   object cache {
     val prefix: MetricName = ExecutionMetrics.this.prefix :+ "cache"
 
     object keyState {
-      val stateCache: CacheMetrics = new CacheMetrics(prefix :+ "key_state", factory)
+      val stateCache: CacheMetrics = new CacheMetrics(prefix :+ "key_state", labeledMetricsFactory)
 
       @MetricDoc.Tag(
         summary = "The time spent to update the cache.",
@@ -137,7 +144,8 @@ class ExecutionMetrics(val prefix: MetricName, val factory: MetricsFactory) {
     }
 
     object contractState {
-      val stateCache: CacheMetrics = new CacheMetrics(prefix :+ "contract_state", factory)
+      val stateCache: CacheMetrics =
+        new CacheMetrics(prefix :+ "contract_state", labeledMetricsFactory)
 
       @MetricDoc.Tag(
         summary = "The time spent to update the cache.",

--- a/ledger/metrics/src/main/scala/com/daml/metrics/IdentityProviderConfigStoreMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/IdentityProviderConfigStoreMetrics.scala
@@ -3,17 +3,16 @@
 
 package com.daml.metrics
 
-import com.daml.metrics.api.MetricHandle.{LabeledMetricsFactory, MetricsFactory}
+import com.daml.metrics.api.MetricHandle.LabeledMetricsFactory
 import com.daml.metrics.api.MetricName
 
 class IdentityProviderConfigStoreMetrics(
     prefix: MetricName,
-    factory: MetricsFactory,
     labeledMetricsFactory: LabeledMetricsFactory,
 ) extends DatabaseMetricsFactory(prefix, labeledMetricsFactory) {
 
-  val idpConfigCache = new CacheMetrics(prefix :+ "idp_config_cache", factory)
-  val verifierCache = new CacheMetrics(prefix :+ "verifier_cache", factory)
+  val idpConfigCache = new CacheMetrics(prefix :+ "idp_config_cache", labeledMetricsFactory)
+  val verifierCache = new CacheMetrics(prefix :+ "verifier_cache", labeledMetricsFactory)
   val createIdpConfig: DatabaseMetrics = createDbMetrics("create_identity_provider_config")
   val getIdpConfig: DatabaseMetrics = createDbMetrics("get_identity_provider_config")
   val deleteIdpConfig: DatabaseMetrics = createDbMetrics("delete_identity_provider_config")

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -44,14 +44,18 @@ final class Metrics(
 
     object commands extends CommandMetrics(prefix :+ "commands", defaultMetricsFactory)
 
-    object execution extends ExecutionMetrics(prefix :+ "execution", defaultMetricsFactory)
+    object execution
+        extends ExecutionMetrics(
+          prefix :+ "execution",
+          defaultMetricsFactory,
+          labeledMetricsFactory,
+        )
 
     object lapi extends LAPIMetrics(prefix :+ "lapi", defaultMetricsFactory)
 
     object userManagement
         extends UserManagementMetrics(
           prefix :+ "user_management",
-          defaultMetricsFactory,
           labeledMetricsFactory,
         )
 
@@ -64,7 +68,6 @@ final class Metrics(
     object identityProviderConfigStore
         extends IdentityProviderConfigStoreMetrics(
           prefix :+ "identity_provider_config_store",
-          defaultMetricsFactory,
           labeledMetricsFactory,
         )
 

--- a/ledger/metrics/src/main/scala/com/daml/metrics/UserManagementMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/UserManagementMetrics.scala
@@ -3,16 +3,15 @@
 
 package com.daml.metrics
 
-import com.daml.metrics.api.MetricHandle.{LabeledMetricsFactory, MetricsFactory}
+import com.daml.metrics.api.MetricHandle.LabeledMetricsFactory
 import com.daml.metrics.api.MetricName
 
 class UserManagementMetrics(
-    val prefix: MetricName,
-    val factory: MetricsFactory,
+    prefix: MetricName,
     labeledFactory: LabeledMetricsFactory,
 ) extends DatabaseMetricsFactory(prefix, labeledFactory) {
 
-  val cache = new CacheMetrics(prefix :+ "cache", factory)
+  val cache = new CacheMetrics(prefix :+ "cache", labeledFactory)
 
   val getUserInfo: DatabaseMetrics = createDbMetrics("get_user_info")
   val createUser: DatabaseMetrics = createDbMetrics("create_user")

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/StateCacheSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/StateCacheSpec.scala
@@ -5,12 +5,11 @@ package com.daml.platform.store.cache
 
 import java.util.concurrent.TimeUnit
 
-import com.codahale.metrics.MetricRegistry
 import com.daml.caching.{CaffeineCache, ConcurrentCache, SizedCache}
 import com.daml.ledger.offset.Offset
 import com.daml.logging.LoggingContext
 import com.daml.metrics.api.MetricName
-import com.daml.metrics.api.dropwizard.DropwizardMetricsFactory
+import com.daml.metrics.api.noop.NoOpMetricsFactory
 import com.daml.metrics.{CacheMetrics, Metrics}
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.mockito.MockitoSugar
@@ -167,7 +166,7 @@ class StateCacheSpec extends AsyncFlatSpec with Matchers with MockitoSugar with 
           SizedCache.Configuration(2),
           new CacheMetrics(
             new MetricName(Vector("test")),
-            new DropwizardMetricsFactory(new MetricRegistry),
+            NoOpMetricsFactory,
           ),
         ),
         registerUpdateTimer = cacheUpdateTimer,

--- a/observability/metrics/src/main/scala/com/daml/metrics/CacheMetrics.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/CacheMetrics.scala
@@ -4,17 +4,22 @@
 package com.daml.metrics
 
 import com.daml.metrics.api.MetricDoc.MetricQualification.Debug
-import com.daml.metrics.api.MetricHandle.{Counter, MetricsFactory}
+import com.daml.metrics.api.MetricHandle.{Counter, LabeledMetricsFactory}
 import com.daml.metrics.api.{MetricDoc, MetricName, MetricsContext}
 import com.daml.scalautil.Statement.discard
 
-final class CacheMetrics(val prefix: MetricName, val factory: MetricsFactory) {
+final class CacheMetrics(name: String, factory: LabeledMetricsFactory) {
+
+  private val prefix = MetricName.Daml :+ "cache"
+
+  private implicit val mc: MetricsContext = MetricsContext("name" -> name)
 
   @MetricDoc.Tag(
     summary = "The number of cache hits.",
     description = """When a cache lookup encounters an existing cache entry, the counter is
                     |incremented.""",
     qualification = Debug,
+    labelsWithDescription = Map("name" -> "The cache for which the metrics are registered."),
   )
   val hitCount: Counter = factory.counter(prefix :+ "hits")
 
@@ -23,6 +28,7 @@ final class CacheMetrics(val prefix: MetricName, val factory: MetricsFactory) {
     description = """When a cache lookup first encounters a missing cache entry, the counter is
                     |incremented.""",
     qualification = Debug,
+    labelsWithDescription = Map("name" -> "The cache for which the metrics are registered."),
   )
   val missCount: Counter = factory.counter(prefix :+ "misses")
 
@@ -30,6 +36,7 @@ final class CacheMetrics(val prefix: MetricName, val factory: MetricsFactory) {
     summary = "The number of the evicted cache entries.",
     description = "When an entry is evicted from the cache, the counter is incremented.",
     qualification = Debug,
+    labelsWithDescription = Map("name" -> "The cache for which the metrics are registered."),
   )
   val evictionCount: Counter = factory.counter(prefix :+ "evictions")
 
@@ -37,6 +44,7 @@ final class CacheMetrics(val prefix: MetricName, val factory: MetricsFactory) {
     summary = "The sum of weights of cache entries evicted.",
     description = "The total weight of the entries evicted from the cache.",
     qualification = Debug,
+    labelsWithDescription = Map("name" -> "The cache for which the metrics are registered."),
   )
   val evictionWeight: Counter = factory.counter(prefix :+ "evicted_weight")
 

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/MetricDoc.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/MetricDoc.scala
@@ -34,6 +34,11 @@ object MetricDoc {
       labelsWithDescription: Map[String, String] = Map.empty,
   ) extends StaticAnnotation
 
+  // The GroupTag can be defined for metrics that belong in the same class, are used in multiple
+  // places and can be grouped using a wildcard (the representative). The metrics of the class
+  // should be annotated with a Tag.
+  case class GroupTag(representative: String, groupableClass: Class[_]) extends StaticAnnotation
+
   // The FanTag is used to define a documentation entry that will fan out and represent all the
   // metrics that are tagged with a FanInstanceTag and whose name matches the given representative
   // wildcard.

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/MetricDoc.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/MetricDoc.scala
@@ -34,11 +34,6 @@ object MetricDoc {
       labelsWithDescription: Map[String, String] = Map.empty,
   ) extends StaticAnnotation
 
-  // The GroupTag can be defined for metrics that belong in the same class, are used in multiple
-  // places and can be grouped using a wildcard (the representative). The metrics of the class
-  // should be annotated with a Tag.
-  case class GroupTag(representative: String, groupableClass: Class[_]) extends StaticAnnotation
-
   // The FanTag is used to define a documentation entry that will fan out and represent all the
   // metrics that are tagged with a FanInstanceTag and whose name matches the given representative
   // wildcard.


### PR DESCRIPTION
This simplifies the cache metrics.
This removes the need to have @GroupTag for metrics documentation.

<table>
<tr>
	<td>Old metric
	<td>New Metric
<tr>
	<td>daml.{{prefix}}.{{cache_name}}.hits
	<td>daml.cache.hits {name={{cache_name}}}
<tr>
	<td>daml.{{prefix}}.{{cache_name}}.misses
	<td>daml.cache.misses {name={{cache_name}}}
<tr>
	<td>daml.{{prefix}}.{{cache_name}}.evictions
	<td>daml.cache.evictions {name={{cache_name}}}
<tr>
	<td>daml.{{prefix}}.{{cache_name}}.evicted_weight
	<td>daml.cache.evicted_weight {name={{cache_name}}}
<tr>
	<td>daml.{{prefix}}.{{cache_name}}.size
	<td>daml.cache.size {name={{cache_name}}}
<tr>
	<td>daml.{{prefix}}.{{cache_name}}.weight
	<td>daml.cache.weight {name={{cache_name}}}
</table>

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
