### PR TITLE
JSON API: LT-9: Fix fetching contracts with Numerics in their keys.

### DIFF
--- a/ledger-service/http-json/src/it/daml/Account.daml
+++ b/ledger-service/http-json/src/it/daml/Account.daml
@@ -46,6 +46,16 @@ template KeyedByVariantAndRecord with
     key (party, fooVariant, bazRecord): (Party, Foo, BazRecord)
     maintainer key._1
 
+type Amount = Numeric 6
+
+template KeyedByDecimal with
+    party: Party
+    amount: Amount
+  where
+    signatory party
+    key (party, amount): (Party, Amount)
+    maintainer key._1
+
 template Helper
   with
     owner : Party

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -1020,6 +1020,51 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         }
       }
     }
+
+    "containing a decimal " - {
+      Seq(
+        "300000",
+        "300000.0",
+        "300000.000001",
+        "300000.00000000000001", // Note this is more than the 6 decimal places allowed by the type
+      ).foreach { numStr =>
+        s"with value $numStr" in withHttpService { fixture =>
+          fixture.getUniquePartyAndAuthHeaders("Alice").flatMap { case (alice, headers) =>
+            testCreateAndFetchDecimalKey(fixture, numStr, alice, headers)
+          }
+        }
+      }
+    }
+  }
+
+  private def testCreateAndFetchDecimalKey(
+      fixture: UriFixture,
+      decimal: String,
+      party: domain.Party,
+      headers: List[HttpHeader],
+  ) = {
+    val createCommand = jsObject(s"""{
+      "templateId": "Account:KeyedByDecimal",
+      "payload": { "party": "$party", "amount": "$decimal" }
+    }""")
+    val fetchRequest = jsObject(s"""{
+      "templateId": "Account:KeyedByDecimal",
+      "key": [ "$party", "$decimal" ]
+    }""")
+
+    fixture
+      .postJsonRequest(Uri.Path("/v1/create"), createCommand, headers)
+      .parseResponse[domain.ActiveContract.ResolvedCtTyId[JsValue]]
+      .flatMap(inside(_) {
+        case domain.OkResponse(created, _, StatusCodes.OK) => {
+          fixture
+            .postJsonRequest(Uri.Path("/v1/fetch"), fetchRequest, headers)
+            .parseResponse[domain.ActiveContract.ResolvedCtTyId[JsValue]]
+            .flatMap(inside(_) { case domain.OkResponse(fetched, _, StatusCodes.OK) =>
+              created.contractId shouldBe fetched.contractId
+            })
+        }
+      }): Future[Assertion]
   }
 
   private def testFetchByCompositeKey(

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/ApiValueToLfValueConverter.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/ApiValueToLfValueConverter.scala
@@ -3,8 +3,9 @@
 
 package com.daml.http.util
 
+import com.daml.error.NoLogging
 import com.daml.lf
-import com.daml.ledger.api.validation.NoLoggingValueValidator
+import com.daml.ledger.api.validation.StricterValueValidator
 import com.daml.ledger.api.{v1 => lav1}
 import io.grpc.StatusRuntimeException
 import scalaz.{Show, \/}
@@ -23,6 +24,6 @@ object ApiValueToLfValueConverter {
     lav1.value.Value => Error \/ lf.value.Value
 
   def apiValueToLfValue: ApiValueToLfValue = { a: lav1.value.Value =>
-    \/.fromEither(NoLoggingValueValidator.validateValue(a)).leftMap(e => Error(e))
+    \/.fromEither(StricterValueValidator.validateValue(a)(NoLogging)).leftMap(e => Error(e))
   }
 }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ApiValueToLfValueConverterTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ApiValueToLfValueConverterTest.scala
@@ -4,7 +4,6 @@
 package com.daml.http
 package util
 
-import com.daml.lf.data.{Numeric => LfNumeric}
 import com.daml.lf.value.test.TypedValueGenerators.genAddend
 import com.daml.lf.value.test.ValueGenerators.coidGen
 import com.daml.lf.value.{Value => V}
@@ -13,16 +12,11 @@ import org.scalacheck.Arbitrary
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import scalaz.Equal
-import scalaz.syntax.bifunctor._
-import scalaz.std.option._
-import scalaz.std.tuple._
 
 class ApiValueToLfValueConverterTest
     extends AnyWordSpec
     with Matchers
     with ScalaCheckDrivenPropertyChecks {
-  import ApiValueToLfValueConverterTest._
 
   private[this] implicit val arbCid: Arbitrary[V.ContractId] = Arbitrary(coidGen)
 
@@ -36,34 +30,8 @@ class ApiValueToLfValueConverterTest
         val vv = va.inj(v)
         val roundTrip =
           lfValueToApiValue(true, vv).toOption flatMap (x => apiValueToLfValue(x).toMaybe.toOption)
-        assert(Equal[Option[V]].equal(roundTrip, Some(vv)))
+        roundTrip shouldBe Some(vv)
       }
     }
-  }
-}
-
-object ApiValueToLfValueConverterTest {
-  // Numeric are normalized when converting from api to lf,
-  // them we have to relax numeric equality
-  private implicit def eqValue: Equal[V] = { (l, r) =>
-    V.`Value Equal instance`
-      .contramap[V](
-        mapNumeric(_, n => LfNumeric assertFromUnscaledBigDecimal n.stripTrailingZeros)
-      )
-      .equal(l, r)
-  }
-
-  private[this] def mapNumeric(fa: V, f: LfNumeric => LfNumeric): V = {
-    def go(fa: V): V = fa match {
-      case V.ValueNumeric(m) => V.ValueNumeric(f(m))
-      case _: V.ValueCidlessLeaf | V.ValueContractId(_) => fa
-      case r @ V.ValueRecord(_, fields) => r copy (fields = fields map (_ rightMap go))
-      case v @ V.ValueVariant(_, _, value) => v copy (value = go(value))
-      case V.ValueList(fs) => V.ValueList(fs map go)
-      case V.ValueOptional(o) => V.ValueOptional(o map go)
-      case V.ValueTextMap(m) => V.ValueTextMap(m mapValue go)
-      case V.ValueGenMap(m) => V.ValueGenMap(m map (_.bimap(go, go)))
-    }
-    go(fa)
   }
 }


### PR DESCRIPTION
Switch to an LF converter which preserves the numeric's scale, allowing keys to match correctly.

Fixes https://digitalasset.atlassian.net/browse/LT-9