### PR TITLE
Windows flaky test fix

### DIFF
--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -1116,7 +1116,7 @@ trait AbstractTriggerServiceTestAuthMiddleware
       _ <- submitCmd(client, aliceExp.unwrap, createACommand(7))
       // Query ACS until we see a B contract
       _ = println("DEBUGGY: fake change to force test to run!")
-      _ <- RetryStrategy.constant(5, 1.seconds) { (_, _) =>
+      _ <- RetryStrategy.constant(5, 2.seconds) { (_, _) =>
         getActiveContracts(client, aliceExp, Identifier(testPkgId, "TestTrigger", "B"))
           .map(_.length shouldBe 1)
       }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -1115,7 +1115,7 @@ trait AbstractTriggerServiceTestAuthMiddleware
       }
       _ <- submitCmd(client, aliceExp.unwrap, createACommand(7))
       // Query ACS until we see a B contract
-      _ <- RetryStrategy.constant(5, 2.seconds) { (_, _) =>
+      _ <- RetryStrategy.constant(5, 1.seconds) { (_, _) =>
         getActiveContracts(client, aliceExp, Identifier(testPkgId, "TestTrigger", "B"))
           .map(_.length shouldBe 1)
       }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -1115,7 +1115,6 @@ trait AbstractTriggerServiceTestAuthMiddleware
       }
       _ <- submitCmd(client, aliceExp.unwrap, createACommand(7))
       // Query ACS until we see a B contract
-      _ = println("DEBUGGY: fake change to force test to run!")
       _ <- RetryStrategy.constant(5, 2.seconds) { (_, _) =>
         getActiveContracts(client, aliceExp, Identifier(testPkgId, "TestTrigger", "B"))
           .map(_.length shouldBe 1)

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -1115,7 +1115,7 @@ trait AbstractTriggerServiceTestAuthMiddleware
       }
       _ <- submitCmd(client, aliceExp.unwrap, createACommand(7))
       // Query ACS until we see a B contract
-      _ <- RetryStrategy.constant(5, 1.seconds) { (_, _) =>
+      _ <- RetryStrategy.constant(5, 2.seconds) { (_, _) =>
         getActiveContracts(client, aliceExp, Identifier(testPkgId, "TestTrigger", "B"))
           .map(_.length shouldBe 1)
       }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -1115,6 +1115,7 @@ trait AbstractTriggerServiceTestAuthMiddleware
       }
       _ <- submitCmd(client, aliceExp.unwrap, createACommand(7))
       // Query ACS until we see a B contract
+      _ = println("DEBUGGY: fake change to force test to run!")
       _ <- RetryStrategy.constant(5, 1.seconds) { (_, _) =>
         getActiveContracts(client, aliceExp, Identifier(testPkgId, "TestTrigger", "B"))
           .map(_.length shouldBe 1)


### PR DESCRIPTION
CI building on windows is displaying a number of failures with the line:
```
//triggers/service:test_6                                                FAILED in 117.3s
  C:/users/u/_bazel_u/vvgx3zjt/execroot/com_github_digital_asset_daml/bazel-out/x64_windows-opt/testlogs/triggers/service/test_6/test.log
```
getting logged.

Downloading CI build artefacts for Windows:
- identifies this being a test failure in the suite `TriggerServiceTestAuthClaims`
- specific test case that is failing being reported as `authenticated service should refresh a token after expiry on the server side`
- test failure message is `Gave up trying after Some(5) attempts and 4.0244786 seconds`
- and exception trace is:
```
com.daml.timer.RetryStrategy$TooManyAttemptsException: Gave up trying after Some(5) attempts and 4.0244786 seconds.
      at com.daml.timer.RetryStrategy$$anonfun$com$daml$timer$RetryStrategy$$go$1$1.applyOrElse(RetryStrategy.scala:94)
      at com.daml.timer.RetryStrategy$$anonfun$com$daml$timer$RetryStrategy$$go$1$1.applyOrElse(RetryStrategy.scala:89)
      at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:490)
      at org.scalatest.concurrent.SerialExecutionContext.recRunNow(SerialExecutionContext.scala:120)
      at org.scalatest.concurrent.SerialExecutionContext.runNow(SerialExecutionContext.scala:111)
      at org.scalatest.AsyncSuperEngine.runTestImpl(AsyncEngine.scala:377)
      at org.scalatest.flatspec.AsyncFlatSpecLike.runTest(AsyncFlatSpecLike.scala:1839)
      at org.scalatest.flatspec.AsyncFlatSpecLike.runTest$(AsyncFlatSpecLike.scala:1818)
      at com.daml.lf.engine.trigger.TriggerServiceTestAuthClaims.org$scalatest$BeforeAndAfterEach$$super$runTest(TriggerServiceTestAuthClaims.scala:6)
      at org.scalatest.BeforeAndAfterEach.runTest(BeforeAndAfterEach.scala:234)
      at org.scalatest.BeforeAndAfterEach.runTest$(BeforeAndAfterEach.scala:227)
      at com.daml.lf.engine.trigger.TriggerServiceTestAuthClaims.runTest(TriggerServiceTestAuthClaims.scala:6)
      at org.scalatest.flatspec.AsyncFlatSpecLike.$anonfun$runTests$1(AsyncFlatSpecLike.scala:1897)
      at org.scalatest.AsyncSuperEngine.$anonfun$runTestsInBranch$3(AsyncEngine.scala:435)
      at org.scalatest.Status.$anonfun$thenRun$1(Status.scala:227)
      at org.scalatest.Status.$anonfun$thenRun$1$adapted(Status.scala:225)
      at org.scalatest.ScalaTestStatefulStatus.whenCompleted(Status.scala:648)
      at org.scalatest.Status.thenRun(Status.scala:225)
      at org.scalatest.Status.thenRun$(Status.scala:220)
      at org.scalatest.ScalaTestStatefulStatus.thenRun(Status.scala:511)
      at org.scalatest.AsyncSuperEngine.$anonfun$runTestsInBranch$1(AsyncEngine.scala:435)
      at scala.collection.LinearSeqOps.foldLeft(LinearSeq.scala:183)
      at scala.collection.LinearSeqOps.foldLeft$(LinearSeq.scala:179)
      at scala.collection.immutable.List.foldLeft(List.scala:79)
      at org.scalatest.AsyncSuperEngine.traverseSubNodes$1(AsyncEngine.scala:406)
      at org.scalatest.AsyncSuperEngine.runTestsInBranch(AsyncEngine.scala:479)
      at org.scalatest.AsyncSuperEngine.$anonfun$runTestsInBranch$4(AsyncEngine.scala:463)
      at org.scalatest.Status.$anonfun$thenRun$1(Status.scala:227)
      at org.scalatest.Status.$anonfun$thenRun$1$adapted(Status.scala:225)
      at org.scalatest.ScalaTestStatefulStatus.whenCompleted(Status.scala:648)
      at org.scalatest.Status.thenRun(Status.scala:225)
      at org.scalatest.Status.thenRun$(Status.scala:220)
      at org.scalatest.ScalaTestStatefulStatus.thenRun(Status.scala:511)
      at org.scalatest.AsyncSuperEngine.$anonfun$runTestsInBranch$1(AsyncEngine.scala:463)
      at scala.collection.LinearSeqOps.foldLeft(LinearSeq.scala:183)
      at scala.collection.LinearSeqOps.foldLeft$(LinearSeq.scala:179)
      at scala.collection.immutable.List.foldLeft(List.scala:79)
      at org.scalatest.AsyncSuperEngine.traverseSubNodes$1(AsyncEngine.scala:406)
      at org.scalatest.AsyncSuperEngine.runTestsInBranch(AsyncEngine.scala:487)
      at org.scalatest.AsyncSuperEngine.runTestsImpl(AsyncEngine.scala:555)
      at org.scalatest.flatspec.AsyncFlatSpecLike.runTests(AsyncFlatSpecLike.scala:1897)
      at org.scalatest.flatspec.AsyncFlatSpecLike.runTests$(AsyncFlatSpecLike.scala:1896)
      at org.scalatest.flatspec.AsyncFlatSpec.runTests(AsyncFlatSpec.scala:2221)
      at org.scalatest.Suite.run(Suite.scala:1112)
      at org.scalatest.Suite.run$(Suite.scala:1094)
      at org.scalatest.flatspec.AsyncFlatSpec.org$scalatest$flatspec$AsyncFlatSpecLike$$super$run(AsyncFlatSpec.scala:2221)
      at org.scalatest.flatspec.AsyncFlatSpecLike.$anonfun$run$1(AsyncFlatSpecLike.scala:1942)
      at org.scalatest.AsyncSuperEngine.runImpl(AsyncEngine.scala:625)
      at org.scalatest.flatspec.AsyncFlatSpecLike.run(AsyncFlatSpecLike.scala:1942)
      at org.scalatest.flatspec.AsyncFlatSpecLike.run$(AsyncFlatSpecLike.scala:1940)
      at com.daml.lf.engine.trigger.TriggerServiceTestAuthClaims.org$scalatest$BeforeAndAfterAll$$super$run(TriggerServiceTestAuthClaims.scala:6)
      at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
      at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
      at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
      at com.daml.lf.engine.trigger.TriggerServiceTestAuthClaims.run(TriggerServiceTestAuthClaims.scala:6)
      at org.scalatest.Suite.callExecuteOnSuite$1(Suite.scala:1175)
      at org.scalatest.Suite.$anonfun$runNestedSuites$1(Suite.scala:1222)
      at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1321)
      at org.scalatest.Suite.runNestedSuites(Suite.scala:1220)
      at org.scalatest.Suite.runNestedSuites$(Suite.scala:1154)
      at org.scalatest.tools.DiscoverySuite.runNestedSuites(DiscoverySuite.scala:30)
      at org.scalatest.Suite.run(Suite.scala:1109)
      at org.scalatest.Suite.run$(Suite.scala:1094)
      at org.scalatest.tools.DiscoverySuite.run(DiscoverySuite.scala:30)
      at org.scalatest.tools.SuiteRunner.run(SuiteRunner.scala:45)
      at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13(Runner.scala:1322)
      at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13$adapted(Runner.scala:1316)
      at scala.collection.immutable.List.foreach(List.scala:333)
      at org.scalatest.tools.Runner$.doRunRunRunDaDoRunRun(Runner.scala:1316)
      at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24(Runner.scala:993)
      at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24$adapted(Runner.scala:971)
      at org.scalatest.tools.Runner$.withClassLoaderAndDispatchReporter(Runner.scala:1482)
      at org.scalatest.tools.Runner$.runOptionallyWithPassFailReporter(Runner.scala:971)
      at org.scalatest.tools.Runner$.main(Runner.scala:775)
      at org.scalatest.tools.Runner.main(Runner.scala)
      at io.bazel.rulesscala.scala_test.Runner.main(Runner.java:33)
      Cause: org.scalatest.exceptions.TestFailedException: 0 was not equal to 1
      at org.scalatest.matchers.MatchersHelper$.indicateFailure(MatchersHelper.scala:402)
      at org.scalatest.matchers.should.Matchers$AnyShouldWrapper.shouldBe(Matchers.scala:7021)
      at com.daml.lf.engine.trigger.AbstractTriggerServiceTestAuthMiddleware.$anonfun$$init$$361(TriggerServiceTest.scala:1120)
      at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467)
      at org.scalatest.concurrent.SerialExecutionContext.recRunNow(SerialExecutionContext.scala:120)
      at org.scalatest.concurrent.SerialExecutionContext.runNow(SerialExecutionContext.scala:111)
      at org.scalatest.AsyncSuperEngine.runTestImpl(AsyncEngine.scala:377)
      at org.scalatest.flatspec.AsyncFlatSpecLike.runTest(AsyncFlatSpecLike.scala:1839)
      at org.scalatest.flatspec.AsyncFlatSpecLike.runTest$(AsyncFlatSpecLike.scala:1818)
      at com.daml.lf.engine.trigger.TriggerServiceTestAuthClaims.org$scalatest$BeforeAndAfterEach$$super$runTest(TriggerServiceTestAuthClaims.scala:6)
      at org.scalatest.BeforeAndAfterEach.runTest(BeforeAndAfterEach.scala:234)
      at org.scalatest.BeforeAndAfterEach.runTest$(BeforeAndAfterEach.scala:227)
      at com.daml.lf.engine.trigger.TriggerServiceTestAuthClaims.runTest(TriggerServiceTestAuthClaims.scala:6)
      at org.scalatest.flatspec.AsyncFlatSpecLike.$anonfun$runTests$1(AsyncFlatSpecLike.scala:1897)
      at org.scalatest.AsyncSuperEngine.$anonfun$runTestsInBranch$3(AsyncEngine.scala:435)
      at org.scalatest.Status.$anonfun$thenRun$1(Status.scala:227)
      at org.scalatest.Status.$anonfun$thenRun$1$adapted(Status.scala:225)
      at org.scalatest.ScalaTestStatefulStatus.whenCompleted(Status.scala:648)
      at org.scalatest.Status.thenRun(Status.scala:225)
      at org.scalatest.Status.thenRun$(Status.scala:220)
      at org.scalatest.ScalaTestStatefulStatus.thenRun(Status.scala:511)
      at org.scalatest.AsyncSuperEngine.$anonfun$runTestsInBranch$1(AsyncEngine.scala:435)
      at scala.collection.LinearSeqOps.foldLeft(LinearSeq.scala:183)
      at scala.collection.LinearSeqOps.foldLeft$(LinearSeq.scala:179)
      at scala.collection.immutable.List.foldLeft(List.scala:79)
      at org.scalatest.AsyncSuperEngine.traverseSubNodes$1(AsyncEngine.scala:406)
      at org.scalatest.AsyncSuperEngine.runTestsInBranch(AsyncEngine.scala:479)
      at org.scalatest.AsyncSuperEngine.$anonfun$runTestsInBranch$4(AsyncEngine.scala:463)
      at org.scalatest.Status.$anonfun$thenRun$1(Status.scala:227)
      at org.scalatest.Status.$anonfun$thenRun$1$adapted(Status.scala:225)
      at org.scalatest.ScalaTestStatefulStatus.whenCompleted(Status.scala:648)
      at org.scalatest.Status.thenRun(Status.scala:225)
      at org.scalatest.Status.thenRun$(Status.scala:220)
      at org.scalatest.ScalaTestStatefulStatus.thenRun(Status.scala:511)
      at org.scalatest.AsyncSuperEngine.$anonfun$runTestsInBranch$1(AsyncEngine.scala:463)
      at scala.collection.LinearSeqOps.foldLeft(LinearSeq.scala:183)
      at scala.collection.LinearSeqOps.foldLeft$(LinearSeq.scala:179)
      at scala.collection.immutable.List.foldLeft(List.scala:79)
      at org.scalatest.AsyncSuperEngine.traverseSubNodes$1(AsyncEngine.scala:406)
      at org.scalatest.AsyncSuperEngine.runTestsInBranch(AsyncEngine.scala:487)
      at org.scalatest.AsyncSuperEngine.runTestsImpl(AsyncEngine.scala:555)
      at org.scalatest.flatspec.AsyncFlatSpecLike.runTests(AsyncFlatSpecLike.scala:1897)
      at org.scalatest.flatspec.AsyncFlatSpecLike.runTests$(AsyncFlatSpecLike.scala:1896)
      at org.scalatest.flatspec.AsyncFlatSpec.runTests(AsyncFlatSpec.scala:2221)
      at org.scalatest.Suite.run(Suite.scala:1112)
      at org.scalatest.Suite.run$(Suite.scala:1094)
      at org.scalatest.flatspec.AsyncFlatSpec.org$scalatest$flatspec$AsyncFlatSpecLike$$super$run(AsyncFlatSpec.scala:2221)
      at org.scalatest.flatspec.AsyncFlatSpecLike.$anonfun$run$1(AsyncFlatSpecLike.scala:1942)
      at org.scalatest.AsyncSuperEngine.runImpl(AsyncEngine.scala:625)
      at org.scalatest.flatspec.AsyncFlatSpecLike.run(AsyncFlatSpecLike.scala:1942)
      at org.scalatest.flatspec.AsyncFlatSpecLike.run$(AsyncFlatSpecLike.scala:1940)
      at com.daml.lf.engine.trigger.TriggerServiceTestAuthClaims.org$scalatest$BeforeAndAfterAll$$super$run(TriggerServiceTestAuthClaims.scala:6)
      at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
      at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
      at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
      at com.daml.lf.engine.trigger.TriggerServiceTestAuthClaims.run(TriggerServiceTestAuthClaims.scala:6)
      at org.scalatest.Suite.callExecuteOnSuite$1(Suite.scala:1175)
      at org.scalatest.Suite.$anonfun$runNestedSuites$1(Suite.scala:1222)
      at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1321)
      at org.scalatest.Suite.runNestedSuites(Suite.scala:1220)
      at org.scalatest.Suite.runNestedSuites$(Suite.scala:1154)
      at org.scalatest.tools.DiscoverySuite.runNestedSuites(DiscoverySuite.scala:30)
      at org.scalatest.Suite.run(Suite.scala:1109)
      at org.scalatest.Suite.run$(Suite.scala:1094)
      at org.scalatest.tools.DiscoverySuite.run(DiscoverySuite.scala:30)
      at org.scalatest.tools.SuiteRunner.run(SuiteRunner.scala:45)
      at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13(Runner.scala:1322)
      at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13$adapted(Runner.scala:1316)
      at scala.collection.immutable.List.foreach(List.scala:333)
      at org.scalatest.tools.Runner$.doRunRunRunDaDoRunRun(Runner.scala:1316)
      at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24(Runner.scala:993)
      at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24$adapted(Runner.scala:971)
      at org.scalatest.tools.Runner$.withClassLoaderAndDispatchReporter(Runner.scala:1482)
      at org.scalatest.tools.Runner$.runOptionallyWithPassFailReporter(Runner.scala:971)
      at org.scalatest.tools.Runner$.main(Runner.scala:775)
      at org.scalatest.tools.Runner.main(Runner.scala)
      at io.bazel.rulesscala.scala_test.Runner.main(Runner.java:33)
```

As it looks like Windows might be taking longer(?), initial attacks on this issue is to increase the retry delays to 2 seconds and see if this improves testing outcomes.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
