### PR TITLE
Use unversioned daml-script where possible

### DIFF
--- a/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
@@ -17,7 +17,6 @@ import DA.Daml.Doc.Render
 import DA.Daml.Doc.Types
 import DA.Daml.Doc.Transform
 import DA.Daml.Doc.Anchor
-import DA.Daml.LF.Ast.Version
 import DA.Test.DamlcIntegration (ScriptPackageData)
 
 import Development.IDE.Types.Location
@@ -418,7 +417,6 @@ runDamldocMany' testfiles importPathM mScriptPackageData = do
         { optHaddock = Haddock True
         , optScenarioService = EnableScenarioService False
         , optImportPath = maybeToList importPathM
-        , optDamlLfVersion = versionDev
         , optPackageDbs = maybeToList $ fst <$> mScriptPackageData
         , optPackageImports = maybeToList $ snd <$> mScriptPackageData
         }

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -250,7 +250,7 @@ da_haskell_test(
         "//compiler/damlc:daml-base-anchors.json",
         "//compiler/damlc/pkg-db",
         "//compiler/damlc/stable-packages",
-        "//daml-script/daml:daml-script-1.dev.dar",
+        "//daml-script/daml:daml-script.dar",
         ghc_pkg,
     ],
     hackage_deps = [
@@ -281,7 +281,7 @@ da_haskell_test(
     data = [
         "//compiler/damlc/pkg-db",
         "//compiler/damlc/stable-packages",
-        "//daml-script/daml:daml-script-1.dev.dar",
+        "//daml-script/daml:daml-script.dar",
         ghc_pkg,
     ],
     hackage_deps = [
@@ -345,7 +345,7 @@ da_haskell_test(
         "//compiler/damlc/pkg-db",
         "//compiler/damlc/stable-packages",
         "//compiler/scenario-service/server:scenario_service_jar",
-        "//daml-script/daml:daml-script-1.15.dar",
+        "//daml-script/daml:daml-script.dar",
         ghc_pkg,
     ],
     hackage_deps = [

--- a/compiler/damlc/tests/src/DA/Test/DamlDoc.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlDoc.hs
@@ -10,7 +10,6 @@ import DA.Daml.Doc.Types
 import qualified DA.Daml.Doc.Tests as Damldoc
 import qualified DA.Daml.Doc.Render.Tests as Render
 import qualified Test.Tasty.Extended as Tasty
-import DA.Daml.LF.Ast.Version (versionDev)
 import DA.Test.DamlcIntegration (ScriptPackageData, withDamlScriptDep)
 import System.Environment.Blank
 
@@ -18,7 +17,7 @@ main :: IO ()
 main = do
   setEnv "TASTY_NUM_THREADS" "1" True
   anchors <- loadExternalAnchors DefaultExternalAnchorPath
-  withDamlScriptDep versionDev $ Tasty.deterministicMain <=< allTests anchors
+  withDamlScriptDep Nothing $ Tasty.deterministicMain <=< allTests anchors
 
 allTests :: AnchorMap -> ScriptPackageData -> IO Tasty.TestTree
 allTests externalAnchors scriptPackageData = Tasty.testGroup "All Daml GHC tests using Tasty" <$> sequence

--- a/compiler/damlc/tests/src/DA/Test/DamlDocTest.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlDocTest.hs
@@ -9,7 +9,6 @@ import Test.Tasty.HUnit
 
 import DA.Daml.DocTest
 import DA.Daml.Options.Types
-import DA.Daml.LF.Ast.Version (versionDev)
 import qualified DA.Service.Logger.Impl.Pure as Logger
 import DA.Test.DamlcIntegration (withDamlScriptDep, ScriptPackageData)
 import Development.IDE.Core.IdeState.Daml
@@ -19,7 +18,7 @@ import Development.IDE.Core.Shake
 import Development.IDE.Types.Location
 
 main :: IO ()
-main = withDamlScriptDep versionDev $ \scriptPackageData -> -- Install Daml.Script once at the start of the suite, rather than for each case
+main = withDamlScriptDep Nothing $ \scriptPackageData -> -- Install Daml.Script once at the start of the suite, rather than for each case
     defaultMain $ testGroup "daml-doctest"
         [ generateTests scriptPackageData
         ]
@@ -91,7 +90,7 @@ generateTests scriptPackageData = testGroup "generate doctest module"
             let moduleName = "Case_" <> T.replace " " "" name
                 tmpFile = T.unpack moduleName <> ".daml"
             T.writeFileUtf8 tmpFile $ T.unlines $ testModuleHeader moduleName <> input
-            let opts = (defaultOptions (Just versionDev))
+            let opts = (defaultOptions Nothing)
                     { optHaddock = Haddock True
                     , optScenarioService = EnableScenarioService False
                     , optPackageDbs = [fst scriptPackageData]

--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -30,7 +30,6 @@ import Development.IDE.Core.API.Testing
 import Development.IDE.Core.Service.Daml(VirtualResource(..))
 
 import DA.Test.DamlcIntegration (ScriptPackageData, withDamlScriptDep)
-import DA.Daml.LF.Ast.Version (versionDefault)
 
 main :: IO ()
 main = SS.withScenarioService LF.versionDefault Logger.makeNopHandle scenarioConfig $ \scenarioService -> do
@@ -39,7 +38,7 @@ main = SS.withScenarioService LF.versionDefault Logger.makeNopHandle scenarioCon
   -- The startup of each scenario service is fairly expensive so instead of launching a separate
   -- service for each test, we launch a single service that is shared across all tests on the same LF version.
   
-  withDamlScriptDep versionDefault $ \scriptPackageData ->
+  withDamlScriptDep Nothing $ \scriptPackageData ->
     Tasty.deterministicMain $ ideTests (Just scenarioService) scriptPackageData
   where scenarioConfig = SS.defaultScenarioServiceConfig { SS.cnfJvmOptions = ["-Xmx200M"] }
 


### PR DESCRIPTION
Following notes in #16587
Just a small refactor to make the tests a little more resilient to a future default LF version change