### PR TITLE
Update 2.2 docs

### DIFF
--- a/docs/canton-refs.rst
+++ b/docs/canton-refs.rst
@@ -4,7 +4,7 @@
 Dummy Canton Refs
 -----------------
 
-.. dummy canton refs so our sphinx build succeds. In the assembly repo
+.. dummy canton refs so our sphinx build succeeds. In the assembly repo
    these point to actual Canton docs.
 
 .. _tls-configuration:

--- a/docs/configs/pdf/index.rst
+++ b/docs/configs/pdf/index.rst
@@ -76,6 +76,7 @@ Background concepts
    concepts/identity-and-package-management
    concepts/time
    concepts/local-ledger
+   concepts/test-evidence
 
 Examples
 --------

--- a/docs/source/app-dev/code-snippets/Types.daml
+++ b/docs/source/app-dev/code-snippets/Types.daml
@@ -7,19 +7,22 @@ module Types where
 import Daml.Script
 import DA.Date
 
-data MyProductType = MyProductType {
-  intField: Int;
-  textField: Text;
-  decimalField: Decimal;
-  boolField: Bool;
-  partyField: Party;
-  timeField: Time;
-  listField: [Int];
-  contractIdField: ContractId SomeTemplate
-}
+-- PRODUCT_TYPE_DEF_BEGIN
+data MyProductType = MyProductType with
+  intField : Int
+  textField : Text
+  decimalField : Decimal
+  boolField : Bool
+  partyField : Party
+  timeField : Time
+  listField : [Int]
+  contractIdField : ContractId SomeTemplate
+-- PRODUCT_TYPE_DEF_END
 
-data MySumType = MySumConstructor1 Int |
-                 MySumConstructor2 (Text, Bool)
+-- SUM_TYPE_DEF_BEGIN
+data MySumType = MySumConstructor1 Int
+               | MySumConstructor2 (Text, Bool)
+-- SUM_TYPE_DEF_END
 
 template SomeTemplate
   with owner: Party
@@ -27,6 +30,7 @@ template SomeTemplate
     signatory owner
 
 myTest = script do
+-- PRODUCT_TYPE_CREATE_BEGIN
     alice <- allocateParty "Alice"
     bob <- allocateParty "Bob"
     someCid <- submit alice do createCmd SomeTemplate with owner=alice
@@ -40,8 +44,11 @@ myTest = script do
                 timeField = datetime 2018 May 16 0 0 0
                 listField = [1,2,3]
                 contractIdField = someCid
+-- PRODUCT_TYPE_CREATE_END
 
+-- SUM_TYPE_CREATE_BEGIN
     let mySum1 = MySumConstructor1 17
     let mySum2 = MySumConstructor2 ("it's a sum", True)
+-- SUM_TYPE_CREATE_END
 
     return ()

--- a/docs/source/app-dev/grpc/daml-to-ledger-api.rst
+++ b/docs/source/app-dev/grpc/daml-to-ledger-api.rst
@@ -34,13 +34,15 @@ Records or product types are translated to :ref:`com.daml.ledger.api.v1.record`.
 
 .. literalinclude:: ../code-snippets/Types.daml
 	:language: daml
-	:lines: 9-18
+	:start-after: -- PRODUCT_TYPE_DEF_BEGIN
+	:end-before: -- PRODUCT_TYPE_DEF_END
 
 And here's an example of creating a value of type `MyProductType`:
 
 .. literalinclude:: ../code-snippets/Types.daml
 	:language: daml
-	:lines: 29,31,33-41
+	:start-after: -- PRODUCT_TYPE_CREATE_BEGIN
+	:end-before: -- PRODUCT_TYPE_CREATE_END
 
 For this data, the respective data on the Ledger API is shown below. Note that this value would be enclosed by a particular contract containing a field of type `MyProductType`. See `Contract templates`_ for the translation of Daml contracts to the representation by the Ledger API.
 
@@ -53,13 +55,15 @@ Variants or sum types are types with multiple constructors. This example defines
 
 .. literalinclude:: ../code-snippets/Types.daml
 	:language: daml
-	:lines: 20-21
+	:start-after: -- SUM_TYPE_DEF_BEGIN
+	:end-before: -- SUM_TYPE_DEF_END
 
-The constructor ``MyConstructor1`` takes a single parameter of type ``Integer``, whereas the constructor ``MyConstructor2`` takes a record with two fields as parameter. The snippet below shows how you can create values with either of the constructors.
+The constructor ``MyConstructor1`` takes a single parameter of type ``Integer``, whereas the constructor ``MyConstructor2`` takes a tuple with two fields as parameter. The snippet below shows how you can create values with either of the constructors.
 
 .. literalinclude:: ../code-snippets/Types.daml
 	:language: daml
-	:lines: 43-44
+	:start-after: -- SUM_TYPE_CREATE_BEGIN
+	:end-before: -- SUM_TYPE_CREATE_END
 
 Similar to records, variants are also enclosed by a contract, a record, or another variant.
 

--- a/docs/source/concepts/test-evidence.rst
+++ b/docs/source/concepts/test-evidence.rst
@@ -1,0 +1,11 @@
+.. Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. _test-evidence:
+
+Test Evidence
+#################
+
+Daml is publishing test evidence for the the most important traits of tests: Security, Operability, Functional and Reliability.
+
+It can be found in the relevant `releases <https://github.com/digital-asset/daml/releases>`_ page, under `Assets`.

--- a/docs/source/getting-started/first-feature.rst
+++ b/docs/source/getting-started/first-feature.rst
@@ -206,6 +206,7 @@ Next Steps
 
 We've gone through the process of setting up a full-stack Daml app and implementing a useful feature end to end.
 As the next step we encourage you to really dig into the fundamentals of Daml and understand its core concepts such as parties, signatories, observers, and controllers.
-You can do that either by :doc:`going through our docs </daml/intro/0_Intro>` or by taking an `online course <https://digitalasset.com/developers/interactive-tutorials/fundamental-concepts>`.
+You can do that either by :doc:`going through our docs </daml/intro/0_Intro>` or by taking an `online course <https://digitalasset.com/developers/interactive-tutorials/fundamental-concepts>`_.
+
 
 After you've got a good grip on these concepts learn :doc:`how to conduct end-to-end testing of your app <testing>`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -76,6 +76,7 @@ Daml Documentation
    concepts/identity-and-package-management
    concepts/time
    concepts/local-ledger
+   concepts/test-evidence
 
 
 .. toctree::


### PR DESCRIPTION
This PR aims at bringing the 2.2 daml branch in line with the docs that were actually released on docs.daml.com under the 2.2.0 version (currently using a 2.3 snapshot). This will make future 2.2 docs updates less confusing.