### PR TITLE
tag trigger tests correctly with dev-canton-test

### DIFF
--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -55,15 +55,16 @@ da_scala_library(
 )
 
 TRIGGER_INTEGRATION_TESTS = [
-    "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsStaticTime.scala",
-    "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsWallClock.scala",
-    "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Jwt.scala",
-    "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala",
     "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/RunnerSpec.scala",
     "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/UnfoldStateSpec.scala",
 ]
 
+# Trigger tests that require Canton
 TRIGGER_CANTON_INTEGRATION_TESTS = [
+    "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsStaticTime.scala",
+    "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsWallClock.scala",
+    "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Jwt.scala",
+    "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala",
     "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/ConfigSpec.scala",
     "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/InterfaceSpec.scala",
 ]


### PR DESCRIPTION
For trigger-integration-tests:
- We only want to build the `acs.dar` file once per LF version we are using.
- For each LF version, some tests need to use canton-lib.jar (and so need a `dev-canton-test` test tag when LF version is 1.dev) and others do not need this tag.

For trigger-failure-integration-tests:
- We only want to build the `acs.dar` file once per LF version we are using.

This PR attempts to capture these requirements without copying and pasting.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
