### PR TITLE
[engine] rename primitive to TYPE_REP_TYCON_NAME

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -300,7 +300,7 @@ instance Pretty BuiltinExpr where
     BETextToCodePoints -> "TEXT_TO_CODE_POINTS"
     BECodePointsToText -> "CODE_POINTS_TO_TEXT"
     BECoerceContractId -> "COERCE_CONTRACT_ID"
-    BETypeRepTyConName -> "TYPEREP_TYCON_NAME"
+    BETypeRepTyConName -> "TYPE_REP_TYCON_NAME"
     BETextToUpper -> "TEXT_TO_UPPER"
     BETextToLower -> "TEXT_TO_LOWER"
     BETextSlice -> "TEXT_SLICE"

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -514,7 +514,7 @@ decodeBuiltinFunction = \case
   LF1.BuiltinFunctionEQUAL_CONTRACT_ID -> pure BEEqualContractId
   LF1.BuiltinFunctionCOERCE_CONTRACT_ID -> pure BECoerceContractId
 
-  LF1.BuiltinFunctionTYPEREP_TYCON_NAME -> pure BETypeRepTyConName
+  LF1.BuiltinFunctionTYPE_REP_TYCON_NAME -> pure BETypeRepTyConName
 
   LF1.BuiltinFunctionTEXT_TO_UPPER -> pure BETextToUpper
   LF1.BuiltinFunctionTEXT_TO_LOWER -> pure BETextToLower

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -551,7 +551,7 @@ encodeBuiltinExpr = \case
     BEEqualContractId -> builtin P.BuiltinFunctionEQUAL_CONTRACT_ID
     BECoerceContractId -> builtin P.BuiltinFunctionCOERCE_CONTRACT_ID
 
-    BETypeRepTyConName -> builtin P.BuiltinFunctionTYPEREP_TYCON_NAME
+    BETypeRepTyConName -> builtin P.BuiltinFunctionTYPE_REP_TYCON_NAME
 
     BETextToUpper -> builtin P.BuiltinFunctionTEXT_TO_UPPER
     BETextToLower -> builtin P.BuiltinFunctionTEXT_TO_LOWER

--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -570,7 +570,7 @@ enum BuiltinFunction {
   NUMERIC_TO_BIGNUMERIC = 145; // *Available in versions >= 1.13*
   BIGNUMERIC_TO_TEXT = 146; // *Available in versions >= 1.13*
 
-  TYPEREP_TYCON_NAME = 148; // *Available in versions >= 1.dev*
+  TYPE_REP_TYCON_NAME = 148; // *Available in versions >= 1.dev*
 
   // Next id is 150.
 

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -2394,7 +2394,7 @@ private[archive] object DecodeV1 {
       BuiltinFunctionInfo(NUMERIC_TO_BIGNUMERIC, BNumericToBigNumeric, minVersion = bigNumeric),
       BuiltinFunctionInfo(BIGNUMERIC_TO_TEXT, BBigNumericToText, minVersion = bigNumeric),
       BuiltinFunctionInfo(ANY_EXCEPTION_MESSAGE, BAnyExceptionMessage, minVersion = exceptions),
-      BuiltinFunctionInfo(TYPEREP_TYCON_NAME, BTypeRepTyConName, minVersion = LV.v1_dev),
+      BuiltinFunctionInfo(TYPE_REP_TYCON_NAME, BTypeRepTyConName, minVersion = LV.v1_dev),
       BuiltinFunctionInfo(TEXT_TO_UPPER, BTextToUpper, minVersion = unstable),
       BuiltinFunctionInfo(TEXT_TO_LOWER, BTextToLower, minVersion = unstable),
       BuiltinFunctionInfo(TEXT_SLICE, BTextSlice, minVersion = unstable),

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -1122,7 +1122,7 @@ class DecodeV1Spec
         val typeRepTyConName = DamlLf1.Expr
           .newBuilder()
           .setBuiltin(
-            DamlLf1.BuiltinFunction.TYPEREP_TYCON_NAME
+            DamlLf1.BuiltinFunction.TYPE_REP_TYCON_NAME
           )
           .build()
 

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -394,7 +394,7 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
     "BIGNUMERIC_TO_NUMERIC" -> BBigNumericToNumeric,
     "NUMERIC_TO_BIGNUMERIC" -> BNumericToBigNumeric,
     "BIGNUMERIC_TO_TEXT" -> BBigNumericToText,
-    "TYPEREP_TYCON_NAME" -> BTypeRepTyConName,
+    "TYPE_REP_TYCON_NAME" -> BTypeRepTyConName,
   )
 
   private lazy val eCallInterface: Parser[ECallInterface] =

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -234,7 +234,7 @@ class ParsersSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matcher
         "GREATER_EQ" -> BGreaterEq,
         "COERCE_CONTRACT_ID" -> BCoerceContractId,
         "ANY_EXCEPTION_MESSAGE" -> BAnyExceptionMessage,
-        "TYPEREP_TYCON_NAME" -> BTypeRepTyConName,
+        "TYPE_REP_TYCON_NAME" -> BTypeRepTyConName,
       )
 
       forEvery(testCases)((stringToParse, expectedBuiltin) =>

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -4776,7 +4776,7 @@ Type Representation function
   [*Available in versions >= 1.7*]
 
 
-* ``TYPEREP_TYCON_NAME`` : 'TypeRep' → 'Optional' 'Text'``
+* ``TYPE_REP_TYCON_NAME`` : 'TypeRep' → 'Optional' 'Text'``
 
   Returns the type constructor name, as a string, of the given ``'TypeRep'``,
   if it is indeed a type constructor. Otherwise returns ``'None'``


### PR DESCRIPTION
Rename: `TYPEREP_TYCON_NAME` --> `TYPE_REP_TYCON_NAME`,
adding underscore for consistency with other ops.

Addressing: https://github.com/digital-asset/daml/pull/16651#issuecomment-1497427793