### PR TITLE
correct to --detect.bazel.workspace.rules to fix bazel JVM and Haskell blackduck scans

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -174,7 +174,7 @@ jobs:
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=BAZEL \
           --detect.bazel.target=//... \
-          --detect.bazel.dependency.type=${BAZEL_DEPENDENCY_TYPE} \
+          --detect.bazel.workspace.rules=${BAZEL_DEPENDENCY_TYPE} \
           --detect.notices.report=true \
           --detect.code.location.name=digital-asset_daml_${BAZEL_DEPENDENCY_TYPE} \
           --detect.timeout=1500
@@ -191,11 +191,11 @@ jobs:
           BAZEL_DEPENDENCY_TYPE="maven_install"
 
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml $(Build.SourceBranchName) \
+          ci-build digital-asset_daml local-main-maven \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=BAZEL \
           --detect.bazel.target=//... \
-          --detect.bazel.dependency.type=${BAZEL_DEPENDENCY_TYPE} \
+          --detect.bazel.workspace.rules=${BAZEL_DEPENDENCY_TYPE} \
           --detect.notices.report=true \
           --detect.code.location.name=digital-asset_daml_${BAZEL_DEPENDENCY_TYPE} \
           --detect.timeout=1500


### PR DESCRIPTION
Use `--detect.bazel.workspace.rules` parameter so `maven_install` and `haskell_cabal_library` bazel dependencies are correctly detected and reported to blackduck

Missed this in the release notes of the various detect scanner upgrades

https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=releasenotes.html&_LANG=enus
```
The following properties (that were deprecated in Synopsys Detect 7.x) have been removed: blackduck.legacy.upload.enabled, detect.bazel.dependency.type, detect.bdio2.enabled, detect.bom.aggregate.name,

Added new property detect.bazel.workspace.rules to replace the now deprecated detect.bazel.dependency.type property.
```

@garyverhaegen-da -- this is the reason why the right `protobuf-java` version was not detected -- scan was going off stale results from prior scans