### PR TITLE
[engine] improve speedy record value representation

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -557,7 +557,7 @@ class EngineTest
         speedy.Command.CreateAndExercise(
           templateId = tmplId,
           createArgument =
-            SRecord(tmplId, ImmArray(Ref.Name.assertFromString("name")), ArrayList(SParty(alice))),
+            SRecord(tmplId, ImmArray(Ref.Name.assertFromString("p")), ArrayList(SParty(alice))),
           choiceId = ChoiceName.assertFromString("Exercise"),
           choiceArgument = SUnit,
         )
@@ -635,7 +635,7 @@ class EngineTest
           templateId = templateId,
           key = SRecord(
             BasicTests_WithKey,
-            ImmArray("p", "k"),
+            ImmArray("_1", "_2"),
             ArrayList(SParty(alice), SInt64(43)),
           ),
         )
@@ -682,9 +682,9 @@ class EngineTest
       val cmds = ImmArray(
         speedy.Command.CreateAndExercise(
           templateId = templateId,
-          SRecord(templateId, ImmArray.Empty, ArrayList(SParty(alice))),
+          SRecord(templateId, ImmArray("p"), ArrayList(SParty(alice))),
           "FetchAfterLookup",
-          SRecord(templateId, ImmArray.Empty, ArrayList(SInt64(43))),
+          SRecord(templateId, ImmArray("n"), ArrayList(SInt64(43))),
         )
       )
 
@@ -2052,7 +2052,14 @@ class EngineTest
       cid -> assertAsVersionedContract(
         ContractInstance(
           TypeConName(exceptionsPkgId, "Exceptions:K"),
-          ValueRecord(None, ImmArray((None, ValueParty(party)), (None, ValueInt64(0)))),
+          ValueRecord(
+            None,
+            ImmArray(
+              (None, ValueParty(party)),
+              (None, ValueInt64(666)),
+              (None, ValueText("text666")),
+            ),
+          ),
         )
       )
     )
@@ -2203,7 +2210,14 @@ class EngineTest
       cid -> assertAsVersionedContract(
         ContractInstance(
           TypeConName(exceptionsPkgId, "Exceptions:K"),
-          ValueRecord(None, ImmArray((None, ValueParty(party)), (None, ValueInt64(0)))),
+          ValueRecord(
+            None,
+            ImmArray(
+              (None, ValueParty(party)),
+              (None, ValueInt64(777)),
+              (None, ValueText("text777")),
+            ),
+          ),
         )
       )
     )
@@ -2282,7 +2296,14 @@ class EngineTest
       cid -> assertAsVersionedContract(
         ContractInstance(
           TypeConName(exceptionsPkgId, "Exceptions:K"),
-          ValueRecord(None, ImmArray((None, ValueParty(party)), (None, ValueInt64(0)))),
+          ValueRecord(
+            None,
+            ImmArray(
+              (None, ValueParty(party)),
+              (None, ValueInt64(0)), // matches 0 in the daml code
+              (None, ValueText("text0")),
+            ),
+          ),
         )
       )
     )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PhaseOne.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PhaseOne.scala
@@ -557,7 +557,7 @@ private[lf] final class PhaseOne(
     tapp match {
       case TypeConApp(tycon, _) =>
         if (fields.isEmpty)
-          Return(SEValue(SRecordRep(tycon, ImmArray.Empty, Map())))
+          Return(SEValue(SRecordRep(tycon, ImmArray.Empty, Map.empty)))
         else {
           val exps = fields.toList.map(_._2)
           compileExps(env, exps) { exps =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -83,7 +83,7 @@ private[lf] object SExpr {
       /* special case for nullary record constructors */
       b match {
         case SBRecCon(id, fields) if b.arity == 0 =>
-          SRecordRep(id, fields, Map())
+          SRecordRep(id, fields, Map.empty)
         case _ =>
           SPAP(PBuiltin(b), ArrayList.empty, b.arity)
       }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -83,7 +83,7 @@ private[lf] object SExpr {
       /* special case for nullary record constructors */
       b match {
         case SBRecCon(id, fields) if b.arity == 0 =>
-          SRecord(id, fields, ArrayList.empty)
+          SRecordRep(id, fields, Map())
         case _ =>
           SPAP(PBuiltin(b), ArrayList.empty, b.arity)
       }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -216,12 +216,7 @@ object SValue {
     }
 
     def values: util.ArrayList[SValue] = {
-      val res = new util.ArrayList[SValue]()
-      fields.foreach { case field =>
-        val value = this.lookupField(field)
-        discard[Boolean](res.add(value))
-      }
-      res
+      fields.toList.map(this.lookupField).to(ArrayList)
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -72,12 +72,14 @@ sealed abstract class SValue {
         case SBool(x) => V.ValueBool(x)
         case SUnit => V.ValueUnit
         case SDate(x) => V.ValueDate(x)
-
-        case SRecord(id, fields, svalues) =>
+        case r: SRecord =>
           V.ValueRecord(
-            maybeEraseTypeInfo(id),
-            (fields.toSeq zip svalues.asScala)
-              .map { case (fld, sv) => (maybeEraseTypeInfo(fld), go(sv, nextMaxNesting)) }
+            maybeEraseTypeInfo(r.id),
+            r.fields.toList
+              .map { case field =>
+                val sv = r.lookupField(field)
+                (maybeEraseTypeInfo(field), go(sv, nextMaxNesting))
+              }
               .to(ImmArray),
           )
         case SVariant(id, variant, _, sv) =>
@@ -151,9 +153,77 @@ object SValue {
       s"SPAP($prim, ${actuals.asScala.mkString("[", ",", "]")}, $arity)"
   }
 
+  /** We split SRecord (interface) from SRecordRep (implementation/representation)
+    *
+    * The interface supports creation from separate arrays of fields and values
+    * This is used throughout test code.
+    *
+    * The interface also supports (via unapply) the (legacy) reverse deconstruction.
+    * This is used by daml-script.
+    *
+    * The implementation/representation is via a scala Map.
+    * This representation is simple to manipulate (lookupField/updateField).
+    *
+    * This representation makes illegal cases unrepresentable -- i.e.
+    * - mismatched counts of fields/values
+    * - repeated field names
+    * And prevent brittle access to element values via indexing.
+    *
+    * Also note updateField has logarithmic complexity (where N is the number of fields)
+    * rather than the linear complexity that an array of element values would entail.
+    *
+    * The representation also includes an ordered field list.
+    * This is needed to support the legacy interface used by daml-script.
+    * And is also used when we convert the svalue back to a normalised LF value.
+    */
+
+  sealed abstract class SRecord extends SValue {
+    def id: Identifier
+    def fields: ImmArray[Name]
+    def values: util.ArrayList[SValue]
+    def lookupField(field: Name): SValue
+    def updateField(field: Name, value: SValue): SRecord
+  }
+
+  object SRecord {
+    def apply(id: Identifier, fields: ImmArray[Name], values: util.ArrayList[SValue]): SRecord = {
+      assert(fields.length == values.size)
+      val zipped = (fields.toSeq zip values.asScala).toList.reverse
+      SRecordRep(id, fields, zipped.toMap)
+    }
+    def unapply(x: SRecord): Option[(Identifier, ImmArray[Name], util.ArrayList[SValue])] = {
+      Some((x.id, x.fields, x.values))
+    }
+  }
+
   @SuppressWarnings(Array("org.wartremover.warts.ArrayEquals"))
-  final case class SRecord(id: Identifier, fields: ImmArray[Name], values: util.ArrayList[SValue])
-      extends SValue
+  final case class SRecordRep(id: Identifier, fields: ImmArray[Name], dict: Map[Name, SValue])
+      extends SRecord {
+
+    def lookupField(field: Name): SValue = {
+      dict.get(field) match {
+        case Some(v) => v
+        case None =>
+          throw SError.SErrorCrash(
+            NameOf.qualifiedNameOfCurrentFunc,
+            s"SRecord.lookupField($field) : no such field, have:[$fields]",
+          )
+      }
+    }
+
+    def updateField(field: Name, value: SValue): SRecord = {
+      this.copy(dict = dict + (field -> value))
+    }
+
+    def values: util.ArrayList[SValue] = {
+      val res = new util.ArrayList[SValue]()
+      fields.foreach { case field =>
+        val value = this.lookupField(field)
+        discard[Boolean](res.add(value))
+      }
+      res
+    }
+  }
 
   @SuppressWarnings(Array("org.wartremover.warts.ArrayEquals"))
   // values must be ordered according fieldNames
@@ -298,12 +368,6 @@ object SValue {
       )
       SAny(ValueArithmeticError.typ, SRecord(ValueArithmeticError.tyCon, fields, array))
     }
-    // Assumes excep is properly typed
-    def unapply(excep: SAny): Option[SValue] =
-      excep match {
-        case SAnyException(SRecord(ValueArithmeticError.tyCon, _, args)) => Some(args.get(0))
-        case _ => None
-      }
   }
 
   // NOTE(JM): We are redefining PrimLit here so it can be unified

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -1098,7 +1098,7 @@ private[lf] object Speedy {
           case TTyCon(tyCon) =>
             value match {
               case V.ValueRecord(_, fields) =>
-                val lookupResult =
+                val lookupResult = // TODO: may fail for upgrade/downgrade
                   assertRight(compiledPackages.pkgInterface.lookupDataRecord(tyCon))
                 lazy val subst = lookupResult.subst(argTypes)
                 val values = (lookupResult.dataRecord.fields.iterator zip fields.iterator)
@@ -1504,7 +1504,7 @@ private[lf] object Speedy {
         }
       case SValue.SContractId(_) | SValue.SDate(_) | SValue.SNumeric(_) | SValue.SInt64(_) |
           SValue.SParty(_) | SValue.SText(_) | SValue.STimestamp(_) | SValue.SStruct(_, _) |
-          SValue.SMap(_, _) | SValue.SRecord(_, _, _) | SValue.SAny(_, _) | SValue.STypeRep(_) |
+          SValue.SMap(_, _) | _: SValue.SRecordRep | SValue.SAny(_, _) | SValue.STypeRep(_) |
           SValue.SBigNumeric(_) | _: SValue.SPAP | SValue.SToken =>
         throw SErrorCrash(NameOf.qualifiedNameOfCurrentFunc, "Match on non-matchable value")
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
@@ -40,7 +40,7 @@ private[speedy] object SExprIterable {
       iterator(prim) ++ actuals.asScala.iterator.flatMap(iterator(_))
     case _: SValue.SPrimLit | SValue.STypeRep(_) | SValue.SToken | SValue.SAny(_, _) |
         SValue.SEnum(_, _, _) | SValue.SMap(_, _) | SValue.SList(_) | SValue.SOptional(_) |
-        SValue.SRecord(_, _, _) | SValue.SStruct(_, _) | SValue.SVariant(_, _, _, _) =>
+        _: SValue.SRecordRep | SValue.SStruct(_, _) | SValue.SVariant(_, _, _, _) =>
       SValueIterable.iterator(v).flatMap(iterator(_))
   }
   private[this] def iterator(v: SValue.Prim): Iterator[SExpr] = v match {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SValueIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SValueIterable.scala
@@ -12,7 +12,7 @@ private[speedy] object SValueIterable {
   that =>
   private[iterable] def iterator(v: SValue): Iterator[SValue] = v match {
     case SValue.SPAP(prim, actuals, _) => iterator(prim) ++ actuals.asScala.iterator
-    case SValue.SRecord(_, _, values) => values.asScala.iterator
+    case SValue.SRecordRep(_, _, dict) => dict.iterator.flatMap({ case (_, v) => Iterator(v) })
     case SValue.SStruct(_, values) => values.asScala.iterator
     case SValue.SVariant(_, _, _, value) => Iterator(value)
     case SValue.SEnum(_, _, _) => Iterator.empty

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala
@@ -1869,7 +1869,7 @@ class EvaluationOrderTest extends AnyFreeSpec with Matchers with Inside {
             val (res, msgs) = evalUpdateApp(
               pkgs,
               e"""\(exercisingParty : Party) ->
-             ubind cId: ContractId M:Human <- create @M:Human M:Human {person = exercisingParty, ob = exercisingParty, ctrl = exercisingParty, precond = True, key = M:toKey exercisingParty, nested = M:buildNested 0} in
+             ubind cId: ContractId M:Human <- create @M:Human M:Human {person = exercisingParty, obs = exercisingParty, ctrl = exercisingParty, precond = True, key = M:toKey exercisingParty, nested = M:buildNested 0} in
              Test:$testCase exercisingParty cId
              """,
               Array(SParty(alice)),
@@ -1893,7 +1893,7 @@ class EvaluationOrderTest extends AnyFreeSpec with Matchers with Inside {
             val (res, msgs) = evalUpdateApp(
               pkgs,
               e"""\(exercisingParty : Party) ->
-             ubind cId: ContractId M:Human <- create @M:Human M:Human {person = exercisingParty, ob = exercisingParty, ctrl = exercisingParty, precond = True, key = M:toKey exercisingParty, nested = M:buildNested 0} in
+             ubind cId: ContractId M:Human <- create @M:Human M:Human {person = exercisingParty, obs = exercisingParty, ctrl = exercisingParty, precond = True, key = M:toKey exercisingParty, nested = M:buildNested 0} in
              ubind x: Unit <- exercise @M:Human Archive cId ()
              in
              Test:$testCase exercisingParty cId
@@ -1955,7 +1955,7 @@ class EvaluationOrderTest extends AnyFreeSpec with Matchers with Inside {
             val (res, msgs) = evalUpdateApp(
               pkgs,
               e"""\(exercisingParty : Party) (other : Party)->
-                  ubind cId: ContractId M:Human <- create @M:Human M:Human {person = exercisingParty, ob = other, ctrl = other, precond = True, key = M:toKey exercisingParty, nested = M:buildNested 0} in
+                  ubind cId: ContractId M:Human <- create @M:Human M:Human {person = exercisingParty, obs = other, ctrl = other, precond = True, key = M:toKey exercisingParty, nested = M:buildNested 0} in
                     Test:$testCase exercisingParty cId
                   """,
               Array(SParty(alice), SParty(bob)),

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -290,7 +290,7 @@ class SpeedyTest extends AnyWordSpec with Matchers with Inside {
             SELet1General(
               SEVal(LfDefRef(qualify("M:origin"))),
               SEAppAtomicSaturatedBuiltin(
-                SBRecUpd(qualify("M:Point"), 0),
+                SBRecUpd(qualify("M:Point"), Name.assertFromString("x")),
                 Array(SELocS(1), SEValue(SInt64(1))),
               ),
             )
@@ -318,7 +318,10 @@ class SpeedyTest extends AnyWordSpec with Matchers with Inside {
             SELet1General(
               SEVal(LfDefRef(qualify("M:origin"))),
               SEAppAtomicSaturatedBuiltin(
-                SBRecUpdMulti(qualify("M:Point"), ImmArray(0, 1)),
+                SBRecUpdMulti(
+                  qualify("M:Point"),
+                  List(Name.assertFromString("x"), Name.assertFromString("y")),
+                ),
                 Array(
                   SELocS(1),
                   SEValue(SInt64(1)),
@@ -359,7 +362,10 @@ class SpeedyTest extends AnyWordSpec with Matchers with Inside {
               SELocation(
                 mkLocation(0),
                 SEAppAtomicSaturatedBuiltin(
-                  SBRecUpdMulti(qualify("M:Point"), ImmArray(0, 1)),
+                  SBRecUpdMulti(
+                    qualify("M:Point"),
+                    List(Name.assertFromString("x"), Name.assertFromString("y")),
+                  ),
                   Array(
                     SELocS(1),
                     SEValue(SInt64(3)),
@@ -398,7 +404,10 @@ class SpeedyTest extends AnyWordSpec with Matchers with Inside {
                     SELet1General(
                       SEAppAtomicGeneral(SELocS(1), Array(SEValue(SInt64(4)))),
                       SEAppAtomicSaturatedBuiltin(
-                        SBRecUpdMulti(qualify("M:Point"), ImmArray(0, 1)),
+                        SBRecUpdMulti(
+                          qualify("M:Point"),
+                          List(Name.assertFromString("x"), Name.assertFromString("y")),
+                        ),
                         Array(
                           SELocS(5),
                           SELocS(3),
@@ -432,7 +441,14 @@ class SpeedyTest extends AnyWordSpec with Matchers with Inside {
             SELet1General(
               SEVal(LfDefRef(qualify("M:origin"))),
               SEAppAtomicSaturatedBuiltin(
-                SBRecUpdMulti(qualify("M:Point"), ImmArray(0, 1, 0)),
+                SBRecUpdMulti(
+                  qualify("M:Point"),
+                  List(
+                    Name.assertFromString("x"),
+                    Name.assertFromString("y"),
+                    Name.assertFromString("x"),
+                  ),
+                ),
                 Array(
                   SELocS(1),
                   SEValue(SInt64(1)),

--- a/daml-script/converter/src/main/scala/Converter.scala
+++ b/daml-script/converter/src/main/scala/Converter.scala
@@ -32,7 +32,7 @@ private[daml] object Converter {
     val fieldNames = fields.view.map { case (n, _) => Name.assertFromString(n) }.to(ImmArray)
     val args =
       new util.ArrayList[SValue](fields.map({ case (_, v) => v }).asJava)
-    SRecord(ty, fieldNames, args)
+    SRecord(ty, fieldNames, args) // TODO: construct SRecord directly from Map
   }
 
   /** Unpack one step of a Pure/Roll-style free monad representation,
@@ -61,8 +61,8 @@ private[daml] object Converter {
 
   object DamlAnyModuleRecord {
     def unapplySeq(v: SRecord): Some[(String, collection.Seq[SValue])] = {
-      val SRecord(Identifier(_, QualifiedName(_, name)), _, values) = v
-      Some((name.dottedName, values.asScala))
+      val Identifier(_, QualifiedName(_, name)) = v.id
+      Some((name.dottedName, v.values.asScala))
     }
   }
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -405,7 +405,7 @@ trait ConverterMethods {
     Right(
       record(
         scriptIds.damlScript("User"),
-        ("id", fromUserId(scriptIds, user.id)),
+        ("userId", fromUserId(scriptIds, user.id)),
         ("primaryParty", SOptional(user.primaryParty.map(SParty(_)))),
       )
     )
@@ -413,7 +413,7 @@ trait ConverterMethods {
   def fromUserId(scriptIds: ScriptIds, userId: UserId): SValue =
     record(
       scriptIds.damlScript("UserId"),
-      ("userName", SText(userId)),
+      ("unpack", SText(userId)),
     )
 
   def toUser(v: SValue): Either[String, User] =

--- a/security-evidence.md
+++ b/security-evidence.md
@@ -149,7 +149,7 @@
 - Evaluation order of successful lookup_by_key of a local contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3020)
 - Evaluation order of successful lookup_by_key of a non-cached global contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L2865)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L26)
-- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2152)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2159)
 - This checks that type checking in exercise_interface is done after checking activeness.: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L1933)
 - This checks that type checking is done after checking activeness.: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L1823)
 - This checks that type checking is done after checking activeness.: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L2809)

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/PrettyPrint.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/PrettyPrint.scala
@@ -112,10 +112,10 @@ object PrettyPrint {
     case SValue.SPAP(_, _, _) =>
       text("...")
 
-    case SValue.SRecord(id, fields, values) =>
-      Pretty.prettyIdentifier(id) + char('{') & fill(
+    case r: SValue.SRecord =>
+      Pretty.prettyIdentifier(r.id) + char('{') & fill(
         text(", "),
-        fields.toSeq.zip(values.asScala).map { case (k, v) =>
+        r.fields.toSeq.zip(r.values.asScala).map { case (k, v) =>
           text(k) & char('=') & prettySValue(v)
         },
       ) & char('}')


### PR DESCRIPTION
Improve the representation for speedy record values. to use a Map.

The previous representation maintained separate arrays for field-names and element-values. That representation looses the link between field names and values; supports/encourages brittle access via indexing, and does not ensure the invariants we would like, allowing representation of illegal values, such as: (1) mismatched counts of fields/values, (2) repeated field names.

Changing to the improved representation uncovered a few bug-lets in engine testing code and daml-script, where we indeed had some cases of (a) mismatched counts of fields/values, and (b) use of incorrect field names.

This work is preparation for new support for up/down-grading, which will requiring manipulation of the record-values which represent the contract instances being up/down-graded.
