### PR TITLE
Remove critical package private access modifiers

### DIFF
--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Decode.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Decode.scala
@@ -49,11 +49,11 @@ object Decode {
   ): (PackageId, Ast.Package) =
     assertRight(decodeArchive(archive, onlySerializableDataDefs))
 
-  private[daml] def decodeInfoPackage(archive: DamlLf.Archive): Either[Error, PackageInfo] =
+  def decodeInfoPackage(archive: DamlLf.Archive): Either[Error, PackageInfo] =
     decodeArchive(archive, onlySerializableDataDefs = true)
       .map(entry => new PackageInfo(Map(entry)))
 
-  private[daml] def assertDecodeInfoPackage(archive: DamlLf.Archive): PackageInfo =
+  def assertDecodeInfoPackage(archive: DamlLf.Archive): PackageInfo =
     assertRight(decodeInfoPackage(archive: DamlLf.Archive))
 
 }


### PR DESCRIPTION
To unblock package rename in canton

[CHANGELOG_BEGIN]
[CHANGELOG_END]

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
