### PR TITLE
Increase daml-assistant GRPC timeout

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -105,7 +105,7 @@ defaultLedgerFlags :: LedgerApi -> LedgerFlags
 defaultLedgerFlags api = LedgerFlags
   { fApi = api
   , fSslConfigM = Nothing
-  , fTimeout = 10
+  , fTimeout = 60
   , fHostM = Nothing
   , fPortM = Nothing
   , fTokFileM = Nothing


### PR DESCRIPTION
10s is definitively too short for the ledger to upload a "big" dar especially when on load. We bump it to 60s following the one uses in the scenario service.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
