### PR TITLE
Refactor of numberOfActiveContracts to expose a more abstract ACS view

### DIFF
--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -55,6 +55,7 @@ import com.daml.lf.language.PackageInterface
 import com.daml.lf.language.Util._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.SValue.SMap.`SMap Ordering`
 import com.daml.lf.speedy.{Compiler, Pretty, SValue, Speedy}
 import com.daml.lf.{CompiledPackages, PureCompiledPackages}
 import com.daml.logging.LoggingContextOf.label
@@ -81,6 +82,7 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 import scala.annotation.{nowarn, tailrec}
 import scala.collection.concurrent.TrieMap
+import scala.collection.immutable.TreeMap
 import scala.concurrent.duration.{FiniteDuration, _}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -1472,11 +1474,11 @@ object Runner {
     smap.expect("SMap", { case SMap(_, entries) if entries.contains(key) => entries(key) })
   }
 
-  private[trigger] def numberOfActiveContracts(
+  private[trigger] def getActiveContracts(
       svalue: SValue,
       level: Trigger.Level,
       version: Trigger.Version,
-  ): Option[Int] = {
+  ): Option[TreeMap[SValue, TreeMap[SValue, SValue]]] = {
     level match {
       case Trigger.Level.High if version <= Trigger.Version.`2.0.0` =>
         // For older trigger code, we do not support extracting active contracts from the ACS
@@ -1488,17 +1490,38 @@ object Runner {
         val result = for {
           acs <- svalue.expect("SRecord", { case SRecord(_, _, values) => values.get(0) })
           activeContracts <- acs.expect("SRecord", { case SRecord(_, _, values) => values.get(0) })
-          size <- activeContracts.expect(
+          templateMap <- activeContracts.expect(
             "SMap",
-            { case SMap(_, values) => values.values.map(mapSize).sum },
+            { case SMap(_, values) => values },
           )
-        } yield size
+          contractMap = templateMap.map { case (templateId, smap) =>
+            smap.expect("SMap", { case SMap(_, values) => (templateId, values) })
+          }
+          resultMap <- contractMap
+            .foldRight[Either[String, TreeMap[SValue, TreeMap[SValue, SValue]]]](
+              Right(TreeMap.empty)
+            ) { case (value, result) =>
+              for {
+                entry <- value
+                res <- result
+                (tid, tmap) = entry
+              } yield res + (tid -> tmap)
+            }
+        } yield resultMap
 
         Some(result.orConverterException)
 
       case Trigger.Level.Low =>
         None
     }
+  }
+
+  private[trigger] def numberOfActiveContracts(
+      svalue: SValue,
+      level: Trigger.Level,
+      version: Trigger.Version,
+  ): Option[Int] = {
+    getActiveContracts(svalue, level, version).map(_.values.map(_.values.size).sum)
   }
 
   private[trigger] def numberOfPendingContracts(


### PR DESCRIPTION
Trigger simulation code benefits from a more abstract view of the ACS being extracted from trigger internal state (e.g. so that the trigger ACS view may be diffed against a ledger view of the ACS state).

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
