### PR TITLE
[engine] speedy evaluation for choice authority

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -439,6 +439,8 @@ final class Conversions(
           optLocation.map(loc => ncBuilder.setLocation(convertLocation(loc)))
           faBuilder.setNoControllers(ncBuilder.build)
 
+        case _: FailedAuthorization.NoAuthorizers => ??? // TODO #15882
+
         case FailedAuthorization.LookupByKeyMissingAuthorization(
               templateId,
               optLocation,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -170,6 +170,17 @@ private[lf] object Pretty {
             text(
               s"Exercise the choice $templateId:$choiceName with ${observers.size} observers but the limit is $limit"
             )
+          case Limit.ChoiceAuthorizers(
+                cid @ _,
+                templateId,
+                choiceName,
+                arg @ _,
+                authorizers,
+                limit,
+              ) =>
+            text(
+              s"Exercise the choice $templateId:$choiceName with ${authorizers.size} authorizers but the limit is $limit"
+            )
           case Limit.TransactionInputContracts(limit) =>
             text(s"Transaction exceeds maximum input contract number of $limit")
         }
@@ -228,6 +239,8 @@ private[lf] object Pretty {
     failure match {
       case nc: FailedAuthorization.NoControllers =>
         s"node $id (${nc.templateId}) has no controllers"
+      case nc: FailedAuthorization.NoAuthorizers =>
+        s"node $id (${nc.templateId}) has no authorizers"
       case ma: FailedAuthorization.CreateMissingAuthorization =>
         s"node $id (${ma.templateId}) requires authorizers ${ma.requiredParties
             .mkString(",")}, but only ${ma.authorizingParties.mkString(",")} were given"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -336,6 +336,19 @@ private[lf] object Speedy {
         IError.Limit.ChoiceObservers(cid, templateId, choiceName, arg, observers, _),
       )
 
+    private[speedy] def enforceChoiceAuthorizersLimit(
+        authorizers: Set[Party],
+        cid: V.ContractId,
+        templateId: TypeConName,
+        choiceName: ChoiceName,
+        arg: V,
+    ): Unit =
+      enforceLimit(
+        authorizers.size,
+        limits.choiceAuthorizers,
+        IError.Limit.ChoiceAuthorizers(cid, templateId, choiceName, arg, authorizers, _),
+      )
+
     // The set of create events for the disclosed contracts that are used by the generated transaction.
     def disclosedCreateEvents: ImmArray[Node.Create] =
       disclosedContracts.iterator

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/AuthorizationChecker.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/AuthorizationChecker.scala
@@ -133,10 +133,13 @@ private[lf] object DefaultAuthorizationChecker extends AuthorizationChecker {
       passIf = ex.actingParties.nonEmpty,
       failWith = FailedAuthorization.NoControllers(ex.templateId, ex.choiceId, optLocation),
     ) ++
-      /*authorize(
-      passIf = ex.authorizers.nonEmpty, // TODO #15882 (when PR #16541 is merged)
-      failWith = FailedAuthorization.NoAuthorizers(ex.templateId, ex.choiceId, optLocation),
-    ) ++ */
+      authorize(
+        passIf = ex.choiceAuthorizers match {
+          case None => true
+          case Some(explicitAuthorizers) => explicitAuthorizers.nonEmpty
+        },
+        failWith = FailedAuthorization.NoAuthorizers(ex.templateId, ex.choiceId, optLocation),
+      ) ++
       authorize(
         passIf = ex.actingParties subsetOf auth.authParties,
         failWith = FailedAuthorization.ExerciseMissingAuthorization(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/AuthorizationChecker.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/AuthorizationChecker.scala
@@ -133,6 +133,10 @@ private[lf] object DefaultAuthorizationChecker extends AuthorizationChecker {
       passIf = ex.actingParties.nonEmpty,
       failWith = FailedAuthorization.NoControllers(ex.templateId, ex.choiceId, optLocation),
     ) ++
+      /*authorize(
+      passIf = ex.authorizers.nonEmpty, // TODO #15882 (when PR #16541 is merged)
+      failWith = FailedAuthorization.NoAuthorizers(ex.templateId, ex.choiceId, optLocation),
+    ) ++ */
       authorize(
         passIf = ex.actingParties subsetOf auth.authParties,
         failWith = FailedAuthorization.ExerciseMissingAuthorization(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -165,7 +165,6 @@ private[lf] object PartialTransaction {
         case None => actingParties union signatories
         case Some(explicitAuthorizers) => explicitAuthorizers
       }
-
   }
 
   final case class TryContextInfo(

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ChoiceAuthorityTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ChoiceAuthorityTest.scala
@@ -1,0 +1,133 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+
+import com.daml.lf.data.FrontStack
+import com.daml.lf.data.Ref.Party
+import com.daml.lf.interpretation.Error.FailedAuthorization
+import com.daml.lf.ledger.FailedAuthorization.CreateMissingAuthorization
+import com.daml.lf.speedy.SError.SError
+import com.daml.lf.speedy.SExpr.SEApp
+import com.daml.lf.speedy.SValue.{SList, SParty}
+import com.daml.lf.testing.parser.Implicits._
+import com.daml.lf.transaction.SubmittedTransaction
+
+import org.scalatest.Inside
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers._
+
+class ChoiceAuthorityTest extends AnyFreeSpec with Inside {
+
+  val transactionSeed = crypto.Hash.hashPrivateKey("ChoiceAuthorityTest.scala")
+
+  val pkgs: PureCompiledPackages = SpeedyTestLib.typeAndCompile(p"""
+      module M {
+
+        record @serializable Goal = { goal: Party } ;
+        template (record : Goal) = {
+          precondition True;
+          signatories Cons @Party [M:Goal {goal} record] (Nil @Party);
+          observers Nil @Party;
+          agreement "Agreement";
+        };
+
+        record @serializable T = { theSig: Party, theCon: Party, theAut: List Party, theGoal: Party };
+        template (this: T) = {
+          precondition True;
+          signatories Cons @Party [M:T {theSig} this] Nil @Party;
+          observers Nil @Party;
+          agreement "Agreement";
+
+          choice TheChoice (self) (u: Unit) : Unit,
+            controllers Cons @Party [M:T {theCon} this] Nil @Party
+            , authorizers M:T {theAut} this
+            to
+              ubind x1: ContractId M:Goal <- create @M:Goal (M:Goal { goal = M:T {theGoal} this })
+              in upure @Unit ();
+        };
+
+        val call : Party -> Party -> List Party -> Party -> Update Unit =
+          \(theSig: Party) ->
+          \(theCon: Party) ->
+          \(theAut: List Party) ->
+          \(theGoal: Party) ->
+          ubind
+          cid : ContractId M:T <- create @M:T (M:T {theSig = theSig, theCon = theCon, theAut = theAut, theGoal = theGoal})
+          in exercise @M:T TheChoice cid ();
+       }
+      """)
+
+  import SpeedyTestLib.AuthRequest
+
+  type Success = (SubmittedTransaction, List[AuthRequest])
+
+  val alice = Party.assertFromString("Alice")
+  val bob = Party.assertFromString("Bob")
+  val charlie = Party.assertFromString("Charlie")
+
+  val theSig: Party = alice
+  val theCon: Party = bob
+
+  def makeSetPartyValue(set: Set[Party]): SValue = {
+    SList(FrontStack(set.toList.map(SParty(_)): _*))
+  }
+
+  def runExample(
+      theAut: Set[Party],
+      theGoal: Party,
+  ): Either[SError, Success] = {
+    import SpeedyTestLib.loggingContext
+    val committers = Set(theSig, theCon)
+    val example = SEApp(
+      pkgs.compiler.unsafeCompile(e"M:call"),
+      Array(
+        SParty(theSig),
+        SParty(theCon),
+        makeSetPartyValue(theAut),
+        SParty(theGoal),
+      ),
+    )
+    val machine = Speedy.Machine.fromUpdateSExpr(pkgs, transactionSeed, example, committers)
+    SpeedyTestLib.buildTransactionCollectAuthRequests(machine)
+  }
+
+  "Explicit choice authority" - {
+
+    "restrict authority" in {
+      inside(runExample(theAut = Set(alice), theGoal = alice)) { case Right((_, ars)) =>
+        ars shouldBe List()
+      }
+    }
+
+    "restrict authority, fail" in {
+      inside(runExample(theAut = Set(bob), theGoal = alice)) { case Left(err) =>
+        inside(err) { case SError.SErrorDamlException(FailedAuthorization(_, why)) =>
+          inside(why) { case cma: CreateMissingAuthorization =>
+            cma.authorizingParties shouldBe Set(bob)
+            cma.requiredParties shouldBe Set(alice)
+          }
+        }
+      }
+    }
+
+    "restrict authority to empty, fail" in {
+      inside(runExample(theAut = Set(), theGoal = alice)) { case Left(err) =>
+        inside(err) { case SError.SErrorDamlException(FailedAuthorization(_, why)) =>
+          inside(why) {
+            case _: CreateMissingAuthorization => // TODO #15882 - should be NoAuthorizers
+          }
+        }
+      }
+    }
+
+    "change authority" in {
+      inside(runExample(theAut = Set(charlie), theGoal = charlie)) { case Right((_, ars)) =>
+        ars shouldBe List(
+          AuthRequest(holding = Set(alice, bob), requesting = Set(charlie))
+        )
+      }
+    }
+  }
+}

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ChoiceAuthorityTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ChoiceAuthorityTest.scala
@@ -7,7 +7,7 @@ package speedy
 import com.daml.lf.data.FrontStack
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.interpretation.Error.FailedAuthorization
-import com.daml.lf.ledger.FailedAuthorization.CreateMissingAuthorization
+import com.daml.lf.ledger.FailedAuthorization.{CreateMissingAuthorization, NoAuthorizers}
 import com.daml.lf.speedy.SError.SError
 import com.daml.lf.speedy.SExpr.SEApp
 import com.daml.lf.speedy.SValue.{SList, SParty}
@@ -115,8 +115,7 @@ class ChoiceAuthorityTest extends AnyFreeSpec with Inside {
     "restrict authority to empty, fail" in {
       inside(runExample(theAut = Set(), theGoal = alice)) { case Left(err) =>
         inside(err) { case SError.SErrorDamlException(FailedAuthorization(_, why)) =>
-          inside(why) {
-            case _: CreateMissingAuthorization => // TODO #15882 - should be NoAuthorizers
+          inside(why) { case _: NoAuthorizers =>
           }
         }
       }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/LimitsSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/LimitsSpec.scala
@@ -281,7 +281,7 @@ class LimitsSpec extends AnyWordSpec with Matchers with Inside with TableDrivenP
       }
     }
 
-    "refuse to exercise a choice with too many observers" in {
+    "refuse to exercise a choice with too many observers" in { // TODO 15882 test authorizers too
       val limits = interpretation.Limits.Lenient.copy(choiceObservers = limit)
       val committers = (0 to 99).view.map(i => Ref.Party.assertFromString(s"Party$i")).toSet
       val e =

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TransactionVersionTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TransactionVersionTest.scala
@@ -302,6 +302,7 @@ object TransactionVersionTest {
     val speedyControllers =
       SExpr.SEValue(SValue.SList(FrontStack.from(controllers.map(SValue.SParty))))
     val speedyObservers = SExpr.SEValue(SValue.SList(FrontStack.Empty))
+    val speedyAuthorizers = SExpr.SEValue(SValue.SList(FrontStack.Empty))
     val machine =
       Speedy.Machine.fromUpdateSExpr(
         pkgs,
@@ -318,7 +319,8 @@ object TransactionVersionTest {
                 choiceName,
                 consuming = true,
                 byKey = false,
-              )(choiceArg, speedyContractId, speedyControllers, speedyObservers)
+                explicitChoiceAuthority = false,
+              )(choiceArg, speedyContractId, speedyControllers, speedyObservers, speedyAuthorizers)
             ),
           ),
         ),

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
@@ -195,14 +195,15 @@ private[parser] class ModParser[P](parameters: ParserParameters[P]) {
       (`:` ~> typ) ~
       (`,` ~> Id("controllers") ~> expr) ~
       opt(`,` ~> Id("observers") ~> expr) ~
+      opt(`,` ~> Id("authorizers") ~> expr) ~
       (`to` ~> expr) ^^ {
-        case choiceTags ~ name ~ self ~ param ~ retTyp ~ controllers ~ choiceObservers ~ update =>
+        case choiceTags ~ name ~ self ~ param ~ retTyp ~ controllers ~ optObservers ~ optAuthorizers ~ update =>
           TemplateChoice(
             name,
             !choiceTags(nonConsumingTag),
             controllers,
-            choiceObservers,
-            None, // TODO #15882 -- support dev-syntax for choice authority
+            optObservers,
+            optAuthorizers,
             self,
             param,
             retTyp,

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -606,6 +606,7 @@ class ParsersSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matcher
             choice @nonConsuming PowerNap (self) (i : Int64): Int64
               , controllers Cons @Party [person] (Nil @Party)
               , observers Cons @Party [person] (Nil @Party)
+              , authorizers Cons @Party [person] (Nil @Party)
               to upure @Int64 i;
             implements Mod1:Human {
               view = Mod1:HumanView { name = "Foo B. Baz" };
@@ -636,7 +637,7 @@ class ParsersSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matcher
                 name = n"Sleep",
                 consuming = true,
                 controllers = e"Cons @Party [person] (Nil @Party)",
-                choiceObservers = None, // TODO #15882 add test for choice-authority dev-syntax
+                choiceObservers = None,
                 choiceAuthorizers = None,
                 selfBinder = n"self",
                 argBinder = n"u" -> TUnit,
@@ -661,7 +662,7 @@ class ParsersSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matcher
                 consuming = false,
                 controllers = e"Cons @Party [person] (Nil @Party)",
                 choiceObservers = Some(e"Cons @Party [person] (Nil @Party)"),
-                choiceAuthorizers = None,
+                choiceAuthorizers = Some(e"Cons @Party [person] (Nil @Party)"),
                 selfBinder = n"self",
                 argBinder = n"i" -> TInt64,
                 returnType = t"Int64",

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -199,6 +199,15 @@ object Error {
         limit: Int,
     ) extends Error
 
+    final case class ChoiceAuthorizers(
+        cid: Value.ContractId,
+        templateId: TypeConName,
+        choiceName: ChoiceName,
+        arg: Value,
+        observers: Set[Party],
+        limit: Int,
+    ) extends Error
+
     final case class TransactionInputContracts(limit: Int) extends Error
   }
 

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/Limits.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/Limits.scala
@@ -5,13 +5,21 @@ package com.daml.lf
 package interpretation
 
 case class Limits(
-    contractSignatories: Int = Int.MaxValue,
-    contractObservers: Int = Int.MaxValue,
-    choiceControllers: Int = Int.MaxValue,
-    choiceObservers: Int = Int.MaxValue,
-    transactionInputContracts: Int = Int.MaxValue,
+    contractSignatories: Int,
+    contractObservers: Int,
+    choiceControllers: Int,
+    choiceObservers: Int,
+    choiceAuthorizers: Int,
+    transactionInputContracts: Int,
 )
 
 object Limits {
-  val Lenient = Limits()
+  val Lenient = Limits(
+    contractSignatories = Int.MaxValue,
+    contractObservers = Int.MaxValue,
+    choiceControllers = Int.MaxValue,
+    choiceObservers = Int.MaxValue,
+    choiceAuthorizers = Int.MaxValue,
+    transactionInputContracts = Int.MaxValue,
+  )
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/ledger/Authorization.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/ledger/Authorization.scala
@@ -52,6 +52,12 @@ object FailedAuthorization {
       optLocation: Option[Location],
   ) extends FailedAuthorization
 
+  final case class NoAuthorizers(
+      templateId: Identifier,
+      choiceid: ChoiceName,
+      optLocation: Option[Location],
+  ) extends FailedAuthorization
+
   final case class LookupByKeyMissingAuthorization(
       templateId: Identifier,
       optLocation: Option[Location],

--- a/ledger/ledger-runner-common/src/test/lib/com/daml/ledger/runner/common/ArbitraryConfig.scala
+++ b/ledger/ledger-runner-common/src/test/lib/com/daml/ledger/runner/common/ArbitraryConfig.scala
@@ -67,12 +67,14 @@ object ArbitraryConfig {
     contractObservers <- Gen.chooseNum(Int.MinValue, Int.MaxValue)
     choiceControllers <- Gen.chooseNum(Int.MinValue, Int.MaxValue)
     choiceObservers <- Gen.chooseNum(Int.MinValue, Int.MaxValue)
+    choiceAuthorizers <- Gen.chooseNum(Int.MinValue, Int.MaxValue)
     transactionInputContracts <- Gen.chooseNum(Int.MinValue, Int.MaxValue)
   } yield Limits(
     contractSignatories,
     contractObservers,
     choiceControllers,
     choiceObservers,
+    choiceAuthorizers,
     transactionInputContracts,
   )
 

--- a/ledger/ledger-runner-common/src/test/scala/com/daml/ledger/runner/common/PureConfigReaderWriterSpec.scala
+++ b/ledger/ledger-runner-common/src/test/scala/com/daml/ledger/runner/common/PureConfigReaderWriterSpec.scala
@@ -228,12 +228,13 @@ class PureConfigReaderWriterSpec
     """
       |      choice-controllers = 2147483647
       |      choice-observers = 2147483647
+      |      choice-authorizers = 2147483647
       |      contract-observers = 2147483647
       |      contract-signatories = 2147483647
       |      transaction-input-contracts = 2147483647""".stripMargin
 
   it should "support current defaults" in {
-    convert(interpretationLimitsConvert, validLimits).value shouldBe Limits()
+    convert(interpretationLimitsConvert, validLimits).value shouldBe Limits.Lenient
   }
 
   it should "validate against odd values" in {
@@ -255,6 +256,7 @@ class PureConfigReaderWriterSpec
         |      contract-observers = 345
         |      contract-signatories = 456
         |      transaction-input-contracts = 567
+        |      choice-authorizers = 678
         |""".stripMargin
       )
 
@@ -264,6 +266,7 @@ class PureConfigReaderWriterSpec
       contractObservers = 345,
       contractSignatories = 456,
       transactionInputContracts = 567,
+      choiceAuthorizers = 678,
     )
     val source = ConfigSource.fromConfig(value).cursor().value
     interpretationLimitsConvert.from(source).value shouldBe expectedValue
@@ -291,6 +294,7 @@ class PureConfigReaderWriterSpec
       |limits {
       |  choice-controllers = 2147483647
       |  choice-observers = 2147483647
+      |  choice-authorizers = 2147483647
       |  contract-observers = 2147483647
       |  contract-signatories = 2147483647
       |  transaction-input-contracts = 2147483647

--- a/ledger/sandbox-on-x/resources/generated-default.conf
+++ b/ledger/sandbox-on-x/resources/generated-default.conf
@@ -15,6 +15,7 @@ ledger {
         forbid-v-0-contract-id=true
         iterations-between-interruptions=10000
         limits {
+            choice-authorizers=2147483647
             choice-controllers=2147483647
             choice-observers=2147483647
             contract-observers=2147483647


### PR DESCRIPTION
Advances: #15882 

Support _choice authority_ in speedy evaluation.
- Make necessary calls to  `NeedAuthority`
- Record explicit choice authority within `Node.Exercise`.
- Add new authorization check -- `NoAuthorizers`
- And new limit `limit.choiceAuthorizers`

Annoyingly, the new limit item breaks canton build. Fixed here: https://github.com/DACH-NY/canton/compare/nick/adapt-to-authorizers-field-of-exe-node...nick/adapt-daml-choice-authority-evaluation
