### PR TITLE
Add template for requesting improvements to errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/error_improvement.md
+++ b/.github/ISSUE_TEMPLATE/error_improvement.md
@@ -1,0 +1,47 @@
+---
+name: Error Message Improvement
+about: Request an improvement to error messages or diagnostics for Daml.
+title: ""
+labels: ''
+
+---
+
+<!--
+I confirm that, if this is a request that has security implications, I already contacted security@digitalasset.com and followed the [responsible disclosure policy](https://digitalasset.com/security/).
+
+I confirm that this is not a question or a request for technical support by the community, for which the [Daml forum](https://discuss.daml.com/) is available.
+-->
+
+### Describe the error message
+
+<!--
+Enter here the error message, where it occurs
+-->
+
+### To reproduce
+
+<!--
+Add here the steps to reproduce the error message...
+1. start such and such service '...'
+2. write the following code
+3. see error
+-->
+
+### What do you think is bad about the error message?
+
+<!--
+- Is it simply wrong, in that it refers to the wrong code?
+- Is it incomplete, in that it refers to only part of the problem?
+- Is it confusing, in that it refers to complex features?
+- Does it show compiler internals, or parts of the pipeline that you don't know about?
+- Is it insufficient, because it doesn't provide advice?
+-->
+
+### What do you think could be done to improve the error message?
+
+<!--
+- If the error is simply wrong, should it be fixed?
+- Should it provide better context on what caused the error?
+- Does it obscure compiler internals and better explain the source of the error?
+- Should it provide better advice on how to fix the error?
+-->

--- a/.github/ISSUE_TEMPLATE/error_improvement.md
+++ b/.github/ISSUE_TEMPLATE/error_improvement.md
@@ -1,8 +1,10 @@
 ---
 name: Error Message Improvement
 about: Request an improvement to error messages or diagnostics for Daml.
-title: ""
-labels: ''
+title: "[Error Message Improvement] "
+labels: ["developer-experience", "language/error-message-improvement"]
+assignees:
+  - dylant-da
 
 ---
 


### PR DESCRIPTION
We've wanted a template for requesting improvements to errors for a bit now. With the new GHC improvements for error messages, we now can really provide nice error messages across the whole compiler pipeline, so I'd like to start prompting users to request error message improvements where they find things confusing.

This should provide users with a nice template and help spread awareness that we can in fact:
- provide better context on what causes an error message
- add advice to error messages for fixes
- obscure compiler internals despite our reliance on GHC's typechecker

I've worded the template to allow people to report any sort of Daml error, which we can then push off to canton if the errors don't fall under the language team's purview, or if the user has a misunderstanding of the issue template.