### PR TITLE
Update bond trading tests

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -752,7 +752,6 @@ damlc_compile_test(
 damlc_compile_test(
     name = "memory-bond-trading",
     srcs = [":bond-trading"],
-    enable_scenarios = True,  # TODO: https://github.com/digital-asset/daml/issues/11316
     enable_scripts = True,
     heap_limit = "200M" if is_windows else "100M",
     main = "bond-trading/Test.daml",

--- a/compiler/damlc/tests/bond-trading/Bond.daml
+++ b/compiler/damlc/tests/bond-trading/Bond.daml
@@ -4,6 +4,10 @@
 
 module Bond where
 
+import Daml.Script
+
+import DA.Assert
+
 type BondId = ContractId Bond
 
 template Bond
@@ -32,7 +36,7 @@ template Bond
       with otherCid : BondId
       controller owner
       do otherBond <- fetch otherCid
-         assert $ this == otherBond with amount
+         this === otherBond with amount
          archive otherCid
          create this with amount = amount + otherBond.amount
 
@@ -66,64 +70,58 @@ template BondTransferRequest
 bondSplitMay : Party -> BondId -> Decimal -> Update (BondId, Optional BondId)
 bondSplitMay owner bondCid splitAmount = do
   bond <- fetch bondCid
-  assert $ bond.owner == owner
+  bond.owner === owner
   if bond.amount == splitAmount
     then return (bondCid, None)
     else do
       r <- exercise bondCid Split with splitAmount
       return (fst r, Some $ snd r)
 
-main = scenario do
-  acmeBank <- getParty "AcmeBank"
-  alice <- getParty "Alice"
-  bob <- getParty "Bob"
+main = script do
+  acmeBank <- allocateParty "AcmeBank"
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
 
-  bondAlice1Cid <-
-    submit acmeBank do
-      create BondTransferRequest with
-        issuer = acmeBank
-        owner = acmeBank
-        newOwner = alice
-        isin = "1234"
-        amount = 100.0
+  bondAlice1Cid <- acmeBank `submit` createCmd
+    BondTransferRequest with
+      issuer = acmeBank
+      owner = acmeBank
+      newOwner = alice
+      isin = "1234"
+      amount = 100.0
 
-  bondAlice1Cid <-
-    submit alice do exercise bondAlice1Cid Accept
+  bondAlice1Cid <- alice `submit` exerciseCmd bondAlice1Cid Accept
 
-  bondBob1Cid <-
-    submit acmeBank do
-      create BondTransferRequest with
-        issuer = acmeBank
-        owner = acmeBank
-        newOwner = bob
-        isin = "1234"
-        amount = 20.0
+  bondBob1Cid <- acmeBank `submit` createCmd
+    BondTransferRequest with
+      issuer = acmeBank
+      owner = acmeBank
+      newOwner = bob
+      isin = "1234"
+      amount = 20.0
 
-  bondBob1Cid <-
-    submit bob do exercise bondBob1Cid Accept
+  bondBob1Cid <- bob `submit` exerciseCmd bondBob1Cid Accept
 
   (bondAlice1Cid, bondAlice2Cid) <-
-    submit alice do exercise bondAlice1Cid Split with splitAmount = 30.0
+    alice `submit` exerciseCmd bondAlice1Cid Split with splitAmount = 30.0
 
   bondBob2Cid <-
-    submit alice do exercise bondAlice1Cid Transfer with newOwner = bob
+    alice `submit` exerciseCmd bondAlice1Cid Transfer with newOwner = bob
 
   bondBob2Cid <-
-    submit bob do exercise bondBob2Cid Accept
+    bob `submit` exerciseCmd bondBob2Cid Accept
 
   bondBob2Cid <-
-    submit bob do exercise bondBob1Cid Merge with otherCid = bondBob2Cid
+    bob `submit` exerciseCmd bondBob1Cid Merge with otherCid = bondBob2Cid
 
-  submit alice do
-    c <- fetch bondAlice2Cid
-    assertMsg "unexpected issuer" $ c.issuer == acmeBank
-    assertMsg "unexpected owner" $ c.owner == alice
-    assertMsg "unexpected isin" $ c.isin == "1234"
-    assertMsg "unexpected amount" $ c.amount == 70.0
+  Some bondAlice2 <- queryContractId alice bondAlice2Cid
+  assertMsg "unexpected issuer" $ bondAlice2.issuer == acmeBank
+  assertMsg "unexpected owner" $ bondAlice2.owner == alice
+  assertMsg "unexpected isin" $ bondAlice2.isin == "1234"
+  assertMsg "unexpected amount" $ bondAlice2.amount == 70.0
 
-  submit bob do
-    c <- fetch bondBob2Cid
-    assertMsg "unexpected issuer" $ c.issuer == acmeBank
-    assertMsg "unexpected owner" $ c.owner == bob
-    assertMsg "unexpected isin" $ c.isin == "1234"
-    assertMsg "unexpected amount" $ c.amount == 50.0
+  Some bondBob2 <- queryContractId bob bondBob2Cid
+  assertMsg "unexpected issuer" $ bondBob2.issuer == acmeBank
+  assertMsg "unexpected owner" $ bondBob2.owner == bob
+  assertMsg "unexpected isin" $ bondBob2.isin == "1234"
+  assertMsg "unexpected amount" $ bondBob2.amount == 50.0

--- a/compiler/damlc/tests/bond-trading/Cash.daml
+++ b/compiler/damlc/tests/bond-trading/Cash.daml
@@ -4,6 +4,9 @@
 
 module Cash where
 
+import Daml.Script
+
+import DA.Assert
 import DA.Optional
 import DA.Time
 
@@ -36,7 +39,7 @@ template Cash
 
     choice TransferToLocker : CashId
       controller owner
-      do assert $ locker /= owner
+      do locker =/= owner
          create this with owner = locker; lockMaturity = None
 
     choice Split : (CashId, CashId)
@@ -52,7 +55,7 @@ template Cash
       do assertUnlocked this
          c <- fetch otherCid
          assertUnlocked c
-         assert $ this == c with amount
+         this === c with amount
          exercise otherCid Archive
          create this with amount = amount + c.amount
 
@@ -112,82 +115,80 @@ template CashTransferRequest
 cashSplitMay : Party -> CashId -> Decimal -> Update (CashId, Optional CashId)
 cashSplitMay owner cashCid splitAmount = do
   cash <- fetch cashCid
-  assert $ cash.owner == owner
+  cash.owner === owner
   if cash.amount == splitAmount
     then return (cashCid, None)
     else do
       r <- exercise cashCid Split with splitAmount
       return (fst r, Some $ snd r)
 
-main = scenario do
-  acmeBank <- getParty "AcmeBank"
-  alice <- getParty "Alice"
-  bob <- getParty "Bob"
+main : Script ()
+main = script do
+  acmeBank <- allocateParty "AcmeBank"
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
 
-  today <- pass $ days 0
-
-  cashAlice1Cid <-
-    submit acmeBank do create CashTransferRequest with
-                              issuer = acmeBank
-                              owner = acmeBank
-                              receiver = alice
-                              currency = "USD"
-                              amount = 100.0
-                              locker = acmeBank
-                              lockMaturity = None
+  today <- getTime
 
   cashAlice1Cid <-
-    submit alice do exercise cashAlice1Cid Accept
+    acmeBank `submit` createCmd 
+      CashTransferRequest with
+        issuer = acmeBank
+        owner = acmeBank
+        receiver = alice
+        currency = "USD"
+        amount = 100.0
+        locker = acmeBank
+        lockMaturity = None
+
+  cashAlice1Cid <- alice `submit` exerciseCmd cashAlice1Cid Accept
 
   cashBob1Cid <-
-    submit acmeBank do create CashTransferRequest with
-                              issuer = acmeBank
-                              owner = acmeBank
-                              receiver = bob
-                              currency = "USD"
-                              amount = 20.0
-                              locker = acmeBank
-                              lockMaturity = None
+    acmeBank `submit` createCmd
+      CashTransferRequest with
+        issuer = acmeBank
+        owner = acmeBank
+        receiver = bob
+        currency = "USD"
+        amount = 20.0
+        locker = acmeBank
+        lockMaturity = None
 
   cashBob1Cid <-
-    submit bob do exercise cashBob1Cid Accept
+    bob `submit` exerciseCmd cashBob1Cid Accept
 
   (cashAlice1Cid, cashAlice2Cid) <-
-    submit alice do exercise cashAlice1Cid Split with splitAmount = 30.0
+    alice `submit` exerciseCmd cashAlice1Cid Split with splitAmount = 30.0
 
   cashBob2Cid <-
-    submit alice do exercise cashAlice1Cid Transfer with newOwner = bob
+    alice `submit` exerciseCmd cashAlice1Cid Transfer with newOwner = bob
 
   cashBob2Cid <-
-    submit bob do exercise cashBob2Cid Accept
+    bob `submit` exerciseCmd cashBob2Cid Accept
 
   cashBob2Cid <-
-    submit bob do exercise cashBob1Cid Merge with otherCid = cashBob2Cid
+    bob `submit` exerciseCmd cashBob1Cid Merge with otherCid = cashBob2Cid
 
-  submit alice do
-    c <- fetch cashAlice2Cid
-    assertMsg "unexpected issuer" $ c.issuer == acmeBank
-    assertMsg "unexpected owner" $ c.owner == alice
-    assertMsg "unexpected currency" $ c.currency == "USD"
-    assertMsg "unexpected amount" $ c.amount == 70.0
+  Some cashAlice2 <- queryContractId alice cashAlice2Cid
+  assertMsg "unexpected issuer" $ cashAlice2.issuer == acmeBank
+  assertMsg "unexpected owner" $ cashAlice2.owner == alice
+  assertMsg "unexpected currency" $ cashAlice2.currency == "USD"
+  assertMsg "unexpected amount" $ cashAlice2.amount == 70.0
 
-  submit bob do
-    c <- fetch cashBob2Cid
-    assertMsg "unexpected issuer" $ c.issuer == acmeBank
-    assertMsg "unexpected owner" $ c.owner == bob
-    assertMsg "unexpected currency" $ c.currency == "USD"
-    assertMsg "unexpected amount" $ c.amount == 50.0
+  Some cashBob2 <- queryContractId bob cashBob2Cid
+  assertMsg "unexpected issuer" $ cashBob2.issuer == acmeBank
+  assertMsg "unexpected owner" $ cashBob2.owner == bob
+  assertMsg "unexpected currency" $ cashBob2.currency == "USD"
+  assertMsg "unexpected amount" $ cashBob2.amount == 50.0
 
-  lid <- submit alice do create LockPoA with locker = alice; issuer = acmeBank; owner = bob
+  lid <- alice `submit` createCmd LockPoA with locker = alice; issuer = acmeBank; owner = bob
 
-  lockedCash <- submit bob do exercise cashBob2Cid Lock with lid; _lockMaturity = addRelTime today (days 1)
+  lockedCash <- bob `submit` exerciseCmd cashBob2Cid Lock with lid; _lockMaturity = addRelTime today (days 1)
 
-  cashAlice3Cid <- submit bob do exercise lockedCash TransferToLocker
+  cashAlice3Cid <- bob `submit` exerciseCmd lockedCash TransferToLocker
 
-  submit alice do
-    c <- fetch cashAlice3Cid
-    assertMsg "unexpected issuer" $ c.issuer == acmeBank
-    assertMsg "unexpected owner" $ c.owner == alice
-    assertMsg "unexpected currency" $ c.currency == "USD"
-    assertMsg "unexpected amount" $ c.amount == 50.0
-
+  Some cashAlice3 <- queryContractId alice cashAlice3Cid
+  assertMsg "unexpected issuer" $ cashAlice3.issuer == acmeBank
+  assertMsg "unexpected owner" $ cashAlice3.owner == alice
+  assertMsg "unexpected currency" $ cashAlice3.currency == "USD"
+  assertMsg "unexpected amount" $ cashAlice3.amount == 50.0

--- a/compiler/damlc/tests/bond-trading/Dvp.daml
+++ b/compiler/damlc/tests/bond-trading/Dvp.daml
@@ -4,6 +4,8 @@
 
 module Dvp where
 
+import Daml.Script
+
 import Bond hiding (Withdraw, Reject, Accept)
 import Bond qualified
 import Cash hiding (Withdraw, Reject, Accept)
@@ -12,6 +14,7 @@ import DvpTerms
 import DvpNotification hiding (Accept)
 import DvpNotification qualified
 
+import DA.Assert
 import DA.Date
 
 template DvpProposal
@@ -48,9 +51,9 @@ template Dvp
       controller c.buyer
       do cash <- fetch cashCid
          assert $ not $ isLocked cash
-         assert $ cash.amount == c.cashAmount
-         assert $ cash.issuer == c.cashIssuer
-         assert $ cash.currency == c.cashCurrency
+         cash.amount === c.cashAmount
+         cash.issuer === c.cashIssuer
+         cash.currency === c.cashCurrency
          lid <- create LockPoA with locker = c.seller; issuer = cash.issuer; owner = cash.owner
          cashCid <- exercise cashCid Lock with lid; _lockMaturity = c.settleTime
          alloc <- create DvpAllocated with c=c; cashCid
@@ -73,20 +76,20 @@ template DvpAllocated
       do assertAfter c.settleTime
 
          bond <- fetch bondCid
-         assert $ bond.amount == c.bondAmount
-         assert $ bond.issuer == c.bondIssuer
-         assert $ bond.isin == c.bondIsin
-         assert $ bond.owner == c.seller
+         bond.amount === c.bondAmount
+         bond.issuer === c.bondIssuer
+         bond.isin === c.bondIsin
+         bond.owner === c.seller
          _ <- create DvpAllocated with c; cashCid
          bondCid <- exercise bondCid Bond.Transfer with newOwner = c.buyer
          bondCid <- exercise bondCid Bond.Accept
 
          cash <- fetch cashCid
          assert $ isLocked cash
-         assert $ cash.amount == c.cashAmount
-         assert $ cash.issuer == c.cashIssuer
-         assert $ cash.currency == c.cashCurrency
-         assert $ cash.owner == c.buyer
+         cash.amount === c.cashAmount
+         cash.issuer === c.cashIssuer
+         cash.currency === c.cashCurrency
+         cash.owner === c.buyer
          cashCid <- exercise cashCid Cash.TransferToLocker
 
          notificationCid <- create DvpNotification with c = c
@@ -98,76 +101,75 @@ data SettleResult = SettleResult
     cashCid : CashId
     notificationCid : DvpNotificationId
 
-main = scenario do
-  _ <- passToDate $ date 2018 May 14
+setDate : Int -> Month -> Int -> Script ()
+setDate year month day = setTime $ datetime year month day 0 0 0
+
+main = script do
+  setDate 2018 May 14
 
    --2018-05-14T00:00Z
-  acmeBank <- getParty "AcmeBank"
-  alice <- getParty "Alice"
-  bob <- getParty "Bob"
+  acmeBank <- allocateParty "AcmeBank"
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
+
+  cashAliceCid <- acmeBank `submit` createCmd
+    CashTransferRequest with
+      issuer = acmeBank
+      owner = acmeBank
+      receiver = alice
+      currency = "USD"
+      amount = 100.0
+      locker = acmeBank
+      lockMaturity = None
 
   cashAliceCid <-
-    submit acmeBank do
-      create CashTransferRequest with
-        issuer = acmeBank
-        owner = acmeBank
-        receiver = alice
-        currency = "USD"
-        amount = 100.0
-        locker = acmeBank
-        lockMaturity = None
+    alice `submit` exerciseCmd cashAliceCid Cash.Accept
 
-  cashAliceCid <-
-    submit alice do exercise cashAliceCid Cash.Accept
+  bondBobCid <- acmeBank `submit` createCmd
+    BondTransferRequest with
+      issuer = acmeBank
+      owner = acmeBank
+      newOwner = bob
+      isin = "1234"
+      amount = 100.0
 
-  bondBobCid <-
-    submit acmeBank do create BondTransferRequest with issuer = acmeBank
-                                                       owner = acmeBank
-                                                       newOwner = bob
-                                                       isin = "1234"
-                                                       amount = 100.0
+  bondBobCid <- bob `submit` exerciseCmd bondBobCid Bond.Accept
 
-  bondBobCid <-
-    submit bob do exercise bondBobCid Bond.Accept
-
-  dvpProposalCid <-
-    submit alice do
-      create DvpProposal with
-        c = DvpTerms with
-          buyer = alice
-          seller = bob
-          bondIssuer = acmeBank
-          bondIsin = "1234"
-          bondAmount = 100.0
-          cashIssuer = acmeBank
-          cashCurrency = "USD"
-          cashAmount = 100.0
-          settleTime = datetime 2018 Aug 14 0 0 0
-          dvpId = "abc"
+  dvpProposalCid <- alice `submit` createCmd
+    DvpProposal with
+      c = DvpTerms with
+        buyer = alice
+        seller = bob
+        bondIssuer = acmeBank
+        bondIsin = "1234"
+        bondAmount = 100.0
+        cashIssuer = acmeBank
+        cashCurrency = "USD"
+        cashAmount = 100.0
+        settleTime = datetime 2018 Aug 14 0 0 0
+        dvpId = "abc"
 
 
-  dvpCid <- submit bob do exercise dvpProposalCid Accept
+  dvpCid <- bob `submit` exerciseCmd dvpProposalCid Accept
 
-  passToDate $ date 2018 Aug 14
+  setDate 2018 Aug 14
 
   (dvpAllocatedCid, _) <-
-    submit alice do exercise dvpCid Allocate with cashCid = cashAliceCid
+    alice `submit` exerciseCmd dvpCid Allocate with cashCid = cashAliceCid
 
   r <-
-    submit bob do exercise dvpAllocatedCid Settle with bondCid = bondBobCid
+    bob `submit` exerciseCmd dvpAllocatedCid Settle with bondCid = bondBobCid
 
-  submit alice do exercise r.notificationCid DvpNotification.Accept
+  alice `submit` exerciseCmd r.notificationCid DvpNotification.Accept
 
-  submit alice do
-    c <- fetch r.bondCid
-    assertMsg "unexpected issuer" $ c.issuer == acmeBank
-    assertMsg "unexpected owner" $ c.owner == alice
-    assertMsg "unexpected isin" $ c.isin == "1234"
-    assertMsg "unexpected amount" $ c.amount == 100.0
+  Some bond <- queryContractId alice r.bondCid
+  assertMsg "unexpected issuer" $ bond.issuer == acmeBank
+  assertMsg "unexpected owner" $ bond.owner == alice
+  assertMsg "unexpected isin" $ bond.isin == "1234"
+  assertMsg "unexpected amount" $ bond.amount == 100.0
 
-  submit bob do
-    c <- fetch r.cashCid
-    assertMsg "unexpected issuer" $ c.issuer == acmeBank
-    assertMsg "unexpected owner" $ c.owner == bob
-    assertMsg "unexpected currency" $ c.currency == "USD"
-    assertMsg "unexpected amount" $ c.amount == 100.0
+  Some cash <- queryContractId bob r.cashCid
+  assertMsg "unexpected issuer" $ cash.issuer == acmeBank
+  assertMsg "unexpected owner" $ cash.owner == bob
+  assertMsg "unexpected currency" $ cash.currency == "USD"
+  assertMsg "unexpected amount" $ cash.amount == 100.0

--- a/compiler/damlc/tests/bond-trading/Helper.daml
+++ b/compiler/damlc/tests/bond-trading/Helper.daml
@@ -4,11 +4,14 @@
 
 module Helper where
 
+import Daml.Script
+
 import Bond
 import Cash
 import Dvp
 import DvpTerms
 
+import DA.Assert
 import DA.Action
 import DA.Date
 
@@ -68,15 +71,15 @@ template Helper
          bondCid <- foldl1A (\cid otherCid -> exercise cid Bond.Merge with otherCid) bondCids
          foldrA settleDvp (HandleBondResult with restCid = Some bondCid; settleResults = []) dvpAllocatedCids
 
-main = scenario do
-  acmeBank <- getParty "Acme Bank"
-  alice <- getParty "Alice"
-  bob <- getParty "Bob"
+main = script do
+  acmeBank <- allocateParty "Acme Bank"
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
 
-  _ <- passToDate $ date 2018 May 14
+  setDate 2018 May 14
 
-  cashAlice1Cid <- submit acmeBank do
-    create CashTransferRequest with
+  cashAlice1Cid <- acmeBank `submit` createCmd
+    CashTransferRequest with
       issuer = acmeBank
       owner = acmeBank
       receiver = alice
@@ -85,8 +88,8 @@ main = scenario do
       locker = acmeBank
       lockMaturity = None
 
-  cashAlice2Cid <- submit acmeBank do
-    create CashTransferRequest with
+  cashAlice2Cid <- acmeBank `submit` createCmd
+    CashTransferRequest with
       issuer = acmeBank
       owner = acmeBank
       receiver = alice
@@ -95,30 +98,30 @@ main = scenario do
       locker = acmeBank
       lockMaturity = None
 
-  cashAlice1Cid <- submit alice do exercise cashAlice1Cid Cash.Accept
-  cashAlice2Cid <- submit alice do exercise cashAlice2Cid Cash.Accept
+  cashAlice1Cid <- alice `submit` exerciseCmd cashAlice1Cid Cash.Accept
+  cashAlice2Cid <- alice `submit` exerciseCmd cashAlice2Cid Cash.Accept
 
-  bondBob1Cid <- submit acmeBank do
-    create BondTransferRequest with
+  bondBob1Cid <- acmeBank `submit` createCmd
+    BondTransferRequest with
       issuer = acmeBank
       owner = acmeBank
       newOwner = bob
       isin = "1234"
       amount = 60.0
 
-  bondBob2Cid <- submit acmeBank do
-    create BondTransferRequest with
+  bondBob2Cid <- acmeBank `submit` createCmd
+    BondTransferRequest with
       issuer = acmeBank
       owner = acmeBank
       newOwner = bob
       isin = "1234"
       amount = 40.0
 
-  bondBob1Cid <- submit bob do exercise bondBob1Cid Bond.Accept
-  bondBob2Cid <- submit bob do exercise bondBob2Cid Bond.Accept
+  bondBob1Cid <- bob `submit` exerciseCmd bondBob1Cid Bond.Accept
+  bondBob2Cid <- bob `submit` exerciseCmd bondBob2Cid Bond.Accept
 
-  dvp1Cid <- submit alice do
-    create DvpProposal with
+  dvp1Cid <- alice `submit` createCmd
+    DvpProposal with
       c = DvpTerms with
         buyer = alice
         seller = bob
@@ -131,8 +134,8 @@ main = scenario do
         settleTime = datetime 2018 May 16 0 0 0
         dvpId = "abc"
 
-  dvp2Cid <- submit alice do
-    create DvpProposal with
+  dvp2Cid <- alice `submit` createCmd
+    DvpProposal with
       c = DvpTerms with
         buyer = alice
         seller = bob
@@ -145,60 +148,56 @@ main = scenario do
         settleTime = datetime 2018 May 16 0 0 0
         dvpId = "abc"
 
-  dvp1Cid <- submit bob do exercise dvp1Cid Dvp.Accept
-  dvp2Cid <- submit bob do exercise dvp2Cid Dvp.Accept
+  dvp1Cid <- bob `submit` exerciseCmd dvp1Cid Dvp.Accept
+  dvp2Cid <- bob `submit` exerciseCmd dvp2Cid Dvp.Accept
 
-  helperAliceCid <- submit alice do create Helper with party = alice
-  helperBobCid <- submit bob do create Helper with party = bob
+  helperAliceCid <- alice `submit` createCmd Helper with party = alice
+  helperBobCid <- bob `submit` createCmd Helper with party = bob
 
-  passToDate $ date 2018 May 16
+  setDate 2018 May 16
 
-  r <- submit alice do
-      exercise helperAliceCid HandleCash with
-          cashCids = [ cashAlice1Cid, cashAlice2Cid ]
-          dvpCids = [ dvp1Cid, dvp2Cid ]
+  r <- alice `submit` exerciseCmd helperAliceCid
+    HandleCash with
+      cashCids = [ cashAlice1Cid, cashAlice2Cid ]
+      dvpCids = [ dvp1Cid, dvp2Cid ]
 
-  submit alice do
-      c <- optional (fail "unexpected rest") fetch r.restCid
-      assert $ c.issuer == acmeBank
-      assert $ c.owner == alice
-      assert $ c.currency == "USD"
-      assert $ c.amount == 30.0
+  Some rest <- optional (fail "unexpected rest") (queryContractId alice) r.restCid
+  rest.issuer === acmeBank
+  rest.owner === alice
+  rest.currency === "USD"
+  rest.amount === 30.0
 
-  r <- submit bob do
-      exercise helperBobCid HandleBond with
-          bondCids = [ bondBob1Cid, bondBob2Cid ]
-          dvpAllocatedCids = r.dvpAllocatedCids
+  r <- bob `submit` exerciseCmd helperBobCid
+    HandleBond with
+      bondCids = [ bondBob1Cid, bondBob2Cid ]
+      dvpAllocatedCids = r.dvpAllocatedCids
 
-  submit bob do
-    c <- optional (fail "unexpected rest") fetch r.restCid
-    assert $ c.issuer == acmeBank
-    assert $ c.owner == bob
-    assert $ c.isin == "1234"
-    assert $ c.amount == 30.0
+  Some rest <- optional (fail "unexpected rest") (queryContractId bob) r.restCid
+  rest.issuer === acmeBank
+  rest.owner === bob
+  rest.isin === "1234"
+  rest.amount === 30.0
 
   let settleResults = r.settleResults
 
-  r <- submit alice do
-      exercise helperAliceCid HandleBond with
-        bondCids = map (\r -> r.bondCid) settleResults
-        dvpAllocatedCids = []
+  r <- alice `submit` exerciseCmd helperAliceCid
+    HandleBond with
+      bondCids = map (\r -> r.bondCid) settleResults
+      dvpAllocatedCids = []
 
-  submit alice do
-    c <- optional (fail "unexpected rest") fetch r.restCid
-    assert $ c.issuer == acmeBank
-    assert $ c.owner == alice
-    assert $ c.isin == "1234"
-    assert $ c.amount == 70.0
+  Some rest <- optional (fail "unexpected rest") (queryContractId alice) r.restCid
+  rest.issuer === acmeBank
+  rest.owner === alice
+  rest.isin === "1234"
+  rest.amount === 70.0
 
-  r <- submit bob do
-      exercise helperBobCid HandleCash with
-        cashCids = map (\r -> r.cashCid) settleResults
-        dvpCids = []
+  r <- bob `submit` exerciseCmd helperBobCid
+    HandleCash with
+      cashCids = map (\r -> r.cashCid) settleResults
+      dvpCids = []
 
-  submit bob do
-    c <- optional (fail "unexpected rest") fetch r.restCid
-    assert $ c.issuer == acmeBank
-    assert $ c.owner == bob
-    assert $ c.currency == "USD"
-    assert $ c.amount == 70.0
+  Some rest <- optional (fail "unexpected rest") (queryContractId bob) r.restCid
+  rest.issuer === acmeBank
+  rest.owner === bob
+  rest.currency === "USD"
+  rest.amount === 70.0

--- a/compiler/damlc/tests/bond-trading/Setup.daml
+++ b/compiler/damlc/tests/bond-trading/Setup.daml
@@ -1,14 +1,19 @@
 -- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE ApplicativeDo #-}
 
 module Setup where
 
+import Daml.Script
+
 import Bond
 import Cash
+import Dvp
 import Helper
 
 import DA.Date
+import DA.Foldable
 
 data MarketSetupEntry = MarketSetupEntry
   with
@@ -76,46 +81,46 @@ template HelperSetupJob
       controller party
       do create Helper with party
 
-marketSetupEntryExample party = do
-  party1 <- getParty party
+marketSetupEntryExample party = script do
+  party1 <- allocateParty party
   return MarketSetupEntry with
     party = party1
     bondEntries = [ BondEntry with isin = "1234"; amount = 100.0 ]
     cashEntries = [ CashEntry with currency = "USD"; amount = 100.0 ]
 
-marketSetupJobExample = do
-  acme <- getParty "Acme Bank"
+marketSetupJobExample acme = script do
   entries <- mapA marketSetupEntryExample ["party1", "party2", "party3", "party4", "party5"]
   return MarketSetupJob with
     issuer = acme
     entries
 
 
-setupExample = scenario do
-    passToDate $ date 2018 May 14
+setupExample = script do
+    setDate 2018 May 14
 
-    acme <- getParty "Acme Bank"
+    acme <- allocateParty "Acme Bank"
 
-    job <- marketSetupJobExample
-    submit acme do create job
+    job <- marketSetupJobExample acme
+    submit acme do createCmd job
 
     return ()
 
-setupExampleFull = scenario do
-    acme <- getParty "Acme Bank"
+setupExampleFull = script do
+    acme <- allocateParty "Acme Bank"
 
-    passToDate $ date 2018 May 14
+    setDate 2018 May 14
 
-    job <- marketSetupJobExample
-    jobCid <- submit acme do create job
+    job <- marketSetupJobExample acme
+    jobCid <- acme `submit` createCmd job
 
-    rs <- submit acme do exercise jobCid Process
+    rs <- acme `submit` exerciseCmd jobCid Process
 
     forA rs $ \r -> submit r.party do
-      exercise r.helperCid Process2
-      forA r.bondCids $ (flip exercise) Bond.Accept
-      forA r.cashCids $ (flip exercise) Cash.Accept
+      exerciseCmd r.helperCid Process2
+      forA_ r.bondCids $ (flip exerciseCmd) Bond.Accept
+      forA_ r.cashCids $ (flip exerciseCmd) Cash.Accept
+      pure ()
 
 
-main = scenario do
+main = script do
     setupExampleFull

--- a/compiler/damlc/tests/bond-trading/Setup.daml
+++ b/compiler/damlc/tests/bond-trading/Setup.daml
@@ -96,31 +96,31 @@ marketSetupJobExample acme = script do
 
 
 setupExample = script do
-    setDate 2018 May 14
+  setDate 2018 May 14
 
-    acme <- allocateParty "Acme Bank"
+  acme <- allocateParty "Acme Bank"
 
-    job <- marketSetupJobExample acme
-    submit acme do createCmd job
+  job <- marketSetupJobExample acme
+  acme `submit` createCmd job
 
-    return ()
+  return ()
 
 setupExampleFull = script do
-    acme <- allocateParty "Acme Bank"
+  acme <- allocateParty "Acme Bank"
 
-    setDate 2018 May 14
+  setDate 2018 May 14
 
-    job <- marketSetupJobExample acme
-    jobCid <- acme `submit` createCmd job
+  job <- marketSetupJobExample acme
+  jobCid <- acme `submit` createCmd job
 
-    rs <- acme `submit` exerciseCmd jobCid Process
+  rs <- acme `submit` exerciseCmd jobCid Process
 
-    forA rs $ \r -> submit r.party do
-      exerciseCmd r.helperCid Process2
-      forA_ r.bondCids $ (flip exerciseCmd) Bond.Accept
-      forA_ r.cashCids $ (flip exerciseCmd) Cash.Accept
-      pure ()
+  forA rs $ \r -> r.party `submit` do
+    exerciseCmd r.helperCid Process2
+    forA_ r.bondCids $ (flip exerciseCmd) Bond.Accept
+    forA_ r.cashCids $ (flip exerciseCmd) Cash.Accept
+    pure ()
 
 
 main = script do
-    setupExampleFull
+  setupExampleFull

--- a/compiler/damlc/tests/bond-trading/Test.daml
+++ b/compiler/damlc/tests/bond-trading/Test.daml
@@ -2,10 +2,12 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- Check that the interning tables don't contain duplicates:
--- @QUERY-LF .interned_strings // [] | (unique | length == length)
--- @QUERY-LF .interned_dotted_names // [] | (unique | length == length)
+--- @QUERY-LF .interned_strings // [] | (unique | length == length)
+--- @QUERY-LF .interned_dotted_names // [] | (unique | length == length)
 
 module Test where
+
+import Daml.Script
 
 import Bond qualified
 import Cash qualified
@@ -13,11 +15,9 @@ import Dvp qualified
 import Helper qualified
 import Setup qualified
 
-main = scenario do
+main = script do
   Bond.main
   Cash.main
-  Setup.main
   Dvp.main
   Helper.main
-
--- @ENABLE-SCENARIOS
+  Setup.main


### PR DESCRIPTION
Resolves #16411 

Update the bond-trading tests to use Script over Scenario

Note, JQ queries can no longer run as the parse depth of the output file is too large. Consider switching to `jj` (separate ticket)