### PR TITLE
TESTONLY rls check ci 2023 03 30 a

### DIFF
--- a/ledger-service/fetch-contracts/BUILD.bazel
+++ b/ledger-service/fetch-contracts/BUILD.bazel
@@ -64,6 +64,7 @@ da_scala_test(
     scalacopts = hj_scalacopts,
     deps = [
         ":fetch-contracts",
+        "//ledger-api/grpc-definitions:ledger_api_proto_scala",
         "//ledger-service/db-backend",
         "//libs-scala/scalatest-utils",
         "@maven//:org_scalatest_scalatest_compatible",

--- a/ledger-service/fetch-contracts/src/test/scala/fetchcontracts/util/AcsTxStreamsTest.scala
+++ b/ledger-service/fetch-contracts/src/test/scala/fetchcontracts/util/AcsTxStreamsTest.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.fetchcontracts
+
+import com.daml.ledger.api.v1
+
+import org.scalatest.wordspec.AsyncWordSpec
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+class AcsTxStreamsTest extends AsyncWordSpec {
+  "foo" when {
+    "bar" should {
+      "baz" in {
+	val txEnd = v1.transaction.Transaction(offset = "84")
+	assert(txEnd == txEnd)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Triggering a CI against the base release 2.3.x to troubleshoot the problems we are seeing in 

https://dev.azure.com/digitalasset/daml/_build/results?buildId=138266&view=logs&j=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&t=ac0b0b0f-051f-52f7-8fb3-a7e384b0dde9

Those failures seem to be unrelated to anything in the PR itself, so testing running without those changes to verify.