### PR TITLE
ci: compress Bazel logs

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -45,6 +45,13 @@ steps:
       platform: '${{parameters.name}}'
       is_release: '${{parameters.is_release}}'
 
+  - bash: |
+      set -euo pipefail
+      cd '$(Build.StagingDirectory)/logs'
+      gzip -9 *
+
+    displayName: compress logs
+
   - task: PublishBuildArtifacts@1
     condition: succeededOrFailed()
     continueOnError: true

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -178,6 +178,10 @@ jobs:
         is_release: variables.is_release
         is_split_release: $(is_split_release)
     - template: upload-bazel-metrics.yml
+    - bash: |
+        set -euo pipefail
+        cd '$(Build.StagingDirectory)/logs'
+        gzip -9 *
     - task: PublishBuildArtifacts@1
       condition: succeededOrFailed()
       inputs:


### PR DESCRIPTION
We routinely have upwards of 3GB of logs. They are very rarely downloaded, most people don't even know they're there. Uploading 3GB takes time. This should make it faster, hopefully.