### PR TITLE
[LF] refactor CantonFixture

### DIFF
--- a/daml-lf/integration-test-lib/BUILD.bazel
+++ b/daml-lf/integration-test-lib/BUILD.bazel
@@ -11,7 +11,7 @@ da_scala_library(
     name = "integration-test-lib",
     srcs = glob(["src/main/**/*.scala"]),
     data = [
-        ":canton-dev_deploy.jar",
+        ":canton-patched_deploy.jar",
         ":canton_deploy.jar",
         "//test-common/test-certificates",
     ],
@@ -61,10 +61,11 @@ java_binary(
 # We replace engine and archive classes in canton
 # This should be used for testing only
 java_binary(
-    name = "canton-dev",
+    name = "canton-patched",
     main_class = "com.digitalasset.canton.CantonCommunityApp",
     visibility = ["//visibility:public"],
     runtime_deps = [
+        # The following prevents buildifier from sorting the deps
         # Do not sort
         "//daml-lf/engine",
         "//daml-lf/archive:daml_lf_archive_reader",

--- a/daml-lf/integration-test-lib/src/main/com/daml/lf/CantonConfig.scala
+++ b/daml-lf/integration-test-lib/src/main/com/daml/lf/CantonConfig.scala
@@ -4,6 +4,7 @@
 package com.daml.lf
 package integrationtest
 
+import com.daml.bazeltools.BazelRunfiles.rlocation
 import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.api.tls.TlsConfiguration
@@ -15,7 +16,7 @@ import com.daml.ports.Port
 import scalaz.syntax.tag._
 
 import scala.concurrent.{ExecutionContext, Future}
-import java.nio.file.Path
+import java.nio.file.{Path, Paths}
 
 object CantonConfig {
 
@@ -36,18 +37,41 @@ object CantonConfig {
   }
 
   def noTlsConfig = TlsConfiguration(false)
+
 }
 
 final case class CantonConfig(
+    applicationId: ApplicationId,
     darFiles: List[Path] = List.empty,
     authSecret: Option[String] = None,
     devMode: Boolean = false,
     nParticipants: Int = 1,
     timeProviderType: TimeProviderType = TimeProviderType.WallClock,
-    tlsConfig: Option[CantonConfig.Tls] = None,
-    applicationId: ApplicationId = ApplicationId("integrationtest"),
+    tlsEnable: Boolean = false,
     debug: Boolean = false,
 ) {
+
+  lazy val tlsConfig =
+    if (tlsEnable)
+      Some(
+        CantonConfig.Tls(
+          Paths.get(rlocation("test-common/test-certificates/server.crt")),
+          Paths.get(rlocation("test-common/test-certificates/server.pem")),
+          Paths.get(rlocation("test-common/test-certificates/ca.crt")),
+          Paths.get(rlocation("test-common/test-certificates/client.crt")),
+          Paths.get(rlocation("test-common/test-certificates/client.pem")),
+        )
+      )
+    else
+      None
+
+  lazy val participantIds =
+    Iterator
+      .range(0, nParticipants)
+      .map(i => Ref.ParticipantId.assertFromString("participant" + i.toString))
+      .toVector
+
+  lazy val ledgerIds = participantIds.asInstanceOf[Vector[String]]
 
   def getToken(userId: Ref.IdString.UserId): Option[String] =
     CantonRunner.getToken(userId, authSecret)

--- a/daml-lf/integration-test-lib/src/main/com/daml/lf/CantonFixture.scala
+++ b/daml-lf/integration-test-lib/src/main/com/daml/lf/CantonFixture.scala
@@ -6,7 +6,12 @@ package integrationtest
 
 import com.daml.bazeltools.BazelRunfiles._
 import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
-import com.daml.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, OwnedResource, SuiteResource}
+import com.daml.ledger.api.testing.utils.{
+  AkkaBeforeAndAfterAll,
+  OwnedResource,
+  SuiteResource,
+  SuiteResourceManagementAroundAll,
+}
 import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.resources.ResourceContext
 import com.daml.lf.data.Ref
@@ -54,8 +59,29 @@ object CantonFixture {
 
 }
 
-trait CantonFixture extends SuiteResource[Vector[Port]] with AkkaBeforeAndAfterAll {
+trait CantonFixture
+    extends SuiteResource[Vector[Port]]
+    with AkkaBeforeAndAfterAll
+    with SuiteResourceManagementAroundAll {
   self: Suite =>
+
+  protected lazy val authSecret: Option[String] = Option.empty
+  protected lazy val darFiles: List[Path] = List.empty
+  protected lazy val devMode: Boolean = false
+  protected lazy val nParticipants: Int = 1
+  protected lazy val timeProviderType: TimeProviderType = TimeProviderType.WallClock
+  protected lazy val tlsEnable: Boolean = false
+
+  // This flag setup some behavior to ease debugging tests.
+  //  If `true`
+  //   - temporary file are not deleted (this requires "--test_tmpdir=/tmp/" or similar for bazel builds)
+  //   - some debug info are logged.
+  protected val cantonFixtureDebugMode = false
+
+  final protected val logger = org.slf4j.LoggerFactory.getLogger(getClass)
+
+  if (cantonFixtureDebugMode)
+    logger.asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.INFO)
 
   override protected def afterAll(): Unit = {
     cantonCleanUp()
@@ -65,52 +91,24 @@ trait CantonFixture extends SuiteResource[Vector[Port]] with AkkaBeforeAndAfterA
   final override protected lazy val suiteResource: OwnedResource[ResourceContext, Vector[Port]] = {
     implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)
     new OwnedResource[ResourceContext, Vector[Port]](
-      CantonRunner.run(config, cantonTmpDir),
+      CantonRunner.run(config, cantonTmpDir, logger),
       acquisitionTimeout = 2.minute,
       releaseTimeout = 2.minute,
     )
   }
 
-  protected def authSecret: Option[String]
-  protected def darFiles: List[Path]
-  protected def devMode: Boolean
-  protected def nParticipants: Int
-  protected def timeProviderType: TimeProviderType
-  protected def tlsEnable: Boolean
-  protected def applicationId: ApplicationId
-
-  lazy val tlsConfig =
-    if (tlsEnable)
-      Some(
-        CantonConfig.Tls(
-          Paths.get(rlocation("test-common/test-certificates/server.crt")),
-          Paths.get(rlocation("test-common/test-certificates/server.pem")),
-          Paths.get(rlocation("test-common/test-certificates/ca.crt")),
-          Paths.get(rlocation("test-common/test-certificates/client.crt")),
-          Paths.get(rlocation("test-common/test-certificates/client.pem")),
-        )
-      )
-    else
-      None
+  final protected lazy val applicationId: ApplicationId = ApplicationId(getClass.getName)
 
   lazy val config = CantonConfig(
-    darFiles: List[Path],
-    authSecret: Option[String],
-    devMode: Boolean,
-    nParticipants: Int,
-    timeProviderType: TimeProviderType,
-    tlsConfig = tlsConfig,
-    applicationId = applicationId: ApplicationId,
+    applicationId = applicationId,
+    darFiles = darFiles,
+    authSecret = authSecret,
+    devMode = devMode,
+    nParticipants = nParticipants,
+    timeProviderType = timeProviderType,
+    tlsEnable = tlsEnable,
     debug = cantonFixtureDebugMode,
   )
-
-  // This flag setup some behavior to ease debugging tests.
-  //  If `true`
-  //   - temporary file are not deleted (this requires "--test_tmpdir=/tmp/" or similar for bazel builds)
-  //   - some debug info are logged.
-  protected val cantonFixtureDebugMode = false
-
-  private val logger = org.slf4j.LoggerFactory.getLogger(getClass)
 
   protected def info(msg: String): Unit =
     if (cantonFixtureDebugMode) logger.info(msg)

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -179,8 +179,8 @@ da_scala_test_suite(
         "@maven//:org_scalaz_scalaz_core",
     ],
     tags = [
-        "canton-dev",
         "cpu:4",
+        "dev-canton-test",
     ],
     deps = [
         ":test-utils",

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/AuthIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/AuthIT.scala
@@ -5,7 +5,6 @@ package com.daml.lf.engine.script
 package test
 
 import com.daml.ledger.api.domain
-import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.engine.script.ledgerinteraction.ScriptTimeMode
 import com.daml.lf.integrationtest._
@@ -16,19 +15,12 @@ import org.scalatest.wordspec.AsyncWordSpec
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
-final class AuthIT
-    extends AsyncWordSpec
-    with AbstractScriptTest
-    with Matchers
-    with SuiteResourceManagementAroundAll {
+final class AuthIT extends AsyncWordSpec with AbstractScriptTest with Matchers {
   import AbstractScriptTest._
 
-  override protected lazy val authSecret = Some("secret")
-  override protected lazy val darFiles = List(stableDarPath)
-  override protected lazy val devMode = false
-  override protected lazy val nParticipants = 1
-  override protected lazy val timeMode = ScriptTimeMode.WallClock
-  override protected lazy val tlsEnable = false
+  final override protected lazy val authSecret = Some("secret")
+  final override protected lazy val darFiles = List(stableDarPath)
+  final override protected lazy val timeMode = ScriptTimeMode.WallClock
 
   "Daml Script against authorized ledger" can {
     "auth" should {

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/DamlScriptTestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/DamlScriptTestRunner.scala
@@ -4,8 +4,6 @@
 package com.daml.lf.engine.script
 
 import com.daml.bazeltools.BazelRunfiles
-import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
-import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.lf.integrationtest.CantonFixture
 import com.daml.platform.services.time.TimeProviderType
 import com.daml.scalautil.Statement.discard
@@ -15,20 +13,10 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import java.nio.file.Files
 
-class DamlScriptTestRunner
-    extends AnyWordSpec
-    with CantonFixture
-    with Matchers
-    with SuiteResourceManagementAroundAll {
+class DamlScriptTestRunner extends AnyWordSpec with CantonFixture with Matchers {
   self: Suite =>
 
-  override protected def authSecret = None
-  override protected def darFiles = List.empty
-  override protected def devMode = false
-  override protected def nParticipants = 1
-  override protected def timeProviderType = TimeProviderType.Static
-  override protected def tlsEnable = false
-  override protected def applicationId: ApplicationId = ApplicationId("daml-script")
+  final override protected lazy val timeProviderType = TimeProviderType.Static
 
   private val exe = if (sys.props("os.name").toLowerCase.contains("windows")) ".exe" else ""
   val scriptPath = BazelRunfiles.rlocation("daml-script/runner/daml-script-binary" + exe)

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/MultiParticipantIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/MultiParticipantIT.scala
@@ -4,7 +4,6 @@
 package com.daml.lf.engine.script
 package test
 
-import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.lf.data.FrontStack
 import com.daml.lf.data.Ref._
 import com.daml.lf.engine.script.ledgerinteraction.ScriptTimeMode
@@ -17,18 +16,15 @@ final class MultiParticipantIT
     extends AsyncWordSpec
     with AbstractScriptTest
     with Inside
-    with Matchers
-    with SuiteResourceManagementAroundAll {
+    with Matchers {
   import AbstractScriptTest._
 
   val dar = stableDar
 
-  override protected lazy val authSecret = None
-  override protected lazy val darFiles = List(stableDarPath)
-  override protected lazy val devMode = true
-  override protected lazy val nParticipants = 2
-  override protected lazy val timeMode = ScriptTimeMode.WallClock
-  override protected lazy val tlsEnable = false
+  final override protected lazy val darFiles = List(stableDarPath)
+  final override protected lazy val devMode = true
+  final override protected lazy val nParticipants = 2
+  final override protected lazy val timeMode = ScriptTimeMode.WallClock
 
   "Multi-participant Daml Script" can {
     "multiTest" should {

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TlsIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TlsIT.scala
@@ -4,26 +4,18 @@
 package com.daml.lf.engine.script
 package test
 
-import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.lf.data.Ref
 import com.daml.lf.engine.script.ledgerinteraction.ScriptTimeMode
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
-final class TlsIT
-    extends AsyncWordSpec
-    with AbstractScriptTest
-    with Matchers
-    with SuiteResourceManagementAroundAll {
+final class TlsIT extends AsyncWordSpec with AbstractScriptTest with Matchers {
 
   import AbstractScriptTest._
 
-  override protected lazy val authSecret = None
-  override protected lazy val darFiles = List(stableDarPath)
-  override protected lazy val devMode = false
-  override protected lazy val nParticipants = 1
-  override protected lazy val timeMode = ScriptTimeMode.WallClock
-  override protected lazy val tlsEnable = true
+  final override protected lazy val darFiles = List(stableDarPath)
+  final override protected lazy val tlsEnable = true
+  final override protected lazy val timeMode = ScriptTimeMode.WallClock
 
   "Daml Script against ledger with TLS" can {
     "test0" should {

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
@@ -4,7 +4,6 @@
 package com.daml.lf.engine.script
 package test
 
-import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.lf.data.ImmArray
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{Numeric, FrontStack, FrontStackCons}
@@ -25,16 +24,12 @@ abstract class AbstractFuncIT
     extends AsyncWordSpec
     with AbstractScriptTest
     with Matchers
-    with Inside
-    with SuiteResourceManagementAroundAll {
+    with Inside {
 
   import AbstractScriptTest._
 
-  override protected lazy val authSecret = None
-  protected override lazy val darFiles = List(stableDarPath, devDarPath)
-  protected override lazy val devMode = true
-  protected override lazy val nParticipants = 1
-  protected override lazy val tlsEnable = false
+  override protected lazy val darFiles = List(stableDarPath, devDarPath)
+  override protected lazy val devMode = true
 
   def assertSTimestamp(v: SValue) =
     v match {

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractScriptTest.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractScriptTest.scala
@@ -6,7 +6,6 @@ package test
 
 import java.nio.file.{Path, Paths}
 import com.daml.bazeltools.BazelRunfiles.rlocation
-import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.engine.script.ledgerinteraction.{
@@ -45,9 +44,8 @@ object AbstractScriptTest {
 trait AbstractScriptTest extends CantonFixture with AkkaBeforeAndAfterAll {
   self: Suite =>
 
-  override protected def applicationId: ApplicationId = ApplicationId("daml-script")
-
   protected def timeMode: ScriptTimeMode
+
   final override protected lazy val timeProviderType = timeMode match {
     case ScriptTimeMode.Static => TimeProviderType.Static
     case ScriptTimeMode.WallClock => TimeProviderType.WallClock

--- a/ledger-test-tool/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger-test-tool/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -115,7 +115,7 @@ conformance_test(
     dev_mod_flag = "",
     extra_data =
         conformance_test_extra_data_base + [
-            "//daml-lf/integration-test-lib:canton-dev_deploy.jar",
+            "//daml-lf/integration-test-lib:canton-patched_deploy.jar",
             ":bootstrap-dev.canton",
             ":canton-dev.conf",
         ],
@@ -131,6 +131,6 @@ conformance_test(
         "--config=$$(canonicalize_rlocation $(rootpath :canton-dev.conf))",
         "--bootstrap=$$(canonicalize_rlocation $(rootpath :bootstrap-dev.canton))",
     ],
-    tags = ["canton-dev"],
+    tags = ["dev-canton-test"],
     test_tool_args = conformance_test_tool_args,
 ) if not is_windows else None

--- a/ledger-test-tool/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger-test-tool/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -34,7 +34,7 @@ canton_jar=canton%s_deploy.jar
 
 EOF
 cat $< >> $@
-""" % suffix,
+""" % ("-patched" if suffix else ""),
         ),
 
         # Required because running `canton-test-runner-with-dependencies-script` directly fails.

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/IntegrationTest.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/IntegrationTest.scala
@@ -11,41 +11,23 @@ import akka.http.scaladsl.settings.ServerSettings
 import akka.util.ByteString
 import com.daml.buildinfo.BuildInfo
 import com.daml.ledger.api.domain
-import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
-import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.ledger.client.LedgerClient
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.UserId
 import com.daml.navigator.config.{Arguments, Config}
 import com.daml.lf.integrationtest.CantonFixture
-import com.daml.platform.services.time.TimeProviderType
 import org.scalatest._
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.matchers.should.Matchers
 import com.daml.timer.RetryStrategy
 import com.google.protobuf.field_mask.FieldMask
-import org.slf4j.LoggerFactory
 
 import java.util.UUID
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
-class IntegrationTest
-    extends AsyncFreeSpec
-    with CantonFixture
-    with SuiteResourceManagementAroundAll
-    with Matchers {
+class IntegrationTest extends AsyncFreeSpec with CantonFixture with Matchers {
   self: Suite =>
-
-  override protected def authSecret = None
-  override protected def darFiles = List()
-  override protected def devMode = false
-  override protected def nParticipants = 1
-  override protected def timeProviderType = TimeProviderType.WallClock
-  override protected def tlsEnable = false
-  override protected def applicationId: ApplicationId = ApplicationId("navigator-backend")
-
-  private val logger = LoggerFactory.getLogger(getClass)
 
   private def withNavigator[A](
       userMgmt: Boolean

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -54,7 +54,6 @@ import com.daml.test.evidence.tag.Security.SecurityTest.Property.{
 import com.daml.test.evidence.tag.Security.{Attack, SecurityTest}
 import com.daml.test.evidence.scalatest.ScalaTestSupport.Implicits._
 import com.google.protobuf.empty.Empty
-import com.typesafe.scalalogging.StrictLogging
 import org.scalatest.time.{Seconds, Span}
 import org.slf4j.LoggerFactory
 
@@ -66,7 +65,6 @@ trait AbstractTriggerServiceTestHelper
     with HttpCookies
     with TriggerServiceFixture
     with Matchers
-    with StrictLogging
     with Eventually {
 
   implicit override val patienceConfig: PatienceConfig =

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -144,7 +144,7 @@ EOF
                 "@maven//:org_scalatestplus_scalacheck_1_15",
                 "@maven//:org_scalaz_scalaz_core",
             ],
-            tags = ["cpu:4"] + (["canton-dev"] if lf_version else []),
+            tags = ["cpu:4"] + (["dev-canton-test"] if lf_version else []),
             deps = [
                 ":test-utils",
                 "//bazel_tools/runfiles:scala_runfiles",

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/CatAndFoodTriggerSimulation.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/CatAndFoodTriggerSimulation.scala
@@ -5,6 +5,7 @@ package com.daml.lf.engine.trigger.simulation
 
 import akka.actor.typed.{ActorRef, Behavior}
 import akka.actor.typed.scaladsl.Behaviors
+import com.daml.ledger.api.refinements.ApiTypes
 import com.daml.ledger.api.v1.event.CreatedEvent
 import com.daml.ledger.api.refinements.ApiTypes.Party
 import com.daml.lf.engine.trigger.simulation.TriggerMultiProcessSimulation.TriggerSimulationConfig
@@ -28,6 +29,7 @@ class CatAndFoodTriggerSimulation
     TriggerSimulationConfig(simulationDuration = 30.seconds)
 
   override protected def triggerMultiProcessSimulation: Behavior[Unit] = {
+    implicit def applicationId: ApiTypes.ApplicationId = config.applicationId
     Behaviors.setup { context =>
       val setup = for {
         client <- defaultLedgerClient()

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/TriggerMultiProcessSimulation.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/TriggerMultiProcessSimulation.scala
@@ -7,7 +7,7 @@ package simulation
 import akka.actor.typed.{ActorRef, ActorSystem, Behavior, SupervisorStrategy}
 import akka.actor.typed.scaladsl.Behaviors
 import akka.stream.Materializer
-import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId, Party}
+import com.daml.ledger.api.refinements.ApiTypes
 import com.daml.ledger.client.LedgerClient
 import com.daml.lf.engine.trigger.simulation.process.TriggerProcessFactory
 import com.daml.lf.engine.trigger.simulation.process.ledger.LedgerProcess
@@ -34,10 +34,6 @@ abstract class TriggerMultiProcessSimulation
   override implicit lazy val materializer: Materializer = Materializer(simulation)
 
   override implicit lazy val executionContext: ExecutionContext = materializer.executionContext
-
-  override protected implicit val applicationId: ApplicationId = ApplicationId(
-    "trigger-multi-process-simulation"
-  )
 
   override protected def triggerRunnerConfiguration: TriggerRunnerConfig =
     super.triggerRunnerConfiguration.copy(hardLimit =
@@ -79,7 +75,7 @@ abstract class TriggerMultiProcessSimulation
       client: LedgerClient,
       ledger: ActorRef[LedgerProcess.Message],
       name: String,
-      actAs: Party,
+      actAs: ApiTypes.Party,
   ): TriggerProcessFactory = {
     new TriggerProcessFactory(
       client,

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala
@@ -8,7 +8,6 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.speedy.SValue
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.value.Value.ContractId
-import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.ledger.api.v1.commands.CreateCommand
 import com.daml.ledger.api.v1.{value => LedgerApi}
 import com.daml.lf.engine.trigger.Runner.TriggerContext
@@ -29,7 +28,6 @@ abstract class AbstractFuncTests
     with AbstractTriggerTestWithCanton
     with Matchers
     with Inside
-    with SuiteResourceManagementAroundAll
     with TryValues {
   self: Suite =>
 

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTestWithCanton.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTestWithCanton.scala
@@ -9,8 +9,7 @@ package test
 import java.util.UUID
 import akka.stream.scaladsl.{Sink, Source}
 import com.daml.bazeltools.BazelRunfiles
-import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId, Party}
-import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.daml.ledger.api.refinements.ApiTypes
 import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.daml.ledger.api.v1.commands.{Command, CreateCommand, ExerciseCommand, _}
 import com.daml.ledger.api.v1.event.CreatedEvent
@@ -28,17 +27,15 @@ import com.daml.lf.engine.trigger.TriggerRunnerConfig.DefaultTriggerRunnerConfig
 import com.daml.lf.integrationtest.CantonFixture
 import com.daml.lf.speedy.SValue
 import com.daml.lf.speedy.SValue._
-import com.daml.platform.services.time.TimeProviderType
 import org.scalatest._
 import scalaz.syntax.tag._
 
-import java.nio.file.Path
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Try, Success, Failure}
 
 // TODO: once test migration work has completed, rename this trait to AbstractTriggerTest
-trait AbstractTriggerTestWithCanton extends CantonFixture with SuiteResourceManagementAroundAll {
+trait AbstractTriggerTestWithCanton extends CantonFixture {
   self: Suite =>
 
   import CantonFixture._
@@ -49,13 +46,8 @@ trait AbstractTriggerTestWithCanton extends CantonFixture with SuiteResourceMana
       case Failure(_) => Left(BazelRunfiles.requiredResource("triggers/tests/acs-1.dev.dar").toPath)
     }
 
-  override protected def authSecret: Option[String] = None
-  override protected def darFiles: List[Path] = List(darFile.merge)
-  override protected def devMode: Boolean = darFile.isLeft
-  override protected def nParticipants: Int = 1
-  override protected def timeProviderType: TimeProviderType = TimeProviderType.Static
-  override protected def tlsEnable: Boolean = false
-  override protected def applicationId: ApplicationId = RunnerConfig.DefaultApplicationId
+  final override protected lazy val darFiles = List(darFile.merge)
+  final override protected lazy val devMode = darFile.isLeft
 
   protected def toHighLevelResult(s: SValue) = s match {
     case SRecord(_, _, values) if values.size == 6 =>
@@ -96,8 +88,8 @@ trait AbstractTriggerTestWithCanton extends CantonFixture with SuiteResourceMana
 
     Trigger.newTriggerLogContext(
       triggerId,
-      Party(party),
-      Party.subst(readAs),
+      ApiTypes.Party(party),
+      ApiTypes.Party.subst(readAs),
       "test-trigger",
       applicationId,
     ) { implicit triggerContext: TriggerLogContext =>
@@ -111,8 +103,8 @@ trait AbstractTriggerTestWithCanton extends CantonFixture with SuiteResourceMana
         timeProviderType,
         applicationId,
         TriggerParties(
-          actAs = Party(party),
-          readAs = Party.subst(readAs),
+          actAs = ApiTypes.Party(party),
+          readAs = ApiTypes.Party.subst(readAs),
         ),
       )
     }

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/ConfigSpec.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/ConfigSpec.scala
@@ -4,14 +4,12 @@
 package com.daml.lf.engine.trigger
 package test
 
-import java.nio.file.{Path, Paths}
+import java.nio.file.Paths
 import com.daml.ledger.api.domain.{ObjectMeta, User, UserRight}
-import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId, Party}
-import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.daml.ledger.api.refinements.ApiTypes
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.UserId
 import com.daml.lf.integrationtest.CantonFixture
-import com.daml.platform.services.time.TimeProviderType
 import com.google.protobuf.field_mask.FieldMask
 import io.grpc.StatusRuntimeException
 import io.grpc.Status.Code
@@ -20,22 +18,12 @@ import org.scalatest.wordspec.AsyncWordSpec
 
 import scala.language.implicitConversions
 
-class ConfigSpec
-    extends AsyncWordSpec
-    with Matchers
-    with CantonFixture
-    with SuiteResourceManagementAroundAll {
+class ConfigSpec extends AsyncWordSpec with Matchers with CantonFixture {
 
-  override protected def authSecret: Option[String] = None
-  override protected def darFiles: List[Path] = List.empty
-  override protected def devMode: Boolean = true
-  override protected def nParticipants: Int = 1
-  override protected def timeProviderType: TimeProviderType = TimeProviderType.Static
-  override protected def tlsEnable: Boolean = false
-  override protected def applicationId: ApplicationId = ApplicationId("myappid")
+  final override protected lazy val devMode: Boolean = true
 
-  private implicit def toParty(s: String): Party =
-    Party(s)
+  private implicit def toParty(s: String): ApiTypes.Party =
+    ApiTypes.Party(s)
   private implicit def toRefParty(s: String): Ref.Party =
     Ref.Party.assertFromString(s)
   private implicit def toUserId(s: String): UserId =
@@ -56,7 +44,7 @@ class ConfigSpec
     )
     "succeed with --ledger-party" in {
       RunnerConfig.parse(defaultArgs ++ Seq("--ledger-party=alice")) shouldBe Some(
-        config.copy(ledgerClaims = PartySpecification(TriggerParties(Party("alice"), Set.empty)))
+        config.copy(ledgerClaims = PartySpecification(TriggerParties(toParty("alice"), Set.empty)))
       )
     }
     "succeed with --ledger-party and --ledger-readas" in {

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsStaticTime.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsStaticTime.scala
@@ -7,5 +7,6 @@ import com.daml.platform.services.time.TimeProviderType
 
 final class FuncTestsStaticTime extends AbstractFuncTests {
 
-  override protected def timeProviderType: TimeProviderType = TimeProviderType.Static
+  final override protected lazy val timeProviderType: TimeProviderType = TimeProviderType.Static
+
 }

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsWallClock.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsWallClock.scala
@@ -7,6 +7,6 @@ import com.daml.platform.services.time.TimeProviderType
 
 final class FuncTestsWallClock extends AbstractFuncTests {
 
-  override protected def timeProviderType: TimeProviderType = TimeProviderType.WallClock
+  final override protected lazy val timeProviderType: TimeProviderType = TimeProviderType.WallClock
 
 }

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala
@@ -15,7 +15,7 @@ import org.scalatest.wordspec.AsyncWordSpec
 
 class Tls extends AsyncWordSpec with AbstractTriggerTestWithCanton with Matchers with TryValues {
 
-  override protected def tlsEnable: Boolean = true
+  final override protected lazy val tlsEnable: Boolean = true
 
   "TLS" can {
     // We just need something simple to test the connection.


### PR DESCRIPTION
- force logging when debug is one
- inherit SuiteResourceManagementAroundAll
- minor cleanup
- add default value for CantonFixture parameter

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
