### PR TITLE
Fix SQL used to build view in Oracle to handle larger number of observers

### DIFF
--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -896,7 +896,7 @@ private final class OracleQueries(
     sql"""CREATE MATERIALIZED VIEW $contractStakeholdersViewName
           BUILD IMMEDIATE REFRESH FAST ON STATEMENT AS
           SELECT contract_id, tpid, stakeholder FROM $contractTableName,
-                 json_table(json_array(signatories, observers), '$$[*][*]'
+                 json_table(json_array(signatories, observers RETURNING CLOB), '$$[*][*]'
                     columns (stakeholder $partyType path '$$'))""",
   )
   private[this] val stakeholdersIndexName = Fragment.const0(s"${tablePrefix}stakeholder_idx")

--- a/ledger-service/http-json/src/it/daml/Account.daml
+++ b/ledger-service/http-json/src/it/daml/Account.daml
@@ -56,6 +56,13 @@ template KeyedByDecimal with
     key (party, amount): (Party, Amount)
     maintainer key._1
 
+template PubSub with
+    publisher: Party
+    subscribers: [Party]
+  where
+    signatory publisher
+    observer subscribers
+
 template Helper
   with
     owner : Party

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
@@ -443,6 +443,7 @@ trait AbstractHttpServiceIntegrationTestFuns
     }
     object Account {
       val Account: TId = CtId.Template(None, "Account", "Account")
+      val PubSub: TId = CtId.Template(None, "Account", "PubSub")
       val KeyedByVariantAndRecord: TId = CtId.Template(None, "Account", "KeyedByVariantAndRecord")
     }
     object Disclosure {
@@ -507,6 +508,23 @@ trait AbstractHttpServiceIntegrationTestFuns
       )
     )
     domain.CreateCommand(templateId, iouT, None)
+  }
+
+  protected def pubSubCreateCommand(
+      publisher: domain.Party,
+      subscribers: Seq[domain.Party],
+  ) = {
+    val payload = recordFromFields(
+      ShRecord(
+        publisher = v.Value.Sum.Party(Ref.Party assertFromString publisher.unwrap),
+        subscribers = lfToApi(VAx.seq(VAx.partyDomain).inj(subscribers)).sum,
+      )
+    )
+    domain.CreateCommand(
+      templateId = TpId.Account.PubSub,
+      payload = payload,
+      meta = None,
+    )
   }
 
   protected def iouExerciseTransferCommand(
@@ -857,5 +875,13 @@ trait AbstractHttpServiceIntegrationTestFuns
       ok.result
     case err: domain.ErrorResponse =>
       fail(s"Expected OK response, got: $err")
+  }
+
+  protected def randomTextN(n: Int) = {
+    import org.scalacheck.Gen
+    Gen
+      .buildableOfN[String, Char](n, Gen.alphaNumChar)
+      .sample
+      .getOrElse(sys.error(s"can't generate ${n}b string"))
   }
 }


### PR DESCRIPTION
When the `observers` list was too long, we were getting an `ORA-40478: output value too large (maximum 4000)` error from Oracle.

This was being hit when the `contract_stakeholders` view was being updated. An intermediate part of the expression which updates the view was being defaulted to a type which didn't allow larger values. Adding an explicit type fixes the problem.

- Added test which could reproduce the previous failure. 
- Moved `randomTextN` to be accessible to the new test.

Fixes https://digitalasset.atlassian.net/browse/LT-11