### PR TITLE
Extract `daml-dar-reader`

### DIFF
--- a/compiler/daml-dar-reader/BUILD.bazel
+++ b/compiler/daml-dar-reader/BUILD.bazel
@@ -1,0 +1,28 @@
+# Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel_tools:haskell.bzl", "da_haskell_library")
+
+da_haskell_library(
+    name = "daml-dar-reader",
+    srcs = glob(["src/**/*.hs"]),
+    hackage_deps = [
+        "aeson",
+        "aeson-pretty",
+        "base",
+        "bytestring",
+        "extra",
+        "filepath",
+        "text",
+        "unordered-containers",
+        "zip-archive",
+    ],
+    src_strip_prefix = "src",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//compiler/daml-lf-ast",
+        "//compiler/daml-lf-proto:daml-lf-proto-decode",
+        "//compiler/daml-lf-reader",
+        "//libs-haskell/da-hs-base",
+    ],
+)

--- a/compiler/daml-dar-reader/src/DA/Daml/Dar/Reader.hs
+++ b/compiler/daml-dar-reader/src/DA/Daml/Dar/Reader.hs
@@ -1,7 +1,7 @@
 -- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module DA.Cli.Damlc.InspectDar
+module DA.Daml.Dar.Reader
     ( Format(..)
     , getDarInfo
     , inspectDar
@@ -12,7 +12,7 @@ module DA.Cli.Damlc.InspectDar
 
 import qualified "zip-archive" Codec.Archive.Zip as ZipArchive
 import qualified DA.Daml.LF.Ast as LF
-import qualified DA.Daml.LF.Proto3.Archive as Archive
+import qualified DA.Daml.LF.Proto3.Archive.Decode as Archive
 import DA.Daml.LF.Reader
 import DA.Pretty (renderPretty)
 import Data.Aeson

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -207,6 +207,7 @@ da_haskell_library(
     visibility = ["//visibility:public"],
     deps = [
         "//:sdk-version-hs-lib",
+        "//compiler/daml-dar-reader",
         "//compiler/daml-lf-ast",
         "//compiler/daml-lf-proto",
         "//compiler/daml-lf-reader",

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -18,7 +18,7 @@ import DA.Bazel.Runfiles
 import qualified DA.Cli.Args as ParseArgs
 import DA.Cli.Options
 import DA.Cli.Damlc.BuildInfo
-import qualified DA.Cli.Damlc.InspectDar as InspectDar
+import qualified DA.Daml.Dar.Reader as InspectDar
 import qualified DA.Cli.Damlc.Command.Damldoc as Damldoc
 import DA.Cli.Damlc.Packaging
 import DA.Cli.Damlc.DependencyDb

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -1029,8 +1029,8 @@ da_haskell_test(
     visibility = ["//visibility:public"],
     deps = [
         "//:sdk-version-hs-lib",
+        "//compiler/daml-dar-reader",
         "//compiler/daml-lf-ast",
-        "//compiler/damlc:damlc-lib",
         "//daml-assistant/daml-helper:daml-helper-lib",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",

--- a/compiler/damlc/tests/src/DamlcPkgManager.hs
+++ b/compiler/damlc/tests/src/DamlcPkgManager.hs
@@ -7,7 +7,7 @@ module DamlcPkgManager
 {- HLINT ignore "locateRunfiles/package_app" -}
 
 import DA.Bazel.Runfiles
-import DA.Cli.Damlc.InspectDar
+import DA.Daml.Dar.Reader
 import DA.Daml.Helper.Ledger (downloadAllReachablePackages)
 import qualified DA.Daml.LF.Ast as LF
 import DA.Test.Sandbox

--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -187,8 +187,8 @@ da_haskell_test(
     tags = ["cpu:4"],
     visibility = ["//visibility:public"],
     deps = [
+        "//compiler/daml-dar-reader",
         "//compiler/daml-lf-ast",
-        "//compiler/damlc:damlc-lib",
         "//language-support/hs/bindings:hs-ledger",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",

--- a/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Ledger.hs
+++ b/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Ledger.hs
@@ -8,7 +8,7 @@ module DA.Daml.Helper.Test.Ledger
 
 import qualified "zip-archive" Codec.Archive.Zip as Zip
 import DA.Bazel.Runfiles
-import DA.Cli.Damlc.InspectDar
+import DA.Daml.Dar.Reader
 import qualified DA.Daml.LF.Ast.Base as LF
 import DA.Ledger.Services.PartyManagementService (PartyDetails(..))
 import DA.Ledger.Types (Party(..))


### PR DESCRIPTION
in an upcoming PR I'll need to use the function `DA.Cli.Damlc.InspectDar.getDarInfo` from `//compiler/damlc/daml-compiler` but it's currently defined in `//compiler/damlc:damlc-lib` (which depends on `//compiler/damlc/daml-compiler`)