### PR TITLE
Sw/daml doc choice return

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -35,7 +35,6 @@ import qualified Development.IDE.Core.OfInterest as Service
 import Development.IDE.Types.Location
 
 import "ghc-lib" GHC
-import "ghc-lib-parser" Name
 import "ghc-lib-parser" TyCon
 import "ghc-lib-parser" ConLike
 import "ghc-lib-parser" DataCon
@@ -45,6 +44,7 @@ import "ghc-lib-parser" Bag (bagToList)
 import "ghc-lib-parser" RdrHsSyn (isDamlGenerated)
 import "ghc-lib-parser" RdrName (rdrNameOcc)
 import "ghc-lib-parser" InstEnv (ClsInst (..))
+import "ghc-lib-parser" Name (occName, occNameString)
 
 import Control.Monad
 import Control.Monad.IO.Class
@@ -219,6 +219,10 @@ getInterfaceInstanceMap ctx@DocCtx{..} decls =
             ] <- [typeToType ctx $ idType id]
         ]
 
+-- | Extracts the return types of choices by looking at the HasExercise
+--   instances. Note that we expect and accept key clashes for `Archive`
+--   but this is acceptable, as choice return types are tied only to the
+--   Choice not the Choice + Template together.
 getChoiceTypeMap :: DocCtx -> [ClsInst] -> MS.Map Typename DDoc.Type
 getChoiceTypeMap ctx insts =
     MS.fromList

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Templates.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Templates.hs
@@ -203,7 +203,7 @@ mkChoiceDoc typeMap choiceTypeMap name =
   -- assumes exactly one constructor (syntactic in the template syntax), or
   -- uses a dummy value otherwise.
     , cd_fields = getFields choiceADT
-    , cd_type = fromMaybe (error "huh") $ MS.lookup name choiceTypeMap
+    , cd_type = fromMaybe (TypeApp Nothing (Typename "UnknownType") []) $ MS.lookup name choiceTypeMap
     }
   where
     choiceADT = asADT typeMap name

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Types.hs
@@ -58,7 +58,7 @@ data DocCtx = DocCtx
     , dc_templates :: Set.Set Typename
         -- ^ Daml templates defined in this module
     , dc_choices :: MS.Map Typename (Set.Set Typename)
-        -- ^ choices per Daml template defined in this module
+        -- ^ choices (as ADT name + return type) per Daml template defined in this module
     , dc_extractOptions :: ExtractOptions
         -- ^ command line options that affect the doc extractor
     , dc_exports :: ExportSet

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
@@ -128,6 +128,7 @@ instance RenderDoc ChoiceDoc where
     renderDoc ChoiceDoc{..} = mconcat
         [ RenderParagraph $ RenderStrong ("Choice " <> unTypename cd_name)
         , renderDoc cd_descr
+        , RenderParagraph $ renderUnwords [RenderPlain "Returns:", renderType cd_type]
         , fieldTable cd_fields
         ]
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -235,6 +235,7 @@ data ChoiceDoc = ChoiceDoc
   { cd_name   :: Typename
   , cd_descr  :: Maybe DocText
   , cd_fields :: [FieldDoc]
+  , cd_type   :: Type
   }
   deriving (Eq, Show, Generic)
 

--- a/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
@@ -161,7 +161,8 @@ unitTests =
                                 check $ isNothing $ fd_descr f1
                                 ch <- getSingle $ td_choicesWithoutArchive t
                                 f2 <- getSingle $ cd_fields ch
-                                check $ Just "field" == fd_descr f2))
+                                check $ Just "field" == fd_descr f2
+                                check $ TypeTuple [] == cd_type ch))
 
          , damldocExpect
            Nothing

--- a/compiler/damlc/tests/daml-test-files/DamlHasVersion.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/DamlHasVersion.EXPECTED.md
@@ -12,6 +12,8 @@ Testing the daml version header.
 >
 > * **Choice Archive**
 >
+>   Returns: ()
+>
 >   (no fields)
 
 ## Functions

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
@@ -11,9 +11,13 @@
 >
 > * **Choice Archive**
 >
+>   Returns: ()
+>
 >   (no fields)
 >
 > * **Choice Choice0**
+>
+>   Returns: ()
 >
 >   (no fields)
 
@@ -26,9 +30,13 @@
 >
 > * **Choice Archive**
 >
+>   Returns: ()
+>
 >   (no fields)
 >
 > * **Choice Choice1**
+>
+>   Returns: ()
 >
 >   (no fields)
 
@@ -41,9 +49,13 @@
 >
 > * **Choice Archive**
 >
+>   Returns: ()
+>
 >   (no fields)
 >
 > * **Choice Choice2**
+>
+>   Returns: ()
 >
 >   (no fields)
 
@@ -56,9 +68,13 @@
 >
 > * **Choice Archive**
 >
+>   Returns: ()
+>
 >   (no fields)
 >
 > * **Choice Choice3**
+>
+>   Returns: ()
 >
 >   (no fields)
 

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
@@ -26,9 +26,13 @@ Templates
 
   + **Choice Archive**
 
+    Returns\: ()
+
     (no fields)
 
   + **Choice Choice0**
+
+    Returns\: ()
 
     (no fields)
 
@@ -52,9 +56,13 @@ Templates
 
   + **Choice Archive**
 
+    Returns\: ()
+
     (no fields)
 
   + **Choice Choice1**
+
+    Returns\: ()
 
     (no fields)
 
@@ -78,9 +86,13 @@ Templates
 
   + **Choice Archive**
 
+    Returns\: ()
+
     (no fields)
 
   + **Choice Choice2**
+
+    Returns\: ()
 
     (no fields)
 
@@ -104,9 +116,13 @@ Templates
 
   + **Choice Archive**
 
+    Returns\: ()
+
     (no fields)
 
   + **Choice Choice3**
+
+    Returns\: ()
 
     (no fields)
 

--- a/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.md
@@ -12,6 +12,8 @@
 >
 > * **Choice Archive**
 >
+>   Returns: ()
+>
 >   (no fields)
 
 > * **interface instance** [Token](#type-interface-token-10651) **for** [Asset](#type-interface-asset-25340)
@@ -26,15 +28,21 @@
 >
 > * **Choice Archive**
 >
+>   Returns: ()
+>
 >   (no fields)
 >
 > * **Choice GetRich**
+>
+>   Returns: [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651)
 >
 >   | Field                                                                          | Type                                                                           | Description |
 >   | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
 >   | byHowMuch                                                                      | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
 >
 > * **Choice Noop**
+>
+>   Returns: ()
 >
 >   | Field   | Type    | Description |
 >   | :------ | :------ | :---------- |
@@ -44,11 +52,15 @@
 >
 >   An interface choice comment.
 >
+>   Returns: ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651), [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651))
+>
 >   | Field                                                                          | Type                                                                           | Description |
 >   | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
 >   | splitAmount                                                                    | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) | A choice field comment. |
 >
 > * **Choice Transfer**
+>
+>   Returns: [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651)
 >
 >   | Field                                                                                   | Type                                                                                    | Description |
 >   | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |

--- a/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.rst
@@ -29,6 +29,8 @@ Templates
 
   + **Choice Archive**
 
+    Returns\: ()
+
     (no fields)
 
   + **interface instance** `Token <type-interface-token-10651_>`_ **for** `Asset <type-interface-asset-25340_>`_
@@ -46,9 +48,13 @@ Interfaces
 
   + **Choice Archive**
 
+    Returns\: ()
+
     (no fields)
 
   + **Choice GetRich**
+
+    Returns\: `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_
 
     .. list-table::
        :widths: 15 10 30
@@ -62,6 +68,8 @@ Interfaces
          -
 
   + **Choice Noop**
+
+    Returns\: ()
 
     .. list-table::
        :widths: 15 10 30
@@ -78,6 +86,8 @@ Interfaces
 
     An interface choice comment\.
 
+    Returns\: (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_, `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_)
+
     .. list-table::
        :widths: 15 10 30
        :header-rows: 1
@@ -90,6 +100,8 @@ Interfaces
          - A choice field comment\.
 
   + **Choice Transfer**
+
+    Returns\: `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_
 
     .. list-table::
        :widths: 15 10 30

--- a/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.md
@@ -14,15 +14,21 @@
 >
 > * **Choice Archive**
 >
+>   Returns: ()
+>
 >   (no fields)
 >
 > * **Choice DoNothing**
+>
+>   Returns: ()
 >
 >   (no fields)
 >
 > * **Choice Merge**
 >
 >   merges two "compatible" `Iou`s
+>
+>   Returns: [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962)
 >
 >   | Field                                                                                                                          | Type                                                                                                                           | Description |
 >   | :----------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------- | :---------- |
@@ -32,6 +38,8 @@
 >
 >   splits into two `Iou`s with smaller amounts
 >
+>   Returns: ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962), [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962))
+>
 >   | Field                                                                                  | Type                                                                                   | Description |
 >   | :------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------- | :---------- |
 >   | splitAmount                                                                            | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135) | must be between zero and original amount |
@@ -39,6 +47,8 @@
 > * **Choice Transfer**
 >
 >   changes the owner
+>
+>   Returns: [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962)
 >
 >   | Field                                                                                   | Type                                                                                    | Description |
 >   | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |

--- a/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.rst
@@ -35,15 +35,21 @@ Templates
 
   + **Choice Archive**
 
+    Returns\: ()
+
     (no fields)
 
   + **Choice DoNothing**
+
+    Returns\: ()
 
     (no fields)
 
   + **Choice Merge**
 
     merges two \"compatible\" ``Iou``s
+
+    Returns\: `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_
 
     .. list-table::
        :widths: 15 10 30
@@ -60,6 +66,8 @@ Templates
 
     splits into two ``Iou``s with smaller amounts
 
+    Returns\: (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_, `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_)
+
     .. list-table::
        :widths: 15 10 30
        :header-rows: 1
@@ -74,6 +82,8 @@ Templates
   + **Choice Transfer**
 
     changes the owner
+
+    Returns\: `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_
 
     .. list-table::
        :widths: 15 10 30

--- a/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.md
@@ -12,6 +12,8 @@
 >
 > * **Choice Archive**
 >
+>   Returns: ()
+>
 >   (no fields)
 
 > * **interface instance** Token **for** [Asset](#type-qualifiedinterface-asset-82061)

--- a/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.rst
@@ -29,6 +29,8 @@ Templates
 
   + **Choice Archive**
 
+    Returns\: ()
+
     (no fields)
 
   + **interface instance** Token **for** `Asset <type-qualifiedinterface-asset-82061_>`_

--- a/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.md
@@ -8,15 +8,21 @@
 >
 > * **Choice Archive**
 >
+>   Returns: ()
+>
 >   (no fields)
 >
 > * **Choice GetRich**
+>
+>   Returns: [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978)
 >
 >   | Field                                                                          | Type                                                                           | Description |
 >   | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
 >   | byHowMuch                                                                      | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
 >
 > * **Choice Noop**
+>
+>   Returns: ()
 >
 >   | Field   | Type    | Description |
 >   | :------ | :------ | :---------- |
@@ -26,11 +32,15 @@
 >
 >   An interface choice comment.
 >
+>   Returns: ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978), [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978))
+>
 >   | Field                                                                          | Type                                                                           | Description |
 >   | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
 >   | splitAmount                                                                    | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) | A choice field comment. |
 >
 > * **Choice Transfer**
+>
+>   Returns: [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978)
 >
 >   | Field                                                                                   | Type                                                                                    | Description |
 >   | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |

--- a/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.rst
@@ -14,9 +14,13 @@ Interfaces
 
   + **Choice Archive**
 
+    Returns\: ()
+
     (no fields)
 
   + **Choice GetRich**
+
+    Returns\: `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_
 
     .. list-table::
        :widths: 15 10 30
@@ -30,6 +34,8 @@ Interfaces
          -
 
   + **Choice Noop**
+
+    Returns\: ()
 
     .. list-table::
        :widths: 15 10 30
@@ -46,6 +52,8 @@ Interfaces
 
     An interface choice comment\.
 
+    Returns\: (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_, `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_)
+
     .. list-table::
        :widths: 15 10 30
        :header-rows: 1
@@ -58,6 +66,8 @@ Interfaces
          - A choice field comment\.
 
   + **Choice Transfer**
+
+    Returns\: `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_
 
     .. list-table::
        :widths: 15 10 30

--- a/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.md
@@ -8,15 +8,21 @@
 >
 > * **Choice Archive**
 >
+>   Returns: ()
+>
 >   (no fields)
 >
 > * **Choice GetRich**
+>
+>   Returns: [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-retroactiveinterfaceinstance-token-49693)
 >
 >   | Field                                                                          | Type                                                                           | Description |
 >   | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
 >   | byHowMuch                                                                      | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
 >
 > * **Choice Noop**
+>
+>   Returns: ()
 >
 >   | Field   | Type    | Description |
 >   | :------ | :------ | :---------- |
@@ -26,11 +32,15 @@
 >
 >   An interface choice comment.
 >
+>   Returns: ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-retroactiveinterfaceinstance-token-49693), [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-retroactiveinterfaceinstance-token-49693))
+>
 >   | Field                                                                          | Type                                                                           | Description |
 >   | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
 >   | splitAmount                                                                    | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) | A choice field comment. |
 >
 > * **Choice Transfer**
+>
+>   Returns: [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-retroactiveinterfaceinstance-token-49693)
 >
 >   | Field                                                                                   | Type                                                                                    | Description |
 >   | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |

--- a/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.rst
@@ -14,9 +14,13 @@ Interfaces
 
   + **Choice Archive**
 
+    Returns\: ()
+
     (no fields)
 
   + **Choice GetRich**
+
+    Returns\: `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-retroactiveinterfaceinstance-token-49693_>`_
 
     .. list-table::
        :widths: 15 10 30
@@ -30,6 +34,8 @@ Interfaces
          -
 
   + **Choice Noop**
+
+    Returns\: ()
 
     .. list-table::
        :widths: 15 10 30
@@ -46,6 +52,8 @@ Interfaces
 
     An interface choice comment\.
 
+    Returns\: (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-retroactiveinterfaceinstance-token-49693_>`_, `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-retroactiveinterfaceinstance-token-49693_>`_)
+
     .. list-table::
        :widths: 15 10 30
        :header-rows: 1
@@ -58,6 +66,8 @@ Interfaces
          - A choice field comment\.
 
   + **Choice Transfer**
+
+    Returns\: `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-retroactiveinterfaceinstance-token-49693_>`_
 
     .. list-table::
        :widths: 15 10 30


### PR DESCRIPTION
Addresses #16533 
Adds `Returns: [thetype]` to choice definitions in generated docs