### PR TITLE
update get-daml-com

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -209,3 +209,5 @@ jobs:
         env:
           GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
       - template: ci/tell-slack-failed.yml
+
+  - template: ci/split-release-job.yml

--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -210,4 +210,4 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
       - template: ci/tell-slack-failed.yml
 
-  - template: ci/split-release-job.yml
+  - template: ci/refresh-get-daml-com.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,3 +160,4 @@ jobs:
     - template: ci/report-end.yml
 
 - template: ci/split-release-job.yml
+- template: ci/refresh-get-daml-com.yml

--- a/ci/refresh-get-daml-com.yml
+++ b/ci/refresh-get-daml-com.yml
@@ -1,0 +1,37 @@
+# Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+jobs:
+- job: get-daml-com
+  condition: eq(variables['Build.SourceBranchName'], 'main')
+  pool:
+    name: 'ubuntu_20_04'
+    demands: assignment -equals default
+  steps:
+    - checkout: self
+    - template: ci/bash-lib.yml
+      parameters:
+        var_name: bash-lib
+    - bash: |
+        set -euo pipefail
+        source $(bash-lib)
+        tmp=$(mktemp)
+        curl --silent \
+             --fail \
+             --location \
+             https://get.daml.com \
+         > $tmp
+        if diff daml-assistant/get-daml.sh $tmp; then
+          echo "Files match, nothing to do."
+        else
+          echo "Files differ; pushing new version."
+          aws s3 cp daml-assistant/get-daml.sh s3://get-daml-com/get-daml.sh --acl public-read --region us-east-1
+          echo "Telling Slack..."
+          tell_slack "Change detected in get.daml.com:\`\`\`$(diff daml-assistant/get-daml.sh $tmp)\`\`\`"
+        fi
+        git checkout $(release_sha)
+      name: push_if_needed
+      env:
+        AWS_ACCESS_KEY_ID: $(AWS_CLIENT_ID)
+        AWS_SECRET_ACCESS_KEY: $(AWS_SECRET)
+

--- a/ci/refresh-get-daml-com.yml
+++ b/ci/refresh-get-daml-com.yml
@@ -29,7 +29,6 @@ jobs:
           echo "Telling Slack..."
           tell_slack "Change detected in get.daml.com:\`\`\`$(diff daml-assistant/get-daml.sh $tmp)\`\`\`"
         fi
-        git checkout $(release_sha)
       name: push_if_needed
       env:
         AWS_ACCESS_KEY_ID: $(AWS_CLIENT_ID)


### PR DESCRIPTION
So far updates to the result of `curl https://get.daml.com` have been made manually. This automates the process.

Fixes #3915.