### PR TITLE
Initial version of trySubmit with single full error

### DIFF
--- a/compiler/damlc/tests/daml-test-files/TrySubmit.daml
+++ b/compiler/damlc/tests/daml-test-files/TrySubmit.daml
@@ -1,0 +1,17 @@
+module TrySubmit where
+
+import Daml.Script
+-- import Daml.Script.Error
+
+template T with
+    p : Party
+  where
+  signatory p
+  
+
+main : Script ()
+main = do
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
+  eRes <- trySubmit [alice] [alice] $ createCmd T with p = bob
+  error $ show eRes

--- a/compiler/damlc/tests/daml-test-files/TrySubmit.daml
+++ b/compiler/damlc/tests/daml-test-files/TrySubmit.daml
@@ -1,7 +1,11 @@
 module TrySubmit where
 
 import Daml.Script
--- import Daml.Script.Error
+import Daml.Script.Error
+
+import DA.Assert
+import DA.Either
+import DA.Optional
 
 template T with
     p : Party
@@ -13,5 +17,15 @@ main : Script ()
 main = do
   alice <- allocateParty "Alice"
   bob <- allocateParty "Bob"
-  eRes <- trySubmit [alice] [alice] $ createCmd T with p = bob
-  error $ show eRes
+  -- Ensure it succeeds when it should
+  res1 <- trySubmit [alice] [alice] $ createCmd T with p = alice
+  assert $ isRight res1
+  -- Ensure it fails when it should with authorization
+  res2 <- trySubmit [alice] [alice] $ createCmd T with p = bob
+  case res2 of
+    Left (SERunnerException (REFailedAuthorization (FACreateMissingAuthorization {..}))) -> do
+      templateId === "-homePackageId-:TrySubmit:T"
+      assert (isNone optLocation) -- Can't use `===` as no Eq for SrcLoc
+      authorizingParties === [alice]
+      requiredParties === [bob]
+    _ -> error "Incorrect error"

--- a/daml-script/daml/BUILD.bazel
+++ b/daml-script/daml/BUILD.bazel
@@ -19,6 +19,7 @@ load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS")
           mkdir -p $$TMP_DIR/daml/Daml/Script
           cp -L $(location Daml/Script.daml) $$TMP_DIR/daml/Daml/
           cp -L $(location Daml/Script/Free.daml) $$TMP_DIR/daml/Daml/Script/
+          cp -L $(location Daml/Script/Error.daml) $$TMP_DIR/daml/Daml/Script/
           cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: {sdk}
 name: daml-script

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -79,6 +79,8 @@ module Daml.Script
   , listUserRightsOn
   , submitUser
   , submitUserOn
+
+  , trySubmit
   ) where
 
 #ifdef DAML_EXCEPTIONS
@@ -92,6 +94,7 @@ import DA.Optional
 import DA.Stack
 import DA.Time
 import Daml.Script.Free (Free(..))
+import Daml.Script.Error
 
 -- | A free applicative, since we don’t have existentials we have to use the weird RankNTypes encoding, this is isomorphic to
 -- forall b. Ap (f b) (Ap f (b -> a))
@@ -146,6 +149,7 @@ data ScriptF a
   | GrantUserRights (GrantUserRightsPayload a)
   | RevokeUserRights (RevokeUserRightsPayload a)
   | ListUserRights (ListUserRightsPayload a)
+  | TrySubmit (NewSubmitCmd LedgerValue a)
 #ifndef DAML_EXCEPTIONS
   deriving Functor
 #else
@@ -153,11 +157,35 @@ data ScriptF a
   | Throw ThrowPayload
   deriving Functor
 
+
+data NewSubmitCmd x a = NewSubmitCmd
+  with
+    actAs : NonEmpty Party
+    readAs : [Party]
+    commands : Commands x
+    continue : (SubmitError -> a, x -> a)
+    locations : [(Text, SrcLoc)]
+  deriving Functor
+
+trySubmit : forall a. HasCallStack => [Party] -> [Party] -> Commands a -> Script (Either SubmitError a)
+trySubmit actAs readAs cmds =
+    lift $ Free $ TrySubmit $ castNewSubmitPayload payload
+  where
+    payload : NewSubmitCmd a (Free ScriptF (Either SubmitError a))
+    payload = NewSubmitCmd with
+      actAs = actAsNonEmpty actAs
+      readAs = readAs
+      commands = cmds
+      continue = (pure . Left, pure . Right)
+      locations = getCallStack callStack
+
 -- `(try x catch f) >>= g` roughly translates to
 -- CatchPayload with
 --   act = \() -> x
 --   handle = f
 --   continue = g
+-- Note however that `g` is not the "next thing" in the bind sequence, but is an inserted identity
+-- TODO: Maybe update this comment, its misleading
 data CatchPayload x a = CatchPayload
   with
     -- TODO(MA): simplify to `act : () -> Free ScriptF x`
@@ -168,8 +196,16 @@ data CatchPayload x a = CatchPayload
 
 -- This wraps a `CatchPayload` whose inner action returns an `x` into an
 -- existential - we forget what `x` was.
+
 castCatchPayload : CatchPayload x a -> CatchPayload LedgerValue a
-castCatchPayload = error "foobar" -- gets replaced by the identity-function in script/Runner.scala
+castCatchPayload = dangerCast
+
+castNewSubmitPayload : NewSubmitCmd x a -> NewSubmitCmd LedgerValue a
+castNewSubmitPayload = dangerCast
+
+-- TODO: we're doing crimes now, undo this once more civilised
+dangerCast : a -> b
+dangerCast = error "foobar" -- gets replaced by the identity-function in script/Runner.scala
 
 data ThrowPayload = ThrowPayload
   with
@@ -462,7 +498,7 @@ data GetTimePayload a = GetTimePayload
 --
 -- Note that this will sleep for the same duration in both wall clock and static time mode.
 sleep : HasCallStack => RelTime -> Script ()
-sleep duration = lift $ Free $Sleep SleepRec with
+sleep duration = lift $ Free $ Sleep SleepRec with
   duration = duration
   continue = pure
   locations = getCallStack callStack
@@ -471,6 +507,7 @@ data SubmitFailure = SubmitFailure
   { status : Int
   , description : Text
   }
+  deriving Show
 
 -- | Details of the @submit@ command.
 --

--- a/daml-script/daml/Daml/Script/Error.daml
+++ b/daml-script/daml/Daml/Script/Error.daml
@@ -1,0 +1,73 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Script.Error where
+
+import DA.Stack
+
+data SubmitError
+  = SERunnerException { unSERunnerException : RunnerException }
+  | SEInternal
+  | SETimeout
+  | SECanceledByRequest
+  | SEContractNotEffective -- Duplicated by RunnerException
+  | SEContractNotActive
+  | SEContractNotVisible
+  | SEContractKeyNotVisible -- Duplicated by RunnerException
+  | SEUniqueKeyViolation
+  | SEPartiesNotAllocated
+  deriving Show
+
+data RunnerException
+  = REUnhandledException
+  | REUserError
+  | REContractNotFound
+  | RERejectedAuthorityRequest
+  | RETemplatePreconditionViolated
+  | REContractNotActive
+  | REDisclosedContractKeyHashingError
+  | REContractKeyNotVisible
+  | REContractKeyNotFound
+  | REDuplicateContractKey
+  | REInconsistentContractKey
+  | RECreateEmptyContractKeyMaintainers
+  | REFetchEmptyContractKeyMaintainers
+  | REWronglyTypedContract
+  | REWronglyTypedContractSoft
+  | REContractDoesNotImplementInterface
+  | REContractDoesNotImplementRequiringInterface
+  | REFailedAuthorization { unREFailedAuthorization : FailedAuthorization }
+  | RENonComparableValues
+  | REContractIdComparability
+  | REContractIdInContractKey
+  | REChoiceGuardFailed
+  | RELimit { unRELimit : Limit }
+  deriving Show
+
+deriving instance Show SrcLoc
+
+data FailedAuthorization
+  = FACreateMissingAuthorization
+      { templateId : Text -- Convert to some kind of TypeRep
+      , optLocation : Optional SrcLoc
+      , authorizingParties : [Party]
+      , requiredParties : [Party]
+      }
+  | FAMaintainersNotSubsetOfSignatories
+  | FAFetchMissingAuthorization
+  | FAExerciseMissingAuthorization
+  | FANoSignatories
+  | FANoControllers
+  | FANoAuthorizers
+  | FALookupByKeyMissingAuthorization
+  deriving Show
+
+data Limit
+  = LEValueNesting
+  | LEContractSignatories
+  | LEContractObservers
+  | LEChoiceControllers
+  | LEChoiceObservers
+  | LEChoiceAuthorizers
+  | LETransactionInputContracts
+  deriving Show

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -403,7 +403,7 @@ private[lf] class Runner(
     val damlScriptDefs: PartialFunction[SDefinitionRef, SDefinition] = {
       case LfDefRef(id) if id == script.scriptIds.damlScript("fromLedgerValue") =>
         SDefinition(SEMakeClo(Array(), 1, SELocA(0)))
-      case LfDefRef(id) if id == script.scriptIds.damlScript("castCatchPayload") =>
+      case LfDefRef(id) if id == script.scriptIds.damlScript("dangerCast") =>
         SDefinition(SEMakeClo(Array(), 1, SELocA(0)))
     }
     new CompiledPackages(Runner.compilerConfig) {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -245,6 +245,28 @@ class IdeLedgerClient(
       }
   }
 
+  // Projects the scenario submission error down to the script submission error
+  private def fromScenarioError(err: scenario.Error): SubmitError = err match {
+    case scenario.Error.RunnerException(err) => SubmitError.RunnerException(err)
+    case scenario.Error.Internal(reason) => SubmitError.Internal(reason)
+    case scenario.Error.Timeout(timeout) => SubmitError.Timeout(timeout)
+    case scenario.Error.ContractNotEffective(coid, templateId, effectiveAt) =>
+      SubmitError.ContractNotEffective(coid, templateId, effectiveAt)
+    case scenario.Error.ContractNotActive(coid, templateId, consumedBy) =>
+      SubmitError.ContractNotActive(coid, templateId, consumedBy)
+    case scenario.Error.ContractNotVisible(coid, templateId, actAs, readAs, observers) =>
+      SubmitError.ContractNotVisible(coid, templateId, actAs, readAs, observers)
+    case scenario.Error.ContractKeyNotVisible(coid, key, actAs, readAs, observers) =>
+      SubmitError.ContractKeyNotVisible(coid, key, actAs, readAs, observers)
+    case scenario.Error.CommitError(
+          ScenarioLedger.CommitError.UniqueKeyViolation(ScenarioLedger.UniqueKeyViolation(gk))
+        ) =>
+      SubmitError.UniqueKeyViolation(gk)
+    case scenario.Error.PartiesNotAllocated(parties) => SubmitError.PartiesNotAllocated(parties)
+    // This covers MustFailSucceeded, InvalidPartyName, PartyAlreadyExists which should not be throwable by a command submission
+    case err => SubmitError.Internal("Unexpected error type: " + err.toString)
+  }
+
   // unsafe version of submit that does not clear the commit.
   private def unsafeSubmit(
       actAs: OneAnd[Set, Ref.Party],
@@ -356,6 +378,44 @@ class IdeLedgerClient(
       case Left(ScenarioRunner.SubmissionError(err, tx)) =>
         _currentSubmission = Some(ScenarioRunner.CurrentSubmission(optLocation, tx))
         throw err
+    }
+
+  override def trySubmit(
+      actAs: OneAnd[Set, Ref.Party],
+      readAs: Set[Ref.Party],
+      commands: List[command.ApiCommand],
+      optLocation: Option[Location],
+  )(implicit
+      ec: ExecutionContext,
+      mat: Materializer,
+  ): Future[Either[SubmitError, Seq[ScriptLedgerClient.CommandResult]]] =
+    unsafeSubmit(actAs, readAs, commands, optLocation).map {
+      case Right(ScenarioRunner.Commit(result, _, _)) =>
+        _currentSubmission = None
+        _ledger = result.newLedger
+        val transaction = result.richTransaction.transaction
+        def convRootEvent(id: NodeId): ScriptLedgerClient.CommandResult = {
+          val node = transaction.nodes.getOrElse(
+            id,
+            throw new IllegalArgumentException(s"Unknown root node id $id"),
+          )
+          node match {
+            case create: Node.Create => ScriptLedgerClient.CreateResult(create.coid)
+            case exercise: Node.Exercise =>
+              ScriptLedgerClient.ExerciseResult(
+                exercise.templateId,
+                exercise.interfaceId,
+                exercise.choiceId,
+                exercise.exerciseResult.get,
+              )
+            case _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback =>
+              throw new IllegalArgumentException(s"Invalid root node: $node")
+          }
+        }
+        Right(transaction.roots.toSeq.map(convRootEvent))
+      case Left(ScenarioRunner.SubmissionError(err, tx)) =>
+        _currentSubmission = Some(ScenarioRunner.CurrentSubmission(optLocation, tx))
+        Left(fromScenarioError(err))
     }
 
   override def submitMustFail(

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/ScriptLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/ScriptLedgerClient.scala
@@ -114,6 +114,17 @@ trait ScriptLedgerClient {
       mat: Materializer,
   ): Future[Option[ScriptLedgerClient.ActiveContract]]
 
+  def trySubmit(
+      actAs: OneAnd[Set, Ref.Party],
+      readAs: Set[Ref.Party],
+      commands: List[command.ApiCommand],
+      optLocation: Option[Location],
+  )(implicit
+      ec: ExecutionContext,
+      mat: Materializer,
+  ): Future[Either[SubmitError, Seq[ScriptLedgerClient.CommandResult]]] =
+    throw new java.lang.UnsupportedOperationException("I'm not ready")
+
   def submit(
       actAs: OneAnd[Set, Ref.Party],
       readAs: Set[Ref.Party],

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/SubmitError.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/SubmitError.scala
@@ -1,0 +1,74 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.engine.script.ledgerinteraction
+
+import com.daml.lf.data.Ref.{Identifier, Party}
+import com.daml.lf.data.Time
+import com.daml.lf.ledger.EventId
+import com.daml.lf.speedy.SError.SError
+import com.daml.lf.transaction.GlobalKey
+import com.daml.lf.value.Value.ContractId
+
+import scala.concurrent.duration.Duration
+import scala.util.control.NoStackTrace
+
+sealed abstract class SubmitError
+    extends RuntimeException
+    with NoStackTrace
+    with Product
+    with Serializable
+
+object SubmitError {
+
+  final case class RunnerException(err: SError) extends SubmitError
+
+  final case class Internal(reason: String) extends SubmitError {
+    override def toString = "CRASH: " + reason
+  }
+
+  final case class Timeout(timeout: Duration) extends SubmitError
+
+  final case class CanceledByRequest() extends SubmitError // Do we need this?
+
+  final case class ContractNotEffective(
+      coid: ContractId,
+      templateId: Identifier,
+      effectiveAt: Time.Timestamp,
+  ) extends SubmitError
+
+  final case class ContractNotActive(
+      coid: ContractId,
+      templateId: Identifier,
+      consumedBy: Option[EventId],
+  ) extends SubmitError
+
+  /** A fetch or exercise was being made against a contract that has not
+    * been disclosed to 'committer'.
+    */
+  final case class ContractNotVisible(
+      coid: ContractId,
+      templateId: Identifier,
+      actAs: Set[Party],
+      readAs: Set[Party],
+      observers: Set[Party],
+  ) extends SubmitError
+
+  /** A fetchByKey or lookupByKey was being made against a key
+    * for which the contract exists but has not
+    * been disclosed to 'committer'.
+    */
+  final case class ContractKeyNotVisible(
+      coid: ContractId,
+      key: GlobalKey,
+      actAs: Set[Party],
+      readAs: Set[Party],
+      stakeholders: Set[Party],
+  ) extends SubmitError
+
+  /** The transaction created a contract that violate unique keys */
+  final case class UniqueKeyViolation(gk: GlobalKey) extends SubmitError
+
+  /** Submitted commands for parties that have not been allocated. */
+  final case class PartiesNotAllocated(parties: Set[Party]) extends SubmitError
+}


### PR DESCRIPTION
WIP
Intention is to add `trySubmit`, which will replace the inner workings of submit and submitMustFail
Factoring out further to `trySubmitTree` is still to be considered, pending limitations with json client.

Currently only fully implemented the Missing Create Authorization exception

Resolves #16895 

TODO:
- Discuss whether this is the interface/error structure we want
- Move over to Daml3.Script pending #16898 