### PR TITLE
fix small oversight in azure config

### DIFF
--- a/infra/ubuntu_azure.tf
+++ b/infra/ubuntu_azure.tf
@@ -3,7 +3,7 @@
 
 resource "azurerm_linux_virtual_machine_scale_set" "ubuntu" {
   count               = length(local.ubuntu.azure)
-  name                = "ubuntu"
+  name                = local.ubuntu.azure[count.index].name
   resource_group_name = azurerm_resource_group.daml-ci.name
   location            = azurerm_resource_group.daml-ci.location
   sku                 = "Standard_D4_v2"


### PR DESCRIPTION
We can't have multiple scale sets with the same name.