### PR TITLE
Add license file

### DIFF
--- a/daml-script/runner/BUILD.bazel
+++ b/daml-script/runner/BUILD.bazel
@@ -87,7 +87,10 @@ da_scala_binary(
     runtime_deps = [
         "@maven//:ch_qos_logback_logback_classic",
     ],
-    deps = [":script-runner-lib"],
+    deps = [
+        ":script-runner-lib",
+        "//release:ee-license",
+    ],
 )
 
 exports_files(["src/main/resources/logback.xml"])

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -148,6 +148,7 @@ json_deps = {
         "//ledger-service/http-json-cli:ee",
         "//ledger-service/http-json-ledger-client:ee",
         "@maven//:com_oracle_database_jdbc_ojdbc8",
+        "//release:ee-license",
     ],
 }
 

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -8,8 +8,8 @@ load("@os_info//:os_info.bzl", "is_windows")
 
 genrule(
     name = "LICENSE",
-    outs = ["LICENSE.txt"],
     srcs = [":ee-license.txt"],
+    outs = ["LICENSE.txt"],
     cmd = """
     cp $(location :ee-license.txt) $@
     """,
@@ -17,8 +17,8 @@ genrule(
 
 java_library(
     name = "ee-license",
-    resources = [":LICENSE.txt"],
     resource_strip_prefix = "release/",
+    resources = [":LICENSE.txt"],
     visibility = ["//visibility:public"],
 )
 

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -6,6 +6,22 @@ load("util.bzl", "protos_zip", "sdk_tarball")
 load("@build_environment//:configuration.bzl", "sdk_version")
 load("@os_info//:os_info.bzl", "is_windows")
 
+genrule(
+    name = "LICENSE",
+    outs = ["LICENSE.txt"],
+    srcs = [":ee-license.txt"],
+    cmd = """
+    cp $(location :ee-license.txt) $@
+    """,
+)
+
+java_library(
+    name = "ee-license",
+    resources = [":LICENSE.txt"],
+    resource_strip_prefix = "release/",
+    visibility = ["//visibility:public"],
+)
+
 da_haskell_binary(
     name = "release",
     srcs = glob(["src/**/*.hs"]),

--- a/release/ee-license.txt
+++ b/release/ee-license.txt
@@ -1,0 +1,19 @@
+The Software contained in this code repository is licensed to You pursuant
+to the Master Product Agreement, Evaluation Agreement, or other similar software
+license agreement (the “License Agreement”) signed between You and Digital Asset
+and which remains in effect as of the date You access the Software. Any use of
+this Software outside of the scope of Your License Agreement is strictly
+prohibited. If You have not signed a License Agreement with Digital Asset or Your
+License Agreement with Digital Asset is no longer in effect, You are not
+authorized to access or use the Software.
+
+“You” or “Your” means the individual or legal entity that signed the License
+Agreement and is accessing Software through this code repository.
+
+“Digital Asset” means Digital Asset Holdings, LLC, a Delaware Limited Liability
+Company with offices at 4 World Trade Center, 150 Greenwich St., 47th Floor,
+New York, NY 10007, or any of its subsidiaries or affiliates.
+
+“Software” means any goods, licensed materials, documentation, or software
+(including object and/or source code) made available for download by Digital
+Asset via this code repository.

--- a/release/ee-license.txt
+++ b/release/ee-license.txt
@@ -1,19 +1,19 @@
 The Software contained in this code repository is licensed to You pursuant
 to the Master Product Agreement, Evaluation Agreement, or other similar software
-license agreement (the “License Agreement”) signed between You and Digital Asset
+license agreement (the "License Agreement") signed between You and Digital Asset
 and which remains in effect as of the date You access the Software. Any use of
 this Software outside of the scope of Your License Agreement is strictly
 prohibited. If You have not signed a License Agreement with Digital Asset or Your
 License Agreement with Digital Asset is no longer in effect, You are not
 authorized to access or use the Software.
 
-“You” or “Your” means the individual or legal entity that signed the License
+"You" or "Your" means the individual or legal entity that signed the License
 Agreement and is accessing Software through this code repository.
 
-“Digital Asset” means Digital Asset Holdings, LLC, a Delaware Limited Liability
+"Digital Asset" means Digital Asset Holdings, LLC, a Delaware Limited Liability
 Company with offices at 4 World Trade Center, 150 Greenwich St., 47th Floor,
 New York, NY 10007, or any of its subsidiaries or affiliates.
 
-“Software” means any goods, licensed materials, documentation, or software
+"Software" means any goods, licensed materials, documentation, or software
 (including object and/or source code) made available for download by Digital
 Asset via this code repository.

--- a/release/util.bzl
+++ b/release/util.bzl
@@ -31,6 +31,7 @@ inputs = {
         "ce": "//daml-assistant/daml-sdk:sdk_deploy.jar",
         "ee": "//daml-assistant/daml-sdk:sdk_ee_deploy.jar",
     },
+    "license": ":ee-license.txt",
 }
 
 def input_target(config, name):
@@ -54,6 +55,10 @@ def sdk_tarball(name, version, config):
           trap "rm -rf $$DIR" EXIT
           OUT=$$DIR/sdk-$$VERSION
           mkdir -p $$OUT
+
+          if [ "{config}" = "ee" ]; then
+            cp $(location {license}) $$OUT/LICENSE.txt
+          fi
 
           cp $(location {NOTICES}) $$OUT/NOTICES
 
@@ -107,6 +112,7 @@ def sdk_tarball(name, version, config):
           $$MKTGZ $$OUT_PATH $$(basename $$OUT)
         """.format(
             version = version,
+            config = config,
             **kwargs
         ),
         visibility = ["//visibility:public"],

--- a/runtime-components/non-repudiation-app/BUILD.bazel
+++ b/runtime-components/non-repudiation-app/BUILD.bazel
@@ -28,6 +28,7 @@ da_scala_binary(
         "//libs-scala/doobie-slf4j",
         "//libs-scala/resources",
         "//libs-scala/resources-akka",
+        "//release:ee-license",
         "//runtime-components/non-repudiation",
         "//runtime-components/non-repudiation-api",
         "//runtime-components/non-repudiation-postgresql",
@@ -35,7 +36,6 @@ da_scala_binary(
         "@maven//:io_grpc_grpc_core",
         "@maven//:io_grpc_grpc_netty",
         "@maven//:org_slf4j_slf4j_api",
-        "//release:ee-license",
     ],
 )
 

--- a/runtime-components/non-repudiation-app/BUILD.bazel
+++ b/runtime-components/non-repudiation-app/BUILD.bazel
@@ -35,6 +35,7 @@ da_scala_binary(
         "@maven//:io_grpc_grpc_core",
         "@maven//:io_grpc_grpc_netty",
         "@maven//:org_slf4j_slf4j_api",
+        "//release:ee-license",
     ],
 )
 

--- a/triggers/runner/BUILD.bazel
+++ b/triggers/runner/BUILD.bazel
@@ -47,7 +47,10 @@ da_scala_binary(
     resources = ["src/main/resources/logback.xml"],
     scalacopts = lf_scalacopts_stricter,
     visibility = ["//visibility:public"],
-    deps = [":trigger-runner-lib"],
+    deps = [
+        ":trigger-runner-lib",
+        "//release:ee-license",
+    ],
 )
 
 exports_files(["src/main/resources/logback.xml"])

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -108,7 +108,7 @@ scala_binary_deps = [
     "@maven//:org_scalaz_scalaz_core",
 ]
 
-binary_deps = [
+common_binary_deps = [
     ":trigger-service",
     "//daml-lf/archive:daml_lf_archive_reader",
     "//daml-lf/archive:daml_lf_1.dev_archive_proto_java",
@@ -126,6 +126,11 @@ binary_deps = [
     "@maven//:ch_qos_logback_logback_classic",
 ]
 
+binary_deps = {
+    "ce": common_binary_deps,
+    "ee": common_binary_deps + ["//release:ee-license"],
+}
+
 trigger_service_runtime_deps = {
     "ce": [],
     "ee": ["@maven//:com_oracle_database_jdbc_ojdbc8"],
@@ -142,7 +147,7 @@ trigger_service_runtime_deps = {
         scalacopts = lf_scalacopts_stricter,
         visibility = ["//visibility:public"],
         runtime_deps = trigger_service_runtime_deps.get(edition),
-        deps = binary_deps + [
+        deps = binary_deps.get(edition) + [
             "//observability/metrics",
             "//runtime-components/jdbc-drivers:jdbc-drivers-{}".format(edition),
         ],


### PR DESCRIPTION
As requested in [DAML-358](https://digitalasset.atlassian.net/browse/DAML-358), this adds an Enterprise Edition license file to:

1. The SDK tarballs across all platforms.
2. The `daml-script` standalone JAR (not part of the CE).
3. The `daml-trigger-runner` standalone JAR (not part of CE).
4. The `http-json` standalone JAR for the EE (license file not included in CE version).
5. The `non-repudiation` standalone JAR (not part of CE).
6. The `trigger-service` standalone JAR for the EE (license file not included in CE version).

[DAML-358]: https://digitalasset.atlassian.net/browse/DAML-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ