### PR TITLE
Add tool for compiling ghcide from a local copy

### DIFF
--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -20,7 +20,7 @@ load("//bazel_tools/ghc-lib:repositories.bzl", "ghc_lib_and_dependencies")
 
 GHCIDE_REV = "434991f74b4cdc6a0983a37ee976c4f62580c2e5"
 GHCIDE_SHA256 = "d3f386643bdd68800cbfd61a5fb8868d6df8ecd23f2dd32331d84e3b7362d832"
-GHCIDE_LOCAL_PATH = "/home/dylan-thinnes/root/faster-ghcide-loop/out.tar.gz"
+GHCIDE_LOCAL_PATH = None
 JS_JQUERY_VERSION = "3.3.1"
 JS_DGTABLE_VERSION = "0.5.2"
 JS_FLOT_VERSION = "0.8.3"

--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -20,6 +20,7 @@ load("//bazel_tools/ghc-lib:repositories.bzl", "ghc_lib_and_dependencies")
 
 GHCIDE_REV = "434991f74b4cdc6a0983a37ee976c4f62580c2e5"
 GHCIDE_SHA256 = "d3f386643bdd68800cbfd61a5fb8868d6df8ecd23f2dd32331d84e3b7362d832"
+USE_GHCIDE_LOCAL = False
 JS_JQUERY_VERSION = "3.3.1"
 JS_DGTABLE_VERSION = "0.5.2"
 JS_FLOT_VERSION = "0.8.3"
@@ -118,9 +119,9 @@ haskell_library(
         patches = [
             "@com_github_digital_asset_daml//bazel_tools:haskell-ghcide-binary-q.patch",
         ],
-        sha256 = GHCIDE_SHA256,
-        strip_prefix = "daml-ghcide-%s" % GHCIDE_REV,
-        urls = ["https://github.com/digital-asset/daml-ghcide/archive/%s.tar.gz" % GHCIDE_REV],
+        sha256 = None if USE_GHCIDE_LOCAL else GHCIDE_SHA256,
+        strip_prefix = None if USE_GHCIDE_LOCAL else "daml-ghcide-%s" % GHCIDE_REV,
+        url = "file:///tmp/ghcide-local-result.tar.gz" if USE_GHCIDE_LOCAL else "https://github.com/digital-asset/daml-ghcide/archive/%s.tar.gz" % GHCIDE_REV,
     )
 
     ghc_lib_and_dependencies()

--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -20,7 +20,7 @@ load("//bazel_tools/ghc-lib:repositories.bzl", "ghc_lib_and_dependencies")
 
 GHCIDE_REV = "434991f74b4cdc6a0983a37ee976c4f62580c2e5"
 GHCIDE_SHA256 = "d3f386643bdd68800cbfd61a5fb8868d6df8ecd23f2dd32331d84e3b7362d832"
-USE_GHCIDE_LOCAL = False
+GHCIDE_LOCAL_PATH = "/home/dylan-thinnes/root/faster-ghcide-loop/out.tar.gz"
 JS_JQUERY_VERSION = "3.3.1"
 JS_DGTABLE_VERSION = "0.5.2"
 JS_FLOT_VERSION = "0.8.3"
@@ -119,9 +119,9 @@ haskell_library(
         patches = [
             "@com_github_digital_asset_daml//bazel_tools:haskell-ghcide-binary-q.patch",
         ],
-        sha256 = None if USE_GHCIDE_LOCAL else GHCIDE_SHA256,
-        strip_prefix = None if USE_GHCIDE_LOCAL else "daml-ghcide-%s" % GHCIDE_REV,
-        url = "file:///tmp/ghcide-local-result.tar.gz" if USE_GHCIDE_LOCAL else "https://github.com/digital-asset/daml-ghcide/archive/%s.tar.gz" % GHCIDE_REV,
+        sha256 = None if GHCIDE_LOCAL_PATH != None else GHCIDE_SHA256,
+        strip_prefix = None if GHCIDE_LOCAL_PATH != None else "daml-ghcide-%s" % GHCIDE_REV,
+        url = "file://" + GHCIDE_LOCAL_PATH if GHCIDE_LOCAL_PATH != None else "https://github.com/digital-asset/daml-ghcide/archive/%s.tar.gz" % GHCIDE_REV,
     )
 
     ghc_lib_and_dependencies()

--- a/dev-env/bin/update-ghcide-local
+++ b/dev-env/bin/update-ghcide-local
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get ghcide directory
+target=${1:-daml-ghcide}
+if [[ ! -e "$target" ]]; then
+  echo "Local GHCIDE location '$target' does not exist"
+  exit 1
+fi
+echo "Found GHCIDE location '$target'"
+
+if [[ ! -e ./bazel-haskell-deps.bzl ]]; then
+  echo "Cannot find bazel-haskell-deps.bzl"
+  exit 1
+fi
+echo "Found ./bazel-haskell-deps.bzl"
+
+if ! grep -E '^USE_GHCIDE_LOCAL *= *True$' >/dev/null ./bazel-haskell-deps.bzl; then
+  echo "Cannot find a definition of USE_GHCIDE_LOCAL = True in ./bazel-haskell-deps.bzl"
+  echo "Make sure to redefine USE_GHCIDE_LOCAL from False to True ./bazel-haskell-deps.bzl"
+  exit 1
+fi
+echo "Found definition of USE_GHCIDE_LOCAL = True in ./bazel-haskell-deps.bzl"
+
+# Make new out
+out=/tmp/ghcide-local-result.tar.gz
+rm "$out"
+cd "$target"
+tar czf "$out" .
+
+# Synchronize new result
+bazel sync --only=ghcide_ghc_lib
+bazel build @ghcide_ghc_lib//:ghcide

--- a/dev-env/bin/update-ghcide-local
+++ b/dev-env/bin/update-ghcide-local
@@ -1,30 +1,36 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Get ghcide directory
+# Get input directory, output file
 target=${1:-daml-ghcide}
+out=${2:-out.tar.gz}
+target=$(realpath $target)
+out=$(realpath ${out%.tar.gz}.tar.gz)
+
+# Check target exists
 if [[ ! -e "$target" ]]; then
   echo "Local GHCIDE location '$target' does not exist"
   exit 1
 fi
-echo "Found GHCIDE location '$target'"
+if [[ ! -d "$target" ]]; then
+  echo "Local GHCIDE location '$target' is not a directory"
+  exit 1
+fi
 
+# Check that correct output path is set in bazel-haskell-deps.bzl
 if [[ ! -e ./bazel-haskell-deps.bzl ]]; then
   echo "Cannot find bazel-haskell-deps.bzl"
   exit 1
 fi
-echo "Found ./bazel-haskell-deps.bzl"
 
-if ! grep -E '^USE_GHCIDE_LOCAL *= *True$' >/dev/null ./bazel-haskell-deps.bzl; then
-  echo "Cannot find a definition of USE_GHCIDE_LOCAL = True in ./bazel-haskell-deps.bzl"
-  echo "Make sure to redefine USE_GHCIDE_LOCAL from False to True ./bazel-haskell-deps.bzl"
+if ! grep -E "^GHCIDE_LOCAL_PATH *= *\"$out\"$" >/dev/null ./bazel-haskell-deps.bzl; then
+  echo "Cannot find a correct definition of GHCIDE_LOCAL_PATH"
+  echo "Make sure to redefine GHCIDE_LOCAL_PATH = \"$out\" in ./bazel-haskell-deps.bzl"
   exit 1
 fi
-echo "Found definition of USE_GHCIDE_LOCAL = True in ./bazel-haskell-deps.bzl"
 
 # Make new out
-out=/tmp/ghcide-local-result.tar.gz
-rm "$out"
+if [[ -e "$out" ]]; then rm "$out"; fi
 cd "$target"
 tar czf "$out" .
 


### PR DESCRIPTION
Previously, when iterating on daml-ghcide, we need to check our changes into the repo and push up to a branch. This means each change takes a bit of a while.

By setting `USE_GHCIDE_LOCAL = True` in `bazel_haskell_deps.bzl` and invoking `update-ghcide-local <dir>`, we can use a custom GHCIDE without needing to push changes up to Github, which should make iterating on `daml-ghcide` a lot faster.

- [x] fix reliance on `/tmp/`