### PR TITLE
Fix controller unused arg warning for interface archives

### DIFF
--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "486d1fe570c9111b0c03ad9cb1ac08e8f6c34d28"
+GHC_REV = "3d4ce6bd43d93085365f7f7c1bfd58637e060ee5"
 GHC_PATCHES = [
 ]
 

--- a/compiler/damlc/tests/daml-test-files/AmbiguousInterfaceInstance.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/AmbiguousInterfaceInstance.EXPECTED.desugared-daml
@@ -157,8 +157,7 @@ _choice$_BarArchive :
    DA.Internal.Desugar.Optional (Bar
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_BarArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Bar BarView where

--- a/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.desugared-daml
@@ -208,8 +208,7 @@ _choice$_TokenArchive :
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_TokenSplit :

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision2.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision2.EXPECTED.desugared-daml
@@ -104,8 +104,7 @@ _choice$_InterfaceArchive :
    DA.Internal.Desugar.Optional (Interface
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_InterfaceArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_InterfaceMyArchive :

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailed.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailed.EXPECTED.desugared-daml
@@ -91,8 +91,7 @@ _choice$_IArchive :
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_IIChoice :

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailedNotExtended.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailedNotExtended.EXPECTED.desugared-daml
@@ -91,8 +91,7 @@ _choice$_IArchive :
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_IIChoice :

--- a/compiler/damlc/tests/daml-test-files/InterfaceContractDoesNotImplementInterface.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceContractDoesNotImplementInterface.EXPECTED.desugared-daml
@@ -64,8 +64,7 @@ _choice$_IArchive :
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
@@ -167,8 +166,7 @@ _choice$_JArchive :
    DA.Internal.Desugar.Optional (J
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_JArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_JJChoice :

--- a/compiler/damlc/tests/daml-test-files/InterfaceControllerUnusedWarning.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceControllerUnusedWarning.daml
@@ -1,0 +1,11 @@
+{-# OPTIONS_GHC -Wunused-matches #-}
+-- @SINCE-LF-FEATURE DAML_INTERFACE
+
+module InterfaceControllerUnusedWarning where
+
+data IView = IView {}
+
+-- Previously "Defined but not used: ‘arg’" was thrown by the Archive method on the interface
+-- This is a regression test for that fix
+interface I where
+  viewtype IView

--- a/compiler/damlc/tests/daml-test-files/InterfaceConversions.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceConversions.EXPECTED.desugared-daml
@@ -94,8 +94,7 @@ _choice$_IfaceArchive :
    DA.Internal.Desugar.Optional (Iface
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IfaceArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_IfaceMyChoice :
@@ -204,8 +203,7 @@ _choice$_Iface2Archive :
    DA.Internal.Desugar.Optional (Iface2
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_Iface2Archive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_Iface2MyChoice2 :

--- a/compiler/damlc/tests/daml-test-files/InterfaceDoubleSpend.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceDoubleSpend.EXPECTED.desugared-daml
@@ -107,8 +107,7 @@ _choice$_TokenArchive :
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_TokenTransfer :

--- a/compiler/damlc/tests/daml-test-files/InterfaceEmpty.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceEmpty.EXPECTED.desugared-daml
@@ -66,8 +66,7 @@ _choice$_IArchive :
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceEq.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceEq.EXPECTED.desugared-daml
@@ -64,8 +64,7 @@ _choice$_IArchive :
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceErrors.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceErrors.EXPECTED.desugared-daml
@@ -94,8 +94,7 @@ _choice$_MyInterfaceArchive :
    DA.Internal.Desugar.Optional (MyInterface
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_MyInterfaceArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_MyInterfaceMyVirtualChoice :

--- a/compiler/damlc/tests/daml-test-files/InterfaceFunctions.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceFunctions.EXPECTED.desugared-daml
@@ -69,8 +69,7 @@ _choice$_TokenArchive :
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceGuarded.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceGuarded.EXPECTED.desugared-daml
@@ -105,8 +105,7 @@ _choice$_TokenArchive :
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_TokenGetRich :
@@ -204,8 +203,7 @@ _choice$_SubTokenArchive :
    DA.Internal.Desugar.Optional (SubToken
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_SubTokenArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView SubToken EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceGuardedNotExtended.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceGuardedNotExtended.EXPECTED.desugared-daml
@@ -105,8 +105,7 @@ _choice$_TokenArchive :
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_TokenGetRich :

--- a/compiler/damlc/tests/daml-test-files/InterfaceNameCollision.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNameCollision.EXPECTED.desugared-daml
@@ -95,8 +95,7 @@ _choice$_IfaceArchive :
    DA.Internal.Desugar.Optional (Iface
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IfaceArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_IfaceFooBar :

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseRequiring.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseRequiring.EXPECTED.desugared-daml
@@ -104,8 +104,7 @@ _choice$_TokenArchive :
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_TokenGetRich :
@@ -203,8 +202,7 @@ _choice$_SubTokenArchive :
    DA.Internal.Desugar.Optional (SubToken
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_SubTokenArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView SubToken EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseTemplate.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseTemplate.EXPECTED.desugared-daml
@@ -104,8 +104,7 @@ _choice$_TokenArchive :
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_TokenGetRich :

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoMethodOnRequiring.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoMethodOnRequiring.EXPECTED.desugared-daml
@@ -75,8 +75,7 @@ _choice$_TokenArchive :
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
@@ -154,8 +153,7 @@ _choice$_SubTokenArchive :
    DA.Internal.Desugar.Optional (SubToken
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_SubTokenArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView SubToken EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoMethodOnTemplate.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoMethodOnTemplate.EXPECTED.desugared-daml
@@ -75,8 +75,7 @@ _choice$_TokenArchive :
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceNotSupported.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNotSupported.EXPECTED.desugared-daml
@@ -64,8 +64,7 @@ _choice$_AArchive :
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircular.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircular.EXPECTED.desugared-daml
@@ -66,8 +66,7 @@ _choice$_AArchive :
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircularIndirect.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircularIndirect.EXPECTED.desugared-daml
@@ -72,8 +72,7 @@ _choice$_AArchive :
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where
@@ -148,8 +147,7 @@ _choice$_BArchive :
    DA.Internal.Desugar.Optional (B
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_BArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView B EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresClash.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresClash.EXPECTED.desugared-daml
@@ -82,8 +82,7 @@ _choice$_CArchive :
    DA.Internal.Desugar.Optional (C
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_CArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView C EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresClashA.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresClashA.EXPECTED.desugared-daml
@@ -64,8 +64,7 @@ _choice$_IArchive :
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresClashB.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresClashB.EXPECTED.desugared-daml
@@ -64,8 +64,7 @@ _choice$_IArchive :
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresError.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresError.EXPECTED.desugared-daml
@@ -64,8 +64,7 @@ _choice$_AArchive :
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where
@@ -140,8 +139,7 @@ _choice$_BArchive :
    DA.Internal.Desugar.Optional (B
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_BArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView B EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresNotClosed.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresNotClosed.EXPECTED.desugared-daml
@@ -64,8 +64,7 @@ _choice$_AArchive :
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where
@@ -140,8 +139,7 @@ _choice$_BArchive :
    DA.Internal.Desugar.Optional (B
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_BArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView B EmptyInterfaceView where
@@ -216,8 +214,7 @@ _choice$_CArchive :
    DA.Internal.Desugar.Optional (C
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_CArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView C EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityArgument.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityArgument.EXPECTED.desugared-daml
@@ -103,8 +103,7 @@ _choice$_IArchive :
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_INonSerializableArgument :

--- a/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityPayload.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityPayload.EXPECTED.desugared-daml
@@ -93,8 +93,7 @@ _choice$_GettableArchive :
    DA.Internal.Desugar.Optional (Gettable
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_GettableArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_GettableGet :

--- a/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityResult.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityResult.EXPECTED.desugared-daml
@@ -96,8 +96,7 @@ _choice$_IArchive :
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_INonSerializableResult :

--- a/compiler/damlc/tests/daml-test-files/InterfaceSyntax.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSyntax.EXPECTED.desugared-daml
@@ -71,8 +71,7 @@ _choice$_IArchive :
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
@@ -139,8 +138,7 @@ _choice$_JArchive :
    DA.Internal.Desugar.Optional (J
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_JArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView J EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.EXPECTED.desugared-daml
@@ -94,8 +94,7 @@ _choice$_AArchive :
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_AChoiceA :
@@ -211,8 +210,7 @@ _choice$_BArchive :
    DA.Internal.Desugar.Optional (B
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_BArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_BChoiceB :

--- a/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.desugared-daml
@@ -213,8 +213,7 @@ _choice$_TokenArchive :
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_TokenSplit :

--- a/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.desugared-daml
@@ -213,8 +213,7 @@ _choice$_TokenArchive :
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
-  = (\ this arg@DA.Internal.Desugar.Archive
-       -> DA.Internal.Desugar.signatory this, 
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.None)
 _choice$_TokenSplit :


### PR DESCRIPTION
Resolves #16416 
Relevant GHC changes: https://github.com/digital-asset/ghc/pull/161

CHANGELOG_BEGIN

- [Daml Compiler] Fix "Defined but not used: ‘arg’" warning for interfaces when `-Wunused-matches` is enabled
See `#16416 <https://github.com/digital-asset/daml/issues/16416>`__.

CHANGELOG_END