### PR TITLE
Attempt at fixing a flaky test in Canton

### DIFF
--- a/ledger-api/sample-service/src/test/scala/com/digitalasset/grpc/adapter/utils/BufferingObserver.scala
+++ b/ledger-api/sample-service/src/test/scala/com/digitalasset/grpc/adapter/utils/BufferingObserver.scala
@@ -16,7 +16,9 @@ class BufferingObserver[T](limit: Option[Int] = None) extends StreamObserver[T] 
   val size = new AtomicInteger(0)
   def resultsF = promise.future
 
-  override def onError(t: Throwable): Unit = promise.tryFailure(t)
+  override def onError(t: Throwable): Unit = {
+    val _ = promise.tryFailure(t)
+  }
 
   override def onCompleted(): Unit = {
     val vec = Vector.newBuilder[T]

--- a/ledger-api/sample-service/src/test/scala/com/digitalasset/grpc/adapter/utils/BufferingObserver.scala
+++ b/ledger-api/sample-service/src/test/scala/com/digitalasset/grpc/adapter/utils/BufferingObserver.scala
@@ -16,7 +16,7 @@ class BufferingObserver[T](limit: Option[Int] = None) extends StreamObserver[T] 
   val size = new AtomicInteger(0)
   def resultsF = promise.future
 
-  override def onError(t: Throwable): Unit = promise.failure(t)
+  override def onError(t: Throwable): Unit = promise.tryFailure(t)
 
   override def onCompleted(): Unit = {
     val vec = Vector.newBuilder[T]


### PR DESCRIPTION
Canton fails because this error appears in the logs:
```
SEVERE: Exception while executing runnable io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed@4e6759b5
java.lang.IllegalStateException: Promise already completed.
	at com.daml.grpc.adapter.utils.BufferingObserver.onError(BufferingObserver.scala:19)
```
	