### PR TITLE
make tests write log output to "console" so we can see it in CI

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -79,4 +79,5 @@ if ($env:SKIP_TESTS -ceq "False") {
       `-`-build_event_json_file test-events.json `
       `-`-build_event_publish_all_actions `
       `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/logs/test_execution_windows.log
+      `-`-test_output=all
 }

--- a/build.sh
+++ b/build.sh
@@ -86,6 +86,7 @@ $bazel test //... \
   --build_event_json_file test-events.json \
   --build_event_publish_all_actions \
   --experimental_execution_log_file "$ARTIFACT_DIRS/logs/test_execution${execution_log_postfix}.log"
+  --test_output=all
 
 # Make sure that Bazel query works.
 $bazel query 'deps(//...)' >/dev/null

--- a/ledger-service/db-backend/BUILD.bazel
+++ b/ledger-service/db-backend/BUILD.bazel
@@ -54,6 +54,7 @@ da_scala_test(
     srcs = glob(["src/test/scala/**/*.scala"]),
     scala_deps = [
         "@maven//:com_chuusai_shapeless",
+        "@maven//:com_lihaoyi_sourcecode",
         "@maven//:org_scalacheck_scalacheck",
         "@maven//:org_scalatestplus_scalacheck_1_15",
         "@maven//:org_scalatest_scalatest_core",
@@ -73,5 +74,7 @@ da_scala_test(
     deps = [
         ":db-backend",
         "//libs-scala/nonempty",
+        "//libs-scala/test-evidence/scalatest:test-evidence-scalatest",
+        "//libs-scala/test-evidence/tag:test-evidence-tag",
     ],
 )

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -1033,7 +1033,7 @@ private final class OracleQueries(
       }
       case JsNull | JsTrue | JsFalse | JsArray(_) | JsObject(_) => sql"$literal"
     }
-    sql""" PASSING $rendered AS "${Fragment.const0(name)}" """
+    sql""" PASSING $rendered AS "${Fragment.const0(name)}""""
   }
 
   private[http] override def equalAtContractPath(path: JsonPath, literal: JsValue): Fragment = {
@@ -1115,7 +1115,7 @@ private final class OracleQueries(
     }
     val pathc = ('$' -: pathSteps(path)) ++ s"?(@ $opc ${"$X"})"
     sql"JSON_EXISTS($contractColumnName, " ++
-      sql"""${oracleShortPathEscape(pathc)} $passingValueAsX)"""
+      sql"""${oracleShortPathEscape(pathc)}${passingValueAsX})"""
   }
 }
 

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -588,7 +588,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
       }
     }
 
-    "nested comparison filters" onlyIfLargeQueries_- {
+    "nested comparison filters" - {
       import shapeless.Coproduct, shapeless.syntax.singleton._
       val irrelevant = Ref.Identifier assertFromString "none:Discarded:Identifier"
       val (_, bazRecordVA) = VA.record(irrelevant, ShRecord(baz = VA.text))
@@ -637,11 +637,20 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           withBazRecord("a"),
         ),
         Scenario(
+          "gt string with unsafe values",
+          kbvarId,
+          kbvarVA,
+          Map("bazRecord" -> Map("baz" -> Map("%gt" -> "bobby'); DROP TABLE Students;--")).toJson),
+        )(
+          withBazRecord("c"),
+          withBazRecord("a"),
+        ),
+        Scenario(
           "gt int",
           kbvarId,
           kbvarVA,
           Map("fooVariant" -> Map("tag" -> "Bar".toJson, "value" -> Map("%gt" -> 2).toJson).toJson),
-        )(withFooVariant(3), withFooVariant(1)),
+        )(withFooVariant(10), withFooVariant(1)),
       ).zipWithIndex.foreach { case (scenario, ix) =>
         import scenario._
         s"$label (scenario $ix)" in withHttpService { fixture =>

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -655,8 +655,8 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           kbvarVA,
           Map("bazRecord" -> Map("baz" -> Map("%lt" -> "'")).toJson),
         )(
-          withBazRecord(" "),
-          withBazRecord("A"),
+          withBazRecord("#"), // Less than '
+          withBazRecord("A"), // Not less than '
         ),
         Scenario(
           "lt string with sketchy value which uses unicode quote char",

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
@@ -249,7 +249,7 @@ class ValuePredicateTest
           """{"_2": "hi there", "_3": false}""",
           tuple3VA,
           sql"payload @> ${"""{"foo":{"_2":"hi there","_3":false}}""".parseJson}::jsonb",
-          sql"""JSON_EXISTS(payload, '$$."foo"."_2"?(@ == $$X)' PASSING ${"hi there"} AS X)"""
+          sql"""JSON_EXISTS(payload, '$$."foo"."_2"?(@ == $$X)' PASSING 'hi there' AS "X")"""
             ++ sql""" AND JSON_EXISTS(payload, '$$."foo"."_3"?(@ == false)')""",
         ),
         (
@@ -262,7 +262,7 @@ class ValuePredicateTest
           """{"%lte": 42}""",
           VA.int64,
           sql"payload->${"foo": String} <= ${JsNumber(42): JsValue}::jsonb AND payload @> ${JsObject(): JsValue}::jsonb",
-          sql"""JSON_EXISTS(payload, '$$."foo"?(@ <= $$X)' PASSING ${42L} AS X) AND 1 = 1""",
+          sql"""JSON_EXISTS(payload, '$$."foo"?(@ <= $$X)' PASSING ${42L} AS "X") AND 1 = 1""",
         ),
         (
           """{"tag": "Left", "value": "42"}""",
@@ -274,8 +274,8 @@ class ValuePredicateTest
           """{"tag": "Left", "value": {"%lte": 42}}""",
           eitherVA,
           sql"payload->${"foo"}->${"value"} <= ${"42".parseJson}::jsonb AND payload @> ${"""{"foo": {"tag": "Left"}}""".parseJson}::jsonb",
-          sql"""JSON_EXISTS(payload, '$$."foo"."value"?(@ <= $$X)' PASSING ${42L} AS X)"""
-            ++ sql""" AND JSON_EXISTS(payload, '$$."foo"."tag"?(@ == $$X)' PASSING ${"Left"} AS X)""",
+          sql"""JSON_EXISTS(payload, '$$."foo"."value"?(@ <= $$X)' PASSING ${42L} AS "X")"""
+            ++ sql""" AND JSON_EXISTS(payload, '$$."foo"."tag"?(@ == $$X)' PASSING 'Left' AS "X")""",
         ),
       )
     }


### PR DESCRIPTION
Child of `json-api-lt-14-rls-use-literal-in-json-queries-when-index-is-on` just created to be able to see test logs so I can diagnose the failure on windows.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
