### PR TITLE
[engine] choice authority syntax

### DIFF
--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "b2be7975c52a0e365e1f87c1ce3b127a669dc1a9"
+GHC_REV = "8f6ee8acf21578902e530cc74b66e00b3de18e5f"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "f1fb42651d849dfb7d14bf9a09d84e05665f8a44"
+GHC_REV = "a9416f064cc1745b96f780c1a9facc17e0f38a86"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "8f6ee8acf21578902e530cc74b66e00b3de18e5f"
+GHC_REV = "f1fb42651d849dfb7d14bf9a09d84e05665f8a44"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "8724efa0e1a095e536310beb94a81ecb72e6a476"
+GHC_REV = "b2be7975c52a0e365e1f87c1ce3b127a669dc1a9"
 GHC_PATCHES = [
 ]
 

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -264,7 +264,7 @@ extractModuleContents env@Env{..} coreModule modIface details = do
                , _controller
                , _observer
                , _authority
-               , _action --tupleElem5
+               , _action -- choiceTupleExpr
                ]) <- [varType name]
         ]
     mcTemplateBinds = scrapeTemplateBinds mcBinds
@@ -1256,13 +1256,13 @@ convertChoice env tbinds (ChoiceData ty expr) = do
     -- The desuaged representation of a Daml Choice is a five tuple.
     -- Constructed by mkChoiceDecls in RdrHsSyn.hs in the ghc repo.
     -- We match against that 5-tuple expression or type in 3 places in this file.
-    -- search for string "tupleElem5"
+    -- search for string "choiceTupleExpr"
 
     TConApp _ [ consumingTy
               , _controller
               , _observer
               , _authority
-              , _ :-> _ :-> choiceTy@(TConApp choiceTyCon _) :-> TUpdate choiceRetTy -- tupleElem5
+              , _ :-> _ :-> choiceTy@(TConApp choiceTyCon _) :-> TUpdate choiceRetTy -- choiceTupleExpr
               ] <- convertType env ty
 
     let choiceName = ChoiceName (T.intercalate "." $ unTypeConName $ qualObject choiceTyCon)
@@ -1271,7 +1271,7 @@ convertChoice env tbinds (ChoiceData ty expr) = do
               , (_, controllers)
               , (_, optObservers)
               , (_, _optAuthority) -- TODO #15882 -- feed this through the compiler pipeline
-              , (_, action) -- tupleElem5
+              , (_, action) -- choiceTupleExpr
               ] <- removeLocations <$> convertExpr env expr
 
     mbObservers <-

--- a/compiler/damlc/tests/daml-test-files/AmbiguousInterfaceInstance.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/AmbiguousInterfaceInstance.EXPECTED.desugared-daml
@@ -57,19 +57,20 @@ instance DA.Internal.Desugar.HasChoiceController Foo DA.Internal.Desugar.Archive
 instance DA.Internal.Desugar.HasChoiceObserver Foo DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_FooArchive :
-  (Foo -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Foo
-   -> Foo
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Foo,
+  (DA.Internal.Desugar.Consuming Foo,
+   Foo -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Foo
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Foo
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Foo
+   -> Foo
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_FooArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_Foo_Bar_Foo :
   DA.Internal.Desugar.InterfaceInstance Foo Bar Foo
 _interface_instance$_Foo_Bar_Foo
@@ -151,19 +152,20 @@ instance DA.Internal.Desugar.HasChoiceController Bar DA.Internal.Desugar.Archive
 instance DA.Internal.Desugar.HasChoiceObserver Bar DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_BarArchive :
-  (Bar -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Bar
-   -> Bar
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Bar,
+  (DA.Internal.Desugar.Consuming Bar,
+   Bar -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Bar
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Bar
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Bar
+   -> Bar
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_BarArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView Bar BarView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Bar BarView where

--- a/compiler/damlc/tests/daml-test-files/AmbiguousInterfaceInstance.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/AmbiguousInterfaceInstance.EXPECTED.desugared-daml
@@ -63,11 +63,13 @@ _choice$_FooArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Foo,
    DA.Internal.Desugar.Optional (Foo
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Foo
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_FooArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_Foo_Bar_Foo :
   DA.Internal.Desugar.InterfaceInstance Foo Bar Foo
 _interface_instance$_Foo_Bar_Foo
@@ -155,11 +157,13 @@ _choice$_BarArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Bar,
    DA.Internal.Desugar.Optional (Bar
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Bar
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_BarArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Bar BarView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Bar BarView where

--- a/compiler/damlc/tests/daml-test-files/ChoiceAuthoritySyntax.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/ChoiceAuthoritySyntax.EXPECTED.desugared-daml
@@ -234,219 +234,215 @@ instance DA.Internal.Desugar.HasChoiceController TrySyntax X_new_authority_contr
 instance DA.Internal.Desugar.HasChoiceObserver TrySyntax X_new_authority_controller_observer where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TrySyntaxArchive :
-  (TrySyntax
+  (DA.Internal.Desugar.Consuming TrySyntax,
+   TrySyntax
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId TrySyntax
-   -> TrySyntax
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming TrySyntax,
    DA.Internal.Desugar.Optional (TrySyntax
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (TrySyntax
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TrySyntaxArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TrySyntaxX_old_just_controller :
-  (TrySyntax -> X_old_just_controller -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId TrySyntax
    -> TrySyntax
-      -> X_old_just_controller -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming TrySyntax,
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TrySyntaxArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TrySyntaxX_old_just_controller :
+  (DA.Internal.Desugar.Consuming TrySyntax,
+   TrySyntax -> X_old_just_controller -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (TrySyntax
                                  -> X_old_just_controller -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_old_just_controller -> [DA.Internal.Desugar.Party]))
-_choice$_TrySyntaxX_old_just_controller
-  = (\ this@TrySyntax {..} arg@X_old_just_controller
-       -> let _ = this in
-          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
-     \ self this@TrySyntax {..} arg@X_old_just_controller
-       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
-_choice$_TrySyntaxX_old_observer_and_controller :
-  (TrySyntax
-   -> X_old_observer_and_controller -> [DA.Internal.Desugar.Party],
+                                 -> X_old_just_controller -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId TrySyntax
    -> TrySyntax
-      -> X_old_observer_and_controller
-         -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming TrySyntax,
+      -> X_old_just_controller -> DA.Internal.Desugar.Update (()))
+_choice$_TrySyntaxX_old_just_controller
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@TrySyntax {..} arg@X_old_just_controller
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ self this@TrySyntax {..} arg@X_old_just_controller
+       -> let _ = self in let _ = this in let _ = arg in do _BODY)
+_choice$_TrySyntaxX_old_observer_and_controller :
+  (DA.Internal.Desugar.Consuming TrySyntax,
+   TrySyntax
+   -> X_old_observer_and_controller -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (TrySyntax
                                  -> X_old_observer_and_controller -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_old_observer_and_controller -> [DA.Internal.Desugar.Party]))
+                                 -> X_old_observer_and_controller -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_old_observer_and_controller
+         -> DA.Internal.Desugar.Update (()))
 _choice$_TrySyntaxX_old_observer_and_controller
-  = (\ this@TrySyntax {..} arg@X_old_observer_and_controller
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@TrySyntax {..} arg@X_old_observer_and_controller
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
-     \ self this@TrySyntax {..} arg@X_old_observer_and_controller
-       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
-     DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.Some
        \ this@TrySyntax {..} arg@X_old_observer_and_controller
          -> let _ = this in
             let _ = arg in DA.Internal.Desugar.toParties (_OBSERVER), 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, 
+     \ self this@TrySyntax {..} arg@X_old_observer_and_controller
+       -> let _ = self in let _ = this in let _ = arg in do _BODY)
 _choice$_TrySyntaxX_new_just_controllerX :
-  (TrySyntax
-   -> X_new_just_controllerX -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId TrySyntax
-   -> TrySyntax
-      -> X_new_just_controllerX -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming TrySyntax,
+  (DA.Internal.Desugar.Consuming TrySyntax,
+   TrySyntax -> X_new_just_controllerX -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (TrySyntax
                                  -> X_new_just_controllerX -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_new_just_controllerX -> [DA.Internal.Desugar.Party]))
-_choice$_TrySyntaxX_new_just_controllerX
-  = (\ this@TrySyntax {..} arg@X_new_just_controllerX
-       -> let _ = this in
-          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
-     \ self this@TrySyntax {..} arg@X_new_just_controllerX
-       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
-_choice$_TrySyntaxX_new_just_controller :
-  (TrySyntax -> X_new_just_controller -> [DA.Internal.Desugar.Party],
+                                 -> X_new_just_controllerX -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId TrySyntax
    -> TrySyntax
-      -> X_new_just_controller -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming TrySyntax,
+      -> X_new_just_controllerX -> DA.Internal.Desugar.Update (()))
+_choice$_TrySyntaxX_new_just_controllerX
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@TrySyntax {..} arg@X_new_just_controllerX
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ self this@TrySyntax {..} arg@X_new_just_controllerX
+       -> let _ = self in let _ = this in let _ = arg in do _BODY)
+_choice$_TrySyntaxX_new_just_controller :
+  (DA.Internal.Desugar.Consuming TrySyntax,
+   TrySyntax -> X_new_just_controller -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (TrySyntax
                                  -> X_new_just_controller -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_new_just_controller -> [DA.Internal.Desugar.Party]))
-_choice$_TrySyntaxX_new_just_controller
-  = (\ this@TrySyntax {..} arg@X_new_just_controller
-       -> let _ = this in
-          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
-     \ self this@TrySyntax {..} arg@X_new_just_controller
-       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
-_choice$_TrySyntaxX_new_observer_and_controllerX :
-  (TrySyntax
-   -> X_new_observer_and_controllerX -> [DA.Internal.Desugar.Party],
+                                 -> X_new_just_controller -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId TrySyntax
    -> TrySyntax
-      -> X_new_observer_and_controllerX
-         -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming TrySyntax,
+      -> X_new_just_controller -> DA.Internal.Desugar.Update (()))
+_choice$_TrySyntaxX_new_just_controller
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@TrySyntax {..} arg@X_new_just_controller
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ self this@TrySyntax {..} arg@X_new_just_controller
+       -> let _ = self in let _ = this in let _ = arg in do _BODY)
+_choice$_TrySyntaxX_new_observer_and_controllerX :
+  (DA.Internal.Desugar.Consuming TrySyntax,
+   TrySyntax
+   -> X_new_observer_and_controllerX -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (TrySyntax
                                  -> X_new_observer_and_controllerX -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_new_observer_and_controllerX -> [DA.Internal.Desugar.Party]))
+                                 -> X_new_observer_and_controllerX -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_new_observer_and_controllerX
+         -> DA.Internal.Desugar.Update (()))
 _choice$_TrySyntaxX_new_observer_and_controllerX
-  = (\ this@TrySyntax {..} arg@X_new_observer_and_controllerX
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@TrySyntax {..} arg@X_new_observer_and_controllerX
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
-     \ self this@TrySyntax {..} arg@X_new_observer_and_controllerX
-       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
-     DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.Some
        \ this@TrySyntax {..} arg@X_new_observer_and_controllerX
          -> let _ = this in
             let _ = arg in DA.Internal.Desugar.toParties (_OBSERVER), 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, 
+     \ self this@TrySyntax {..} arg@X_new_observer_and_controllerX
+       -> let _ = self in let _ = this in let _ = arg in do _BODY)
 _choice$_TrySyntaxX_new_observer_and_controller :
-  (TrySyntax
+  (DA.Internal.Desugar.Consuming TrySyntax,
+   TrySyntax
    -> X_new_observer_and_controller -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId TrySyntax
-   -> TrySyntax
-      -> X_new_observer_and_controller
-         -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming TrySyntax,
    DA.Internal.Desugar.Optional (TrySyntax
                                  -> X_new_observer_and_controller -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_new_observer_and_controller -> [DA.Internal.Desugar.Party]))
+                                 -> X_new_observer_and_controller -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_new_observer_and_controller
+         -> DA.Internal.Desugar.Update (()))
 _choice$_TrySyntaxX_new_observer_and_controller
-  = (\ this@TrySyntax {..} arg@X_new_observer_and_controller
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@TrySyntax {..} arg@X_new_observer_and_controller
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
-     \ self this@TrySyntax {..} arg@X_new_observer_and_controller
-       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
-     DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.Some
        \ this@TrySyntax {..} arg@X_new_observer_and_controller
          -> let _ = this in
             let _ = arg in DA.Internal.Desugar.toParties (_OBSERVER), 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, 
+     \ self this@TrySyntax {..} arg@X_new_observer_and_controller
+       -> let _ = self in let _ = this in let _ = arg in do _BODY)
 _choice$_TrySyntaxX_new_controller_and_observer :
-  (TrySyntax
+  (DA.Internal.Desugar.Consuming TrySyntax,
+   TrySyntax
    -> X_new_controller_and_observer -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId TrySyntax
-   -> TrySyntax
-      -> X_new_controller_and_observer
-         -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming TrySyntax,
    DA.Internal.Desugar.Optional (TrySyntax
                                  -> X_new_controller_and_observer -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_new_controller_and_observer -> [DA.Internal.Desugar.Party]))
+                                 -> X_new_controller_and_observer -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_new_controller_and_observer
+         -> DA.Internal.Desugar.Update (()))
 _choice$_TrySyntaxX_new_controller_and_observer
-  = (\ this@TrySyntax {..} arg@X_new_controller_and_observer
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@TrySyntax {..} arg@X_new_controller_and_observer
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
-     \ self this@TrySyntax {..} arg@X_new_controller_and_observer
-       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
-     DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.Some
        \ this@TrySyntax {..} arg@X_new_controller_and_observer
          -> let _ = this in
             let _ = arg in DA.Internal.Desugar.toParties (_OBSERVER), 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, 
+     \ self this@TrySyntax {..} arg@X_new_controller_and_observer
+       -> let _ = self in let _ = this in let _ = arg in do _BODY)
 _choice$_TrySyntaxX_new_authority_and_controller :
-  (TrySyntax
+  (DA.Internal.Desugar.Consuming TrySyntax,
+   TrySyntax
    -> X_new_authority_and_controller -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId TrySyntax
-   -> TrySyntax
-      -> X_new_authority_and_controller
-         -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming TrySyntax,
    DA.Internal.Desugar.Optional (TrySyntax
                                  -> X_new_authority_and_controller -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_new_authority_and_controller -> [DA.Internal.Desugar.Party]))
+                                 -> X_new_authority_and_controller -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_new_authority_and_controller
+         -> DA.Internal.Desugar.Update (()))
 _choice$_TrySyntaxX_new_authority_and_controller
-  = (\ this@TrySyntax {..} arg@X_new_authority_and_controller
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@TrySyntax {..} arg@X_new_authority_and_controller
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
-     \ self this@TrySyntax {..} arg@X_new_authority_and_controller
-       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None, 
      DA.Internal.Desugar.Some
        \ this@TrySyntax {..} arg@X_new_authority_and_controller
          -> let _ = this in
-            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY))
+            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY), 
+     \ self this@TrySyntax {..} arg@X_new_authority_and_controller
+       -> let _ = self in let _ = this in let _ = arg in do _BODY)
 _choice$_TrySyntaxX_new_observer_authority_and_controllerX :
-  (TrySyntax
+  (DA.Internal.Desugar.Consuming TrySyntax,
+   TrySyntax
    -> X_new_observer_authority_and_controllerX
       -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_observer_authority_and_controllerX
+                                    -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_observer_authority_and_controllerX
+                                    -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId TrySyntax
    -> TrySyntax
       -> X_new_observer_authority_and_controllerX
-         -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming TrySyntax,
-   DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_new_observer_authority_and_controllerX
-                                    -> [DA.Internal.Desugar.Party]),
-   DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_new_observer_authority_and_controllerX
-                                    -> [DA.Internal.Desugar.Party]))
+         -> DA.Internal.Desugar.Update (()))
 _choice$_TrySyntaxX_new_observer_authority_and_controllerX
-  = (\ this@TrySyntax {..}
-       arg@X_new_observer_authority_and_controllerX
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@TrySyntax {..} arg@X_new_observer_authority_and_controllerX
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
-     \ self
-       this@TrySyntax {..}
-       arg@X_new_observer_authority_and_controllerX
-       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
-     DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.Some
        \ this@TrySyntax {..} arg@X_new_observer_authority_and_controllerX
          -> let _ = this in
@@ -454,32 +450,31 @@ _choice$_TrySyntaxX_new_observer_authority_and_controllerX
      DA.Internal.Desugar.Some
        \ this@TrySyntax {..} arg@X_new_observer_authority_and_controllerX
          -> let _ = this in
-            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY))
+            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY), 
+     \ self
+       this@TrySyntax {..}
+       arg@X_new_observer_authority_and_controllerX
+       -> let _ = self in let _ = this in let _ = arg in do _BODY)
 _choice$_TrySyntaxX_new_observer_authority_and_controller :
-  (TrySyntax
+  (DA.Internal.Desugar.Consuming TrySyntax,
+   TrySyntax
    -> X_new_observer_authority_and_controller
       -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_observer_authority_and_controller
+                                    -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_observer_authority_and_controller
+                                    -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId TrySyntax
    -> TrySyntax
       -> X_new_observer_authority_and_controller
-         -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming TrySyntax,
-   DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_new_observer_authority_and_controller
-                                    -> [DA.Internal.Desugar.Party]),
-   DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_new_observer_authority_and_controller
-                                    -> [DA.Internal.Desugar.Party]))
+         -> DA.Internal.Desugar.Update (()))
 _choice$_TrySyntaxX_new_observer_authority_and_controller
-  = (\ this@TrySyntax {..}
-       arg@X_new_observer_authority_and_controller
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@TrySyntax {..} arg@X_new_observer_authority_and_controller
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
-     \ self
-       this@TrySyntax {..}
-       arg@X_new_observer_authority_and_controller
-       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
-     DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.Some
        \ this@TrySyntax {..} arg@X_new_observer_authority_and_controller
          -> let _ = this in
@@ -487,62 +482,63 @@ _choice$_TrySyntaxX_new_observer_authority_and_controller
      DA.Internal.Desugar.Some
        \ this@TrySyntax {..} arg@X_new_observer_authority_and_controller
          -> let _ = this in
-            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY))
+            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY), 
+     \ self
+       this@TrySyntax {..}
+       arg@X_new_observer_authority_and_controller
+       -> let _ = self in let _ = this in let _ = arg in do _BODY)
 _choice$_TrySyntaxX_new_authority_observer_and_controller :
-  (TrySyntax
+  (DA.Internal.Desugar.Consuming TrySyntax,
+   TrySyntax
    -> X_new_authority_observer_and_controller
       -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_authority_observer_and_controller
+                                    -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_authority_observer_and_controller
+                                    -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId TrySyntax
    -> TrySyntax
       -> X_new_authority_observer_and_controller
-         -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming TrySyntax,
-   DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_new_authority_observer_and_controller
-                                    -> [DA.Internal.Desugar.Party]),
-   DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_new_authority_observer_and_controller
-                                    -> [DA.Internal.Desugar.Party]))
+         -> DA.Internal.Desugar.Update (()))
 _choice$_TrySyntaxX_new_authority_observer_and_controller
-  = (\ this@TrySyntax {..}
-       arg@X_new_authority_observer_and_controller
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@TrySyntax {..} arg@X_new_authority_observer_and_controller
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_new_authority_observer_and_controller
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_OBSERVER), 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_new_authority_observer_and_controller
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY), 
      \ self
        this@TrySyntax {..}
        arg@X_new_authority_observer_and_controller
-       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
-     DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.Some
-       \ this@TrySyntax {..} arg@X_new_authority_observer_and_controller
-         -> let _ = this in
-            let _ = arg in DA.Internal.Desugar.toParties (_OBSERVER), 
-     DA.Internal.Desugar.Some
-       \ this@TrySyntax {..} arg@X_new_authority_observer_and_controller
-         -> let _ = this in
-            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY))
+       -> let _ = self in let _ = this in let _ = arg in do _BODY)
 _choice$_TrySyntaxX_new_controller_authority_observer :
-  (TrySyntax
+  (DA.Internal.Desugar.Consuming TrySyntax,
+   TrySyntax
    -> X_new_controller_authority_observer
       -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_controller_authority_observer
+                                    -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_controller_authority_observer
+                                    -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId TrySyntax
    -> TrySyntax
       -> X_new_controller_authority_observer
-         -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming TrySyntax,
-   DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_new_controller_authority_observer
-                                    -> [DA.Internal.Desugar.Party]),
-   DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_new_controller_authority_observer
-                                    -> [DA.Internal.Desugar.Party]))
+         -> DA.Internal.Desugar.Update (()))
 _choice$_TrySyntaxX_new_controller_authority_observer
-  = (\ this@TrySyntax {..} arg@X_new_controller_authority_observer
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@TrySyntax {..} arg@X_new_controller_authority_observer
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
-     \ self this@TrySyntax {..} arg@X_new_controller_authority_observer
-       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
-     DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.Some
        \ this@TrySyntax {..} arg@X_new_controller_authority_observer
          -> let _ = this in
@@ -550,29 +546,29 @@ _choice$_TrySyntaxX_new_controller_authority_observer
      DA.Internal.Desugar.Some
        \ this@TrySyntax {..} arg@X_new_controller_authority_observer
          -> let _ = this in
-            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY))
+            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY), 
+     \ self this@TrySyntax {..} arg@X_new_controller_authority_observer
+       -> let _ = self in let _ = this in let _ = arg in do _BODY)
 _choice$_TrySyntaxX_new_authority_controller_observer :
-  (TrySyntax
+  (DA.Internal.Desugar.Consuming TrySyntax,
+   TrySyntax
    -> X_new_authority_controller_observer
       -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_authority_controller_observer
+                                    -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_authority_controller_observer
+                                    -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId TrySyntax
    -> TrySyntax
       -> X_new_authority_controller_observer
-         -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming TrySyntax,
-   DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_new_authority_controller_observer
-                                    -> [DA.Internal.Desugar.Party]),
-   DA.Internal.Desugar.Optional (TrySyntax
-                                 -> X_new_authority_controller_observer
-                                    -> [DA.Internal.Desugar.Party]))
+         -> DA.Internal.Desugar.Update (()))
 _choice$_TrySyntaxX_new_authority_controller_observer
-  = (\ this@TrySyntax {..} arg@X_new_authority_controller_observer
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@TrySyntax {..} arg@X_new_authority_controller_observer
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
-     \ self this@TrySyntax {..} arg@X_new_authority_controller_observer
-       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
-     DA.Internal.Desugar.Consuming, 
      DA.Internal.Desugar.Some
        \ this@TrySyntax {..} arg@X_new_authority_controller_observer
          -> let _ = this in
@@ -580,4 +576,6 @@ _choice$_TrySyntaxX_new_authority_controller_observer
      DA.Internal.Desugar.Some
        \ this@TrySyntax {..} arg@X_new_authority_controller_observer
          -> let _ = this in
-            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY))
+            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY), 
+     \ self this@TrySyntax {..} arg@X_new_authority_controller_observer
+       -> let _ = self in let _ = this in let _ = arg in do _BODY)

--- a/compiler/damlc/tests/daml-test-files/ChoiceAuthoritySyntax.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/ChoiceAuthoritySyntax.EXPECTED.desugared-daml
@@ -1,0 +1,583 @@
+module ChoiceAuthoritySyntax where
+import (implicit) qualified DA.Internal.Record
+import (implicit) qualified GHC.Types
+import (implicit) qualified DA.Internal.Desugar
+import (implicit) DA.Internal.RebindableSyntax
+_CONTROLLER : [Party]
+_CONTROLLER = undefined
+_OBSERVER : [Party]
+_OBSERVER = undefined
+_AUTHORITY : [Party]
+_AUTHORITY = undefined
+_BODY : Update ()
+_BODY = undefined
+data GHC.Types.DamlTemplate => TrySyntax
+  = TrySyntax {p : Party}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+instance DA.Internal.Record.HasField "p" TrySyntax Party where
+  getField = DA.Internal.Record.getFieldPrim @"p" @TrySyntax @Party
+  setField = DA.Internal.Record.setFieldPrim @"p" @TrySyntax @Party
+data X_old_just_controller
+  = X_old_just_controller {}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+data X_old_observer_and_controller
+  = X_old_observer_and_controller {}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+data X_new_just_controllerX
+  = X_new_just_controllerX {}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+data X_new_just_controller
+  = X_new_just_controller {}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+data X_new_observer_and_controllerX
+  = X_new_observer_and_controllerX {}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+data X_new_observer_and_controller
+  = X_new_observer_and_controller {}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+data X_new_controller_and_observer
+  = X_new_controller_and_observer {}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+data X_new_authority_and_controller
+  = X_new_authority_and_controller {}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+data X_new_observer_authority_and_controllerX
+  = X_new_observer_authority_and_controllerX {}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+data X_new_observer_authority_and_controller
+  = X_new_observer_authority_and_controller {}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+data X_new_authority_observer_and_controller
+  = X_new_authority_observer_and_controller {}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+data X_new_controller_authority_observer
+  = X_new_controller_authority_observer {}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+data X_new_authority_controller_observer
+  = X_new_authority_controller_observer {}
+  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
+instance DA.Internal.Desugar.HasSignatory TrySyntax where
+  signatory this@TrySyntax {..}
+    = DA.Internal.Desugar.toParties (p)
+    where
+        _ = this
+instance DA.Internal.Desugar.HasObserver TrySyntax where
+  observer this@TrySyntax {..}
+    = []
+    where
+        _ = this
+instance DA.Internal.Desugar.HasEnsure TrySyntax where
+  ensure this@TrySyntax {..}
+    = DA.Internal.Desugar.True
+    where
+        _ = this
+instance DA.Internal.Desugar.HasAgreement TrySyntax where
+  agreement this@TrySyntax {..}
+    = ""
+    where
+        _ = this
+instance DA.Internal.Desugar.HasArchive TrySyntax where
+  archive cid
+    = DA.Internal.Desugar.exercise cid DA.Internal.Desugar.Archive
+    where
+        _ = cid
+instance DA.Internal.Desugar.HasCreate TrySyntax where
+  create = GHC.Types.primitive @"UCreate"
+instance DA.Internal.Desugar.HasFetch TrySyntax where
+  fetch = GHC.Types.primitive @"UFetch"
+instance DA.Internal.Desugar.HasToAnyTemplate TrySyntax where
+  _toAnyTemplate = GHC.Types.primitive @"EToAnyTemplate"
+instance DA.Internal.Desugar.HasFromAnyTemplate TrySyntax where
+  _fromAnyTemplate = GHC.Types.primitive @"EFromAnyTemplate"
+instance DA.Internal.Desugar.HasTemplateTypeRep TrySyntax where
+  _templateTypeRep = GHC.Types.primitive @"ETemplateTypeRep"
+instance DA.Internal.Desugar.HasIsInterfaceType TrySyntax where
+  _isInterfaceType _ = DA.Internal.Desugar.False
+instance DA.Internal.Desugar.HasExercise TrySyntax DA.Internal.Desugar.Archive (()) where
+  exercise = GHC.Types.primitive @"UExercise"
+instance DA.Internal.Desugar.HasToAnyChoice TrySyntax DA.Internal.Desugar.Archive (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice TrySyntax DA.Internal.Desugar.Archive (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasChoiceController TrySyntax DA.Internal.Desugar.Archive where
+  _choiceController = GHC.Types.primitive @"EChoiceController"
+instance DA.Internal.Desugar.HasChoiceObserver TrySyntax DA.Internal.Desugar.Archive where
+  _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
+instance DA.Internal.Desugar.HasExercise TrySyntax X_old_just_controller (()) where
+  exercise = GHC.Types.primitive @"UExercise"
+instance DA.Internal.Desugar.HasToAnyChoice TrySyntax X_old_just_controller (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice TrySyntax X_old_just_controller (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasChoiceController TrySyntax X_old_just_controller where
+  _choiceController = GHC.Types.primitive @"EChoiceController"
+instance DA.Internal.Desugar.HasChoiceObserver TrySyntax X_old_just_controller where
+  _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
+instance DA.Internal.Desugar.HasExercise TrySyntax X_old_observer_and_controller (()) where
+  exercise = GHC.Types.primitive @"UExercise"
+instance DA.Internal.Desugar.HasToAnyChoice TrySyntax X_old_observer_and_controller (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice TrySyntax X_old_observer_and_controller (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasChoiceController TrySyntax X_old_observer_and_controller where
+  _choiceController = GHC.Types.primitive @"EChoiceController"
+instance DA.Internal.Desugar.HasChoiceObserver TrySyntax X_old_observer_and_controller where
+  _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
+instance DA.Internal.Desugar.HasExercise TrySyntax X_new_just_controllerX (()) where
+  exercise = GHC.Types.primitive @"UExercise"
+instance DA.Internal.Desugar.HasToAnyChoice TrySyntax X_new_just_controllerX (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice TrySyntax X_new_just_controllerX (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasChoiceController TrySyntax X_new_just_controllerX where
+  _choiceController = GHC.Types.primitive @"EChoiceController"
+instance DA.Internal.Desugar.HasChoiceObserver TrySyntax X_new_just_controllerX where
+  _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
+instance DA.Internal.Desugar.HasExercise TrySyntax X_new_just_controller (()) where
+  exercise = GHC.Types.primitive @"UExercise"
+instance DA.Internal.Desugar.HasToAnyChoice TrySyntax X_new_just_controller (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice TrySyntax X_new_just_controller (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasChoiceController TrySyntax X_new_just_controller where
+  _choiceController = GHC.Types.primitive @"EChoiceController"
+instance DA.Internal.Desugar.HasChoiceObserver TrySyntax X_new_just_controller where
+  _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
+instance DA.Internal.Desugar.HasExercise TrySyntax X_new_observer_and_controllerX (()) where
+  exercise = GHC.Types.primitive @"UExercise"
+instance DA.Internal.Desugar.HasToAnyChoice TrySyntax X_new_observer_and_controllerX (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice TrySyntax X_new_observer_and_controllerX (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasChoiceController TrySyntax X_new_observer_and_controllerX where
+  _choiceController = GHC.Types.primitive @"EChoiceController"
+instance DA.Internal.Desugar.HasChoiceObserver TrySyntax X_new_observer_and_controllerX where
+  _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
+instance DA.Internal.Desugar.HasExercise TrySyntax X_new_observer_and_controller (()) where
+  exercise = GHC.Types.primitive @"UExercise"
+instance DA.Internal.Desugar.HasToAnyChoice TrySyntax X_new_observer_and_controller (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice TrySyntax X_new_observer_and_controller (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasChoiceController TrySyntax X_new_observer_and_controller where
+  _choiceController = GHC.Types.primitive @"EChoiceController"
+instance DA.Internal.Desugar.HasChoiceObserver TrySyntax X_new_observer_and_controller where
+  _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
+instance DA.Internal.Desugar.HasExercise TrySyntax X_new_controller_and_observer (()) where
+  exercise = GHC.Types.primitive @"UExercise"
+instance DA.Internal.Desugar.HasToAnyChoice TrySyntax X_new_controller_and_observer (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice TrySyntax X_new_controller_and_observer (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasChoiceController TrySyntax X_new_controller_and_observer where
+  _choiceController = GHC.Types.primitive @"EChoiceController"
+instance DA.Internal.Desugar.HasChoiceObserver TrySyntax X_new_controller_and_observer where
+  _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
+instance DA.Internal.Desugar.HasExercise TrySyntax X_new_authority_and_controller (()) where
+  exercise = GHC.Types.primitive @"UExercise"
+instance DA.Internal.Desugar.HasToAnyChoice TrySyntax X_new_authority_and_controller (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice TrySyntax X_new_authority_and_controller (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasChoiceController TrySyntax X_new_authority_and_controller where
+  _choiceController = GHC.Types.primitive @"EChoiceController"
+instance DA.Internal.Desugar.HasChoiceObserver TrySyntax X_new_authority_and_controller where
+  _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
+instance DA.Internal.Desugar.HasExercise TrySyntax X_new_observer_authority_and_controllerX (()) where
+  exercise = GHC.Types.primitive @"UExercise"
+instance DA.Internal.Desugar.HasToAnyChoice TrySyntax X_new_observer_authority_and_controllerX (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice TrySyntax X_new_observer_authority_and_controllerX (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasChoiceController TrySyntax X_new_observer_authority_and_controllerX where
+  _choiceController = GHC.Types.primitive @"EChoiceController"
+instance DA.Internal.Desugar.HasChoiceObserver TrySyntax X_new_observer_authority_and_controllerX where
+  _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
+instance DA.Internal.Desugar.HasExercise TrySyntax X_new_observer_authority_and_controller (()) where
+  exercise = GHC.Types.primitive @"UExercise"
+instance DA.Internal.Desugar.HasToAnyChoice TrySyntax X_new_observer_authority_and_controller (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice TrySyntax X_new_observer_authority_and_controller (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasChoiceController TrySyntax X_new_observer_authority_and_controller where
+  _choiceController = GHC.Types.primitive @"EChoiceController"
+instance DA.Internal.Desugar.HasChoiceObserver TrySyntax X_new_observer_authority_and_controller where
+  _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
+instance DA.Internal.Desugar.HasExercise TrySyntax X_new_authority_observer_and_controller (()) where
+  exercise = GHC.Types.primitive @"UExercise"
+instance DA.Internal.Desugar.HasToAnyChoice TrySyntax X_new_authority_observer_and_controller (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice TrySyntax X_new_authority_observer_and_controller (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasChoiceController TrySyntax X_new_authority_observer_and_controller where
+  _choiceController = GHC.Types.primitive @"EChoiceController"
+instance DA.Internal.Desugar.HasChoiceObserver TrySyntax X_new_authority_observer_and_controller where
+  _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
+instance DA.Internal.Desugar.HasExercise TrySyntax X_new_controller_authority_observer (()) where
+  exercise = GHC.Types.primitive @"UExercise"
+instance DA.Internal.Desugar.HasToAnyChoice TrySyntax X_new_controller_authority_observer (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice TrySyntax X_new_controller_authority_observer (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasChoiceController TrySyntax X_new_controller_authority_observer where
+  _choiceController = GHC.Types.primitive @"EChoiceController"
+instance DA.Internal.Desugar.HasChoiceObserver TrySyntax X_new_controller_authority_observer where
+  _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
+instance DA.Internal.Desugar.HasExercise TrySyntax X_new_authority_controller_observer (()) where
+  exercise = GHC.Types.primitive @"UExercise"
+instance DA.Internal.Desugar.HasToAnyChoice TrySyntax X_new_authority_controller_observer (()) where
+  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+instance DA.Internal.Desugar.HasFromAnyChoice TrySyntax X_new_authority_controller_observer (()) where
+  _fromAnyChoice = GHC.Types.primitive @"EFromAnyChoice"
+instance DA.Internal.Desugar.HasChoiceController TrySyntax X_new_authority_controller_observer where
+  _choiceController = GHC.Types.primitive @"EChoiceController"
+instance DA.Internal.Desugar.HasChoiceObserver TrySyntax X_new_authority_controller_observer where
+  _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
+_choice$_TrySyntaxArchive :
+  (TrySyntax
+   -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming TrySyntax,
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+_choice$_TrySyntaxArchive
+  = (\ this _ -> DA.Internal.Desugar.signatory this, 
+     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+_choice$_TrySyntaxX_old_just_controller :
+  (TrySyntax -> X_old_just_controller -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_old_just_controller -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming TrySyntax,
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_old_just_controller -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_old_just_controller -> [DA.Internal.Desugar.Party]))
+_choice$_TrySyntaxX_old_just_controller
+  = (\ this@TrySyntax {..} arg@X_old_just_controller
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     \ self this@TrySyntax {..} arg@X_old_just_controller
+       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
+_choice$_TrySyntaxX_old_observer_and_controller :
+  (TrySyntax
+   -> X_old_observer_and_controller -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_old_observer_and_controller
+         -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming TrySyntax,
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_old_observer_and_controller -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_old_observer_and_controller -> [DA.Internal.Desugar.Party]))
+_choice$_TrySyntaxX_old_observer_and_controller
+  = (\ this@TrySyntax {..} arg@X_old_observer_and_controller
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     \ self this@TrySyntax {..} arg@X_old_observer_and_controller
+       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
+     DA.Internal.Desugar.Consuming, 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_old_observer_and_controller
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_OBSERVER), 
+     DA.Internal.Desugar.None)
+_choice$_TrySyntaxX_new_just_controllerX :
+  (TrySyntax
+   -> X_new_just_controllerX -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_new_just_controllerX -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming TrySyntax,
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_just_controllerX -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_just_controllerX -> [DA.Internal.Desugar.Party]))
+_choice$_TrySyntaxX_new_just_controllerX
+  = (\ this@TrySyntax {..} arg@X_new_just_controllerX
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     \ self this@TrySyntax {..} arg@X_new_just_controllerX
+       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
+_choice$_TrySyntaxX_new_just_controller :
+  (TrySyntax -> X_new_just_controller -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_new_just_controller -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming TrySyntax,
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_just_controller -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_just_controller -> [DA.Internal.Desugar.Party]))
+_choice$_TrySyntaxX_new_just_controller
+  = (\ this@TrySyntax {..} arg@X_new_just_controller
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     \ self this@TrySyntax {..} arg@X_new_just_controller
+       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
+_choice$_TrySyntaxX_new_observer_and_controllerX :
+  (TrySyntax
+   -> X_new_observer_and_controllerX -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_new_observer_and_controllerX
+         -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming TrySyntax,
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_observer_and_controllerX -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_observer_and_controllerX -> [DA.Internal.Desugar.Party]))
+_choice$_TrySyntaxX_new_observer_and_controllerX
+  = (\ this@TrySyntax {..} arg@X_new_observer_and_controllerX
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     \ self this@TrySyntax {..} arg@X_new_observer_and_controllerX
+       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
+     DA.Internal.Desugar.Consuming, 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_new_observer_and_controllerX
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_OBSERVER), 
+     DA.Internal.Desugar.None)
+_choice$_TrySyntaxX_new_observer_and_controller :
+  (TrySyntax
+   -> X_new_observer_and_controller -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_new_observer_and_controller
+         -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming TrySyntax,
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_observer_and_controller -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_observer_and_controller -> [DA.Internal.Desugar.Party]))
+_choice$_TrySyntaxX_new_observer_and_controller
+  = (\ this@TrySyntax {..} arg@X_new_observer_and_controller
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     \ self this@TrySyntax {..} arg@X_new_observer_and_controller
+       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
+     DA.Internal.Desugar.Consuming, 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_new_observer_and_controller
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_OBSERVER), 
+     DA.Internal.Desugar.None)
+_choice$_TrySyntaxX_new_controller_and_observer :
+  (TrySyntax
+   -> X_new_controller_and_observer -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_new_controller_and_observer
+         -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming TrySyntax,
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_controller_and_observer -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_controller_and_observer -> [DA.Internal.Desugar.Party]))
+_choice$_TrySyntaxX_new_controller_and_observer
+  = (\ this@TrySyntax {..} arg@X_new_controller_and_observer
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     \ self this@TrySyntax {..} arg@X_new_controller_and_observer
+       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
+     DA.Internal.Desugar.Consuming, 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_new_controller_and_observer
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_OBSERVER), 
+     DA.Internal.Desugar.None)
+_choice$_TrySyntaxX_new_authority_and_controller :
+  (TrySyntax
+   -> X_new_authority_and_controller -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_new_authority_and_controller
+         -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming TrySyntax,
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_authority_and_controller -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_authority_and_controller -> [DA.Internal.Desugar.Party]))
+_choice$_TrySyntaxX_new_authority_and_controller
+  = (\ this@TrySyntax {..} arg@X_new_authority_and_controller
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     \ self this@TrySyntax {..} arg@X_new_authority_and_controller
+       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_new_authority_and_controller
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY))
+_choice$_TrySyntaxX_new_observer_authority_and_controllerX :
+  (TrySyntax
+   -> X_new_observer_authority_and_controllerX
+      -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_new_observer_authority_and_controllerX
+         -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming TrySyntax,
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_observer_authority_and_controllerX
+                                    -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_observer_authority_and_controllerX
+                                    -> [DA.Internal.Desugar.Party]))
+_choice$_TrySyntaxX_new_observer_authority_and_controllerX
+  = (\ this@TrySyntax {..}
+       arg@X_new_observer_authority_and_controllerX
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     \ self
+       this@TrySyntax {..}
+       arg@X_new_observer_authority_and_controllerX
+       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
+     DA.Internal.Desugar.Consuming, 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_new_observer_authority_and_controllerX
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_OBSERVER), 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_new_observer_authority_and_controllerX
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY))
+_choice$_TrySyntaxX_new_observer_authority_and_controller :
+  (TrySyntax
+   -> X_new_observer_authority_and_controller
+      -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_new_observer_authority_and_controller
+         -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming TrySyntax,
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_observer_authority_and_controller
+                                    -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_observer_authority_and_controller
+                                    -> [DA.Internal.Desugar.Party]))
+_choice$_TrySyntaxX_new_observer_authority_and_controller
+  = (\ this@TrySyntax {..}
+       arg@X_new_observer_authority_and_controller
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     \ self
+       this@TrySyntax {..}
+       arg@X_new_observer_authority_and_controller
+       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
+     DA.Internal.Desugar.Consuming, 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_new_observer_authority_and_controller
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_OBSERVER), 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_new_observer_authority_and_controller
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY))
+_choice$_TrySyntaxX_new_authority_observer_and_controller :
+  (TrySyntax
+   -> X_new_authority_observer_and_controller
+      -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_new_authority_observer_and_controller
+         -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming TrySyntax,
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_authority_observer_and_controller
+                                    -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_authority_observer_and_controller
+                                    -> [DA.Internal.Desugar.Party]))
+_choice$_TrySyntaxX_new_authority_observer_and_controller
+  = (\ this@TrySyntax {..}
+       arg@X_new_authority_observer_and_controller
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     \ self
+       this@TrySyntax {..}
+       arg@X_new_authority_observer_and_controller
+       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
+     DA.Internal.Desugar.Consuming, 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_new_authority_observer_and_controller
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_OBSERVER), 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_new_authority_observer_and_controller
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY))
+_choice$_TrySyntaxX_new_controller_authority_observer :
+  (TrySyntax
+   -> X_new_controller_authority_observer
+      -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_new_controller_authority_observer
+         -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming TrySyntax,
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_controller_authority_observer
+                                    -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_controller_authority_observer
+                                    -> [DA.Internal.Desugar.Party]))
+_choice$_TrySyntaxX_new_controller_authority_observer
+  = (\ this@TrySyntax {..} arg@X_new_controller_authority_observer
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     \ self this@TrySyntax {..} arg@X_new_controller_authority_observer
+       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
+     DA.Internal.Desugar.Consuming, 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_new_controller_authority_observer
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_OBSERVER), 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_new_controller_authority_observer
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY))
+_choice$_TrySyntaxX_new_authority_controller_observer :
+  (TrySyntax
+   -> X_new_authority_controller_observer
+      -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.ContractId TrySyntax
+   -> TrySyntax
+      -> X_new_authority_controller_observer
+         -> DA.Internal.Desugar.Update (()),
+   DA.Internal.Desugar.Consuming TrySyntax,
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_authority_controller_observer
+                                    -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (TrySyntax
+                                 -> X_new_authority_controller_observer
+                                    -> [DA.Internal.Desugar.Party]))
+_choice$_TrySyntaxX_new_authority_controller_observer
+  = (\ this@TrySyntax {..} arg@X_new_authority_controller_observer
+       -> let _ = this in
+          let _ = arg in DA.Internal.Desugar.toParties (_CONTROLLER), 
+     \ self this@TrySyntax {..} arg@X_new_authority_controller_observer
+       -> let _ = self in let _ = this in let _ = arg in do _BODY, 
+     DA.Internal.Desugar.Consuming, 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_new_authority_controller_observer
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_OBSERVER), 
+     DA.Internal.Desugar.Some
+       \ this@TrySyntax {..} arg@X_new_authority_controller_observer
+         -> let _ = this in
+            let _ = arg in DA.Internal.Desugar.toParties (_AUTHORITY))

--- a/compiler/damlc/tests/daml-test-files/ChoiceAuthoritySyntax.daml
+++ b/compiler/damlc/tests/daml-test-files/ChoiceAuthoritySyntax.daml
@@ -1,0 +1,87 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+module ChoiceAuthoritySyntax where
+
+_CONTROLLER : [Party]
+_CONTROLLER = undefined
+_OBSERVER : [Party]
+_OBSERVER = undefined
+_AUTHORITY : [Party]
+_AUTHORITY = undefined
+
+_BODY : Update ()
+_BODY = undefined
+
+template TrySyntax
+  with
+    p: Party
+  where
+    signatory p
+
+    choice X_old_just_controller : ()
+      controller _CONTROLLER
+      do _BODY
+
+    choice X_old_observer_and_controller : ()
+      observer _OBSERVER
+      controller _CONTROLLER
+      do _BODY
+
+    choice X_new_just_controllerX : () where { controller _CONTROLLER } do _BODY
+
+    choice X_new_just_controller : ()
+      where
+        controller _CONTROLLER
+      do _BODY
+
+    choice X_new_observer_and_controllerX : () where { observer _OBSERVER; controller _CONTROLLER } do _BODY
+
+    choice X_new_observer_and_controller : ()
+      where
+        observer _OBSERVER
+        controller _CONTROLLER
+      do _BODY
+
+    choice X_new_controller_and_observer : ()
+      where
+        controller _CONTROLLER
+        observer _OBSERVER
+      do _BODY
+
+    choice X_new_authority_and_controller : ()
+      where
+        authority _AUTHORITY
+        controller _CONTROLLER
+      do _BODY
+
+    choice X_new_observer_authority_and_controllerX : ()
+      where { observer _OBSERVER; authority _AUTHORITY; controller _CONTROLLER } do _BODY
+
+    choice X_new_observer_authority_and_controller : ()
+      where
+        observer _OBSERVER
+        authority _AUTHORITY
+        controller _CONTROLLER
+      do _BODY
+
+    choice X_new_authority_observer_and_controller : ()
+      where
+        authority _AUTHORITY
+        observer _OBSERVER
+        controller _CONTROLLER
+      do _BODY
+
+    choice X_new_controller_authority_observer : ()
+      where
+        controller _CONTROLLER
+        authority _AUTHORITY
+        observer _OBSERVER
+      do _BODY
+
+    choice X_new_authority_controller_observer : ()
+      where
+        authority _AUTHORITY
+        controller _CONTROLLER
+        observer _OBSERVER
+      do _BODY

--- a/compiler/damlc/tests/daml-test-files/ChoiceShadowing.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/ChoiceShadowing.EXPECTED.desugared-daml
@@ -78,41 +78,42 @@ instance DA.Internal.Desugar.HasChoiceController T Call where
 instance DA.Internal.Desugar.HasChoiceObserver T Call where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TArchive :
-  (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming T,
+  (DA.Internal.Desugar.Consuming T,
+   T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TCall :
-  (T -> Call -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId T
-   -> T -> Call -> DA.Internal.Desugar.Update (ContractId T),
-   DA.Internal.Desugar.Consuming T,
+   -> T
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TCall :
+  (DA.Internal.Desugar.Consuming T,
+   T -> Call -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> Call -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> Call -> [DA.Internal.Desugar.Party]))
+                                 -> Call -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T -> Call -> DA.Internal.Desugar.Update (ContractId T))
 _choice$_TCall
-  = (\ this@T {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@T {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@Call {..}
               -> let _ = this in
                  let _ = arg in DA.Internal.Desugar.toParties (p2), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@T {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@Call {..}
               -> let _ = self in
-                 let _ = this in let _ = arg in do create T {p = p, p2 = p2}, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+                 let _ = this in let _ = arg in do create T {p = p, p2 = p2})
 test1
   = script
       do alice <- allocateParty "Alice"

--- a/compiler/damlc/tests/daml-test-files/ChoiceShadowing.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/ChoiceShadowing.EXPECTED.desugared-daml
@@ -84,16 +84,20 @@ _choice$_TArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TCall :
   (T -> Call -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> Call -> DA.Internal.Desugar.Update (ContractId T),
    DA.Internal.Desugar.Consuming T,
+   DA.Internal.Desugar.Optional (T
+                                 -> Call -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
                                  -> Call -> [DA.Internal.Desugar.Party]))
 _choice$_TCall
@@ -107,7 +111,8 @@ _choice$_TCall
             \ arg@Call {..}
               -> let _ = self in
                  let _ = this in let _ = arg in do create T {p = p, p2 = p2}, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 test1
   = script
       do alice <- allocateParty "Alice"

--- a/compiler/damlc/tests/daml-test-files/ExceptionCreate.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionCreate.EXPECTED.desugared-daml
@@ -60,20 +60,21 @@ instance DA.Internal.Desugar.HasChoiceController MyTemplate DA.Internal.Desugar.
 instance DA.Internal.Desugar.HasChoiceObserver MyTemplate DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_MyTemplateArchive :
-  (MyTemplate
+  (DA.Internal.Desugar.Consuming MyTemplate,
+   MyTemplate
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId MyTemplate
-   -> MyTemplate
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming MyTemplate,
    DA.Internal.Desugar.Optional (MyTemplate
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (MyTemplate
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId MyTemplate
+   -> MyTemplate
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_MyTemplateArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 data GHC.Types.DamlTemplate => Test
   = Test {p : Party}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
@@ -141,33 +142,35 @@ instance DA.Internal.Desugar.HasChoiceController Test Call where
 instance DA.Internal.Desugar.HasChoiceObserver Test Call where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TestArchive :
-  (Test
-   -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Test,
+  (DA.Internal.Desugar.Consuming Test,
+   Test -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TestArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TestCall :
-  (Test -> Call -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Test
-   -> Test -> Call -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Test,
+   -> Test
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TestArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TestCall :
+  (DA.Internal.Desugar.Consuming Test,
+   Test -> Call -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> Call -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> Call -> [DA.Internal.Desugar.Party]))
+                                 -> Call -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> Call -> DA.Internal.Desugar.Update (()))
 _choice$_TestCall
-  = (\ this@Test {..} arg@Call
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@Test {..} arg@Call
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@Call
        -> let _ = self in
           let _ = this in
@@ -181,9 +184,7 @@ _choice$_TestCall
                         (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some (PreconditionFailed msg))
                           -> DA.Internal.Desugar.Some pure msg
                         _ -> DA.Internal.Desugar.None
-               m === "Template precondition violated: MyTemplate {p = 'Alice'}", 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               m === "Template precondition violated: MyTemplate {p = 'Alice'}")
 test
   = script
       do p <- allocateParty "Alice"

--- a/compiler/damlc/tests/daml-test-files/ExceptionCreate.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionCreate.EXPECTED.desugared-daml
@@ -67,11 +67,13 @@ _choice$_MyTemplateArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming MyTemplate,
    DA.Internal.Desugar.Optional (MyTemplate
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (MyTemplate
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_MyTemplateArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 data GHC.Types.DamlTemplate => Test
   = Test {p : Party}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
@@ -146,16 +148,20 @@ _choice$_TestArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Test,
    DA.Internal.Desugar.Optional (Test
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TestArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TestCall :
   (Test -> Call -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> Call -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> Call -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> Call -> [DA.Internal.Desugar.Party]))
 _choice$_TestCall
@@ -176,7 +182,8 @@ _choice$_TestCall
                           -> DA.Internal.Desugar.Some pure msg
                         _ -> DA.Internal.Desugar.None
                m === "Template precondition violated: MyTemplate {p = 'Alice'}", 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 test
   = script
       do p <- allocateParty "Alice"

--- a/compiler/damlc/tests/daml-test-files/ExceptionSemantics.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionSemantics.EXPECTED.desugared-daml
@@ -74,19 +74,20 @@ instance DA.Internal.Desugar.HasChoiceController K DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver K DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_KArchive :
-  (K -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId K
-   -> K
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming K,
+  (DA.Internal.Desugar.Consuming K,
+   K -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (K
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (K
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId K
+   -> K
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_KArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasExerciseByKey K (Party,
                                                  Int) DA.Internal.Desugar.Archive (()) where
   _exerciseByKey = GHC.Types.primitive @"UExerciseByKey"
@@ -325,49 +326,52 @@ instance DA.Internal.Desugar.HasChoiceController T NonRollbackArchive where
 instance DA.Internal.Desugar.HasChoiceObserver T NonRollbackArchive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TArchive :
-  (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming T,
+  (DA.Internal.Desugar.Consuming T,
+   T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TThrow :
-  (T -> Throw -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId T
-   -> T -> Throw -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming T,
+   -> T
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TThrow :
+  (DA.Internal.Desugar.NonConsuming T,
+   T -> Throw -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> Throw -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> Throw -> [DA.Internal.Desugar.Party]))
+                                 -> Throw -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T -> Throw -> DA.Internal.Desugar.Update (()))
 _choice$_TThrow
-  = (\ this@T {..} arg@Throw
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@T {..} arg@Throw
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@T {..} arg@Throw
-       -> let _ = self in let _ = this in let _ = arg in do throw E, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+       -> let _ = self in let _ = this in let _ = arg in do throw E)
 _choice$_TCatch :
-  (T -> Catch -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T -> Catch -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming T,
+  (DA.Internal.Desugar.NonConsuming T,
+   T -> Catch -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> Catch -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> Catch -> [DA.Internal.Desugar.Party]))
+                                 -> Catch -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T -> Catch -> DA.Internal.Desugar.Update (()))
 _choice$_TCatch
-  = (\ this@T {..} arg@Catch
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@T {..} arg@Catch
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@T {..} arg@Catch
        -> let _ = self in
           let _ = this in
@@ -378,39 +382,39 @@ _choice$_TCatch
                  \case
                    (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
                      -> DA.Internal.Desugar.Some pure ()
-                   _ -> DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+                   _ -> DA.Internal.Desugar.None)
 _choice$_TThrowArithmeticError :
-  (T -> ThrowArithmeticError -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T -> ThrowArithmeticError -> DA.Internal.Desugar.Update (Int),
-   DA.Internal.Desugar.NonConsuming T,
+  (DA.Internal.Desugar.NonConsuming T,
+   T -> ThrowArithmeticError -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> ThrowArithmeticError -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> ThrowArithmeticError -> [DA.Internal.Desugar.Party]))
+                                 -> ThrowArithmeticError -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T -> ThrowArithmeticError -> DA.Internal.Desugar.Update (Int))
 _choice$_TThrowArithmeticError
-  = (\ this@T {..} arg@ThrowArithmeticError
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@T {..} arg@ThrowArithmeticError
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@T {..} arg@ThrowArithmeticError
-       -> let _ = self in let _ = this in let _ = arg in do pure (1 / 0), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+       -> let _ = self in let _ = this in let _ = arg in do pure (1 / 0))
 _choice$_TCatchArithmeticError :
-  (T -> CatchArithmeticError -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T -> CatchArithmeticError -> DA.Internal.Desugar.Update (Int),
-   DA.Internal.Desugar.NonConsuming T,
+  (DA.Internal.Desugar.NonConsuming T,
+   T -> CatchArithmeticError -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> CatchArithmeticError -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> CatchArithmeticError -> [DA.Internal.Desugar.Party]))
+                                 -> CatchArithmeticError -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T -> CatchArithmeticError -> DA.Internal.Desugar.Update (Int))
 _choice$_TCatchArithmeticError
-  = (\ this@T {..} arg@CatchArithmeticError
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@T {..} arg@CatchArithmeticError
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@T {..} arg@CatchArithmeticError
        -> let _ = self in
           let _ = this in
@@ -421,24 +425,24 @@ _choice$_TCatchArithmeticError
                  \case
                    (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some (_ : ArithmeticError))
                      -> DA.Internal.Desugar.Some pure 42
-                   _ -> DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+                   _ -> DA.Internal.Desugar.None)
 _choice$_TUncatchableTry :
-  (T -> UncatchableTry -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T -> UncatchableTry -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming T,
+  (DA.Internal.Desugar.NonConsuming T,
+   T -> UncatchableTry -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> UncatchableTry -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> UncatchableTry -> [DA.Internal.Desugar.Party]))
+                                 -> UncatchableTry -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T -> UncatchableTry -> DA.Internal.Desugar.Update (()))
 _choice$_TUncatchableTry
-  = (\ this@T {..}
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@T {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@UncatchableTry {..}
               -> let _ = this in
                  let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@T {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@UncatchableTry {..}
@@ -451,24 +455,24 @@ _choice$_TUncatchableTry
                         \case
                           (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
                             -> DA.Internal.Desugar.Some pure ()
-                          _ -> DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+                          _ -> DA.Internal.Desugar.None)
 _choice$_TTransientDuplicate :
-  (T -> TransientDuplicate -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T -> TransientDuplicate -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming T,
+  (DA.Internal.Desugar.NonConsuming T,
+   T -> TransientDuplicate -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> TransientDuplicate -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> TransientDuplicate -> [DA.Internal.Desugar.Party]))
+                                 -> TransientDuplicate -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T -> TransientDuplicate -> DA.Internal.Desugar.Update (()))
 _choice$_TTransientDuplicate
-  = (\ this@T {..}
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@T {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@TransientDuplicate {..}
               -> let _ = this in
                  let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@T {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@TransientDuplicate {..}
@@ -484,24 +488,24 @@ _choice$_TTransientDuplicate
                         \case
                           (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
                             -> DA.Internal.Desugar.Some pure ()
-                          _ -> DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+                          _ -> DA.Internal.Desugar.None)
 _choice$_TNonTransientDuplicate :
-  (T -> NonTransientDuplicate -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T -> NonTransientDuplicate -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming T,
+  (DA.Internal.Desugar.NonConsuming T,
+   T -> NonTransientDuplicate -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> NonTransientDuplicate -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> NonTransientDuplicate -> [DA.Internal.Desugar.Party]))
+                                 -> NonTransientDuplicate -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T -> NonTransientDuplicate -> DA.Internal.Desugar.Update (()))
 _choice$_TNonTransientDuplicate
-  = (\ this@T {..}
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@T {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@NonTransientDuplicate {..}
               -> let _ = this in
                  let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@T {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@NonTransientDuplicate {..}
@@ -516,24 +520,24 @@ _choice$_TNonTransientDuplicate
                         \case
                           (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
                             -> DA.Internal.Desugar.Some pure ()
-                          _ -> DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+                          _ -> DA.Internal.Desugar.None)
 _choice$_TRollbackKey :
-  (T -> RollbackKey -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T -> RollbackKey -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming T,
+  (DA.Internal.Desugar.NonConsuming T,
+   T -> RollbackKey -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> RollbackKey -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> RollbackKey -> [DA.Internal.Desugar.Party]))
+                                 -> RollbackKey -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T -> RollbackKey -> DA.Internal.Desugar.Update (()))
 _choice$_TRollbackKey
-  = (\ this@T {..}
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@T {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@RollbackKey {..}
               -> let _ = this in
                  let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@T {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@RollbackKey {..}
@@ -548,24 +552,24 @@ _choice$_TRollbackKey
                         \case
                           (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
                             -> DA.Internal.Desugar.Some create (K p i) >> pure ()
-                          _ -> DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+                          _ -> DA.Internal.Desugar.None)
 _choice$_TRollbackArchive :
-  (T -> RollbackArchive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T -> RollbackArchive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming T,
+  (DA.Internal.Desugar.NonConsuming T,
+   T -> RollbackArchive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> RollbackArchive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> RollbackArchive -> [DA.Internal.Desugar.Party]))
+                                 -> RollbackArchive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T -> RollbackArchive -> DA.Internal.Desugar.Update (()))
 _choice$_TRollbackArchive
-  = (\ this@T {..}
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@T {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@RollbackArchive {..}
               -> let _ = this in
                  let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@T {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@RollbackArchive {..}
@@ -579,24 +583,24 @@ _choice$_TRollbackArchive
                         \case
                           (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
                             -> DA.Internal.Desugar.Some archive cid
-                          _ -> DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+                          _ -> DA.Internal.Desugar.None)
 _choice$_TNonRollbackArchive :
-  (T -> NonRollbackArchive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T -> NonRollbackArchive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming T,
+  (DA.Internal.Desugar.NonConsuming T,
+   T -> NonRollbackArchive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> NonRollbackArchive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> NonRollbackArchive -> [DA.Internal.Desugar.Party]))
+                                 -> NonRollbackArchive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T -> NonRollbackArchive -> DA.Internal.Desugar.Update (()))
 _choice$_TNonRollbackArchive
-  = (\ this@T {..}
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@T {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@NonRollbackArchive {..}
               -> let _ = this in
                  let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@T {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@NonRollbackArchive {..}
@@ -611,9 +615,7 @@ _choice$_TNonRollbackArchive
                           (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
                             -> DA.Internal.Desugar.Some pure ()
                           _ -> DA.Internal.Desugar.None
-                      archive cid, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+                      archive cid)
 data GHC.Types.DamlTemplate => Fetcher
   = Fetcher {sig : Party, obs : Party}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
@@ -709,56 +711,59 @@ instance DA.Internal.Desugar.HasChoiceController Fetcher RollbackFetch where
 instance DA.Internal.Desugar.HasChoiceObserver Fetcher RollbackFetch where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_FetcherArchive :
-  (Fetcher
+  (DA.Internal.Desugar.Consuming Fetcher,
+   Fetcher
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Fetcher
-   -> Fetcher
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Fetcher,
    DA.Internal.Desugar.Optional (Fetcher
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Fetcher
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_FetcherArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_FetcherFetch :
-  (Fetcher -> Fetch -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Fetcher
-   -> Fetcher -> Fetch -> DA.Internal.Desugar.Update (K),
-   DA.Internal.Desugar.Consuming Fetcher,
+   -> Fetcher
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_FetcherArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_FetcherFetch :
+  (DA.Internal.Desugar.Consuming Fetcher,
+   Fetcher -> Fetch -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Fetcher
                                  -> Fetch -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Fetcher
-                                 -> Fetch -> [DA.Internal.Desugar.Party]))
+                                 -> Fetch -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Fetcher
+   -> Fetcher -> Fetch -> DA.Internal.Desugar.Update (K))
 _choice$_FetcherFetch
-  = (\ this@Fetcher {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@Fetcher {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@Fetch {..}
               -> let _ = this in
                  let _ = arg in DA.Internal.Desugar.toParties (obs), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Fetcher {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@Fetch {..}
-              -> let _ = self in let _ = this in let _ = arg in do fetch cid, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+              -> let _ = self in let _ = this in let _ = arg in do fetch cid)
 _choice$_FetcherRollbackFetch :
-  (Fetcher -> RollbackFetch -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Fetcher
-   -> Fetcher -> RollbackFetch -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Fetcher,
+  (DA.Internal.Desugar.Consuming Fetcher,
+   Fetcher -> RollbackFetch -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Fetcher
                                  -> RollbackFetch -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Fetcher
-                                 -> RollbackFetch -> [DA.Internal.Desugar.Party]))
+                                 -> RollbackFetch -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Fetcher
+   -> Fetcher -> RollbackFetch -> DA.Internal.Desugar.Update (()))
 _choice$_FetcherRollbackFetch
-  = (\ this@Fetcher {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@Fetcher {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@RollbackFetch {..}
               -> let _ = this in
                  let _ = arg in DA.Internal.Desugar.toParties (obs), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Fetcher {..}
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@RollbackFetch {..}
@@ -771,9 +776,7 @@ _choice$_FetcherRollbackFetch
                         \case
                           (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
                             -> DA.Internal.Desugar.Some pure ()
-                          _ -> DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+                          _ -> DA.Internal.Desugar.None)
 uncaughtUserException
   = script
       do p <- allocateParty "p"

--- a/compiler/damlc/tests/daml-test-files/ExceptionSemantics.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionSemantics.EXPECTED.desugared-daml
@@ -80,11 +80,13 @@ _choice$_KArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming K,
    DA.Internal.Desugar.Optional (K
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (K
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_KArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasExerciseByKey K (Party,
                                                  Int) DA.Internal.Desugar.Archive (()) where
   _exerciseByKey = GHC.Types.primitive @"UExerciseByKey"
@@ -329,16 +331,20 @@ _choice$_TArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TThrow :
   (T -> Throw -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> Throw -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming T,
+   DA.Internal.Desugar.Optional (T
+                                 -> Throw -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
                                  -> Throw -> [DA.Internal.Desugar.Party]))
 _choice$_TThrow
@@ -347,12 +353,15 @@ _choice$_TThrow
           let _ = arg in DA.Internal.Desugar.toParties (p), 
      \ self this@T {..} arg@Throw
        -> let _ = self in let _ = this in let _ = arg in do throw E, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TCatch :
   (T -> Catch -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> Catch -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming T,
+   DA.Internal.Desugar.Optional (T
+                                 -> Catch -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
                                  -> Catch -> [DA.Internal.Desugar.Party]))
 _choice$_TCatch
@@ -370,12 +379,15 @@ _choice$_TCatch
                    (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
                      -> DA.Internal.Desugar.Some pure ()
                    _ -> DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TThrowArithmeticError :
   (T -> ThrowArithmeticError -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> ThrowArithmeticError -> DA.Internal.Desugar.Update (Int),
    DA.Internal.Desugar.NonConsuming T,
+   DA.Internal.Desugar.Optional (T
+                                 -> ThrowArithmeticError -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
                                  -> ThrowArithmeticError -> [DA.Internal.Desugar.Party]))
 _choice$_TThrowArithmeticError
@@ -384,12 +396,15 @@ _choice$_TThrowArithmeticError
           let _ = arg in DA.Internal.Desugar.toParties (p), 
      \ self this@T {..} arg@ThrowArithmeticError
        -> let _ = self in let _ = this in let _ = arg in do pure (1 / 0), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TCatchArithmeticError :
   (T -> CatchArithmeticError -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> CatchArithmeticError -> DA.Internal.Desugar.Update (Int),
    DA.Internal.Desugar.NonConsuming T,
+   DA.Internal.Desugar.Optional (T
+                                 -> CatchArithmeticError -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
                                  -> CatchArithmeticError -> [DA.Internal.Desugar.Party]))
 _choice$_TCatchArithmeticError
@@ -407,12 +422,15 @@ _choice$_TCatchArithmeticError
                    (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some (_ : ArithmeticError))
                      -> DA.Internal.Desugar.Some pure 42
                    _ -> DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TUncatchableTry :
   (T -> UncatchableTry -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> UncatchableTry -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming T,
+   DA.Internal.Desugar.Optional (T
+                                 -> UncatchableTry -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
                                  -> UncatchableTry -> [DA.Internal.Desugar.Party]))
 _choice$_TUncatchableTry
@@ -434,12 +452,15 @@ _choice$_TUncatchableTry
                           (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
                             -> DA.Internal.Desugar.Some pure ()
                           _ -> DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TTransientDuplicate :
   (T -> TransientDuplicate -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> TransientDuplicate -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming T,
+   DA.Internal.Desugar.Optional (T
+                                 -> TransientDuplicate -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
                                  -> TransientDuplicate -> [DA.Internal.Desugar.Party]))
 _choice$_TTransientDuplicate
@@ -464,12 +485,15 @@ _choice$_TTransientDuplicate
                           (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
                             -> DA.Internal.Desugar.Some pure ()
                           _ -> DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TNonTransientDuplicate :
   (T -> NonTransientDuplicate -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> NonTransientDuplicate -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming T,
+   DA.Internal.Desugar.Optional (T
+                                 -> NonTransientDuplicate -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
                                  -> NonTransientDuplicate -> [DA.Internal.Desugar.Party]))
 _choice$_TNonTransientDuplicate
@@ -493,12 +517,15 @@ _choice$_TNonTransientDuplicate
                           (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
                             -> DA.Internal.Desugar.Some pure ()
                           _ -> DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TRollbackKey :
   (T -> RollbackKey -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> RollbackKey -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming T,
+   DA.Internal.Desugar.Optional (T
+                                 -> RollbackKey -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
                                  -> RollbackKey -> [DA.Internal.Desugar.Party]))
 _choice$_TRollbackKey
@@ -522,12 +549,15 @@ _choice$_TRollbackKey
                           (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
                             -> DA.Internal.Desugar.Some create (K p i) >> pure ()
                           _ -> DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TRollbackArchive :
   (T -> RollbackArchive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> RollbackArchive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming T,
+   DA.Internal.Desugar.Optional (T
+                                 -> RollbackArchive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
                                  -> RollbackArchive -> [DA.Internal.Desugar.Party]))
 _choice$_TRollbackArchive
@@ -550,12 +580,15 @@ _choice$_TRollbackArchive
                           (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
                             -> DA.Internal.Desugar.Some archive cid
                           _ -> DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TNonRollbackArchive :
   (T -> NonRollbackArchive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> NonRollbackArchive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming T,
+   DA.Internal.Desugar.Optional (T
+                                 -> NonRollbackArchive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
                                  -> NonRollbackArchive -> [DA.Internal.Desugar.Party]))
 _choice$_TNonRollbackArchive
@@ -579,7 +612,8 @@ _choice$_TNonRollbackArchive
                             -> DA.Internal.Desugar.Some pure ()
                           _ -> DA.Internal.Desugar.None
                       archive cid, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 data GHC.Types.DamlTemplate => Fetcher
   = Fetcher {sig : Party, obs : Party}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
@@ -682,16 +716,20 @@ _choice$_FetcherArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Fetcher,
    DA.Internal.Desugar.Optional (Fetcher
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Fetcher
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_FetcherArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_FetcherFetch :
   (Fetcher -> Fetch -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Fetcher
    -> Fetcher -> Fetch -> DA.Internal.Desugar.Update (K),
    DA.Internal.Desugar.Consuming Fetcher,
+   DA.Internal.Desugar.Optional (Fetcher
+                                 -> Fetch -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Fetcher
                                  -> Fetch -> [DA.Internal.Desugar.Party]))
 _choice$_FetcherFetch
@@ -704,12 +742,15 @@ _choice$_FetcherFetch
        -> DA.Internal.Desugar.bypassReduceLambda
             \ arg@Fetch {..}
               -> let _ = self in let _ = this in let _ = arg in do fetch cid, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_FetcherRollbackFetch :
   (Fetcher -> RollbackFetch -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Fetcher
    -> Fetcher -> RollbackFetch -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Fetcher,
+   DA.Internal.Desugar.Optional (Fetcher
+                                 -> RollbackFetch -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Fetcher
                                  -> RollbackFetch -> [DA.Internal.Desugar.Party]))
 _choice$_FetcherRollbackFetch
@@ -731,7 +772,8 @@ _choice$_FetcherRollbackFetch
                           (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some E)
                             -> DA.Internal.Desugar.Some pure ()
                           _ -> DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 uncaughtUserException
   = script
       do p <- allocateParty "p"

--- a/compiler/damlc/tests/daml-test-files/ExceptionSyntax.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionSyntax.EXPECTED.desugared-daml
@@ -94,16 +94,20 @@ _choice$_TestArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Test,
    DA.Internal.Desugar.Optional (Test
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TestArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TestCall :
   (Test -> Call -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> Call -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> Call -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> Call -> [DA.Internal.Desugar.Party]))
 _choice$_TestCall
@@ -124,7 +128,8 @@ _choice$_TestCall
                           -> DA.Internal.Desugar.Some pure m
                         _ -> DA.Internal.Desugar.None
                x === "ok", 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 tryCatchExample
   = script
       do p <- allocateParty "Alice"

--- a/compiler/damlc/tests/daml-test-files/ExceptionSyntax.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionSyntax.EXPECTED.desugared-daml
@@ -87,33 +87,35 @@ instance DA.Internal.Desugar.HasChoiceController Test Call where
 instance DA.Internal.Desugar.HasChoiceObserver Test Call where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TestArchive :
-  (Test
-   -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Test,
+  (DA.Internal.Desugar.Consuming Test,
+   Test -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TestArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TestCall :
-  (Test -> Call -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Test
-   -> Test -> Call -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Test,
+   -> Test
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TestArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TestCall :
+  (DA.Internal.Desugar.Consuming Test,
+   Test -> Call -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> Call -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> Call -> [DA.Internal.Desugar.Party]))
+                                 -> Call -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> Call -> DA.Internal.Desugar.Update (()))
 _choice$_TestCall
-  = (\ this@Test {..} arg@Call
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@Test {..} arg@Call
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@Call
        -> let _ = self in
           let _ = this in
@@ -127,9 +129,7 @@ _choice$_TestCall
                         (DA.Internal.Desugar.fromAnyException -> DA.Internal.Desugar.Some (MyException m))
                           -> DA.Internal.Desugar.Some pure m
                         _ -> DA.Internal.Desugar.None
-               x === "ok", 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               x === "ok")
 tryCatchExample
   = script
       do p <- allocateParty "Alice"

--- a/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.desugared-daml
@@ -201,105 +201,106 @@ instance DA.Internal.Record.HasField "byHowMuch" GetRich Int where
   setField
     = DA.Internal.Record.setFieldPrim @"byHowMuch" @GetRich @Int
 _choice$_TokenArchive :
-  (Token
+  (DA.Internal.Desugar.Consuming Token,
+   Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_TokenArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _choice$_TokenSplit :
-  (Token -> Split -> [DA.Internal.Desugar.Party],
+  (DA.Internal.Desugar.Consuming Token,
+   Token -> Split -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.Optional (Token
+                                 -> Split -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Token
+                                 -> Split -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Token
    -> Token
       -> Split
          -> DA.Internal.Desugar.Update ((ContractId Token,
-                                         ContractId Token)),
-   DA.Internal.Desugar.Consuming Token,
-   DA.Internal.Desugar.Optional (Token
-                                 -> Split -> [DA.Internal.Desugar.Party]),
-   DA.Internal.Desugar.Optional (Token
-                                 -> Split -> [DA.Internal.Desugar.Party]))
+                                         ContractId Token)))
 _choice$_TokenSplit
-  = (\ this arg@Split {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@Split {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@Split {..}
        -> let _ = self in
-          let _ = this in let _ = arg in do splitImpl this splitAmount, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = this in let _ = arg in do splitImpl this splitAmount)
 _choice$_TokenTransfer :
-  (Token -> Transfer -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> Transfer -> DA.Internal.Desugar.Update (ContractId Token),
-   DA.Internal.Desugar.Consuming Token,
+  (DA.Internal.Desugar.Consuming Token,
+   Token -> Transfer -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Token
                                  -> Transfer -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> Transfer -> [DA.Internal.Desugar.Party]))
+                                 -> Transfer -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> Transfer -> DA.Internal.Desugar.Update (ContractId Token))
 _choice$_TokenTransfer
-  = (\ this arg@Transfer {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@Transfer {..}
        -> let _ = this in
           let _ = arg
           in
             DA.Internal.Desugar.concat
               [DA.Internal.Desugar.toParties (getOwner this),
                DA.Internal.Desugar.toParties (newOwner)], 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@Transfer {..}
        -> let _ = self in
-          let _ = this in let _ = arg in do transferImpl this newOwner, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = this in let _ = arg in do transferImpl this newOwner)
 _choice$_TokenNoop :
-  (Token -> Noop -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token -> Noop -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Token,
+  (DA.Internal.Desugar.NonConsuming Token,
+   Token -> Noop -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Token
                                  -> Noop -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> Noop -> [DA.Internal.Desugar.Party]))
+                                 -> Noop -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token -> Noop -> DA.Internal.Desugar.Update (()))
 _choice$_TokenNoop
-  = (\ this arg@Noop {..}
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this arg@Noop {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@Noop {..}
        -> let _ = self in
-          let _ = this in let _ = arg in do noopImpl this nothing, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = this in let _ = arg in do noopImpl this nothing)
 _choice$_TokenGetRich :
-  (Token -> GetRich -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> GetRich -> DA.Internal.Desugar.Update (ContractId Token),
-   DA.Internal.Desugar.Consuming Token,
+  (DA.Internal.Desugar.Consuming Token,
+   Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> GetRich -> [DA.Internal.Desugar.Party]))
+                                 -> GetRich -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> GetRich -> DA.Internal.Desugar.Update (ContractId Token))
 _choice$_TokenGetRich
-  = (\ this arg@GetRich {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@GetRich {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@GetRich {..}
        -> let _ = self in
           let _ = this in
           let _ = arg
           in
             do assert (byHowMuch > 0)
-               create $ setAmount this (getAmount this + byHowMuch), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               create $ setAmount this (getAmount this + byHowMuch))
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -366,20 +367,21 @@ instance DA.Internal.Desugar.HasChoiceController Asset DA.Internal.Desugar.Archi
 instance DA.Internal.Desugar.HasChoiceObserver Asset DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_AssetArchive :
-  (Asset
+  (DA.Internal.Desugar.Consuming Asset,
+   Asset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Asset
-   -> Asset
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Asset
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Asset
+   -> Asset
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_AssetArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
 _interface_instance$_Asset_Token_Asset

--- a/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.desugared-daml
@@ -208,11 +208,13 @@ _choice$_TokenArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TokenSplit :
   (Token -> Split -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
@@ -222,6 +224,8 @@ _choice$_TokenSplit :
                                          ContractId Token)),
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
+                                 -> Split -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Token
                                  -> Split -> [DA.Internal.Desugar.Party]))
 _choice$_TokenSplit
   = (\ this arg@Split {..}
@@ -230,13 +234,16 @@ _choice$_TokenSplit
      \ self this arg@Split {..}
        -> let _ = self in
           let _ = this in let _ = arg in do splitImpl this splitAmount, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TokenTransfer :
   (Token -> Transfer -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
       -> Transfer -> DA.Internal.Desugar.Update (ContractId Token),
    DA.Internal.Desugar.Consuming Token,
+   DA.Internal.Desugar.Optional (Token
+                                 -> Transfer -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
                                  -> Transfer -> [DA.Internal.Desugar.Party]))
 _choice$_TokenTransfer
@@ -250,12 +257,15 @@ _choice$_TokenTransfer
      \ self this arg@Transfer {..}
        -> let _ = self in
           let _ = this in let _ = arg in do transferImpl this newOwner, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TokenNoop :
   (Token -> Noop -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token -> Noop -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Token,
+   DA.Internal.Desugar.Optional (Token
+                                 -> Noop -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
                                  -> Noop -> [DA.Internal.Desugar.Party]))
 _choice$_TokenNoop
@@ -265,13 +275,16 @@ _choice$_TokenNoop
      \ self this arg@Noop {..}
        -> let _ = self in
           let _ = this in let _ = arg in do noopImpl this nothing, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TokenGetRich :
   (Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
       -> GetRich -> DA.Internal.Desugar.Update (ContractId Token),
    DA.Internal.Desugar.Consuming Token,
+   DA.Internal.Desugar.Optional (Token
+                                 -> GetRich -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]))
 _choice$_TokenGetRich
@@ -285,7 +298,8 @@ _choice$_TokenGetRich
           in
             do assert (byHowMuch > 0)
                create $ setAmount this (getAmount this + byHowMuch), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -359,11 +373,13 @@ _choice$_AssetArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
 _interface_instance$_Asset_Token_Asset

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision.EXPECTED.desugared-daml
@@ -59,19 +59,20 @@ instance DA.Internal.Desugar.HasChoiceController T DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver T DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TArchive :
-  (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming T,
+  (DA.Internal.Desugar.Consuming T,
+   T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_TArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_T_InterfaceChoiceCollision1:Interface_T :
   DA.Internal.Desugar.InterfaceInstance T InterfaceChoiceCollision1.Interface T
 _interface_instance$_T_InterfaceChoiceCollision1:Interface_T

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision.EXPECTED.desugared-daml
@@ -65,11 +65,13 @@ _choice$_TArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_T_InterfaceChoiceCollision1:Interface_T :
   DA.Internal.Desugar.InterfaceInstance T InterfaceChoiceCollision1.Interface T
 _interface_instance$_T_InterfaceChoiceCollision1:Interface_T

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision2.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision2.EXPECTED.desugared-daml
@@ -95,37 +95,38 @@ data MyArchive
   = MyArchive {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
 _choice$_InterfaceArchive :
-  (Interface
+  (DA.Internal.Desugar.Consuming Interface,
+   Interface
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Interface
-   -> Interface
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Interface,
    DA.Internal.Desugar.Optional (Interface
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Interface
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_InterfaceArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_InterfaceMyArchive :
-  (Interface -> MyArchive -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Interface
-   -> Interface -> MyArchive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Interface,
+   -> Interface
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_InterfaceArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_InterfaceMyArchive :
+  (DA.Internal.Desugar.Consuming Interface,
+   Interface -> MyArchive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Interface
                                  -> MyArchive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Interface
-                                 -> MyArchive -> [DA.Internal.Desugar.Party]))
+                                 -> MyArchive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Interface
+   -> Interface -> MyArchive -> DA.Internal.Desugar.Update (()))
 _choice$_InterfaceMyArchive
-  = (\ this arg@MyArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@MyArchive
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@MyArchive
-       -> let _ = self in let _ = this in let _ = arg in do pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+       -> let _ = self in let _ = this in let _ = arg in do pure ())
 instance DA.Internal.Desugar.HasInterfaceView Interface EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Interface EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision2.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision2.EXPECTED.desugared-daml
@@ -102,16 +102,20 @@ _choice$_InterfaceArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Interface,
    DA.Internal.Desugar.Optional (Interface
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Interface
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_InterfaceArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_InterfaceMyArchive :
   (Interface -> MyArchive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Interface
    -> Interface -> MyArchive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Interface,
+   DA.Internal.Desugar.Optional (Interface
+                                 -> MyArchive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Interface
                                  -> MyArchive -> [DA.Internal.Desugar.Party]))
 _choice$_InterfaceMyArchive
@@ -120,7 +124,8 @@ _choice$_InterfaceMyArchive
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
      \ self this arg@MyArchive
        -> let _ = self in let _ = this in let _ = arg in do pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Interface EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Interface EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailed.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailed.EXPECTED.desugared-daml
@@ -90,16 +90,20 @@ _choice$_IArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_IIChoice :
   (I -> IChoice -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I -> IChoice -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming I,
+   DA.Internal.Desugar.Optional (I
+                                 -> IChoice -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
                                  -> IChoice -> [DA.Internal.Desugar.Party]))
 _choice$_IIChoice
@@ -108,7 +112,8 @@ _choice$_IIChoice
           let _ = arg in DA.Internal.Desugar.toParties (getController this), 
      \ self this arg@IChoice
        -> let _ = self in let _ = this in let _ = arg in do pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where
@@ -173,11 +178,13 @@ _choice$_TArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
 _interface_instance$_T_I_T
@@ -284,16 +291,20 @@ _choice$_TestArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Test,
    DA.Internal.Desugar.Optional (Test
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TestArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TestCall :
   (Test -> Call -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> Call -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> Call -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> Call -> [DA.Internal.Desugar.Party]))
 _choice$_TestCall
@@ -304,7 +315,8 @@ _choice$_TestCall
        -> let _ = self in
           let _ = this in
           let _ = arg in do exerciseGuarded (const False) cidI IChoice, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 main
   = script
       do alice <- allocateParty "alice"

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailed.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailed.EXPECTED.desugared-daml
@@ -84,36 +84,37 @@ data IChoice
   = IChoice {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
 _choice$_IArchive :
-  (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId I
-   -> I
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming I,
+  (DA.Internal.Desugar.Consuming I,
+   I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_IArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_IIChoice :
-  (I -> IChoice -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId I
-   -> I -> IChoice -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming I,
+   -> I
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_IArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_IIChoice :
+  (DA.Internal.Desugar.Consuming I,
+   I -> IChoice -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (I
                                  -> IChoice -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
-                                 -> IChoice -> [DA.Internal.Desugar.Party]))
+                                 -> IChoice -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId I
+   -> I -> IChoice -> DA.Internal.Desugar.Update (()))
 _choice$_IIChoice
-  = (\ this arg@IChoice
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@IChoice
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getController this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@IChoice
-       -> let _ = self in let _ = this in let _ = arg in do pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+       -> let _ = self in let _ = this in let _ = arg in do pure ())
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where
@@ -172,19 +173,20 @@ instance DA.Internal.Desugar.HasChoiceController T DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver T DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TArchive :
-  (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming T,
+  (DA.Internal.Desugar.Consuming T,
+   T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_TArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
 _interface_instance$_T_I_T
@@ -284,39 +286,39 @@ instance DA.Internal.Desugar.HasChoiceController Test Call where
 instance DA.Internal.Desugar.HasChoiceObserver Test Call where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TestArchive :
-  (Test
-   -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Test,
+  (DA.Internal.Desugar.Consuming Test,
+   Test -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TestArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TestCall :
-  (Test -> Call -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Test
-   -> Test -> Call -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Test,
+   -> Test
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TestArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TestCall :
+  (DA.Internal.Desugar.Consuming Test,
+   Test -> Call -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> Call -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> Call -> [DA.Internal.Desugar.Party]))
+                                 -> Call -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> Call -> DA.Internal.Desugar.Update (()))
 _choice$_TestCall
-  = (\ this@Test {..} arg@Call
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@Test {..} arg@Call
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (party), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@Call
        -> let _ = self in
           let _ = this in
-          let _ = arg in do exerciseGuarded (const False) cidI IChoice, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = arg in do exerciseGuarded (const False) cidI IChoice)
 main
   = script
       do alice <- allocateParty "alice"

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailedNotExtended.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailedNotExtended.EXPECTED.desugared-daml
@@ -84,36 +84,37 @@ data IChoice
   = IChoice {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
 _choice$_IArchive :
-  (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId I
-   -> I
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming I,
+  (DA.Internal.Desugar.Consuming I,
+   I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_IArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_IIChoice :
-  (I -> IChoice -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId I
-   -> I -> IChoice -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming I,
+   -> I
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_IArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_IIChoice :
+  (DA.Internal.Desugar.Consuming I,
+   I -> IChoice -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (I
                                  -> IChoice -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
-                                 -> IChoice -> [DA.Internal.Desugar.Party]))
+                                 -> IChoice -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId I
+   -> I -> IChoice -> DA.Internal.Desugar.Update (()))
 _choice$_IIChoice
-  = (\ this arg@IChoice
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@IChoice
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getController this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@IChoice
-       -> let _ = self in let _ = this in let _ = arg in do pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+       -> let _ = self in let _ = this in let _ = arg in do pure ())
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where
@@ -172,19 +173,20 @@ instance DA.Internal.Desugar.HasChoiceController T DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver T DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TArchive :
-  (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming T,
+  (DA.Internal.Desugar.Consuming T,
+   T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_TArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
 _interface_instance$_T_I_T
@@ -288,42 +290,43 @@ instance DA.Internal.Desugar.HasChoiceController ExerciseGuarded Call where
 instance DA.Internal.Desugar.HasChoiceObserver ExerciseGuarded Call where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_ExerciseGuardedArchive :
-  (ExerciseGuarded
+  (DA.Internal.Desugar.Consuming ExerciseGuarded,
+   ExerciseGuarded
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId ExerciseGuarded
-   -> ExerciseGuarded
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming ExerciseGuarded,
    DA.Internal.Desugar.Optional (ExerciseGuarded
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (ExerciseGuarded
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_ExerciseGuardedArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_ExerciseGuardedCall :
-  (ExerciseGuarded -> Call -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId ExerciseGuarded
-   -> ExerciseGuarded -> Call -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming ExerciseGuarded,
+   -> ExerciseGuarded
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_ExerciseGuardedArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_ExerciseGuardedCall :
+  (DA.Internal.Desugar.Consuming ExerciseGuarded,
+   ExerciseGuarded -> Call -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (ExerciseGuarded
                                  -> Call -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (ExerciseGuarded
-                                 -> Call -> [DA.Internal.Desugar.Party]))
+                                 -> Call -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId ExerciseGuarded
+   -> ExerciseGuarded -> Call -> DA.Internal.Desugar.Update (()))
 _choice$_ExerciseGuardedCall
-  = (\ this@ExerciseGuarded {..} arg@Call
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@ExerciseGuarded {..} arg@Call
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@ExerciseGuarded {..} arg@Call
        -> let _ = self in
           let _ = this in
           let _ = arg
           in
             do exerciseGuarded (const False) cidI IChoice
-               pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               pure ())
 main
   = script
       do alice <- allocateParty "alice"

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailedNotExtended.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailedNotExtended.EXPECTED.desugared-daml
@@ -90,16 +90,20 @@ _choice$_IArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_IIChoice :
   (I -> IChoice -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I -> IChoice -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming I,
+   DA.Internal.Desugar.Optional (I
+                                 -> IChoice -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
                                  -> IChoice -> [DA.Internal.Desugar.Party]))
 _choice$_IIChoice
@@ -108,7 +112,8 @@ _choice$_IIChoice
           let _ = arg in DA.Internal.Desugar.toParties (getController this), 
      \ self this arg@IChoice
        -> let _ = self in let _ = this in let _ = arg in do pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where
@@ -173,11 +178,13 @@ _choice$_TArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
 _interface_instance$_T_I_T
@@ -288,16 +295,20 @@ _choice$_ExerciseGuardedArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming ExerciseGuarded,
    DA.Internal.Desugar.Optional (ExerciseGuarded
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (ExerciseGuarded
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_ExerciseGuardedArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_ExerciseGuardedCall :
   (ExerciseGuarded -> Call -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId ExerciseGuarded
    -> ExerciseGuarded -> Call -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming ExerciseGuarded,
+   DA.Internal.Desugar.Optional (ExerciseGuarded
+                                 -> Call -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (ExerciseGuarded
                                  -> Call -> [DA.Internal.Desugar.Party]))
 _choice$_ExerciseGuardedCall
@@ -311,7 +322,8 @@ _choice$_ExerciseGuardedCall
           in
             do exerciseGuarded (const False) cidI IChoice
                pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 main
   = script
       do alice <- allocateParty "alice"

--- a/compiler/damlc/tests/daml-test-files/InterfaceContractDoesNotImplementInterface.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceContractDoesNotImplementInterface.EXPECTED.desugared-daml
@@ -63,11 +63,13 @@ _choice$_IArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where
@@ -165,16 +167,20 @@ _choice$_JArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming J,
    DA.Internal.Desugar.Optional (J
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (J
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_JArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_JJChoice :
   (J -> JChoice -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId J
    -> J -> JChoice -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming J,
+   DA.Internal.Desugar.Optional (J
+                                 -> JChoice -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (J
                                  -> JChoice -> [DA.Internal.Desugar.Party]))
 _choice$_JJChoice
@@ -183,7 +189,8 @@ _choice$_JJChoice
           let _ = arg in DA.Internal.Desugar.toParties (getController this), 
      \ self this arg@JChoice
        -> let _ = self in let _ = this in let _ = arg in do pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView J EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView J EmptyInterfaceView where
@@ -248,11 +255,13 @@ _choice$_TArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
 _interface_instance$_T_I_T

--- a/compiler/damlc/tests/daml-test-files/InterfaceContractDoesNotImplementInterface.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceContractDoesNotImplementInterface.EXPECTED.desugared-daml
@@ -57,19 +57,20 @@ instance DA.Internal.Desugar.HasChoiceController I DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver I DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_IArchive :
-  (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId I
-   -> I
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming I,
+  (DA.Internal.Desugar.Consuming I,
+   I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId I
+   -> I
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_IArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where
@@ -161,36 +162,37 @@ data JChoice
   = JChoice {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
 _choice$_JArchive :
-  (J -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId J
-   -> J
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming J,
+  (DA.Internal.Desugar.Consuming J,
+   J -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (J
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (J
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_JArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_JJChoice :
-  (J -> JChoice -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId J
-   -> J -> JChoice -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming J,
+   -> J
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_JArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_JJChoice :
+  (DA.Internal.Desugar.Consuming J,
+   J -> JChoice -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (J
                                  -> JChoice -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (J
-                                 -> JChoice -> [DA.Internal.Desugar.Party]))
+                                 -> JChoice -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId J
+   -> J -> JChoice -> DA.Internal.Desugar.Update (()))
 _choice$_JJChoice
-  = (\ this arg@JChoice
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@JChoice
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getController this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@JChoice
-       -> let _ = self in let _ = this in let _ = arg in do pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+       -> let _ = self in let _ = this in let _ = arg in do pure ())
 instance DA.Internal.Desugar.HasInterfaceView J EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView J EmptyInterfaceView where
@@ -249,19 +251,20 @@ instance DA.Internal.Desugar.HasChoiceController T DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver T DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TArchive :
-  (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming T,
+  (DA.Internal.Desugar.Consuming T,
+   T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_TArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
 _interface_instance$_T_I_T

--- a/compiler/damlc/tests/daml-test-files/InterfaceConversions.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceConversions.EXPECTED.desugared-daml
@@ -93,16 +93,20 @@ _choice$_IfaceArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Iface,
    DA.Internal.Desugar.Optional (Iface
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Iface
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IfaceArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_IfaceMyChoice :
   (Iface -> MyChoice -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Iface
    -> Iface -> MyChoice -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Iface,
+   DA.Internal.Desugar.Optional (Iface
+                                 -> MyChoice -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Iface
                                  -> MyChoice -> [DA.Internal.Desugar.Party]))
 _choice$_IfaceMyChoice
@@ -111,7 +115,8 @@ _choice$_IfaceMyChoice
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
      \ self this arg@MyChoice
        -> let _ = self in let _ = this in let _ = arg in do pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Iface EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Iface EmptyInterfaceView where
@@ -202,16 +207,20 @@ _choice$_Iface2Archive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Iface2,
    DA.Internal.Desugar.Optional (Iface2
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Iface2
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_Iface2Archive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_Iface2MyChoice2 :
   (Iface2 -> MyChoice2 -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Iface2
    -> Iface2 -> MyChoice2 -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Iface2,
+   DA.Internal.Desugar.Optional (Iface2
+                                 -> MyChoice2 -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Iface2
                                  -> MyChoice2 -> [DA.Internal.Desugar.Party]))
 _choice$_Iface2MyChoice2
@@ -220,7 +229,8 @@ _choice$_Iface2MyChoice2
           let _ = arg in DA.Internal.Desugar.toParties (getOwner2 this), 
      \ self this arg@MyChoice2
        -> let _ = self in let _ = this in let _ = arg in do pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Iface2 EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Iface2 EmptyInterfaceView where
@@ -293,11 +303,13 @@ _choice$_Template1Archive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Template1,
    DA.Internal.Desugar.Optional (Template1
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Template1
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_Template1Archive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_Template1_Iface_Template1 :
   DA.Internal.Desugar.InterfaceInstance Template1 Iface Template1
 _interface_instance$_Template1_Iface_Template1
@@ -395,11 +407,13 @@ _choice$_Template2Archive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Template2,
    DA.Internal.Desugar.Optional (Template2
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Template2
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_Template2Archive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_Template2_Iface_Template2 :
   DA.Internal.Desugar.InterfaceInstance Template2 Iface Template2
 _interface_instance$_Template2_Iface_Template2
@@ -604,17 +618,21 @@ _choice$_TestArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Test,
    DA.Internal.Desugar.Optional (Test
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TestArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TestTemplateInterfaceMatching :
   (Test -> TemplateInterfaceMatching -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test
       -> TemplateInterfaceMatching -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> TemplateInterfaceMatching -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> TemplateInterfaceMatching -> [DA.Internal.Desugar.Party]))
 _choice$_TestTemplateInterfaceMatching
@@ -648,12 +666,15 @@ _choice$_TestTemplateInterfaceMatching
                x2 === None
                x3 === None
                x4 === Some userWrittenTuple (templateCid2, template2), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestVoidFromInterface :
   (Test -> VoidFromInterface -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> VoidFromInterface -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> VoidFromInterface -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> VoidFromInterface -> [DA.Internal.Desugar.Party]))
 _choice$_TestVoidFromInterface
@@ -664,12 +685,15 @@ _choice$_TestVoidFromInterface
        -> let _ = self in
           let _ = this in
           let _ = arg in do useActionFrom party $ \ _cid -> pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestFetchFromInterface :
   (Test -> FetchFromInterface -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> FetchFromInterface -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> FetchFromInterface -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> FetchFromInterface -> [DA.Internal.Desugar.Party]))
 _choice$_TestFetchFromInterface
@@ -680,12 +704,15 @@ _choice$_TestFetchFromInterface
        -> let _ = self in
           let _ = this in
           let _ = arg in do useActionFrom party $ \ cid -> void (fetch cid), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestArchiveFromInterface :
   (Test -> ArchiveFromInterface -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> ArchiveFromInterface -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> ArchiveFromInterface -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> ArchiveFromInterface -> [DA.Internal.Desugar.Party]))
 _choice$_TestArchiveFromInterface
@@ -696,12 +723,15 @@ _choice$_TestArchiveFromInterface
        -> let _ = self in
           let _ = this in
           let _ = arg in do useActionFrom party $ \ cid -> archive cid, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestVoidCoerceInterface :
   (Test -> VoidCoerceInterface -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> VoidCoerceInterface -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> VoidCoerceInterface -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> VoidCoerceInterface -> [DA.Internal.Desugar.Party]))
 _choice$_TestVoidCoerceInterface
@@ -712,13 +742,16 @@ _choice$_TestVoidCoerceInterface
        -> let _ = self in
           let _ = this in
           let _ = arg in do useActionCoerce party $ \ _cid -> pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestExerciseCoerceInterface :
   (Test -> ExerciseCoerceInterface -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test
       -> ExerciseCoerceInterface -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> ExerciseCoerceInterface -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> ExerciseCoerceInterface -> [DA.Internal.Desugar.Party]))
 _choice$_TestExerciseCoerceInterface
@@ -730,12 +763,15 @@ _choice$_TestExerciseCoerceInterface
           let _ = this in
           let _ = arg
           in do useActionCoerce party $ \ cid -> exercise cid MyChoice2, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestFetchCoerceInterface :
   (Test -> FetchCoerceInterface -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> FetchCoerceInterface -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> FetchCoerceInterface -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> FetchCoerceInterface -> [DA.Internal.Desugar.Party]))
 _choice$_TestFetchCoerceInterface
@@ -747,13 +783,16 @@ _choice$_TestFetchCoerceInterface
           let _ = this in
           let _ = arg
           in do useActionCoerce party $ \ cid -> void (fetch cid), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestArchiveCoerceInterface :
   (Test -> ArchiveCoerceInterface -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test
       -> ArchiveCoerceInterface -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> ArchiveCoerceInterface -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> ArchiveCoerceInterface -> [DA.Internal.Desugar.Party]))
 _choice$_TestArchiveCoerceInterface
@@ -764,7 +803,8 @@ _choice$_TestArchiveCoerceInterface
        -> let _ = self in
           let _ = this in
           let _ = arg in do useActionCoerce party $ \ cid -> archive cid, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 exerciseTest : Choice Test c () => c -> Script ()
 exerciseTest c
   = script

--- a/compiler/damlc/tests/daml-test-files/InterfaceConversions.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceConversions.EXPECTED.desugared-daml
@@ -86,37 +86,38 @@ data MyChoice
   = MyChoice {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
 _choice$_IfaceArchive :
-  (Iface
+  (DA.Internal.Desugar.Consuming Iface,
+   Iface
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Iface
-   -> Iface
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Iface,
    DA.Internal.Desugar.Optional (Iface
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Iface
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_IfaceArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_IfaceMyChoice :
-  (Iface -> MyChoice -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Iface
-   -> Iface -> MyChoice -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Iface,
+   -> Iface
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_IfaceArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_IfaceMyChoice :
+  (DA.Internal.Desugar.Consuming Iface,
+   Iface -> MyChoice -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Iface
                                  -> MyChoice -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Iface
-                                 -> MyChoice -> [DA.Internal.Desugar.Party]))
+                                 -> MyChoice -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Iface
+   -> Iface -> MyChoice -> DA.Internal.Desugar.Update (()))
 _choice$_IfaceMyChoice
-  = (\ this arg@MyChoice
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@MyChoice
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@MyChoice
-       -> let _ = self in let _ = this in let _ = arg in do pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+       -> let _ = self in let _ = this in let _ = arg in do pure ())
 instance DA.Internal.Desugar.HasInterfaceView Iface EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Iface EmptyInterfaceView where
@@ -200,37 +201,38 @@ data MyChoice2
   = MyChoice2 {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
 _choice$_Iface2Archive :
-  (Iface2
+  (DA.Internal.Desugar.Consuming Iface2,
+   Iface2
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Iface2
-   -> Iface2
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Iface2,
    DA.Internal.Desugar.Optional (Iface2
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Iface2
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_Iface2Archive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_Iface2MyChoice2 :
-  (Iface2 -> MyChoice2 -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Iface2
-   -> Iface2 -> MyChoice2 -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Iface2,
+   -> Iface2
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_Iface2Archive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_Iface2MyChoice2 :
+  (DA.Internal.Desugar.Consuming Iface2,
+   Iface2 -> MyChoice2 -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Iface2
                                  -> MyChoice2 -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Iface2
-                                 -> MyChoice2 -> [DA.Internal.Desugar.Party]))
+                                 -> MyChoice2 -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Iface2
+   -> Iface2 -> MyChoice2 -> DA.Internal.Desugar.Update (()))
 _choice$_Iface2MyChoice2
-  = (\ this arg@MyChoice2
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@MyChoice2
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner2 this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@MyChoice2
-       -> let _ = self in let _ = this in let _ = arg in do pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+       -> let _ = self in let _ = this in let _ = arg in do pure ())
 instance DA.Internal.Desugar.HasInterfaceView Iface2 EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Iface2 EmptyInterfaceView where
@@ -296,20 +298,21 @@ instance DA.Internal.Desugar.HasChoiceController Template1 DA.Internal.Desugar.A
 instance DA.Internal.Desugar.HasChoiceObserver Template1 DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_Template1Archive :
-  (Template1
+  (DA.Internal.Desugar.Consuming Template1,
+   Template1
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Template1
-   -> Template1
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Template1,
    DA.Internal.Desugar.Optional (Template1
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Template1
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Template1
+   -> Template1
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_Template1Archive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_Template1_Iface_Template1 :
   DA.Internal.Desugar.InterfaceInstance Template1 Iface Template1
 _interface_instance$_Template1_Iface_Template1
@@ -400,20 +403,21 @@ instance DA.Internal.Desugar.HasChoiceController Template2 DA.Internal.Desugar.A
 instance DA.Internal.Desugar.HasChoiceObserver Template2 DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_Template2Archive :
-  (Template2
+  (DA.Internal.Desugar.Consuming Template2,
+   Template2
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Template2
-   -> Template2
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Template2,
    DA.Internal.Desugar.Optional (Template2
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Template2
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Template2
+   -> Template2
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_Template2Archive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_Template2_Iface_Template2 :
   DA.Internal.Desugar.InterfaceInstance Template2 Iface Template2
 _interface_instance$_Template2_Iface_Template2
@@ -611,34 +615,36 @@ instance DA.Internal.Desugar.HasChoiceController Test ArchiveCoerceInterface whe
 instance DA.Internal.Desugar.HasChoiceObserver Test ArchiveCoerceInterface where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TestArchive :
-  (Test
-   -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Test,
+  (DA.Internal.Desugar.Consuming Test,
+   Test -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TestArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TestTemplateInterfaceMatching :
-  (Test -> TemplateInterfaceMatching -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Test
    -> Test
-      -> TemplateInterfaceMatching -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TestArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TestTemplateInterfaceMatching :
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> TemplateInterfaceMatching -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> TemplateInterfaceMatching -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> TemplateInterfaceMatching -> [DA.Internal.Desugar.Party]))
+                                 -> TemplateInterfaceMatching -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test
+      -> TemplateInterfaceMatching -> DA.Internal.Desugar.Update (()))
 _choice$_TestTemplateInterfaceMatching
-  = (\ this@Test {..} arg@TemplateInterfaceMatching
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@TemplateInterfaceMatching
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (party), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@TemplateInterfaceMatching
        -> let _ = self in
           let _ = this in
@@ -665,146 +671,144 @@ _choice$_TestTemplateInterfaceMatching
                x1 === Some userWrittenTuple (templateCid1, template1)
                x2 === None
                x3 === None
-               x4 === Some userWrittenTuple (templateCid2, template2), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               x4 === Some userWrittenTuple (templateCid2, template2))
 _choice$_TestVoidFromInterface :
-  (Test -> VoidFromInterface -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> VoidFromInterface -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> VoidFromInterface -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> VoidFromInterface -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> VoidFromInterface -> [DA.Internal.Desugar.Party]))
+                                 -> VoidFromInterface -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> VoidFromInterface -> DA.Internal.Desugar.Update (()))
 _choice$_TestVoidFromInterface
-  = (\ this@Test {..} arg@VoidFromInterface
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@VoidFromInterface
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (party), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@VoidFromInterface
        -> let _ = self in
           let _ = this in
-          let _ = arg in do useActionFrom party $ \ _cid -> pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = arg in do useActionFrom party $ \ _cid -> pure ())
 _choice$_TestFetchFromInterface :
-  (Test -> FetchFromInterface -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> FetchFromInterface -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> FetchFromInterface -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> FetchFromInterface -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> FetchFromInterface -> [DA.Internal.Desugar.Party]))
+                                 -> FetchFromInterface -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> FetchFromInterface -> DA.Internal.Desugar.Update (()))
 _choice$_TestFetchFromInterface
-  = (\ this@Test {..} arg@FetchFromInterface
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@FetchFromInterface
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (party), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@FetchFromInterface
        -> let _ = self in
           let _ = this in
-          let _ = arg in do useActionFrom party $ \ cid -> void (fetch cid), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = arg in do useActionFrom party $ \ cid -> void (fetch cid))
 _choice$_TestArchiveFromInterface :
-  (Test -> ArchiveFromInterface -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> ArchiveFromInterface -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> ArchiveFromInterface -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> ArchiveFromInterface -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> ArchiveFromInterface -> [DA.Internal.Desugar.Party]))
+                                 -> ArchiveFromInterface -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> ArchiveFromInterface -> DA.Internal.Desugar.Update (()))
 _choice$_TestArchiveFromInterface
-  = (\ this@Test {..} arg@ArchiveFromInterface
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@ArchiveFromInterface
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (party), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@ArchiveFromInterface
        -> let _ = self in
           let _ = this in
-          let _ = arg in do useActionFrom party $ \ cid -> archive cid, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = arg in do useActionFrom party $ \ cid -> archive cid)
 _choice$_TestVoidCoerceInterface :
-  (Test -> VoidCoerceInterface -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> VoidCoerceInterface -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> VoidCoerceInterface -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> VoidCoerceInterface -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> VoidCoerceInterface -> [DA.Internal.Desugar.Party]))
+                                 -> VoidCoerceInterface -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> VoidCoerceInterface -> DA.Internal.Desugar.Update (()))
 _choice$_TestVoidCoerceInterface
-  = (\ this@Test {..} arg@VoidCoerceInterface
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@VoidCoerceInterface
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (party), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@VoidCoerceInterface
        -> let _ = self in
           let _ = this in
-          let _ = arg in do useActionCoerce party $ \ _cid -> pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = arg in do useActionCoerce party $ \ _cid -> pure ())
 _choice$_TestExerciseCoerceInterface :
-  (Test -> ExerciseCoerceInterface -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test
-      -> ExerciseCoerceInterface -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> ExerciseCoerceInterface -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> ExerciseCoerceInterface -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> ExerciseCoerceInterface -> [DA.Internal.Desugar.Party]))
+                                 -> ExerciseCoerceInterface -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test
+      -> ExerciseCoerceInterface -> DA.Internal.Desugar.Update (()))
 _choice$_TestExerciseCoerceInterface
-  = (\ this@Test {..} arg@ExerciseCoerceInterface
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@ExerciseCoerceInterface
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (party), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@ExerciseCoerceInterface
        -> let _ = self in
           let _ = this in
           let _ = arg
-          in do useActionCoerce party $ \ cid -> exercise cid MyChoice2, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          in do useActionCoerce party $ \ cid -> exercise cid MyChoice2)
 _choice$_TestFetchCoerceInterface :
-  (Test -> FetchCoerceInterface -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> FetchCoerceInterface -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> FetchCoerceInterface -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> FetchCoerceInterface -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> FetchCoerceInterface -> [DA.Internal.Desugar.Party]))
+                                 -> FetchCoerceInterface -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> FetchCoerceInterface -> DA.Internal.Desugar.Update (()))
 _choice$_TestFetchCoerceInterface
-  = (\ this@Test {..} arg@FetchCoerceInterface
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@FetchCoerceInterface
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (party), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@FetchCoerceInterface
        -> let _ = self in
           let _ = this in
           let _ = arg
-          in do useActionCoerce party $ \ cid -> void (fetch cid), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          in do useActionCoerce party $ \ cid -> void (fetch cid))
 _choice$_TestArchiveCoerceInterface :
-  (Test -> ArchiveCoerceInterface -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test
-      -> ArchiveCoerceInterface -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> ArchiveCoerceInterface -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> ArchiveCoerceInterface -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> ArchiveCoerceInterface -> [DA.Internal.Desugar.Party]))
+                                 -> ArchiveCoerceInterface -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test
+      -> ArchiveCoerceInterface -> DA.Internal.Desugar.Update (()))
 _choice$_TestArchiveCoerceInterface
-  = (\ this@Test {..} arg@ArchiveCoerceInterface
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@ArchiveCoerceInterface
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (party), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@ArchiveCoerceInterface
        -> let _ = self in
           let _ = this in
-          let _ = arg in do useActionCoerce party $ \ cid -> archive cid, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = arg in do useActionCoerce party $ \ cid -> archive cid)
 exerciseTest : Choice Test c () => c -> Script ()
 exerciseTest c
   = script

--- a/compiler/damlc/tests/daml-test-files/InterfaceDoubleSpend.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceDoubleSpend.EXPECTED.desugared-daml
@@ -99,39 +99,40 @@ instance DA.Internal.Record.HasField "newOwner" Transfer Party where
   setField
     = DA.Internal.Record.setFieldPrim @"newOwner" @Transfer @Party
 _choice$_TokenArchive :
-  (Token
+  (DA.Internal.Desugar.Consuming Token,
+   Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TokenArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TokenTransfer :
-  (Token -> Transfer -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Token
    -> Token
-      -> Transfer -> DA.Internal.Desugar.Update (ContractId Token),
-   DA.Internal.Desugar.Consuming Token,
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TokenArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TokenTransfer :
+  (DA.Internal.Desugar.Consuming Token,
+   Token -> Transfer -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Token
                                  -> Transfer -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> Transfer -> [DA.Internal.Desugar.Party]))
+                                 -> Transfer -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> Transfer -> DA.Internal.Desugar.Update (ContractId Token))
 _choice$_TokenTransfer
-  = (\ this arg@Transfer {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@Transfer {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getIssuer this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@Transfer {..}
        -> let _ = self in
-          let _ = this in let _ = arg in do transferImpl this newOwner, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = this in let _ = arg in do transferImpl this newOwner)
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -196,20 +197,21 @@ instance DA.Internal.Desugar.HasChoiceController Asset DA.Internal.Desugar.Archi
 instance DA.Internal.Desugar.HasChoiceObserver Asset DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_AssetArchive :
-  (Asset
+  (DA.Internal.Desugar.Consuming Asset,
+   Asset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Asset
-   -> Asset
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Asset
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Asset
+   -> Asset
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_AssetArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
 _interface_instance$_Asset_Token_Asset

--- a/compiler/damlc/tests/daml-test-files/InterfaceDoubleSpend.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceDoubleSpend.EXPECTED.desugared-daml
@@ -106,17 +106,21 @@ _choice$_TokenArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TokenTransfer :
   (Token -> Transfer -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
       -> Transfer -> DA.Internal.Desugar.Update (ContractId Token),
    DA.Internal.Desugar.Consuming Token,
+   DA.Internal.Desugar.Optional (Token
+                                 -> Transfer -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
                                  -> Transfer -> [DA.Internal.Desugar.Party]))
 _choice$_TokenTransfer
@@ -126,7 +130,8 @@ _choice$_TokenTransfer
      \ self this arg@Transfer {..}
        -> let _ = self in
           let _ = this in let _ = arg in do transferImpl this newOwner, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -198,11 +203,13 @@ _choice$_AssetArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
 _interface_instance$_Asset_Token_Asset

--- a/compiler/damlc/tests/daml-test-files/InterfaceEmpty.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceEmpty.EXPECTED.desugared-daml
@@ -58,19 +58,20 @@ instance DA.Internal.Desugar.HasChoiceController I DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver I DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_IArchive :
-  (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId I
-   -> I
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming I,
+  (DA.Internal.Desugar.Consuming I,
+   I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId I
+   -> I
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_IArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where
@@ -129,19 +130,20 @@ instance DA.Internal.Desugar.HasChoiceController T DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver T DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TArchive :
-  (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming T,
+  (DA.Internal.Desugar.Consuming T,
+   T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_TArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
 _interface_instance$_T_I_T

--- a/compiler/damlc/tests/daml-test-files/InterfaceEmpty.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceEmpty.EXPECTED.desugared-daml
@@ -64,11 +64,13 @@ _choice$_IArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where
@@ -133,11 +135,13 @@ _choice$_TArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
 _interface_instance$_T_I_T

--- a/compiler/damlc/tests/daml-test-files/InterfaceEmptyIndirect.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceEmptyIndirect.EXPECTED.desugared-daml
@@ -58,19 +58,20 @@ instance DA.Internal.Desugar.HasChoiceController T DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver T DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TArchive :
-  (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming T,
+  (DA.Internal.Desugar.Consuming T,
+   T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_TArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
 _interface_instance$_T_I_T

--- a/compiler/damlc/tests/daml-test-files/InterfaceEmptyIndirect.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceEmptyIndirect.EXPECTED.desugared-daml
@@ -64,11 +64,13 @@ _choice$_TArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
 _interface_instance$_T_I_T

--- a/compiler/damlc/tests/daml-test-files/InterfaceEq.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceEq.EXPECTED.desugared-daml
@@ -57,19 +57,20 @@ instance DA.Internal.Desugar.HasChoiceController I DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver I DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_IArchive :
-  (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId I
-   -> I
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming I,
+  (DA.Internal.Desugar.Consuming I,
+   I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId I
+   -> I
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_IArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where
@@ -131,19 +132,20 @@ instance DA.Internal.Desugar.HasChoiceController T DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver T DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TArchive :
-  (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming T,
+  (DA.Internal.Desugar.Consuming T,
+   T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_TArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
 _interface_instance$_T_I_T
@@ -218,19 +220,20 @@ instance DA.Internal.Desugar.HasChoiceController U DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver U DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_UArchive :
-  (U -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId U
-   -> U
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming U,
+  (DA.Internal.Desugar.Consuming U,
+   U -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (U
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (U
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId U
+   -> U
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_UArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_U_I_U :
   DA.Internal.Desugar.InterfaceInstance U I U
 _interface_instance$_U_I_U

--- a/compiler/damlc/tests/daml-test-files/InterfaceEq.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceEq.EXPECTED.desugared-daml
@@ -63,11 +63,13 @@ _choice$_IArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where
@@ -135,11 +137,13 @@ _choice$_TArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
 _interface_instance$_T_I_T
@@ -220,11 +224,13 @@ _choice$_UArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming U,
    DA.Internal.Desugar.Optional (U
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (U
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_UArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_U_I_U :
   DA.Internal.Desugar.InterfaceInstance U I U
 _interface_instance$_U_I_U

--- a/compiler/damlc/tests/daml-test-files/InterfaceErrors.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceErrors.EXPECTED.desugared-daml
@@ -93,17 +93,21 @@ _choice$_MyInterfaceArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming MyInterface,
    DA.Internal.Desugar.Optional (MyInterface
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (MyInterface
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_MyInterfaceArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_MyInterfaceMyVirtualChoice :
   (MyInterface -> MyVirtualChoice -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId MyInterface
    -> MyInterface
       -> MyVirtualChoice -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming MyInterface,
+   DA.Internal.Desugar.Optional (MyInterface
+                                 -> MyVirtualChoice -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (MyInterface
                                  -> MyVirtualChoice -> [DA.Internal.Desugar.Party]))
 _choice$_MyInterfaceMyVirtualChoice
@@ -113,7 +117,8 @@ _choice$_MyInterfaceMyVirtualChoice
      \ self this arg@MyVirtualChoice
        -> let _ = self in
           let _ = this in let _ = arg in do myVirtualChoiceImpl this, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView MyInterface EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView MyInterface EmptyInterfaceView where
@@ -179,11 +184,13 @@ _choice$_MyTemplateArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming MyTemplate,
    DA.Internal.Desugar.Optional (MyTemplate
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (MyTemplate
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_MyTemplateArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 data GHC.Types.DamlTemplate => Test
   = Test {p : Party}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
@@ -271,16 +278,20 @@ _choice$_TestArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Test,
    DA.Internal.Desugar.Optional (Test
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TestArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TestCoercedFetch :
   (Test -> CoercedFetch -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> CoercedFetch -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> CoercedFetch -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> CoercedFetch -> [DA.Internal.Desugar.Party]))
 _choice$_TestCoercedFetch
@@ -296,12 +307,15 @@ _choice$_TestCoercedFetch
                let cid' : ContractId MyInterface = coerceContractId cid
                fetch cid'
                pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestCoercedExercise :
   (Test -> CoercedExercise -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> CoercedExercise -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> CoercedExercise -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> CoercedExercise -> [DA.Internal.Desugar.Party]))
 _choice$_TestCoercedExercise
@@ -317,7 +331,8 @@ _choice$_TestCoercedExercise
                let cid' : ContractId MyInterface = coerceContractId cid
                exercise cid' MyVirtualChoice
                pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 fetchBadContract
   = script
       do p <- allocateParty "Alice"

--- a/compiler/damlc/tests/daml-test-files/InterfaceErrors.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceErrors.EXPECTED.desugared-daml
@@ -86,39 +86,40 @@ data MyVirtualChoice
   = MyVirtualChoice {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
 _choice$_MyInterfaceArchive :
-  (MyInterface
+  (DA.Internal.Desugar.Consuming MyInterface,
+   MyInterface
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId MyInterface
-   -> MyInterface
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming MyInterface,
    DA.Internal.Desugar.Optional (MyInterface
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (MyInterface
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_MyInterfaceArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_MyInterfaceMyVirtualChoice :
-  (MyInterface -> MyVirtualChoice -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId MyInterface
    -> MyInterface
-      -> MyVirtualChoice -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming MyInterface,
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_MyInterfaceArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_MyInterfaceMyVirtualChoice :
+  (DA.Internal.Desugar.Consuming MyInterface,
+   MyInterface -> MyVirtualChoice -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (MyInterface
                                  -> MyVirtualChoice -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (MyInterface
-                                 -> MyVirtualChoice -> [DA.Internal.Desugar.Party]))
+                                 -> MyVirtualChoice -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId MyInterface
+   -> MyInterface
+      -> MyVirtualChoice -> DA.Internal.Desugar.Update (()))
 _choice$_MyInterfaceMyVirtualChoice
-  = (\ this arg@MyVirtualChoice
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@MyVirtualChoice
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties ([] : [Party]), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@MyVirtualChoice
        -> let _ = self in
-          let _ = this in let _ = arg in do myVirtualChoiceImpl this, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = this in let _ = arg in do myVirtualChoiceImpl this)
 instance DA.Internal.Desugar.HasInterfaceView MyInterface EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView MyInterface EmptyInterfaceView where
@@ -177,20 +178,21 @@ instance DA.Internal.Desugar.HasChoiceController MyTemplate DA.Internal.Desugar.
 instance DA.Internal.Desugar.HasChoiceObserver MyTemplate DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_MyTemplateArchive :
-  (MyTemplate
+  (DA.Internal.Desugar.Consuming MyTemplate,
+   MyTemplate
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId MyTemplate
-   -> MyTemplate
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming MyTemplate,
    DA.Internal.Desugar.Optional (MyTemplate
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (MyTemplate
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId MyTemplate
+   -> MyTemplate
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_MyTemplateArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 data GHC.Types.DamlTemplate => Test
   = Test {p : Party}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
@@ -271,33 +273,35 @@ instance DA.Internal.Desugar.HasChoiceController Test CoercedExercise where
 instance DA.Internal.Desugar.HasChoiceObserver Test CoercedExercise where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TestArchive :
-  (Test
-   -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Test,
+  (DA.Internal.Desugar.Consuming Test,
+   Test -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TestArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TestCoercedFetch :
-  (Test -> CoercedFetch -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Test
-   -> Test -> CoercedFetch -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Test,
+   -> Test
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TestArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TestCoercedFetch :
+  (DA.Internal.Desugar.Consuming Test,
+   Test -> CoercedFetch -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> CoercedFetch -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> CoercedFetch -> [DA.Internal.Desugar.Party]))
+                                 -> CoercedFetch -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> CoercedFetch -> DA.Internal.Desugar.Update (()))
 _choice$_TestCoercedFetch
-  = (\ this@Test {..} arg@CoercedFetch
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@Test {..} arg@CoercedFetch
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@CoercedFetch
        -> let _ = self in
           let _ = this in
@@ -306,22 +310,22 @@ _choice$_TestCoercedFetch
             do cid <- create (MyTemplate p)
                let cid' : ContractId MyInterface = coerceContractId cid
                fetch cid'
-               pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               pure ())
 _choice$_TestCoercedExercise :
-  (Test -> CoercedExercise -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> CoercedExercise -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Test,
+  (DA.Internal.Desugar.Consuming Test,
+   Test -> CoercedExercise -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> CoercedExercise -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> CoercedExercise -> [DA.Internal.Desugar.Party]))
+                                 -> CoercedExercise -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> CoercedExercise -> DA.Internal.Desugar.Update (()))
 _choice$_TestCoercedExercise
-  = (\ this@Test {..} arg@CoercedExercise
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@Test {..} arg@CoercedExercise
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@CoercedExercise
        -> let _ = self in
           let _ = this in
@@ -330,9 +334,7 @@ _choice$_TestCoercedExercise
             do cid <- create (MyTemplate p)
                let cid' : ContractId MyInterface = coerceContractId cid
                exercise cid' MyVirtualChoice
-               pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               pure ())
 fetchBadContract
   = script
       do p <- allocateParty "Alice"

--- a/compiler/damlc/tests/daml-test-files/InterfaceFunctions.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceFunctions.EXPECTED.desugared-daml
@@ -68,11 +68,13 @@ _choice$_TokenArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -146,11 +148,13 @@ _choice$_AssetArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
 _interface_instance$_Asset_Token_Asset
@@ -256,16 +260,20 @@ _choice$_TestArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Test,
    DA.Internal.Desugar.Optional (Test
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TestArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TestCall :
   (Test -> Call -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> Call -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> Call -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> Call -> [DA.Internal.Desugar.Party]))
 _choice$_TestCall
@@ -289,7 +297,8 @@ _choice$_TestCall
                observer token === [bob, alice]
                assert (interfaceTypeRep token == templateTypeRep @Asset)
                assert (interfaceTypeRep token /= templateTypeRep @Token), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 main
   = script
       do alice <- allocateParty "Alice"

--- a/compiler/damlc/tests/daml-test-files/InterfaceFunctions.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceFunctions.EXPECTED.desugared-daml
@@ -61,20 +61,21 @@ instance DA.Internal.Desugar.HasChoiceController Token DA.Internal.Desugar.Archi
 instance DA.Internal.Desugar.HasChoiceObserver Token DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TokenArchive :
-  (Token
+  (DA.Internal.Desugar.Consuming Token,
+   Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_TokenArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -141,20 +142,21 @@ instance DA.Internal.Desugar.HasChoiceController Asset DA.Internal.Desugar.Archi
 instance DA.Internal.Desugar.HasChoiceObserver Asset DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_AssetArchive :
-  (Asset
+  (DA.Internal.Desugar.Consuming Asset,
+   Asset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Asset
-   -> Asset
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Asset
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Asset
+   -> Asset
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_AssetArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
 _interface_instance$_Asset_Token_Asset
@@ -253,33 +255,35 @@ instance DA.Internal.Desugar.HasChoiceController Test Call where
 instance DA.Internal.Desugar.HasChoiceObserver Test Call where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TestArchive :
-  (Test
-   -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Test,
+  (DA.Internal.Desugar.Consuming Test,
+   Test -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TestArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TestCall :
-  (Test -> Call -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Test
-   -> Test -> Call -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Test,
+   -> Test
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TestArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TestCall :
+  (DA.Internal.Desugar.Consuming Test,
+   Test -> Call -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> Call -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> Call -> [DA.Internal.Desugar.Party]))
+                                 -> Call -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> Call -> DA.Internal.Desugar.Update (()))
 _choice$_TestCall
-  = (\ this@Test {..} arg@Call
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@Test {..} arg@Call
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (alice), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@Call
        -> let _ = self in
           let _ = this in
@@ -296,9 +300,7 @@ _choice$_TestCall
                signatory token === [alice]
                observer token === [bob, alice]
                assert (interfaceTypeRep token == templateTypeRep @Asset)
-               assert (interfaceTypeRep token /= templateTypeRep @Token), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               assert (interfaceTypeRep token /= templateTypeRep @Token))
 main
   = script
       do alice <- allocateParty "Alice"

--- a/compiler/damlc/tests/daml-test-files/InterfaceGuarded.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceGuarded.EXPECTED.desugared-daml
@@ -97,43 +97,44 @@ instance DA.Internal.Record.HasField "byHowMuch" GetRich Int where
   setField
     = DA.Internal.Record.setFieldPrim @"byHowMuch" @GetRich @Int
 _choice$_TokenArchive :
-  (Token
+  (DA.Internal.Desugar.Consuming Token,
+   Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TokenArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TokenGetRich :
-  (Token -> GetRich -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Token
    -> Token
-      -> GetRich -> DA.Internal.Desugar.Update (ContractId Token),
-   DA.Internal.Desugar.Consuming Token,
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TokenArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TokenGetRich :
+  (DA.Internal.Desugar.Consuming Token,
+   Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> GetRich -> [DA.Internal.Desugar.Party]))
+                                 -> GetRich -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> GetRich -> DA.Internal.Desugar.Update (ContractId Token))
 _choice$_TokenGetRich
-  = (\ this arg@GetRich {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@GetRich {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@GetRich {..}
        -> let _ = self in
           let _ = this in
           let _ = arg
           in
             do assert (byHowMuch > 0)
-               create $ setAmount this (getAmount this + byHowMuch), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               create $ setAmount this (getAmount this + byHowMuch))
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -200,20 +201,21 @@ instance DA.Internal.Desugar.HasChoiceController SubToken DA.Internal.Desugar.Ar
 instance DA.Internal.Desugar.HasChoiceObserver SubToken DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_SubTokenArchive :
-  (SubToken
+  (DA.Internal.Desugar.Consuming SubToken,
+   SubToken
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId SubToken
-   -> SubToken
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming SubToken,
    DA.Internal.Desugar.Optional (SubToken
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (SubToken
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId SubToken
+   -> SubToken
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_SubTokenArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView SubToken EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView SubToken EmptyInterfaceView where
@@ -278,20 +280,21 @@ instance DA.Internal.Desugar.HasChoiceController Asset DA.Internal.Desugar.Archi
 instance DA.Internal.Desugar.HasChoiceObserver Asset DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_AssetArchive :
-  (Asset
+  (DA.Internal.Desugar.Consuming Asset,
+   Asset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Asset
-   -> Asset
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Asset
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Asset
+   -> Asset
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_AssetArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
 _interface_instance$_Asset_Token_Asset
@@ -403,20 +406,21 @@ instance DA.Internal.Desugar.HasChoiceController AnotherAsset DA.Internal.Desuga
 instance DA.Internal.Desugar.HasChoiceObserver AnotherAsset DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_AnotherAssetArchive :
-  (AnotherAsset
+  (DA.Internal.Desugar.Consuming AnotherAsset,
+   AnotherAsset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId AnotherAsset
-   -> AnotherAsset
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming AnotherAsset,
    DA.Internal.Desugar.Optional (AnotherAsset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (AnotherAsset
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId AnotherAsset
+   -> AnotherAsset
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_AnotherAssetArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_AnotherAsset_Token_AnotherAsset :
   DA.Internal.Desugar.InterfaceInstance AnotherAsset Token AnotherAsset
 _interface_instance$_AnotherAsset_Token_AnotherAsset
@@ -654,35 +658,37 @@ instance DA.Internal.Desugar.HasChoiceController Test TryCustomErrorGuard where
 instance DA.Internal.Desugar.HasChoiceObserver Test TryCustomErrorGuard where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TestArchive :
-  (Test
-   -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Test,
+  (DA.Internal.Desugar.Consuming Test,
+   Test -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TestArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TestTrueGuard :
-  (Test -> TrueGuard -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Test
-   -> Test -> TrueGuard -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+   -> Test
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TestArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TestTrueGuard :
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> TrueGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> TrueGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> TrueGuard -> [DA.Internal.Desugar.Party]))
+                                 -> TrueGuard -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> TrueGuard -> DA.Internal.Desugar.Update (()))
 _choice$_TestTrueGuard
-  = (\ this@Test {..} arg@TrueGuard
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@TrueGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
           let _ = getRich in
           let _ = this in let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@TrueGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
@@ -693,24 +699,24 @@ _choice$_TestTrueGuard
           in
             do assetAsToken <- create assetAsTokenTpl
                exerciseGuarded (const True) assetAsToken getRich
-               pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               pure ())
 _choice$_TestFalseGuard :
-  (Test -> FalseGuard -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> FalseGuard -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> FalseGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> FalseGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> FalseGuard -> [DA.Internal.Desugar.Party]))
+                                 -> FalseGuard -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> FalseGuard -> DA.Internal.Desugar.Update (()))
 _choice$_TestFalseGuard
-  = (\ this@Test {..} arg@FalseGuard
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@FalseGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
           let _ = getRich in
           let _ = this in let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@FalseGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
@@ -721,24 +727,24 @@ _choice$_TestFalseGuard
           in
             do assetAsToken <- create assetAsTokenTpl
                exerciseGuarded (const False) assetAsToken getRich
-               pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               pure ())
 _choice$_TestErrorGuard :
-  (Test -> ErrorGuard -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> ErrorGuard -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> ErrorGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> ErrorGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> ErrorGuard -> [DA.Internal.Desugar.Party]))
+                                 -> ErrorGuard -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> ErrorGuard -> DA.Internal.Desugar.Update (()))
 _choice$_TestErrorGuard
-  = (\ this@Test {..} arg@ErrorGuard
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@ErrorGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
           let _ = getRich in
           let _ = this in let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@ErrorGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
@@ -749,24 +755,24 @@ _choice$_TestErrorGuard
           in
             do assetAsToken <- create assetAsTokenTpl
                exerciseGuarded (\ _ -> error "foo") assetAsToken getRich
-               pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               pure ())
 _choice$_TestCustomErrorGuard :
-  (Test -> CustomErrorGuard -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> CustomErrorGuard -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> CustomErrorGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> CustomErrorGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> CustomErrorGuard -> [DA.Internal.Desugar.Party]))
+                                 -> CustomErrorGuard -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> CustomErrorGuard -> DA.Internal.Desugar.Update (()))
 _choice$_TestCustomErrorGuard
-  = (\ this@Test {..} arg@CustomErrorGuard
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@CustomErrorGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
           let _ = getRich in
           let _ = this in let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@CustomErrorGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
@@ -778,24 +784,24 @@ _choice$_TestCustomErrorGuard
             do assetAsToken <- create assetAsTokenTpl
                exerciseGuarded
                  (\ _ -> throwPure (GuardException "bar")) assetAsToken getRich
-               pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               pure ())
 _choice$_TestTryErrorGuard :
-  (Test -> TryErrorGuard -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> TryErrorGuard -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> TryErrorGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> TryErrorGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> TryErrorGuard -> [DA.Internal.Desugar.Party]))
+                                 -> TryErrorGuard -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> TryErrorGuard -> DA.Internal.Desugar.Update (()))
 _choice$_TestTryErrorGuard
-  = (\ this@Test {..} arg@TryErrorGuard
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@TryErrorGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
           let _ = getRich in
           let _ = this in let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@TryErrorGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
@@ -812,24 +818,24 @@ _choice$_TestTryErrorGuard
                      -> DA.Internal.Desugar.Some
                           pure $ toInterfaceContractId @Token assetAsToken
                    _ -> DA.Internal.Desugar.None
-               pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               pure ())
 _choice$_TestTryCustomErrorGuard :
-  (Test -> TryCustomErrorGuard -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> TryCustomErrorGuard -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> TryCustomErrorGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> TryCustomErrorGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> TryCustomErrorGuard -> [DA.Internal.Desugar.Party]))
+                                 -> TryCustomErrorGuard -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> TryCustomErrorGuard -> DA.Internal.Desugar.Update (()))
 _choice$_TestTryCustomErrorGuard
-  = (\ this@Test {..} arg@TryCustomErrorGuard
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@TryCustomErrorGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
           let _ = getRich in
           let _ = this in let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@TryCustomErrorGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
@@ -848,9 +854,7 @@ _choice$_TestTryCustomErrorGuard
                      -> DA.Internal.Desugar.Some
                           pure $ toInterfaceContractId @Token assetAsToken
                    _ -> DA.Internal.Desugar.None
-               pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               pure ())
 exerciseTest : Choice Test c () => c -> Script ()
 exerciseTest c
   = script

--- a/compiler/damlc/tests/daml-test-files/InterfaceGuarded.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceGuarded.EXPECTED.desugared-daml
@@ -104,17 +104,21 @@ _choice$_TokenArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TokenGetRich :
   (Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
       -> GetRich -> DA.Internal.Desugar.Update (ContractId Token),
    DA.Internal.Desugar.Consuming Token,
+   DA.Internal.Desugar.Optional (Token
+                                 -> GetRich -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]))
 _choice$_TokenGetRich
@@ -128,7 +132,8 @@ _choice$_TokenGetRich
           in
             do assert (byHowMuch > 0)
                create $ setAmount this (getAmount this + byHowMuch), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -202,11 +207,13 @@ _choice$_SubTokenArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming SubToken,
    DA.Internal.Desugar.Optional (SubToken
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (SubToken
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_SubTokenArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView SubToken EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView SubToken EmptyInterfaceView where
@@ -278,11 +285,13 @@ _choice$_AssetArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
 _interface_instance$_Asset_Token_Asset
@@ -401,11 +410,13 @@ _choice$_AnotherAssetArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming AnotherAsset,
    DA.Internal.Desugar.Optional (AnotherAsset
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (AnotherAsset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AnotherAssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_AnotherAsset_Token_AnotherAsset :
   DA.Internal.Desugar.InterfaceInstance AnotherAsset Token AnotherAsset
 _interface_instance$_AnotherAsset_Token_AnotherAsset
@@ -650,16 +661,20 @@ _choice$_TestArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Test,
    DA.Internal.Desugar.Optional (Test
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TestArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TestTrueGuard :
   (Test -> TrueGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> TrueGuard -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> TrueGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> TrueGuard -> [DA.Internal.Desugar.Party]))
 _choice$_TestTrueGuard
@@ -679,12 +694,15 @@ _choice$_TestTrueGuard
             do assetAsToken <- create assetAsTokenTpl
                exerciseGuarded (const True) assetAsToken getRich
                pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestFalseGuard :
   (Test -> FalseGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> FalseGuard -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> FalseGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> FalseGuard -> [DA.Internal.Desugar.Party]))
 _choice$_TestFalseGuard
@@ -704,12 +722,15 @@ _choice$_TestFalseGuard
             do assetAsToken <- create assetAsTokenTpl
                exerciseGuarded (const False) assetAsToken getRich
                pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestErrorGuard :
   (Test -> ErrorGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> ErrorGuard -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> ErrorGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> ErrorGuard -> [DA.Internal.Desugar.Party]))
 _choice$_TestErrorGuard
@@ -729,12 +750,15 @@ _choice$_TestErrorGuard
             do assetAsToken <- create assetAsTokenTpl
                exerciseGuarded (\ _ -> error "foo") assetAsToken getRich
                pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestCustomErrorGuard :
   (Test -> CustomErrorGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> CustomErrorGuard -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> CustomErrorGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> CustomErrorGuard -> [DA.Internal.Desugar.Party]))
 _choice$_TestCustomErrorGuard
@@ -755,12 +779,15 @@ _choice$_TestCustomErrorGuard
                exerciseGuarded
                  (\ _ -> throwPure (GuardException "bar")) assetAsToken getRich
                pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestTryErrorGuard :
   (Test -> TryErrorGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> TryErrorGuard -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> TryErrorGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> TryErrorGuard -> [DA.Internal.Desugar.Party]))
 _choice$_TestTryErrorGuard
@@ -786,12 +813,15 @@ _choice$_TestTryErrorGuard
                           pure $ toInterfaceContractId @Token assetAsToken
                    _ -> DA.Internal.Desugar.None
                pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestTryCustomErrorGuard :
   (Test -> TryCustomErrorGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> TryCustomErrorGuard -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> TryCustomErrorGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> TryCustomErrorGuard -> [DA.Internal.Desugar.Party]))
 _choice$_TestTryCustomErrorGuard
@@ -819,7 +849,8 @@ _choice$_TestTryCustomErrorGuard
                           pure $ toInterfaceContractId @Token assetAsToken
                    _ -> DA.Internal.Desugar.None
                pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 exerciseTest : Choice Test c () => c -> Script ()
 exerciseTest c
   = script

--- a/compiler/damlc/tests/daml-test-files/InterfaceGuardedNotExtended.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceGuardedNotExtended.EXPECTED.desugared-daml
@@ -97,43 +97,44 @@ instance DA.Internal.Record.HasField "byHowMuch" GetRich Int where
   setField
     = DA.Internal.Record.setFieldPrim @"byHowMuch" @GetRich @Int
 _choice$_TokenArchive :
-  (Token
+  (DA.Internal.Desugar.Consuming Token,
+   Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TokenArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TokenGetRich :
-  (Token -> GetRich -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Token
    -> Token
-      -> GetRich -> DA.Internal.Desugar.Update (ContractId Token),
-   DA.Internal.Desugar.Consuming Token,
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TokenArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TokenGetRich :
+  (DA.Internal.Desugar.Consuming Token,
+   Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> GetRich -> [DA.Internal.Desugar.Party]))
+                                 -> GetRich -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> GetRich -> DA.Internal.Desugar.Update (ContractId Token))
 _choice$_TokenGetRich
-  = (\ this arg@GetRich {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@GetRich {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@GetRich {..}
        -> let _ = self in
           let _ = this in
           let _ = arg
           in
             do assert (byHowMuch > 0)
-               create $ setAmount this (getAmount this + byHowMuch), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               create $ setAmount this (getAmount this + byHowMuch))
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -200,20 +201,21 @@ instance DA.Internal.Desugar.HasChoiceController SubToken DA.Internal.Desugar.Ar
 instance DA.Internal.Desugar.HasChoiceObserver SubToken DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_SubTokenArchive :
-  (SubToken
+  (DA.Internal.Desugar.Consuming SubToken,
+   SubToken
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId SubToken
-   -> SubToken
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming SubToken,
    DA.Internal.Desugar.Optional (SubToken
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (SubToken
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId SubToken
+   -> SubToken
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_SubTokenArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView SubToken EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView SubToken EmptyInterfaceView where
@@ -278,20 +280,21 @@ instance DA.Internal.Desugar.HasChoiceController Asset DA.Internal.Desugar.Archi
 instance DA.Internal.Desugar.HasChoiceObserver Asset DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_AssetArchive :
-  (Asset
+  (DA.Internal.Desugar.Consuming Asset,
+   Asset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Asset
-   -> Asset
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Asset
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Asset
+   -> Asset
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_AssetArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
 _interface_instance$_Asset_Token_Asset
@@ -403,20 +406,21 @@ instance DA.Internal.Desugar.HasChoiceController AnotherAsset DA.Internal.Desuga
 instance DA.Internal.Desugar.HasChoiceObserver AnotherAsset DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_AnotherAssetArchive :
-  (AnotherAsset
+  (DA.Internal.Desugar.Consuming AnotherAsset,
+   AnotherAsset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId AnotherAsset
-   -> AnotherAsset
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming AnotherAsset,
    DA.Internal.Desugar.Optional (AnotherAsset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (AnotherAsset
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId AnotherAsset
+   -> AnotherAsset
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_AnotherAssetArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_AnotherAsset_Token_AnotherAsset :
   DA.Internal.Desugar.InterfaceInstance AnotherAsset Token AnotherAsset
 _interface_instance$_AnotherAsset_Token_AnotherAsset
@@ -654,35 +658,37 @@ instance DA.Internal.Desugar.HasChoiceController Test TryCustomErrorGuard where
 instance DA.Internal.Desugar.HasChoiceObserver Test TryCustomErrorGuard where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TestArchive :
-  (Test
-   -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Test,
+  (DA.Internal.Desugar.Consuming Test,
+   Test -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TestArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TestTrueGuard :
-  (Test -> TrueGuard -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Test
-   -> Test -> TrueGuard -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+   -> Test
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TestArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TestTrueGuard :
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> TrueGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> TrueGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> TrueGuard -> [DA.Internal.Desugar.Party]))
+                                 -> TrueGuard -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> TrueGuard -> DA.Internal.Desugar.Update (()))
 _choice$_TestTrueGuard
-  = (\ this@Test {..} arg@TrueGuard
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@TrueGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
           let _ = getRich in
           let _ = this in let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@TrueGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
@@ -693,24 +699,24 @@ _choice$_TestTrueGuard
           in
             do assetAsToken <- create assetAsTokenTpl
                exerciseGuarded (const True) assetAsToken getRich
-               pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               pure ())
 _choice$_TestFalseGuard :
-  (Test -> FalseGuard -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> FalseGuard -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> FalseGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> FalseGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> FalseGuard -> [DA.Internal.Desugar.Party]))
+                                 -> FalseGuard -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> FalseGuard -> DA.Internal.Desugar.Update (()))
 _choice$_TestFalseGuard
-  = (\ this@Test {..} arg@FalseGuard
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@FalseGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
           let _ = getRich in
           let _ = this in let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@FalseGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
@@ -721,24 +727,24 @@ _choice$_TestFalseGuard
           in
             do assetAsToken <- create assetAsTokenTpl
                exerciseGuarded (const False) assetAsToken getRich
-               pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               pure ())
 _choice$_TestErrorGuard :
-  (Test -> ErrorGuard -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> ErrorGuard -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> ErrorGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> ErrorGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> ErrorGuard -> [DA.Internal.Desugar.Party]))
+                                 -> ErrorGuard -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> ErrorGuard -> DA.Internal.Desugar.Update (()))
 _choice$_TestErrorGuard
-  = (\ this@Test {..} arg@ErrorGuard
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@ErrorGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
           let _ = getRich in
           let _ = this in let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@ErrorGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
@@ -749,24 +755,24 @@ _choice$_TestErrorGuard
           in
             do assetAsToken <- create assetAsTokenTpl
                exerciseGuarded (\ _ -> error "foo") assetAsToken getRich
-               pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               pure ())
 _choice$_TestCustomErrorGuard :
-  (Test -> CustomErrorGuard -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> CustomErrorGuard -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> CustomErrorGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> CustomErrorGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> CustomErrorGuard -> [DA.Internal.Desugar.Party]))
+                                 -> CustomErrorGuard -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> CustomErrorGuard -> DA.Internal.Desugar.Update (()))
 _choice$_TestCustomErrorGuard
-  = (\ this@Test {..} arg@CustomErrorGuard
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@CustomErrorGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
           let _ = getRich in
           let _ = this in let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@CustomErrorGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
@@ -778,24 +784,24 @@ _choice$_TestCustomErrorGuard
             do assetAsToken <- create assetAsTokenTpl
                exerciseGuarded
                  (\ _ -> throwPure (GuardException "bar")) assetAsToken getRich
-               pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               pure ())
 _choice$_TestTryErrorGuard :
-  (Test -> TryErrorGuard -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> TryErrorGuard -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> TryErrorGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> TryErrorGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> TryErrorGuard -> [DA.Internal.Desugar.Party]))
+                                 -> TryErrorGuard -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> TryErrorGuard -> DA.Internal.Desugar.Update (()))
 _choice$_TestTryErrorGuard
-  = (\ this@Test {..} arg@TryErrorGuard
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@TryErrorGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
           let _ = getRich in
           let _ = this in let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@TryErrorGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
@@ -812,24 +818,24 @@ _choice$_TestTryErrorGuard
                      -> DA.Internal.Desugar.Some
                           pure $ toInterfaceContractId @Token assetAsToken
                    _ -> DA.Internal.Desugar.None
-               pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               pure ())
 _choice$_TestTryCustomErrorGuard :
-  (Test -> TryCustomErrorGuard -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> TryCustomErrorGuard -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> TryCustomErrorGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> TryCustomErrorGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> TryCustomErrorGuard -> [DA.Internal.Desugar.Party]))
+                                 -> TryCustomErrorGuard -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> TryCustomErrorGuard -> DA.Internal.Desugar.Update (()))
 _choice$_TestTryCustomErrorGuard
-  = (\ this@Test {..} arg@TryCustomErrorGuard
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@TryCustomErrorGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
           let _ = getRich in
           let _ = this in let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@TryCustomErrorGuard
        -> let (assetAsTokenTpl, getRich) = _templateLet_Test this in
           let _ = assetAsTokenTpl in
@@ -848,9 +854,7 @@ _choice$_TestTryCustomErrorGuard
                      -> DA.Internal.Desugar.Some
                           pure $ toInterfaceContractId @Token assetAsToken
                    _ -> DA.Internal.Desugar.None
-               pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               pure ())
 exerciseTest : Choice Test c () => c -> Script ()
 exerciseTest c
   = script

--- a/compiler/damlc/tests/daml-test-files/InterfaceGuardedNotExtended.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceGuardedNotExtended.EXPECTED.desugared-daml
@@ -104,17 +104,21 @@ _choice$_TokenArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TokenGetRich :
   (Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
       -> GetRich -> DA.Internal.Desugar.Update (ContractId Token),
    DA.Internal.Desugar.Consuming Token,
+   DA.Internal.Desugar.Optional (Token
+                                 -> GetRich -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]))
 _choice$_TokenGetRich
@@ -128,7 +132,8 @@ _choice$_TokenGetRich
           in
             do assert (byHowMuch > 0)
                create $ setAmount this (getAmount this + byHowMuch), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -202,11 +207,13 @@ _choice$_SubTokenArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming SubToken,
    DA.Internal.Desugar.Optional (SubToken
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (SubToken
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_SubTokenArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView SubToken EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView SubToken EmptyInterfaceView where
@@ -278,11 +285,13 @@ _choice$_AssetArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
 _interface_instance$_Asset_Token_Asset
@@ -401,11 +410,13 @@ _choice$_AnotherAssetArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming AnotherAsset,
    DA.Internal.Desugar.Optional (AnotherAsset
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (AnotherAsset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AnotherAssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_AnotherAsset_Token_AnotherAsset :
   DA.Internal.Desugar.InterfaceInstance AnotherAsset Token AnotherAsset
 _interface_instance$_AnotherAsset_Token_AnotherAsset
@@ -650,16 +661,20 @@ _choice$_TestArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Test,
    DA.Internal.Desugar.Optional (Test
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TestArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TestTrueGuard :
   (Test -> TrueGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> TrueGuard -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> TrueGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> TrueGuard -> [DA.Internal.Desugar.Party]))
 _choice$_TestTrueGuard
@@ -679,12 +694,15 @@ _choice$_TestTrueGuard
             do assetAsToken <- create assetAsTokenTpl
                exerciseGuarded (const True) assetAsToken getRich
                pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestFalseGuard :
   (Test -> FalseGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> FalseGuard -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> FalseGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> FalseGuard -> [DA.Internal.Desugar.Party]))
 _choice$_TestFalseGuard
@@ -704,12 +722,15 @@ _choice$_TestFalseGuard
             do assetAsToken <- create assetAsTokenTpl
                exerciseGuarded (const False) assetAsToken getRich
                pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestErrorGuard :
   (Test -> ErrorGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> ErrorGuard -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> ErrorGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> ErrorGuard -> [DA.Internal.Desugar.Party]))
 _choice$_TestErrorGuard
@@ -729,12 +750,15 @@ _choice$_TestErrorGuard
             do assetAsToken <- create assetAsTokenTpl
                exerciseGuarded (\ _ -> error "foo") assetAsToken getRich
                pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestCustomErrorGuard :
   (Test -> CustomErrorGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> CustomErrorGuard -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> CustomErrorGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> CustomErrorGuard -> [DA.Internal.Desugar.Party]))
 _choice$_TestCustomErrorGuard
@@ -755,12 +779,15 @@ _choice$_TestCustomErrorGuard
                exerciseGuarded
                  (\ _ -> throwPure (GuardException "bar")) assetAsToken getRich
                pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestTryErrorGuard :
   (Test -> TryErrorGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> TryErrorGuard -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> TryErrorGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> TryErrorGuard -> [DA.Internal.Desugar.Party]))
 _choice$_TestTryErrorGuard
@@ -786,12 +813,15 @@ _choice$_TestTryErrorGuard
                           pure $ toInterfaceContractId @Token assetAsToken
                    _ -> DA.Internal.Desugar.None
                pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestTryCustomErrorGuard :
   (Test -> TryCustomErrorGuard -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> TryCustomErrorGuard -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> TryCustomErrorGuard -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> TryCustomErrorGuard -> [DA.Internal.Desugar.Party]))
 _choice$_TestTryCustomErrorGuard
@@ -819,7 +849,8 @@ _choice$_TestTryCustomErrorGuard
                           pure $ toInterfaceContractId @Token assetAsToken
                    _ -> DA.Internal.Desugar.None
                pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 exerciseTest : Choice Test c () => c -> Script ()
 exerciseTest c
   = script

--- a/compiler/damlc/tests/daml-test-files/InterfaceNameCollision.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNameCollision.EXPECTED.desugared-daml
@@ -86,37 +86,38 @@ data FooBar
   = FooBar {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
 _choice$_IfaceArchive :
-  (Iface
+  (DA.Internal.Desugar.Consuming Iface,
+   Iface
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Iface
-   -> Iface
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Iface,
    DA.Internal.Desugar.Optional (Iface
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Iface
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_IfaceArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_IfaceFooBar :
-  (Iface -> FooBar -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Iface
-   -> Iface -> FooBar -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Iface,
+   -> Iface
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_IfaceArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_IfaceFooBar :
+  (DA.Internal.Desugar.Consuming Iface,
+   Iface -> FooBar -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Iface
                                  -> FooBar -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Iface
-                                 -> FooBar -> [DA.Internal.Desugar.Party]))
+                                 -> FooBar -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Iface
+   -> Iface -> FooBar -> DA.Internal.Desugar.Update (()))
 _choice$_IfaceFooBar
-  = (\ this arg@FooBar
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@FooBar
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (owner this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@FooBar
-       -> let _ = self in let _ = this in let _ = arg in do pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+       -> let _ = self in let _ = this in let _ = arg in do pure ())
 instance DA.Internal.Desugar.HasInterfaceView Iface EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Iface EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceNameCollision.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNameCollision.EXPECTED.desugared-daml
@@ -93,16 +93,20 @@ _choice$_IfaceArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Iface,
    DA.Internal.Desugar.Optional (Iface
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Iface
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IfaceArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_IfaceFooBar :
   (Iface -> FooBar -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Iface
    -> Iface -> FooBar -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Iface,
+   DA.Internal.Desugar.Optional (Iface
+                                 -> FooBar -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Iface
                                  -> FooBar -> [DA.Internal.Desugar.Party]))
 _choice$_IfaceFooBar
@@ -111,7 +115,8 @@ _choice$_IfaceFooBar
           let _ = arg in DA.Internal.Desugar.toParties (owner this), 
      \ self this arg@FooBar
        -> let _ = self in let _ = this in let _ = arg in do pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Iface EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Iface EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseRequiring.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseRequiring.EXPECTED.desugared-daml
@@ -95,43 +95,44 @@ instance DA.Internal.Record.HasField "byHowMuch" GetRich Int where
   setField
     = DA.Internal.Record.setFieldPrim @"byHowMuch" @GetRich @Int
 _choice$_TokenArchive :
-  (Token
+  (DA.Internal.Desugar.Consuming Token,
+   Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TokenArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TokenGetRich :
-  (Token -> GetRich -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Token
    -> Token
-      -> GetRich -> DA.Internal.Desugar.Update (ContractId Token),
-   DA.Internal.Desugar.Consuming Token,
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TokenArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TokenGetRich :
+  (DA.Internal.Desugar.Consuming Token,
+   Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> GetRich -> [DA.Internal.Desugar.Party]))
+                                 -> GetRich -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> GetRich -> DA.Internal.Desugar.Update (ContractId Token))
 _choice$_TokenGetRich
-  = (\ this arg@GetRich {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@GetRich {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@GetRich {..}
        -> let _ = self in
           let _ = this in
           let _ = arg
           in
             do assert (byHowMuch > 0)
-               create $ setAmount this (getAmount this + byHowMuch), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               create $ setAmount this (getAmount this + byHowMuch))
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -198,20 +199,21 @@ instance DA.Internal.Desugar.HasChoiceController SubToken DA.Internal.Desugar.Ar
 instance DA.Internal.Desugar.HasChoiceObserver SubToken DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_SubTokenArchive :
-  (SubToken
+  (DA.Internal.Desugar.Consuming SubToken,
+   SubToken
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId SubToken
-   -> SubToken
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming SubToken,
    DA.Internal.Desugar.Optional (SubToken
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (SubToken
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId SubToken
+   -> SubToken
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_SubTokenArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView SubToken EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView SubToken EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseRequiring.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseRequiring.EXPECTED.desugared-daml
@@ -102,17 +102,21 @@ _choice$_TokenArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TokenGetRich :
   (Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
       -> GetRich -> DA.Internal.Desugar.Update (ContractId Token),
    DA.Internal.Desugar.Consuming Token,
+   DA.Internal.Desugar.Optional (Token
+                                 -> GetRich -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]))
 _choice$_TokenGetRich
@@ -126,7 +130,8 @@ _choice$_TokenGetRich
           in
             do assert (byHowMuch > 0)
                create $ setAmount this (getAmount this + byHowMuch), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -200,11 +205,13 @@ _choice$_SubTokenArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming SubToken,
    DA.Internal.Desugar.Optional (SubToken
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (SubToken
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_SubTokenArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView SubToken EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView SubToken EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseTemplate.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseTemplate.EXPECTED.desugared-daml
@@ -95,43 +95,44 @@ instance DA.Internal.Record.HasField "byHowMuch" GetRich Int where
   setField
     = DA.Internal.Record.setFieldPrim @"byHowMuch" @GetRich @Int
 _choice$_TokenArchive :
-  (Token
+  (DA.Internal.Desugar.Consuming Token,
+   Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TokenArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TokenGetRich :
-  (Token -> GetRich -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Token
    -> Token
-      -> GetRich -> DA.Internal.Desugar.Update (ContractId Token),
-   DA.Internal.Desugar.Consuming Token,
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TokenArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TokenGetRich :
+  (DA.Internal.Desugar.Consuming Token,
+   Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> GetRich -> [DA.Internal.Desugar.Party]))
+                                 -> GetRich -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> GetRich -> DA.Internal.Desugar.Update (ContractId Token))
 _choice$_TokenGetRich
-  = (\ this arg@GetRich {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@GetRich {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@GetRich {..}
        -> let _ = self in
           let _ = this in
           let _ = arg
           in
             do assert (byHowMuch > 0)
-               create $ setAmount this (getAmount this + byHowMuch), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               create $ setAmount this (getAmount this + byHowMuch))
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -196,20 +197,21 @@ instance DA.Internal.Desugar.HasChoiceController Asset DA.Internal.Desugar.Archi
 instance DA.Internal.Desugar.HasChoiceObserver Asset DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_AssetArchive :
-  (Asset
+  (DA.Internal.Desugar.Consuming Asset,
+   Asset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Asset
-   -> Asset
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Asset
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Asset
+   -> Asset
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_AssetArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
 _interface_instance$_Asset_Token_Asset

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseTemplate.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoExerciseTemplate.EXPECTED.desugared-daml
@@ -102,17 +102,21 @@ _choice$_TokenArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TokenGetRich :
   (Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
       -> GetRich -> DA.Internal.Desugar.Update (ContractId Token),
    DA.Internal.Desugar.Consuming Token,
+   DA.Internal.Desugar.Optional (Token
+                                 -> GetRich -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]))
 _choice$_TokenGetRich
@@ -126,7 +130,8 @@ _choice$_TokenGetRich
           in
             do assert (byHowMuch > 0)
                create $ setAmount this (getAmount this + byHowMuch), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -198,11 +203,13 @@ _choice$_AssetArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
 _interface_instance$_Asset_Token_Asset

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoMethodOnRequiring.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoMethodOnRequiring.EXPECTED.desugared-daml
@@ -66,20 +66,21 @@ instance DA.Internal.Desugar.HasChoiceController Token DA.Internal.Desugar.Archi
 instance DA.Internal.Desugar.HasChoiceObserver Token DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TokenArchive :
-  (Token
+  (DA.Internal.Desugar.Consuming Token,
+   Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_TokenArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -146,20 +147,21 @@ instance DA.Internal.Desugar.HasChoiceController SubToken DA.Internal.Desugar.Ar
 instance DA.Internal.Desugar.HasChoiceObserver SubToken DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_SubTokenArchive :
-  (SubToken
+  (DA.Internal.Desugar.Consuming SubToken,
+   SubToken
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId SubToken
-   -> SubToken
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming SubToken,
    DA.Internal.Desugar.Optional (SubToken
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (SubToken
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId SubToken
+   -> SubToken
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_SubTokenArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView SubToken EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView SubToken EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoMethodOnRequiring.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoMethodOnRequiring.EXPECTED.desugared-daml
@@ -73,11 +73,13 @@ _choice$_TokenArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -151,11 +153,13 @@ _choice$_SubTokenArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming SubToken,
    DA.Internal.Desugar.Optional (SubToken
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (SubToken
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_SubTokenArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView SubToken EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView SubToken EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoMethodOnTemplate.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoMethodOnTemplate.EXPECTED.desugared-daml
@@ -66,20 +66,21 @@ instance DA.Internal.Desugar.HasChoiceController Token DA.Internal.Desugar.Archi
 instance DA.Internal.Desugar.HasChoiceObserver Token DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TokenArchive :
-  (Token
+  (DA.Internal.Desugar.Consuming Token,
+   Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_TokenArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -144,20 +145,21 @@ instance DA.Internal.Desugar.HasChoiceController Asset DA.Internal.Desugar.Archi
 instance DA.Internal.Desugar.HasChoiceObserver Asset DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_AssetArchive :
-  (Asset
+  (DA.Internal.Desugar.Consuming Asset,
+   Asset
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Asset
-   -> Asset
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Asset
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Asset
+   -> Asset
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_AssetArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
 _interface_instance$_Asset_Token_Asset

--- a/compiler/damlc/tests/daml-test-files/InterfaceNoMethodOnTemplate.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNoMethodOnTemplate.EXPECTED.desugared-daml
@@ -73,11 +73,13 @@ _choice$_TokenArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Token EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token EmptyInterfaceView where
@@ -149,11 +151,13 @@ _choice$_AssetArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Asset,
    DA.Internal.Desugar.Optional (Asset
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Asset
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AssetArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_Asset_Token_Asset :
   DA.Internal.Desugar.InterfaceInstance Asset Token Asset
 _interface_instance$_Asset_Token_Asset

--- a/compiler/damlc/tests/daml-test-files/InterfaceNotSupported.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNotSupported.EXPECTED.desugared-daml
@@ -56,19 +56,20 @@ instance DA.Internal.Desugar.HasChoiceController A DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver A DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_AArchive :
-  (A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId A
-   -> A
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming A,
+  (DA.Internal.Desugar.Consuming A,
+   A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (A
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId A
+   -> A
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_AArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView A EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceNotSupported.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceNotSupported.EXPECTED.desugared-daml
@@ -62,11 +62,13 @@ _choice$_AArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming A,
    DA.Internal.Desugar.Optional (A
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView A EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircular.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircular.EXPECTED.desugared-daml
@@ -64,11 +64,13 @@ _choice$_AArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming A,
    DA.Internal.Desugar.Optional (A
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView A EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircular.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircular.EXPECTED.desugared-daml
@@ -58,19 +58,20 @@ instance DA.Internal.Desugar.HasChoiceController A DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver A DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_AArchive :
-  (A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId A
-   -> A
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming A,
+  (DA.Internal.Desugar.Consuming A,
+   A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (A
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId A
+   -> A
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_AArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView A EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircularIndirect.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircularIndirect.EXPECTED.desugared-daml
@@ -70,11 +70,13 @@ _choice$_AArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming A,
    DA.Internal.Desugar.Optional (A
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView A EmptyInterfaceView where
@@ -145,11 +147,13 @@ _choice$_BArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming B,
    DA.Internal.Desugar.Optional (B
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (B
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_BArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView B EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView B EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircularIndirect.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircularIndirect.EXPECTED.desugared-daml
@@ -64,19 +64,20 @@ instance DA.Internal.Desugar.HasChoiceController A DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver A DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_AArchive :
-  (A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId A
-   -> A
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming A,
+  (DA.Internal.Desugar.Consuming A,
+   A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (A
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId A
+   -> A
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_AArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView A EmptyInterfaceView where
@@ -141,19 +142,20 @@ instance DA.Internal.Desugar.HasChoiceController B DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver B DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_BArchive :
-  (B -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId B
-   -> B
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming B,
+  (DA.Internal.Desugar.Consuming B,
+   B -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (B
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (B
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId B
+   -> B
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_BArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView B EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView B EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresClash.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresClash.EXPECTED.desugared-daml
@@ -80,11 +80,13 @@ _choice$_CArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming C,
    DA.Internal.Desugar.Optional (C
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (C
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_CArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView C EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView C EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresClash.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresClash.EXPECTED.desugared-daml
@@ -74,19 +74,20 @@ instance DA.Internal.Desugar.HasChoiceController C DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver C DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_CArchive :
-  (C -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId C
-   -> C
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming C,
+  (DA.Internal.Desugar.Consuming C,
+   C -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (C
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (C
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId C
+   -> C
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_CArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView C EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView C EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresClashA.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresClashA.EXPECTED.desugared-daml
@@ -62,11 +62,13 @@ _choice$_IArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresClashA.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresClashA.EXPECTED.desugared-daml
@@ -56,19 +56,20 @@ instance DA.Internal.Desugar.HasChoiceController I DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver I DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_IArchive :
-  (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId I
-   -> I
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming I,
+  (DA.Internal.Desugar.Consuming I,
+   I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId I
+   -> I
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_IArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresClashB.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresClashB.EXPECTED.desugared-daml
@@ -62,11 +62,13 @@ _choice$_IArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresClashB.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresClashB.EXPECTED.desugared-daml
@@ -56,19 +56,20 @@ instance DA.Internal.Desugar.HasChoiceController I DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver I DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_IArchive :
-  (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId I
-   -> I
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming I,
+  (DA.Internal.Desugar.Consuming I,
+   I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId I
+   -> I
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_IArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresError.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresError.EXPECTED.desugared-daml
@@ -62,11 +62,13 @@ _choice$_AArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming A,
    DA.Internal.Desugar.Optional (A
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView A EmptyInterfaceView where
@@ -137,11 +139,13 @@ _choice$_BArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming B,
    DA.Internal.Desugar.Optional (B
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (B
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_BArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView B EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView B EmptyInterfaceView where
@@ -206,11 +210,13 @@ _choice$_TArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_T_B_T :
   DA.Internal.Desugar.InterfaceInstance T B T
 _interface_instance$_T_B_T

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresError.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresError.EXPECTED.desugared-daml
@@ -56,19 +56,20 @@ instance DA.Internal.Desugar.HasChoiceController A DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver A DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_AArchive :
-  (A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId A
-   -> A
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming A,
+  (DA.Internal.Desugar.Consuming A,
+   A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (A
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId A
+   -> A
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_AArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView A EmptyInterfaceView where
@@ -133,19 +134,20 @@ instance DA.Internal.Desugar.HasChoiceController B DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver B DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_BArchive :
-  (B -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId B
-   -> B
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming B,
+  (DA.Internal.Desugar.Consuming B,
+   B -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (B
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (B
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId B
+   -> B
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_BArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView B EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView B EmptyInterfaceView where
@@ -204,19 +206,20 @@ instance DA.Internal.Desugar.HasChoiceController T DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver T DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TArchive :
-  (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming T,
+  (DA.Internal.Desugar.Consuming T,
+   T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_TArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_T_B_T :
   DA.Internal.Desugar.InterfaceInstance T B T
 _interface_instance$_T_B_T

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresNotClosed.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresNotClosed.EXPECTED.desugared-daml
@@ -62,11 +62,13 @@ _choice$_AArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming A,
    DA.Internal.Desugar.Optional (A
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView A EmptyInterfaceView where
@@ -137,11 +139,13 @@ _choice$_BArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming B,
    DA.Internal.Desugar.Optional (B
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (B
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_BArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView B EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView B EmptyInterfaceView where
@@ -212,11 +216,13 @@ _choice$_CArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming C,
    DA.Internal.Desugar.Optional (C
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (C
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_CArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView C EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView C EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresNotClosed.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresNotClosed.EXPECTED.desugared-daml
@@ -56,19 +56,20 @@ instance DA.Internal.Desugar.HasChoiceController A DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver A DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_AArchive :
-  (A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId A
-   -> A
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming A,
+  (DA.Internal.Desugar.Consuming A,
+   A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (A
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId A
+   -> A
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_AArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView A EmptyInterfaceView where
@@ -133,19 +134,20 @@ instance DA.Internal.Desugar.HasChoiceController B DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver B DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_BArchive :
-  (B -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId B
-   -> B
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming B,
+  (DA.Internal.Desugar.Consuming B,
+   B -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (B
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (B
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId B
+   -> B
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_BArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView B EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView B EmptyInterfaceView where
@@ -210,19 +212,20 @@ instance DA.Internal.Desugar.HasChoiceController C DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver C DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_CArchive :
-  (C -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId C
-   -> C
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming C,
+  (DA.Internal.Desugar.Consuming C,
+   C -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (C
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (C
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId C
+   -> C
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_CArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView C EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView C EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityArgument.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityArgument.EXPECTED.desugared-daml
@@ -101,16 +101,20 @@ _choice$_IArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_INonSerializableArgument :
   (I -> NonSerializableArgument -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
    -> I -> NonSerializableArgument -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming I,
+   DA.Internal.Desugar.Optional (I
+                                 -> NonSerializableArgument -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
                                  -> NonSerializableArgument -> [DA.Internal.Desugar.Party]))
 _choice$_INonSerializableArgument
@@ -119,7 +123,8 @@ _choice$_INonSerializableArgument
           let _ = arg in DA.Internal.Desugar.toParties (p this), 
      \ self this arg@NonSerializableArgument {..}
        -> let _ = self in let _ = this in let _ = arg in do pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityArgument.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityArgument.EXPECTED.desugared-daml
@@ -95,36 +95,37 @@ instance DA.Internal.Record.HasField "f" NonSerializableArgument NonSerializable
     = DA.Internal.Record.setFieldPrim
         @"f" @NonSerializableArgument @NonSerializable
 _choice$_IArchive :
-  (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId I
-   -> I
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming I,
+  (DA.Internal.Desugar.Consuming I,
+   I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_IArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_INonSerializableArgument :
-  (I -> NonSerializableArgument -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId I
-   -> I -> NonSerializableArgument -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming I,
+   -> I
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_IArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_INonSerializableArgument :
+  (DA.Internal.Desugar.Consuming I,
+   I -> NonSerializableArgument -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (I
                                  -> NonSerializableArgument -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
-                                 -> NonSerializableArgument -> [DA.Internal.Desugar.Party]))
+                                 -> NonSerializableArgument -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId I
+   -> I -> NonSerializableArgument -> DA.Internal.Desugar.Update (()))
 _choice$_INonSerializableArgument
-  = (\ this arg@NonSerializableArgument {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@NonSerializableArgument {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@NonSerializableArgument {..}
-       -> let _ = self in let _ = this in let _ = arg in do pure (), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+       -> let _ = self in let _ = this in let _ = arg in do pure ())
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityPayload.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityPayload.EXPECTED.desugared-daml
@@ -84,37 +84,38 @@ instance DA.Internal.Record.HasField "anyActor" Get Party where
   getField = DA.Internal.Record.getFieldPrim @"anyActor" @Get @Party
   setField = DA.Internal.Record.setFieldPrim @"anyActor" @Get @Party
 _choice$_GettableArchive :
-  (Gettable
+  (DA.Internal.Desugar.Consuming Gettable,
+   Gettable
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Gettable
-   -> Gettable
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Gettable,
    DA.Internal.Desugar.Optional (Gettable
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Gettable
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_GettableArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_GettableGet :
-  (Gettable -> Get -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Gettable
-   -> Gettable -> Get -> DA.Internal.Desugar.Update (Gettable),
-   DA.Internal.Desugar.NonConsuming Gettable,
+   -> Gettable
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_GettableArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_GettableGet :
+  (DA.Internal.Desugar.NonConsuming Gettable,
+   Gettable -> Get -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Gettable
                                  -> Get -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Gettable
-                                 -> Get -> [DA.Internal.Desugar.Party]))
+                                 -> Get -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Gettable
+   -> Gettable -> Get -> DA.Internal.Desugar.Update (Gettable))
 _choice$_GettableGet
-  = (\ this arg@Get {..}
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this arg@Get {..}
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (anyActor), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@Get {..}
-       -> let _ = self in let _ = this in let _ = arg in do return this, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+       -> let _ = self in let _ = this in let _ = arg in do return this)
 instance DA.Internal.Desugar.HasInterfaceView Gettable EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Gettable EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityPayload.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityPayload.EXPECTED.desugared-daml
@@ -91,16 +91,20 @@ _choice$_GettableArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Gettable,
    DA.Internal.Desugar.Optional (Gettable
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Gettable
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_GettableArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_GettableGet :
   (Gettable -> Get -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Gettable
    -> Gettable -> Get -> DA.Internal.Desugar.Update (Gettable),
    DA.Internal.Desugar.NonConsuming Gettable,
+   DA.Internal.Desugar.Optional (Gettable
+                                 -> Get -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Gettable
                                  -> Get -> [DA.Internal.Desugar.Party]))
 _choice$_GettableGet
@@ -109,7 +113,8 @@ _choice$_GettableGet
           let _ = arg in DA.Internal.Desugar.toParties (anyActor), 
      \ self this arg@Get {..}
        -> let _ = self in let _ = this in let _ = arg in do return this, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Gettable EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Gettable EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityResult.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityResult.EXPECTED.desugared-daml
@@ -88,39 +88,40 @@ data NonSerializableResult
   = NonSerializableResult {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
 _choice$_IArchive :
-  (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId I
-   -> I
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming I,
+  (DA.Internal.Desugar.Consuming I,
+   I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_IArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_INonSerializableResult :
-  (I -> NonSerializableResult -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId I
    -> I
-      -> NonSerializableResult
-         -> DA.Internal.Desugar.Update (NonSerializable),
-   DA.Internal.Desugar.Consuming I,
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_IArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_INonSerializableResult :
+  (DA.Internal.Desugar.Consuming I,
+   I -> NonSerializableResult -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (I
                                  -> NonSerializableResult -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
-                                 -> NonSerializableResult -> [DA.Internal.Desugar.Party]))
+                                 -> NonSerializableResult -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId I
+   -> I
+      -> NonSerializableResult
+         -> DA.Internal.Desugar.Update (NonSerializable))
 _choice$_INonSerializableResult
-  = (\ this arg@NonSerializableResult
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@NonSerializableResult
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@NonSerializableResult
        -> let _ = self in
-          let _ = this in let _ = arg in do pure (NonSerializable identity), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = this in let _ = arg in do pure (NonSerializable identity))
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityResult.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityResult.EXPECTED.desugared-daml
@@ -94,11 +94,13 @@ _choice$_IArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_INonSerializableResult :
   (I -> NonSerializableResult -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId I
@@ -106,6 +108,8 @@ _choice$_INonSerializableResult :
       -> NonSerializableResult
          -> DA.Internal.Desugar.Update (NonSerializable),
    DA.Internal.Desugar.Consuming I,
+   DA.Internal.Desugar.Optional (I
+                                 -> NonSerializableResult -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
                                  -> NonSerializableResult -> [DA.Internal.Desugar.Party]))
 _choice$_INonSerializableResult
@@ -115,7 +119,8 @@ _choice$_INonSerializableResult
      \ self this arg@NonSerializableResult
        -> let _ = self in
           let _ = this in let _ = arg in do pure (NonSerializable identity), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where

--- a/compiler/damlc/tests/daml-test-files/InterfaceSyntax.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSyntax.EXPECTED.desugared-daml
@@ -69,11 +69,13 @@ _choice$_IArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming I,
    DA.Internal.Desugar.Optional (I
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_IArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where
@@ -136,11 +138,13 @@ _choice$_JArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming J,
    DA.Internal.Desugar.Optional (J
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (J
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_JArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView J EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView J EmptyInterfaceView where
@@ -213,11 +217,13 @@ _choice$_TArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
 _interface_instance$_T_I_T

--- a/compiler/damlc/tests/daml-test-files/InterfaceSyntax.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSyntax.EXPECTED.desugared-daml
@@ -63,19 +63,20 @@ instance DA.Internal.Desugar.HasChoiceController I DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver I DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_IArchive :
-  (I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId I
-   -> I
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming I,
+  (DA.Internal.Desugar.Consuming I,
+   I -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (I
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (I
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId I
+   -> I
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_IArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView I EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView I EmptyInterfaceView where
@@ -132,19 +133,20 @@ instance DA.Internal.Desugar.HasChoiceController J DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver J DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_JArchive :
-  (J -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId J
-   -> J
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming J,
+  (DA.Internal.Desugar.Consuming J,
+   J -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (J
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (J
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId J
+   -> J
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_JArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 instance DA.Internal.Desugar.HasInterfaceView J EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView J EmptyInterfaceView where
@@ -211,19 +213,20 @@ instance DA.Internal.Desugar.HasChoiceController T DA.Internal.Desugar.Archive w
 instance DA.Internal.Desugar.HasChoiceObserver T DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TArchive :
-  (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming T,
+  (DA.Internal.Desugar.Consuming T,
+   T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_TArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_T_I_T :
   DA.Internal.Desugar.InterfaceInstance T I T
 _interface_instance$_T_I_T

--- a/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.EXPECTED.desugared-daml
@@ -93,16 +93,20 @@ _choice$_AArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming A,
    DA.Internal.Desugar.Optional (A
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_AArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_AChoiceA :
   (A -> ChoiceA -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId A
    -> A -> ChoiceA -> DA.Internal.Desugar.Update (Int),
    DA.Internal.Desugar.NonConsuming A,
+   DA.Internal.Desugar.Optional (A
+                                 -> ChoiceA -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (A
                                  -> ChoiceA -> [DA.Internal.Desugar.Party]))
 _choice$_AChoiceA
@@ -111,7 +115,8 @@ _choice$_AChoiceA
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
      \ self this arg@ChoiceA
        -> let _ = self in let _ = this in let _ = arg in do pure 10, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView A EmptyInterfaceView where
@@ -209,16 +214,20 @@ _choice$_BArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming B,
    DA.Internal.Desugar.Optional (B
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (B
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_BArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_BChoiceB :
   (B -> ChoiceB -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId B
    -> B -> ChoiceB -> DA.Internal.Desugar.Update (Int),
    DA.Internal.Desugar.NonConsuming B,
+   DA.Internal.Desugar.Optional (B
+                                 -> ChoiceB -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (B
                                  -> ChoiceB -> [DA.Internal.Desugar.Party]))
 _choice$_BChoiceB
@@ -229,7 +238,8 @@ _choice$_BChoiceB
      \ self this arg@ChoiceB
        -> let _ = self in
           let _ = this in let _ = arg in do pure (getCoolness this), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView B EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView B EmptyInterfaceView where
@@ -294,11 +304,13 @@ _choice$_T1Archive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming T1,
    DA.Internal.Desugar.Optional (T1
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (T1
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_T1Archive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_T1_A_T1 :
   DA.Internal.Desugar.InterfaceInstance T1 A T1
 _interface_instance$_T1_A_T1
@@ -412,11 +424,13 @@ _choice$_T2Archive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming T2,
    DA.Internal.Desugar.Optional (T2
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (T2
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_T2Archive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _interface_instance$_T2_A_T2 :
   DA.Internal.Desugar.InterfaceInstance T2 A T2
 _interface_instance$_T2_A_T2
@@ -560,17 +574,21 @@ _choice$_TestArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Test,
    DA.Internal.Desugar.Optional (Test
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TestArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TestTemplateInterfaceMatching :
   (Test -> TemplateInterfaceMatching -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test
       -> TemplateInterfaceMatching -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> TemplateInterfaceMatching -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> TemplateInterfaceMatching -> [DA.Internal.Desugar.Party]))
 _choice$_TestTemplateInterfaceMatching
@@ -610,12 +628,15 @@ _choice$_TestTemplateInterfaceMatching
                exercise cidt1a ChoiceA
                exercise cidt1b ChoiceB
                pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestVoidUseAction :
   (Test -> VoidUseAction -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> VoidUseAction -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> VoidUseAction -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> VoidUseAction -> [DA.Internal.Desugar.Party]))
 _choice$_TestVoidUseAction
@@ -626,12 +647,15 @@ _choice$_TestVoidUseAction
        -> let _ = self in
           let _ = this in
           let _ = arg in do useAction p $ \ _bcid -> pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestFetchUseAction :
   (Test -> FetchUseAction -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> FetchUseAction -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> FetchUseAction -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> FetchUseAction -> [DA.Internal.Desugar.Party]))
 _choice$_TestFetchUseAction
@@ -642,12 +666,15 @@ _choice$_TestFetchUseAction
        -> let _ = self in
           let _ = this in
           let _ = arg in do useAction p $ \ bcid -> void (fetch bcid), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TestExerciseUseAction :
   (Test -> ExerciseUseAction -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Test
    -> Test -> ExerciseUseAction -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Test,
+   DA.Internal.Desugar.Optional (Test
+                                 -> ExerciseUseAction -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
                                  -> ExerciseUseAction -> [DA.Internal.Desugar.Party]))
 _choice$_TestExerciseUseAction
@@ -659,7 +686,8 @@ _choice$_TestExerciseUseAction
           let _ = this in
           let _ = arg
           in do useAction p $ \ bcid -> void (exercise bcid ChoiceB), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 exerciseTest : Choice Test c () => c -> Script ()
 exerciseTest c
   = script

--- a/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.EXPECTED.desugared-daml
@@ -87,36 +87,37 @@ data ChoiceA
   = ChoiceA {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
 _choice$_AArchive :
-  (A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId A
-   -> A
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming A,
+  (DA.Internal.Desugar.Consuming A,
+   A -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (A
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (A
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_AArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_AChoiceA :
-  (A -> ChoiceA -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId A
-   -> A -> ChoiceA -> DA.Internal.Desugar.Update (Int),
-   DA.Internal.Desugar.NonConsuming A,
+   -> A
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_AArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_AChoiceA :
+  (DA.Internal.Desugar.NonConsuming A,
+   A -> ChoiceA -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (A
                                  -> ChoiceA -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (A
-                                 -> ChoiceA -> [DA.Internal.Desugar.Party]))
+                                 -> ChoiceA -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId A
+   -> A -> ChoiceA -> DA.Internal.Desugar.Update (Int))
 _choice$_AChoiceA
-  = (\ this arg@ChoiceA
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this arg@ChoiceA
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (getOwner this), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@ChoiceA
-       -> let _ = self in let _ = this in let _ = arg in do pure 10, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+       -> let _ = self in let _ = this in let _ = arg in do pure 10)
 instance DA.Internal.Desugar.HasInterfaceView A EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView A EmptyInterfaceView where
@@ -208,38 +209,39 @@ data ChoiceB
   = ChoiceB {}
   deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
 _choice$_BArchive :
-  (B -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId B
-   -> B
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming B,
+  (DA.Internal.Desugar.Consuming B,
+   B -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (B
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (B
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_BArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_BChoiceB :
-  (B -> ChoiceB -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId B
-   -> B -> ChoiceB -> DA.Internal.Desugar.Update (Int),
-   DA.Internal.Desugar.NonConsuming B,
+   -> B
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_BArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_BChoiceB :
+  (DA.Internal.Desugar.NonConsuming B,
+   B -> ChoiceB -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (B
                                  -> ChoiceB -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (B
-                                 -> ChoiceB -> [DA.Internal.Desugar.Party]))
+                                 -> ChoiceB -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId B
+   -> B -> ChoiceB -> DA.Internal.Desugar.Update (Int))
 _choice$_BChoiceB
-  = (\ this arg@ChoiceB
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this arg@ChoiceB
        -> let _ = this in
           let _ = arg
           in DA.Internal.Desugar.toParties (getOwner (toInterface @A this)), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@ChoiceB
        -> let _ = self in
-          let _ = this in let _ = arg in do pure (getCoolness this), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = this in let _ = arg in do pure (getCoolness this))
 instance DA.Internal.Desugar.HasInterfaceView B EmptyInterfaceView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView B EmptyInterfaceView where
@@ -298,19 +300,20 @@ instance DA.Internal.Desugar.HasChoiceController T1 DA.Internal.Desugar.Archive 
 instance DA.Internal.Desugar.HasChoiceObserver T1 DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_T1Archive :
-  (T1 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T1
-   -> T1
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming T1,
+  (DA.Internal.Desugar.Consuming T1,
+   T1 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T1
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T1
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T1
+   -> T1
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_T1Archive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_T1_A_T1 :
   DA.Internal.Desugar.InterfaceInstance T1 A T1
 _interface_instance$_T1_A_T1
@@ -418,19 +421,20 @@ instance DA.Internal.Desugar.HasChoiceController T2 DA.Internal.Desugar.Archive 
 instance DA.Internal.Desugar.HasChoiceObserver T2 DA.Internal.Desugar.Archive where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_T2Archive :
-  (T2 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T2
-   -> T2
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming T2,
+  (DA.Internal.Desugar.Consuming T2,
+   T2 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T2
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T2
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T2
+   -> T2
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_T2Archive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _interface_instance$_T2_A_T2 :
   DA.Internal.Desugar.InterfaceInstance T2 A T2
 _interface_instance$_T2_A_T2
@@ -567,34 +571,36 @@ instance DA.Internal.Desugar.HasChoiceController Test ExerciseUseAction where
 instance DA.Internal.Desugar.HasChoiceObserver Test ExerciseUseAction where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TestArchive :
-  (Test
-   -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Test,
+  (DA.Internal.Desugar.Consuming Test,
+   Test -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TestArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TestTemplateInterfaceMatching :
-  (Test -> TemplateInterfaceMatching -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Test
    -> Test
-      -> TemplateInterfaceMatching -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TestArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TestTemplateInterfaceMatching :
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> TemplateInterfaceMatching -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> TemplateInterfaceMatching -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> TemplateInterfaceMatching -> [DA.Internal.Desugar.Party]))
+                                 -> TemplateInterfaceMatching -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test
+      -> TemplateInterfaceMatching -> DA.Internal.Desugar.Update (()))
 _choice$_TestTemplateInterfaceMatching
-  = (\ this@Test {..} arg@TemplateInterfaceMatching
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@TemplateInterfaceMatching
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@TemplateInterfaceMatching
        -> let _ = self in
           let _ = this in
@@ -627,67 +633,64 @@ _choice$_TestTemplateInterfaceMatching
                assertMsg "fetchPair2 != None" (isNone fetchPair2)
                exercise cidt1a ChoiceA
                exercise cidt1b ChoiceB
-               pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+               pure ())
 _choice$_TestVoidUseAction :
-  (Test -> VoidUseAction -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> VoidUseAction -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> VoidUseAction -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> VoidUseAction -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> VoidUseAction -> [DA.Internal.Desugar.Party]))
+                                 -> VoidUseAction -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> VoidUseAction -> DA.Internal.Desugar.Update (()))
 _choice$_TestVoidUseAction
-  = (\ this@Test {..} arg@VoidUseAction
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@VoidUseAction
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@VoidUseAction
        -> let _ = self in
-          let _ = this in
-          let _ = arg in do useAction p $ \ _bcid -> pure (), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = this in let _ = arg in do useAction p $ \ _bcid -> pure ())
 _choice$_TestFetchUseAction :
-  (Test -> FetchUseAction -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> FetchUseAction -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> FetchUseAction -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> FetchUseAction -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> FetchUseAction -> [DA.Internal.Desugar.Party]))
+                                 -> FetchUseAction -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> FetchUseAction -> DA.Internal.Desugar.Update (()))
 _choice$_TestFetchUseAction
-  = (\ this@Test {..} arg@FetchUseAction
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@FetchUseAction
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@FetchUseAction
        -> let _ = self in
           let _ = this in
-          let _ = arg in do useAction p $ \ bcid -> void (fetch bcid), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = arg in do useAction p $ \ bcid -> void (fetch bcid))
 _choice$_TestExerciseUseAction :
-  (Test -> ExerciseUseAction -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Test
-   -> Test -> ExerciseUseAction -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Test,
+  (DA.Internal.Desugar.NonConsuming Test,
+   Test -> ExerciseUseAction -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Test
                                  -> ExerciseUseAction -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Test
-                                 -> ExerciseUseAction -> [DA.Internal.Desugar.Party]))
+                                 -> ExerciseUseAction -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Test
+   -> Test -> ExerciseUseAction -> DA.Internal.Desugar.Update (()))
 _choice$_TestExerciseUseAction
-  = (\ this@Test {..} arg@ExerciseUseAction
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this@Test {..} arg@ExerciseUseAction
        -> let _ = this in
           let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@Test {..} arg@ExerciseUseAction
        -> let _ = self in
           let _ = this in
           let _ = arg
-          in do useAction p $ \ bcid -> void (exercise bcid ChoiceB), 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          in do useAction p $ \ bcid -> void (exercise bcid ChoiceB))
 exerciseTest : Choice Test c () => c -> Script ()
 exerciseTest c
   = script

--- a/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.desugared-daml
@@ -206,56 +206,58 @@ instance DA.Internal.Record.HasField "byHowMuch" GetRich Int where
   setField
     = DA.Internal.Record.setFieldPrim @"byHowMuch" @GetRich @Int
 _choice$_TokenArchive :
-  (Token
+  (DA.Internal.Desugar.Consuming Token,
+   Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_TokenArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _choice$_TokenSplit :
-  (Token -> Split -> [DA.Internal.Desugar.Party],
+  (DA.Internal.Desugar.Consuming Token,
+   Token -> Split -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.Optional (Token
+                                 -> Split -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Token
+                                 -> Split -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Token
    -> Token
       -> Split
          -> DA.Internal.Desugar.Update ((ContractId Token,
-                                         ContractId Token)),
-   DA.Internal.Desugar.Consuming Token,
-   DA.Internal.Desugar.Optional (Token
-                                 -> Split -> [DA.Internal.Desugar.Party]),
-   DA.Internal.Desugar.Optional (Token
-                                 -> Split -> [DA.Internal.Desugar.Party]))
+                                         ContractId Token)))
 _choice$_TokenSplit
-  = (\ this arg@Split {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@Split {..}
        -> let _ = this in
           let _ = arg
           in
             DA.Internal.Desugar.toParties
               ((DA.Internal.Record.getField @"owner" (view this))), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@Split {..}
        -> let _ = self in
-          let _ = this in let _ = arg in do splitImpl this splitAmount, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = this in let _ = arg in do splitImpl this splitAmount)
 _choice$_TokenTransfer :
-  (Token -> Transfer -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> Transfer -> DA.Internal.Desugar.Update (ContractId Token),
-   DA.Internal.Desugar.Consuming Token,
+  (DA.Internal.Desugar.Consuming Token,
+   Token -> Transfer -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Token
                                  -> Transfer -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> Transfer -> [DA.Internal.Desugar.Party]))
+                                 -> Transfer -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> Transfer -> DA.Internal.Desugar.Update (ContractId Token))
 _choice$_TokenTransfer
-  = (\ this arg@Transfer {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@Transfer {..}
        -> let _ = this in
           let _ = arg
           in
@@ -263,49 +265,50 @@ _choice$_TokenTransfer
               [DA.Internal.Desugar.toParties
                  ((DA.Internal.Record.getField @"owner" (view this))),
                DA.Internal.Desugar.toParties (newOwner)], 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@Transfer {..}
        -> let _ = self in
-          let _ = this in let _ = arg in do transferImpl this newOwner, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = this in let _ = arg in do transferImpl this newOwner)
 _choice$_TokenNoop :
-  (Token -> Noop -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token -> Noop -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Token,
+  (DA.Internal.Desugar.NonConsuming Token,
+   Token -> Noop -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Token
                                  -> Noop -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> Noop -> [DA.Internal.Desugar.Party]))
+                                 -> Noop -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token -> Noop -> DA.Internal.Desugar.Update (()))
 _choice$_TokenNoop
-  = (\ this arg@Noop {..}
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this arg@Noop {..}
        -> let _ = this in
           let _ = arg
           in
             DA.Internal.Desugar.toParties
               ((DA.Internal.Record.getField @"owner" (view this))), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@Noop {..}
        -> let _ = self in
-          let _ = this in let _ = arg in do noopImpl this nothing, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = this in let _ = arg in do noopImpl this nothing)
 _choice$_TokenGetRich :
-  (Token -> GetRich -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> GetRich -> DA.Internal.Desugar.Update (ContractId Token),
-   DA.Internal.Desugar.Consuming Token,
+  (DA.Internal.Desugar.Consuming Token,
+   Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> GetRich -> [DA.Internal.Desugar.Party]))
+                                 -> GetRich -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> GetRich -> DA.Internal.Desugar.Update (ContractId Token))
 _choice$_TokenGetRich
-  = (\ this arg@GetRich {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@GetRich {..}
        -> let _ = this in
           let _ = arg
           in
             DA.Internal.Desugar.toParties
               ((DA.Internal.Record.getField @"owner" (view this))), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@GetRich {..}
        -> let _ = self in
           let _ = this in
@@ -315,9 +318,7 @@ _choice$_TokenGetRich
                create
                  $ setAmount
                      this
-                     ((DA.Internal.Record.getField @"amount" (view this)) + byHowMuch), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+                     ((DA.Internal.Record.getField @"amount" (view this)) + byHowMuch))
 instance DA.Internal.Desugar.HasInterfaceView Token TokenView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token TokenView where

--- a/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.desugared-daml
@@ -213,11 +213,13 @@ _choice$_TokenArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TokenSplit :
   (Token -> Split -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
@@ -226,6 +228,8 @@ _choice$_TokenSplit :
          -> DA.Internal.Desugar.Update ((ContractId Token,
                                          ContractId Token)),
    DA.Internal.Desugar.Consuming Token,
+   DA.Internal.Desugar.Optional (Token
+                                 -> Split -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
                                  -> Split -> [DA.Internal.Desugar.Party]))
 _choice$_TokenSplit
@@ -238,13 +242,16 @@ _choice$_TokenSplit
      \ self this arg@Split {..}
        -> let _ = self in
           let _ = this in let _ = arg in do splitImpl this splitAmount, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TokenTransfer :
   (Token -> Transfer -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
       -> Transfer -> DA.Internal.Desugar.Update (ContractId Token),
    DA.Internal.Desugar.Consuming Token,
+   DA.Internal.Desugar.Optional (Token
+                                 -> Transfer -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
                                  -> Transfer -> [DA.Internal.Desugar.Party]))
 _choice$_TokenTransfer
@@ -259,12 +266,15 @@ _choice$_TokenTransfer
      \ self this arg@Transfer {..}
        -> let _ = self in
           let _ = this in let _ = arg in do transferImpl this newOwner, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TokenNoop :
   (Token -> Noop -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token -> Noop -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Token,
+   DA.Internal.Desugar.Optional (Token
+                                 -> Noop -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
                                  -> Noop -> [DA.Internal.Desugar.Party]))
 _choice$_TokenNoop
@@ -277,13 +287,16 @@ _choice$_TokenNoop
      \ self this arg@Noop {..}
        -> let _ = self in
           let _ = this in let _ = arg in do noopImpl this nothing, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TokenGetRich :
   (Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
       -> GetRich -> DA.Internal.Desugar.Update (ContractId Token),
    DA.Internal.Desugar.Consuming Token,
+   DA.Internal.Desugar.Optional (Token
+                                 -> GetRich -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]))
 _choice$_TokenGetRich
@@ -303,7 +316,8 @@ _choice$_TokenGetRich
                  $ setAmount
                      this
                      ((DA.Internal.Record.getField @"amount" (view this)) + byHowMuch), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Token TokenView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token TokenView where

--- a/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.desugared-daml
@@ -206,56 +206,58 @@ instance DA.Internal.Record.HasField "byHowMuch" GetRich Int where
   setField
     = DA.Internal.Record.setFieldPrim @"byHowMuch" @GetRich @Int
 _choice$_TokenArchive :
-  (Token
+  (DA.Internal.Desugar.Consuming Token,
+   Token
    -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
 _choice$_TokenArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
 _choice$_TokenSplit :
-  (Token -> Split -> [DA.Internal.Desugar.Party],
+  (DA.Internal.Desugar.Consuming Token,
+   Token -> Split -> [DA.Internal.Desugar.Party],
+   DA.Internal.Desugar.Optional (Token
+                                 -> Split -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Token
+                                 -> Split -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId Token
    -> Token
       -> Split
          -> DA.Internal.Desugar.Update ((ContractId Token,
-                                         ContractId Token)),
-   DA.Internal.Desugar.Consuming Token,
-   DA.Internal.Desugar.Optional (Token
-                                 -> Split -> [DA.Internal.Desugar.Party]),
-   DA.Internal.Desugar.Optional (Token
-                                 -> Split -> [DA.Internal.Desugar.Party]))
+                                         ContractId Token)))
 _choice$_TokenSplit
-  = (\ this arg@Split {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@Split {..}
        -> let _ = this in
           let _ = arg
           in
             DA.Internal.Desugar.toParties
               ((DA.Internal.Record.getField @"owner" (view this))), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@Split {..}
        -> let _ = self in
-          let _ = this in let _ = arg in do splitImpl this splitAmount, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = this in let _ = arg in do splitImpl this splitAmount)
 _choice$_TokenTransfer :
-  (Token -> Transfer -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> Transfer -> DA.Internal.Desugar.Update (ContractId Token),
-   DA.Internal.Desugar.Consuming Token,
+  (DA.Internal.Desugar.Consuming Token,
+   Token -> Transfer -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Token
                                  -> Transfer -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> Transfer -> [DA.Internal.Desugar.Party]))
+                                 -> Transfer -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> Transfer -> DA.Internal.Desugar.Update (ContractId Token))
 _choice$_TokenTransfer
-  = (\ this arg@Transfer {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@Transfer {..}
        -> let _ = this in
           let _ = arg
           in
@@ -263,49 +265,50 @@ _choice$_TokenTransfer
               [DA.Internal.Desugar.toParties
                  ((DA.Internal.Record.getField @"owner" (view this))),
                DA.Internal.Desugar.toParties (newOwner)], 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@Transfer {..}
        -> let _ = self in
-          let _ = this in let _ = arg in do transferImpl this newOwner, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = this in let _ = arg in do transferImpl this newOwner)
 _choice$_TokenNoop :
-  (Token -> Noop -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token -> Noop -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.NonConsuming Token,
+  (DA.Internal.Desugar.NonConsuming Token,
+   Token -> Noop -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Token
                                  -> Noop -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> Noop -> [DA.Internal.Desugar.Party]))
+                                 -> Noop -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token -> Noop -> DA.Internal.Desugar.Update (()))
 _choice$_TokenNoop
-  = (\ this arg@Noop {..}
+  = (DA.Internal.Desugar.NonConsuming, 
+     \ this arg@Noop {..}
        -> let _ = this in
           let _ = arg
           in
             DA.Internal.Desugar.toParties
               ((DA.Internal.Record.getField @"owner" (view this))), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@Noop {..}
        -> let _ = self in
-          let _ = this in let _ = arg in do noopImpl this nothing, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = this in let _ = arg in do noopImpl this nothing)
 _choice$_TokenGetRich :
-  (Token -> GetRich -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId Token
-   -> Token
-      -> GetRich -> DA.Internal.Desugar.Update (ContractId Token),
-   DA.Internal.Desugar.Consuming Token,
+  (DA.Internal.Desugar.Consuming Token,
+   Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
-                                 -> GetRich -> [DA.Internal.Desugar.Party]))
+                                 -> GetRich -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId Token
+   -> Token
+      -> GetRich -> DA.Internal.Desugar.Update (ContractId Token))
 _choice$_TokenGetRich
-  = (\ this arg@GetRich {..}
+  = (DA.Internal.Desugar.Consuming, 
+     \ this arg@GetRich {..}
        -> let _ = this in
           let _ = arg
           in
             DA.Internal.Desugar.toParties
               ((DA.Internal.Record.getField @"owner" (view this))), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this arg@GetRich {..}
        -> let _ = self in
           let _ = this in
@@ -315,9 +318,7 @@ _choice$_TokenGetRich
                create
                  $ setAmount
                      this
-                     ((DA.Internal.Record.getField @"amount" (view this)) + byHowMuch), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+                     ((DA.Internal.Record.getField @"amount" (view this)) + byHowMuch))
 instance DA.Internal.Desugar.HasInterfaceView Token TokenView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token TokenView where

--- a/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.desugared-daml
@@ -213,11 +213,13 @@ _choice$_TokenArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming Token,
    DA.Internal.Desugar.Optional (Token
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (Token
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TokenArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TokenSplit :
   (Token -> Split -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
@@ -226,6 +228,8 @@ _choice$_TokenSplit :
          -> DA.Internal.Desugar.Update ((ContractId Token,
                                          ContractId Token)),
    DA.Internal.Desugar.Consuming Token,
+   DA.Internal.Desugar.Optional (Token
+                                 -> Split -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
                                  -> Split -> [DA.Internal.Desugar.Party]))
 _choice$_TokenSplit
@@ -238,13 +242,16 @@ _choice$_TokenSplit
      \ self this arg@Split {..}
        -> let _ = self in
           let _ = this in let _ = arg in do splitImpl this splitAmount, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TokenTransfer :
   (Token -> Transfer -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
       -> Transfer -> DA.Internal.Desugar.Update (ContractId Token),
    DA.Internal.Desugar.Consuming Token,
+   DA.Internal.Desugar.Optional (Token
+                                 -> Transfer -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
                                  -> Transfer -> [DA.Internal.Desugar.Party]))
 _choice$_TokenTransfer
@@ -259,12 +266,15 @@ _choice$_TokenTransfer
      \ self this arg@Transfer {..}
        -> let _ = self in
           let _ = this in let _ = arg in do transferImpl this newOwner, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TokenNoop :
   (Token -> Noop -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token -> Noop -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.NonConsuming Token,
+   DA.Internal.Desugar.Optional (Token
+                                 -> Noop -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
                                  -> Noop -> [DA.Internal.Desugar.Party]))
 _choice$_TokenNoop
@@ -277,13 +287,16 @@ _choice$_TokenNoop
      \ self this arg@Noop {..}
        -> let _ = self in
           let _ = this in let _ = arg in do noopImpl this nothing, 
-     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.NonConsuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 _choice$_TokenGetRich :
   (Token -> GetRich -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId Token
    -> Token
       -> GetRich -> DA.Internal.Desugar.Update (ContractId Token),
    DA.Internal.Desugar.Consuming Token,
+   DA.Internal.Desugar.Optional (Token
+                                 -> GetRich -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (Token
                                  -> GetRich -> [DA.Internal.Desugar.Party]))
 _choice$_TokenGetRich
@@ -303,7 +316,8 @@ _choice$_TokenGetRich
                  $ setAmount
                      this
                      ((DA.Internal.Record.getField @"amount" (view this)) + byHowMuch), 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasInterfaceView Token TokenView where
   _view = GHC.Types.primitive @"EViewInterface"
 instance DA.Internal.Desugar.HasFromAnyView Token TokenView where

--- a/compiler/damlc/tests/daml-test-files/UnusedMatchTests.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/UnusedMatchTests.EXPECTED.desugared-daml
@@ -114,30 +114,32 @@ instance DA.Internal.Desugar.HasChoiceController T Revoke where
 instance DA.Internal.Desugar.HasChoiceObserver T Revoke where
   _choiceObserver = GHC.Types.primitive @"EChoiceObserver"
 _choice$_TArchive :
-  (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
-   DA.Internal.Desugar.ContractId T
-   -> T
-      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming T,
+  (DA.Internal.Desugar.Consuming T,
+   T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
-_choice$_TArchive
-  = (\ this _ -> DA.Internal.Desugar.signatory this, 
-     \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
-_choice$_TRevoke :
-  (T -> Revoke -> [DA.Internal.Desugar.Party],
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.ContractId T
-   -> T -> Revoke -> DA.Internal.Desugar.Update (()),
-   DA.Internal.Desugar.Consuming T,
+   -> T
+      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()))
+_choice$_TArchive
+  = (DA.Internal.Desugar.Consuming, 
+     \ this _ -> DA.Internal.Desugar.signatory this, 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
+     \ _ _ _ -> pure ())
+_choice$_TRevoke :
+  (DA.Internal.Desugar.Consuming T,
+   T -> Revoke -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.Optional (T
                                  -> Revoke -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
-                                 -> Revoke -> [DA.Internal.Desugar.Party]))
+                                 -> Revoke -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.ContractId T
+   -> T -> Revoke -> DA.Internal.Desugar.Update (()))
 _choice$_TRevoke
-  = (\ this@T {..} arg@Revoke
+  = (DA.Internal.Desugar.Consuming, 
+     \ this@T {..} arg@Revoke
        -> let
             (revokeRetVal, sig, obs, assertion, plainEnglish, ident)
               = _templateLet_T this in
@@ -148,6 +150,7 @@ _choice$_TRevoke
           let _ = plainEnglish in
           let _ = ident in
           let _ = this in let _ = arg in DA.Internal.Desugar.toParties (p), 
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None, 
      \ self this@T {..} arg@Revoke
        -> let
             (revokeRetVal, sig, obs, assertion, plainEnglish, ident)
@@ -159,9 +162,7 @@ _choice$_TRevoke
           let _ = plainEnglish in
           let _ = ident in
           let _ = self in
-          let _ = this in let _ = arg in do pure revokeRetVal, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
-     DA.Internal.Desugar.None)
+          let _ = this in let _ = arg in do pure revokeRetVal)
 instance DA.Internal.Desugar.HasExerciseByKey T (Party,
                                                  Text) DA.Internal.Desugar.Archive (()) where
   _exerciseByKey = GHC.Types.primitive @"UExerciseByKey"

--- a/compiler/damlc/tests/daml-test-files/UnusedMatchTests.EXPECTED.desugared-daml
+++ b/compiler/damlc/tests/daml-test-files/UnusedMatchTests.EXPECTED.desugared-daml
@@ -120,16 +120,20 @@ _choice$_TArchive :
       -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming T,
    DA.Internal.Desugar.Optional (T
+                                 -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]),
+   DA.Internal.Desugar.Optional (T
                                  -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party]))
 _choice$_TArchive
   = (\ this _ -> DA.Internal.Desugar.signatory this, 
      \ _ _ _ -> pure (), DA.Internal.Desugar.Consuming, 
-     DA.Internal.Desugar.None)
+     DA.Internal.Desugar.None, DA.Internal.Desugar.None)
 _choice$_TRevoke :
   (T -> Revoke -> [DA.Internal.Desugar.Party],
    DA.Internal.Desugar.ContractId T
    -> T -> Revoke -> DA.Internal.Desugar.Update (()),
    DA.Internal.Desugar.Consuming T,
+   DA.Internal.Desugar.Optional (T
+                                 -> Revoke -> [DA.Internal.Desugar.Party]),
    DA.Internal.Desugar.Optional (T
                                  -> Revoke -> [DA.Internal.Desugar.Party]))
 _choice$_TRevoke
@@ -156,7 +160,8 @@ _choice$_TRevoke
           let _ = ident in
           let _ = self in
           let _ = this in let _ = arg in do pure revokeRetVal, 
-     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None)
+     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.None, 
+     DA.Internal.Desugar.None)
 instance DA.Internal.Desugar.HasExerciseByKey T (Party,
                                                  Text) DA.Internal.Desugar.Archive (()) where
   _exerciseByKey = GHC.Types.primitive @"UExerciseByKey"


### PR DESCRIPTION
Advance https://github.com/digital-asset/daml/issues/15882

Support _choice authority_ syntax, as required by:
https://docs.google.com/document/d/1Z8lbvTQcxik3_1rGpIie5Dw216M_grtwY2LA2Nn3zT8/edit#heading=h.4mr0cryy64m5

Related ghc PR: https://github.com/digital-asset/ghc/pull/165