### PR TITLE
infra: larger virtual disks

### DIFF
--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -12,7 +12,7 @@ locals {
     {
       name       = "ci-u2",
       disk_size  = 400,
-      size       = 10,
+      size       = 0,
       trunc_size = 400,
     },
   ]

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -12,8 +12,8 @@ locals {
     {
       name       = "ci-u2",
       disk_size  = 400,
-      size       = 0,
-      trunc_size = 200,
+      size       = 10,
+      trunc_size = 400,
     },
   ]
 }

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -4,14 +4,16 @@
 locals {
   ubuntu = [
     {
-      name      = "ci-u1",
-      disk_size = 400,
-      size      = 30,
+      name       = "ci-u1",
+      disk_size  = 400,
+      size       = 30,
+      trunc_size = 200,
     },
     {
-      name      = "ci-u2",
-      disk_size = 400,
-      size      = 0,
+      name       = "ci-u2",
+      disk_size  = 400,
+      size       = 0,
+      trunc_size = 200,
     },
   ]
 }
@@ -63,6 +65,7 @@ resource "google_compute_instance_template" "vsts-agent-ubuntu_20_04" {
       vsts_token   = secret_resource.vsts-token.value
       vsts_account = "digitalasset"
       vsts_pool    = "ubuntu_20_04"
+      size         = local.ubuntu[count.index].trunc_size
     })
 
     shutdown-script = nonsensitive("#!/usr/bin/env bash\nset -euo pipefail\ncd /home/vsts/agent\nsu vsts <<SHUTDOWN_AGENT\nexport VSTS_AGENT_INPUT_TOKEN='${secret_resource.vsts-token.value}'\n./config.sh remove --unattended --auth PAT\nSHUTDOWN_AGENT\n    ")

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -4,16 +4,14 @@
 locals {
   ubuntu = [
     {
-      name       = "ci-u1",
-      disk_size  = 400,
-      size       = 30,
-      trunc_size = 400,
+      name      = "ci-u1",
+      disk_size = 400,
+      size      = 30,
     },
     {
-      name       = "ci-u2",
-      disk_size  = 400,
-      size       = 0,
-      trunc_size = 400,
+      name      = "ci-u2",
+      disk_size = 400,
+      size      = 0,
     },
   ]
 }
@@ -65,7 +63,7 @@ resource "google_compute_instance_template" "vsts-agent-ubuntu_20_04" {
       vsts_token   = secret_resource.vsts-token.value
       vsts_account = "digitalasset"
       vsts_pool    = "ubuntu_20_04"
-      size         = local.ubuntu[count.index].trunc_size
+      size         = local.ubuntu[count.index].disk_size
     })
 
     shutdown-script = nonsensitive("#!/usr/bin/env bash\nset -euo pipefail\ncd /home/vsts/agent\nsu vsts <<SHUTDOWN_AGENT\nexport VSTS_AGENT_INPUT_TOKEN='${secret_resource.vsts-token.value}'\n./config.sh remove --unattended --auth PAT\nSHUTDOWN_AGENT\n    ")

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -7,7 +7,7 @@ locals {
       name       = "ci-u1",
       disk_size  = 400,
       size       = 30,
-      trunc_size = 200,
+      trunc_size = 400,
     },
     {
       name       = "ci-u2",

--- a/infra/vsts_agent_ubuntu_20_04_startup.sh
+++ b/infra/vsts_agent_ubuntu_20_04_startup.sh
@@ -137,7 +137,7 @@ reset_cache() {
     fi
 
     rm -f $file
-    truncate -s 200g $file
+    truncate -s 400g $file
     mkfs.ext2 -E root_owner=$(id -u):$(id -g) $file
     mkdir -p $mount_point
     mount $mount_point

--- a/infra/vsts_agent_ubuntu_20_04_startup.sh
+++ b/infra/vsts_agent_ubuntu_20_04_startup.sh
@@ -137,7 +137,7 @@ reset_cache() {
     fi
 
     rm -f $file
-    truncate -s 400g $file
+    truncate -s ${size}g $file
     mkfs.ext2 -E root_owner=$(id -u):$(id -g) $file
     mkdir -p $mount_point
     mount $mount_point


### PR DESCRIPTION
I've seen a few "disk full" errors recently on CI, and they don't quite make sense because we do have this "reset cache" step that looks at available disk space and cleans up if needed.

So I dug a little bit more and found this discrepancy: the real hard drives are 400g, the virtual disks are 200g. So what may happen is we still have plenty of space on the real drives (well, they're virtual, but bear with me), while the virtual ones are full. And since the clean-up step only looks at the free space on the real drives, it goes ahead without cleaning up and then when we try to download stuff there's no free space on the virtual drives.

This didn't use to be a problem because the size of the virtual drives mapped to the size of the real ones. This PR aims at restoring that equivalence.