### PR TITLE
Drop scenarios from incremental and data deps tests

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -365,8 +365,8 @@ da_haskell_test(
     srcs = ["src/DA/Test/IncrementalBuilds.hs"],
     data = [
         "//compiler/damlc",
-        "//daml-script/runner:daml-script-binary",
         "//daml-script/daml:daml-script.dar",
+        "//daml-script/runner:daml-script-binary",
     ],
     hackage_deps = [
         "base",
@@ -382,6 +382,7 @@ da_haskell_test(
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [
+        "//:sdk-version-hs-lib",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/test-utils",
     ],

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -365,7 +365,8 @@ da_haskell_test(
     srcs = ["src/DA/Test/IncrementalBuilds.hs"],
     data = [
         "//compiler/damlc",
-        "//daml-lf/repl",
+        "//daml-script/runner:daml-script-binary",
+        "//daml-script/daml:daml-script.dar",
     ],
     hackage_deps = [
         "base",
@@ -464,6 +465,7 @@ da_haskell_test(
         "//compiler/damlc",
         "@damlc_legacy",
         "//compiler/damlc/tests:generate-simple-dalf",
+        "//daml-script/daml:daml-script-1.dev.dar",
         # Feel free to update this to 0.13.55 once that is frozen.
         ":dars/old-proj-0.13.55-snapshot.20200309.3401.0.6f8c3ad8-1.8.dar",
     ],

--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -1358,8 +1358,6 @@ tests tools = testGroup "Data Dependencies" $
         (_pkgId, pkg) <- either (fail . show) pure (LFArchive.decodeArchive LFArchive.DecodeAsMain (BSL.toStrict mainDalf))
 
         Just mod <- pure $ NM.lookup (LF.ModuleName ["Foo"]) (LF.packageModules pkg)
-        -- let _f x = (fst $ LF.dvalBinder x, LF.dvalBody x)
-        -- mapM_ print $ LF.dvalBinder <$> NM.toList (LF.moduleValues mod)
         let callStackInstances = do
                 v@LF.DefValue{dvalBinder = (_, ty)} <- NM.toList (LF.moduleValues mod)
                 LF.TSynApp
@@ -1822,7 +1820,7 @@ tests tools = testGroup "Data Dependencies" $
             , "    exerciseCmd cidToken1 (Noop ())"
             , "    r <- exerciseCmd cidToken1 (Split 10)"
             , "    pure r"
-                 -- Equililent to `fetch` when passing in an interface contract id.
+                 -- Equivalent to `fetch` when passing in an interface contract id.
             , "  let queryAssert cid = toInterface . fromSome <$> queryContractId p (fromInterfaceContractId @Asset cid)"
 
             , "  token2 <- queryAssert cidToken2"

--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -2204,19 +2204,20 @@ tests tools = testGroup "Data Dependencies" $
           dar proj = path proj </> proj <.> "dar"
           step proj = step' ("building '" <> proj <> "' project")
 
-          damlYamlBody name useScript dataDeps = unlines
+          damlYamlBody :: String -> [FilePath] -> [String] -> String
+          damlYamlBody name extraDeps dataDeps = unlines
             [ "sdk-version: " <> sdkVersion
             , "name: " <> name
             , "build-options: [--target=1.dev]"
             , "source: ."
             , "version: 0.1.0"
-            , "dependencies: [daml-prim, daml-stdlib" <> (if useScript then ", " <> show scriptDar1dev else "") <> "]"
+            , "dependencies: [" <> intercalate ", " (["daml-prim", "daml-stdlib"] <> fmap show extraDeps) <> "]"
             , "data-dependencies: [" <> intercalate ", " (fmap dar dataDeps) <> "]"
             ]
 
         step tokenProj >> do
           createDirectoryIfMissing True (path tokenProj)
-          writeFileUTF8 (damlYaml tokenProj) $ damlYamlBody tokenProj False []
+          writeFileUTF8 (damlYaml tokenProj) $ damlYamlBody tokenProj [] []
           writeFileUTF8 (damlMod tokenProj "Token") $ unlines
             [ "module Token where"
 
@@ -2260,7 +2261,7 @@ tests tools = testGroup "Data Dependencies" $
 
         step fancyTokenProj >> do
           createDirectoryIfMissing True (path fancyTokenProj)
-          writeFileUTF8 (damlYaml fancyTokenProj) $ damlYamlBody fancyTokenProj False
+          writeFileUTF8 (damlYaml fancyTokenProj) $ damlYamlBody fancyTokenProj []
             [ tokenProj
             ]
           writeFileUTF8 (damlMod fancyTokenProj "FancyToken") $ unlines
@@ -2288,7 +2289,7 @@ tests tools = testGroup "Data Dependencies" $
 
         step assetProj >> do
           createDirectoryIfMissing True (path assetProj)
-          writeFileUTF8 (damlYaml assetProj) $ damlYamlBody assetProj False
+          writeFileUTF8 (damlYaml assetProj) $ damlYamlBody assetProj []
             [ tokenProj
             , fancyTokenProj
             ]
@@ -2338,7 +2339,7 @@ tests tools = testGroup "Data Dependencies" $
 
         step mainProj >> do
           createDirectoryIfMissing True (path mainProj)
-          writeFileUTF8 (damlYaml mainProj) $ damlYamlBody mainProj True
+          writeFileUTF8 (damlYaml mainProj) $ damlYamlBody mainProj [scriptDar1dev]
             [ tokenProj
             , fancyTokenProj
             , assetProj

--- a/compiler/damlc/tests/src/DA/Test/IncrementalBuilds.hs
+++ b/compiler/damlc/tests/src/DA/Test/IncrementalBuilds.hs
@@ -1,6 +1,8 @@
 -- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# OPTIONS_GHC -w #-}
+
 module DA.Test.IncrementalBuilds (main) where
 
 {- HLINT ignore "locateRunfiles/package_app" -}
@@ -20,11 +22,12 @@ import Test.Tasty.HUnit
 main :: IO ()
 main = do
     damlc <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> exe "damlc")
-    repl <- locateRunfiles (mainWorkspace </> "daml-lf" </> "repl" </> exe "repl")
-    defaultMain $ tests damlc repl
+    damlScript <- locateRunfiles (mainWorkspace </> "daml-script" </> "runner" </> exe "daml-script-binary")
+    scriptDar <- locateRunfiles (mainWorkspace </> "daml-script" </> "daml" </> "daml-script.dar")
+    defaultMain $ tests damlc damlScript scriptDar
 
-tests :: FilePath -> FilePath -> TestTree
-tests damlc repl = testGroup "Incremental builds"
+tests :: FilePath -> FilePath -> FilePath -> TestTree
+tests damlc damlScript scriptDar = testGroup "Incremental builds"
     [ test "No changes"
         [ ("daml/A.daml", unlines
            [ "module A where"
@@ -37,13 +40,17 @@ tests damlc repl = testGroup "Incremental builds"
     , test "Modify single file"
         [ ("daml/A.daml", unlines
            [ "module A where"
-           , "test = scenario $ assert True"
+           , "import Daml.Script"
+           , "test : Script ()"
+           , "test = script $ assert True"
            ]
           )
         ]
         [ ("daml/A.daml", unlines
            [ "module A where"
-           , "test = scenario $ assert False"
+           , "import Daml.Script"
+           , "test : Script ()"
+           , "test = script $ assert False"
            ]
           )
         ]
@@ -52,19 +59,24 @@ tests damlc repl = testGroup "Incremental builds"
     , test "Modify dependency without ABI change"
         [ ("daml/A.daml", unlines
            [ "module A where"
+           , "import Daml.Script"
            , "import B"
-           , "test = scenario $ b"
+           , "test = script $ b"
            ]
           )
         , ("daml/B.daml", unlines
            [ "module B where"
-           , "b = scenario $ assert True"
+           , "import Daml.Script"
+           , "b : Script ()"
+           , "b = script $ assert True"
            ]
           )
         ]
         [ ("daml/B.daml", unlines
            [ "module B where"
-           , "b = scenario $ assert False"
+           , "import Daml.Script"
+           , "b : Script ()"
+           , "b = script $ assert False"
            ]
           )
         ]
@@ -73,20 +85,24 @@ tests damlc repl = testGroup "Incremental builds"
     , test "Modify dependency with ABI change"
         [ ("daml/A.daml", unlines
            [ "module A where"
+           , "import Daml.Script"
            , "import B"
-           , "test = scenario $ do _ <- b; pure ()"
+           , "test : Script ()"
+           , "test = script $ do _ <- b; pure ()"
            ]
           )
         , ("daml/B.daml", unlines
            [ "module B where"
-           , "b : Scenario Bool"
+           , "import Daml.Script"
+           , "b : Script Bool"
            , "b = pure True"
            ]
           )
         ]
         [ ("daml/B.daml", unlines
            [ "module B where"
-           , "b : Scenario ()"
+           , "import Daml.Script"
+           , "b : Script ()"
            , "b = assert False"
            ]
           )
@@ -98,11 +114,14 @@ tests damlc repl = testGroup "Incremental builds"
       -- to trigger this. The modules actually need to use identifiers from the other modules.
       [ ("daml/A.daml", unlines
          [ "module A where"
+         , "import Daml.Script"
          , "import B"
-         , "test = scenario $ do"
-         , "  p <- getParty \"Alice\""
-         , "  cid <- submit p $ create X with p = p"
-         , "  submit p $ create Y with p = p; cid = cid"
+         , "test : Script ()"
+         , "test = script $ do"
+         , "  p <- allocateParty \"Alice\""
+         , "  cid <- submit p $ createCmd X with p = p"
+         , "  submit p $ createCmd Y with p = p; cid = cid"
+         , "  pure ()"
          ]
         )
       , ("daml/B.daml", unlines
@@ -135,7 +154,7 @@ tests damlc repl = testGroup "Incremental builds"
             , "name: test-project"
             , "source: daml"
             , "version: 0.0.1"
-            , "dependencies: [daml-prim, daml-stdlib]"
+            , "dependencies: [daml-prim, daml-stdlib, " <> show scriptDar <> "]"
             ]
           for_ initial $ \(file, content) -> do
               createDirectoryIfMissing True (takeDirectory $ dir </> file)
@@ -143,13 +162,16 @@ tests damlc repl = testGroup "Incremental builds"
           let dar = dir </> "out.dar"
           callProcessSilent damlc
             [ "build"
-            , "--enable-scenarios=yes" -- TODO: https://github.com/digital-asset/daml/issues/11316
             , "--project-root"
             , dir
             , "-o"
             , dar
             , "--incremental=yes" ]
-          callProcessSilent repl ["testAll", dar]
+          callProcessSilent damlc 
+            [ "test"
+            , "--project-root"
+            , dir
+            ]
           dalfFiles <- getDalfFiles $ dir </> ".daml/build"
           dalfModTimes <- for dalfFiles $ \f -> do
               modTime <- getModificationTime f
@@ -159,7 +181,6 @@ tests damlc repl = testGroup "Incremental builds"
               writeFileUTF8 (dir </> file) content
           callProcessSilent damlc
             ["build"
-            , "--enable-scenarios=yes" -- TODO: https://github.com/digital-asset/daml/issues/11316
             , "--project-root"
             , dir
             , "-o"
@@ -171,12 +192,12 @@ tests damlc repl = testGroup "Incremental builds"
                   then Nothing
                   else Just (makeRelative (dir </> ".daml/build") f -<.> ".daml")
           assertEqual "Expected rebuilds" (Set.fromList $ map normalise expectedRebuilds) (Set.fromList $ map normalise rebuilds)
-          callProcessSilent repl ["validate", dar]
+          callProcessSilent damlc ["validate-dar", dar]
           if shouldSucceed
             then
-              callProcessSilent repl ["testAll", dar]
+              callProcessSilent damlScript ["--ide-ledger", "--all", "--dar", dar]
             else
-              callProcessSilentError repl ["testAll", dar]
+              callProcessSilentError damlScript ["--ide-ledger", "--all", "--dar", dar]
           pure ()
 
 getDalfFiles :: FilePath -> IO [FilePath]

--- a/compiler/damlc/tests/src/DA/Test/IncrementalBuilds.hs
+++ b/compiler/damlc/tests/src/DA/Test/IncrementalBuilds.hs
@@ -18,6 +18,7 @@ import System.IO.Extra
 import DA.Test.Process
 import Test.Tasty
 import Test.Tasty.HUnit
+import SdkVersion
 
 main :: IO ()
 main = do
@@ -150,7 +151,7 @@ tests damlc damlScript scriptDar = testGroup "Incremental builds"
       test :: String -> [(FilePath, String)] -> [(FilePath, String)] -> [FilePath] -> ShouldSucceed -> TestTree
       test name initial modification expectedRebuilds (ShouldSucceed shouldSucceed) = testCase name $ withTempDir $ \dir -> do
           writeFileUTF8 (dir </> "daml.yaml") $ unlines
-            [ "sdk-version: 0.0.0"
+            [ "sdk-version: " <> sdkVersion
             , "name: test-project"
             , "source: daml"
             , "version: 0.0.1"

--- a/compiler/damlc/tests/src/DA/Test/IncrementalBuilds.hs
+++ b/compiler/damlc/tests/src/DA/Test/IncrementalBuilds.hs
@@ -1,8 +1,6 @@
 -- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# OPTIONS_GHC -w #-}
-
 module DA.Test.IncrementalBuilds (main) where
 
 {- HLINT ignore "locateRunfiles/package_app" -}


### PR DESCRIPTION
Partially address #16525 
Switches from using `daml-lf-repl` to `damlc`/`daml script` cli tool in IncrementalBuild.
Removes Scenarios from incremental build and data deps, replacing with scripts where needed.
Tested with snapshot SDK_RELEASE 