### PR TITLE
JSON API: Avoid populating both `"result"` and `"errors"` in response

### DIFF
--- a/daml-script/test/daml/TestInterfaces.daml
+++ b/daml-script/test/daml/TestInterfaces.daml
@@ -203,12 +203,8 @@ sharedQueryInterfaceTest caller p = script do
       v3.info === "C:I-am-c1"
 
     -- TODO https://github.com/digital-asset/daml/issues/14830
-    -- contracts with failed-views are not returned over the Json API
+    -- contracts with failed-views currently cannot be queried via the interface with the failing view
     JSON -> do
-      [(i2,Some v2),(i3,Some v3)] <- sortOn snd <$> queryInterface @MyInterface2 p
-      i2 === i2b1
-      i3 === i2c1
-      v2.info === "B:44"
-      v3.info === "C:I-am-c1"
+      pure ()
 
   pure ()

--- a/ledger-service/http-json/src/failurelib/scala/http/FailureTests.scala
+++ b/ledger-service/http-json/src/failurelib/scala/http/FailureTests.scala
@@ -188,7 +188,7 @@ abstract class FailureTests
       )
       _ <- inside(output) { case JsObject(fields) =>
         inside(fields.get("status")) { case Some(JsNumber(code)) =>
-          code shouldBe 501
+          code shouldBe 500
         }
       }
       // TODO Document this properly or adjust it
@@ -235,7 +235,7 @@ abstract class FailureTests
       )
       _ <- inside(output) { case JsObject(fields) =>
         inside(fields.get("status")) { case Some(JsNumber(code)) =>
-          code shouldBe 501
+          code shouldBe 500
         }
       }
       // TODO Document this properly or adjust it
@@ -299,7 +299,7 @@ abstract class FailureTests
         )
         _ <- inside(output) { case JsObject(fields) =>
           inside(fields.get("status")) { case Some(JsNumber(code)) =>
-            code shouldBe 501
+            code shouldBe 500
           }
         }
         // TODO Document this properly or adjust it

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/ResponseFormats.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/ResponseFormats.scala
@@ -4,13 +4,11 @@
 package com.daml.http.json
 
 import akka.NotUsed
-import akka.http.scaladsl.model._
-import akka.stream.scaladsl.{Concat, Source, _}
-import akka.stream.{FanOutShape2, SourceShape, UniformFanInShape}
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
-import com.daml.fetchcontracts.util.AkkaStreamsDoobie
 import scalaz.syntax.show._
-import scalaz.{Show, \/}
+import scalaz.{Show, -\/, \/, \/-}
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
@@ -32,44 +30,37 @@ private[http] object ResponseFormats {
       jsVals: Source[E \/ JsValue, NotUsed],
       warnings: Option[JsValue],
   ): Source[ByteString, NotUsed] = {
-
-    val graph = GraphDSL.create() { implicit b =>
-      import GraphDSL.Implicits._
-
-      val partition: FanOutShape2[E \/ JsValue, E, JsValue] = b add AkkaStreamsDoobie.partition
-      val concat: UniformFanInShape[ByteString, ByteString] = b add Concat(3)
-
-      // first produce optional warnings and result element
-      warnings match {
-        case Some(x) =>
-          Source.single(ByteString(s"""{"warnings":${x.compactPrint},"result":[""")) ~> concat.in(0)
-        case None =>
-          Source.single(ByteString("""{"result":[""")) ~> concat.in(0)
+    jsVals
+      // Collapse the stream of `E \/ JsValue` into a single pair of errors and results,
+      // only one of which may be non-empty.
+      .fold((Vector.empty[E], Vector.empty[JsValue])) {
+        case ((errors, results), \/-(r)) if errors.isEmpty => (Vector.empty, results :+ r)
+        case ((errors, _), \/-(_)) => (errors, Vector.empty)
+        case ((errors, _), -\/(e)) => (errors :+ e, Vector.empty)
       }
+      // Convert that into the appropriate JSON response object
+      .map {
+        case (errors, results) => {
+          val response = JsObject(
+            (
+              if (errors.isEmpty)
+                Map[String, JsValue](
+                  "result" -> JsArray(results),
+                  statusField(StatusCodes.OK),
+                )
+              else
+                Map[String, JsValue](
+                  "errors" -> JsArray(errors.map(e => JsString(e.shows))),
+                  statusField(StatusCodes.InternalServerError),
+                )
+            )
+              ++
+                warnings.toList.map("warnings" -> _).toMap
+          )
 
-      jsVals ~> partition.in
-
-      // second consume all successes
-      partition.out1.zipWithIndex.map(a => formatOneElement(a._1, a._2)) ~> concat.in(1)
-
-      // then consume all failures and produce the status and optional errors
-      partition.out0.fold(Vector.empty[E])((b, a) => b :+ a).map {
-        case Vector() =>
-          ByteString("""],"status":200}""")
-        case errors =>
-          val jsErrors: Vector[JsString] = errors.map(e => JsString(e.shows))
-          ByteString(s"""],"errors":${JsArray(jsErrors).compactPrint},"status":501}""")
-      } ~> concat.in(2)
-
-      SourceShape(concat.out)
-    }
-
-    Source.fromGraph(graph)
-  }
-
-  private def formatOneElement(a: JsValue, index: Long): ByteString = {
-    if (index == 0L) ByteString(a.compactPrint)
-    else ByteString("," + a.compactPrint)
+          ByteString(response.compactPrint)
+        }
+      }
   }
 
   def statusField(status: StatusCode): (String, JsNumber) =

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/ResponseFormatsTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/ResponseFormatsTest.scala
@@ -72,11 +72,7 @@ class ResponseFormatsTest
       if (failures.isEmpty)
         Map[String, JsValue]("result" -> JsArray(successes), "status" -> JsNumber("200"))
       else
-        Map[String, JsValue](
-          "result" -> JsArray(successes),
-          "errors" -> JsArray(failures),
-          "status" -> JsNumber("501"),
-        )
+        Map[String, JsValue]("errors" -> JsArray(failures), "status" -> JsNumber("500"))
 
     JsObject(map1 ++ map2)
   }


### PR DESCRIPTION
According to current documentation, only one of these may be set, but we can currently return both.

Also in this case we currently return a status code of 501, which is not one of the documented status codes. This PR switches that to 500 instead.

https://docs.daml.com/json-api/index.html#http-status-codes