### PR TITLE
Windows clean up

### DIFF
--- a/infra/azure.tf
+++ b/infra/azure.tf
@@ -102,7 +102,7 @@ cat <<'CRON' > /root/daily-reset.sh
 set -euo pipefail
 echo "$(date -Is -u) start"
 
-scale_sets='${jsonencode(local.ubuntu.azure)}'
+scale_sets='${jsonencode(concat(local.ubuntu.azure, local.windows.azure))}'
 
 for set in $(echo $scale_sets | jq -r '.[] | .name'); do
   echo "$(date -Is -u) Setting scale set $set size to 0"

--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -38,6 +38,7 @@ resource "google_project_iam_member" "periodic-killer" {
 }
 
 resource "google_compute_instance" "periodic-killer" {
+  count        = 0
   name         = "periodic-killer"
   machine_type = "g1-small"
   zone         = "us-east4-a"

--- a/infra/windows.tf
+++ b/infra/windows.tf
@@ -15,7 +15,7 @@ locals {
       },
       {
         name       = "ci-w2"
-        size       = 6,
+        size       = 0,
         assignment = "default",
         disk_size  = 400,
       },


### PR DESCRIPTION
- Shut down remaining GCP Windows nodes.
- Shut down the periodic-killer node as there are not more nodes for it to kill.
- Add Azure Windows scale sets to the list of scale sets to cycle every night.