### PR TITLE
Fix errors with status code 200 not being handled properly

### DIFF
--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -998,7 +998,7 @@ class Ledger {
       decodeLedgerResponse.run(json),
     );
     if (!(ledgerResponse.status >= 200 && ledgerResponse.status <= 299)) {
-      console.error(
+      console.log(
         `Request to ${endpoint} returned status ${
           ledgerResponse.status
         } with response body: ${JSON.stringify(json)}.`,

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -997,6 +997,14 @@ class Ledger {
     const ledgerResponse = jtv.Result.withException(
       decodeLedgerResponse.run(json),
     );
+    if (!(ledgerResponse.status >= 200 && ledgerResponse.status <= 299)) {
+      console.error(
+        `Request to ${endpoint} returned status ${
+          ledgerResponse.status
+        } with response body: ${JSON.stringify(json)}.`,
+      );
+      throw decode(decodeLedgerError, json);
+    }
     if (ledgerResponse.warnings) {
       console.warn(ledgerResponse.warnings);
     }


### PR DESCRIPTION
Fixes an issue where:
- The HTTP response is streamed
- The HTTP Status code is 200 OK
BUT
- The content of the response contains errors (status non-2xx)

We observed this when calling `ledger.query(OurTemplate)`, where the decoding step in `query` would then try to read `undefined` as an array, and fail.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
