### PR TITLE
update hash of canton snapshot

### DIFF
--- a/canton_dep.bzl
+++ b/canton_dep.bzl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 canton = {
-    "sha": "c686ae191e71a7b2d16e329a92aa6e013024b1aca504c25554dfc31815ecd7b8",
+    "sha": "1e7499e098eccb9097629ccc53bd4c9c2ce0676e3bac035cc97071d4d6ee9fca",
     "prefix": "canton-open-source-2.7.0-SNAPSHOT",
     "url": "https://www.canton.io/releases/canton-open-source-20230510.tar.gz",
 }


### PR DESCRIPTION
Canton team accidentally published twice the daily snapshot

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
