### PR TITLE
Move tests from sandbox to canton

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//bazel_tools:haskell.bzl", "da_haskell_binary", "da_haskell_library", "da_haskell_test")
-load("@os_info//:os_info.bzl", "is_windows")
+load("@os_info//:os_info.bzl", "is_darwin", "is_windows")
 load(":util.bzl", "damlc_compile_test")
 load("//rules_daml:daml.bzl", "daml_build_test", "daml_compile", "daml_compile_with_dalf", "daml_test")
 load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
@@ -648,7 +648,7 @@ da_haskell_test(
         "//daml-script/daml:daml-script.dar",
         "//test-common/test-certificates",
         "@canton//:lib",
-    ],
+    ] + ["@sysctl_nix//:bin/sysctl"] if is_darwin else [],
     hackage_deps = [
         "aeson",
         "base",
@@ -690,7 +690,7 @@ da_haskell_test(
         "//compiler/repl-service/server:repl_service_jar",
         "//daml-script/daml:daml-script.dar",
         "@canton//:lib",
-    ],
+    ] + ["@sysctl_nix//:bin/sysctl"] if is_darwin else [],
     hackage_deps = [
         "async",
         "base",
@@ -1008,7 +1008,7 @@ da_haskell_test(
         ":pkg-manager-test.dar",
         "//compiler/damlc",
         "@canton//:lib",
-    ],
+    ] + ["@sysctl_nix//:bin/sysctl"] if is_darwin else [],
     hackage_deps = [
         "base",
         "bytestring",

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -646,8 +646,8 @@ da_haskell_test(
         ":repl-test.dar",
         "//compiler/damlc",
         "//daml-script/daml:daml-script.dar",
-        "//ledger/sandbox-on-x:app",
         "//test-common/test-certificates",
+        "@canton//:lib",
     ],
     hackage_deps = [
         "aeson",
@@ -689,7 +689,7 @@ da_haskell_test(
         "//compiler/damlc/stable-packages",
         "//compiler/repl-service/server:repl_service_jar",
         "//daml-script/daml:daml-script.dar",
-        "//ledger/sandbox-on-x:app",
+        "@canton//:lib",
     ],
     hackage_deps = [
         "async",
@@ -1007,7 +1007,7 @@ da_haskell_test(
     data = [
         ":pkg-manager-test.dar",
         "//compiler/damlc",
-        "//ledger/sandbox-on-x:app",
+        "@canton//:lib",
     ],
     hackage_deps = [
         "base",

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -648,7 +648,7 @@ da_haskell_test(
         "//daml-script/daml:daml-script.dar",
         "//test-common/test-certificates",
         "@canton//:lib",
-    ] + ["@sysctl_nix//:bin/sysctl"] if is_darwin else [],
+    ] + (["@sysctl_nix//:bin/sysctl"] if is_darwin else []),
     hackage_deps = [
         "aeson",
         "base",
@@ -690,7 +690,7 @@ da_haskell_test(
         "//compiler/repl-service/server:repl_service_jar",
         "//daml-script/daml:daml-script.dar",
         "@canton//:lib",
-    ] + ["@sysctl_nix//:bin/sysctl"] if is_darwin else [],
+    ] + (["@sysctl_nix//:bin/sysctl"] if is_darwin else []),
     hackage_deps = [
         "async",
         "base",
@@ -1008,7 +1008,7 @@ da_haskell_test(
         ":pkg-manager-test.dar",
         "//compiler/damlc",
         "@canton//:lib",
-    ] + ["@sysctl_nix//:bin/sysctl"] if is_darwin else [],
+    ] + (["@sysctl_nix//:bin/sysctl"] if is_darwin else []),
     hackage_deps = [
         "base",
         "bytestring",

--- a/compiler/damlc/tests/src/DA/Test/Repl.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl.hs
@@ -117,7 +117,7 @@ testConnection damlc scriptDar ledgerPort mbTokenFile mbCaCrt = do
         [ "alice <- allocatePartyWithHint \"Alice\" (PartyIdHint \"Alice\")"
         , "debug alice"
         ]
-    let regexString = "^.*daml>.*: 'Alice[^\n]*\ndaml> Goodbye.\n$" :: String
+    let regexString = "^.*daml>.*: 'Alice::[a-f0-9]+'\ndaml> Goodbye.\n$" :: String
     let regex = makeRegexOpts defaultCompOpt { multiline = False } defaultExecOpt regexString
     unless (matchTest regex out) $
         assertFailure (show out <> " did not match " <> show regexString <> ".")

--- a/compiler/damlc/tests/src/DA/Test/Repl.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl.hs
@@ -40,19 +40,18 @@ main = do
     testDar <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "tests" </> "repl-test.dar")
     multiTestDar <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "tests" </> "repl-multi-test.dar")
     certDir <- locateRunfiles (mainWorkspace </> "test-common" </> "test-certificates")
-    defaultMain $ withSandbox defaultSandboxConf
+    defaultMain $ withCantonSandbox defaultSandboxConf
                   { dars = [testDar]
-                  , mbLedgerId = Just testLedgerId
                   , timeMode = Static
                   } $ \getSandboxPort ->
         testGroup "repl"
-            [ withSandbox defaultSandboxConf
+            [ withCantonSandbox defaultSandboxConf
                   { mbSharedSecret = Just testSecret
                   , mbLedgerId = Just testLedgerId
                   } $ \getSandboxPort ->
               withTokenFile $ \getTokenFile ->
               authTests damlc scriptDar getSandboxPort getTokenFile
-            , withSandbox defaultSandboxConf
+            , withCantonSandbox defaultSandboxConf
                   { enableTls = True
                   , mbClientAuth = Just None
                   } $ \getSandboxPort ->
@@ -118,7 +117,7 @@ testConnection damlc scriptDar ledgerPort mbTokenFile mbCaCrt = do
         [ "alice <- allocatePartyWithHint \"Alice\" (PartyIdHint \"Alice\")"
         , "debug alice"
         ]
-    let regexString = "^.*daml>.*: 'Alice'\ndaml> Goodbye.\n$" :: String
+    let regexString = "^.*daml>.*: 'Alice[^\n]*\ndaml> Goodbye.\n$" :: String
     let regex = makeRegexOpts defaultCompOpt { multiline = False } defaultExecOpt regexString
     unless (matchTest regex out) $
         assertFailure (show out <> " did not match " <> show regexString <> ".")

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -276,18 +276,18 @@ functionalTests replClient replLogger serviceOut options ideState = describe "re
           , input "bob <- allocatePartyWithHint \"Bob\" (PartyIdHint \"bob\")"
           , input "proposal <- pure (T alice bob)"
           , input "debug proposal.proposer"
-          , matchServiceOutput "'alice:"
+          , matchServiceOutput "'alice::[a-f0-9]+'"
           , input "debug proposal.accepter"
-          , matchServiceOutput "'bob:"
+          , matchServiceOutput "'bob::[a-f0-9]+'"
           ]
     , testInteraction' "symbols from different DARs"
           [ input "party <- allocatePartyWithHint \"Party\" (PartyIdHint \"two_dars_party\")"
           , input "proposal <- pure (T party party)"
           , input "debug proposal"
-          , matchServiceOutput "^.*: T {proposer = 'two_dars_party[^']*', accepter = 'two_dars_party[^']*'}"
+          , matchServiceOutput "^.*: T {proposer = 'two_dars_party::[a-f0-9]+', accepter = 'two_dars_party::[a-f0-9]+'}"
           , input "t2 <- pure (T2 party)"
           , input "debug t2"
-          , matchServiceOutput "^.*: T2 {owner = 'two_dars_party[^']*'}"
+          , matchServiceOutput "^.*: T2 {owner = 'two_dars_party::[a-f0-9]+'}"
           ]
     , testInteraction' "repl output"
           [ input "pure ()" -- no output

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -64,10 +64,8 @@ main = do
     -- allocate the resources before handing over to tasty and accept that
     -- it will spin up sandbox and the repl client.
     withTempDir $ \tmpDir ->
-        let portFile = tmpDir </> "sandbox-portfile"
-        in
         withBinaryFile nullDevice WriteMode $ \devNull ->
-        bracket (createSandbox portFile devNull defaultSandboxConf { dars = testDars }) destroySandbox $ \SandboxResource{sandboxPort} ->
+        bracket (createCantonSandbox tmpDir devNull defaultSandboxConf { dars = testDars }) destroySandbox $ \SandboxResource{sandboxPort} ->
         ReplClient.withReplClient (ReplClient.Options replJar (Just ("localhost", show sandboxPort)) Nothing Nothing Nothing Nothing ReplClient.ReplWallClock CreatePipe) $ \replHandle ->
         -- TODO We could share some of this setup with the actual repl code in damlc.
         withTempDir $ \dir ->
@@ -199,7 +197,7 @@ functionalTests replClient replLogger serviceOut options ideState = describe "re
     , testInteraction' "server error"
           [ input "alice <- allocatePartyWithHint \"Alice\" (PartyIdHint \"alice_doubly_allocated\")"
           , input "alice <- allocatePartyWithHint \"Alice\" (PartyIdHint \"alice_doubly_allocated\")"
-          , matchOutput "^.*INVALID_ARGUMENT\\(8,alice_do\\): The submitted command has invalid arguments: Party already exists$"
+          , matchOutput "^.*INVALID_ARGUMENT\\(8,alice_do\\): The submitted command has invalid arguments: Party already exists.*$"
           , input "debug 1"
           , matchServiceOutput "^.*: 1"
           ]
@@ -278,18 +276,18 @@ functionalTests replClient replLogger serviceOut options ideState = describe "re
           , input "bob <- allocatePartyWithHint \"Bob\" (PartyIdHint \"bob\")"
           , input "proposal <- pure (T alice bob)"
           , input "debug proposal.proposer"
-          , matchServiceOutput "'alice'"
+          , matchServiceOutput "'alice:"
           , input "debug proposal.accepter"
-          , matchServiceOutput "'bob'"
+          , matchServiceOutput "'bob:"
           ]
     , testInteraction' "symbols from different DARs"
           [ input "party <- allocatePartyWithHint \"Party\" (PartyIdHint \"two_dars_party\")"
           , input "proposal <- pure (T party party)"
           , input "debug proposal"
-          , matchServiceOutput "^.*: T {proposer = 'two_dars_party', accepter = 'two_dars_party'}"
+          , matchServiceOutput "^.*: T {proposer = 'two_dars_party[^']*', accepter = 'two_dars_party[^']*'}"
           , input "t2 <- pure (T2 party)"
           , input "debug t2"
-          , matchServiceOutput "^.*: T2 {owner = 'two_dars_party'}"
+          , matchServiceOutput "^.*: T2 {owner = 'two_dars_party[^']*'}"
           ]
     , testInteraction' "repl output"
           [ input "pure ()" -- no output

--- a/compiler/damlc/tests/src/DamlcPkgManager.hs
+++ b/compiler/damlc/tests/src/DamlcPkgManager.hs
@@ -42,7 +42,7 @@ tests damlc dar =
 testsForRemoteDataDependencies :: FilePath -> FilePath -> TestTree
 testsForRemoteDataDependencies damlc dar =
     testGroup "Remote dependencies"
-    [ withSandbox defaultSandboxConf {dars = [dar]} $ \getSandboxPort -> do
+    [ withCantonSandbox defaultSandboxConf {dars = [dar]} $ \getSandboxPort -> do
           testGroup
               "un-authenticated"
               [ testCase "Package id data-dependency" $
@@ -156,7 +156,7 @@ testsForRemoteDataDependencies damlc dar =
                   -- only the main package needs to be downloaded, while the direct dependencies are
                   -- already present.
               ]
-    , withSandbox defaultSandboxConf {mbSharedSecret = Just "secret", dars = [dar]} $ \getSandboxPort
+    , withCantonSandbox defaultSandboxConf {mbSharedSecret = Just "secret", dars = [dar]} $ \getSandboxPort
     -- run the sandbox with authentication to check that we can access it given an authentication
     -- token.
        -> do

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -28,6 +28,7 @@ module DA.Daml.Helper.Util
   , SandboxPorts(..)
   , defaultSandboxPorts
   , CantonOptions(..)
+  , decodeCantonPort
   , decodeCantonSandboxPort
   , CantonReplApi(..)
   , CantonReplParticipant(..)
@@ -339,11 +340,14 @@ cantonConfig CantonOptions{..} =
     port p = Aeson.object [ "port" Aeson..= p ]
     storage = "storage" Aeson..= Aeson.object [ "type" Aeson..= ("memory" :: T.Text) ]
 
-decodeCantonSandboxPort :: String -> Maybe Int
-decodeCantonSandboxPort json = do
+decodeCantonPort :: String -> String -> Maybe Int
+decodeCantonPort participantName json = do
     participants :: Map.Map String (Map.Map String Int) <- Aeson.decode (BSL8.pack json)
-    ports <- Map.lookup "sandbox" participants
+    ports <- Map.lookup participantName participants
     Map.lookup "ledgerApi" ports
+
+decodeCantonSandboxPort :: String -> Maybe Int
+decodeCantonSandboxPort = decodeCantonPort "sandbox"
 
 data CantonReplApi = CantonReplApi
     { craHost :: String

--- a/libs-haskell/test-utils/BUILD.bazel
+++ b/libs-haskell/test-utils/BUILD.bazel
@@ -23,6 +23,8 @@ da_haskell_library(
         "network",
         "process",
         "QuickCheck",
+        "regex-tdfa",
+        "safe",
         "safe-exceptions",
         "tasty",
         "tasty-hunit",

--- a/libs-haskell/test-utils/BUILD.bazel
+++ b/libs-haskell/test-utils/BUILD.bazel
@@ -3,8 +3,8 @@
 
 load(
     "//bazel_tools:haskell.bzl",
-    "da_haskell_library",
     "da_haskell_binary",
+    "da_haskell_library",
 )
 
 da_haskell_library(

--- a/libs-haskell/test-utils/BUILD.bazel
+++ b/libs-haskell/test-utils/BUILD.bazel
@@ -4,6 +4,7 @@
 load(
     "//bazel_tools:haskell.bzl",
     "da_haskell_library",
+    "da_haskell_binary",
 )
 
 da_haskell_library(
@@ -16,10 +17,12 @@ da_haskell_library(
         "containers",
         "directory",
         "extra",
+        "filelock",
         "filepath",
         "jwt",
         "network",
         "process",
+        "QuickCheck",
         "safe-exceptions",
         "tasty",
         "tasty-hunit",

--- a/libs-haskell/test-utils/BUILD.bazel
+++ b/libs-haskell/test-utils/BUILD.bazel
@@ -40,5 +40,6 @@ da_haskell_library(
         "//language-support/hs/bindings:hs-ledger",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
+        "@rules_haskell//tools/runfiles",
     ],
 )

--- a/libs-haskell/test-utils/BUILD.bazel
+++ b/libs-haskell/test-utils/BUILD.bazel
@@ -3,7 +3,6 @@
 
 load(
     "//bazel_tools:haskell.bzl",
-    "da_haskell_binary",
     "da_haskell_library",
 )
 

--- a/libs-haskell/test-utils/DA/Test/FreePort.hs
+++ b/libs-haskell/test-utils/DA/Test/FreePort.hs
@@ -1,0 +1,41 @@
+module DA.Test.FreePort (withAvailablePort) where
+
+import Control.Exception (bracket, throwIO)
+import DA.Test.FreePort.Error
+import DA.Test.FreePort.PortGen
+import DA.Test.FreePort.PortLock
+import Data.Either (isRight)
+import Data.Foldable.Extra (firstJustM)
+import UnliftIO.Exception (tryIO)
+import Test.QuickCheck
+
+import Network.Socket
+
+maxAttempts :: Int
+maxAttempts = 100
+
+withAvailablePort :: (Int -> IO a) -> IO a
+withAvailablePort k = do
+  portGen <- getPortGen
+  ports <- generate $ vectorOf maxAttempts portGen
+  mRes <- firstJustM (tryPort k) ports
+  maybe (throwIO NoPortsAvailableError) pure mRes
+
+tryPort :: (Int -> IO a) -> Int -> IO (Maybe a)
+tryPort k port = do
+  available <- portAvailable port
+  if available
+    then withPortLock port (k port)
+    else pure Nothing
+
+portAvailable :: Int -> IO Bool
+portAvailable port = do
+  let hints = defaultHints { addrFlags = [AI_NUMERICHOST, AI_NUMERICSERV], addrSocketType = Stream }
+      checkConnection addr =
+        bracket
+          (socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr))
+          close
+          (\s -> bind s (addrAddress addr))
+
+  addr : _ <- getAddrInfo (Just hints) (Just "127.0.0.1") (Just $ show port)
+  isRight <$> tryIO (checkConnection addr)

--- a/libs-haskell/test-utils/DA/Test/FreePort/Error.hs
+++ b/libs-haskell/test-utils/DA/Test/FreePort/Error.hs
@@ -9,6 +9,7 @@ import Type.Reflection (Typeable)
 data FreePortError
   = DynamicRangeFileReadError IOError
   | DynamicRangeInvalidFormatError String
+  | DynamicRangeShellFailure IOError
   | NoPortsAvailableError
   deriving (Show, Typeable)
 instance Exception FreePortError

--- a/libs-haskell/test-utils/DA/Test/FreePort/Error.hs
+++ b/libs-haskell/test-utils/DA/Test/FreePort/Error.hs
@@ -1,0 +1,11 @@
+module DA.Test.FreePort.Error where
+
+import Control.Exception (Exception)
+import Type.Reflection (Typeable)
+
+data FreePortError
+  = DynamicRangeFileReadError IOError
+  | DynamicRangeInvalidFormatError String
+  | NoPortsAvailableError
+  deriving (Show, Typeable)
+instance Exception FreePortError

--- a/libs-haskell/test-utils/DA/Test/FreePort/Error.hs
+++ b/libs-haskell/test-utils/DA/Test/FreePort/Error.hs
@@ -1,4 +1,7 @@
-module DA.Test.FreePort.Error where
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DA.Test.FreePort.Error (FreePortError (..)) where
 
 import Control.Exception (Exception)
 import Type.Reflection (Typeable)
@@ -9,3 +12,4 @@ data FreePortError
   | NoPortsAvailableError
   deriving (Show, Typeable)
 instance Exception FreePortError
+

--- a/libs-haskell/test-utils/DA/Test/FreePort/OS.hs
+++ b/libs-haskell/test-utils/DA/Test/FreePort/OS.hs
@@ -5,7 +5,7 @@
 
 module DA.Test.FreePort.OS (OS (..), os) where
 
-import System.Info.Extra
+import System.Info.Extra (isWindows, isMac)
 
 data OS
   = Windows

--- a/libs-haskell/test-utils/DA/Test/FreePort/OS.hs
+++ b/libs-haskell/test-utils/DA/Test/FreePort/OS.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE MultiWayIf #-}
+
+module DA.Test.FreePort.OS where
+
+import System.Info.Extra
+
+data OS
+  = Windows
+  | Linux
+  | MacOS
+
+-- TODO: Linux being a catchall is risky, consider alternate check
+os :: OS
+os = if
+  | isWindows -> Windows
+  | isMac -> MacOS
+  | otherwise -> Linux

--- a/libs-haskell/test-utils/DA/Test/FreePort/OS.hs
+++ b/libs-haskell/test-utils/DA/Test/FreePort/OS.hs
@@ -1,6 +1,9 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 {-# LANGUAGE MultiWayIf #-}
 
-module DA.Test.FreePort.OS where
+module DA.Test.FreePort.OS (OS (..), os) where
 
 import System.Info.Extra
 
@@ -15,3 +18,4 @@ os = if
   | isWindows -> Windows
   | isMac -> MacOS
   | otherwise -> Linux
+

--- a/libs-haskell/test-utils/DA/Test/FreePort/PortGen.hs
+++ b/libs-haskell/test-utils/DA/Test/FreePort/PortGen.hs
@@ -6,10 +6,11 @@ module DA.Test.FreePort.PortGen (getPortGen) where
 {- HLINT ignore "locateRunfiles/package_app" -}
 
 import Control.Exception (mapException, throwIO)
-import DA.Bazel.Runfiles
+import DA.Bazel.Runfiles (locateRunfiles, mainWorkspace)
 import DA.Test.FreePort.Error (FreePortError (..))
 import DA.Test.FreePort.OS (os, OS (..))
 import Safe (tailMay)
+import System.FilePath ((</>))
 import System.Process (readProcess)
 import Test.QuickCheck(Gen, chooseInt)
 import Text.Read (readMaybe)
@@ -71,7 +72,7 @@ getWindowsDynamicPortRange = do
 
 getMacOSDynamicPortRange :: IO DynamicPortRange
 getMacOSDynamicPortRange = do
-  sysctl <- locateRunfiles "external/sysctl_nix/bin/sysctl"
+  sysctl <- locateRunfiles $ mainWorkspace </> "external" </> "sysctl_nix" </> "bin" </> "sysctl"
   portData <- mapException DynamicRangeShellFailure $ readProcess sysctl
     [ "net.inet.ip.portrange.first"
     , "net.inet.ip.portrange.last"

--- a/libs-haskell/test-utils/DA/Test/FreePort/PortGen.hs
+++ b/libs-haskell/test-utils/DA/Test/FreePort/PortGen.hs
@@ -6,10 +6,11 @@ module DA.Test.FreePort.PortGen (getPortGen) where
 import Control.Exception (mapException, throwIO)
 import DA.Test.FreePort.Error (FreePortError (..))
 import DA.Test.FreePort.OS (os, OS (..))
+import Safe (tailMay)
+import System.Process (readProcess)
 import Test.QuickCheck(Gen, chooseInt)
 import Text.Read (readMaybe)
 import Text.Regex.TDFA
-import Safe (tailMay)
 
 newtype PortRange = PortRange (Int, Int) deriving Show -- The main port range
 newtype DynamicPortRange = DynamicPortRange (Int, Int) deriving Show -- Port range to exclude from main port range

--- a/libs-haskell/test-utils/DA/Test/FreePort/PortGen.hs
+++ b/libs-haskell/test-utils/DA/Test/FreePort/PortGen.hs
@@ -3,6 +3,8 @@
 
 module DA.Test.FreePort.PortGen (getPortGen) where
 
+{- HLINT ignore "locateRunfiles/package_app" -}
+
 import Control.Exception (mapException, throwIO)
 import DA.Bazel.Runfiles
 import DA.Test.FreePort.Error (FreePortError (..))
@@ -12,7 +14,6 @@ import System.Process (readProcess)
 import Test.QuickCheck(Gen, chooseInt)
 import Text.Read (readMaybe)
 import Text.Regex.TDFA
-
 
 newtype PortRange = PortRange (Int, Int) deriving Show -- The main port range
 newtype DynamicPortRange = DynamicPortRange (Int, Int) deriving Show -- Port range to exclude from main port range

--- a/libs-haskell/test-utils/DA/Test/FreePort/PortGen.hs
+++ b/libs-haskell/test-utils/DA/Test/FreePort/PortGen.hs
@@ -1,0 +1,59 @@
+module DA.Test.FreePort.PortGen (getPortGen) where
+
+import Control.Exception (mapException, throwIO)
+import DA.Test.FreePort.Error (FreePortError (..))
+import DA.Test.FreePort.OS (os, OS (..))
+import Test.QuickCheck(Gen, chooseInt)
+import Text.Read (readMaybe)
+
+newtype PortRange = PortRange (Int, Int) -- The main port range
+newtype DynamicPortRange = DynamicPortRange (Int, Int) -- Port range to exclude from main port range
+
+defPortRange :: PortRange
+defPortRange = PortRange (1024, 65536)
+
+-- | Clamps an integer within a given min max range
+clampInt :: Int -> Int -> Int -> Int
+clampInt minVal maxVal = min maxVal . max minVal
+
+portGen :: PortRange -> DynamicPortRange -> Gen Int
+portGen (PortRange (minPort, maxPort)) (DynamicPortRange (minExclPort, maxExclPort)) = do
+  -- Exclude the dynamic port range (cropped to within the valid port range).
+  -- E.g. 32768 60999 on most Linux systems.
+
+  let -- Clamp the dyn range into the main port range
+      minExcl = clampInt minPort maxPort minExclPort
+      maxExcl = clampInt minPort maxPort maxExclPort
+
+      -- Get count of ports before and after the excluded port range (where excluded is inclusive)
+      numLowerPorts = minExcl - minPort
+      numUpperPorts = maxPort - maxExcl
+      numAvailablePorts = numLowerPorts + numUpperPorts
+
+  n <- chooseInt (0, numAvailablePorts - 1)
+  pure $ if n < numLowerPorts
+    then n + minPort
+    else n - numLowerPorts + maxExcl + 1
+
+getPortGen :: IO (Gen Int)
+getPortGen = portGen defPortRange <$> getDynamicPortRange
+
+getDynamicPortRange :: IO DynamicPortRange
+getDynamicPortRange = case os of
+  Windows -> getWindowsDynamicPortRange
+  Linux -> getLinuxDynamicPortRange
+  MacOS -> getMacOSDynamicPortRange
+
+getLinuxDynamicPortRange :: IO DynamicPortRange
+getLinuxDynamicPortRange = do
+  rangeStr <- mapException DynamicRangeFileReadError $ readFile "/proc/sys/net/ipv4/ip_local_port_range"
+  let ports = traverse readMaybe $ words rangeStr
+  case ports of
+    Just [min, max] -> pure $ DynamicPortRange (min, max)
+    _ -> throwIO $ DynamicRangeInvalidFormatError $ "Expected 2 ports, got " <> rangeStr
+
+getWindowsDynamicPortRange :: IO DynamicPortRange
+getWindowsDynamicPortRange = undefined -- TODO
+
+getMacOSDynamicPortRange :: IO DynamicPortRange
+getMacOSDynamicPortRange = undefined -- TODO

--- a/libs-haskell/test-utils/DA/Test/FreePort/PortGen.hs
+++ b/libs-haskell/test-utils/DA/Test/FreePort/PortGen.hs
@@ -1,3 +1,6 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module DA.Test.FreePort.PortGen (getPortGen) where
 
 import Control.Exception (mapException, throwIO)
@@ -57,3 +60,4 @@ getWindowsDynamicPortRange = undefined -- TODO
 
 getMacOSDynamicPortRange :: IO DynamicPortRange
 getMacOSDynamicPortRange = undefined -- TODO
+

--- a/libs-haskell/test-utils/DA/Test/FreePort/PortGen.hs
+++ b/libs-haskell/test-utils/DA/Test/FreePort/PortGen.hs
@@ -4,6 +4,7 @@
 module DA.Test.FreePort.PortGen (getPortGen) where
 
 import Control.Exception (mapException, throwIO)
+import DA.Bazel.Runfiles
 import DA.Test.FreePort.Error (FreePortError (..))
 import DA.Test.FreePort.OS (os, OS (..))
 import Safe (tailMay)
@@ -12,7 +13,6 @@ import Test.QuickCheck(Gen, chooseInt)
 import Text.Read (readMaybe)
 import Text.Regex.TDFA
 
-import qualified Bazel.Runfiles
 
 newtype PortRange = PortRange (Int, Int) deriving Show -- The main port range
 newtype DynamicPortRange = DynamicPortRange (Int, Int) deriving Show -- Port range to exclude from main port range
@@ -70,8 +70,7 @@ getWindowsDynamicPortRange = do
 
 getMacOSDynamicPortRange :: IO DynamicPortRange
 getMacOSDynamicPortRange = do
-  runFiles <- Bazel.Runfiles.create
-  let sysctl = Bazel.Runfiles.rlocation runFiles "external/sysctl_nix/bin/sysctl"
+  sysctl <- locateRunfiles "external/sysctl_nix/bin/sysctl"
   portData <- mapException DynamicRangeShellFailure $ readProcess sysctl
     [ "net.inet.ip.portrange.first"
     , "net.inet.ip.portrange.last"

--- a/libs-haskell/test-utils/DA/Test/FreePort/PortLock.hs
+++ b/libs-haskell/test-utils/DA/Test/FreePort/PortLock.hs
@@ -1,0 +1,23 @@
+module DA.Test.FreePort.PortLock (withPortLock) where
+
+import DA.Test.FreePort.OS (os, OS (Windows))
+import System.Directory (getHomeDirectory, createDirectoryIfMissing)
+import System.FileLock (withTryFileLock, SharedExclusive (Exclusive))
+import System.FilePath ((</>))
+
+-- This should try to create a port lock file and run your comp if it works
+-- Should use a determinsitic path (for windows or unix based)
+withPortLock :: Int -> IO a -> IO (Maybe a)
+withPortLock p k = do
+  tmpDir <- getTmpDir
+  createDirectoryIfMissing True tmpDir
+  withTryFileLock (tmpDir </> show p) Exclusive (const k)
+
+getTmpDir :: IO FilePath
+getTmpDir = do
+  tmpDir <- case os of
+    Windows -> do
+      home <- getHomeDirectory
+      pure $ home </> "Appdata" </> "Local" </> "Temp"
+    _ -> pure "/tmp"
+  pure $ tmpDir </> "daml" </> "build" </> "postgresql-testing" </> "ports"

--- a/libs-haskell/test-utils/DA/Test/FreePort/PortLock.hs
+++ b/libs-haskell/test-utils/DA/Test/FreePort/PortLock.hs
@@ -1,17 +1,18 @@
-module DA.Test.FreePort.PortLock (withPortLock) where
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DA.Test.FreePort.PortLock (lockPort) where
 
 import DA.Test.FreePort.OS (os, OS (Windows))
 import System.Directory (getHomeDirectory, createDirectoryIfMissing)
-import System.FileLock (withTryFileLock, SharedExclusive (Exclusive))
+import System.FileLock (tryLockFile, FileLock, SharedExclusive (Exclusive))
 import System.FilePath ((</>))
 
--- This should try to create a port lock file and run your comp if it works
--- Should use a determinsitic path (for windows or unix based)
-withPortLock :: Int -> IO a -> IO (Maybe a)
-withPortLock p k = do
+lockPort :: Int -> IO (Maybe FileLock)
+lockPort p = do
   tmpDir <- getTmpDir
   createDirectoryIfMissing True tmpDir
-  withTryFileLock (tmpDir </> show p) Exclusive (const k)
+  tryLockFile (tmpDir </> show p) Exclusive
 
 getTmpDir :: IO FilePath
 getTmpDir = do
@@ -21,3 +22,4 @@ getTmpDir = do
       pure $ home </> "Appdata" </> "Local" </> "Temp"
     _ -> pure "/tmp"
   pure $ tmpDir </> "daml" </> "build" </> "postgresql-testing" </> "ports"
+

--- a/libs-haskell/test-utils/DA/Test/Sandbox.hs
+++ b/libs-haskell/test-utils/DA/Test/Sandbox.hs
@@ -9,7 +9,9 @@ module DA.Test.Sandbox
     , TimeMode(..)
     , defaultSandboxConf
     , withSandbox
+    , withCantonSandbox
     , createSandbox
+    , createCantonSandbox
     , destroySandbox
     , makeSignedJwt
     ) where
@@ -17,18 +19,26 @@ module DA.Test.Sandbox
 {- HLINT ignore "locateRunfiles/package_app" -}
 
 import Control.Exception
+import Control.Monad (replicateM)
+import Control.Monad.Extra (whenMaybe)
 import DA.Bazel.Runfiles
 import DA.Daml.Helper.Ledger
+import DA.Daml.Helper.Util (decodeCantonPort)
 import Data.Foldable
 import qualified DA.Ledger as L
 import DA.PortFile
+import qualified DA.Test.FreePort as FreePort
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as AesonKey
+import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Map as Map
 import qualified Data.Text as T
 import qualified Data.Vector as Vector
 import qualified Data.Maybe as Maybe
+import System.Environment (getEnv)
 import System.FilePath
 import System.IO.Extra
+import System.Info.Extra (isWindows)
 import System.Process
 import Test.Tasty
 import qualified Web.JWT as JWT
@@ -38,9 +48,20 @@ data ClientAuth
     | Optional
     | Require
 
+instance Show ClientAuth where
+    show None = "none"
+    show Optional = "optional"
+    show Require = "require"
+
 data TimeMode
     = WallClock
     | Static
+
+data Certs = Certs
+    { trustedRootCrt :: FilePath
+    , serverCrt :: FilePath
+    , serverPem :: FilePath
+    }
 
 data SandboxConfig = SandboxConfig
     { enableTls :: Bool
@@ -61,16 +82,25 @@ defaultSandboxConf = SandboxConfig
     , mbLedgerId = Just "MyLedger"
     }
 
+getCerts :: IO Certs
+getCerts = do
+    certDir <- locateRunfiles (mainWorkspace </> "test-common" </> "test-certificates")
+    pure Certs
+        { trustedRootCrt = certDir </> "ca.crt"
+        , serverCrt = certDir </> "server.crt"
+        , serverPem = certDir </> "server.pem"
+        }
+
 getSandboxProc :: SandboxConfig -> FilePath -> IO CreateProcess
 getSandboxProc SandboxConfig{..} portFile = do
     sandbox <- locateRunfiles (mainWorkspace </> "ledger" </> "sandbox-on-x" </> exe "app")
     tlsArgs <- if enableTls
         then do
-            certDir <- locateRunfiles (mainWorkspace </> "test-common" </> "test-certificates")
+            certs <- getCerts
             pure
-                [ "--cacrt", certDir </> "ca.crt"
-                , "--pem", certDir </> "server.pem"
-                , "--crt", certDir </> "server.crt"
+                [ "--cacrt", trustedRootCrt certs
+                , "--pem", serverPem certs
+                , "--crt", serverCrt certs
                 ]
         else pure []
     pure $ proc sandbox $ concat
@@ -78,20 +108,17 @@ getSandboxProc SandboxConfig{..} portFile = do
         , [ "--participant=participant-id=sandbox-participant,port=0,port-file=" <> portFile ]
         , tlsArgs
         , Maybe.maybeToList timeArg
-        , [ "--client-auth=" <> clientAuthArg auth | Just auth <- [mbClientAuth] ]
+        , [ "--client-auth=" <> show auth | Just auth <- [mbClientAuth] ]
         , [ "--auth-jwt-hs256-unsafe=" <> secret | Just secret <- [mbSharedSecret] ]
         , [ "--ledger-id=" <> ledgerId | Just ledgerId <- [mbLedgerId] ]
         ]
   where timeArg = case timeMode of
             WallClock -> Nothing
             Static ->  Just "--static-time"
-        clientAuthArg auth = case auth of
-            None ->  "none"
-            Optional -> "optional"
-            Require -> "require"
 
 createSandbox :: FilePath -> Handle -> SandboxConfig -> IO SandboxResource
-createSandbox portFile sandboxOutput conf@SandboxConfig{..} = do
+createSandbox portFileDir sandboxOutput conf@SandboxConfig{..} = do
+    let portFile = portFileDir </> "sandbox-portfile"
     sandboxProc <- getSandboxProc conf portFile
     mask $ \unmask -> do
         ph@(_,_,_,ph') <- createProcess sandboxProc { std_out = UseHandle sandboxOutput }
@@ -101,25 +128,30 @@ createSandbox portFile sandboxOutput conf@SandboxConfig{..} = do
                     let args = (defaultLedgerArgs Grpc) { port = port, tokM = fmap (\s -> L.Token $ makeSignedJwt s []) mbSharedSecret }
                     runLedgerUploadDar' args (Just darPath)
 
-                pure (SandboxResource ph port)
+                pure (SandboxResource ph port [])
         unmask (waitForStart `onException` cleanupProcess ph)
 
-withSandbox :: SandboxConfig -> (IO Int -> TestTree) -> TestTree
-withSandbox conf f =
+withGeneralSandbox :: (FilePath -> Handle -> SandboxConfig -> IO SandboxResource) -> SandboxConfig -> (IO Int -> TestTree) -> TestTree
+withGeneralSandbox create conf f =
     withResource newTempDir snd $ \getTmpDir ->
         let createSandbox' = do
                 (tempDir, _) <- getTmpDir
-                let portFile = tempDir </> "sandbox-portfile"
-                createSandbox portFile stdout conf
+                create tempDir stdout conf
         in withResource createSandbox' destroySandbox (f . fmap sandboxPort)
+
+withSandbox :: SandboxConfig -> (IO Int -> TestTree) -> TestTree
+withSandbox = withGeneralSandbox createSandbox
 
 data SandboxResource = SandboxResource
     { sandboxProcess :: (Maybe Handle, Maybe Handle, Maybe Handle, ProcessHandle)
     , sandboxPort :: Int
+    , sandboxPortLocks :: [FreePort.LockedPort]
     }
 
 destroySandbox :: SandboxResource -> IO ()
-destroySandbox = cleanupProcess . sandboxProcess
+destroySandbox SandboxResource {..} = do
+  cleanupProcess sandboxProcess
+  traverse_ FreePort.unlock sandboxPortLocks
 
 makeSignedJwt :: String -> [String] -> String
 makeSignedJwt sharedSecret actAs = do
@@ -133,3 +165,112 @@ makeSignedJwt sharedSecret actAs = do
     let key = JWT.hmacSecret $ T.pack sharedSecret
     let text = JWT.encodeSigned key mempty cs
     T.unpack text
+
+withCantonSandbox :: SandboxConfig -> (IO Int -> TestTree) -> TestTree
+withCantonSandbox = withGeneralSandbox createCantonSandbox
+
+getParticipantName :: SandboxConfig -> String
+getParticipantName = Maybe.fromMaybe "participant" . mbLedgerId
+
+createCantonSandbox :: FilePath -> Handle -> SandboxConfig -> IO SandboxResource
+createCantonSandbox dir sandboxOutput conf = do
+    lockedPorts <- replicateM 4 FreePort.getAvailablePort
+    [ledgerPort, adminPort, domainPublicPort, domainAdminPort] <- pure $ FreePort.port <$> lockedPorts
+    mCerts <- whenMaybe (enableTls conf) getCerts
+    let portFile = dir </> "sandbox-portfile"
+        configStr = getCantonConfig conf portFile mCerts (ledgerPort, adminPort, domainPublicPort, domainAdminPort)
+        configPath = dir </> "canton-config.conf"
+        bootstrapStr = getCantonBootstrap conf portFile
+        bootstrapPath = dir </> "canton-bootstrap.canton"
+    BSL.writeFile configPath configStr
+    writeFile bootstrapPath bootstrapStr
+    cantonSandboxProc <- getCantonSandboxProc configPath bootstrapPath
+
+    mask $ \unmask -> do
+        ph@(_,_,_,ph') <- createProcess cantonSandboxProc { std_out = UseHandle sandboxOutput }
+        let waitForStart = do
+                port <- readPortFileWith (decodeCantonPort $ getParticipantName conf) ph' maxRetries (portFile <> "-bootstrapped")
+                pure (SandboxResource ph port lockedPorts)
+        unmask (waitForStart `onException` cleanupProcess ph)
+
+getCantonBootstrap :: SandboxConfig -> FilePath -> String
+getCantonBootstrap conf portFile = unlines $ (upload <$> dars conf) <> [cpPortFile]
+  where
+    upload dar = "participants.all.dars.upload(" <> show dar <> ")"
+    -- We copy out the port file after bootstrap is finished to get a true setup marker
+    -- As the normal portfile is created before the bootstrap command is run
+    cpPortFile = "os.copy(os.Path(" <> show portFile <> "), os.Path(" <> show (portFile <> "-bootstrapped") <> "))"
+
+getCantonConfig :: SandboxConfig -> FilePath -> Maybe Certs -> (Int, Int, Int, Int) -> BSL.ByteString
+getCantonConfig conf@SandboxConfig{..} portFile mCerts (ledgerPort, adminPort, domainPublicPort, domainAdminPort) =
+    Aeson.encode $ Aeson.object
+        [ "canton" Aeson..= Aeson.object
+            [ "parameters" Aeson..= Aeson.object ( concat
+                [ [ "ports-file" Aeson..= portFile ]
+                , [ "clock" Aeson..= Aeson.object
+                        [ "type" Aeson..= ("sim-clock" :: T.Text) ]
+                  | Static <- [timeMode] ]
+                ] )
+            , "participants" Aeson..= Aeson.object
+                [ (AesonKey.fromString $ getParticipantName conf) Aeson..= Aeson.object
+                    (
+                     [ storage
+                     , "admin-api" Aeson..= port adminPort
+                     , "ledger-api" Aeson..= Aeson.object (
+                          [ "port" Aeson..= ledgerPort
+                          ] <>
+                          [ tlsOpts certs
+                          | Just certs <- [mCerts]
+                          ] <>
+                          [ "auth-services" Aeson..= aesonArray [ Aeson.object 
+                                [ "type" Aeson..= ("unsafe-jwt-hmac-256" :: T.Text)
+                                , "secret" Aeson..= secret
+                                ] ]
+                          | Just secret <- [mbSharedSecret] ]
+                          )
+                     ] <>
+                     [ "testing-time" Aeson..= Aeson.object [ "type" Aeson..= ("monotonic-time" :: T.Text) ]
+                     | Static <- [timeMode]
+                     ]
+                    )
+                ]
+            , "domains" Aeson..= Aeson.object
+                [ "domain" Aeson..= Aeson.object
+                     [ storage
+                     , "public-api" Aeson..= port domainPublicPort
+                     , "admin-api" Aeson..= port domainAdminPort
+                     ]
+                ]
+            ]
+        ]
+  where
+    storage = "storage" Aeson..= Aeson.object [ "type" Aeson..= ("memory" :: T.Text) ]
+    port p = Aeson.object [ "port" Aeson..= p ]
+    tlsOpts certs =
+        "tls" Aeson..= Aeson.object (
+            [ "cert-chain-file" Aeson..= serverCrt certs
+            , "private-key-file" Aeson..= serverPem certs
+            , "trust-collection-file" Aeson..= trustedRootCrt certs
+            ] <>
+            [ "client-auth" Aeson..= Aeson.object ["type" Aeson..= show auth]
+            | Just auth <- [mbClientAuth]
+            ] )
+    aesonArray = Aeson.Array . Vector.fromList
+
+getCantonSandboxProc :: FilePath -> FilePath -> IO CreateProcess
+getCantonSandboxProc configPath bootstrapPath = do
+    canton <- locateRunfiles $ mainWorkspace </> "external" </> "canton" </> "lib" </> "canton-open-source-2.7.0-SNAPSHOT.jar"
+    java <- getJava
+    pure $ proc java $ concat
+      [ ["-jar", canton]
+      , ["daemon"]
+      , ["-c", configPath]
+      , ["--bootstrap", bootstrapPath]
+      , ["--auto-connect-local"]
+      ]
+
+getJava :: IO FilePath
+getJava = do
+    javaHome <- getEnv "JAVA_HOME"
+    let exe = if isWindows then ".exe" else ""
+    pure $ javaHome </> "bin" </> "java" <> exe


### PR DESCRIPTION
Implements `withCantonSandbox`, which directly replaces `withSandbox` in the various tests.
Also implements a haskell FreePort to support this correctly. Should cooperate directly with the existing scala implementation

TODO: verify co-operability