### PR TITLE
Updated oracle image to 19.18

### DIFF
--- a/ci/oracle_image
+++ b/ci/oracle_image
@@ -1,1 +1,1 @@
-digitalasset/oracle:enterprise-19.15.0-preloaded-20220524-28-4ac7634
+digitalasset/oracle:enterprise-19.18.0-preloaded-20230414-36-5f03be2


### PR DESCRIPTION
Previously, I've noticed that the `DBF` resizing didn't actually resize the `system01.dbf`. This image is now smaller (should load faster) and has larger initial `DBF` files which means it shouldn't have to resize during CI. 

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
