### PR TITLE
Add `internal` to errorIfTwiceParser

### DIFF
--- a/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
+++ b/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
@@ -75,7 +75,7 @@ optionOnce' :: String -> ReadM a -> Mod OptionFields a -> Parser a
 optionOnce' errMsg reader options = const <$> actualParser <*> errorIfTwiceParser
     where
     actualParser = option reader options
-    errorIfTwiceParser = option (readerError errMsg) (options <> hidden <> internal <> value (error "optionOnce: should not happen"))
+    errorIfTwiceParser = option (readerError errMsg) (options <> internal <> value (error "optionOnce: should not happen"))
 
 strOptionOnce :: IsString a => Mod OptionFields a -> Parser a
 strOptionOnce = optionOnce str

--- a/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
+++ b/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
@@ -75,7 +75,7 @@ optionOnce' :: String -> ReadM a -> Mod OptionFields a -> Parser a
 optionOnce' errMsg reader options = const <$> actualParser <*> errorIfTwiceParser
     where
     actualParser = option reader options
-    errorIfTwiceParser = option (readerError errMsg) (options <> hidden <> value (error "optionOnce: should not happen"))
+    errorIfTwiceParser = option (readerError errMsg) (options <> hidden <> internal <> value (error "optionOnce: should not happen"))
 
 strOptionOnce :: IsString a => Mod OptionFields a -> Parser a
 strOptionOnce = optionOnce str


### PR DESCRIPTION
Addresses issue https://github.com/digital-asset/daml/issues/16490

Trying both `internal <> hidden` for now, will check if we can get away with just `internal`