### PR TITLE
Bump integration tests timeout to 3s

### DIFF
--- a/compiler/damlc/tests/daml-test-files/Loop.daml
+++ b/compiler/damlc/tests/daml-test-files/Loop.daml
@@ -20,30 +20,30 @@ template Helper
       do
         pure $ loop 1
 
--- @ERROR range=24:1-24:16; Evaluation timed out after 1 seconds
+-- @ERROR range=24:1-24:16; Evaluation timed out after 3 seconds
 scenarioMachine = scenario do
   pure $ loop 1
 
--- @ERROR range=28:1-28:32; Evaluation timed out after 1 seconds
+-- @ERROR range=28:1-28:32; Evaluation timed out after 3 seconds
 ledgerMachineFromScenarioSubmit = scenario do
    alice <- getParty "p"
    alice `submit` createAndExercise (Helper alice) Loop
 
--- @ERROR range=33:1-33:40; Evaluation timed out after 1 seconds
+-- @ERROR range=33:1-33:40; Evaluation timed out after 3 seconds
 ledgerMachineFromScenarioSubmitMustFail = scenario do
    alice <- getParty "p"
    alice `submitMustFail` createAndExercise (Helper alice) Loop
 
--- @ERROR range=38:1-38:14; Evaluation timed out after 1 seconds
+-- @ERROR range=38:1-38:14; Evaluation timed out after 3 seconds
 scriptMachine = script do
     pure $ loop 1
 
--- @ERROR range=42:1-42:30; Evaluation timed out after 1 seconds
+-- @ERROR range=42:1-42:30; Evaluation timed out after 3 seconds
 ledgerMachineFromScriptSubmit = script do
    alice <- allocateParty "p"
    alice `submit` createAndExerciseCmd (Helper alice) Loop
 
--- @ERROR range=47:1-47:38; Evaluation timed out after 1 seconds
+-- @ERROR range=47:1-47:38; Evaluation timed out after 3 seconds
 ledgerMachineFromScriptSubmitMustFail= script do
    alice <- allocateParty "p"
    alice `submitMustFail` createAndExerciseCmd (Helper alice) Loop

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -139,7 +139,7 @@ withDamlScriptDep lfVer cont = do
 
 main :: IO ()
 main = do
-  let scenarioConf = SS.defaultScenarioServiceConfig { SS.cnfJvmOptions = ["-Xmx200M"], SS.cnfEvaluationTimeout = Just 1 }
+  let scenarioConf = SS.defaultScenarioServiceConfig { SS.cnfJvmOptions = ["-Xmx200M"], SS.cnfEvaluationTimeout = Just 3 }
   -- This is a bit hacky, we want the LF version before we hand over to
   -- tasty. To achieve that we first pass with optparse-applicative ignoring
   -- everything apart from the LF version.


### PR DESCRIPTION
bond-trading tests have been flaky since integration timeout got reduced. Bump it up to 3s to address this.