### PR TITLE
[engine] kill Node.Authority with fire

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -558,7 +558,6 @@ final class Conversions(
       .map(eventId => builder.setConsumedBy(convertEventId(eventId)))
 
     nodeInfo.node match {
-      case _: Node.Authority => ??? // TODO #15882 -- we need to extend IDE-communication proto
       case rollback: Node.Rollback =>
         val rollbackBuilder = proto.Node.Rollback.newBuilder
           .addAllChildren(
@@ -653,7 +652,6 @@ final class Conversions(
       .setNodeId(proto.NodeId.newBuilder.setId(nodeId.index.toString).build)
     // FIXME(JM): consumedBy, parent, ...
     node match {
-      case _: Node.Authority => ??? // TODO #15882 -- we need to extend IDE-communication proto
       case rollback: Node.Rollback =>
         val rollbackBuilder =
           proto.Node.Rollback.newBuilder

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -63,8 +63,6 @@ object Blinding {
             go(filteredRoots :+ root, remainingRoots)
           } else {
             tx.nodes(root) match {
-              case na: Node.Authority =>
-                go(filteredRoots, na.children ++: remainingRoots)
               case nr: Node.Rollback =>
                 go(filteredRoots, nr.children ++: remainingRoots)
               case _: Node.Fetch | _: Node.Create | _: Node.LookupByKey =>
@@ -89,8 +87,6 @@ object Blinding {
     val entries = blindingInfo.disclosure.view.flatMap { case (nodeId, parties) =>
       def toEntries(tyCon: Ref.TypeConName) = parties.view.map(_ -> tyCon.packageId)
       tx.nodes(nodeId) match {
-        case _: Node.Authority =>
-          Iterable.empty
         case action: Node.LeafOnlyAction =>
           toEntries(action.templateId)
         case exe: Node.Exercise =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -589,7 +589,6 @@ object Engine {
       val makeDesc = (kind: String, tmpl: Ref.Identifier, extra: Option[String]) =>
         s"$kind:${tmpl.qualifiedName.name}${extra.map(extra => s":$extra").getOrElse("")}"
       tx.nodes.get(tx.roots(0)).toList.head match {
-        case _: Node.Authority => "authority"
         case _: Node.Rollback => "rollback"
         case create: Node.Create => makeDesc("create", create.templateId, None)
         case exercise: Node.Exercise =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
@@ -156,8 +156,6 @@ final class ValueEnricher(
 
   def enrichNode(node: Node): Result[Node] =
     node match {
-      case na: Node.Authority =>
-        ResultDone(na)
       case rb @ Node.Rollback(_) =>
         ResultDone(rb)
       case create: Node.Create =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
@@ -95,8 +95,6 @@ private[preprocessing] final class TransactionPreprocessor(
             case _: Node.LookupByKey =>
               invalidRootNode(id, s"Transaction contains a lookup by key root node $id")
           }
-        case Some(_: Node.Authority) =>
-          invalidRootNode(id, s"invalid transaction, root refers to a authority node $id")
         case Some(_: Node.Rollback) =>
           invalidRootNode(id, s"invalid transaction, root refers to a rollback node $id")
         case None =>

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -2731,8 +2731,6 @@ object EngineTest {
                   exe.choiceId,
                   exe.chosenValue,
                 )
-              case _: Node.Authority =>
-                sys.error("unexpected authority node")
               case _: Node.Rollback =>
                 sys.error("unexpected rollback node")
             }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
@@ -98,20 +98,6 @@ object BlindingTransaction {
               }
           }
 
-        case Some(authNode: Node.Authority) =>
-          // TODO #15882 -- should an authNode have informees?
-          // TODO #15882 -- should an authNode be a kind of actionNode?
-          // val witnesses = parentExerciseWitnesses
-          val witnesses = parentExerciseWitnesses // TODO #15882 -- union authNode.informeesOfNode
-          val state = state0.discloseNode(witnesses, nodeId)
-          authNode.children.foldLeft(state) { (s, childNodeId) =>
-            processNode(
-              s,
-              witnesses,
-              childNodeId,
-            )
-          }
-
         case Some(rollback: Node.Rollback) =>
           // Rollback nodes are disclosed to the witnesses of the parent exercise.
           val state = state0.discloseNode(parentExerciseWitnesses, nodeId)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -633,8 +633,7 @@ final case class ScenarioLedger(
                 create.stakeholders,
               )
 
-          case _: Node.Exercise | _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback |
-              _: Node.Authority =>
+          case _: Node.Exercise | _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback =>
             LookupContractNotFound(coid)
         }
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -211,8 +211,6 @@ private[lf] object Pretty {
   // A minimal pretty-print of an update transaction node, without recursing into child nodes..
   def prettyPartialTransactionNode(node: Node): Doc =
     node match {
-      case _: Node.Authority =>
-        text("authority")
       case Node.Rollback(_) =>
         text("rollback")
       case create: Node.Create =>
@@ -307,8 +305,6 @@ private[lf] object Pretty {
     val eventId = EventId(txId.id, nodeId)
     val ni = l.ledgerData.nodeInfos(eventId)
     val ppNode = ni.node match {
-      case na: Node.Authority =>
-        text("authority:") / stack(na.children.toList.map(prettyEventInfo(l, txId)))
       case Node.Rollback(children) =>
         text("rollback:") / stack(children.toList.map(prettyEventInfo(l, txId)))
       case create: Node.Create =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
@@ -63,11 +63,6 @@ private[lf] object NormalizeRollbacks {
                   k(Vector(Norm.Exe(exe, norms.toList)))
                 }
 
-              case aut: Node.Authority =>
-                traverseNodeIds(aut.children.toList) { norms =>
-                  k(Vector(Norm.Aut(aut, norms.toList)))
-                }
-
               case leaf: Node.LeafOnlyAction =>
                 k(Vector(Norm.Leaf(leaf)))
             }
@@ -185,11 +180,6 @@ private[lf] object NormalizeRollbacks {
                 s.push(me, node)(k)
               }
             }
-          case Norm.Aut(aut, subs) =>
-            pushNorms(s, subs) { (s, children) =>
-              val node = aut.copy(children = children.to(ImmArray))
-              s.push(me, node)(k)
-            }
         }
       }
     }
@@ -257,7 +247,6 @@ private[lf] object NormalizeRollbacks {
       sealed abstract class Act extends Norm
       final case class Leaf(node: Node.LeafOnlyAction) extends Act
       final case class Exe(node: Node.Exercise, children: List[Norm]) extends Act
-      final case class Aut(node: Node.Authority, children: List[Norm]) extends Act
 
       // A *normalized* rollback tx/node. 2 cases:
       // - rollback containing a single non-rollback tx/node.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -260,7 +260,6 @@ private[speedy] case class PartialTransaction(
       // so we need to compute them.
       val rootNodes = {
         val allChildNodeIds: Set[NodeId] = nodes.values.iterator.flatMap {
-          case au: Node.Authority => au.children.toSeq
           case rb: Node.Rollback => rb.children.toSeq
           case _: Node.LeafOnlyAction => Nil
           case ex: Node.Exercise => ex.children.toSeq

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/NormalizeRollbacksSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/NormalizeRollbacksSpec.scala
@@ -200,7 +200,6 @@ object NormalizeRollbackSpec {
         case _: Node.LeafOnlyAction => acc
         case node: Node.Exercise => fromNids(acc, node.children.toList)
         case node: Node.Rollback => fromNids(acc, node.children.toList)
-        case node: Node.Authority => fromNids(acc, node.children.toList)
       }
     }
     fromNids(Nil, tx.roots.toList).reverse
@@ -248,7 +247,6 @@ object NormalizeRollbackSpec {
     final case class Create(x: Long) extends Shape
     final case class Exercise(x: List[Shape]) extends Shape
     final case class Rollback(x: List[Shape]) extends Shape
-    final case class Authority(x: List[Shape]) extends Shape
 
     def toTransaction(top: Top): TX = {
       val ids = Iterator.from(0).map(NodeId(_))
@@ -267,9 +265,6 @@ object NormalizeRollbackSpec {
           case Rollback(shapes) =>
             val children = shapes.map(toNid)
             add(Node.Rollback(children = children.to(ImmArray)))
-          case Authority(shapes) =>
-            val children = shapes.map(toNid)
-            add(dummyAuthorityNode(children.to(ImmArray)))
         }
       }
       val roots: List[NodeId] = top.xs.map(toNid)
@@ -288,7 +283,6 @@ object NormalizeRollbackSpec {
             sys.error(s"Shape.ofTransaction, unexpected leaf: $leaf")
           case node: Node.Exercise => Exercise(node.children.toList.map(ofNid))
           case node: Node.Rollback => Rollback(node.children.toList.map(ofNid))
-          case node: Node.Authority => Authority(node.children.toList.map(ofNid))
         }
       }
       Top(tx.roots.toList.map(nid => ofNid(nid)))
@@ -309,15 +303,6 @@ object NormalizeRollbackSpec {
       keyOpt = None,
       version = TransactionVersion.minVersion,
     )
-
-  private def dummyAuthorityNode(
-      children: ImmArray[NodeId]
-  ): Node.Authority = {
-    Node.Authority(
-      obtained = Set.empty,
-      children = children,
-    )
-  }
 
   private def dummyExerciseNode(
       children: ImmArray[NodeId]

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
@@ -206,7 +206,6 @@ object RollbackTest {
   final case class C(x: Long) extends Tree // Create Node
   final case class X(x: List[Tree]) extends Tree // Exercise Node
   final case class R(x: List[Tree]) extends Tree // Rollback Node
-  final case class A(x: List[Tree]) extends Tree // Authority Node
 
   private def shapeOfTransaction(tx: SubmittedTransaction): List[Tree] = {
     def trees(nid: NodeId): List[Tree] = {
@@ -224,8 +223,6 @@ object RollbackTest {
           List(X(node.children.toList.flatMap(nid => trees(nid))))
         case node: Node.Rollback =>
           List(R(node.children.toList.flatMap(nid => trees(nid))))
-        case node: Node.Authority =>
-          List(A(node.children.toList.flatMap(nid => trees(nid))))
       }
     }
     tx.roots.toList.flatMap(nid => trees(nid))

--- a/daml-lf/kv-support/src/main/scala/com/daml/lf/kv/transactions/TransactionNormalizer.scala
+++ b/daml-lf/kv-support/src/main/scala/com/daml/lf/kv/transactions/TransactionNormalizer.scala
@@ -20,7 +20,6 @@ object TransactionNormalizer {
       tx.foldInExecutionOrder[Set[NodeId]](Set.empty)(
         exerciseBegin = (acc, nid, _) => (acc + nid, ChildrenRecursion.DoRecurse),
         rollbackBegin = (acc, _, _) => (acc, ChildrenRecursion.DoNotRecurse),
-        authorityBegin = (acc, _, _) => (acc, ChildrenRecursion.DoRecurse),
         leaf = (acc, nid, node) =>
           node match {
             case _: Node.Create => acc + nid
@@ -29,7 +28,6 @@ object TransactionNormalizer {
           },
         exerciseEnd = (acc, _, _) => acc,
         rollbackEnd = (acc, _, _) => acc,
-        authorityEnd = (acc, _, _) => acc,
       )
     val filteredNodes =
       tx.nodes

--- a/daml-lf/snapshot/src/main/scala/com/daml/Adapter.scala
+++ b/daml-lf/snapshot/src/main/scala/com/daml/Adapter.scala
@@ -27,8 +27,6 @@ final class Adapter(
   // drop value version and children
   private[this] def adapt(node: Node): Node =
     node match {
-      case authority: Node.Authority =>
-        authority.copy(children = ImmArray.Empty)
       case rollback: Node.Rollback =>
         rollback.copy(children = ImmArray.Empty)
       case create: Node.Create =>

--- a/daml-lf/snapshot/src/main/scala/com/daml/TransactionSnapshot.scala
+++ b/daml-lf/snapshot/src/main/scala/com/daml/TransactionSnapshot.scala
@@ -147,14 +147,12 @@ private[snapshot] object TransactionSnapshot {
           ChildrenRecursion.DoRecurse
         },
         rollbackBegin = (_, _) => ChildrenRecursion.DoNotRecurse,
-        authorityBegin = (_, _) => ChildrenRecursion.DoRecurse,
         leaf = {
           case (_, create: Node.Create) => activeCreates += (create.coid -> create)
           case (_, _) =>
         },
         exerciseEnd = (_, _) => (),
         rollbackEnd = (_, _) => (),
-        authorityEnd = (_, _) => (),
       )
 
     def updateWithArchive(archive: ByteString) =

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -39,11 +39,11 @@ final class TransactionBuilder(pkgTxVersion: Ref.PackageId => TransactionVersion
   def add(node: Node, parentId: NodeId): NodeId = ids.synchronized {
     lazy val nodeId = newNode(node) // lazy to avoid getting the next id if the method later throws
     nodes(parentId) match {
-      case _: Node.Exercise | _: Node.Rollback | _: Node.Authority =>
+      case _: Node.Exercise | _: Node.Rollback =>
         children += parentId -> (children(parentId) :+ nodeId)
       case _ =>
         throw new IllegalArgumentException(
-          s"Node ${parentId.index} either does not exist or is not an exercise, rollback or authority"
+          s"Node ${parentId.index} either does not exist or is not an exercise or rollback"
         )
     }
     nodeId
@@ -52,8 +52,6 @@ final class TransactionBuilder(pkgTxVersion: Ref.PackageId => TransactionVersion
   def build(): VersionedTransaction = ids.synchronized {
     import TransactionVersion.Ordering
     val finalNodes = nodes.transform {
-      case (nid, au: Node.Authority) =>
-        au.copy(children = children(nid).toImmArray)
       case (nid, rb: Node.Rollback) =>
         rb.copy(children = children(nid).toImmArray)
       case (nid, exe: Node.Exercise) =>

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/TransactionNodeStatistics.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/TransactionNodeStatistics.scala
@@ -143,9 +143,6 @@ object TransactionNodeStatistics {
         rollbackDepth += 1
         Transaction.ChildrenRecursion.DoRecurse
       },
-      authorityBegin = { (_, _) =>
-        Transaction.ChildrenRecursion.DoRecurse
-      },
       leaf = { (_, node) =>
         val idx = node match {
           case _: Node.Create =>
@@ -162,7 +159,6 @@ object TransactionNodeStatistics {
       },
       exerciseEnd = (_, _) => (),
       rollbackEnd = (_, _) => rollbackDepth -= 1,
-      authorityEnd = (_, _) => (),
     )
 
     TransactionNodeStatistics(build(committed), build(rolledBack))

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -17,7 +17,6 @@ sealed abstract class Node extends Product with Serializable with CidContainer[N
   def optVersion: Option[TransactionVersion] = this match {
     case node: Node.Action => Some(node.version)
     case _: Node.Rollback => None
-    case _: Node.Authority => None
   }
 
   def mapNodeId(f: NodeId => NodeId): Node
@@ -228,18 +227,6 @@ object Node {
     override def mapCid(f: ContractId => ContractId): Node.Rollback = this
     override def mapNodeId(f: NodeId => NodeId): Node.Rollback =
       copy(children.map(f))
-
-    override protected def self: Node = this
-  }
-
-  final case class Authority(
-      obtained: Set[Party],
-      children: ImmArray[NodeId],
-  ) extends Node {
-
-    override def mapCid(f: ContractId => ContractId): Node.Authority = this
-    override def mapNodeId(f: NodeId => NodeId): Node.Authority =
-      copy(children = children.map(f))
 
     override protected def self: Node = this
   }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Normalization.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Normalization.scala
@@ -50,8 +50,6 @@ class Normalization {
     import scala.Ordering.Implicits.infixOrderingOps
     node match {
 
-      case old: Node.Authority => old
-
       case old: Node.Create =>
         old
           .copy(arg = normValue(old.version)(old.arg))

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -250,7 +250,6 @@ object TransactionCoder {
       TransactionOuterClass.Node.newBuilder().setNodeId(encodeNid.asString(nodeId))
 
     node match {
-      case _: Node.Authority => ??? // TODO #15882 -- we need to extend the transaction proto
       case Node.Rollback(children) =>
         val builder = TransactionOuterClass.NodeRollback.newBuilder()
         children.foreach(id => discard(builder.addChildren(encodeNid.asString(id))))

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -52,7 +52,6 @@ object TransactionVersion {
   private[lf] val minByKey = V14
   private[lf] val minInterfaces = V15
   private[lf] val minExplicitDisclosure = VDev
-  private[lf] val minWithAuthority = VDev
 
   private[lf] val assignNodeVersion: LanguageVersion => TransactionVersion = {
     import LanguageVersion._
@@ -74,7 +73,6 @@ object TransactionVersion {
     tx.nodes.valuesIterator.foldLeft(TransactionVersion.minVersion) {
       case (acc, action: Node.Action) => acc max action.version
       case (acc, _: Node.Rollback) => acc max minExceptions
-      case (acc, _: Node.Authority) => acc max minWithAuthority
     }
   }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/ContractStateMachineSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/ContractStateMachineSpec.scala
@@ -632,7 +632,6 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
     case _: Node.Create | _: Node.Fetch | _: Node.LookupByKey => ImmArray.empty[NodeId]
     case exercise: Node.Exercise => exercise.children
     case rollback: Node.Rollback => rollback.children
-    case authority: Node.Authority => authority.children
   }
 
   /** Visits the `root` node and all its children in execution order and updates the `state` accordingly,
@@ -662,8 +661,6 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
     val node = nodes(root)
     for {
       next <- node match {
-        case _: Node.Authority =>
-          ??? // TODO #15882 -- treat like exercise with no keys. recurse directly on children
         case actionNode: Node.Action =>
           state.handleNode((), actionNode, actionNode.gkeyOpt.flatMap(resolver))
         case _: Node.Rollback =>
@@ -673,7 +670,6 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
         visitSubtrees(ksm)(nodes, children(node).toSeq, resolver, next)
       }
       exited = node match {
-        case _: Node.Authority => ??? // TODO #15882
         case _: Node.Rollback => afterChildren.endRollback()
         case _ => afterChildren
       }
@@ -765,8 +761,6 @@ object ContractStateMachineSpec {
         },
       rollbackBegin = (s, _, _) => s -> ChildrenRecursion.DoRecurse,
       rollbackEnd = (s, _, _) => s,
-      authorityBegin = (s, _, _) => s -> ChildrenRecursion.DoRecurse,
-      authorityEnd = (s, _, _) => s,
     )
   }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -895,7 +895,6 @@ class TransactionCoderSpec
 
   private[this] def normalizeNode(node: Node) =
     node match {
-      case na: Node.Authority => na // nothing to normalize
       case rb: Node.Rollback => rb // nothing to normalize
       case exe: Node.Exercise => normalizeExe(exe)
       case fetch: Node.Fetch => normalizeFetch(fetch)
@@ -973,7 +972,6 @@ class TransactionCoderSpec
       node: Node,
       version: TransactionVersion,
   ): Node = node match {
-    case node: Node.Authority => node
     case node: Node.Action => node.updateVersion(version)
     case node: Node.Rollback => node
   }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -103,7 +103,7 @@ class TransactionSpec
 
   }
 
-  "foldInExecutionOrder" - { // TODO #15882 -- extend test for Node.Authority
+  "foldInExecutionOrder" - {
     "should traverse the transaction in execution order" in {
 
       val tx = mkTransaction(
@@ -123,12 +123,9 @@ class TransactionSpec
           (acc, nid, _) => (s"exerciseBegin(${nid.index})" :: acc, ChildrenRecursion.DoRecurse),
         rollbackBegin =
           (acc, nid, _) => (s"rollbackBegin(${nid.index})" :: acc, ChildrenRecursion.DoRecurse),
-        authorityBegin =
-          (acc, nid, _) => (s"authorityBegin(${nid.index})" :: acc, ChildrenRecursion.DoRecurse),
         leaf = (acc, nid, _) => s"leaf(${nid.index})" :: acc,
         exerciseEnd = (acc, nid, _) => s"exerciseEnd(${nid.index})" :: acc,
         rollbackEnd = (acc, nid, _) => s"rollbackEnd(${nid.index})" :: acc,
-        authorityEnd = (acc, nid, _) => s"authorityEnd(${nid.index})" :: acc,
       )
 
       result.reverse.mkString(", ") shouldBe
@@ -198,8 +195,6 @@ class TransactionSpec
       for {
         entry <- danglingRefGenNode
         node = entry match {
-          case (_, na: Node.Authority) =>
-            na.copy(children = ImmArray.Empty)
           case (_, nr: Node.Rollback) =>
             nr.copy(children = ImmArray.Empty)
           case (_, n: Node.LeafOnlyAction) => n
@@ -224,7 +219,6 @@ class TransactionSpec
       forAll(genEmptyNode, minSuccessful(10)) { n =>
         val version = n.optVersion.getOrElse(TransactionVersion.minExceptions)
         n match {
-          case _: Node.Authority => ()
           case _: Node.Rollback => ()
           case n: Node.Action =>
             val m = n.updateVersion(diffVersion(version))

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -348,7 +348,7 @@ class IdeLedgerClient(
                 exercise.choiceId,
                 exercise.exerciseResult.get,
               )
-            case _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback | _: Node.Authority =>
+            case _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback =>
               throw new IllegalArgumentException(s"Invalid root node: $node")
           }
         }
@@ -403,7 +403,7 @@ class IdeLedgerClient(
                   exercise.children.collect(Function.unlift(convEvent(_))).toList,
                 )
               )
-            case _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback | _: Node.Authority => None
+            case _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback => None
           }
         ScriptLedgerClient.TransactionTree(
           transaction.roots.collect(Function.unlift(convEvent(_))).toList

--- a/ledger/participant-integration-api/src/main/scala/platform/index/InMemoryStateUpdater.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/InMemoryStateUpdater.scala
@@ -224,11 +224,9 @@ private[platform] object InMemoryStateUpdater {
         exerciseBegin = (acc, nid, node) => ((nid -> node) :: acc, ChildrenRecursion.DoRecurse),
         // Rollback nodes are not indexed
         rollbackBegin = (acc, _, _) => (acc, ChildrenRecursion.DoNotRecurse),
-        authorityBegin = (acc, _, _) => (acc, ChildrenRecursion.DoRecurse),
         leaf = (acc, nid, node) => (nid -> node) :: acc,
         exerciseEnd = (acc, _, _) => acc,
         rollbackEnd = (acc, _, _) => acc,
-        authorityEnd = (acc, _, _) => acc,
       )
       .reverseIterator
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/UpdateToDbDto.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/UpdateToDbDto.scala
@@ -190,11 +190,9 @@ object UpdateToDbDto {
             exerciseBegin = (acc, nid, node) => ((nid -> node) :: acc, ChildrenRecursion.DoRecurse),
             // Rollback nodes are not included in the indexer
             rollbackBegin = (acc, _, _) => (acc, ChildrenRecursion.DoNotRecurse),
-            authorityBegin = (acc, _, _) => (acc, ChildrenRecursion.DoRecurse),
             leaf = (acc, nid, node) => (nid -> node) :: acc,
             exerciseEnd = (acc, _, _) => acc,
             rollbackEnd = (acc, _, _) => acc,
-            authorityEnd = (acc, _, _) => acc,
           )
           .reverse
 


### PR DESCRIPTION
Advance #15882

- Kill `Node.Authority` following redesign of consortium party support

canton fix:
https://github.com/DACH-NY/canton/compare/nick/adapt-daml-choice-authority-evaluation...nick/adapt-kill-Node.Authority