### PR TITLE
Fix TLS and other settings not being applied when using --all

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptConfig.scala
@@ -81,6 +81,9 @@ case class ScriptConfig(
               participantMode = participantMode,
               timeMode = resolvedTimeMode,
               maxInboundMessageSize = maxInboundMessageSize,
+              accessTokenFile = accessTokenFile,
+              tlsConfig = tlsConfig,
+              applicationId = applicationId,
             )
           )
       }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestConfig.scala
@@ -3,7 +3,11 @@
 
 package com.daml.lf.engine.script
 
+import java.nio.file.Path
 import java.io.File
+
+import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
+import com.daml.ledger.api.tls.TlsConfiguration
 
 import com.daml.lf.engine.script.ScriptTimeMode
 
@@ -12,4 +16,7 @@ case class TestConfig(
     participantMode: ParticipantMode,
     timeMode: ScriptTimeMode,
     maxInboundMessageSize: Int,
+    accessTokenFile: Option[Path],
+    tlsConfig: TlsConfiguration,
+    applicationId: Option[ApplicationId],
 )


### PR DESCRIPTION
Resolves #17058

Future note, we should _really_ unify the `TestConfig` and `ScriptConfig`, alongside their respective runners at some point. They perform almost exactly the same action.