### PR TITLE
Wrote TXEventsByContractKeyDecimalNonNormalized

### DIFF
--- a/test-common/src/main/daml/model/Test.daml
+++ b/test-common/src/main/daml/model/Test.daml
@@ -334,6 +334,16 @@ template TextKey
       controller tkParty
       do create this with tkDisclosedTo = tkNewDisclosedTo
 
+type Amount = Numeric 6
+
+template KeyedByDecimal with
+    party: Party
+    amount: Amount
+  where
+    signatory party
+    key (party, amount): (Party, Amount)
+    maintainer key._1
+
 template TextKeyOperations
   with
     tkoParty: Party


### PR DESCRIPTION
Highlight of a shortcoming in the EvenQueryService/GetEventsByContractKey where usage of a key with non-normalized Numeric value fails in retrieving events. Not sure about the urgency of fixing this, although the UX would be better if addressed

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
