### PR TITLE
dev-env/windows: pin nsis

### DIFF
--- a/dev-env/windows/manifests/nsis-3.04.json
+++ b/dev-env/windows/manifests/nsis-3.04.json
@@ -2,7 +2,8 @@
     "homepage": "http://nsis.sourceforge.net/",
     "license": "Zlib",
     "version": "3.04",
-    "url": "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.04/nsis-3.04.zip",
+    "_url": "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.04/nsis-3.04.zip",
+    "url": "https://storage.googleapis.com/daml-binaries/dev-env/windows/2023-06-16/nsis-3.04.zip",
     "bin": [
         "makensis.exe"
     ],


### PR DESCRIPTION
I've seen a handful of failures of the form:

```
>> Installing 'nsis-3.04' ...
<< Unknown state:
Installing 'nsis-3.04' (3.04) [64bit]
The request was aborted: Could not create SSL/TLS secure channel.
URL https://downloads.sourceforge.net/project/nsis/NSIS%203/3.04/nsis-3.04.zip is not valid

<< Unknown state:
Installing 'nsis-3.04' (3.04) [64bit]
The request was aborted: Could not create SSL/TLS secure channel.
URL https://downloads.sourceforge.net/project/nsis/NSIS%203/3.04/nsis-3.04.zip is not valid
At D:\a\3\s\dev-env\windows\libexec\core.ps1:159 char:13
+             throw $msg
+             ~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (<< Unknown stat...s not valid
:String) [], RuntimeException
    + FullyQualifiedErrorId : << Unknown state:
Installing 'nsis-3.04' (3.04) [64bit]
The request was aborted: Could not create SSL/TLS secure channel.
URL https://downloads.sourceforge.net/project/nsis/NSIS%203/3.04/nsis-3.04.zip is not valid
```

on CI recently. Hopefully this will fix it. As usual, you can check that the file is the same because the hash has not changed.