### PR TITLE
Improvements for trigger simulations that throw exceptions during initialization

### DIFF
--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/CatAndFoodTriggerSimulation.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/CatAndFoodTriggerSimulation.scala
@@ -43,25 +43,21 @@ class CatAndFoodTriggerSimulation
       val ledger = context.spawn(LedgerProcess.create(client), "ledger")
       val triggerFactory: TriggerProcessFactory =
         triggerProcessFactory(client, ledger, "Cats:feedingTrigger", actAs)
+
       // With a negative start state, Cats:feedingTrigger will have a behaviour that is dependent on Cat and Food contract generators
-      val trigger1 = context.spawn(triggerFactory.create(SValue.SInt64(-1)), "trigger1")
-      val trigger2 = context.spawn(triggerFactory.create(SValue.SInt64(-1)), "trigger2")
-      val workload =
-        context.spawn(
-          workloadProcess(ledger, actAs)(
-            batchSize = 2000,
-            maxNumOfCats = 1000L,
-            workloadFrequency = 1.second,
-            catDelay = 2.seconds,
-            foodDelay = 2.seconds,
-            jitter = 2.seconds,
-          ),
-          "workload",
-        )
-      context.watch(ledger)
-      context.watch(trigger1)
-      context.watch(trigger2)
-      context.watch(workload)
+      context.spawn(triggerFactory.create(SValue.SInt64(-1)), "trigger1")
+      context.spawn(triggerFactory.create(SValue.SInt64(-1)), "trigger2")
+      context.spawn(
+        workloadProcess(ledger, actAs)(
+          batchSize = 2000,
+          maxNumOfCats = 1000L,
+          workloadFrequency = 1.second,
+          catDelay = 2.seconds,
+          foodDelay = 2.seconds,
+          jitter = 2.seconds,
+        ),
+        "workload",
+      )
 
       Behaviors.empty
     }

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/TriggerMultiProcessSimulation.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/TriggerMultiProcessSimulation.scala
@@ -60,7 +60,7 @@ abstract class TriggerMultiProcessSimulation extends AsyncWordSpec with Abstract
       Behaviors
         .supervise[Message] {
           Behaviors.setup { context =>
-            var processSimulation: Option[ActorRef[Unit]] = None
+            var simulationController: Option[ActorRef[Unit]] = None
 
             context.log.info(s"Simulation will run for ${simulationConfig.simulationDuration}")
             context.self ! StartSimulation
@@ -69,17 +69,17 @@ abstract class TriggerMultiProcessSimulation extends AsyncWordSpec with Abstract
               Behaviors
                 .receiveMessage[Message] {
                   case StartSimulation =>
-                    processSimulation =
+                    simulationController =
                       Some(context.spawn(triggerMultiProcessSimulation, "simulation-controller"))
-                    processSimulation.foreach(context.watch)
+                    simulationController.foreach(context.watch)
                     Behaviors.same
 
                   case StopSimulation =>
                     context.log.info(
                       s"Simulation stopped after ${simulationConfig.simulationDuration}"
                     )
-                    processSimulation.foreach(context.stop)
-                    processSimulation = None
+                    simulationController.foreach(context.stop)
+                    simulationController = None
                     simulationTerminatedNormally.success(())
                     Behaviors.stopped
                 }


### PR DESCRIPTION
By default, typed actors will supervise and stop any actor that throws an exception - hence there's no need to `watch` actors that simulations create.

Exceptions thrown during actor initialisation are currently logged, but not ow seen by the test. Using a promise and actor supervisions, we can work around this and ensure correct and proper error reporting occurs with tests actually failing now (under such scenarios).

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
