### PR TITLE
Export shows function

### DIFF
--- a/compiler/damlc/daml-prim-src/GHC/Show.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Show.daml
@@ -9,6 +9,7 @@
 module GHC.Show
   ( Show(..)
   , ShowS
+  , shows
   , showParen
   , showString
   , showCommaSpace


### PR DESCRIPTION
Currently the linter always suggests replacing `showsPrec 0` with `shows`. However the fix does not actually work because `shows` is not exported from `GHC.Show`. This fix exports that function so that the suggestion from the linter will not cause a compilation error.

<img width="794" alt="image" src="https://github.com/digital-asset/daml/assets/109506013/89089f3d-5798-4926-bef4-b10f4a8d0419">


<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
