### PR TITLE
Remove protobuf compatibility exclusion

### DIFF
--- a/buf-ledger-api.yaml
+++ b/buf-ledger-api.yaml
@@ -17,6 +17,3 @@ breaking:
     #
     # We rely in particular on fields not getting renamed in `UpdateXXX` calls that use a `FieldMask`
     # to select the fields to update, see https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/field_mask.proto
-
-  ignore:
-    - com/daml/ledger/api/v2/reassignment.proto


### PR DESCRIPTION
This was only introduced to allow a non backwards compatible change to the V2 Ledger API

[CHANGELOG_BEGIN]
[CHANGELOG_END]

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
