### PR TITLE
Refactored Converter.to* methods to be static

### DIFF
--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
@@ -37,6 +37,8 @@ import com.daml.platform.participant.util.LfEngineToApi.{
   toApiIdentifier,
 }
 import com.daml.script.converter.ConverterException
+import com.daml.script.converter.Converter._
+import com.daml.script.converter.Converter.Implicits._
 
 import scala.collection.mutable
 import scala.concurrent.duration.{FiniteDuration, MICROSECONDS}
@@ -48,7 +50,6 @@ final class Converter(
 ) {
 
   import Converter._
-  import com.daml.script.converter.Converter._, Implicits._
 
   private[this] val valueTranslator = new preprocessing.ValueTranslator(
     compiledPackages.pkgInterface,
@@ -96,12 +97,6 @@ final class Converter(
       mod <- DottedName.fromString(identifier.moduleName)
       name <- DottedName.fromString(identifier.entityName)
     } yield Identifier(pkgId, QualifiedName(mod, name))
-
-  private[this] def toLedgerRecord(v: SValue): Either[String, value.Record] =
-    lfValueToApiRecord(verbose = true, v.toUnnormalizedValue)
-
-  private[this] def toLedgerValue(v: SValue): Either[String, value.Value] =
-    lfValueToApiValue(verbose = true, v.toUnnormalizedValue)
 
   private[this] def fromTemplateTypeRep(tyCon: value.Identifier): SValue =
     record(
@@ -442,192 +437,12 @@ final class Converter(
       "config" -> config,
     )
   }
-
-  def toFiniteDuration(value: SValue): Either[String, FiniteDuration] =
-    value.expect(
-      "RelTime",
-      { case SRecord(_, _, ArrayList(SInt64(microseconds))) =>
-        FiniteDuration(microseconds, MICROSECONDS)
-      },
-    )
-
-  private[this] def toIdentifier(v: SValue): Either[String, Identifier] =
-    v.expect(
-      "STypeRep",
-      { case STypeRep(TTyCon(id)) =>
-        id
-      },
-    )
-
-  private[this] def toTemplateTypeRep(v: SValue): Either[String, Identifier] =
-    v.expectE(
-      "TemplateTypeRep",
-      { case SRecord(_, _, ArrayList(id)) =>
-        toIdentifier(id)
-      },
-    )
-
-  private[this] def toRegisteredTemplate(v: SValue): Either[String, Identifier] =
-    v.expectE(
-      "RegisteredTemplate",
-      { case SRecord(_, _, ArrayList(sttr)) =>
-        toTemplateTypeRep(sttr)
-      },
-    )
-
-  def toRegisteredTemplates(v: SValue): Either[String, Seq[Identifier]] =
-    v.expectE(
-      "list of RegisteredTemplate",
-      { case SList(tpls) =>
-        tpls.traverse(toRegisteredTemplate).map(_.toImmArray.toSeq)
-      },
-    )
-
-  private[this] def toAnyContractId(v: SValue): Either[String, AnyContractId] =
-    v.expectE(
-      "AnyContractId",
-      { case SRecord(_, _, ArrayList(stid, scid)) =>
-        for {
-          templateId <- toTemplateTypeRep(stid)
-          contractId <- toContractId(scid)
-        } yield AnyContractId(templateId, contractId)
-      },
-    )
-
-  private[this] def toAnyTemplate(v: SValue): Either[String, AnyTemplate] =
-    v match {
-      case SRecord(_, _, ArrayList(SAny(TTyCon(tmplId), value))) =>
-        Right(AnyTemplate(tmplId, value))
-      case _ => Left(s"Expected AnyTemplate but got $v")
-    }
-
-  private[this] def choiceArgTypeToChoiceName(choiceCons: TypeConName) = {
-    // This exploits the fact that in Daml, choice argument type names
-    // and choice names match up.
-    assert(choiceCons.qualifiedName.name.segments.length == 1)
-    choiceCons.qualifiedName.name.segments.head
-  }
-
-  private[this] def toAnyChoice(v: SValue): Either[String, AnyChoice] =
-    v match {
-      case SRecord(_, _, ArrayList(SAny(TTyCon(choiceCons), choiceVal), _)) =>
-        Right(AnyChoice(choiceArgTypeToChoiceName(choiceCons), choiceVal))
-      case _ =>
-        Left(s"Expected AnyChoice but got $v")
-    }
-
-  private[this] def toAnyContractKey(v: SValue): Either[String, AnyContractKey] =
-    v.expect(
-      "AnyContractKey",
-      { case SRecord(_, _, ArrayList(SAny(_, v), _)) =>
-        AnyContractKey(v)
-      },
-    )
-
-  private[this] def toCreate(v: SValue): Either[String, CreateCommand] =
-    v.expectE(
-      "CreateCommand",
-      { case SRecord(_, _, ArrayList(sTpl)) =>
-        for {
-          anyTmpl <- toAnyTemplate(sTpl)
-          templateArg <- toLedgerRecord(anyTmpl.arg)
-        } yield CreateCommand(Some(toApiIdentifier(anyTmpl.ty)), Some(templateArg))
-      },
-    )
-
-  private[this] def toExercise(v: SValue): Either[String, ExerciseCommand] =
-    v.expectE(
-      "ExerciseCommand",
-      { case SRecord(_, _, ArrayList(sAnyContractId, sChoiceVal)) =>
-        for {
-          anyContractId <- toAnyContractId(sAnyContractId)
-          anyChoice <- toAnyChoice(sChoiceVal)
-          choiceArg <- toLedgerValue(anyChoice.arg)
-        } yield ExerciseCommand(
-          Some(toApiIdentifier(anyContractId.templateId)),
-          anyContractId.contractId.coid,
-          anyChoice.name,
-          Some(choiceArg),
-        )
-      },
-    )
-
-  private[this] def toExerciseByKey(v: SValue): Either[String, ExerciseByKeyCommand] =
-    v.expectE(
-      "ExerciseByKeyCommand",
-      { case SRecord(_, _, ArrayList(stplId, skeyVal, sChoiceVal)) =>
-        for {
-          tplId <- toTemplateTypeRep(stplId)
-          keyVal <- toAnyContractKey(skeyVal)
-          keyArg <- toLedgerValue(keyVal.key)
-          anyChoice <- toAnyChoice(sChoiceVal)
-          choiceArg <- toLedgerValue(anyChoice.arg)
-        } yield ExerciseByKeyCommand(
-          Some(toApiIdentifier(tplId)),
-          Some(keyArg),
-          anyChoice.name,
-          Some(choiceArg),
-        )
-      },
-    )
-
-  private[this] def toCreateAndExercise(v: SValue): Either[String, CreateAndExerciseCommand] =
-    v.expectE(
-      "CreateAndExerciseCommand",
-      { case SRecord(_, _, ArrayList(sTpl, sChoiceVal)) =>
-        for {
-          anyTmpl <- toAnyTemplate(sTpl)
-          templateArg <- toLedgerRecord(anyTmpl.arg)
-          anyChoice <- toAnyChoice(sChoiceVal)
-          choiceArg <- toLedgerValue(anyChoice.arg)
-        } yield CreateAndExerciseCommand(
-          Some(toApiIdentifier(anyTmpl.ty)),
-          Some(templateArg),
-          anyChoice.name,
-          Some(choiceArg),
-        )
-      },
-    )
-
-  private[this] def toCommand(v: SValue): Either[String, ApiCommand] = {
-    v match {
-      case SVariant(_, "CreateCommand", _, createVal) =>
-        for {
-          create <- toCreate(createVal)
-        } yield ApiCommand().withCreate(create)
-      case SVariant(_, "ExerciseCommand", _, exerciseVal) =>
-        for {
-          exercise <- toExercise(exerciseVal)
-        } yield ApiCommand().withExercise(exercise)
-      case SVariant(_, "ExerciseByKeyCommand", _, exerciseByKeyVal) =>
-        for {
-          exerciseByKey <- toExerciseByKey(exerciseByKeyVal)
-        } yield ApiCommand().withExerciseByKey(exerciseByKey)
-      case SVariant(_, "CreateAndExerciseCommand", _, createAndExerciseVal) =>
-        for {
-          createAndExercise <- toCreateAndExercise(createAndExerciseVal)
-        } yield ApiCommand().withCreateAndExercise(createAndExercise)
-      case _ => Left(s"Expected a Command but got $v")
-    }
-  }
-
-  def toCommands(v: SValue): Either[String, Seq[ApiCommand]] =
-    for {
-      cmdValues <- v.expect(
-        "[Command]",
-        { case SList(cmdValues) =>
-          cmdValues
-        },
-      )
-      commands <- cmdValues.traverse(toCommand)
-    } yield commands.toImmArray.toSeq
-
 }
 
 object Converter {
 
-  private final case class AnyContractId(templateId: Identifier, contractId: ContractId)
-  private final case class AnyTemplate(ty: Identifier, arg: SValue)
+  final case class AnyContractId(templateId: Identifier, contractId: ContractId)
+  final case class AnyTemplate(ty: Identifier, arg: SValue)
 
   private final case class AnyChoice(name: ChoiceName, arg: SValue)
   private final case class AnyContractKey(key: SValue)
@@ -660,16 +475,202 @@ object Converter {
     val SucceedVariantConstructor = Name.assertFromString("Succeeded")
     val SucceedVariantConstrcutor = 1
   }
+
+  private def toLedgerRecord(v: SValue): Either[String, value.Record] =
+    lfValueToApiRecord(verbose = true, v.toUnnormalizedValue)
+
+  private def toLedgerValue(v: SValue): Either[String, value.Value] =
+    lfValueToApiValue(verbose = true, v.toUnnormalizedValue)
+
+  private def toIdentifier(v: SValue): Either[String, Identifier] =
+    v.expect(
+      "STypeRep",
+      { case STypeRep(TTyCon(id)) =>
+        id
+      },
+    )
+
+  private def toAnyContractId(v: SValue): Either[String, AnyContractId] =
+    v.expectE(
+      "AnyContractId",
+      { case SRecord(_, _, ArrayList(stid, scid)) =>
+        for {
+          templateId <- toTemplateTypeRep(stid)
+          contractId <- toContractId(scid)
+        } yield AnyContractId(templateId, contractId)
+      },
+    )
+
+  private def toTemplateTypeRep(v: SValue): Either[String, Identifier] =
+    v.expectE(
+      "TemplateTypeRep",
+      { case SRecord(_, _, ArrayList(id)) =>
+        toIdentifier(id)
+      },
+    )
+
+  def toFiniteDuration(value: SValue): Either[String, FiniteDuration] =
+    value.expect(
+      "RelTime",
+      { case SRecord(_, _, ArrayList(SInt64(microseconds))) =>
+        FiniteDuration(microseconds, MICROSECONDS)
+      },
+    )
+
+  private def toRegisteredTemplate(v: SValue): Either[String, Identifier] =
+    v.expectE(
+      "RegisteredTemplate",
+      { case SRecord(_, _, ArrayList(sttr)) =>
+        toTemplateTypeRep(sttr)
+      },
+    )
+
+  def toRegisteredTemplates(v: SValue): Either[String, Seq[Identifier]] =
+    v.expectE(
+      "list of RegisteredTemplate",
+      { case SList(tpls) =>
+        tpls.traverse(toRegisteredTemplate).map(_.toImmArray.toSeq)
+      },
+    )
+
+  private def toAnyTemplate(v: SValue): Either[String, AnyTemplate] =
+    v match {
+      case SRecord(_, _, ArrayList(SAny(TTyCon(tmplId), value))) =>
+        Right(AnyTemplate(tmplId, value))
+      case _ => Left(s"Expected AnyTemplate but got $v")
+    }
+
+  private def choiceArgTypeToChoiceName(choiceCons: TypeConName) = {
+    // This exploits the fact that in Daml, choice argument type names
+    // and choice names match up.
+    assert(choiceCons.qualifiedName.name.segments.length == 1)
+    choiceCons.qualifiedName.name.segments.head
+  }
+
+  private def toAnyChoice(v: SValue): Either[String, AnyChoice] =
+    v match {
+      case SRecord(_, _, ArrayList(SAny(TTyCon(choiceCons), choiceVal), _)) =>
+        Right(AnyChoice(choiceArgTypeToChoiceName(choiceCons), choiceVal))
+      case _ =>
+        Left(s"Expected AnyChoice but got $v")
+    }
+
+  private def toAnyContractKey(v: SValue): Either[String, AnyContractKey] =
+    v.expect(
+      "AnyContractKey",
+      { case SRecord(_, _, ArrayList(SAny(_, v), _)) =>
+        AnyContractKey(v)
+      },
+    )
+
+  private def toCreate(v: SValue): Either[String, CreateCommand] =
+    v.expectE(
+      "CreateCommand",
+      { case SRecord(_, _, ArrayList(sTpl)) =>
+        for {
+          anyTmpl <- toAnyTemplate(sTpl)
+          templateArg <- toLedgerRecord(anyTmpl.arg)
+        } yield CreateCommand(Some(toApiIdentifier(anyTmpl.ty)), Some(templateArg))
+      },
+    )
+
+  private def toExercise(v: SValue): Either[String, ExerciseCommand] =
+    v.expectE(
+      "ExerciseCommand",
+      { case SRecord(_, _, ArrayList(sAnyContractId, sChoiceVal)) =>
+        for {
+          anyContractId <- toAnyContractId(sAnyContractId)
+          anyChoice <- toAnyChoice(sChoiceVal)
+          choiceArg <- toLedgerValue(anyChoice.arg)
+        } yield ExerciseCommand(
+          Some(toApiIdentifier(anyContractId.templateId)),
+          anyContractId.contractId.coid,
+          anyChoice.name,
+          Some(choiceArg),
+        )
+      },
+    )
+
+  private def toExerciseByKey(v: SValue): Either[String, ExerciseByKeyCommand] =
+    v.expectE(
+      "ExerciseByKeyCommand",
+      { case SRecord(_, _, ArrayList(stplId, skeyVal, sChoiceVal)) =>
+        for {
+          tplId <- toTemplateTypeRep(stplId)
+          keyVal <- toAnyContractKey(skeyVal)
+          keyArg <- toLedgerValue(keyVal.key)
+          anyChoice <- toAnyChoice(sChoiceVal)
+          choiceArg <- toLedgerValue(anyChoice.arg)
+        } yield ExerciseByKeyCommand(
+          Some(toApiIdentifier(tplId)),
+          Some(keyArg),
+          anyChoice.name,
+          Some(choiceArg),
+        )
+      },
+    )
+
+  private def toCreateAndExercise(v: SValue): Either[String, CreateAndExerciseCommand] =
+    v.expectE(
+      "CreateAndExerciseCommand",
+      { case SRecord(_, _, ArrayList(sTpl, sChoiceVal)) =>
+        for {
+          anyTmpl <- toAnyTemplate(sTpl)
+          templateArg <- toLedgerRecord(anyTmpl.arg)
+          anyChoice <- toAnyChoice(sChoiceVal)
+          choiceArg <- toLedgerValue(anyChoice.arg)
+        } yield CreateAndExerciseCommand(
+          Some(toApiIdentifier(anyTmpl.ty)),
+          Some(templateArg),
+          anyChoice.name,
+          Some(choiceArg),
+        )
+      },
+    )
+
+  private def toCommand(v: SValue): Either[String, ApiCommand] = {
+    v match {
+      case SVariant(_, "CreateCommand", _, createVal) =>
+        for {
+          create <- toCreate(createVal)
+        } yield ApiCommand().withCreate(create)
+      case SVariant(_, "ExerciseCommand", _, exerciseVal) =>
+        for {
+          exercise <- toExercise(exerciseVal)
+        } yield ApiCommand().withExercise(exercise)
+      case SVariant(_, "ExerciseByKeyCommand", _, exerciseByKeyVal) =>
+        for {
+          exerciseByKey <- toExerciseByKey(exerciseByKeyVal)
+        } yield ApiCommand().withExerciseByKey(exerciseByKey)
+      case SVariant(_, "CreateAndExerciseCommand", _, createAndExerciseVal) =>
+        for {
+          createAndExercise <- toCreateAndExercise(createAndExerciseVal)
+        } yield ApiCommand().withCreateAndExercise(createAndExercise)
+      case _ => Left(s"Expected a Command but got $v")
+    }
+  }
+
+  def toCommands(v: SValue): Either[String, Seq[ApiCommand]] =
+    for {
+      cmdValues <- v.expect(
+        "[Command]",
+        { case SList(cmdValues) =>
+          cmdValues
+        },
+      )
+      commands <- cmdValues.traverse(toCommand)
+    } yield commands.toImmArray.toSeq
 }
 
 // Helper to create identifiers pointing to the Daml.Trigger module
-final case class TriggerIds(val triggerPackageId: PackageId) {
-  def damlTrigger(s: String) =
+final case class TriggerIds(triggerPackageId: PackageId) {
+  def damlTrigger(s: String): Identifier =
     Identifier(
       triggerPackageId,
       QualifiedName(ModuleName.assertFromString("Daml.Trigger"), DottedName.assertFromString(s)),
     )
-  def damlTriggerLowLevel(s: String) =
+
+  def damlTriggerLowLevel(s: String): Identifier =
     Identifier(
       triggerPackageId,
       QualifiedName(
@@ -677,7 +678,8 @@ final case class TriggerIds(val triggerPackageId: PackageId) {
         DottedName.assertFromString(s),
       ),
     )
-  def damlTriggerInternal(s: String) =
+
+  def damlTriggerInternal(s: String): Identifier =
     Identifier(
       triggerPackageId,
       QualifiedName(

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -355,9 +355,8 @@ object Trigger {
     for {
       triggerDef <- detectTriggerDefinition(compiledPackages.pkgInterface, triggerId)
       hasReadAs <- detectHasReadAs(compiledPackages.pkgInterface, triggerDef.triggerIds)
-      converter = new Converter(compiledPackages, triggerDef)
-      filter <- getTriggerFilter(compiledPackages, compiler, converter, triggerDef)
-      heartbeat <- getTriggerHeartbeat(compiledPackages, compiler, converter, triggerDef)
+      filter <- getTriggerFilter(compiledPackages, compiler, triggerDef)
+      heartbeat <- getTriggerHeartbeat(compiledPackages, compiler, triggerDef)
     } yield Trigger(triggerDef, filter, heartbeat, hasReadAs)
   }
 
@@ -365,7 +364,6 @@ object Trigger {
   private def getTriggerHeartbeat(
       compiledPackages: CompiledPackages,
       compiler: Compiler,
-      converter: Converter,
       triggerDef: TriggerDefinition,
   )(implicit triggerContext: TriggerLogContext): Either[String, Option[FiniteDuration]] = {
     val heartbeat = compiler.unsafeCompile(
@@ -373,7 +371,7 @@ object Trigger {
     )
     Machine.stepToValue(compiledPackages, heartbeat) match {
       case SOptional(None) => Right(None)
-      case SOptional(Some(relTime)) => converter.toFiniteDuration(relTime).map(Some(_))
+      case SOptional(Some(relTime)) => Converter.toFiniteDuration(relTime).map(Some(_))
       case value => Left(s"Expected Optional but got $value.")
     }
   }
@@ -382,7 +380,6 @@ object Trigger {
   def getTriggerFilter(
       compiledPackages: CompiledPackages,
       compiler: Compiler,
-      converter: Converter,
       triggerDef: TriggerDefinition,
   )(implicit triggerContext: TriggerLogContext): Either[String, Filters] = {
     val registeredTemplates = compiler.unsafeCompile(
@@ -431,7 +428,7 @@ object Trigger {
         )
 
       case SVariant(_, "RegisteredTemplates", _, v) =>
-        converter.toRegisteredTemplates(v) match {
+        Converter.toRegisteredTemplates(v) match {
           case Right(identifiers) =>
             val isRegistered: Identifier => Boolean = identifiers.toSet.contains
             Right(
@@ -684,7 +681,7 @@ private[lf] class Runner private (
                     case DamlTuple2(sCommands, DamlFun(textA)) =>
                       numberOfSubmissions += 1
 
-                      val commands = converter.toCommands(sCommands).orConverterException
+                      val commands = Converter.toCommands(sCommands).orConverterException
                       val (commandUUID, submitRequest) = handleCommands(commands)
 
                       numberOfCreates += commands.count(_.command.isCreate)


### PR DESCRIPTION
Trigger `Converter.to*` methods have no dependence on compiled packages and the trigger definition, hence these methods may be made static.

In trigger simulation code, doing this will allow conversions from `SValue`s without the need for an explicit converter instance to be passed in.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
