### PR TITLE
Clean up dead trackers on attempted reuse

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/QueueBackedTracker.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/QueueBackedTracker.scala
@@ -99,6 +99,8 @@ private[services] final class QueueBackedTracker(
       ()
     }
   }
+
+  override def isCompleted: Boolean = done.isCompleted
 }
 
 private[services] object QueueBackedTracker {

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/Tracker.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/Tracker.scala
@@ -21,4 +21,6 @@ trait Tracker extends AutoCloseable {
       loggingContext: LoggingContext,
   ): Future[Either[TrackedCompletionFailure, CompletionSuccess]]
 
+  def isCompleted: Boolean
+
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerMap.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerMap.scala
@@ -115,6 +115,12 @@ private[services] final class TrackerMap[Key](
     trackerBySubmitter.foreach { case (submitter, trackerResource) =>
       trackerResource.currentState match {
         case Waiting => // there is nothing to clean up
+        case Ready(tracker) if tracker.isCompleted =>
+          logger.info(
+            s"Removing completed tracker for $submitter"
+          )(trackerResource.loggingContext)
+          tracker.close()
+          trackerBySubmitter -= submitter
         case Ready(tracker) =>
           // close and forget expired trackers
           if (currentTime - tracker.getLastSubmission > retentionNanos) {

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerMapSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerMapSpec.scala
@@ -210,6 +210,7 @@ class TrackerMapSpec extends AsyncWordSpec with Matchers {
                 closedTrackerCount.incrementAndGet()
                 ()
               }
+              override def isCompleted: Boolean = false
             }
           },
       )
@@ -260,6 +261,7 @@ class TrackerMapSpec extends AsyncWordSpec with Matchers {
                 closedTracker.set(true)
                 ()
               }
+              override def isCompleted: Boolean = false
             }
           },
       )
@@ -297,5 +299,6 @@ object TrackerMapSpec {
       )
 
     override def close(): Unit = ()
+    override def isCompleted: Boolean = false
   }
 }


### PR DESCRIPTION
Previously dead trackers were only removed on periodic clean-up. Now they are also removed on attempted reuse. Following lines are testament to that:

```
2023-06-28 21:45:35,910 [⋮] INFO  c.d.c.p.a.s.tracking.TrackerMap - Removing completed tracker for Key(RWManyNonConsumingChoicesViaCommand,Set(RWManyNonConsumingChoicesViaCommand-alpha-2bc672af04b50-party-0::12205df7b4d68a4c054f1ecacab6c83a36340fc8eec4348ddbbfe174797feb9a4c11)), context: {participant: "participant1"}
2023-06-28 21:45:35,911 [⋮] INFO  c.d.c.p.a.s.t.QueueBackedTracker - Tracker already complete, context: {participant: "participant1"}
2023-06-28 21:45:35,911 [⋮] INFO  c.d.c.p.a.s.tracking.TrackerMap - Removing completed tracker for Key(RWManyNonConsumingChoicesViaCommand,Set(RWManyNonConsumingChoicesViaCommand-alpha-2bc672af04b50-party-1::12205df7b4d68a4c054f1ecacab6c83a36340fc8eec4348ddbbfe174797feb9a4c11)), context: {participant: "participant1"}
2023-06-28 21:45:35,911 [⋮] INFO  c.d.c.p.a.s.t.QueueBackedTracker - Tracker already complete, context: {participant: "participant1"}
2023-06-28 21:45:35,911 [⋮] INFO  c.d.c.p.a.s.tracking.TrackerMap - Removing completed tracker for Key(RWManyNonConsumingChoicesViaCommand,Set(RWManyNonConsumingChoicesViaCommand-alpha-2bc672af04b50-party-2::12205df7b4d68a4c054f1ecacab6c83a36340fc8eec4348ddbbfe174797feb9a4c11)), context: {participant: "participant1"}
2023-06-28 21:45:35,911 [⋮] INFO  c.d.c.p.a.s.t.QueueBackedTracker - Tracker already complete, context: {participant: "participant1"}
2023-06-28 21:45:35,912 [⋮] INFO  c.d.c.p.a.s.tracking.TrackerMap - Registered a tracker for submitter Key(RWManyNonConsumingChoicesViaCommand,Set(RWManyNonConsumingChoicesViaCommand-alpha-2bc672af04b50-party-2::12205df7b4d68a4c054f1ecacab6c83a36340fc8eec4348ddbbfe174797feb9a4c11))., context: {participant: "participant1"}
2023-06-28 21:45:35,912 [⋮] INFO  c.d.c.p.a.s.tracking.TrackerMap - Registered a tracker for submitter Key(RWManyNonConsumingChoicesViaCommand,Set(RWManyNonConsumingChoicesViaCommand-alpha-2bc672af04b50-party-1::12205df7b4d68a4c054f1ecacab6c83a36340fc8eec4348ddbbfe174797feb9a4c11))., context: {participant: "participant1"}
2023-06-28 21:45:35,912 [⋮] INFO  c.d.c.p.a.s.tracking.TrackerMap - Registered a tracker for submitter Key(RWManyNonConsumingChoicesViaCommand,Set(RWManyNonConsumingChoicesViaCommand-alpha-2bc672af04b50-party-0::12205df7b4d68a4c054f1ecacab6c83a36340fc8eec4348ddbbfe174797feb9a4c11))., context: {participant: "participant1"}
```
