### PR TITLE
Migrate trigger-integration-tests to Canton

### DIFF
--- a/daml-lf/integration-test-lib/src/main/com/daml/lf/CantonFixture.scala
+++ b/daml-lf/integration-test-lib/src/main/com/daml/lf/CantonFixture.scala
@@ -5,11 +5,12 @@ package com.daml.lf
 package integrationtest
 
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Path, Paths, Files}
+import java.nio.file.{Files, Path, Paths}
 import com.daml.bazeltools.BazelRunfiles._
 import com.daml.jwt.JwtSigner
 import com.daml.jwt.domain.DecodedJwt
 import com.daml.ledger.api.auth
+import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, OwnedResource, SuiteResource}
 import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.ledger.client.LedgerClient
@@ -22,6 +23,7 @@ import com.daml.timer.RetryStrategy
 import com.google.protobuf.ByteString
 import org.scalatest.Suite
 import spray.json.JsString
+import scalaz.syntax.tag._
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
@@ -78,6 +80,7 @@ trait CantonFixture extends SuiteResource[Vector[Port]] with AkkaBeforeAndAfterA
   protected def nParticipants: Int
   protected def timeProviderType: TimeProviderType
   protected def tlsEnable: Boolean
+  protected def applicationId: ApplicationId
 
   // This flag setup some behavior to ease debugging tests.
   //  If `true`
@@ -136,7 +139,7 @@ trait CantonFixture extends SuiteResource[Vector[Port]] with AkkaBeforeAndAfterA
           val domainAdminApi = LockedFreePort.find()
 
           val cantonPath = rlocation(
-            "external/canton/lib/canton-open-source-2.7.0-SNAPSHOT.jar"
+            "external/canton/lib/canton-open-source-2.7.0-SNAPSHOT.jar" // FIXME: remove hard coded version!!
           )
           val exe = if (sys.props("os.name").toLowerCase.contains("windows")) ".exe" else ""
           val java = s"${System.getenv("JAVA_HOME")}/bin/java${exe}"
@@ -176,7 +179,7 @@ trait CantonFixture extends SuiteResource[Vector[Port]] with AkkaBeforeAndAfterA
                |    }""".stripMargin
           }
           val participantsConfig =
-            (0 until nParticipants).map(participantConfig(_)).mkString("\n")
+            (0 until nParticipants).map(participantConfig).mkString("\n")
           val cantonConfig =
             s"""canton {
                |  parameters.non-standard-config = yes
@@ -201,7 +204,7 @@ trait CantonFixture extends SuiteResource[Vector[Port]] with AkkaBeforeAndAfterA
           """.stripMargin
           discard(Files.write(cantonConfigFile, cantonConfig.getBytes(StandardCharsets.UTF_8)))
           val debugOptions =
-            if (cantonFixtureDebugMode) List("--log-file-name", cantonLogFile.toString)
+            if (cantonFixtureDebugMode) List("--log-file-name", cantonLogFile.toString, "--verbose")
             else List.empty
           for {
             proc <- Future(
@@ -217,7 +220,7 @@ trait CantonFixture extends SuiteResource[Vector[Port]] with AkkaBeforeAndAfterA
               ).run()
             )
             _ <- RetryStrategy.constant(attempts = 240, waitTime = 1.seconds) { (_, _) =>
-              info(s"waiting for Canton to start")
+              info("waiting for Canton to start")
               Future(Files.size(portFile))
             }
             _ = info("Canton started")
@@ -303,7 +306,7 @@ trait CantonFixture extends SuiteResource[Vector[Port]] with AkkaBeforeAndAfterA
       hostIp = "localhost",
       port = port.value,
       configuration = LedgerClientConfiguration(
-        applicationId = token.fold("daml-script")(_ => ""),
+        applicationId = token.fold(applicationId.unwrap)(_ => ""),
         ledgerIdRequirement = LedgerIdRequirement.none,
         commandClient = CommandClientConfiguration.default,
         token = token,

--- a/daml-lf/integration-test-lib/src/main/com/daml/lf/CantonFixture.scala
+++ b/daml-lf/integration-test-lib/src/main/com/daml/lf/CantonFixture.scala
@@ -303,7 +303,6 @@ trait CantonFixture extends SuiteResource[Vector[Port]] with AkkaBeforeAndAfterA
       hostIp = "localhost",
       port = port.value,
       configuration = LedgerClientConfiguration(
-        // FIXME: should this be daml-script? Maybe daml-test?
         applicationId = token.fold("daml-script")(_ => ""),
         ledgerIdRequirement = LedgerIdRequirement.none,
         commandClient = CommandClientConfiguration.default,

--- a/daml-lf/integration-test-lib/src/main/com/daml/lf/CantonFixture.scala
+++ b/daml-lf/integration-test-lib/src/main/com/daml/lf/CantonFixture.scala
@@ -81,7 +81,7 @@ trait CantonFixture extends SuiteResource[Vector[Port]] with AkkaBeforeAndAfterA
 
   // This flag setup some behavior to ease debugging tests.
   //  If `true`
-  //   - temporary file are not deleted
+  //   - temporary file are not deleted (this requires "--test_tmpdir=/tmp/" or similar for bazel builds)
   //   - some debug info are logged.
   protected val cantonFixtureDebugMode = false
 
@@ -303,6 +303,7 @@ trait CantonFixture extends SuiteResource[Vector[Port]] with AkkaBeforeAndAfterA
       hostIp = "localhost",
       port = port.value,
       configuration = LedgerClientConfiguration(
+        // FIXME: should this be daml-script? Maybe daml-test?
         applicationId = token.fold("daml-script")(_ => ""),
         ledgerIdRequirement = LedgerIdRequirement.none,
         commandClient = CommandClientConfiguration.default,

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/DamlScriptTestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/DamlScriptTestRunner.scala
@@ -4,6 +4,7 @@
 package com.daml.lf.engine.script
 
 import com.daml.bazeltools.BazelRunfiles
+import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.lf.integrationtest.CantonFixture
 import com.daml.platform.services.time.TimeProviderType
@@ -27,6 +28,7 @@ class DamlScriptTestRunner
   override protected def nParticipants = 1
   override protected def timeProviderType = TimeProviderType.Static
   override protected def tlsEnable = false
+  override protected def applicationId: ApplicationId = ApplicationId("daml-script")
 
   private val exe = if (sys.props("os.name").toLowerCase.contains("windows")) ".exe" else ""
   val scriptPath = BazelRunfiles.rlocation("daml-script/runner/daml-script-binary" + exe)

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractScriptTest.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractScriptTest.scala
@@ -5,10 +5,10 @@ package com.daml.lf.engine.script
 package test
 
 import java.nio.file.{Path, Paths}
-
 import com.daml.bazeltools.BazelRunfiles.rlocation
+import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
-import com.daml.lf.data.{Ref, ImmArray}
+import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.engine.script.ledgerinteraction.{
   GrpcLedgerClient,
   ScriptLedgerClient,
@@ -17,7 +17,7 @@ import com.daml.lf.engine.script.ledgerinteraction.{
 import com.daml.lf.integrationtest.CantonFixture
 import com.daml.lf.language.Ast
 import com.daml.lf.language.StablePackage.DA
-import com.daml.lf.speedy.{SValue, ArrayList}
+import com.daml.lf.speedy.{ArrayList, SValue}
 import com.daml.lf.value.Value
 import com.daml.platform.services.time.TimeProviderType
 import org.scalatest.Suite
@@ -44,6 +44,8 @@ object AbstractScriptTest {
 // Fixture for a set of participants used in Daml Script tests
 trait AbstractScriptTest extends CantonFixture with AkkaBeforeAndAfterAll {
   self: Suite =>
+
+  override protected def applicationId: ApplicationId = ApplicationId("daml-script")
 
   protected def timeMode: ScriptTimeMode
   final override protected lazy val timeProviderType = timeMode match {

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -142,6 +142,7 @@ da_scala_library(
         data = [
             ":acs%s.dar" % suffix,
             "//test-common/test-certificates",
+            "@canton//:lib",
         ],
         resources = ["//triggers/runner:src/main/resources/logback.xml"],
         scala_deps = [
@@ -156,6 +157,7 @@ da_scala_library(
             "//daml-lf/archive:daml_lf_archive_reader",
             "//daml-lf/data",
             "//daml-lf/engine",
+            "//daml-lf/integration-test-lib",
             "//daml-lf/interpreter",
             "//daml-lf/language",
             "//language-support/scala/bindings",

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala
@@ -11,7 +11,6 @@ import com.daml.lf.value.Value.ContractId
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.ledger.api.v1.commands.CreateCommand
 import com.daml.ledger.api.v1.{value => LedgerApi}
-import com.daml.ledger.sandbox.SandboxOnXForTest.ParticipantId
 import com.daml.lf.engine.trigger.Runner.TriggerContext
 import com.daml.platform.services.time.TimeProviderType
 import io.grpc.{Status => grpcStatus, StatusRuntimeException}
@@ -27,7 +26,7 @@ import java.util.UUID
 
 abstract class AbstractFuncTests
     extends AsyncWordSpec
-    with AbstractTriggerTest
+    with AbstractTriggerTestWithCanton
     with Matchers
     with Inside
     with SuiteResourceManagementAroundAll
@@ -40,7 +39,7 @@ abstract class AbstractFuncTests
 
       "process and track contract creation, exercise and archive" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, triggerId, party)
           (acs, offset) <- runner.queryACS()
@@ -98,7 +97,7 @@ abstract class AbstractFuncTests
 
       "1 create" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, QualifiedName.assertFromString("ACS:test"), party)
           (acs, offset) <- runner.queryACS()
@@ -123,7 +122,7 @@ abstract class AbstractFuncTests
 
       "2 creates" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, QualifiedName.assertFromString("ACS:test"), party)
           (acs, offset) <- runner.queryACS()
@@ -152,7 +151,7 @@ abstract class AbstractFuncTests
 
       "2 creates and 2 archives" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, QualifiedName.assertFromString("ACS:test"), party)
           (acs, offset) <- runner.queryACS()
@@ -219,7 +218,7 @@ abstract class AbstractFuncTests
 
       "1 original, 0 subscriber" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, triggerId, party)
           (acs, offset) <- runner.queryACS()
@@ -240,7 +239,7 @@ abstract class AbstractFuncTests
 
       "1 original, 1 subscriber" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, triggerId, party)
           (acs, offset) <- runner.queryACS()
@@ -265,7 +264,7 @@ abstract class AbstractFuncTests
 
       "2 original, 1 subscriber" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, triggerId, party)
           (acs, offset) <- runner.queryACS()
@@ -296,7 +295,7 @@ abstract class AbstractFuncTests
 
       "3 retries" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, triggerId, party)
           (acs, offset) <- runner.queryACS()
@@ -321,7 +320,7 @@ abstract class AbstractFuncTests
 
       "1 exerciseByKey" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, triggerId, party)
           (acs, offset) <- runner.queryACS()
@@ -345,7 +344,7 @@ abstract class AbstractFuncTests
 
       "createAndExercise" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, triggerId, party)
           (acs, offset) <- runner.queryACS()
@@ -366,7 +365,7 @@ abstract class AbstractFuncTests
 
       "fail" in {
         for {
-          client <- ledgerClient(
+          client <- defaultLedgerClient(
             // Sufficiently low that the transaction is larger than the max inbound message size
             maxInboundMessageSize = 100
           )
@@ -391,7 +390,7 @@ abstract class AbstractFuncTests
 
       "numeric" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, triggerId, party)
           (acs, offset) <- runner.queryACS()
@@ -413,7 +412,7 @@ abstract class AbstractFuncTests
 
       "command-id" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, triggerId, party)
           (acs, offset) <- runner.queryACS()
@@ -444,7 +443,7 @@ abstract class AbstractFuncTests
 
       "pending set" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, triggerId, party)
           (acs, offset) <- runner.queryACS()
@@ -490,7 +489,7 @@ abstract class AbstractFuncTests
 
       "filter to One" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(
             client,
@@ -512,7 +511,7 @@ abstract class AbstractFuncTests
 
       "filter to Two" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(
             client,
@@ -538,7 +537,7 @@ abstract class AbstractFuncTests
 
       "test" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, triggerId, party)
           (acs, offset) <- runner.queryACS()
@@ -555,7 +554,7 @@ abstract class AbstractFuncTests
     "TimeTests" should {
       "test" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, QualifiedName.assertFromString("Time:test"), party)
           (acs, offset) <- runner.queryACS()
@@ -569,10 +568,7 @@ abstract class AbstractFuncTests
                 case SList(items) if items.length == 2 =>
                   val t0 = items.slowApply(0).asInstanceOf[STimestamp].value
                   val t1 = items.slowApply(1).asInstanceOf[STimestamp].value
-                  config
-                    .participants(ParticipantId)
-                    .apiServer
-                    .timeProviderType match {
+                  timeProviderType match {
                     case TimeProviderType.WallClock =>
                       // Given the limited resolution it can happen that t0 == t1
                       t0 should be >= t1
@@ -601,7 +597,7 @@ abstract class AbstractFuncTests
 
       "respected by trigger runner" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           public <- allocateParty(client)
           party <- allocateParty(client)
           _ <- create(client, public, visibleToPublic(public))
@@ -626,7 +622,7 @@ abstract class AbstractFuncTests
     "getActAs" should {
       "produce a consistent party" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(
             client,
@@ -654,7 +650,7 @@ abstract class AbstractFuncTests
     "queryFilter" should {
       "return contracts matching predicates" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(
             client,

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala
@@ -365,12 +365,14 @@ abstract class AbstractFuncTests
 
       "fail" in {
         for {
-          client <- defaultLedgerClient(
+          // We use 2 ledger clients to avoid the allocateParty call triggering a GRPC RESOURCE_EXHAUSTED exception
+          goodClient <- defaultLedgerClient()
+          badClient <- defaultLedgerClient(
             // Sufficiently low that the transaction is larger than the max inbound message size
             maxInboundMessageSize = 100
           )
-          party <- allocateParty(client)
-          runner = getRunner(client, triggerId, party)
+          party <- allocateParty(goodClient)
+          runner = getRunner(badClient, triggerId, party)
           (acs, offset) <- runner.queryACS()
           // 1 for create and exercise
           // 1 for completion

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTestWithCanton.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTestWithCanton.scala
@@ -32,6 +32,7 @@ import com.daml.platform.services.time.TimeProviderType
 import org.scalatest._
 import scalaz.syntax.tag._
 
+import java.nio.file.Path
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -46,12 +47,12 @@ trait AbstractTriggerTestWithCanton extends CantonFixture with SuiteResourceMana
     Try(BazelRunfiles.requiredResource("triggers/tests/acs.dar"))
       .getOrElse(BazelRunfiles.requiredResource("triggers/tests/acs-1.dev.dar"))
 
-  override protected def authSecret = None
-  override protected def darFiles = List(darFile.toPath)
-  override protected def devMode = true
-  override protected def nParticipants = 1
-  override protected def timeProviderType = TimeProviderType.Static
-  override protected def tlsEnable = false
+  override protected def authSecret: Option[String] = None
+  override protected def darFiles: List[Path] = List(darFile.toPath)
+  override protected def devMode: Boolean = true
+  override protected def nParticipants: Int = 1
+  override protected def timeProviderType: TimeProviderType = TimeProviderType.Static
+  override protected def tlsEnable: Boolean = false
 
   protected def toHighLevelResult(s: SValue) = s match {
     case SRecord(_, _, values) if values.size == 6 =>

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTestWithCanton.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTestWithCanton.scala
@@ -53,6 +53,7 @@ trait AbstractTriggerTestWithCanton extends CantonFixture with SuiteResourceMana
   override protected def nParticipants: Int = 1
   override protected def timeProviderType: TimeProviderType = TimeProviderType.Static
   override protected def tlsEnable: Boolean = false
+  override protected def applicationId: ApplicationId = RunnerConfig.DefaultApplicationId
 
   protected def toHighLevelResult(s: SValue) = s match {
     case SRecord(_, _, values) if values.size == 6 =>
@@ -67,11 +68,9 @@ trait AbstractTriggerTestWithCanton extends CantonFixture with SuiteResourceMana
     case _ => throw new IllegalArgumentException(s"Expected record with 6 fields but got $s")
   }
 
-  protected val applicationId: ApplicationId = RunnerConfig.DefaultApplicationId
-
   protected def ledgerClientConfiguration: LedgerClientConfiguration =
     LedgerClientConfiguration(
-      applicationId = ApplicationId.unwrap(applicationId),
+      applicationId = applicationId.unwrap,
       ledgerIdRequirement = LedgerIdRequirement.none,
       commandClient = CommandClientConfiguration.default,
       token = None,
@@ -98,7 +97,7 @@ trait AbstractTriggerTestWithCanton extends CantonFixture with SuiteResourceMana
       Party(party),
       Party.subst(readAs),
       "test-trigger",
-      ApplicationId("test-trigger-app"),
+      applicationId,
     ) { implicit triggerContext: TriggerLogContext =>
       val trigger = Trigger.fromIdentifier(compiledPackages, triggerId).toOption.get
 
@@ -130,7 +129,7 @@ trait AbstractTriggerTestWithCanton extends CantonFixture with SuiteResourceMana
           party = party,
           commands = commands,
           ledgerId = client.ledgerId.unwrap,
-          applicationId = ApplicationId.unwrap(applicationId),
+          applicationId = applicationId.unwrap,
           commandId = UUID.randomUUID.toString,
         )
       )
@@ -180,7 +179,7 @@ trait AbstractTriggerTestWithCanton extends CantonFixture with SuiteResourceMana
           party = party,
           commands = commands,
           ledgerId = client.ledgerId.unwrap,
-          applicationId = ApplicationId.unwrap(applicationId),
+          applicationId = applicationId.unwrap,
           commandId = UUID.randomUUID.toString,
         )
       )

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/DevOnly.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/DevOnly.scala
@@ -5,7 +5,6 @@ package com.daml.lf.engine.trigger.test
 
 import akka.stream.scaladsl.Flow
 import com.daml.lf.data.Ref._
-import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.ledger.api.v1.commands.CreateCommand
 import com.daml.ledger.api.v1.event.{CreatedEvent, Event}
 import com.daml.ledger.api.v1.event.Event.Event.Created
@@ -22,10 +21,9 @@ import scala.collection.concurrent.TrieMap
 
 class DevOnly
     extends AsyncWordSpec
-    with AbstractTriggerTest
+    with AbstractTriggerTestWithCanton
     with Matchers
     with Inside
-    with SuiteResourceManagementAroundAll
     with TryValues {
   self: Suite =>
 
@@ -37,7 +35,7 @@ class DevOnly
       val tId = LedgerApi.Identifier(packageId, "Interface", "Asset")
       "1 transfer" in {
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, triggerId, party)
           (acs, offset) <- runner.queryACS()
@@ -65,7 +63,7 @@ class DevOnly
         val transactionEvents = TrieMap.empty[String, Seq[Event]]
 
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, triggerId, party)
 
@@ -142,7 +140,7 @@ class DevOnly
         val transactionEvents = TrieMap.empty[String, Seq[Event]]
 
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, triggerId, party)
 
@@ -225,7 +223,7 @@ class DevOnly
         val transactionEvents = TrieMap.empty[String, Seq[Event]]
 
         for {
-          client <- ledgerClient()
+          client <- defaultLedgerClient()
           party <- allocateParty(client)
           runner = getRunner(client, triggerId, party)
 

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/DevOnly.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/DevOnly.scala
@@ -28,6 +28,8 @@ class DevOnly
 
   import DevOnly._
 
+  override protected val cantonFixtureDebugMode = true
+
   this.getClass.getSimpleName can {
     "InterfaceTest" should {
       val triggerId = QualifiedName.assertFromString("Interface:test")

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/DevOnly.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/DevOnly.scala
@@ -28,8 +28,6 @@ class DevOnly
 
   import DevOnly._
 
-  override protected val cantonFixtureDebugMode = true
-
   this.getClass.getSimpleName can {
     "InterfaceTest" should {
       val triggerId = QualifiedName.assertFromString("Interface:test")

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/DevOnly.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/DevOnly.scala
@@ -28,8 +28,6 @@ class DevOnly
 
   import DevOnly._
 
-  override protected val cantonFixtureDebugMode = true
-
   this.getClass.getSimpleName can {
     "InterfaceTest" should {
       val triggerId = QualifiedName.assertFromString("Interface:test")
@@ -105,6 +103,8 @@ class DevOnly
           // Determine ACS for this test run's setup
           (acs, _) <- runner.queryACS()
 
+          // 1 for ledger create command completion
+          // 1 for ledger create command completion
           // 1 for transactional create of template A
           // 1 for transactional create of template B
           _ <- runner
@@ -118,7 +118,7 @@ class DevOnly
                   case _ =>
                   // No evidence to collect
                 }
-                .take(2),
+                .take(4),
             )
             ._2
         } yield {
@@ -185,6 +185,8 @@ class DevOnly
           // Determine ACS for this test run's setup
           (acs, _) <- runner.queryACS()
 
+          // 1 for ledger create command completion
+          // 1 for ledger create command completion
           // 1 for transactional create of template A
           // 1 for transactional create of template B, via interface I
           _ <- runner
@@ -198,7 +200,7 @@ class DevOnly
                   case _ =>
                   // No evidence to collect
                 }
-                .take(2),
+                .take(4),
             )
             ._2
         } yield {
@@ -265,6 +267,8 @@ class DevOnly
           // Determine ACS for this test run's setup
           (acs, _) <- runner.queryACS()
 
+          // 1 for ledger create command completion
+          // 1 for ledger create command completion
           // 1 for transactional create of template A, via interface I
           // 1 for transactional create of template B, via interface I
           _ <- runner
@@ -278,7 +282,7 @@ class DevOnly
                   case _ =>
                   // No evidence to collect
                 }
-                .take(2),
+                .take(4),
             )
             ._2
         } yield {

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsStaticTime.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsStaticTime.scala
@@ -3,16 +3,9 @@
 
 package com.daml.lf.engine.trigger.test
 
-import com.daml.ledger.sandbox.SandboxOnXForTest.{ApiServerConfig, singleParticipant}
 import com.daml.platform.services.time.TimeProviderType
 
 final class FuncTestsStaticTime extends AbstractFuncTests {
 
-  override def config = super.config.copy(
-    participants = singleParticipant(
-      ApiServerConfig.copy(
-        timeProviderType = TimeProviderType.Static
-      )
-    )
-  )
+  override protected def timeProviderType: TimeProviderType = TimeProviderType.Static
 }

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsWallClock.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsWallClock.scala
@@ -3,16 +3,9 @@
 
 package com.daml.lf.engine.trigger.test
 
-import com.daml.ledger.sandbox.SandboxOnXForTest.{ApiServerConfig, singleParticipant}
 import com.daml.platform.services.time.TimeProviderType
 
 final class FuncTestsWallClock extends AbstractFuncTests {
 
-  override def config = super.config.copy(participants =
-    singleParticipant(
-      ApiServerConfig.copy(
-        timeProviderType = TimeProviderType.WallClock
-      )
-    )
-  )
+  override protected def timeProviderType: TimeProviderType = TimeProviderType.WallClock
 }


### PR DESCRIPTION
Migrate the following test suites to Canton:
- [x] `DevOnly`
- [x] `AbstractFuncTests`
    - [x] `FuncTestsStaticTime`
    - [x] `FuncTestsWallClock`

N.B. `Jwt`, `Tls` and `ConfigSpec` will be migrated on a separate PR - see https://github.com/digital-asset/daml/pull/16663

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
