### PR TITLE
place 'templateTypeRepToText' behind its own feature flag

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -148,6 +148,13 @@ featureChoiceFuncs = Feature
     , featureCppFlag = Just "DAML_CHOICE_FUNCS"
     }
 
+featureTemplateTypeRepToText :: Feature
+featureTemplateTypeRepToText = Feature
+    { featureName = "templateTypeRepToText function"
+    , featureMinVersion = versionDev
+    , featureCppFlag = Just "DAML_TEMPLATE_TYPEREP_TO_TEXT"
+    }
+
 featureDynamicExercise :: Feature
 featureDynamicExercise = Feature
     { featureName = "dynamicExercise function"
@@ -172,6 +179,7 @@ allFeatures =
     , featureSimpleInterfaces
     , featureExtendedInterfaces
     , featureChoiceFuncs
+    , featureTemplateTypeRepToText
     , featureUnstable
     , featureExperimental
     , featureWithAuthority

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Template/Functions.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Template/Functions.daml
@@ -288,7 +288,7 @@ instance Eq TemplateTypeRep where
 
 deriving instance Ord TemplateTypeRep
 
-#ifdef DAML_EXPERIMENTAL
+#ifdef DAML_TEMPLATE_TYPEREP_TO_TEXT
 
 -- | (experimental, 1.dev only) Get the template id (or interface id)
 -- represented by a TemplateTypeRep, as a string.
@@ -301,7 +301,7 @@ templateTypeRepToText (TemplateTypeRep x) =
 instance Show TemplateTypeRep where
   show = templateTypeRepToText
 
-#endif
+#endif -- DAML_TEMPLATE_TYPEREP_TO_TEXT
 
 -- | Wrap the template in `AnyTemplate`.
 --

--- a/compiler/damlc/tests/daml-test-files/TemplateTypeRepToText.daml
+++ b/compiler/damlc/tests/daml-test-files/TemplateTypeRepToText.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @SINCE-LF-FEATURE DAML_EXPERIMENTAL
+-- @SINCE-LF-FEATURE DAML_TEMPLATE_TYPEREP_TO_TEXT
 module TemplateTypeRepToText where
 
 import Daml.Script

--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -450,7 +450,6 @@ enum BuiltinFunction {
 
   FOLDL = 20;
   FOLDR = 21;
-  WITH_AUTHORITY = 149;
 
   TEXTMAP_EMPTY = 96;
   TEXTMAP_INSERT = 97;
@@ -571,6 +570,8 @@ enum BuiltinFunction {
   BIGNUMERIC_TO_TEXT = 146; // *Available in versions >= 1.13*
 
   TYPEREP_TYCON_NAME = 148; // *Available in versions >= 1.dev*
+
+  WITH_AUTHORITY = 149; // *Available in versions >= 1.dev*
 
   // Next id is 150.
 


### PR DESCRIPTION
Prompted by https://github.com/digital-asset/daml/pull/16651#discussion_r1158224657, I noticed `templateTypeRepToText` was correctly limited to LF `1.dev` using the incorrect feature flag `DAML_EXPERIMENTAL`; this PR fixes that.

I also noticed the `WITH_AUTHORITY` primitive was located in a weird position in `daml_lf_1.proto` so I moved it down