### PR TITLE
Increase port timeout and cpu reserve for canton tests

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -668,9 +668,8 @@ da_haskell_test(
     ],
     main_function = "DA.Test.Repl.main",
     src_strip_prefix = "src",
-    tags = ["cpu:4"],
     # Spinning up Sandbox is expensive, so require 2 CPUs.
-    tags = ["cpu:2"],
+    tags = ["cpu:4"],
     visibility = ["//visibility:public"],
     deps = [
         "//libs-haskell/bazel-runfiles",

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -668,6 +668,7 @@ da_haskell_test(
     ],
     main_function = "DA.Test.Repl.main",
     src_strip_prefix = "src",
+    tags = ["cpu:4"],
     # Spinning up Sandbox is expensive, so require 2 CPUs.
     tags = ["cpu:2"],
     visibility = ["//visibility:public"],
@@ -709,6 +710,7 @@ da_haskell_test(
     ],
     main_function = "DA.Test.Repl.FuncTests.main",
     src_strip_prefix = "src",
+    tags = ["cpu:4"],
     visibility = ["//visibility:public"],
     deps = [
         "//:sdk-version-hs-lib",
@@ -1024,6 +1026,7 @@ da_haskell_test(
         "zip-archive",
     ],
     main_function = "DamlcPkgManager.main",
+    tags = ["cpu:4"],
     visibility = ["//visibility:public"],
     deps = [
         "//:sdk-version-hs-lib",

--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -127,6 +127,7 @@ da_haskell_test(
         "//daml-assistant/daml-helper",
         "@canton//:lib",
     ] + (["@sysctl_nix//:bin/sysctl"] if is_darwin else []),
+    # TODO (MK) https://github.com/digital-asset/daml/issues/9768
     flaky = True,
     hackage_deps = [
         "aeson",
@@ -148,7 +149,6 @@ da_haskell_test(
     ],
     main_function = "DA.Daml.Helper.Test.Deployment.main",
     src_strip_prefix = "test",
-    # TODO (MK) https://github.com/digital-asset/daml/issues/9768
     tags = ["cpu:4"],
     visibility = ["//visibility:public"],
     deps = [

--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -110,6 +110,7 @@ da_haskell_test(
         "tasty-hunit",
     ],
     main_function = "DA.Daml.Helper.Test.Tls.main",
+    tags = ["cpu:4"],
     visibility = ["//visibility:public"],
     deps = [
         "//libs-haskell/bazel-runfiles",
@@ -126,7 +127,6 @@ da_haskell_test(
         "//daml-assistant/daml-helper",
         "@canton//:lib",
     ] + (["@sysctl_nix//:bin/sysctl"] if is_darwin else []),
-    # TODO (MK) https://github.com/digital-asset/daml/issues/9768
     flaky = True,
     hackage_deps = [
         "aeson",
@@ -148,6 +148,8 @@ da_haskell_test(
     ],
     main_function = "DA.Daml.Helper.Test.Deployment.main",
     src_strip_prefix = "test",
+    # TODO (MK) https://github.com/digital-asset/daml/issues/9768
+    tags = ["cpu:4"],
     visibility = ["//visibility:public"],
     deps = [
         "//:sdk-version-hs-lib",
@@ -182,7 +184,7 @@ da_haskell_test(
     ],
     main_function = "DA.Daml.Helper.Test.Ledger.main",
     # Starts Sandbox & JSON-API so needs more resources.
-    tags = ["cpu:3"],
+    tags = ["cpu:4"],
     visibility = ["//visibility:public"],
     deps = [
         "//compiler/daml-lf-ast",
@@ -216,7 +218,7 @@ da_haskell_test(
     ],
     main_function = "DA.Daml.Helper.Test.Packages.main",
     # Starts Sandbox & JSON-API so needs more resources.
-    tags = ["cpu:3"],
+    tags = ["cpu:4"],
     visibility = ["//visibility:public"],
     deps = [
         "//compiler/daml-lf-ast",

--- a/libs-haskell/da-hs-base/src/DA/PortFile.hs
+++ b/libs-haskell/da-hs-base/src/DA/PortFile.hs
@@ -57,4 +57,4 @@ retryDelayMillis :: Int
 retryDelayMillis = 50
 
 maxRetries :: Int
-maxRetries = 120 * (1000 `div` retryDelayMillis)
+maxRetries = 180 * (1000 `div` retryDelayMillis)


### PR DESCRIPTION
Following #16722, we saw a flake likely due to canton tests being too parallelised.
Increased the port timeout and added the cpu:4 tag to reduce the number of canton tests running in parallel
