### PR TITLE
Testing bug fix: ensure package ID is only calculated once per Dar file load

### DIFF
--- a/ledger/sandbox-on-x/src/test/lib/scala/com/daml/platform/sandbox/services/TestCommands.scala
+++ b/ledger/sandbox-on-x/src/test/lib/scala/com/daml/platform/sandbox/services/TestCommands.scala
@@ -27,9 +27,9 @@ trait TestCommands {
 
   protected def darFile: File
 
-  protected def packageId: PackageId = DarReader.assertReadArchiveFromFile(darFile).main.pkgId
+  protected lazy val packageId: PackageId = DarReader.assertReadArchiveFromFile(darFile).main.pkgId
 
-  protected def templateIds = new TestTemplateIdentifiers(packageId)
+  protected lazy val templateIds = new TestTemplateIdentifiers(packageId)
 
   protected def buildRequest(
       ledgerId: domain.LedgerId,


### PR DESCRIPTION
`TestCommands` provides utility code for tests to load Dar files and build commands etc. Unfortunately, the package ID is recalculated every time it is referenced. This in turn can lead to some testing code becoming IO bound.

For my use case, these changes allowed testing times to drop from ~13mins to ~8secs.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
