### PR TITLE
Trigger logging context fix for speedy machine evaluations

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -532,6 +532,7 @@ private[lf] object Speedy {
       unhandledException(excep)
 
     @nowarn("msg=dead code following this construct")
+    @tailrec
     def runPure(): Either[SError, SValue] =
       run() match {
         case SResultError(err) => Left(err)

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -54,7 +54,6 @@ import com.daml.lf.language.Ast._
 import com.daml.lf.language.PackageInterface
 import com.daml.lf.language.Util._
 import com.daml.lf.speedy.SExpr._
-import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.{Compiler, Pretty, SValue, Speedy}
 import com.daml.lf.{CompiledPackages, PureCompiledPackages}
@@ -169,19 +168,14 @@ private[lf] object Machine {
 
   // Run speedy until we arrive at a value.
   def stepToValue(
-      machine: Speedy.PureMachine
+      compiledPackages: CompiledPackages,
+      expr: SExpr,
   )(implicit triggerContext: TriggerLogContext): SValue = {
-    machine.run() match {
-      case SResultFinal(v) => v
-      case SResultError(err) => {
+    Speedy.Machine.runPureSExpr(expr, compiledPackages) match {
+      case Right(v) => v
+      case Left(err) =>
         triggerContext.logError(Pretty.prettyError(err).render(80))
         throw err
-      }
-      case res => {
-        val errMsg = s"Unexpected speedy result: $res"
-        triggerContext.logError(errMsg)
-        throw new RuntimeException(errMsg)
-      }
     }
   }
 }
@@ -377,8 +371,7 @@ object Trigger {
     val heartbeat = compiler.unsafeCompile(
       ERecProj(triggerDef.ty, Name.assertFromString("heartbeat"), triggerDef.expr)
     )
-    val machine = Speedy.Machine.fromPureSExpr(compiledPackages, heartbeat)
-    Machine.stepToValue(machine) match {
+    Machine.stepToValue(compiledPackages, heartbeat) match {
       case SOptional(None) => Right(None)
       case SOptional(Some(relTime)) => converter.toFiniteDuration(relTime).map(Some(_))
       case value => Left(s"Expected Optional but got $value.")
@@ -395,7 +388,6 @@ object Trigger {
     val registeredTemplates = compiler.unsafeCompile(
       ERecProj(triggerDef.ty, Name.assertFromString("registeredTemplates"), triggerDef.expr)
     )
-    val machine = Speedy.Machine.fromPureSExpr(compiledPackages, registeredTemplates)
     val packages = compiledPackages.packageIds
       .map(pkgId => (pkgId, compiledPackages.pkgInterface.lookupPackage(pkgId).toOption.get))
       .toSeq
@@ -425,7 +417,7 @@ object Trigger {
         })
       })
 
-    Machine.stepToValue(machine) match {
+    Machine.stepToValue(compiledPackages, registeredTemplates) match {
       case SVariant(_, "AllInDar", _, _) =>
         Right(
           Filters(
@@ -652,15 +644,6 @@ private[lf] class Runner private (
     }
 
     triggerContext.childSpan("step") { implicit triggerContext: TriggerLogContext =>
-      def evaluate(se: SExpr): SValue = {
-        val machine: Speedy.PureMachine =
-          Speedy.Machine.fromPureSExpr(compiledPackages, se)
-
-        // Evaluate it.
-        machine.setExpressionToEvaluate(se)
-        Machine.stepToValue(machine)
-      }
-
       type Termination = SValue \/ (TriggerContext[SubmitRequest], SValue)
       @tailrec def go(v: SValue): Termination = {
         numberOfRuleEvaluations += 1
@@ -693,7 +676,9 @@ private[lf] class Runner private (
                 vvv.match2 {
                   case "GetTime" /*(Time -> a)*/ => { case DamlFun(timeA) =>
                     numberOfGetTimes += 1
-                    Right(evaluate(makeAppD(timeA, STimestamp(clientTime))))
+                    Right(
+                      Machine.stepToValue(compiledPackages, makeAppD(timeA, STimestamp(clientTime)))
+                    )
                   }
                   case "Submit" /*([Command], Text -> a)*/ => {
                     case DamlTuple2(sCommands, DamlFun(textA)) =>
@@ -711,7 +696,10 @@ private[lf] class Runner private (
                         \/-(
                           (
                             Ctx(triggerContext, submitRequest),
-                            evaluate(makeAppD(textA, SText((commandUUID: UUID).toString))),
+                            Machine.stepToValue(
+                              compiledPackages,
+                              makeAppD(textA, SText((commandUUID: UUID).toString)),
+                            ),
                           )
                         ): Termination
                       )
@@ -919,7 +907,7 @@ private[lf] class Runner private (
 
   private[this] def getTriggerInitialStateLambda(
       acs: Seq[CreatedEvent]
-  )(implicit machine: Speedy.PureMachine, triggerContext: TriggerLogContext): SValue = {
+  )(implicit triggerContext: TriggerLogContext): SValue = {
     // Compile the trigger initialState LF function to a speedy expression
     val getInitialState: SExpr =
       compiler.unsafeCompile(
@@ -932,9 +920,8 @@ private[lf] class Runner private (
         trigger.initialStateArguments(parties, acs, triggerConfig, converter),
       )
 
-    machine.setExpressionToEvaluate(initialState)
     Machine
-      .stepToValue(machine)
+      .stepToValue(compiledPackages, initialState)
       .expect(
         "TriggerSetup",
         { case DamlAnyModuleRecord("TriggerSetup", fts) => fts }: @nowarn(
@@ -945,8 +932,7 @@ private[lf] class Runner private (
   }
 
   private[this] def getTriggerUpdateLambda()(implicit
-      machine: Speedy.PureMachine,
-      triggerContext: TriggerLogContext,
+      triggerContext: TriggerLogContext
   ): SValue = {
     // Compile the trigger Update LF function to a speedy expression
     val update: SExpr =
@@ -954,8 +940,7 @@ private[lf] class Runner private (
         ERecProj(trigger.defn.ty, Name.assertFromString("update"), trigger.defn.expr)
       )
 
-    machine.setExpressionToEvaluate(update)
-    Machine.stepToValue(machine)
+    Machine.stepToValue(compiledPackages, update)
   }
 
   private[this] def encodeMsgs: TriggerContextualFlow[TriggerMsg, SValue, NotUsed] =
@@ -1027,7 +1012,6 @@ private[lf] class Runner private (
   private[trigger] def runInitialState(clientTime: Timestamp, killSwitch: KillSwitch)(
       acs: Seq[CreatedEvent]
   )(implicit
-      machine: Speedy.PureMachine,
       materializer: Materializer,
       triggerContext: TriggerLogContext,
   ): Graph[SourceShape2[SValue, TriggerContext[SubmitRequest]], NotUsed] = {
@@ -1109,7 +1093,6 @@ private[lf] class Runner private (
   private[trigger] def runRuleOnMsgs(
       killSwitch: KillSwitch
   )(implicit
-      machine: Speedy.PureMachine,
       materializer: Materializer,
       triggerContext: TriggerLogContext,
   ): Graph[
@@ -1155,9 +1138,8 @@ private[lf] class Runner private (
 
       val clientTime: Timestamp =
         Timestamp.assertFromInstant(Runner.getTimeProvider(timeProviderType).getCurrentTime)
-      machine.setExpressionToEvaluate(makeAppD(updateStateLambda, messageVal.value))
       val stateFun = Machine
-        .stepToValue(machine)
+        .stepToValue(compiledPackages, makeAppD(updateStateLambda, messageVal.value))
         .expect(
           "TriggerRule",
           { case DamlAnyModuleRecord("TriggerRule", DamlAnyModuleRecord("StateT", fun)) =>
@@ -1165,8 +1147,7 @@ private[lf] class Runner private (
           }: @nowarn("msg=A repeated case parameter .* is not matched by a sequence wildcard"),
         )
         .orConverterException
-      machine.setExpressionToEvaluate(makeAppD(stateFun, state))
-      val updateWithNewState = Machine.stepToValue(machine)
+      val updateWithNewState = Machine.stepToValue(compiledPackages, makeAppD(stateFun, state))
 
       freeTriggerSubmits(clientTime, v = updateWithNewState, killSwitch)
         .leftMap(
@@ -1247,10 +1228,6 @@ private[lf] class Runner private (
     val clientTime: Timestamp =
       Timestamp.assertFromInstant(Runner.getTimeProvider(timeProviderType).getCurrentTime)
     val hardLimitKillSwitch = KillSwitches.shared("hard-limit")
-
-    // Prepare a speedy machine for evaluating expressions
-    implicit val machine: Speedy.PureMachine =
-      Speedy.Machine.fromPureSExpr(compiledPackages, SEValue(SUnit))
 
     import UnfoldState.{flatMapConcatNodeOps, toSourceOps}
 


### PR DESCRIPTION
Previously, the trigger would reuse the Speedy machine (a premature optimisation). As creation of the Speedy machine fixes the logging context it will use, this could lead to an invalid logging context being used when evaluating Speedy expressions - especially builtins such as `SBTrace`.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
