### PR TITLE
Prevent scripts from restarting when users trigger other IDE actions, like hover

### DIFF
--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -725,6 +725,12 @@ hTakeUntil handle regex = go
           line <- hGetLine handle
           if pred line then pure (Just line) else go
 
+-- Takes lines from the handle until matching the first pattern `until`. If any
+-- of the lines before the matching line match the second pattern `without`
+-- then fail the test
+-- Useful for cases where we want to assert that some message has been emitted
+-- without a different message being emitted in the interim, e.g. a script
+-- finished without restarts in between.
 assertUntilWithout :: Handle -> T.Text -> T.Text -> IO (Maybe String)
 assertUntilWithout handle until without = go
   where

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -663,8 +663,7 @@ scriptTests runScripts = testGroup "scripts"
 
           closeDoc script
           closeDoc main'
-    -- TODO https://github.com/digital-asset/daml/issues/16772
-    , localOption (mkTimeout 30000000) $ -- 30s timeout
+    , localOption (mkTimeout 60000000) $ -- 60s timeout
         testCaseSteps "scenario service does not interrupt on non-script messages" $ \step -> runScripts $ \_stderr -> do
           -- open document with long-running script
           main' <- openDoc' "Main.daml" damlId $

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -483,6 +483,7 @@ runBiDiLive runner Handle{..} (ContextId ctxId) name logger stopSemaphore status
           NoResultUpdate -> loop
           _ -> pure ()
         pure ()
+  _ <- tryPutMVar stopSemaphore False -- once we exit, stop the semaphore checking thread
   case response of
     ClientBiDiResponse _ StatusOk _ -> getFinalResponse
     ClientBiDiResponse _ status _ -> pure (Left (BackendError (BErrorFail status)))

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
@@ -143,6 +143,7 @@ object ScriptStream {
         }
         internal.onNext(message)
         internal.onCompleted()
+        println(f"Script finished.")
       }
 
     override def sendStatus(status: ScenarioStatus): Unit = {}
@@ -166,6 +167,7 @@ object ScriptStream {
         }
         internal.onNext(message)
         internal.onCompleted()
+        println(f"Script finished.")
       }
 
     override def sendStatus(status: ScenarioStatus): Unit = internal.synchronized {
@@ -268,9 +270,7 @@ class ScenarioService(
         println(f"Received error $t")
       }
 
-      override def onCompleted(): Unit = {
-        println("Completed.")
-      }
+      override def onCompleted(): Unit = {}
     }
   }
 


### PR DESCRIPTION
For issue: https://github.com/digital-asset/daml/issues/16772

We can disambiguate runs with ContextId and the script that is being run, while storing the forked IO action elsewhere - this builds on a discussion had with Zubin at ZuriHac that made it clear we can achieve most of our objectives within the Shake framework.

This means we can solve this longstanding issue using fairly minimal changes - in the future, I'd still like to spin this into its own subsystem that is also responsible for caching, resumption, etc, because this enables quicker iteration and more features in the long term. However, in the short term, we can deal with this issue quickly.