### PR TITLE
Bug fix: use retries to manage logger/metrics race condition

### DIFF
--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRuleSimulationLib.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRuleSimulationLib.scala
@@ -70,7 +70,7 @@ private class TriggerRuleMetrics {
       retries: Int = 5
   )(implicit materializer: Materializer): Future[TriggerRuleMetrics.RuleMetrics] = {
     val backoff = 50.milliseconds
-    val timeLimit = backoff * (1 to retries).sum
+    val timeLimit = backoff * (1L to retries.toLong).sum
     val restartSettings =
       RestartSettings(minBackoff = backoff, maxBackoff = 1.second, randomFactor = 0.1)
         .withMaxRestarts(retries, timeLimit)

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRuleSimulationLib.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRuleSimulationLib.scala
@@ -70,7 +70,7 @@ private class TriggerRuleMetrics {
       retries: Int = 5
   )(implicit materializer: Materializer): Future[TriggerRuleMetrics.RuleMetrics] = {
     val backoff = 50.milliseconds
-    val timeLimit = backoff * retries
+    val timeLimit = backoff * (1 to retries).sum
     val restartSettings =
       RestartSettings(minBackoff = backoff, maxBackoff = 1.second, randomFactor = 0.1)
         .withMaxRestarts(retries, timeLimit)
@@ -79,7 +79,7 @@ private class TriggerRuleMetrics {
       .withBackoff(restartSettings) { () =>
         Source.single(getMetrics)
       }
-      .initialTimeout(retries.seconds)
+      .initialTimeout(timeLimit)
       .runWith(Sink.head)
   }
 

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRuleSimulationLib.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRuleSimulationLib.scala
@@ -30,7 +30,7 @@ import org.scalacheck.Gen
 import java.util.UUID
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.duration._
 import scala.util.Try
 
 @SuppressWarnings(
@@ -74,7 +74,7 @@ private class TriggerRuleMetrics {
       .recoverWithRetries(
         retries,
         { case _: IllegalArgumentException =>
-          Source.single(getMetrics)
+          Source.single(getMetrics).initialDelay(50.milliseconds)
         },
       )
       .runWith(Sink.head)


### PR DESCRIPTION
When trigger simulation tests call `ruleMetrics.getMetrics`, the last log line (contains ACS data) might not yet have been flushed by the logging appenders. As a result, trigger simulation tests will fail as the `TriggerRuleMetrics.getMetrics` preconditions will not all be satisfied.

This issue is resolved by retrying (with a fixed backoff time of 50ms) the attempt to extract metric data from the logs. The number of retries is set to 5 (by default).

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
