### PR TITLE
[LF] make Timestamp parsing consistent accross Java versions

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
@@ -4,8 +4,7 @@
 package com.daml.lf.data
 
 import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoField
-import java.time.temporal.ChronoUnit.MICROS
+import java.time.temporal.{ChronoField, ChronoUnit}
 import java.time.{Duration, Instant, LocalDate, ZoneId}
 import java.util.concurrent.TimeUnit
 
@@ -17,10 +16,16 @@ import scala.util.Try
 
 object Time {
 
-  case class Date private (days: Int) extends Ordered[Date] {
+  class Date private (val days: Int) extends Ordered[Date] {
 
     override def toString: String =
       Date.formatter.format(LocalDate.ofEpochDay(days.toLong))
+
+    override def equals(obj: Any): Boolean =
+      obj match {
+        case that: Date => this.days == that.days
+        case _ => false
+      }
 
     override def compare(that: Date): Int =
       days.compareTo(that.days)
@@ -28,14 +33,11 @@ object Time {
 
   object Date {
 
-    type T = Date
-
     private val formatter: DateTimeFormatter =
       DateTimeFormatter.ISO_DATE.withZone(ZoneId.of("Z"))
 
-    private def assertDaysFromString(str: String) = {
+    private def assertDaysFromString(str: String) =
       asInt(formatter.parse(str).getLong(ChronoField.EPOCH_DAY)).fold(sys.error, identity)
-    }
 
     private[lf] def asInt(days: Long): Either[String, Int] = {
       val daysI = days.toInt
@@ -44,17 +46,17 @@ object Time {
     }
 
     val MinValue: Date =
-      Date(assertDaysFromString("0001-01-01"))
+      new Date(assertDaysFromString("0001-01-01"))
 
     val MaxValue: Date =
-      Date(assertDaysFromString("9999-12-31"))
+      new Date(assertDaysFromString("9999-12-31"))
 
     val Epoch: Date =
-      Date(0)
+      assertFromDaysSinceEpoch(0)
 
     def fromDaysSinceEpoch(days: Int): Either[String, Date] =
       if (MinValue.days <= days && days <= MaxValue.days)
-        Right(Date(days))
+        Right(new Date(days))
       else
         Left(s"out of bound Date $days")
 
@@ -64,7 +66,7 @@ object Time {
         .flatMap(fromDaysSinceEpoch)
 
     @throws[IllegalArgumentException]
-    final def assertFromString(s: String): T =
+    final def assertFromString(s: String): Date =
       assertRight(fromString(s))
 
     def assertFromDaysSinceEpoch(days: Int): Date =
@@ -80,10 +82,16 @@ object Time {
 
   }
 
-  case class Timestamp private (micros: Long) extends Ordered[Timestamp] {
+  class Timestamp private (val micros: Long) extends Ordered[Timestamp] {
 
     override def toString: String =
       Timestamp.formatter.format(toInstant)
+
+    override def equals(obj: Any): Boolean =
+      obj match {
+        case that: Timestamp => this.micros == that.micros
+        case _ => false
+      }
 
     def compare(that: Timestamp): Int =
       micros.compareTo(that.micros)
@@ -112,34 +120,28 @@ object Time {
 
   object Timestamp {
 
-    type T = Timestamp
-
-    private val formatter: DateTimeFormatter =
+    private lazy val formatter: DateTimeFormatter =
       DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.of("Z"))
 
-    private def assertMicrosFromInstant(i: Instant): Long =
+    private def microsOfInstant(i: Instant): Long =
       TimeUnit.SECONDS.toMicros(i.getEpochSecond) + TimeUnit.NANOSECONDS.toMicros(i.getNano.toLong)
 
-    private def assertMicrosFromString(str: String): Long =
-      assertMicrosFromInstant(Instant.parse(str))
-
     val MinValue: Timestamp =
-      Timestamp(assertMicrosFromString("0001-01-01T00:00:00.000000Z"))
+      new Timestamp(microsOfInstant(Instant.parse("0001-01-01T00:00:00.000000Z")))
 
     val MaxValue: Timestamp =
-      Timestamp(assertMicrosFromString("9999-12-31T23:59:59.999999Z"))
+      new Timestamp(microsOfInstant(Instant.parse("9999-12-31T23:59:59.999999Z")))
 
-    val Resolution: Duration = Duration.of(1L, MICROS)
+    val Resolution: Duration = Duration.of(1L, ChronoUnit.MICROS)
 
-    val Epoch: Timestamp =
-      Timestamp(0)
+    val Epoch: Timestamp = assertFromLong(0)
 
     def now(): Timestamp =
-      assertFromLong(assertMicrosFromInstant(Instant.now()))
+      assertLenientFromInstant(Instant.now())
 
     def fromLong(micros: Long): Either[String, Timestamp] =
       if (MinValue.micros <= micros && micros <= MaxValue.micros)
-        Right(Timestamp(micros))
+        Right(new Timestamp(micros))
       else
         Left(s"out of bound Timestamp $micros")
 
@@ -147,27 +149,77 @@ object Time {
     def assertFromLong(micros: Long): Timestamp =
       assertRight(fromLong(micros))
 
-    def fromString(str: String): Either[String, Timestamp] =
-      Try(assertMicrosFromString(str)).toEither.left
-        .map(_ => s"cannot interpret $str as Timestamp")
-        .flatMap(fromLong)
+    // Drop nanoseconds
+    def lenientFromInstant(i: Instant): Either[String, Timestamp] =
+      fromLong(microsOfInstant(i))
 
     @throws[IllegalArgumentException]
-    final def assertFromString(s: String): T =
-      assertRight(fromString(s))
+    def assertLenientFromInstant(i: Instant): Timestamp =
+      assertRight(lenientFromInstant(i))
 
-    def fromInstant(i: Instant): Either[String, Timestamp] =
-      Try(assertMicrosFromInstant(i)).toEither.left
-        .map(_ => s"cannot interpret $i as Timestamp")
-        .flatMap(fromLong)
+    private val nanosInOneMicros: Long =
+      TimeUnit.MICROSECONDS.toNanos(1)
 
-    def assertFromInstant(i: Instant): Timestamp =
-      assertFromLong(assertMicrosFromInstant(i))
+    // reject if cannot be converted without loss of precision
+    def strictFromInstant(i: Instant): Either[String, Timestamp] =
+      if (i.getNano % nanosInOneMicros == 0)
+        lenientFromInstant(i)
+      else
+        Left(s"cannot interpret $i as Timestamp")
+
+    @deprecated(
+      "use lenientFromInstant or strictFromInstant, legacy behavior is lenient, preferred is strict",
+      since = " 2.7.0",
+    )
+    def fromInstant(i: Instant): Either[String, Timestamp] = lenientFromInstant(i)
+
+    @deprecated(
+      "use lenientFromInstant or strictFromInstant, legacy behavior is lenient, preferred is strict",
+      since = " 2.7.0",
+    )
+    def assertFromInstant(i: Instant): Timestamp = assertLenientFromInstant(i)
+
+    @throws[IllegalArgumentException]
+    def assertStrictFromInstant(i: Instant): Timestamp =
+      assertRight(strictFromInstant(i))
+
+    private def instantFromString(str: String): Either[String, Instant] =
+      try {
+        Right(Instant.parse(str))
+      } catch {
+        case scala.util.control.NonFatal(_) => Left(s"cannot interpret $str as Timestamp")
+      }
+
+    def lenientFromString(str: String): Either[String, Timestamp] =
+      instantFromString(str).flatMap(lenientFromInstant)
+
+    @throws[IllegalArgumentException]
+    def assertLenientFromString(str: String): Timestamp =
+      assertRight(lenientFromString(str))
+
+    def strictFromString(str: String): Either[String, Timestamp] =
+      instantFromString(str).flatMap(strictFromInstant)
+
+    @throws[IllegalArgumentException]
+    def assertStrictFromString(str: String): Timestamp =
+      assertRight(strictFromString(str))
+
+    @deprecated(
+      "use lenientFromString or strictFromString, legacy behavior is lenient, preferred is strict",
+      since = " 2.7.0",
+    )
+    def fromString(str: String): Either[String, Timestamp] = lenientFromString(str)
+
+    @deprecated(
+      "use lenientFromString or strictFromString, legacy behavior is lenient, preferred is strict",
+      since = " 2.7.0",
+    )
+    def assertFromString(str: String): Timestamp = assertLenientFromString(str)
 
     implicit val `Time.Timestamp Order`: Order[Timestamp] = new Order[Timestamp] {
       override def equalIsNatural = true
 
-      override def equal(x: Timestamp, y: Timestamp): Boolean = x == y
+      override def equal(x: Timestamp, y: Timestamp): Boolean = x.micros == y.micros
 
       override def order(x: Timestamp, y: Timestamp): Ordering = x.micros ?|? y.micros
     }

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
@@ -167,6 +167,10 @@ object Time {
       else
         Left(s"cannot interpret $i as Timestamp")
 
+    @throws[IllegalArgumentException]
+    def assertStrictFromInstant(i: Instant): Timestamp =
+      assertRight(strictFromInstant(i))
+
     @deprecated(
       "use lenientFromInstant or strictFromInstant, legacy behavior is lenient, preferred is strict",
       since = " 2.7.0",
@@ -178,10 +182,6 @@ object Time {
       since = " 2.7.0",
     )
     def assertFromInstant(i: Instant): Timestamp = assertLenientFromInstant(i)
-
-    @throws[IllegalArgumentException]
-    def assertStrictFromInstant(i: Instant): Timestamp =
-      assertRight(strictFromInstant(i))
 
     private def instantFromString(str: String): Either[String, Instant] =
       try {

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
@@ -27,6 +27,8 @@ object Time {
         case _ => false
       }
 
+    override def hashCode(): Int = days + Date.hashCode()
+
     override def compare(that: Date): Int =
       days.compareTo(that.days)
   }
@@ -92,6 +94,8 @@ object Time {
         case that: Timestamp => this.micros == that.micros
         case _ => false
       }
+
+    override def hashCode(): Int = micros.hashCode() + Timestamp.hashCode()
 
     def compare(that: Timestamp): Int =
       micros.compareTo(that.micros)

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
@@ -27,13 +27,15 @@ object Time {
         case _ => false
       }
 
-    override def hashCode(): Int = days + Date.hashCode()
+    override def hashCode(): Int = days + Date.seed
 
     override def compare(that: Date): Int =
       days.compareTo(that.days)
   }
 
   object Date {
+
+    private val seed: Int = getClass.getName.hashCode
 
     private val formatter: DateTimeFormatter =
       DateTimeFormatter.ISO_DATE.withZone(ZoneId.of("Z"))
@@ -95,7 +97,7 @@ object Time {
         case _ => false
       }
 
-    override def hashCode(): Int = micros.hashCode() + Timestamp.hashCode()
+    override def hashCode(): Int = micros.hashCode() + Timestamp.seed
 
     def compare(that: Timestamp): Int =
       micros.compareTo(that.micros)
@@ -123,6 +125,8 @@ object Time {
   }
 
   object Timestamp {
+
+    private val seed: Int = getClass.getName.hashCode
 
     private lazy val formatter: DateTimeFormatter =
       DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.of("Z"))

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
@@ -193,7 +193,7 @@ object Time {
 
     private def instantFromString(str: String): Either[String, Instant] =
       try {
-        Right(Instant.parse(str))
+        Right(Instant.from(formatter.parse(str)))
       } catch {
         case scala.util.control.NonFatal(_) => Left(s"cannot interpret $str as Timestamp")
       }

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
@@ -177,13 +177,13 @@ object Time {
 
     @deprecated(
       "use lenientFromInstant or strictFromInstant, legacy behavior is lenient, preferred is strict",
-      since = " 2.7.0",
+      since = "2.7.0",
     )
     def fromInstant(i: Instant): Either[String, Timestamp] = lenientFromInstant(i)
 
     @deprecated(
       "use lenientFromInstant or strictFromInstant, legacy behavior is lenient, preferred is strict",
-      since = " 2.7.0",
+      since = "2.7.0",
     )
     def assertFromInstant(i: Instant): Timestamp = assertLenientFromInstant(i)
 
@@ -210,13 +210,13 @@ object Time {
 
     @deprecated(
       "use lenientFromString or strictFromString, legacy behavior is lenient, preferred is strict",
-      since = " 2.7.0",
+      since = "2.7.0",
     )
     def fromString(str: String): Either[String, Timestamp] = lenientFromString(str)
 
     @deprecated(
       "use lenientFromString or strictFromString, legacy behavior is lenient, preferred is strict",
-      since = " 2.7.0",
+      since = "2.7.0",
     )
     def assertFromString(str: String): Timestamp = assertLenientFromString(str)
 

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TimeSpec.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TimeSpec.scala
@@ -148,6 +148,7 @@ class TimeSpec extends AnyFreeSpec with Inside with Matchers with TableDrivenPro
         "1970-01-01T01:00:00Z",
         "2023-06-28T07:19:12Z",
         "1969-07-20T20:17:00Z",
+        "1969-07-20T20:17:00z",
         "1969-07-20T20:17:00.100Z",
         "1969-07-20T20:17:00.120Z",
         "1969-07-20T20:17:00.123Z",
@@ -159,7 +160,7 @@ class TimeSpec extends AnyFreeSpec with Inside with Matchers with TableDrivenPro
       forEvery(fromStringFunctions)(f =>
         forEvery(testCases)(str =>
           inside(f(str)) { case Right(timestamp) =>
-            timestamp.toString shouldBe str
+            timestamp.toString shouldBe str.toUpperCase
           }
         )
       )
@@ -200,7 +201,7 @@ class TimeSpec extends AnyFreeSpec with Inside with Matchers with TableDrivenPro
       )
     }
 
-    "strictFromString reject a UTC ISO 8601 compliant string with singificant nanos" in {
+    "strictFromString reject a UTC ISO 8601 compliant string with significant nanos" in {
       val testCases = Table(
         "withNanos",
         "0001-01-01T00:00:00.000000009Z",
@@ -255,21 +256,27 @@ class TimeSpec extends AnyFreeSpec with Inside with Matchers with TableDrivenPro
 
     "fromString functions reject non UTC ISO 8601 compliant time strings" in {
       val testCases = Table(
-        "withNanos",
+        "string",
+        "",
         "001-01-01Z",
         "0001-01-01Z",
         "1970-01-01T01",
         "2023-06-28T07:19",
         "1969-07-20T20:17:00.0000000000Z",
         "01969-07-20T20:17:00.0000000000Z",
+        "1969-13-20T20:17:00",
+        "1969-07-20T20:17:00Z ",
+        " 1969-07-20T20:17:00Z",
         "1969-13-20T20:17:00Z",
         "1969-07-32T20:17:00Z",
-        "1969-07-32T20:17:00Z−07:01",
-        "1969-07-32T20:17:00Z−0700",
-        "1969-07-32T20:17:00Z−07",
-        "1969-07-32T20:17:00Z+07:00",
-        "1969-07-32T20:17:00Z+0701",
-        "1969-07-32T20:17:00Z+07",
+        "1969-07-20T20:17:00+00:00",
+        "1969-07-20T20:17:00-00:00",
+        "1969-07-20T20:17:00−07:01",
+        "1969-07-20T20:17:00−0700",
+        "1969-07-20T20:17:00−07",
+        "1969-07-20T20:17:00+07:00",
+        "1969-07-20T20:17:00+0701",
+        "1969-07-20T20:17:00+07",
         "Last friday",
       )
       forEvery(fromStringFunctions)(f => forEvery(testCases)(str => f(str) shouldBe a[Left[_, _]]))

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TimeSpec.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TimeSpec.scala
@@ -218,7 +218,7 @@ class TimeSpec extends AnyFreeSpec with Inside with Matchers with TableDrivenPro
       forEvery(testCases)(str => Timestamp.strictFromString(str) shouldBe a[Left[_, _]])
     }
 
-    "strict FromString ignore non significant zeros" in {
+    "FromString functions ignore non significant zeros" in {
       val testCases = Table(
         ("normal form", "not normal form"),
         "0001-01-01T00:00:00Z" ->

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TimeSpec.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TimeSpec.scala
@@ -253,7 +253,7 @@ class TimeSpec extends AnyFreeSpec with Inside with Matchers with TableDrivenPro
       )
     }
 
-    "fromString function reject non UTC ISO 8601 compliant time strings" in {
+    "fromString functions reject non UTC ISO 8601 compliant time strings" in {
       val testCases = Table(
         "withNanos",
         "001-01-01Z",
@@ -275,7 +275,7 @@ class TimeSpec extends AnyFreeSpec with Inside with Matchers with TableDrivenPro
       forEvery(fromStringFunctions)(f => forEvery(testCases)(str => f(str) shouldBe a[Left[_, _]]))
     }
 
-    "fromString function fail in case of overflows" in {
+    "fromString functions fail in case of overflows" in {
       val max = Timestamp.MaxValue.toString
       val min = Timestamp.MinValue.toString
       forEvery(fromStringFunctions) { f =>

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TimeSpec.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TimeSpec.scala
@@ -5,15 +5,18 @@ package com.daml.lf.data
 
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoField
-import java.time.{Duration, Instant, LocalDate}
+import java.time.{Instant, Duration, LocalDate}
 import java.util.concurrent.TimeUnit
-
 import com.daml.lf.data.Time._
+import org.scalatest.Inside
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.freespec.AnyFreeSpec
 
-class TimeSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks {
+import scala.annotation.nowarn
+
+@nowarn("msg=deprecated")
+class TimeSpec extends AnyFreeSpec with Inside with Matchers with TableDrivenPropertyChecks {
 
   "Date operations" - {
 
@@ -66,7 +69,7 @@ class TimeSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks 
     }
 
     "Timestamp.Epoch is 1970-01-01T00:00:00Z" in {
-      Timestamp.Epoch shouldBe Timestamp.assertFromString("1970-01-01T00:00:00Z")
+      Timestamp.Epoch shouldBe Timestamp.assertStrictFromString("1970-01-01T00:00:00Z")
     }
 
     "Timestamp.fromLong fails if it overflows" in {
@@ -78,17 +81,8 @@ class TimeSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks 
       Timestamp.fromLong(min - 1) shouldBe a[Left[_, _]]
     }
 
-    "Timestamp.fromString fails if it overflows" in {
-      val max = Timestamp.MaxValue.toString
-      val min = Timestamp.MinValue.toString
-      Timestamp.fromString(max) shouldBe a[Right[_, _]]
-      Timestamp.fromString(Instant.parse(max).plusMillis(1).toString) shouldBe a[Left[_, _]]
-      Timestamp.fromString(min) shouldBe a[Right[_, _]]
-      Timestamp.fromString(Instant.parse(min).plusMillis(-1).toString) shouldBe a[Left[_, _]]
-    }
-
     "add increments the timestamp" in {
-      val timestamp = Timestamp.assertFromString("2019-04-04T08:33:38.123456Z")
+      val timestamp = Timestamp.assertStrictFromString("2019-04-04T08:33:38.123456Z")
       val incrementedTimestamp = timestamp.add(Duration.ofNanos(1234567000))
       incrementedTimestamp.toString shouldBe "2019-04-04T08:33:39.358023Z"
     }
@@ -100,7 +94,7 @@ class TimeSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks 
     }
 
     "addMicros increments the timestamp" in {
-      val timestamp = Timestamp.assertFromString("2019-04-04T08:33:38.123456Z")
+      val timestamp = Timestamp.assertStrictFromString("2019-04-04T08:33:38.123456Z")
       val incrementedTimestamp = timestamp.addMicros(1234567)
       incrementedTimestamp.toString shouldBe "2019-04-04T08:33:39.358023Z"
     }
@@ -110,28 +104,185 @@ class TimeSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks 
       an[IllegalArgumentException] should be thrownBy Timestamp.MaxValue.addMicros(1)
     }
 
-    "toString produces an ISO 8601 compliant string" in {
+    "toString produces a UTC ISO 8601 compliant string without nano seconds" in {
       val testCases = Table(
-        "timeStamp",
+        "timestamp",
         Timestamp.MinValue,
         Timestamp.Epoch,
-        Timestamp.assertFromString("1969-07-20T20:17:00Z"),
-        Timestamp.assertFromString("1969-07-20T20:17:00.1Z"),
-        Timestamp.assertFromString("1969-07-20T20:17:00.12Z"),
-        Timestamp.assertFromString("1969-07-20T20:17:00.123Z"),
-        Timestamp.assertFromString("1969-07-20T20:17:00.1234Z"),
-        Timestamp.assertFromString("1969-07-20T20:17:00.12345Z"),
-        Timestamp.assertFromString("1969-07-20T20:17:00.123456Z"),
+        Timestamp.assertStrictFromString("1969-07-20T20:17:00Z"),
+        Timestamp.assertStrictFromString("1969-07-20T20:17:00.1Z"),
+        Timestamp.assertStrictFromString("1969-07-20T20:17:00.12Z"),
+        Timestamp.assertStrictFromString("1969-07-20T20:17:00.123Z"),
+        Timestamp.assertStrictFromString("1969-07-20T20:17:00.1234Z"),
+        Timestamp.assertStrictFromString("1969-07-20T20:17:00.12345Z"),
+        Timestamp.assertStrictFromString("1969-07-20T20:17:00.123456Z"),
         Timestamp.MaxValue,
       )
-
-      forEvery(testCases) { date =>
-        val i = Instant.parse(date.toString)
+      forEvery(testCases) { timestamp =>
+        val i = Instant.parse(timestamp.toString)
         val micros =
           TimeUnit.SECONDS.toMicros(i.getEpochSecond) +
             TimeUnit.NANOSECONDS.toMicros(i.getNano.toLong)
 
-        micros shouldBe date.micros
+        micros shouldBe timestamp.micros
+      }
+    }
+
+    val fromStringFunctions = Table(
+      "function",
+      Timestamp.fromString(_),
+      Timestamp.strictFromString(_),
+      Timestamp.lenientFromString(_),
+    )
+
+    val lenientFromStringFunctions = Table(
+      "function",
+      Timestamp.fromString(_),
+      Timestamp.lenientFromString(_),
+    )
+
+    "fromString functions convert a UTC ISO 8601 compliant string without nano without loss of precision" in {
+      val testCases = Table(
+        "timestamp",
+        "0001-01-01T00:00:00Z",
+        "1970-01-01T01:00:00Z",
+        "2023-06-28T07:19:12Z",
+        "1969-07-20T20:17:00Z",
+        "1969-07-20T20:17:00.100Z",
+        "1969-07-20T20:17:00.120Z",
+        "1969-07-20T20:17:00.123Z",
+        "1969-07-20T20:17:00.123400Z",
+        "1969-07-20T20:17:00.123450Z",
+        "1969-07-20T20:17:00.123456Z",
+        "9999-12-31T23:59:59.999999Z",
+      )
+      forEvery(fromStringFunctions)(f =>
+        forEvery(testCases)(str =>
+          inside(f(str)) { case Right(timestamp) =>
+            timestamp.toString shouldBe str
+          }
+        )
+      )
+    }
+
+    "lenient FromString convert a UTC ISO 8601 compliant string with nanos while dropping nanos" in {
+      val testCases = Table(
+        ("withoutNanos", "withNanos"),
+        "0001-01-01T00:00:00Z" ->
+          "0001-01-01T00:00:00.000000009Z",
+        "1970-01-01T01:00:00Z" ->
+          "1970-01-01T01:00:00.000000099Z",
+        "2023-06-28T07:19:12Z" ->
+          "2023-06-28T07:19:12.000000090Z",
+        "1969-07-20T20:17:00Z" ->
+          "1969-07-20T20:17:00.000000990Z",
+        "1969-07-20T20:17:00.100Z" ->
+          "1969-07-20T20:17:00.100000999Z",
+        "1969-07-20T20:17:00.120Z" ->
+          "1969-07-20T20:17:00.120000909Z",
+        "1969-07-20T20:17:00.123Z" ->
+          "1969-07-20T20:17:00.123000900Z",
+        "1969-07-20T20:17:00.123400Z" ->
+          "1969-07-20T20:17:00.123400500Z",
+        "1969-07-20T20:17:00.123450Z" ->
+          "1969-07-20T20:17:00.123450499Z",
+        "1969-07-20T20:17:00.123456Z" ->
+          "1969-07-20T20:17:00.123456501Z",
+        "9999-12-31T23:59:59.999999Z" ->
+          "9999-12-31T23:59:59.999999999Z",
+      )
+      forEvery(lenientFromStringFunctions)(f =>
+        forEvery(testCases)((withoutNanos, withNanos) =>
+          inside(f(withNanos)) { case Right(timestamp) =>
+            timestamp.toString shouldBe withoutNanos
+          }
+        )
+      )
+    }
+
+    "strictFromString reject a UTC ISO 8601 compliant string with singificant nanos" in {
+      val testCases = Table(
+        "withNanos",
+        "0001-01-01T00:00:00.000000009Z",
+        "1970-01-01T01:00:00.000000099Z",
+        "2023-06-28T07:19:12.000000090Z",
+        "1969-07-20T20:17:00.000000990Z",
+        "1969-07-20T20:17:00.100000999Z",
+        "1969-07-20T20:17:00.120000909Z",
+        "1969-07-20T20:17:00.123000900Z",
+        "1969-07-20T20:17:00.123400500Z",
+        "1969-07-20T20:17:00.123450499Z",
+        "1969-07-20T20:17:00.123456501Z",
+        "9999-12-31T23:59:59.999999999Z",
+      )
+      forEvery(testCases)(str => Timestamp.strictFromString(str) shouldBe a[Left[_, _]])
+    }
+
+    "strict FromString ignore non significant zeros" in {
+      val testCases = Table(
+        ("normal form", "not normal form"),
+        "0001-01-01T00:00:00Z" ->
+          "0001-01-01T00:00:00.0Z",
+        "1970-01-01T01:00:00Z" ->
+          "1970-01-01T01:00:00.00Z",
+        "2023-06-28T07:19:12Z" ->
+          "2023-06-28T07:19:12.000Z",
+        "1969-07-20T20:17:00Z" ->
+          "1969-07-20T20:17:00.0000Z",
+        "1969-07-20T20:17:00.100Z" ->
+          "1969-07-20T20:17:00.10000Z",
+        "1969-07-20T20:17:00.120Z" ->
+          "1969-07-20T20:17:00.120000Z",
+        "1969-07-20T20:17:00.123Z" ->
+          "1969-07-20T20:17:00.1230000Z",
+        "1969-07-20T20:17:00.123400Z" ->
+          "1969-07-20T20:17:00.12340000Z",
+        "1969-07-20T20:17:00.123450Z" ->
+          "1969-07-20T20:17:00.123450000Z",
+        "1969-07-20T20:17:00.123456Z" ->
+          "1969-07-20T20:17:00.12345600Z",
+        "9999-12-31T23:59:59.999999Z" ->
+          "9999-12-31T23:59:59.9999990Z",
+      )
+      forEvery(fromStringFunctions)(f =>
+        forEvery(testCases)((normal, nonNormal) =>
+          inside(f(nonNormal)) { case Right(timestamp) =>
+            timestamp.toString shouldBe normal
+          }
+        )
+      )
+    }
+
+    "fromString function reject non UTC ISO 8601 compliant time strings" in {
+      val testCases = Table(
+        "withNanos",
+        "001-01-01Z",
+        "0001-01-01Z",
+        "1970-01-01T01",
+        "2023-06-28T07:19",
+        "1969-07-20T20:17:00.0000000000Z",
+        "01969-07-20T20:17:00.0000000000Z",
+        "1969-13-20T20:17:00Z",
+        "1969-07-32T20:17:00Z",
+        "1969-07-32T20:17:00Z−07:01",
+        "1969-07-32T20:17:00Z−0700",
+        "1969-07-32T20:17:00Z−07",
+        "1969-07-32T20:17:00Z+07:00",
+        "1969-07-32T20:17:00Z+0701",
+        "1969-07-32T20:17:00Z+07",
+        "Last friday",
+      )
+      forEvery(fromStringFunctions)(f => forEvery(testCases)(str => f(str) shouldBe a[Left[_, _]]))
+    }
+
+    "fromString function fail in case of overflows" in {
+      val max = Timestamp.MaxValue.toString
+      val min = Timestamp.MinValue.toString
+      forEvery(fromStringFunctions) { f =>
+        f(max) shouldBe a[Right[_, _]]
+        f(Instant.parse(max).plusMillis(1).toString) shouldBe a[Left[_, _]]
+        f(min) shouldBe a[Right[_, _]]
+        f(Instant.parse(min).plusMillis(-1).toString) shouldBe a[Left[_, _]]
       }
     }
   }

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TimeSpec.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TimeSpec.scala
@@ -5,7 +5,7 @@ package com.daml.lf.data
 
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoField
-import java.time.{Instant, Duration, LocalDate}
+import java.time.{Duration, Instant, LocalDate}
 import java.util.concurrent.TimeUnit
 import com.daml.lf.data.Time._
 import org.scalatest.Inside

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -1061,7 +1061,7 @@ class EngineTest
     val originalCoid = toContractId("BasicTests:CallablePayout:1")
     val templateId = Identifier(basicTestsPkgId, "BasicTests:CallablePayout")
     // we need to fix time as cid are depending on it
-    val let = Time.Timestamp.assertFromString("1969-07-20T20:17:00Z")
+    val let = Time.Timestamp.assertStrictFromString("1969-07-20T20:17:00Z")
     val command = ApiCommand.Exercise(
       templateId,
       originalCoid,

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValueTranslatorSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValueTranslatorSpec.scala
@@ -75,8 +75,8 @@ class ValueTranslatorSpec
       (TInt64, ValueInt64(42), SInt64(42)),
       (
         TTimestamp,
-        ValueTimestamp(Time.Timestamp.assertFromString("1969-07-20T20:17:00Z")),
-        STimestamp(Time.Timestamp.assertFromString("1969-07-20T20:17:00Z")),
+        ValueTimestamp(Time.Timestamp.assertStrictFromString("1969-07-20T20:17:00Z")),
+        STimestamp(Time.Timestamp.assertStrictFromString("1969-07-20T20:17:00Z")),
       ),
       (
         TDate,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -709,10 +709,11 @@ private[lf] object SBuiltin {
   }
 
   final case object SBUnixDaysToDate extends SBuiltinArithmetic("UNIX_DAYS_TO_DATE", 1) {
-    override private[speedy] def compute(args: util.ArrayList[SValue]): Option[SDate] = {
-      val days = getSInt64(args, 0)
-      Time.Date.asInt(days).flatMap(Time.Date.fromDaysSinceEpoch).toOption.map(SDate)
-    }
+    override private[speedy] def compute(args: util.ArrayList[SValue]): Option[SDate] =
+      for {
+        days <- toInt(getSInt64(args, 0))
+        date <- Time.Date.fromDaysSinceEpoch(days).toOption
+      } yield SDate(date)
   }
 
   final case object SBTimestampToUnixMicroseconds extends SBuiltinPure(1) {
@@ -902,7 +903,7 @@ private[lf] object SBuiltin {
       val y = getSBigNumeric(args, 3)
       for {
         scale <- SBigNumeric.checkScale(unchekedScale).toOption
-        roundingModeIndex <- scala.util.Try(Math.toIntExact(unchekedRoundingMode)).toOption
+        roundingModeIndex <- toInt(unchekedRoundingMode)
         roundingMode <- java.math.RoundingMode.values().lift(roundingModeIndex)
         uncheckedResult <- handleArithmeticException(x.divide(y, scale, roundingMode))
         result <- SBigNumeric.fromBigDecimal(uncheckedResult).toOption
@@ -2142,6 +2143,8 @@ private[lf] object SBuiltin {
       case SText(text) => text
       case _ => throw SErrorCrash(where, s"value not a text: $v")
     }
+
+  private[this] def toInt(l: Long): Option[Int] = Some(l.toInt).filter(_ == l)
 
   private[this] val keyWithMaintainersStructFields: Struct[Unit] =
     Struct.assertFromNameSeq(List(Ast.keyFieldName, Ast.maintainersFieldName))

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -1350,9 +1350,9 @@ class SBuiltinTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
 
         forEvery(testCases) { (date, int) =>
           eval(e"DATE_TO_UNIX_DAYS $date") shouldBe Right(SInt64(int))
-          eval(e"UNIX_DAYS_TO_DATE $int") shouldBe Time.Date
-            .asInt(int)
-            .map(i => SDate(Time.Date.assertFromDaysSinceEpoch(i)))
+          eval(e"UNIX_DAYS_TO_DATE $int") shouldBe Right(
+            SDate(Time.Date.assertFromDaysSinceEpoch(int.toInt))
+          )
           eval(e"EQUAL @Date (UNIX_DAYS_TO_DATE $int) $date") shouldBe Right(SBool(true))
         }
       }

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
@@ -93,7 +93,7 @@ private[parser] object Lexer extends RegexParsers {
 
   private def toTimestamp(s: String): Parser[Timestamp] =
     (in: Input) =>
-      Time.Timestamp.fromString(s) match {
+      Time.Timestamp.strictFromString(s) match {
         case Right(x) => Success(Timestamp(x), in)
         case Left(_) =>
           Error(s"cannot interpret $s as a Timestamp", in)

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -358,7 +358,7 @@ object TransactionBuilder {
       Ref.Identifier(defaultPackageId, s)
 
     implicit def toTimestamp(s: String): Time.Timestamp =
-      Time.Timestamp.assertFromString(s)
+      Time.Timestamp.assertStrictFromString(s)
 
     implicit def toDate(s: String): Time.Date =
       Time.Date.assertFromString(s)

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
@@ -364,8 +364,8 @@ class HashSpec extends AnyWordSpec with Matchers {
       val timestamps =
         List(
           Time.Timestamp.assertFromLong(0),
-          Time.Timestamp.assertFromString("1969-07-21T02:56:15.000000Z"),
-          Time.Timestamp.assertFromString("2019-12-16T11:17:54.940779363Z"),
+          Time.Timestamp.assertStrictFromString("1969-07-21T02:56:15.000000Z"),
+          Time.Timestamp.assertStrictFromString("2019-12-16T11:17:54.940779Z"),
         ).map(VA.timestamp.inj(_))
       val parties =
         List(

--- a/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
@@ -501,7 +501,7 @@ object TreeUtils {
   }
 
   def timestampFromTree(tree: TransactionTree): Timestamp = {
-    Timestamp.assertFromInstant(
+    Timestamp.assertStrictFromInstant(
       Instant.ofEpochSecond(tree.getEffectiveAt.seconds, tree.getEffectiveAt.nanos.toLong)
     )
   }

--- a/daml-script/export/src/test/scala/com/daml/script/export/ActionsFromTreesSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/ActionsFromTreesSpec.scala
@@ -16,7 +16,7 @@ class ActionsFromTreesSpec extends AnyFreeSpec with Matchers {
         Action.fromTrees(Seq.empty, setTime = true) shouldBe empty
       }
       "single transaction" in {
-        val t1 = Timestamp.assertFromString("1990-01-01T01:00:00Z")
+        val t1 = Timestamp.assertStrictFromString("1990-01-01T01:00:00Z")
         val trees = Seq(
           TestData
             .Tree(
@@ -33,7 +33,7 @@ class ActionsFromTreesSpec extends AnyFreeSpec with Matchers {
         actions(1) shouldBe a[SubmitSimpleSingle]
       }
       "multipe transaction at same time" in {
-        val t1 = Timestamp.assertFromString("1990-01-01T01:00:00Z")
+        val t1 = Timestamp.assertStrictFromString("1990-01-01T01:00:00Z")
         val trees = Seq(
           TestData
             .Tree(
@@ -59,8 +59,8 @@ class ActionsFromTreesSpec extends AnyFreeSpec with Matchers {
         actions(2) shouldBe a[SubmitSimpleSingle]
       }
       "multipe transaction at different times" in {
-        val t1 = Timestamp.assertFromString("1990-01-01T01:00:00Z")
-        val t2 = Timestamp.assertFromString("1990-01-02T01:00:00Z")
+        val t1 = Timestamp.assertStrictFromString("1990-01-01T01:00:00Z")
+        val t2 = Timestamp.assertStrictFromString("1990-01-02T01:00:00Z")
         val trees = Seq(
           TestData
             .Tree(
@@ -89,8 +89,8 @@ class ActionsFromTreesSpec extends AnyFreeSpec with Matchers {
     }
     "setTime disabled" - {
       "multipe transaction at different times" in {
-        val t1 = Timestamp.assertFromString("1990-01-01T01:00:00Z")
-        val t2 = Timestamp.assertFromString("1990-01-02T01:00:00Z")
+        val t1 = Timestamp.assertStrictFromString("1990-01-01T01:00:00Z")
+        val t2 = Timestamp.assertStrictFromString("1990-01-02T01:00:00Z")
         val trees = Seq(
           TestData
             .Tree(

--- a/daml-script/export/src/test/scala/com/daml/script/export/EncodeSetTimeSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/EncodeSetTimeSpec.scala
@@ -10,7 +10,8 @@ import org.scalatest.matchers.should.Matchers
 class EncodeSetTimeSpec extends AnyFreeSpec with Matchers {
   import Encode._
   "encodeSetTime" in {
-    encodeSetTime(Timestamp.assertFromString("1990-11-09T04:30:23.123456Z")).render(80) shouldBe
+    encodeSetTime(Timestamp.assertStrictFromString("1990-11-09T04:30:23.123456Z"))
+      .render(80) shouldBe
       """setTime (DA.Time.time (DA.Date.date 1990 DA.Date.Nov 9) 4 30 23)"""
   }
 }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ScriptF.scala
@@ -424,7 +424,7 @@ object ScriptF {
           }
           case ScriptTimeMode.WallClock =>
             Future {
-              Timestamp.assertFromInstant(env.utcClock.instant())
+              Timestamp.assertLenientFromInstant(env.utcClock.instant())
             }
         }
       } yield SEAppAtomic(SEValue(continue), Array(SEValue(STimestamp(time))))

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/JsonLedgerClient.scala
@@ -3,7 +3,6 @@
 
 package com.daml.lf.engine.script.v1.ledgerinteraction
 
-import java.time.Instant
 import akka.util.ByteString
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
@@ -383,7 +382,7 @@ class JsonLedgerClient(
       mat: Materializer,
   ): Future[Time.Timestamp] = {
     // There is no time service in the JSON API so we default to the Unix epoch.
-    Future { Time.Timestamp.assertFromInstant(Instant.EPOCH) }
+    Future { Time.Timestamp.Epoch }
   }
 
   override def setStaticTime(time: Time.Timestamp)(implicit

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
@@ -424,7 +424,7 @@ object ScriptF {
           }
           case ScriptTimeMode.WallClock =>
             Future {
-              Timestamp.assertFromInstant(env.utcClock.instant())
+              Timestamp.assertLenientFromInstant(env.utcClock.instant())
             }
         }
       } yield SEAppAtomic(SEValue(continue), Array(SEValue(STimestamp(time))))

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/JsonLedgerClient.scala
@@ -383,7 +383,7 @@ class JsonLedgerClient(
       mat: Materializer,
   ): Future[Time.Timestamp] = {
     // There is no time service in the JSON API so we default to the Unix epoch.
-    Future { Time.Timestamp.assertFromInstant(Instant.EPOCH) }
+    Future { Time.Timestamp.Epoch }
   }
 
   override def setStaticTime(time: Time.Timestamp)(implicit

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/JsonLedgerClient.scala
@@ -3,7 +3,6 @@
 
 package com.daml.lf.engine.script.v2.ledgerinteraction
 
-import java.time.Instant
 import akka.util.ByteString
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/FuncStaticTimeIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/FuncStaticTimeIT.scala
@@ -26,8 +26,8 @@ final class FuncStaticTimeIT extends AbstractFuncIT {
         assert(vals.size == 2)
         val t0 = assertSTimestamp(vals.get(0))
         val t1 = assertSTimestamp(vals.get(1))
-        assert(t0 == Timestamp.assertFromString("1970-01-01T00:00:00Z"))
-        assert(t1 == Timestamp.assertFromString("2000-02-02T00:01:02Z"))
+        assert(t0 == Timestamp.assertStrictFromString("1970-01-01T00:00:00Z"))
+        assert(t1 == Timestamp.assertStrictFromString("2000-02-02T00:01:02Z"))
       }
     }
   }

--- a/language-support/java/json/src/main/scala/com/daml/lf/codegen/json/ValueConversion.scala
+++ b/language-support/java/json/src/main/scala/com/daml/lf/codegen/json/ValueConversion.scala
@@ -73,7 +73,7 @@ object ValueConversion {
     case text: JData.Text => LfValue.ValueText(text.getValue)
     case timestamp: JData.Timestamp =>
       LfValue.ValueTimestamp(
-        Time.Timestamp.assertFromInstant(timestamp.getValue)
+        Time.Timestamp.assertLenientFromInstant(timestamp.getValue)
       )
     case date: JData.Date =>
       LfValue.ValueDate(Time.Date.assertFromDaysSinceEpoch(date.getValue.toEpochDay.toInt))

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/api/util/util/TimeProvider.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/api/util/util/TimeProvider.scala
@@ -12,7 +12,7 @@ trait TimeProvider { self =>
 
   def getCurrentTime: Instant
 
-  def getCurrentTimestamp: Timestamp = Timestamp.assertFromInstant(getCurrentTime)
+  def getCurrentTimestamp: Timestamp = Timestamp.assertLenientFromInstant(getCurrentTime)
 
   def map(transform: Instant => Instant): TimeProvider = MappedTimeProvider(this, transform)
 }

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/api/util/util/TimestampConversion.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/api/util/util/TimestampConversion.scala
@@ -47,7 +47,7 @@ object TimestampConversion {
 
   def toLf(protoTimestamp: ProtoTimestamp, mode: ConversionMode): LfTimestamp = {
     val instant = roundToMicros(toInstant(protoTimestamp), mode)
-    LfTimestamp.assertFromInstant(instant)
+    LfTimestamp.assertStrictFromInstant(instant)
   }
 
   def fromLf(timestamp: LfTimestamp): ProtoTimestamp = {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/MeteringReportEndpoint.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/MeteringReportEndpoint.scala
@@ -47,7 +47,9 @@ private[http] object MeteringReportEndpoint {
   private val startOfDay = LocalTime.of(0, 0, 0)
 
   private[endpoints] def toTimestamp(ts: LocalDate): Timestamp = {
-    Timestamp.assertFromInstant(Instant.ofEpochSecond(ts.toEpochSecond(startOfDay, ZoneOffset.UTC)))
+    Timestamp.assertStrictFromInstant(
+      Instant.ofEpochSecond(ts.toEpochSecond(startOfDay, ZoneOffset.UTC))
+    )
   }
 
   private[endpoints] def toPbTimestamp(ts: Timestamp): protobuf.timestamp.Timestamp = {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -54,7 +54,7 @@ object JsonProtocol extends JsonProtocolLow {
     taggedJsonFormat
 
   private implicit val TimestampFormat: JsonFormat[Time.Timestamp] =
-    xemapStringJsonFormat(Time.Timestamp.fromString)(_.toString)
+    xemapStringJsonFormat(Time.Timestamp.lenientFromString)(_.toString)
 
   implicit def NonEmptyListFormat[A: JsonReader: JsonWriter]: JsonFormat[NonEmptyList[A]] =
     jsonFormatFromReaderWriter(NonEmptyListReader, NonEmptyListWriter)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/query/ValuePredicate.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/query/ValuePredicate.scala
@@ -373,7 +373,7 @@ object ValuePredicate {
   )(V.ValueDate)
   private[this] val TimestampRangeExpr = RangeExpr(
     { case JsString(q) =>
-      Time.Timestamp.fromString(q).fold(predicateParseError(_), identity)
+      Time.Timestamp.lenientFromString(q).fold(predicateParseError(_), identity)
     },
     { case V.ValueTimestamp(v) => v },
   )(V.ValueTimestamp)

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/endpoints/MeteringReportEndpointTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/endpoints/MeteringReportEndpointTest.scala
@@ -36,7 +36,7 @@ class MeteringReportEndpointTest extends AnyFreeSpec with Matchers {
     }
 
     "should convert to timestamp to protobuf timestamp" in {
-      val expected = Timestamp.assertFromString("2022-02-03T00:00:00Z")
+      val expected = Timestamp.assertStrictFromString("2022-02-03T00:00:00Z")
       val actual = toTimestamp(LocalDate.of(2022, 2, 3))
       actual shouldBe expected
     }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
@@ -341,7 +341,7 @@ class JsonProtocolTest
         domain.ContractTypeId.Template(Option.empty[String], "Mod", "Tmpl"),
         argumentsDecoded,
         DisclosedContract.Metadata(
-          Time.Timestamp.assertFromString("2023-03-21T18:00:33.246813Z"),
+          Time.Timestamp.assertStrictFromString("2023-03-21T18:00:33.246813Z"),
           Some(domain.Base16(ByteString.copyFrom("well hello", utf8))),
           Some(domain.Base64(ByteString.copyFrom("there reader", utf8))),
         ),

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
@@ -140,7 +140,7 @@ class ValuePredicateTest
         true,
       ),
       c("""{"%gte": "1980-01-01T00:00:00Z", "%lt": "2000-01-01T00:00:00Z"}""", VA.timestamp)(
-        Time.Timestamp assertFromString "1986-06-21T00:00:00Z",
+        Time.Timestamp assertStrictFromString "1986-06-21T00:00:00Z",
         true,
       ),
     )

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
@@ -135,7 +135,7 @@ class ApiCodecCompressed(val encodeDecimalAsString: Boolean, val encodeInt64AsSt
       }
       case Model.DamlLfPrimType.Unit => { case JsObject(_) => V.ValueUnit }
       case Model.DamlLfPrimType.Timestamp => { case JsString(v) =>
-        V.ValueTimestamp(assertDE(Time.Timestamp fromString v))
+        V.ValueTimestamp(assertDE(Time.Timestamp lenientFromString v))
       }
       case Model.DamlLfPrimType.Date => { case JsString(v) =>
         try {

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiValueImplicits.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiValueImplicits.scala
@@ -27,9 +27,10 @@ object ApiValueImplicits {
   // Timestamp has microsecond resolution
   implicit final class `ApiTimestamp.type additions`(private val it: V.ValueTimestamp.type)
       extends AnyVal {
-    def fromIso8601(t: String): V.ValueTimestamp = fromInstant(Instant.parse(t))
+    def fromIso8601(t: String): V.ValueTimestamp =
+      fromInstant(Instant.parse(t))
     def fromInstant(t: Instant): V.ValueTimestamp =
-      V.ValueTimestamp(Time.Timestamp.assertFromInstant(t))
+      V.ValueTimestamp(Time.Timestamp.assertLenientFromInstant(t))
     def fromMillis(t: Long): V.ValueTimestamp =
       V.ValueTimestamp(Time.Timestamp.assertFromLong(micros = t * 1000L))
   }

--- a/ledger-service/lf-value-json/src/test/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressedSpec.scala
+++ b/ledger-service/lf-value-json/src/test/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressedSpec.scala
@@ -123,7 +123,7 @@ class ApiCodecCompressedSpec
         fListOfText = Vector("foo", "bar"),
         fListOfUnit = Vector((), ()),
         fDate = Time.Date assertFromString "2019-01-28",
-        fTimestamp = Time.Timestamp assertFromString "2019-01-28T12:44:33.22Z",
+        fTimestamp = Time.Timestamp assertStrictFromString "2019-01-28T12:44:33.22Z",
         fOptionalText = None,
         fOptionalUnit = Some(()),
         fOptOptText = Some(Some("foo")),
@@ -309,7 +309,7 @@ class ApiCodecCompressedSpec
         "\"0.12345123445001\"",
       ),
       c("\"1990-11-09T04:30:23.123456Z\"", VA.timestamp)(
-        Time.Timestamp assertFromString "1990-11-09T04:30:23.123456Z",
+        Time.Timestamp assertStrictFromString "1990-11-09T04:30:23.123456Z",
         "\"1990-11-09T04:30:23.1234569Z\"",
       ),
       c("\"1970-01-01T00:00:00Z\"", VA.timestamp)(Time.Timestamp assertFromLong 0),

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -1136,7 +1136,7 @@ private[lf] class Runner private (
       }
 
       val clientTime: Timestamp =
-        Timestamp.assertFromInstant(Runner.getTimeProvider(timeProviderType).getCurrentTime)
+        Timestamp.assertLenientFromInstant(Runner.getTimeProvider(timeProviderType).getCurrentTime)
       val stateFun = Machine
         .stepToValue(compiledPackages, makeAppD(updateStateLambda, messageVal.value))
         .expect(
@@ -1225,7 +1225,7 @@ private[lf] class Runner private (
     triggerContext.logInfo("Trigger starting")
 
     val clientTime: Timestamp =
-      Timestamp.assertFromInstant(Runner.getTimeProvider(timeProviderType).getCurrentTime)
+      Timestamp.assertLenientFromInstant(Runner.getTimeProvider(timeProviderType).getCurrentTime)
     val hardLimitKillSwitch = KillSwitches.shared("hard-limit")
 
     import UnfoldState.{flatMapConcatNodeOps, toSourceOps}

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/TriggerRuleSimulationLib.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/TriggerRuleSimulationLib.scala
@@ -780,7 +780,7 @@ final class TriggerRuleSimulationLib private[simulation] (
           import GraphDSL.Implicits._
 
           val clientTime: Timestamp =
-            Timestamp.assertFromInstant(
+            Timestamp.assertLenientFromInstant(
               Runner.getTimeProvider(RunnerConfig.DefaultTimeProviderType).getCurrentTime
             )
           val killSwitch = KillSwitches.shared("init-state-simulation")


### PR DESCRIPTION
Between Java 11 and Java 17 there is one bug fix on Instant.parse that expands the range of values that can be parsed into an Instant. See https://bugs.openjdk.org/browse/JDK-8166138

Daml-LF happened to uses Instant.parse to parse a string into a Daml-LF timestamp and we observe a different behavior when running Daml on Java 11 and Java 17

additionally make explicit that conversion form java Instant and string may drop nanoseconds, i.e. we create a lenient version that may drop the significant nanoseconds (legacyor) and a strict version that reject instant/string that cannot be converted without loss of precision.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
