### PR TITLE
infra: tweak Azure config

### DIFF
--- a/infra/ubuntu_azure.tf
+++ b/infra/ubuntu_azure.tf
@@ -6,7 +6,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "ubuntu" {
   name                = local.ubuntu.azure[count.index].name
   resource_group_name = azurerm_resource_group.daml-ci.name
   location            = azurerm_resource_group.daml-ci.location
-  sku                 = "Standard_D4_v2"
+  sku                 = "Standard_D8_v5"
   instances           = local.ubuntu.azure[count.index].size
 
   admin_username                  = local.azure-admin-login
@@ -38,7 +38,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "ubuntu" {
   }
 
   os_disk {
-    caching              = "ReadOnly"
+    caching              = "ReadWrite"
     storage_account_type = "Standard_LRS"
     disk_size_gb         = local.ubuntu.azure[count.index].disk_size
   }

--- a/infra/windows.tf
+++ b/infra/windows.tf
@@ -11,13 +11,13 @@ locals {
         name       = "ci-w1",
         size       = 0,
         assignment = "default",
-        disk_size  = 800,
+        disk_size  = 400,
       },
       {
         name       = "ci-w2"
         size       = 0,
         assignment = "default",
-        disk_size  = 800,
+        disk_size  = 400,
       },
     ],
     azure = [
@@ -25,13 +25,13 @@ locals {
         name       = "dw1",
         size       = 6,
         assignment = "default",
-        disk_size  = 800,
+        disk_size  = 400,
       },
       {
         name       = "dw2"
         size       = 0,
         assignment = "default",
-        disk_size  = 800,
+        disk_size  = 400,
       },
     ],
   }

--- a/infra/windows_azure.tf
+++ b/infra/windows_azure.tf
@@ -11,7 +11,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "deployment" {
   name                = local.windows.azure[count.index].name
   resource_group_name = azurerm_resource_group.daml-ci.name
   location            = azurerm_resource_group.daml-ci.location
-  sku                 = "Standard_D4_v2"
+  sku                 = "Standard_D8_v5"
   instances           = local.windows.azure[count.index].size
 
   admin_username = local.azure-admin-login
@@ -28,6 +28,13 @@ resource "azurerm_windows_virtual_machine_scale_set" "deployment" {
     vsts_pool    = "windows-pool"
     gcp_logging  = ""
     assignment   = local.windows.azure[count.index].assignment
+    azure_disk   = <<EOF
+
+select volume d
+remove letter="D"
+select volume c
+extend
+EOF
   }))
 
   source_image_reference {
@@ -38,7 +45,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "deployment" {
   }
 
   os_disk {
-    caching              = "ReadOnly"
+    caching              = "ReadWrite"
     storage_account_type = "Standard_LRS"
     disk_size_gb         = local.windows.azure[count.index].disk_size
 

--- a/infra/windows_gcp.tf
+++ b/infra/windows_gcp.tf
@@ -75,6 +75,7 @@ Invoke-WebRequest https://dl.google.com/cloudagents/windows/StackdriverLogging-v
 .\StackdriverLogging-v1-9.exe /S /D="C:\Stackdriver\Logging\"
 EOF
       assignment   = local.windows.gcp[count.index].assignment
+      azure_disk   = ""
     })
     windows-shutdown-script-ps1 = nonsensitive("c://agent/config remove --unattended --auth PAT --token '${secret_resource.vsts-token.value}'")
   }

--- a/infra/windows_startup.ps1
+++ b/infra/windows_startup.ps1
@@ -36,7 +36,7 @@ Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Co
 
 echo "== Prepare the D:\ drive"
 
-$partition = @"
+$partition = @"${azure_disk}
 select disk 1
 clean
 convert gpt


### PR DESCRIPTION
- Change machine types to be closer to GCP profiles.
- Set partition sizes correctly on Windows (bigger disks mean little if partitions don't match).
- Enable full caching on disk access as the only downside seems to be "risk of data loss if the machine shuts down unexpectedly", and we never want a machine to come back if it shut down.