### PR TITLE
Extract available snapshot versions from Github

### DIFF
--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -38,6 +38,7 @@ da_haskell_library(
         "bytestring",
         "conduit",
         "conduit-extra",
+        "containers",
         "unordered-containers",
         "directory",
         "extra",

--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -99,8 +99,8 @@ commandWantsProjectPath cmd = LookForProjectPath $
 -- | Perform version checks, i.e. warn user if project SDK version or assistant SDK
 -- versions are out of date with the latest known release.
 versionChecks :: Env -> IO ()
-versionChecks env@Env{..} = do
-    envLatestStableSdkVersion <- getEnvLatestStableSdkVersion env
+versionChecks Env{..} = do
+    envLatestStableSdkVersion <- envLatestStableSdkVersion
     whenJust envLatestStableSdkVersion $ \latestVersion -> do
         let isHead = maybe False isHeadVersion envSdkVersion
             projectSdkVersionIsOld = isJust envProjectPath && envSdkVersion < Just latestVersion

--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -155,6 +155,7 @@ autoInstall env@Env{..} = do
             installEnv = InstallEnv
                 { options = options
                 , damlPath = envDamlPath
+                , useCache = envUseCache env
                 , targetVersionM = Just sdkVersion
                 , missingAssistant = False
                 , installingFromOutside = False
@@ -266,7 +267,7 @@ runCommand env@Env{..} = \case
         putStr . unpack $ T.unlines ("SDK versions:" : versionLines)
 
     Builtin (Install options) -> wrapErr "Installing the SDK." $ do
-        install options envDamlPath envProjectPath envDamlAssistantSdkVersion
+        install options envDamlPath (envUseCache env) envProjectPath envDamlAssistantSdkVersion
 
     Builtin (Uninstall version) -> do
         uninstallVersion env version

--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -199,7 +199,7 @@ runCommand env@Env{..} = \case
         installedVersionsE <- tryAssistant $ getInstalledSdkVersions envDamlPath
         snapshotVersionsEUnfiltered <- tryAssistant $ fst <$> getAvailableSdkSnapshotVersions useCache
         let snapshotVersionsE = if vSnapshots then snapshotVersionsEUnfiltered else pure []
-            availableVersionsE = extractVersionsFromSnapshots <$> snapshotVersionsEUnfiltered
+            availableVersionsE = extractReleasesFromSnapshots <$> snapshotVersionsEUnfiltered
         defaultVersionM <- tryAssistantM $ getDefaultSdkVersion envDamlPath
         projectVersionM <- mapM getSdkVersionFromProjectPath envProjectPath
         envSelectedVersionM <- lookupEnv sdkVersionEnvVar

--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -99,7 +99,8 @@ commandWantsProjectPath cmd = LookForProjectPath $
 -- | Perform version checks, i.e. warn user if project SDK version or assistant SDK
 -- versions are out of date with the latest known release.
 versionChecks :: Env -> IO ()
-versionChecks Env{..} =
+versionChecks env@Env{..} = do
+    envLatestStableSdkVersion <- getEnvLatestStableSdkVersion env
     whenJust envLatestStableSdkVersion $ \latestVersion -> do
         let isHead = maybe False isHeadVersion envSdkVersion
             projectSdkVersionIsOld = isJust envProjectPath && envSdkVersion < Just latestVersion

--- a/daml-assistant/src/DA/Daml/Assistant/Cache.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Cache.hs
@@ -68,7 +68,7 @@ cacheAvailableSdkVersions UseCache { forceReload, cachePath, damlPath } getVersi
     let configUpdateCheckM = join $ eitherToMaybe (queryDamlConfig ["update-check"] =<< damlConfigE)
         updateCheck | forceReload = UpdateCheckEvery (CacheTimeout 1)
                     | Just updateCheck <- configUpdateCheckM = updateCheck
-                    | otherwise = UpdateCheckEvery (CacheTimeout 86400)
+                    | otherwise = UpdateCheckEvery (CacheTimeout 86400) -- One day, in seconds
     case updateCheck of
         UpdateCheckNever -> do
             valueAgeM <- loadFromCacheWith cachePath versionsKey (CacheTimeout 0) deserializeVersions

--- a/daml-assistant/src/DA/Daml/Assistant/Command.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Command.hs
@@ -104,9 +104,10 @@ commandParser cmds | (hidden, visible) <- partition isHidden cmds = asum
 
 versionParser :: Parser VersionOptions
 versionParser = VersionOptions
-    <$> flagYesNoAuto "all" False "Display all available versions." idm
-    <*> flagYesNoAuto "snapshots" False "Display all available snapshot versions." idm
+    <$> flagYesNoAuto "all" False "Display all available versions (cached for 1 day)." idm
+    <*> flagYesNoAuto "snapshots" False "Display all available snapshot versions (cached for 1 day)." idm
     <*> flagYesNoAuto "assistant" False "Display Daml assistant version." idm
+    <*> flagYesNoAuto "force-reload" False "Force reloading available versions and snapshot versions." idm
 
 installParser :: Parser InstallOptions
 installParser = InstallOptions

--- a/daml-assistant/src/DA/Daml/Assistant/Command.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Command.hs
@@ -104,10 +104,10 @@ commandParser cmds | (hidden, visible) <- partition isHidden cmds = asum
 
 versionParser :: Parser VersionOptions
 versionParser = VersionOptions
-    <$> flagYesNoAuto "all" False "Display all available versions (cached for 1 day)." hidden
-    <*> flagYesNoAuto "snapshots" False "Display all available snapshot versions (cached for 1 day)." hidden
+    <$> flagYesNoAuto "all" False "Display all available versions (cached for 1 day)." internal
+    <*> flagYesNoAuto "snapshots" False "Display all available snapshot versions (cached for 1 day)." internal
     <*> flagYesNoAuto "assistant" False "Display Daml assistant version." idm
-    <*> flagYesNoAuto "force-reload" False "Force reloading available versions and snapshot versions." hidden
+    <*> flagYesNoAuto "force-reload" False "Force reloading available versions and snapshot versions." internal
 
 installParser :: Parser InstallOptions
 installParser = InstallOptions

--- a/daml-assistant/src/DA/Daml/Assistant/Command.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Command.hs
@@ -104,10 +104,10 @@ commandParser cmds | (hidden, visible) <- partition isHidden cmds = asum
 
 versionParser :: Parser VersionOptions
 versionParser = VersionOptions
-    <$> flagYesNoAuto "all" False "Display all available versions (cached for 1 day)." idm
-    <*> flagYesNoAuto "snapshots" False "Display all available snapshot versions (cached for 1 day)." idm
+    <$> flagYesNoAuto "all" False "Display all available versions (cached for 1 day)." hidden
+    <*> flagYesNoAuto "snapshots" False "Display all available snapshot versions (cached for 1 day)." hidden
     <*> flagYesNoAuto "assistant" False "Display Daml assistant version." idm
-    <*> flagYesNoAuto "force-reload" False "Force reloading available versions and snapshot versions." idm
+    <*> flagYesNoAuto "force-reload" False "Force reloading available versions and snapshot versions." hidden
 
 installParser :: Parser InstallOptions
 installParser = InstallOptions

--- a/daml-assistant/src/DA/Daml/Assistant/Env.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Env.hs
@@ -76,7 +76,7 @@ overrideWithEnvVarMaybe envVar normalize parse calculate = do
 getLatestStableSdkVersion :: DamlPath -> CachePath -> IO (Maybe SdkVersion)
 getLatestStableSdkVersion damlPath cachePath =
     overrideWithEnvVarMaybe sdkVersionLatestEnvVar pure (parseVersion . pack) $
-        getLatestSdkVersionCached damlPath cachePath
+        getLatestSdkVersion (UseCache { damlPath, cachePath, forceReload = False })
 
 -- | Determine the viability of running sdk commands in the environment.
 -- Returns the first failing test's error message.

--- a/daml-assistant/src/DA/Daml/Assistant/Env.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Env.hs
@@ -37,7 +37,7 @@ getDamlEnv envDamlPath lookForProjectPath = do
     envProjectPath <- getProjectPath lookForProjectPath
     (envSdkVersion, envSdkPath) <- getSdk envDamlPath envProjectPath
     envCachePath <- getCachePath
-    envLatestStableSdkVersion <- getLatestStableSdkVersion envDamlPath envCachePath
+    envLatestStableSdkVersion <- getLatestStableSdkVersion
     pure Env {..}
 
 -- | (internal) Override function with environment variable
@@ -73,10 +73,8 @@ overrideWithEnvVarMaybe envVar normalize parse calculate = do
 
 -- | Get the latest stable SDK version. Can be overriden with
 -- DAML_SDK_LATEST_VERSION environment variable.
-getLatestStableSdkVersion :: DamlPath -> CachePath -> IO (Maybe SdkVersion)
-getLatestStableSdkVersion damlPath cachePath =
-    overrideWithEnvVarMaybe sdkVersionLatestEnvVar pure (parseVersion . pack) $
-        getLatestSdkVersion (UseCache { damlPath, cachePath, forceReload = False })
+getLatestStableSdkVersion :: IO (Maybe SdkVersion)
+getLatestStableSdkVersion = overrideWithEnvVarMaybe sdkVersionLatestEnvVar pure (parseVersion . pack) getLatestSdkVersion
 
 -- | Determine the viability of running sdk commands in the environment.
 -- Returns the first failing test's error message.

--- a/daml-assistant/src/DA/Daml/Assistant/Install.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install.hs
@@ -21,7 +21,7 @@ import qualified DA.Daml.Assistant.Install.Artifactory as Artifactory
 import qualified DA.Daml.Assistant.Install.Github as Github
 import DA.Daml.Assistant.Install.Path
 import DA.Daml.Assistant.Install.Completion
-import DA.Daml.Assistant.Version (getLatestSdkSnapshotVersion, getLatestReleaseVersion)
+import DA.Daml.Assistant.Version (getLatestSdkSnapshotVersion, getLatestReleaseVersion, UseCache (..))
 import DA.Daml.Project.Consts
 import DA.Daml.Project.Config
 import Safe
@@ -76,6 +76,8 @@ data InstallEnv = InstallEnv
         -- ^ version of running daml assistant
     , damlPath :: DamlPath
         -- ^ path to install daml assistant
+    , useCache :: UseCache
+        -- ^ path to daml assistant cache
     , missingAssistant :: Bool
         -- ^ daml assistant is not installed in expected path.
     , installingFromOutside :: Bool
@@ -415,9 +417,9 @@ versionInstall env@InstallEnv{..} version = withInstallLock env $ do
 -- | Install the latest version of the SDK.
 latestInstall :: InstallEnv -> IO ()
 latestInstall env@InstallEnv{..} = do
-    version1 <- getLatestReleaseVersion
+    version1 <- getLatestReleaseVersion useCache
     version2M <- if iSnapshots options
-        then getLatestSdkSnapshotVersion
+        then getLatestSdkSnapshotVersion useCache
         else pure Nothing
     let version = maybe version1 (max version1) version2M
     versionInstall env version
@@ -445,8 +447,8 @@ pattern RawInstallTarget_Latest :: RawInstallTarget
 pattern RawInstallTarget_Latest = RawInstallTarget "latest"
 
 -- | Run install command.
-install :: InstallOptions -> DamlPath -> Maybe ProjectPath -> Maybe DamlAssistantSdkVersion -> IO ()
-install options damlPath projectPathM assistantVersion = do
+install :: InstallOptions -> DamlPath -> UseCache -> Maybe ProjectPath -> Maybe DamlAssistantSdkVersion -> IO ()
+install options damlPath useCache projectPathM assistantVersion = do
     when (unActivateInstall (iActivate options)) $
         hPutStr stderr . unlines $
             [ "WARNING: --activate is deprecated, use --install-assistant=yes instead."

--- a/daml-assistant/src/DA/Daml/Assistant/Types.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Types.hs
@@ -83,6 +83,7 @@ data VersionOptions = VersionOptions
     { vAll :: Bool -- ^ show all versions (stable + snapshot)
     , vSnapshots :: Bool -- ^ show all snapshot versions
     , vAssistant :: Bool -- ^ show assistant version
+    , vForceRefresh :: Bool -- ^ force refresh available versions, don't use 1-day cache
     } deriving (Eq, Show)
 
 -- | Command-line options for daml install command.

--- a/daml-assistant/src/DA/Daml/Assistant/Types.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Types.hs
@@ -56,7 +56,6 @@ data Env = Env
     , envProjectPath   :: Maybe ProjectPath
     , envSdkPath       :: Maybe SdkPath
     , envSdkVersion    :: Maybe SdkVersion
-    , envLatestStableSdkVersion :: Maybe SdkVersion
     } deriving (Eq, Show)
 
 data BuiltinCommand

--- a/daml-assistant/src/DA/Daml/Assistant/Types.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Types.hs
@@ -1,6 +1,7 @@
 -- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE UndecidableInstances #-}
 
 module DA.Daml.Assistant.Types
     ( module DA.Daml.Assistant.Types
@@ -16,6 +17,7 @@ import Data.Maybe
 import Network.HTTP.Types.Header
 import Options.Applicative.Extended (YesNoAuto (..))
 import Control.Exception.Safe
+import Data.Functor.Identity
 
 data AssistantError = AssistantError
     { errContext  :: Maybe Text -- ^ Context in which error occurs.
@@ -48,7 +50,7 @@ assistantErrorDetails msg details =
     assistantErrorBecause (pack msg) . pack . concat $
         ["\n    " <> k <> ": " <> v | (k,v) <- details]
 
-data Env = Env
+data EnvF f = Env
     { envDamlPath      :: DamlPath
     , envCachePath :: CachePath
     , envDamlAssistantPath :: DamlAssistantPath
@@ -56,7 +58,18 @@ data Env = Env
     , envProjectPath   :: Maybe ProjectPath
     , envSdkPath       :: Maybe SdkPath
     , envSdkVersion    :: Maybe SdkVersion
-    } deriving (Eq, Show)
+    , envLatestStableSdkVersion :: f (Maybe SdkVersion)
+    }
+
+deriving instance Eq (f (Maybe SdkVersion)) => Eq (EnvF f)
+deriving instance Show (f (Maybe SdkVersion)) => Show (EnvF f)
+
+type Env = EnvF IO
+
+forceEnv :: Monad m => EnvF m -> m (EnvF Identity)
+forceEnv Env{..} = do
+  envLatestStableSdkVersion <- fmap Identity envLatestStableSdkVersion
+  pure Env{..}
 
 data BuiltinCommand
     = Version VersionOptions

--- a/daml-assistant/src/DA/Daml/Assistant/Version.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Version.hs
@@ -269,24 +269,24 @@ instance FromJSON ParsedSdkVersion where
         Right sdkVersion -> pure ParsedSdkVersion { unParsedSdkVersion = sdkVersion, isPrerelease }
 
 -- | Get the latest released SDK version
-getLatestSdkVersion :: IO (Maybe SdkVersion)
-getLatestSdkVersion = do
-    versionE <- tryAssistant (getAvailableReleaseVersions DontUseCache)
+getLatestSdkVersion :: UseCache -> IO (Maybe SdkVersion)
+getLatestSdkVersion useCache = do
+    versionE <- tryAssistant (getAvailableReleaseVersions useCache)
     pure $ do
       (versions, _cacheAge) <- eitherToMaybe versionE
       maximumMay versions
 
 -- | Get the latest snapshot SDK version.
-getLatestSdkSnapshotVersion :: IO (Maybe SdkVersion)
-getLatestSdkSnapshotVersion = do
-    versionE <- tryAssistant (getAvailableSdkSnapshotVersions DontUseCache)
+getLatestSdkSnapshotVersion :: UseCache -> IO (Maybe SdkVersion)
+getLatestSdkSnapshotVersion useCache = do
+    versionE <- tryAssistant (getAvailableSdkSnapshotVersions useCache)
     pure $ do
       (versions, _cacheAge) <- eitherToMaybe versionE
       maximumMay versions
 
-getLatestReleaseVersion :: IO SdkVersion
-getLatestReleaseVersion = do
-    mbReleaseVersion <- getLatestSdkVersion
+getLatestReleaseVersion :: UseCache -> IO SdkVersion
+getLatestReleaseVersion useCache = do
+    mbReleaseVersion <- getLatestSdkVersion useCache
     case mbReleaseVersion of
       Nothing -> throwIO $ assistantError (pack "Failed to get latest release version from github.com")
       Just rv -> pure rv

--- a/daml-assistant/src/DA/Daml/Assistant/Version.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Version.hs
@@ -34,18 +34,12 @@ import Data.Either.Extra
 import Data.Aeson (FromJSON(..), eitherDecodeStrict')
 import Data.Aeson.Types (listParser, withObject, (.:), Value, Parser)
 import qualified Data.Text as T
-import Data.Text.Encoding
 import Safe
 import Network.HTTP.Simple
 import Network.HTTP.Client
     ( Request(responseTimeout)
-    , responseBody
-    , responseStatus
     , responseTimeoutMicro
     )
-import qualified Network.HTTP.Client as Http
-import Network.HTTP.Types (ok200)
-import Network.HTTP.Client.TLS (newTlsManager)
 
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BSC

--- a/daml-assistant/src/DA/Daml/Assistant/Version.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Version.hs
@@ -243,13 +243,13 @@ getAvailableSdkSnapshotVersionsUncached = do
           _ -> Nothing
 
   extractVersions :: ByteString -> Either String [SdkVersion]
-  extractVersions bs = filterPrereleases <$> eitherDecodeStrict' bs
+  extractVersions bs = filterOutPrereleases <$> eitherDecodeStrict' bs
 
-  filterPrereleases :: ParsedSdkVersions -> [SdkVersion]
-  filterPrereleases parsedVersions =
+  filterOutPrereleases :: ParsedSdkVersions -> [SdkVersion]
+  filterOutPrereleases parsedVersions =
     [ unParsedSdkVersion
     | ParsedSdkVersion {..} <- unParsedSdkVersions parsedVersions
-    , isPrerelease
+    , not isPrerelease
     ]
 
 newtype ParsedSdkVersions = ParsedSdkVersions { unParsedSdkVersions :: [ParsedSdkVersion] }

--- a/daml-assistant/test/DA/Daml/Assistant/Tests.hs
+++ b/daml-assistant/test/DA/Daml/Assistant/Tests.hs
@@ -292,7 +292,7 @@ testGetDispatchEnv = Tasty.testGroup "DA.Daml.Assistant.Env.getDispatchEnv"
                     , envDamlAssistantPath = DamlAssistantPath (base </> ".daml" </> "bin" </> "strange-daml")
                     , envDamlAssistantSdkVersion = Just $ DamlAssistantSdkVersion version
                     , envSdkVersion = Just version
-                    , envLatestStableSdkVersion = Just version
+                    , envLatestStableSdkVersion = pure (Just version)
                     , envSdkPath = Just $ SdkPath (base </> "sdk")
                     , envProjectPath = Just $ ProjectPath (base </> "proj")
                     }
@@ -309,13 +309,15 @@ testGetDispatchEnv = Tasty.testGroup "DA.Daml.Assistant.Env.getDispatchEnv"
                     , envDamlAssistantPath = DamlAssistantPath (base </> ".daml" </> "bin" </> "strange-daml")
                     , envDamlAssistantSdkVersion = Just $ DamlAssistantSdkVersion version
                     , envSdkVersion = Just version
-                    , envLatestStableSdkVersion = Just version
+                    , envLatestStableSdkVersion = pure (Just version)
                     , envSdkPath = Just $ SdkPath (base </> "sdk")
                     , envProjectPath = Just $ ProjectPath (base </> "proj")
                     }
             env <- withEnv [] (getDispatchEnv denv1)
             denv2 <- withEnv (fmap (fmap Just) env) (getDamlEnv' =<< getDamlPath)
-            Tasty.assertEqual "daml envs" denv1 denv2
+            forcedDenv1 <- forceEnv denv1
+            forcedDenv2 <- forceEnv denv2
+            Tasty.assertEqual "daml envs" forcedDenv1 forcedDenv2
 
     , Tasty.testCase "getDispatchEnv should override getDamlEnv (2)" $ do
         withSystemTempDirectory "test-getDispatchEnv" $ \base -> do
@@ -325,13 +327,15 @@ testGetDispatchEnv = Tasty.testGroup "DA.Daml.Assistant.Env.getDispatchEnv"
                     , envDamlAssistantPath = DamlAssistantPath (base </> ".daml" </> "bin" </> "strange-daml")
                     , envDamlAssistantSdkVersion = Nothing
                     , envSdkVersion = Nothing
-                    , envLatestStableSdkVersion = Nothing
+                    , envLatestStableSdkVersion = pure Nothing
                     , envSdkPath = Nothing
                     , envProjectPath = Nothing
                     }
             env <- withEnv [] (getDispatchEnv denv1)
             denv2 <- withEnv (fmap (fmap Just) env) (getDamlEnv' =<< getDamlPath)
-            Tasty.assertEqual "daml envs" denv1 denv2
+            forcedDenv1 <- forceEnv denv1
+            forcedDenv2 <- forceEnv denv2
+            Tasty.assertEqual "daml envs" forcedDenv1 forcedDenv2
     ]
     where
         getDamlEnv' x = getDamlEnv x (LookForProjectPath True)

--- a/daml-assistant/test/DA/Daml/Assistant/Tests.hs
+++ b/daml-assistant/test/DA/Daml/Assistant/Tests.hs
@@ -7,6 +7,7 @@ module DA.Daml.Assistant.Tests
 
 import DA.Daml.Assistant.Env
 import DA.Daml.Assistant.Install
+import DA.Daml.Assistant.Cache (UseCache (DontUseCache))
 import DA.Daml.Assistant.Types
 import DA.Daml.Assistant.Util
 import DA.Daml.Project.Consts hiding (getDamlPath, getProjectPath)
@@ -395,7 +396,7 @@ testInstall = Tasty.testGroup "DA.Daml.Assistant.Install"
                 .| Zlib.gzip
                 .| sinkFile "source.tar.gz"
 
-            install options damlPath Nothing Nothing
+            install options damlPath DontUseCache Nothing Nothing
     , if isWindows
         then testInstallWindows
         else testInstallUnix
@@ -432,7 +433,7 @@ testInstallUnix = Tasty.testGroup "unix-specific tests"
                       .| Zlib.gzip
                       .| sinkFile "source.tar.gz"
 
-                  install options damlPath Nothing Nothing,
+                  install options damlPath DontUseCache Nothing Nothing,
 
       Tasty.testCase "reject an absolute symlink in a tarball" $ do
         withSystemTempDirectory "test-install" $ \ base -> do
@@ -463,7 +464,7 @@ testInstallUnix = Tasty.testGroup "unix-specific tests"
 
             assertError "Extracting SDK release tarball."
                 "Invalid SDK release: symbolic link target is absolute."
-                (install options damlPath Nothing Nothing)
+                (install options damlPath DontUseCache Nothing Nothing)
 
     , Tasty.testCase "reject an escaping symlink in a tarball" $ do
         withSystemTempDirectory "test-install" $ \ base -> do
@@ -494,7 +495,7 @@ testInstallUnix = Tasty.testGroup "unix-specific tests"
 
             assertError "Extracting SDK release tarball."
                 "Invalid SDK release: symbolic link target escapes tarball."
-                (install options damlPath Nothing Nothing)
+                (install options damlPath DontUseCache Nothing Nothing)
 
     , Tasty.testCase "check that relative symlink is used in installation" $ do
         withSystemTempDirectory "test-install" $ \ base -> do
@@ -524,7 +525,7 @@ testInstallUnix = Tasty.testGroup "unix-specific tests"
                 .| Zlib.gzip
                 .| sinkFile "source.tar.gz"
 
-            install options damlPath Nothing Nothing
+            install options damlPath DontUseCache Nothing Nothing
             renamePath "daml" "daml2"
             x <- readFileUTF8 ("daml2" </> "bin" </> "daml")
                 -- ^ this will fail if the symlink created for


### PR DESCRIPTION
Modify assistant to use Github instead of docs.daml.com for the list of versions and releases.

Solves https://github.com/digital-asset/daml/issues/17045