### PR TITLE
[engine] fix node seeds for tx with auth node

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -344,11 +344,20 @@ private[lf] object Speedy {
         }
         .to(ImmArray)
 
+    def zipSameLength[X, Y](xs: ImmArray[X], ys: ImmArray[Y]): ImmArray[(X, Y)] = {
+      val n1 = xs.length
+      val n2 = ys.length
+      if (n1 != n2) {
+        sys.error(s"sameLengthZip, $n1 /= $n2")
+      }
+      xs.zip(ys)
+    }
+
     def finish: Either[SErrorCrash, UpdateMachine.Result] = ptx.finish.map { case (tx, seeds) =>
       UpdateMachine.Result(
         tx,
         ptx.locationInfo(),
-        seeds zip ptx.actionNodeSeeds.toImmArray, // TODO: assert same length before zip
+        zipSameLength(seeds, ptx.actionNodeSeeds.toImmArray),
         ptx.contractState.globalKeyInputs.transform((_, v) => v.toKeyMapping),
         disclosedCreateEvents,
       )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -344,11 +344,12 @@ private[lf] object Speedy {
         }
         .to(ImmArray)
 
+    @throws[IllegalArgumentException]
     def zipSameLength[X, Y](xs: ImmArray[X], ys: ImmArray[Y]): ImmArray[(X, Y)] = {
       val n1 = xs.length
       val n2 = ys.length
       if (n1 != n2) {
-        sys.error(s"sameLengthZip, $n1 /= $n2")
+        throw new IllegalArgumentException(s"sameLengthZip, $n1 /= $n2")
       }
       xs.zip(ys)
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -348,7 +348,7 @@ private[lf] object Speedy {
       UpdateMachine.Result(
         tx,
         ptx.locationInfo(),
-        seeds zip ptx.actionNodeSeeds.toImmArray,
+        seeds zip ptx.actionNodeSeeds.toImmArray, // TODO: assert same length before zip
         ptx.contractState.globalKeyInputs.transform((_, v) => v.toKeyMapping),
         disclosedCreateEvents,
       )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
@@ -186,11 +186,9 @@ private[lf] object NormalizeRollbacks {
               }
             }
           case Norm.Aut(aut, subs) =>
-            s.pushSeedId(me) { s =>
-              pushNorms(s, subs) { (s, children) =>
-                val node = aut.copy(children = children.to(ImmArray))
-                s.push(me, node)(k)
-              }
+            pushNorms(s, subs) { (s, children) =>
+              val node = aut.copy(children = children.to(ImmArray))
+              s.push(me, node)(k)
             }
         }
       }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -542,13 +542,10 @@ private[speedy] case class PartialTransaction(
       case ec: ExercisesContextInfo =>
         val exerciseNode = makeExNode(ec).copy(children = context.children.toImmArray)
         val nodeId = ec.nodeId
-        val actionNodeSeed = context.nextActionChildSeed
         copy(
           context =
             ec.parent.addActionChild(nodeId, exerciseNode.version min context.minChildVersion),
           nodes = nodes.updated(nodeId, exerciseNode),
-          actionNodeSeeds =
-            actionNodeSeeds :+ actionNodeSeed, // (NC) pushed by 'beginExercises'; why push again?
         )
       case _ =>
         InternalError.runtimeException(

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
@@ -186,7 +186,10 @@ class RollbackTest extends AnyWordSpec with Matchers with TableDrivenPropertyChe
     ("create3throwAndCatch", List[Tree](R(List(C(100), C(200))), C(300))),
     ("create3throwAndOuterCatch", List[Tree](R(List(C(100), C(200))), C(300))),
     ("exer1", List[Tree](C(100), X(List(C(400), C(500))), C(200), C(300))),
-    ("exer2", List[Tree](C(100), R(List(X(List(C(400))))), C(300))),
+    (
+      "exer2", // TODO: this test fails if we add a _seeds length match_ assertion in Speedy.finish
+      List[Tree](C(100), R(List(X(List(C(400))))), C(300)),
+    ),
   )
 
   forEvery(testCases) { (exp: String, expected: List[Tree]) =>

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
@@ -186,10 +186,7 @@ class RollbackTest extends AnyWordSpec with Matchers with TableDrivenPropertyChe
     ("create3throwAndCatch", List[Tree](R(List(C(100), C(200))), C(300))),
     ("create3throwAndOuterCatch", List[Tree](R(List(C(100), C(200))), C(300))),
     ("exer1", List[Tree](C(100), X(List(C(400), C(500))), C(200), C(300))),
-    (
-      "exer2", // TODO: this test fails if we add a _seeds length match_ assertion in Speedy.finish
-      List[Tree](C(100), R(List(X(List(C(400))))), C(300)),
-    ),
+    ("exer2", List[Tree](C(100), R(List(X(List(C(400))))), C(300))),
   )
 
   forEvery(testCases) { (exp: String, expected: List[Tree]) =>


### PR DESCRIPTION
This fixes the problem with the node-seeds for a TX with an authority node.

The code in `NormalizeRollbacks.scala` post-processes the transaction constructed by `PartialTransaction.scala` to produce a TX which satisfies the rollback-normalization rules. In the process the node-ids are completely rewritten.

As a secondary job, this code returns a list (`seeds`) of (rewritten) node-ids which correspond to a pre-order traversal of the Create and Exercise nodes. This `seeds` list should match up with the `actionNodeSeeds` contained in the original `PartialTransaction`, and is `zip`ed together in `Speedy.finish`

The bug (which is fixed in this PR) is that `NormalizeRollbacks` was calling `pushSeedId` for the `Authority` nodes as it reconstructed the TX. This bug might have been detected if the `zip` in `Speedy.finish` was guarded by an assertion that the two lists/arrays had equal size.

Unfortunately if we add this assertion, it is triggered by the `exer2` test in `RollbackTest.scala` -- I suspect that this indicates a further bug (which I am investigating). ... YES.

Found and fixed bug in `PartialTransaction.endExercises`.

Add the assertion in `Speedy.finish` to ensure the two zipped arrays have the same length,
