### PR TITLE
Fix daml-doc `md`

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
@@ -61,6 +61,7 @@ data DamldocOptions = DamldocOptions
     , do_hooglePath :: Maybe FilePath -- ^ hoogle database output path
     , do_anchorPath :: Maybe FilePath -- ^ anchor table output path
     , do_externalAnchorPath :: ExternalAnchorPath -- ^ external anchor table input path
+    , do_globalInternalExt :: String -- ^ File extension for internal links
     }
 
 data InputFormat = InputJson | InputDaml
@@ -170,5 +171,6 @@ renderDocData DamldocOptions{..} docData = do
                         , ro_hooglePath = do_hooglePath
                         , ro_anchorPath = do_anchorPath
                         , ro_externalAnchors = externalAnchors
+                        , ro_globalInternalExt = do_globalInternalExt
                         }
                 renderDocs renderOptions docData

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render.hs
@@ -55,11 +55,6 @@ renderDocs ro@RenderOptions{..} mods = do
         templateText = fromMaybe (defaultTemplate ro_format) ro_template
         renderMap = Map.fromList [(md_name mod, renderModule mod) | mod <- mods]
         externalAnchors = ro_externalAnchors
-        extension =
-            case ro_format of
-                Markdown -> "md"
-                Rst -> "rst"
-                Html -> "html"
 
     template <- compileTemplate "template" templateText
 
@@ -73,7 +68,12 @@ renderDocs ro@RenderOptions{..} mods = do
                 $ fold renderMap
 
         RenderToFolder path -> do
-            let (outputIndex, outputMap) = renderFolder formatter externalAnchors extension renderMap
+            let (outputIndex, outputMap) = renderFolder formatter externalAnchors ro_globalInternalExt renderMap
+                extension =
+                    case ro_format of
+                        Markdown -> "md"
+                        Rst -> "rst"
+                        Html -> "html"
 
                 outputPath mod = path </> moduleNameToFileName mod <.> extension
 
@@ -94,7 +94,7 @@ renderDocs ro@RenderOptions{..} mods = do
                 . postProcessing
                 $ outputIndex
 
-    let anchorTable = buildAnchorTable ro extension renderMap
+    let anchorTable = buildAnchorTable ro renderMap
     whenJust ro_anchorPath $ \anchorPath -> do
         A.encodeFile anchorPath anchorTable
     whenJust ro_hooglePath $ \hooglePath -> do

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render.hs
@@ -69,12 +69,12 @@ renderDocs ro@RenderOptions{..} mods = do
 
         RenderToFolder path -> do
             let
-                (outputIndex, outputMap) = renderFolder formatter externalAnchors renderMap
                 extension =
                     case ro_format of
                         Markdown -> "md"
                         Rst -> "rst"
                         Html -> "html"
+                (outputIndex, outputMap) = renderFolder formatter externalAnchors extension renderMap
 
                 outputPath mod = path </> moduleNameToFileName mod <.> extension
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render.hs
@@ -55,6 +55,11 @@ renderDocs ro@RenderOptions{..} mods = do
         templateText = fromMaybe (defaultTemplate ro_format) ro_template
         renderMap = Map.fromList [(md_name mod, renderModule mod) | mod <- mods]
         externalAnchors = ro_externalAnchors
+        extension =
+            case ro_format of
+                Markdown -> "md"
+                Rst -> "rst"
+                Html -> "html"
 
     template <- compileTemplate "template" templateText
 
@@ -68,13 +73,7 @@ renderDocs ro@RenderOptions{..} mods = do
                 $ fold renderMap
 
         RenderToFolder path -> do
-            let
-                extension =
-                    case ro_format of
-                        Markdown -> "md"
-                        Rst -> "rst"
-                        Html -> "html"
-                (outputIndex, outputMap) = renderFolder formatter externalAnchors extension renderMap
+            let (outputIndex, outputMap) = renderFolder formatter externalAnchors extension renderMap
 
                 outputPath mod = path </> moduleNameToFileName mod <.> extension
 
@@ -95,7 +94,7 @@ renderDocs ro@RenderOptions{..} mods = do
                 . postProcessing
                 $ outputIndex
 
-    let anchorTable = buildAnchorTable ro renderMap
+    let anchorTable = buildAnchorTable ro extension renderMap
     whenJust ro_anchorPath $ \anchorPath -> do
         A.encodeFile anchorPath anchorTable
     whenJust ro_hooglePath $ \hooglePath -> do

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
@@ -144,12 +144,12 @@ renderFolder ::
     -> String
     -> Map.Map Modulename RenderOut
     -> (T.Text, Map.Map Modulename T.Text)
-renderFolder formatter externalAnchors globalInternalFileExt fileMap =
+renderFolder formatter externalAnchors globalInternalExt fileMap =
     let moduleAnchors = Map.map getRenderAnchors fileMap
         re_externalAnchors = externalAnchors
         re_separateModules = True
         re_globalAnchors = Map.fromList
-            [ (anchor, moduleNameToFileName moduleName <.> globalInternalFileExt)
+            [ (anchor, moduleNameToFileName moduleName <.> globalInternalExt)
             | (moduleName, anchors) <- Map.toList moduleAnchors
             , anchor <- Set.toList anchors
             ]
@@ -168,8 +168,8 @@ moduleNameToFileName :: Modulename -> FilePath
 moduleNameToFileName =
     T.unpack . T.replace "." "-" . unModulename
 
-buildAnchorTable :: RenderOptions -> String -> Map.Map Modulename RenderOut -> HMS.HashMap Anchor T.Text
-buildAnchorTable RenderOptions{..} globalInternalFileExt outputs
+buildAnchorTable :: RenderOptions -> Map.Map Modulename RenderOut -> HMS.HashMap Anchor T.Text
+buildAnchorTable RenderOptions{..} outputs
     | Just baseURL <- ro_baseURL
     = HMS.fromList
         [ (anchor, buildURL baseURL moduleName anchor)
@@ -196,9 +196,9 @@ buildAnchorTable RenderOptions{..} globalInternalFileExt outputs
         buildFolderURL baseURL moduleName anchor = T.concat
             [ stripTrailingSlash baseURL
             , "/"
-            , T.pack (moduleNameToFileName moduleName <.> globalInternalFileExt)
+            , T.pack (moduleNameToFileName moduleName <.> ro_globalInternalExt)
             , "#"
             , unAnchor anchor
             ]
 
-buildAnchorTable _ _ _ = HMS.empty
+buildAnchorTable _ _ = HMS.empty

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
@@ -168,8 +168,8 @@ moduleNameToFileName :: Modulename -> FilePath
 moduleNameToFileName =
     T.unpack . T.replace "." "-" . unModulename
 
-buildAnchorTable :: RenderOptions -> Map.Map Modulename RenderOut -> HMS.HashMap Anchor T.Text
-buildAnchorTable RenderOptions{..} outputs
+buildAnchorTable :: RenderOptions -> String -> Map.Map Modulename RenderOut -> HMS.HashMap Anchor T.Text
+buildAnchorTable RenderOptions{..} globalInternalFileExt outputs
     | Just baseURL <- ro_baseURL
     = HMS.fromList
         [ (anchor, buildURL baseURL moduleName anchor)
@@ -196,7 +196,7 @@ buildAnchorTable RenderOptions{..} outputs
         buildFolderURL baseURL moduleName anchor = T.concat
             [ stripTrailingSlash baseURL
             , "/"
-            , T.pack (moduleNameToFileName moduleName <.> "html")
+            , T.pack (moduleNameToFileName moduleName <.> globalInternalFileExt)
             , "#"
             , unAnchor anchor
             ]

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
@@ -141,14 +141,15 @@ renderPage formatter externalAnchors output =
 renderFolder ::
     RenderFormatter
     -> AnchorMap
+    -> String
     -> Map.Map Modulename RenderOut
     -> (T.Text, Map.Map Modulename T.Text)
-renderFolder formatter externalAnchors fileMap =
+renderFolder formatter externalAnchors globalInternalFileExt fileMap =
     let moduleAnchors = Map.map getRenderAnchors fileMap
         re_externalAnchors = externalAnchors
         re_separateModules = True
         re_globalAnchors = Map.fromList
-            [ (anchor, moduleNameToFileName moduleName <.> "html")
+            [ (anchor, moduleNameToFileName moduleName <.> globalInternalFileExt)
             | (moduleName, anchors) <- Map.toList moduleAnchors
             , anchor <- Set.toList anchors
             ]

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
@@ -201,4 +201,4 @@ buildAnchorTable RenderOptions{..} globalInternalFileExt outputs
             , unAnchor anchor
             ]
 
-buildAnchorTable _ _ = HMS.empty
+buildAnchorTable _ _ _ = HMS.empty

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Types.hs
@@ -30,4 +30,5 @@ data RenderOptions = RenderOptions
     , ro_hooglePath :: Maybe FilePath -- ^ path to output hoogle database
     , ro_anchorPath :: Maybe FilePath -- ^ path to output anchor table
     , ro_externalAnchors :: AnchorMap -- ^ external input anchor table
+    , ro_globalInternalExt :: String -- ^ File extension for internal links
     }

--- a/compiler/damlc/daml-doc/test/DA/Daml/Doc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/Doc/Render/Tests.hs
@@ -423,8 +423,8 @@ renderFolderTest format externalAnchors (name, input) expected =
     (expectIndex, expectModules) = strip expected
 
     renderer = case format of
-      Rst -> renderFolder renderRst externalAnchors "rst" . renderMap
-      Markdown -> renderFolder renderMd externalAnchors "md" . renderMap
+      Rst -> renderFolder renderRst externalAnchors "html" . renderMap
+      Markdown -> renderFolder renderMd externalAnchors "html" . renderMap
       Html -> error "HTML testing not supported (use Markdown)"
 
     renderMap mods = Map.fromList

--- a/compiler/damlc/daml-doc/test/DA/Daml/Doc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/Doc/Render/Tests.hs
@@ -423,8 +423,8 @@ renderFolderTest format externalAnchors (name, input) expected =
     (expectIndex, expectModules) = strip expected
 
     renderer = case format of
-      Rst -> renderFolder renderRst externalAnchors . renderMap
-      Markdown -> renderFolder renderMd externalAnchors . renderMap
+      Rst -> renderFolder renderRst externalAnchors "rst" . renderMap
+      Markdown -> renderFolder renderMd externalAnchors "md" . renderMap
       Html -> error "HTML testing not supported (use Markdown)"
 
     renderMap mods = Map.fromList


### PR DESCRIPTION
Resolves #16474 
Relevant question: https://discuss.daml.com/t/markdown-referencing-html-in-generated-doc/6222

Simply switches the generated `md` files and hoogle db to use `.md` on internal global anchors, when run with `format=md`