### PR TITLE
[engine] temp revert WronglyTypedContractSoft

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -202,13 +202,15 @@ final class Conversions(
                     .setContractRef(mkContractRef(coid, actual))
                     .setExpected(convertIdentifier(expected))
                 )
-              case WronglyTypedContractSoft(coid, expected, accepted, actual) =>
+              // TODO https://github.com/digital-asset/daml/issues/16151
+              // Reinstate when #16859 lands
+              /*case WronglyTypedContractSoft(coid, expected, accepted, actual) =>
                 builder.setWronglyTypedContractSoft(
                   proto.ScenarioError.WronglyTypedContractSoft.newBuilder
                     .setContractRef(mkContractRef(coid, actual))
                     .setExpected(convertIdentifier(expected))
                     .addAllAccepted(accepted.map(convertIdentifier(_)).asJava)
-                )
+                )*/
               case ContractDoesNotImplementInterface(interfaceId, coid, templateId) =>
                 builder.setContractDoesNotImplementInterface(
                   proto.ScenarioError.ContractDoesNotImplementInterface.newBuilder

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -98,7 +98,9 @@ private[lf] object Pretty {
           ) & prettyTypeConName(
             actual
           )
-      case WronglyTypedContractSoft(coid, expected, accepted, actual) =>
+      // TODO https://github.com/digital-asset/daml/issues/16151
+      // Reinstate when #16859 lands
+      /*case WronglyTypedContractSoft(coid, expected, accepted, actual) =>
         text("Update failed due to wrongly typed contract id") & prettyContractId(coid) /
           text("Expected contract of type") & prettyTypeConName(expected) & (
             if (accepted.nonEmpty)
@@ -110,7 +112,7 @@ private[lf] object Pretty {
             "but got"
           ) & prettyTypeConName(
             actual
-          )
+          )*/
       case ContractDoesNotImplementInterface(interfaceId, coid, templateId) =>
         text("Update failed due to contract") & prettyContractId(coid) & text(
           "not implementing an interface"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1110,7 +1110,10 @@ private[lf] object SBuiltin {
         Control.Value(record.copy(id = templateId))
       } else {
         Control.Error(
-          IE.WronglyTypedContractSoft(coid, templateId, acceptedTemplateIds, actualTemplateId)
+          // TODO https://github.com/digital-asset/daml/issues/16151
+          // Use an existing error constructor until #16859 lands
+          IE.WronglyTypedContract(coid, templateId, actualTemplateId)
+          // IE.WronglyTypedContractSoft(coid, templateId, acceptedTemplateIds, actualTemplateId)
         )
       }
     }

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -109,15 +109,19 @@ object Error {
       actual: TypeConName,
   ) extends Error
 
+  // TODO: https://github.com/digital-asset/daml/issues/16151
+  // Reinstate when #16859 lands
+  /*
   /** We tried to soft fetch / soft exercise a contract of the wrong type --
-    * see <https://github.com/digital-asset/daml/issues/16151>.
-    */
+   * see <https://github.com/digital-asset/daml/issues/16151>.
+   */
   final case class WronglyTypedContractSoft(
       coid: ContractId,
       expected: TypeConName,
       accepted: List[TypeConName],
       actual: TypeConName,
   ) extends Error
+   */
 
   /** We tried to fetch / exercise a contract by interface, but
     * the contract does not implement this interface.

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/PackageUpgradesIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/PackageUpgradesIT.scala
@@ -78,9 +78,7 @@ final class PackageUpgradesIT
       } yield r shouldBe SUnit
     }
 
-    // TODO: https://github.com/digital-asset/daml/issues/16151
-    // reenable test once `WronglyTypedContractSoft` is handled in Canton
-    "fail when given a contract id of a non-predecessor type of Coin V1, Coin V2" ignore {
+    "fail when given a contract id of a non-predecessor type of Coin V1, Coin V2" in {
       for {
         clients <- scriptClients()
         r <-
@@ -104,9 +102,7 @@ final class PackageUpgradesIT
       } yield r shouldBe SUnit
     }
 
-    // TODO: https://github.com/digital-asset/daml/issues/16151
-    // reenable test once `WronglyTypedContractSoft` is handled in Canton
-    "fail when given a contract id of a non-predecessor type of Coin V1, Coin V3" ignore {
+    "fail when given a contract id of a non-predecessor type of Coin V1, Coin V3" in {
       for {
         clients <- scriptClients()
         r <-

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/RejectionGenerators.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/RejectionGenerators.scala
@@ -110,11 +110,6 @@ object RejectionGenerators {
             .Error(
               renderedMessage
             )
-        case _: LfInterpretationError.WronglyTypedContractSoft =>
-          LedgerApiErrors.CommandExecution.Interpreter.InvalidArgumentInterpretationError
-            .Error(
-              renderedMessage
-            )
         case _: LfInterpretationError.ContractDoesNotImplementInterface =>
           LedgerApiErrors.CommandExecution.Interpreter.InvalidArgumentInterpretationError
             .Error(


### PR DESCRIPTION
Advances #16151
Temp revert of `WronglyTypedContractSoft` added by #16839 -- avoiding breaking canton right now
Can reinstate after #16859 has landed. -- letting this be the PR which breaks canton!
Enable the two tests in `PackageUpgradesIT.scala`
