### PR TITLE
Ensure trigger span starts and ends are always logged

### DIFF
--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerLogContext.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerLogContext.scala
@@ -72,10 +72,10 @@ final class TriggerLogContext private (
     )
 
     try {
-      context.logInfo("span start")
+      context.logInfo("span entry")
       f(context)
     } finally {
-      context.logInfo("span end")
+      context.logInfo("span exit")
     }
   }
 
@@ -93,10 +93,10 @@ final class TriggerLogContext private (
     )
 
     try {
-      context.logInfo("span start")
+      context.logInfo("span entry")
       f(context)
     } finally {
-      context.logInfo("span end")
+      context.logInfo("span exit")
     }
   }
 

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerLogContext.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerLogContext.scala
@@ -61,29 +61,43 @@ final class TriggerLogContext private (
   def nextSpan[A](
       name: String,
       additionalEntries: (String, LoggingValue)*
-  )(f: TriggerLogContext => A): A = {
-    f(
-      new TriggerLogContext(
-        loggingContext,
-        entries ++ additionalEntries,
-        span.nextSpan(name),
-        callback,
-      )
+  )(f: TriggerLogContext => A)(implicit
+      logger: ContextualizedLogger
+  ): A = {
+    val context = new TriggerLogContext(
+      loggingContext,
+      entries ++ additionalEntries,
+      span.nextSpan(name),
+      callback,
     )
+
+    try {
+      context.logInfo("span start")
+      f(context)
+    } finally {
+      context.logInfo("span end")
+    }
   }
 
   def childSpan[A](
       name: String,
       additionalEntries: (String, LoggingValue)*
-  )(f: TriggerLogContext => A): A = {
-    f(
-      new TriggerLogContext(
-        loggingContext,
-        entries ++ additionalEntries,
-        span.childSpan(name),
-        callback,
-      )
+  )(f: TriggerLogContext => A)(implicit
+      logger: ContextualizedLogger
+  ): A = {
+    val context = new TriggerLogContext(
+      loggingContext,
+      entries ++ additionalEntries,
+      span.childSpan(name),
+      callback,
     )
+
+    try {
+      context.logInfo("span start")
+      f(context)
+    } finally {
+      context.logInfo("span end")
+    }
   }
 
   def groupWith(contexts: TriggerLogContext*): TriggerLogContext = {

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRuleSimulationLib.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRuleSimulationLib.scala
@@ -18,7 +18,7 @@ import com.daml.lf.engine.trigger.Runner.{TriggerContext, TriggerContextualFlow}
 import com.daml.lf.engine.trigger.UnfoldState.{flatMapConcatNodeOps, toSourceOps}
 import com.daml.lf.speedy.SValue.SList
 import com.daml.lf.speedy.SValue
-import com.daml.logging.LoggingContextOf
+import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
 import com.daml.logging.entries.LoggingValue
 import com.daml.logging.entries.LoggingValue.{Nested, OfInt, OfLong, OfString}
 import com.daml.platform.services.time.TimeProviderType
@@ -701,6 +701,8 @@ final class TriggerRuleSimulationLib private (
     // TODO: a future PR will provide a more meaningful implementation
   }
 
+  private[this] implicit val logger: ContextualizedLogger =
+    ContextualizedLogger.get(classOf[Runner])
   private[this] implicit val materializer: Materializer = Materializer(
     ActorSystem("TriggerRuleSimulator")
   )


### PR DESCRIPTION
As described under https://github.com/digital-asset/daml/issues/16535, current trigger logging analysis of span information can result in orphaned logging events - and this degrades the value obtained from an automated analysis.

This PR fixes part of the issues described under https://github.com/digital-asset/daml/issues/16535 by always logging entry and exit to each span we create. That way, regardless of what logging does or does not occur on a span, we always log the correct parent span IDs.

N.B. timestamp information for the entry and exit logging entries can be used to provide a crude millisecond timing for how long it took to execute all code associated with a span.
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
