### PR TITLE
[engine] handle Authority nodes in engine blinding

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -89,7 +89,8 @@ object Blinding {
     val entries = blindingInfo.disclosure.view.flatMap { case (nodeId, parties) =>
       def toEntries(tyCon: Ref.TypeConName) = parties.view.map(_ -> tyCon.packageId)
       tx.nodes(nodeId) match {
-        case _: Node.Authority => ??? // TODO #15882 -- we are not sure. leave for now
+        case _: Node.Authority =>
+          Iterable.empty
         case action: Node.LeafOnlyAction =>
           toEntries(action.templateId)
         case exe: Node.Exercise =>


### PR DESCRIPTION
Advances #15882

Seems that nothing must be done for `Authority` nodes.
No traversal of children is required (same as exercise) because this code is already iterating over all a set of node-ids.