### PR TITLE
Fix tracker recovery after db connection outage

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/QueueBackedTracker.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/QueueBackedTracker.scala
@@ -92,10 +92,10 @@ private[services] final class QueueBackedTracker(
   override def close(): Unit = {
     logger.debug("Shutting down tracking component.")
     if (done.isCompleted)
-      logger.info("Tracker already complete")
+      logger.info("Tracker already completed")
     else {
       queue.complete()
-      Await.result(done, 30.seconds).discard
+      Await.result(done, 30.seconds)
       ()
     }
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/QueueBackedTracker.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/QueueBackedTracker.scala
@@ -91,9 +91,13 @@ private[services] final class QueueBackedTracker(
 
   override def close(): Unit = {
     logger.debug("Shutting down tracking component.")
-    queue.complete()
-    Await.result(done, 30.seconds)
-    ()
+    if (done.isCompleted)
+      logger.info("Tracker already complete")
+    else {
+      queue.complete()
+      Await.result(done, 30.seconds).discard
+      ()
+    }
   }
 }
 


### PR DESCRIPTION
This is how it plays out:
connection to the database is lost, recovering indexer decides to restart
```
2023-06-26 12:35:30.954 [canton-env-execution-context-6386] ERROR c.d.p.indexer.RecoveringIndexer - Error while running indexer, restart scheduled after 10 seconds , context: {participant: "particip│ 
```
after 10s indexer makes good on its promise
```
2023-06-26 12:35:40.978 [canton-env-execution-context-6387] INFO  c.d.p.indexer.RecoveringIndexer - Restarting Indexer Server , context: {participant: "particip"} 
2023-06-26 12:35:40.980 [canton-env-execution-context-6387] INFO  c.d.p.indexer.RecoveringIndexer - Restarted Indexer Server , context: {participant: "particip"} 
```
This results in restart of other components downstream from the indexer. Crucially ledger end dispatcher it shut down
```
2023-06-26 12:35:44.596 [canton-env-execution-context-58] INFO  c.d.p.i.p.InitializeParallelIngestion - Attempting to initialize with ledger ID di-execution and participant ID di-execution::12201ecbb1ba55dfdae1d11b5a82d300fb8828ec41e89a2264ad475c63915d844a64 , context: {participant: "particip"} 
2023-06-26 12:35:47.007 [canton-env-execution-context-6385] INFO  com.daml.platform.InMemoryState - Initializing participant in-memory state to ledger end: LedgerEnd(Offset(Bytes(00000000000001e891)),527887,67) , context: {participant: "particip"} 
2023-06-26 12:35:47.007 [canton-env-execution-context-6385] INFO  com.daml.platform.DispatcherState - Stopping active Ledger API offset dispatcher. , context: {participant: "particip"} 
```
this however goes very slowly. 5 seconds elapse just to get the interning views up an running again
```
2023-06-26 12:35:47.042 [canton-env-execution-context-6382] INFO  c.daml.platform.indexer.JdbcIndexer - Package Metadata View initialization has been started. , context: {participant: "particip"} 
...
2023-06-26 12:35:52.738 [canton-env-execution-context-30] INFO  c.daml.platform.indexer.JdbcIndexer - Package Metadata View has been initialized (5695 ms) , context: {participant: "particip"} 
```
finally the dispatcher is back up again
```
2023-06-26 12:35:52.799 [canton-env-execution-context-52] INFO  com.daml.platform.DispatcherState - SERVICE_NOT_RUNNING(1,0): Ledger API offset dispatcher has been shut down. , context: {participant: "particip", err-context: "{location=DispatcherState.scala:130, service_name=Ledger API offset dispatcher}"} 
2023-06-26 12:35:52.983 [canton-env-execution-context-30] INFO  com.daml.platform.DispatcherState - Started a Ledger API offset dispatcher at initialization offset: Offset(Bytes(00000000000001e891)). , context: {participant: "particip"} 
```
in the meantime the akka pipelines that rely on it being around have already timed out and we got this error many times over
```
2023-06-26 12:35:48.062 [canton-env-execution-context-6387] ERROR c.d.p.a.s.t.QueueBackedTracker - Error in tracker , context: {participant: "particip"} 
```
This leaves the tracker in a semi-dead state. The flow has been aborted, the queue canceled, but the debris is still present in the tracker map. Any attempt to use it results in
```
2023-06-26 12:35:50.656 [canton-env-execution-context-55] ERROR c.d.p.a.s.t.QueueBackedTracker - LEDGER_API_INTERNAL_ERROR(4,37766780): Failed to enqueue: NoMoreElementsNeeded$: null , context: {participant: "particip", readAs: [], parties: ["Daml-Party-pp::12201ecbb1ba55dfdae1d11b5a82d300fb8828ec41e89a2264ad475c63915d844a64"], submissionId: "37766780-6781-4cac-b12f-5651af73bd78", actAs: ["Daml-Party-pp::12201ecbb1ba55dfdae1d11b5a82d300fb8828ec41e89a2264ad475c63915d844a64"], commandId: "f0a8490c-1e49-4804-ad3a-c542262ea68c", err-context: "{location=QueueBackedTracker.scala:56, throwableO=Some(akka.stream.SubscriptionWithCancelException$NoMoreElementsNeeded$)}"} 
akka.stream.SubscriptionWithCancelException$NoMoreElementsNeeded$: null
```
Periodic tracker map cleanup stumbles over a half-dead tracker and throws an exception. This results in thread termination which means no more cleanups henceforth. The in-memory state becomes unrecoverable at this point and only a restart helps.
```
2023-06-26 12:46:50.687 [canton-env-execution-context-30] INFO  c.d.p.a.services.tracking.TrackerMap - Shutting down tracker for Key(di-execution-main,Set(Daml-Party-BerlinHyp::12201ecbb1ba55dfdae1d11b5a82d300fb8828ec41e89a2264ad475c63915d844a64)) after inactivity of PT5M , context: {participant: "particip"} 
2023-06-26 12:46:50.689 [canton-env-execution-context-30] ERROR c.d.c.e.EnterpriseEnvironment - A fatal error has occurred in canton-env-execution-context. Terminating thread.  
java.lang.IllegalStateException: The queue has already been completed.
	at akka.stream.impl.BoundedSourceQueueStage$Mat$1$.complete(BoundedSourceQueue.scala:125)
	at com.daml.metrics.InstrumentedGraph$InstrumentedBoundedSourceQueue.complete(InstrumentedGraph.scala:25)
	at com.daml.platform.apiserver.services.tracking.QueueBackedTracker.close(QueueBackedTracker.scala:94)
	at com.daml.platform.apiserver.services.tracking.TrackerMap$TrackerWithLastSubmission.close(TrackerMap.scala:223)
	at com.daml.platform.apiserver.services.tracking.TrackerMap.$anonfun$cleanup$1(TrackerMap.scala:104)
	at com.daml.platform.apiserver.services.tracking.TrackerMap.$anonfun$cleanup$1$adapted(TrackerMap.scala:95)
```