### PR TITLE
fix Windows

### DIFF
--- a/infra/windows_azure.tf
+++ b/infra/windows_azure.tf
@@ -40,7 +40,7 @@ EOF
   source_image_reference {
     publisher = "MicrosoftWindowsServer"
     offer     = "WindowsServer"
-    sku       = "2016-datacenter"
+    sku       = "2022-datacenter"
     version   = "latest"
   }
 


### PR DESCRIPTION
Today we hit an error trying to install Chocolatey, which prevented all Windows nodes from starting. The error message was along the lines of ".Net Framework 4.8 was installed but you need to reboot before you can use it." (I didn't save the exact text, shame on me.)

I wasn't sure whether that was an issue with the base image, or with Chocolatey (I could see both: maybe the base image was not rebooted after a "standard" installation of .NET 4.8; maybe Chocolatey suddenly wants a new version that's not in the base image and thus installs it, hence the error), but either way I thought trying a newer image might fix it (assuming it would come bundled with .NET 4.8 already installed and ready to use), and it did.

Builds seem to work about as well as before, so there doesn't seem to be a great reason to investigate further or put much effort to try to stay 7 years behind.