### PR TITLE
Changes to allow simulations to alter dar files in abstract trigger tests

### DIFF
--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
@@ -32,6 +32,7 @@ import com.daml.lf.speedy.SValue._
 import org.scalatest._
 import scalaz.syntax.tag._
 
+import java.nio.file.Path
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -39,14 +40,14 @@ import scala.util.{Failure, Success, Try}
 trait AbstractTriggerTest extends CantonFixture {
   self: Suite =>
 
-  private[this] lazy val darFile =
+  protected lazy val darFile: Either[Path, Path] =
     Try(BazelRunfiles.requiredResource("triggers/tests/acs.dar").toPath) match {
       case Success(value) => Right(value)
       case Failure(_) => Left(BazelRunfiles.requiredResource("triggers/tests/acs-1.dev.dar").toPath)
     }
 
-  final override protected lazy val darFiles = List(darFile.merge)
-  final override protected lazy val devMode = darFile.isLeft
+  override protected lazy val darFiles: List[Path] = List(darFile.merge)
+  override protected lazy val devMode: Boolean = darFile.isLeft
 
   implicit override protected lazy val applicationId: ApplicationId =
     RunnerConfig.DefaultApplicationId


### PR DESCRIPTION
Trigger simulations need to be able to modify the dar project files used by the underlying simulation. These changes allow this (e.g. with env vars defining the actual Daml project dar to be used).

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
