### PR TITLE
[engine] fix cantonJar given devMode

### DIFF
--- a/canton/it-lib/src/main/com/daml/CantonFixture.scala
+++ b/canton/it-lib/src/main/com/daml/CantonFixture.scala
@@ -60,7 +60,7 @@ trait CantonFixtureWithResource[A]
   protected lazy val enableDisclosedContracts: Boolean = false
   protected lazy val applicationId: ApplicationId = ApplicationId(getClass.getName)
   protected lazy val cantonJar: Path =
-    if (devMode) CantonRunner.cantonPath else CantonRunner.cantonPatchPath
+    if (devMode) CantonRunner.cantonPatchPath else CantonRunner.cantonPath
 
   // This flag setup some behavior to ease debugging tests.
   //  If `true`


### PR DESCRIPTION
Fix bug in the setting of `cantonJar` given `devMode`. This bug appears to have been introduced when the line was moved from `CantonRunner` to `CantonFixure` by: https://github.com/digital-asset/daml/pull/17034
