### PR TITLE
[engine] choice authorizers in TX protocol

### DIFF
--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -382,6 +382,8 @@ object ValueGenerators {
       stakeholders <- genNonEmptyParties
       signatories <- genNonEmptyParties
       choiceObservers <- genMaybeEmptyParties
+      choiceAuthorizersList <- genMaybeEmptyParties
+      choiceAuthorizers = if (choiceAuthorizersList.isEmpty) None else Some(choiceAuthorizersList)
       children <- Gen
         .listOf(Arbitrary.arbInt.arbitrary)
         .map(_.map(NodeId(_)))
@@ -401,9 +403,7 @@ object ValueGenerators {
       stakeholders = stakeholders,
       signatories = signatories,
       choiceObservers = choiceObservers,
-      // TODO: https://github.com/digital-asset/daml/issues/15882
-      // -- Generate non-empty choice authorizers here.
-      choiceAuthorizers = None,
+      choiceAuthorizers = choiceAuthorizers,
       children = children,
       exerciseResult = exerciseResult,
       keyOpt = key,

--- a/daml-lf/transaction/src/main/protobuf/com/daml/lf/transaction.proto
+++ b/daml-lf/transaction/src/main/protobuf/com/daml/lf/transaction.proto
@@ -110,6 +110,8 @@ message NodeExercise {
     reserved 13; // was contract_key
     KeyWithMaintainers key_with_maintainers = 14; // optional
     repeated string observers = 15;  // *since version 11*
+    // No listed authorizers indicates default authorizers (signatories + actors)
+    repeated string authorizers = 20;  // *since version dev*
     bool by_key = 18; // *since version 14*
 }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -339,9 +339,10 @@ object TransactionCoder {
               ne.stakeholders.foreach(builder.addStakeholders)
               ne.choiceObservers.foreach(builder.addObservers)
 
-              // TODO: https://github.com/digital-asset/daml/issues/15882
-              // -- Implement encode/decode for explicit choice authorizers:
-              // -- ne.choiceAuthorizers.foreach...
+              ne.choiceAuthorizers match {
+                case None => ()
+                case Some(xs) => xs.foreach(builder.addAuthorizers)
+              }
 
               if (nodeVersion >= TransactionVersion.minByKey) {
                 discard(builder.setByKey(ne.byKey))
@@ -357,6 +358,12 @@ object TransactionCoder {
                     ne.choiceObservers.isEmpty,
                   right = (),
                   left = EncodeError(nodeVersion, isTooOldFor = "non-empty choice-observers"),
+                )
+                _ <- Either.cond(
+                  test = ne.version >= TransactionVersion.minChoiceAuthorizers ||
+                    !(ne.choiceAuthorizers.isDefined),
+                  right = (),
+                  left = EncodeError(nodeVersion, isTooOldFor = "explicit choice-authorizers"),
                 )
                 _ <- encodeAndSetValue(
                   encodeCid,
@@ -599,6 +606,12 @@ object TransactionCoder {
             } else {
               toPartySet(protoExe.getObserversList)
             }
+          choiceAuthorizers <-
+            if (nodeVersion < TransactionVersion.minChoiceAuthorizers) { Right(None) }
+            else {
+              for { choiceAuthorizersList <- toPartySet(protoExe.getAuthorizersList) } yield
+                if (choiceAuthorizersList.isEmpty) None else Some(choiceAuthorizersList)
+            }
           choiceName <- toIdentifier(protoExe.getChoice)
           byKey =
             if (nodeVersion >= TransactionVersion.minByKey)
@@ -621,9 +634,7 @@ object TransactionCoder {
           stakeholders = stakeholders,
           signatories = signatories,
           choiceObservers = choiceObservers,
-          // TODO: https://github.com/digital-asset/daml/issues/15882
-          // -- Implement decode for explicit choice authorizers (when version is recent enough):
-          choiceAuthorizers = None,
+          choiceAuthorizers = choiceAuthorizers,
           children = children,
           exerciseResult = rvOpt,
           keyOpt = keyWithMaintainers,
@@ -888,6 +899,8 @@ object TransactionCoder {
             def stakeholders = stakeholders_
             def actingParties = actingParties_
             def choiceObservers = choiceObservers_
+            // TODO: https://github.com/digital-asset/daml/issues/15882
+            // -- Does ActionNodeInfo need to be extended with choiceAuthorizers?
             def consuming = protoExe.getConsuming
           }
         }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -52,6 +52,7 @@ object TransactionVersion {
   private[lf] val minByKey = V14
   private[lf] val minInterfaces = V15
   private[lf] val minExplicitDisclosure = VDev
+  private[lf] val minChoiceAuthorizers = VDev
 
   private[lf] val assignNodeVersion: LanguageVersion => TransactionVersion = {
     import LanguageVersion._

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -269,6 +269,12 @@ class TransactionCoderSpec
   "encodeVersionedNode" should {
 
     "fail iff try to encode choice observers in version < 11" in {
+
+      // This test-code is a terrible way to test this property!
+      // Future changes to .proto have to consider if this test needs updating.
+      // Or else this might fail, but only in a very flaky way.
+      // TODO: improve this. Or kill this test.
+
       forAll(danglingRefExerciseNodeGen, minSuccessful(10)) { node =>
         val shouldFail = node.choiceObservers.nonEmpty
 
@@ -277,6 +283,7 @@ class TransactionCoderSpec
             exe.copy(
               choiceObservers = node.choiceObservers,
               exerciseResult = Some(Value.ValueText("not-missing")),
+              choiceAuthorizers = None,
             )
           case otherwise => otherwise
         }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -939,6 +939,8 @@ class TransactionCoderSpec
       },
       choiceObservers =
         exe.choiceObservers.filter(_ => exe.version >= TransactionVersion.minChoiceObservers),
+      choiceAuthorizers =
+        if (exe.version >= TransactionVersion.minChoiceAuthorizers) exe.choiceAuthorizers else None,
       keyOpt = exe.keyOpt.map(normalizeKey(_, exe.version)),
       byKey =
         if (exe.version >= TransactionVersion.minByKey)


### PR DESCRIPTION
Advances #15882

Support choice-authorizers in TX protocol:
- Add `authorizers` field to `NodeExercise` in `transaction.proto`
- Add `minChoiceAuthorizers` to `TransactionVersion`
- for testing, extend `ValueGenerators` and `TransactionCoderSpec` (`normalizeExe`)
- implement by extending encode/decode in `TransactionCoder`
