### PR TITLE
Fix blackduck

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -170,7 +170,7 @@ jobs:
           BAZEL_DEPENDENCY_TYPE="haskell_cabal_library"
 
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml $(Build.SourceBranchName) \
+          ci-build digital-asset_daml local-main-maven \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=BAZEL \
           --detect.bazel.target=//... \
@@ -209,7 +209,7 @@ jobs:
           (cd language-support/ts && yarn install)
 
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml $(Build.SourceBranchName) \
+          ci-build digital-asset_daml local-main-maven \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=DETECTOR \
           --detect.included.detector.types=YARN,NPM,CLANG \
@@ -230,7 +230,7 @@ jobs:
           eval "$(dev-env/bin/dade-assist)"
 
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml $(Build.SourceBranchName) \
+          ci-build digital-asset_daml local-main-maven \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=DETECTOR \
           --detect.included.detector.types=PIP,POETRY \
@@ -249,7 +249,7 @@ jobs:
           eval "$(dev-env/bin/dade-assist)"
 
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml $(Build.SourceBranchName) \
+          ci-build digital-asset_daml local-main-maven \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=DETECTOR \
           --detect.included.detector.types=GIT,GO_MOD,GO_DEP,GO_VNDR,GO_VENDOR,GO_GRADLE \
@@ -273,7 +273,7 @@ jobs:
 
           branch="notices-update-$(Build.BuildId)"
 
-          tr -d '\015' <*_Black_Duck_Notices_Report.txt | grep -v digital-asset_daml >NOTICES
+          tr -d '\015' < digital_asset_daml_local_main_maven_Black_Duck_Notices_Report.txt | grep -v digital-asset_daml > NOTICES
           if git diff --exit-code -- NOTICES; then
               echo "NOTICES file already up-to-date."
               setvar need_to_build false

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -170,7 +170,7 @@ jobs:
           BAZEL_DEPENDENCY_TYPE="haskell_cabal_library"
 
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml local-main-maven \
+          ci-build digital-asset_daml main \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=BAZEL \
           --detect.bazel.target=//... \
@@ -191,7 +191,7 @@ jobs:
           BAZEL_DEPENDENCY_TYPE="maven_install"
 
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml local-main-maven \
+          ci-build digital-asset_daml main \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=BAZEL \
           --detect.bazel.target=//... \
@@ -209,7 +209,7 @@ jobs:
           (cd language-support/ts && yarn install)
 
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml local-main-maven \
+          ci-build digital-asset_daml main \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=DETECTOR \
           --detect.included.detector.types=YARN,NPM,CLANG \
@@ -230,7 +230,7 @@ jobs:
           eval "$(dev-env/bin/dade-assist)"
 
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml local-main-maven \
+          ci-build digital-asset_daml main \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=DETECTOR \
           --detect.included.detector.types=PIP,POETRY \
@@ -249,7 +249,7 @@ jobs:
           eval "$(dev-env/bin/dade-assist)"
 
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml local-main-maven \
+          ci-build digital-asset_daml main \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=DETECTOR \
           --detect.included.detector.types=GIT,GO_MOD,GO_DEP,GO_VNDR,GO_VENDOR,GO_GRADLE \
@@ -273,7 +273,7 @@ jobs:
 
           branch="notices-update-$(Build.BuildId)"
 
-          tr -d '\015' < digital_asset_daml_local_main_maven_Black_Duck_Notices_Report.txt | grep -v digital-asset_daml > NOTICES
+          tr -d '\015' < digital_asset_daml_main_Black_Duck_Notices_Report.txt | grep -v digital-asset_daml > NOTICES
           if git diff --exit-code -- NOTICES; then
               echo "NOTICES file already up-to-date."
               setvar need_to_build false


### PR DESCRIPTION
BlackDuck is currently failing to run because it creates multiple report files and then expects a single one. This is due to https://github.com/digital-asset/daml/pull/16552 changing only one of the output file names.

This PR resolves this by:

1. Changing the name everywhere, so all runs aggregate their results on the same file.
2. Changing the PR step code to expect the given file name, rather than try and glob it.

My understanding of the BlackDuck setup is very fuzzy so please double-check carefully.

See https://github.com/digital-asset/daml/pull/16600 for an example of what the update would be from this PR.