### PR TITLE
JSON API: avoid excessive iterations in benchmarks

### DIFF
--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -670,6 +670,9 @@ exports_files(["src/main/resources/logback.xml"])
 da_scala_benchmark_jmh(
     name = "contractdao-bench",
     srcs = glob(["src/bench/scala/**/*.scala"]),
+    resources = [
+        ":src/main/resources/logback.xml",
+    ],
     scala_deps = [
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:io_spray_spray_json",

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/ContractDaoBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/ContractDaoBenchmark.scala
@@ -38,7 +38,7 @@ abstract class ContractDaoBenchmark {
   var batchSize: Int = _
 
   @Setup(Level.Trial)
-  def setup(): Unit = {
+  def trialSetup(): Unit = {
     connectToDb()
     val cfg = createDbJdbcConfig
     val cDao = ContractDao(cfg)
@@ -47,10 +47,14 @@ abstract class ContractDaoBenchmark {
     import cDao.jdbcDriver
 
     dao.transact(ContractDao.initialize).unsafeRunSync()
+
+    trialSetupPostInitialize()
   }
 
+  def trialSetupPostInitialize(): Unit
+
   @TearDown(Level.Trial)
-  def teardown(): Unit = {
+  def trialTearDown(): Unit = {
     dao.close()
     cleanup()
   }

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/InsertBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/InsertBenchmark.scala
@@ -14,7 +14,7 @@ import spray.json.DefaultJsonProtocol._
 trait InsertBenchmark extends ContractDaoBenchmark {
   self: BenchmarkDbConnection =>
 
-  @Param(Array("1", "3", "5", "7", "9"))
+  @Param(Array("1", "100"))
   var batches: Int = _
 
   @Param(Array("1000"))
@@ -26,9 +26,7 @@ trait InsertBenchmark extends ContractDaoBenchmark {
 
   private var tpid: SurrogateTpId = _
 
-  @Setup(Level.Trial)
-  override def setup(): Unit = {
-    super.setup()
+  override def trialSetupPostInitialize(): Unit = {
     tpid = insertTemplate(ContractTypeId.Template("-pkg-", "M", "T"))
     contracts = (1 until numContracts + 1).map { i =>
       // Use negative cids to avoid collisions with other contracts
@@ -50,6 +48,9 @@ trait InsertBenchmark extends ContractDaoBenchmark {
   }
 
   @Benchmark @BenchmarkMode(Array(Mode.AverageTime))
+  @Fork(1)
+  @Warmup(iterations = 1)
+  @Measurement(iterations = 1)
   def run(): Unit = {
     val inserted = dao.transact(queries.insertContracts(contracts)).unsafeRunSync()
     assert(inserted == numContracts)

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryBenchmark.scala
@@ -13,19 +13,17 @@ import org.openjdk.jmh.annotations._
 trait QueryBenchmark extends ContractDaoBenchmark {
   self: BenchmarkDbConnection =>
 
-  @Param(Array("1", "5", "9"))
+  @Param(Array("1", "10"))
   var extraParties: Int = _
 
-  @Param(Array("1", "5", "9"))
+  @Param(Array("1", "10"))
   var extraTemplates: Int = _
 
   private val tpid = ContractTypeId.Template("-pkg-", "M", "T")
   private var surrogateTpid: SurrogateTpId = _
   val party = "Alice"
 
-  @Setup(Level.Trial)
-  override def setup(): Unit = {
-    super.setup()
+  override def trialSetupPostInitialize(): Unit = {
     surrogateTpid = insertTemplate(tpid)
 
     val surrogateTpids = surrogateTpid :: (0 until extraTemplates)
@@ -44,6 +42,9 @@ trait QueryBenchmark extends ContractDaoBenchmark {
   }
 
   @Benchmark @BenchmarkMode(Array(Mode.AverageTime))
+  @Fork(1)
+  @Warmup(iterations = 3)
+  @Measurement(iterations = 10)
   def run(): Unit = {
     implicit val driver: SupportedJdbcDriver.TC = dao.jdbcDriver
     val result = instanceUUIDLogCtx(implicit lc =>

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryPayloadBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryPayloadBenchmark.scala
@@ -17,10 +17,10 @@ import spray.json._
 trait QueryPayloadBenchmark extends ContractDaoBenchmark {
   self: BenchmarkDbConnection =>
 
-  @Param(Array("1", "10", "100"))
+  @Param(Array("1", "10"))
   var extraParties: Int = _
 
-  @Param(Array("1", "100", "100"))
+  @Param(Array("1", "10"))
   var extraPayloadValues: Int = _
 
   private val tpid = ContractTypeId.Template("-pkg-", "M", "T")
@@ -54,9 +54,7 @@ trait QueryPayloadBenchmark extends ContractDaoBenchmark {
 
   def whereClause = predicate.toSqlWhereClause(dao.jdbcDriver)
 
-  @Setup(Level.Trial)
-  override def setup(): Unit = {
-    super.setup()
+  override def trialSetupPostInitialize(): Unit = {
     surrogateTpid = insertTemplate(tpid)
 
     val parties: List[String] = party :: (0 until extraParties).map(i => s"p$i").toList
@@ -71,6 +69,9 @@ trait QueryPayloadBenchmark extends ContractDaoBenchmark {
   }
 
   @Benchmark @BenchmarkMode(Array(Mode.AverageTime))
+  @Fork(1)
+  @Warmup(iterations = 3)
+  @Measurement(iterations = 10)
   def run(): Unit = {
     implicit val sjd: SupportedJdbcDriver.TC = dao.jdbcDriver
     val result = instanceUUIDLogCtx(implicit lc =>

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
@@ -71,6 +71,7 @@ trait PostgresAround {
       logger.info(s"PostgreSQL has started on port $port.")
     } catch {
       case NonFatal(e) =>
+        logger.error(s"Error while starting postgres: $e")
         lockedPort.unlock()
         stopPostgresql(dataDir)
         deleteRecursively(root)


### PR DESCRIPTION
Also:
* fix db connection setup - the combination of annotations and inheritance meant it was trying to setup the trial twice, causing Postgres benchmarks to fail
* log when an error occurs during test setup
* add logback resources to the benchmarks, to enable configuration of logging, and avoid dumping all the debug logs by default

With these changes, on my 20 core 64G linux laptop, the benchmarks now all run in under 6 mins

```
# Run complete. Total time: 00:05:51

Benchmark                          (batchSize)  (batches)  (extraParties)  (extraPayloadValues)  (extraTemplates)  (numContracts)  Mode  Cnt  Score    Error  Units
InsertBenchmarkOracle.run                 1000          1             N/A                   N/A               N/A            1000  avgt       0.127            s/op
InsertBenchmarkOracle.run                 1000        100             N/A                   N/A               N/A            1000  avgt       0.134            s/op
InsertBenchmarkPostgres.run               1000          1             N/A                   N/A               N/A            1000  avgt       0.040            s/op
InsertBenchmarkPostgres.run               1000        100             N/A                   N/A               N/A            1000  avgt       0.035            s/op
QueryBenchmarkOracle.run                  1000        N/A               1                   N/A                 1             N/A  avgt   10  0.008 ±  0.001   s/op
QueryBenchmarkOracle.run                  1000        N/A               1                   N/A                10             N/A  avgt   10  0.009 ±  0.001   s/op
QueryBenchmarkOracle.run                  1000        N/A              10                   N/A                 1             N/A  avgt   10  0.015 ±  0.001   s/op
QueryBenchmarkOracle.run                  1000        N/A              10                   N/A                10             N/A  avgt   10  0.008 ±  0.001   s/op
QueryBenchmarkPostgres.run                1000        N/A               1                   N/A                 1             N/A  avgt   10  0.002 ±  0.001   s/op
QueryBenchmarkPostgres.run                1000        N/A               1                   N/A                10             N/A  avgt   10  0.002 ±  0.001   s/op
QueryBenchmarkPostgres.run                1000        N/A              10                   N/A                 1             N/A  avgt   10  0.003 ±  0.001   s/op
QueryBenchmarkPostgres.run                1000        N/A              10                   N/A                10             N/A  avgt   10  0.003 ±  0.001   s/op
QueryPayloadBenchmarkOracle.run           1000        N/A               1                     1               N/A             N/A  avgt   10  0.011 ±  0.001   s/op
QueryPayloadBenchmarkOracle.run           1000        N/A               1                    10               N/A             N/A  avgt   10  0.047 ±  0.001   s/op
QueryPayloadBenchmarkOracle.run           1000        N/A              10                     1               N/A             N/A  avgt   10  0.011 ±  0.001   s/op
QueryPayloadBenchmarkOracle.run           1000        N/A              10                    10               N/A             N/A  avgt   10  0.051 ±  0.005   s/op
QueryPayloadBenchmarkPostgres.run         1000        N/A               1                     1               N/A             N/A  avgt   10  0.006 ±  0.003   s/op
QueryPayloadBenchmarkPostgres.run         1000        N/A               1                    10               N/A             N/A  avgt   10  0.011 ±  0.001   s/op
QueryPayloadBenchmarkPostgres.run         1000        N/A              10                     1               N/A             N/A  avgt   10  0.007 ±  0.005   s/op
QueryPayloadBenchmarkPostgres.run         1000        N/A              10                    10               N/A             N/A  avgt   10  0.032 ±  0.001   s/op

```

without this change, it took over 9 hours in total and none of the Postgres benchmarks were successful.

```
# Run complete. Total time: 09:13:36

Benchmark                        (batchSize)  (batches)  (extraParties)  (extraPayloadValues)  (extraTemplates)  (numContracts)  Mode  Cnt  Score    Error  Units
InsertBenchmarkOracle.run               1000          1             N/A                   N/A               N/A            1000  avgt  200  0.109 ±  0.002   s/op
InsertBenchmarkOracle.run               1000          3             N/A                   N/A               N/A            1000  avgt  200  0.114 ±  0.005   s/op
InsertBenchmarkOracle.run               1000          5             N/A                   N/A               N/A            1000  avgt  200  0.120 ±  0.018   s/op
InsertBenchmarkOracle.run               1000          7             N/A                   N/A               N/A            1000  avgt  200  0.118 ±  0.012   s/op
InsertBenchmarkOracle.run               1000          9             N/A                   N/A               N/A            1000  avgt  200  0.126 ±  0.023   s/op
QueryBenchmarkOracle.run                1000        N/A               1                   N/A                 1             N/A  avgt  200  0.008 ±  0.001   s/op
QueryBenchmarkOracle.run                1000        N/A               1                   N/A                 5             N/A  avgt  200  0.009 ±  0.001   s/op
QueryBenchmarkOracle.run                1000        N/A               1                   N/A                 9             N/A  avgt  200  0.009 ±  0.001   s/op
QueryBenchmarkOracle.run                1000        N/A               5                   N/A                 1             N/A  avgt  200  0.011 ±  0.001   s/op
QueryBenchmarkOracle.run                1000        N/A               5                   N/A                 5             N/A  avgt  200  0.013 ±  0.001   s/op
QueryBenchmarkOracle.run                1000        N/A               5                   N/A                 9             N/A  avgt  200  0.013 ±  0.001   s/op
QueryBenchmarkOracle.run                1000        N/A               9                   N/A                 1             N/A  avgt  200  0.014 ±  0.001   s/op
QueryBenchmarkOracle.run                1000        N/A               9                   N/A                 5             N/A  avgt  200  0.016 ±  0.001   s/op
QueryBenchmarkOracle.run                1000        N/A               9                   N/A                 9             N/A  avgt  200  0.017 ±  0.001   s/op
QueryPayloadBenchmarkOracle.run         1000        N/A               1                     1               N/A             N/A  avgt  200  0.011 ±  0.001   s/op
QueryPayloadBenchmarkOracle.run         1000        N/A               1                   100               N/A             N/A  avgt  200  0.387 ±  0.001   s/op
QueryPayloadBenchmarkOracle.run         1000        N/A               1                   100               N/A             N/A  avgt  200  0.387 ±  0.001   s/op
QueryPayloadBenchmarkOracle.run         1000        N/A              10                     1               N/A             N/A  avgt  200  0.011 ±  0.001   s/op
QueryPayloadBenchmarkOracle.run         1000        N/A              10                   100               N/A             N/A  avgt  200  0.417 ±  0.001   s/op
QueryPayloadBenchmarkOracle.run         1000        N/A              10                   100               N/A             N/A  avgt  200  0.417 ±  0.001   s/op
QueryPayloadBenchmarkOracle.run         1000        N/A             100                     1               N/A             N/A  avgt  200  0.011 ±  0.001   s/op
QueryPayloadBenchmarkOracle.run         1000        N/A             100                   100               N/A             N/A  avgt   40  0.475 ±  0.001   s/op
```