### PR TITLE
Using batching to preload contract ids before interpretation

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
@@ -147,6 +147,10 @@ private[daml] final class TimedIndexService(delegate: IndexService, metrics: Met
       delegate.lookupActiveContract(readers, contractId),
     )
 
+  override def prefetchContracts(contractIds: Seq[ContractId])(implicit
+      loggingContext: LoggingContext
+  ): Future[Unit] = delegate.prefetchContracts(contractIds)
+
   override def lookupContractKey(
       readers: Set[Ref.Party],
       key: GlobalKey,

--- a/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
@@ -283,6 +283,10 @@ private[index] class IndexServiceImpl(
   ): Future[Option[VersionedContractInstance]] =
     contractStore.lookupActiveContract(forParties, contractId)
 
+  override def prefetchContracts(contractIds: Seq[ContractId])(implicit
+      loggingContext: LoggingContext
+  ): Future[Unit] = contractStore.prefetchContracts(contractIds)
+
   override def getTransactionById(
       transactionId: TransactionId,
       requestingParties: Set[Ref.Party],

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/StorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/StorageBackend.scala
@@ -215,6 +215,9 @@ trait ContractStorageBackend {
   def contractState(contractId: ContractId, before: Offset)(
       connection: Connection
   ): Option[ContractStorageBackend.RawContractState]
+  def contractStates(contractIds: Seq[ContractId], before: Offset)(
+      connection: Connection
+  ): Map[ContractId, ContractStorageBackend.RawContractState]
   def activeContractWithArgument(readers: Set[Party], contractId: ContractId)(
       connection: Connection
   ): Option[ContractStorageBackend.RawContract]

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
@@ -7,6 +7,7 @@ import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.index.v2
 import com.daml.ledger.participant.state.index.v2.ContractStore
 import com.daml.lf.transaction.GlobalKey
+import com.daml.lf.value.Value.ContractId
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
 import com.daml.platform.store.cache.ContractKeyStateValue._
@@ -49,6 +50,33 @@ private[platform] class MutableCacheBackedContractStore(
         case _: Archived => v2.ContractState.Archived
         case NotFound => v2.ContractState.NotFound
       }
+
+  def prefetchContracts(
+      contractIds: Seq[ContractId]
+  )(implicit loggingContext: LoggingContext): Future[Unit] = {
+    val needsFetch = contractIds.filterNot(contractStateCaches.contractState.isCached)
+    // we don't prefetch if we just have 1 contract
+    if (needsFetch.length < 2)
+      Future.unit
+    else {
+      val readThroughRequest =
+        (validAt: Offset) => {
+          contractsReader
+            .lookupContractStates(needsFetch, validAt)
+            .map(_.map { case (k, v) => (k, toContractCacheValueDefined(v)) })
+            .map { res =>
+              logger.debug(s"Prefetched ${res.size} out of ${needsFetch.length} contracts")
+              res
+            }
+        }
+      contractStateCaches.contractState
+        .putAsyncMany(
+          needsFetch,
+          readThroughRequest,
+          cid => Future.failed(ContractReadThroughNotFound(cid)),
+        )
+    }
+  }
 
   private def lookupContractStateValue(
       contractId: ContractId
@@ -146,11 +174,15 @@ private[platform] class MutableCacheBackedContractStore(
         )
     }
 
-  private val toContractCacheValue: Option[ContractState] => ContractStateValue = {
-    case Some(ActiveContract(contract, stakeholders, ledgerEffectiveTime)) =>
+  private val toContractCacheValueDefined: ContractState => ContractStateValue = {
+    case ActiveContract(contract, stakeholders, ledgerEffectiveTime) =>
       ContractStateValue.Active(contract, stakeholders, ledgerEffectiveTime)
-    case Some(ArchivedContract(stakeholders)) =>
+    case ArchivedContract(stakeholders) =>
       ContractStateValue.Archived(stakeholders)
+  }
+
+  private val toContractCacheValue: Option[ContractState] => ContractStateValue = {
+    case Some(value) => toContractCacheValueDefined(value)
     case None => ContractStateValue.NotFound
   }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
@@ -44,47 +44,64 @@ private[dao] sealed class ContractsReader(
       ),
     )
 
+  override def lookupContractStates(contractIds: Seq[ContractId], before: Offset)(implicit
+      loggingContext: LoggingContext
+  ): Future[Map[ContractId, ContractState]] = {
+    dispatcher
+      .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics)(
+        storageBackend.contractStates(contractIds, before)
+      )
+      .map(_.map { case (k, v) => (k, rawToContractState(k)(v)) })
+  }
+
   override def lookupContractState(contractId: ContractId, before: Offset)(implicit
       loggingContext: LoggingContext
   ): Future[Option[ContractState]] = {
-    implicit val errorLogger: ContextualizedErrorLogger =
-      new DamlContextualizedErrorLogger(logger, loggingContext, None)
     Timed.future(
       metrics.daml.index.db.lookupActiveContract,
       dispatcher
         .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics)(
           storageBackend.contractState(contractId, before)
         )
-        .map(_.map {
-          case raw if raw.eventKind == 10 =>
-            val contract = toContract(
-              contractId = contractId,
-              templateId =
-                assertPresent(raw.templateId)("template_id must be present for a create event"),
-              createArgument = assertPresent(raw.createArgument)(
-                "create_argument must be present for a create event"
-              ),
-              createArgumentCompression =
-                Compression.Algorithm.assertLookup(raw.createArgumentCompression),
-              decompressionTimer =
-                metrics.daml.index.db.lookupActiveContractDbMetrics.compressionTimer,
-              deserializationTimer =
-                metrics.daml.index.db.lookupActiveContractDbMetrics.translationTimer,
-            )
-            ActiveContract(
-              contract,
-              raw.flatEventWitnesses,
-              assertPresent(raw.ledgerEffectiveTime)(
-                "ledger_effective_time must be present for a create event"
-              ),
-            )
-          case raw if raw.eventKind == 20 => ArchivedContract(raw.flatEventWitnesses)
-          case raw =>
-            throw throw IndexErrors.DatabaseErrors.ResultSetError
-              .Reject(s"Unexpected event kind ${raw.eventKind}")
-              .asGrpcError
-        }),
+        .map(_.map(rawToContractState(contractId))),
     )
+  }
+
+  private def rawToContractState(
+      contractId: ContractId
+  )(raw: ContractStorageBackend.RawContractState)(implicit
+      loggingContext: LoggingContext
+  ): ContractState = {
+    implicit val errorLogger: ContextualizedErrorLogger =
+      new DamlContextualizedErrorLogger(logger, loggingContext, None)
+    raw match {
+      case raw if raw.eventKind == 10 =>
+        val contract = toContract(
+          contractId = contractId,
+          templateId =
+            assertPresent(raw.templateId)("template_id must be present for a create event"),
+          createArgument = assertPresent(raw.createArgument)(
+            "create_argument must be present for a create event"
+          ),
+          createArgumentCompression =
+            Compression.Algorithm.assertLookup(raw.createArgumentCompression),
+          decompressionTimer = metrics.daml.index.db.lookupActiveContractDbMetrics.compressionTimer,
+          deserializationTimer =
+            metrics.daml.index.db.lookupActiveContractDbMetrics.translationTimer,
+        )
+        ActiveContract(
+          contract,
+          raw.flatEventWitnesses,
+          assertPresent(raw.ledgerEffectiveTime)(
+            "ledger_effective_time must be present for a create event"
+          ),
+        )
+      case raw if raw.eventKind == 20 => ArchivedContract(raw.flatEventWitnesses)
+      case raw =>
+        throw throw IndexErrors.DatabaseErrors.ResultSetError
+          .Reject(s"Unexpected event kind ${raw.eventKind}")
+          .asGrpcError
+    }
   }
 
   /** Lookup of a contract in the case the contract value is not already known */

--- a/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/LedgerDaoContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/LedgerDaoContractsReader.scala
@@ -50,6 +50,11 @@ private[platform] trait LedgerDaoContractsReader {
       loggingContext: LoggingContext
   ): Future[Option[ContractState]]
 
+  /** Batching variant of above */
+  def lookupContractStates(contractIds: Seq[ContractId], validAt: Offset)(implicit
+      loggingContext: LoggingContext
+  ): Future[Map[ContractId, ContractState]]
+
   /** Looks up the state of a contract key at a specific event sequential id.
     *
     * @param key the contract key to query

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ContractStore.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ContractStore.scala
@@ -39,6 +39,12 @@ trait ContractStore {
   )(implicit
       loggingContext: LoggingContext
   ): Future[ContractState]
+
+  /** Eagerly load contracts using a batch query into the store */
+  def prefetchContracts(contractIds: Seq[ContractId])(implicit
+      loggingContext: LoggingContext
+  ): Future[Unit]
+
 }
 
 sealed trait ContractState


### PR DESCRIPTION
This change adds contract pre-fetching to transaction interpretation. Not sure yet about testing. 

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
