### PR TITLE
allow disclosed contracts to be passed to create-and-exercise

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonEncoder.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonEncoder.scala
@@ -59,9 +59,10 @@ class DomainJsonEncoder(
       ev: JsonWriter[domain.CreateAndExerciseCommand[JsValue, JsValue, CtId, IfceId]]
   ): JsonError \/ JsValue =
     for {
-      payload <- apiRecordToJsObject(cmd.payload): JsonError \/ JsValue
-      argument <- apiValueToJsValue(cmd.argument)
-      y <- SprayJson.encode(cmd.copy(payload = payload, argument = argument)).liftErr(JsonError)
+      jsCmd <- cmd.traversePayloadsAndArgument(apiRecordToJsObject, apiValueToJsValue)
+      y <- SprayJson
+        .encode(jsCmd: domain.CreateAndExerciseCommand[JsValue, JsValue, CtId, IfceId])
+        .liftErr(JsonError)
 
     } yield y
 


### PR DESCRIPTION
Builds upon #16529 for #16623 by adding create-and-exercise support as well.

* [x] merge #16529 
* [x] rebase and change target to `main` after that merge