### PR TITLE
JSON API: fix empty string comparisons on Oracle

### DIFF
--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -1059,10 +1059,10 @@ private final class OracleQueries(
       sql"JSON_EXISTS($contractColumnName, ${oracleShortPathEscape(opath ++ Cord(pred))}$extension)"
 
     // Oracle conflates empty string and NULL
-    lazy val eqEmptyString =
+    def eqEmptyString =
       sql"""JSON_VALUE($contractColumnName, ${oracleShortPathEscape(opath)}) IS NULL"""
 
-    lazy val eqJsonNonScalar =
+    def eqJsonNonScalar =
       sql"JSON_EQUAL(JSON_QUERY($contractColumnName, ${oracleShortPathEscape(opath)} RETURNING CLOB), $literal)"
 
     // you cannot put a positional parameter in a path, which _must_ be a literal
@@ -1135,7 +1135,7 @@ private final class OracleQueries(
 
     // Oracle conflates "" and NULL, which makes comparison operations against the empty string surprising.
     // This attempts to implement the semantic meaning of the comparison operators against an empty string on Oracle.
-    lazy val compareEmptyString = {
+    def compareEmptyString = {
       op match {
         case LT =>
           // Always false, as no string value can be < ""

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -1054,22 +1054,26 @@ private final class OracleQueries(
 
   private[http] override def equalAtContractPath(path: JsonPath, literal: JsValue): Fragment = {
     val opath: Cord = '$' -: pathSteps(path)
+
+    def eqJsonScalar(pred: String, extension: Fragment) =
+      sql"JSON_EXISTS($contractColumnName, ${oracleShortPathEscape(opath ++ Cord(pred))}$extension)"
+
+    // Oracle conflates empty string and NULL
+    lazy val eqEmptyString =
+      sql"""JSON_VALUE($contractColumnName, ${oracleShortPathEscape(opath)}) IS NULL"""
+
+    lazy val eqJsonNonScalar =
+      sql"JSON_EQUAL(JSON_QUERY($contractColumnName, ${oracleShortPathEscape(opath)} RETURNING CLOB), $literal)"
+
     // you cannot put a positional parameter in a path, which _must_ be a literal
     // so pass it as the path-local variable X instead
-    val predExtension = literal match {
-      case JsNumber(n) => Some(("?(@ == $X)", passingNumberAsX(n)))
-      case JsString(s) => Some(("?(@ == $X)", passingStringAsX(s)))
-      case JsTrue | JsFalse | JsNull => Some((s"?(@ == $literal)", sql""))
-      case JsObject(_) | JsArray(_) => None
+    literal match {
+      case JsNumber(n) => eqJsonScalar("?(@ == $X)", passingNumberAsX(n))
+      case JsString("") => eqEmptyString
+      case JsString(s) => eqJsonScalar("?(@ == $X)", passingStringAsX(s))
+      case JsTrue | JsFalse | JsNull => eqJsonScalar(s"?(@ == $literal)", sql"")
+      case JsObject(_) | JsArray(_) => eqJsonNonScalar
     }
-    predExtension.cata(
-      { case (pred, extension) =>
-        sql"JSON_EXISTS($contractColumnName, " ++
-          sql"${oracleShortPathEscape(opath ++ Cord(pred))}$extension)"
-      },
-      sql"JSON_EQUAL(JSON_QUERY($contractColumnName, " ++
-        sql"${oracleShortPathEscape(opath)} RETURNING CLOB), $literal)",
-    )
   }
 
   // XXX JsValue is _too big_ a type for `literal`; we can make this function
@@ -1116,24 +1120,49 @@ private final class OracleQueries(
       op: OrderOperator,
       literalScalar: JsValue,
   ) = {
-    val passingValueAsX = literalScalar match {
-      case JsNumber(n) => passingNumberAsX(n)
-      case JsString(s) => passingStringAsX(s)
+    import OrderOperator._
+
+    def compareJsonValue(passingValueAsX: Fragment): Fragment = {
+      val opc = op match {
+        case LT => "<"
+        case LTEQ => "<="
+        case GT => ">"
+        case GTEQ => ">="
+      }
+      val pathc = ('$' -: pathSteps(path)) ++ s"?(@ $opc ${"$X"})"
+      sql"""JSON_EXISTS($contractColumnName, ${oracleShortPathEscape(pathc)}${passingValueAsX})"""
+    }
+
+    // Oracle conflates "" and NULL, which makes comparison operations against the empty string surprising.
+    // This attempts to implement the semantic meaning of the comparison operators against an empty string on Oracle.
+    lazy val compareEmptyString = {
+      op match {
+        case LT =>
+          // Always false, as no string value can be < ""
+          sql"(0=1)"
+        case LTEQ =>
+          // True iff value is empty string
+          equalAtContractPath(path, literalScalar)
+        case GT => {
+          // True iff value is a non-empty string.
+          val jsonPath = '$' -: pathSteps(path)
+          sql"""JSON_VALUE($contractColumnName, ${oracleShortPathEscape(jsonPath)}) IS NOT NULL"""
+        }
+        case GTEQ =>
+          // Always true, as all string values are >= ""
+          sql"(1=1)"
+      }
+    }
+
+    literalScalar match {
+      case JsNumber(s) => compareJsonValue(passingNumberAsX(s))
+      case JsString("") => compareEmptyString
+      case JsString(s) => compareJsonValue(passingStringAsX(s))
       case JsNull | JsTrue | JsFalse | JsArray(_) | JsObject(_) =>
         throw new IllegalArgumentException(
           s"${literalScalar.compactPrint} is not comparable in JSON queries"
         )
     }
-    import OrderOperator._
-    val opc = op match {
-      case LT => "<"
-      case LTEQ => "<="
-      case GT => ">"
-      case GTEQ => ">="
-    }
-    val pathc = ('$' -: pathSteps(path)) ++ s"?(@ $opc ${"$X"})"
-    sql"JSON_EXISTS($contractColumnName, " ++
-      sql"""${oracleShortPathEscape(pathc)}${passingValueAsX})"""
   }
 
   protected override def insertTemplateIdIfNotExists(

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -636,8 +636,8 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           kbvarVA,
           Map("bazRecord" -> Map("baz" -> Map("%gt" -> "b")).toJson),
         )(
-          withBazRecord("c"),
-          withBazRecord("a"),
+          matches = Seq(withBazRecord("c")),
+          doesNotMatch = Seq(withBazRecord("a")),
         ),
         Scenario(
           "gt string with sketchy value",
@@ -645,8 +645,8 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           kbvarVA,
           Map("bazRecord" -> Map("baz" -> Map("%gt" -> "bobby'); DROP TABLE Students;--")).toJson),
         )(
-          withBazRecord("c"),
-          withBazRecord("a"),
+          matches = Seq(withBazRecord("c")),
+          doesNotMatch = Seq(withBazRecord("a")),
         ),
         /* TODO(raphael-speyer-da) Re-enable this test. See https://digitalasset.atlassian.net/browse/LT-15
         Scenario(
@@ -655,8 +655,8 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           kbvarVA,
           Map("bazRecord" -> Map("baz" -> Map("%lt" -> "'")).toJson),
         )(
-          withBazRecord(" "), // Less than '
-          withBazRecord("A"), // Not less than '
+          matches = Seq(withBazRecord(" ")), // Less than '
+          doesNotMatch = Seq(withBazRecord("A")), // Not less than '
         ),
          */
         Scenario(
@@ -665,31 +665,76 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           kbvarVA,
           Map("bazRecord" -> Map("baz" -> Map("%lt" -> "O\u02bcReilly")).toJson),
         )(
-          withBazRecord("A"),
-          withBazRecord("Z"),
+          matches = Seq(withBazRecord("A")),
+          doesNotMatch = Seq(withBazRecord("Z")),
+        ),
+        Scenario(
+          "eq empty string matches just that",
+          kbvarId,
+          kbvarVA,
+          Map("bazRecord" -> Map("baz" -> "").toJson),
+        )(
+          matches = Seq(withBazRecord("")),
+          doesNotMatch = Seq(withBazRecord("a")),
+        ),
+        Scenario(
+          "lt empty string matches nothing",
+          kbvarId,
+          kbvarVA,
+          Map("bazRecord" -> Map("baz" -> Map("%lt" -> "")).toJson),
+        )(
+          matches = Seq.empty,
+          doesNotMatch = Seq(withBazRecord("a"), withBazRecord("")),
+        ),
+        Scenario(
+          "lte empty string only matches empty string",
+          kbvarId,
+          kbvarVA,
+          Map("bazRecord" -> Map("baz" -> Map("%lte" -> "")).toJson),
+        )(
+          matches = Seq(withBazRecord("")),
+          doesNotMatch = Seq(withBazRecord("a")),
+        ),
+        Scenario(
+          "gt empty string only matches non-empty string",
+          kbvarId,
+          kbvarVA,
+          Map("bazRecord" -> Map("baz" -> Map("%gt" -> "")).toJson),
+        )(
+          matches = Seq(withBazRecord("a")),
+          doesNotMatch = Seq(withBazRecord("")),
+        ),
+        Scenario(
+          "gte empty string matches everything",
+          kbvarId,
+          kbvarVA,
+          Map("bazRecord" -> Map("baz" -> Map("%gte" -> "")).toJson),
+        )(
+          matches = Seq(withBazRecord("a"), withBazRecord("")),
+          doesNotMatch = Seq.empty,
         ),
         Scenario(
           "gt int",
           kbvarId,
           kbvarVA,
           Map("fooVariant" -> Map("tag" -> "Bar".toJson, "value" -> Map("%gt" -> 2).toJson).toJson),
-        )(withFooVariant(10), withFooVariant(1)),
+        )(matches = Seq(withFooVariant(10)), doesNotMatch = Seq(withFooVariant(1))),
       ).zipWithIndex.foreach { case (scenario, ix) =>
         import scenario._
         s"$label (scenario $ix)" in withHttpService { fixture =>
           for {
             (alice, headers) <- fixture.getUniquePartyAndAuthHeaders("Alice")
             contracts <- searchExpectOk(
-              List(matches, doesNotMatch).map { payload =>
+              (matches ++ doesNotMatch).toList.map { payload =>
                 domain.CreateCommand(ctId, argToApi(va)(payload(alice)), None)
               },
               JsObject(Map("templateIds" -> Seq(ctId).toJson, "query" -> query.toJson)),
               fixture,
               headers,
             )
-          } yield contracts.map(_.payload) should contain theSameElementsAs Seq(
-            LfValueCodec.apiValueToJsValue(va.inj(matches(alice)))
-          )
+          } yield contracts.map(_.payload) should contain theSameElementsAs matches.map { m =>
+            LfValueCodec.apiValueToJsValue(va.inj(m(alice)))
+          }
         }
       }
     }

--- a/ledger-service/http-json/src/itlib/scala/http/FilterDiscriminatorScenario.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/FilterDiscriminatorScenario.scala
@@ -13,8 +13,8 @@ class FilterDiscriminatorScenario[Inj](
     val ctId: domain.ContractTypeId.Template.OptionalPkg,
     val va: VA.Aux[Inj],
     val query: Map[String, JsValue],
-    val matches: domain.Party => Inj,
-    val doesNotMatch: domain.Party => Inj,
+    val matches: Seq[domain.Party => Inj],
+    val doesNotMatch: Seq[domain.Party => Inj],
 )
 
 object FilterDiscriminatorScenario {
@@ -24,8 +24,8 @@ object FilterDiscriminatorScenario {
       va: VA,
       query: Map[String, JsValue],
   )(
-      matches: domain.Party => va.Inj,
-      doesNotMatch: domain.Party => va.Inj,
+      matches: Seq[domain.Party => va.Inj],
+      doesNotMatch: Seq[domain.Party => va.Inj],
   ): FilterDiscriminatorScenario[va.Inj] =
     new FilterDiscriminatorScenario(label, ctId, va, query, matches, doesNotMatch)
 }


### PR DESCRIPTION
Oracle conflates empty strings with NULL, which breaks comparison operations against empty strings.

This change makes Oracle-backed queries have the behaviour you'd expect when comparing empty strings, in line with what we see on Postgres and in-memory backed queries.

We had to take a bit of care to ensure it worked irrespective of whether the JSON index was enabled.

Fixes https://digitalasset.atlassian.net/browse/LT-24