### PR TITLE
Omit versions for daml-script/daml-triggers in EXPECTED.json files

### DIFF
--- a/compiler/damlc/daml-doc/BUILD.bazel
+++ b/compiler/damlc/daml-doc/BUILD.bazel
@@ -79,6 +79,7 @@ da_haskell_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//:sdk-version-hs-lib",
         "//compiler/daml-lf-ast",
         "//compiler/damlc/daml-compiler",
         "//compiler/damlc/daml-doc",

--- a/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
@@ -39,6 +39,7 @@ import qualified Test.Tasty.Extended as Tasty
 import           Test.Tasty.Golden
 import           Test.Tasty.HUnit
 import Data.Maybe
+import SdkVersion (sdkPackageVersion)
 
 mkTestTree :: AnchorMap -> ScriptPackageData -> IO Tasty.TestTree
 mkTestTree externalAnchors scriptPackageData = do
@@ -468,7 +469,15 @@ fileTest externalAnchors scriptPackageData damlFile = do
           case takeExtension expectation of
             ".rst" -> TL.encodeUtf8 $ TL.fromStrict $ renderPage renderRst externalAnchors $ renderModule doc
             ".md" -> TL.encodeUtf8 $ TL.fromStrict $ renderPage renderMd externalAnchors $ renderModule doc
-            ".json" -> AP.encodePretty' jsonConf doc
+            ".json" -> replaceDamlScript $ AP.encodePretty' jsonConf doc
             other -> error $ "Unsupported file extension " <> other
   where
     diff ref new = [POSIX_DIFF, "--strip-trailing-cr", ref, new]
+    -- In cases where daml-script/daml-trigger is used, the version of the package is embedded in the json.
+    -- When we release, this version changes, which would break the golden file test.
+    -- Instead, we omit daml-script/daml-trigger versions from .EXPECTED.json files in golden tests.
+    replaceDamlScript = 
+      TL.encodeUtf8
+      . TL.replace (TL.pack $ "daml-script-" <> sdkPackageVersion) "daml-script-UNVERSIONED"
+      . TL.replace (TL.pack $ "daml-trigger-" <> sdkPackageVersion) "daml-trigger-UNVERSIONED"
+      . TL.decodeUtf8

--- a/compiler/damlc/tests/daml-test-files/DamlDocsScriptImport.EXPECTED.json
+++ b/compiler/damlc/tests/daml-test-files/DamlDocsScriptImport.EXPECTED.json
@@ -1,0 +1,32 @@
+{
+  "md_adts": [],
+  "md_anchor": "module-damldocsscriptimport-97896",
+  "md_classes": [],
+  "md_descr": "My documented module",
+  "md_functions": [
+    {
+      "fct_anchor": "function-damldocsscriptimport-main-98373",
+      "fct_context": [],
+      "fct_descr": "My documented script",
+      "fct_name": "main",
+      "fct_type": {
+        "TypeApp": [
+          {
+            "referenceAnchor": "type-daml-script-script-90248",
+            "referencePackage": "daml-script-UNVERSIONED"
+          },
+          "Script",
+          [
+            {
+              "TypeTuple": []
+            }
+          ]
+        ]
+      }
+    }
+  ],
+  "md_instances": [],
+  "md_interfaces": [],
+  "md_name": "DamlDocsScriptImport",
+  "md_templates": []
+}


### PR DESCRIPTION
Resolves #16540 
Converts any occurrences of `daml-script-<version>` and `daml-trigger-<version>` with `daml-script-UNVERSIONED` and `daml-trigger-UNVERSIONED` respectively in .EXPECTED.json golden files.