### PR TITLE
[Speedy] drop bultins made useless by #16320

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -13,7 +13,6 @@ import com.daml.lf.speedy.ClosureConversion.closureConvert
 import com.daml.lf.speedy.PhaseOne.{Env, Position}
 import com.daml.lf.speedy.Profile.LabelModule
 import com.daml.lf.speedy.SBuiltin._
-import com.daml.lf.speedy.SExpr.{ContractKeyWithMaintainersDefRef, ToCachedContractDefRef}
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.{SExpr => t} // target expressions
 import com.daml.lf.speedy.{SExpr0 => s} // source expressions
@@ -340,11 +339,11 @@ private[lf] final class Compiler(
       sexpr: t.SExpr,
       disclosures: ImmArray[DisclosedContract],
   ): t.SExpr = {
-    val disclosureLambda = pipeline(
-      translateContractDisclosureLambda(Env.Empty, disclosures)
+    val disclosuresExpr = pipeline(
+      translateContractDisclosures(Env.Empty, disclosures)
     )
     t.SELet1(
-      t.SEApp(disclosureLambda, Array(SValue.Unit)),
+      disclosuresExpr,
       sexpr,
     )
   }
@@ -1061,107 +1060,37 @@ private[lf] final class Compiler(
         }
     }
 
-  private[this] def translateDisclosedContractWithTemplateChecked(
-      env: Env,
-      templateId: Identifier,
-      disclosedContract: DisclosedContract,
-  ): s.SExpr = {
-    let(env, s.SEApp(s.SEBuiltin(SBCheckTemplateKey(templateId)), List(s.SEValue.Unit))) {
-      (templateKeyCheck, env) =>
-        val contract = s.SEValue(disclosedContract.argument)
-
-        s.SECase(
-          env.toSEVar(templateKeyCheck),
-          List(
-            s.SCaseAlt(
-              t.SCPPrimCon(PCTrue),
-              let(
-                env,
-                s.SEApp(
-                  s.SEVal(ContractKeyWithMaintainersDefRef(templateId)),
-                  List(contract),
-                ),
-              ) { (contractPos, env) =>
-                let(env, s.SEApp(s.SEBuiltin(SBSome), List(env.toSEVar(contractPos)))) {
-                  (optionalContractPos, env) =>
-                    s.SEApp(
-                      s.SEVal(ToCachedContractDefRef(templateId)),
-                      List(contract, env.toSEVar(optionalContractPos)),
-                    )
-                }
-              },
-            ),
-            s.SCaseAlt(
-              t.SCPDefault,
-              s.SEApp(
-                s.SEVal(ToCachedContractDefRef(templateId)),
-                List(contract, s.SEValue.None),
-              ),
-            ),
-          ),
-        )
-    }
-  }
-
-  private[this] def translateDisclosedContract(
-      env: Env,
-      disclosedContract: DisclosedContract,
-  ): s.SExpr = {
-    val templateId = disclosedContract.templateId
-    val contract = s.SEValue(disclosedContract.argument)
-
-    let(env, s.SEApp(s.SEBuiltin(SBCheckTemplate(templateId)), List(s.SEValue.Unit))) {
-      (templateCheck, env) =>
-        s.SECase(
-          env.toSEVar(templateCheck),
-          List(
-            s.SCaseAlt(
-              t.SCPPrimCon(PCTrue),
-              checkPreCondition(
-                env,
-                templateId,
-                contract,
-              ) { (env: Env) =>
-                translateDisclosedContractWithTemplateChecked(env, templateId, disclosedContract)
-              },
-            ),
-            s.SCaseAlt(
-              t.SCPDefault,
-              s.SEApp(
-                s.SEBuiltin(SBCrash(s"Template $templateId does not exist and it should")),
-                List(s.SEValue.Unit),
-              ),
-            ),
-          ),
-        )
-    }
-  }
-
-  private[this] def translateContractDisclosureLambda(
-      env: Env,
+  private[this] def translateContractDisclosures(
+      env0: Env,
       disclosures: ImmArray[DisclosedContract],
   ): s.SExpr = {
     // The next free environment variable will be the bound variable in the contract disclosure lambda
-    val baseIndex = env.nextPosition.idx
+    var env = env0
 
-    s.SEAbs(
-      1,
-      s.SELet(
-        disclosures.toList.zipWithIndex.flatMap { case (disclosedContract, offset) =>
-          // Let bounded variables occur after the contract disclosure bound variable - hence baseIndex+1
-          // For each disclosed contract, we add 2 members to our let bounded list - hence 2*offset
-          val contractIndex = baseIndex + 2 * offset + 1
+    s.SELet(
+      disclosures.toList.flatMap { case DisclosedContract(templateId, contractId, argument, _) =>
+        // Let bounded variables occur after the contract disclosure bound variable - hence baseIndex+1
+        // For each disclosed contract, we add 2 members to our let bounded list - hence 2*offset
 
-          List(
-            translateDisclosedContract(env.copy(contractIndex), disclosedContract),
-            app(
-              s.SEBuiltin(SBCacheDisclosedContract(disclosedContract.contractId.value)),
-              s.SEVarLevel(contractIndex),
-            ),
+        val expr1 = checkPreCondition(
+          env,
+          templateId,
+          s.SEValue(argument),
+        )((_) =>
+          s.SEApp(
+            s.SEVal(t.ToCachedContractDefRef(templateId)),
+            List(s.SEValue(argument), s.SEValue.None),
           )
-        },
-        s.SEVarLevel(baseIndex),
-      ),
+        )
+        val contractPos = env.nextPosition
+        env = env.pushVar
+        val expr2 =
+          app(s.SEBuiltin(SBCacheDisclosedContract(contractId.value)), env.toSEVar(contractPos))
+        env = env.pushVar
+
+        List(expr1, expr2)
+      },
+      s.SEValue.Unit,
     )
   }
 }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -948,33 +948,6 @@ private[lf] object SBuiltin {
     }
   }
 
-  /** $checkTemplate[T] :: Unit -> bool */
-  private[speedy] final case class SBCheckTemplate(templateId: TypeConName) extends SBuiltin(1) {
-
-    override private[speedy] def execute[Q](
-        args: util.ArrayList[SValue],
-        machine: Machine[Q],
-    ): Control.Value = {
-      getSUnit(args, 0)
-      Control.Value(SBool(machine.compiledPackages.pkgInterface.lookupTemplate(templateId).isRight))
-    }
-  }
-
-  /** $checkTemplateKey[T] :: Unit -> bool */
-  private[speedy] final case class SBCheckTemplateKey(templateId: TypeConName) extends SBuiltin(1) {
-
-    override private[speedy] def execute[Q](
-        args: util.ArrayList[SValue],
-        machine: Machine[Q],
-    ): Control[Q] = {
-      getSUnit(args, 0)
-
-      Control.Value(
-        SBool(machine.compiledPackages.pkgInterface.lookupTemplateKey(templateId).isRight)
-      )
-    }
-  }
-
   /** $create
     *    :: Text (agreement text)
     *    -> CachedContract

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/CompilerTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/CompilerTest.scala
@@ -9,7 +9,7 @@ import com.daml.lf.data.Ref.Party
 import com.daml.lf.data._
 import com.daml.lf.interpretation.Error.TemplatePreconditionViolated
 import com.daml.lf.language.Ast._
-import com.daml.lf.speedy.SError.{SError, SErrorCrash, SErrorDamlException}
+import com.daml.lf.speedy.SError.{SError, SErrorDamlException}
 import com.daml.lf.speedy.SExpr.SExpr
 import com.daml.lf.speedy.SValue.SContractId
 import com.daml.lf.speedy.Speedy.CachedContract
@@ -62,25 +62,6 @@ class CompilerTest extends AnyWordSpec with Matchers with Inside {
       Value.ContractId.V1(crypto.Hash.hashPrivateKey("disclosed-test-contract-id-1"))
     val disclosedCid2 =
       Value.ContractId.V1(crypto.Hash.hashPrivateKey("disclosed-test-contract-id-2"))
-
-    "non-existent templates should crash compilation" in {
-      val invalidTemplateId = Ref.Identifier.assertFromString("-pkgId-:Module:Invalid")
-      val invalidDisclosedContract = buildDisclosedContract(cid1, alice, invalidTemplateId)
-      val invalidVersionedContract = VersionedContractInstance(
-        version,
-        invalidTemplateId,
-        invalidDisclosedContract.argument.toUnnormalizedValue,
-      )
-      val sexpr = compiledPackages.compiler.unsafeCompileWithContractDisclosures(
-        tokenApp(compiledPackages.compiler.unsafeCompile(ImmArray.Empty)),
-        ImmArray(invalidDisclosedContract),
-      )
-
-      inside(evalSExpr(sexpr, getContract = Map(cid1 -> invalidVersionedContract))) {
-        case Left(SErrorCrash(_, message)) =>
-          message should endWith(s"Template $invalidTemplateId does not exist and it should")
-      }
-    }
 
     "using a template with preconditions" should {
       val templateId = Ref.Identifier.assertFromString("-pkgId-:Module:PreCondRecord")

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureLib.scala
@@ -156,19 +156,22 @@ object ExplicitDisclosureLib {
     )
   }
 
-  def buildContractKey(maintainer: Party, label: String = testKeyName): GlobalKey =
-    GlobalKey.assertBuild(
-      houseTemplateType,
-      Value.ValueRecord(
-        None,
-        ImmArray(
-          None -> Value.ValueText(label),
-          None -> Value.ValueList(FrontStack.from(ImmArray(Value.ValueParty(maintainer)))),
-        ),
+  def buildContractKeyValue(maintainer: Party, label: String = testKeyName) =
+    Value.ValueRecord(
+      None,
+      ImmArray(
+        None -> Value.ValueText(label),
+        None -> Value.ValueList(FrontStack.from(ImmArray(Value.ValueParty(maintainer)))),
       ),
     )
 
-  def buildContractSKey(maintainer: Party): SValue =
+  def buildContractKey(maintainer: Party, label: String = testKeyName): GlobalKey =
+    GlobalKey.assertBuild(
+      houseTemplateType,
+      buildContractKeyValue(maintainer, label),
+    )
+
+  def buildContractSKey(maintainer: Party, label: String = testKeyName): SValue =
     SValue.SStruct(
       fieldNames =
         Struct.assertFromNameSeq(Seq("globalKey", "maintainers").map(Ref.Name.assertFromString)),
@@ -177,7 +180,7 @@ object ExplicitDisclosureLib {
           keyType,
           ImmArray("label", "maintainers").map(Ref.Name.assertFromString),
           ArrayList(
-            SValue.SText(testKeyName),
+            SValue.SText(label),
             SValue.SList(FrontStack.from(ImmArray(SValue.SParty(maintainer)))),
           ),
         ),

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -10,13 +10,7 @@ import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.{Ref, _}
 import com.daml.lf.interpretation.{Error => IE}
 import com.daml.lf.language.Ast._
-import com.daml.lf.speedy.SBuiltin.{
-  SBCacheDisclosedContract,
-  SBCheckTemplate,
-  SBCheckTemplateKey,
-  SBCrash,
-  SBuildCachedContract,
-}
+import com.daml.lf.speedy.SBuiltin.{SBCacheDisclosedContract, SBCrash, SBuildCachedContract}
 import com.daml.lf.speedy.SError.{SError, SErrorCrash}
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue.{SValue => _, _}
@@ -1608,38 +1602,6 @@ class SBuiltinTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
       s"""eval[$exp] --> "$res"""" in {
         eval(e"$exp") shouldBe Right(res)
       }
-    }
-  }
-
-  "SBCheckTemplate" - {
-    "detects templates that exist" in {
-      val templateId = Ref.Identifier.assertFromString("-pkgId-:Mod:Iou")
-      eval(
-        SEApp(SEBuiltin(SBCheckTemplate(templateId)), Array(SUnit))
-      ) shouldBe Right(SBool(true))
-    }
-
-    "detects non-existent templates" in {
-      val templateId = Ref.Identifier.assertFromString("-pkgId-:Mod:NonExistent")
-      eval(
-        SEApp(SEBuiltin(SBCheckTemplate(templateId)), Array(SUnit))
-      ) shouldBe Right(SBool(false))
-    }
-  }
-
-  "SBCheckTemplateKey" - {
-    "detects keys that exist for the template" in {
-      val templateId = Ref.Identifier.assertFromString("-pkgId-:Mod:IouWithKey")
-      eval(
-        SEApp(SEBuiltin(SBCheckTemplateKey(templateId)), Array(SUnit))
-      ) shouldBe Right(SBool(true))
-    }
-
-    "detects non-existent template keys" in {
-      val templateId = Ref.Identifier.assertFromString("-pkgId-:Mod:Iou")
-      eval(
-        SEApp(SEBuiltin(SBCheckTemplateKey(templateId)), Array(SUnit))
-      ) shouldBe Right(SBool(false))
     }
   }
 

--- a/ledger/ledger-api-tests/tool/BUILD.bazel
+++ b/ledger/ledger-api-tests/tool/BUILD.bazel
@@ -113,7 +113,7 @@ conformance_test(
         "--crt $$(rlocation $$TEST_WORKSPACE/$(rootpath //test-common/test-certificates:client.crt))",
         "--cacrt $$(rlocation $$TEST_WORKSPACE/$(rootpath //test-common/test-certificates:ca.crt))",
         "--pem $$(rlocation $$TEST_WORKSPACE/$(rootpath //test-common/test-certificates:client.pem))",
-        "--additional=TLSOnePointThreeIT",
+        "--include=ExplicitDisclosureIT",
     ],
 )
 

--- a/ledger/ledger-api-tests/tool/BUILD.bazel
+++ b/ledger/ledger-api-tests/tool/BUILD.bazel
@@ -113,7 +113,7 @@ conformance_test(
         "--crt $$(rlocation $$TEST_WORKSPACE/$(rootpath //test-common/test-certificates:client.crt))",
         "--cacrt $$(rlocation $$TEST_WORKSPACE/$(rootpath //test-common/test-certificates:ca.crt))",
         "--pem $$(rlocation $$TEST_WORKSPACE/$(rootpath //test-common/test-certificates:client.pem))",
-        "--include=ExplicitDisclosureIT",
+        "--additional=TLSOnePointThreeIT",
     ],
 )
 


### PR DESCRIPTION
nameley SBCheckTemplate and SBCheckTemplateKey.  They were design to
dynamic checks which are done now by the preprocessing.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
