### PR TITLE
ci: run fewer things on m1

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -40,10 +40,12 @@ steps:
       ARTIFACTORY_USERNAME: $(ARTIFACTORY_USERNAME)
       ARTIFACTORY_PASSWORD: $(ARTIFACTORY_PASSWORD)
 
-  - template: publish-platform-independence-dar.yml
-    parameters:
-      platform: '${{parameters.name}}'
-      is_release: '${{parameters.is_release}}'
+  # Do not publish dar from m1
+  - ${{ if ne(parameters.name, 'm1') }}:
+    - template: publish-platform-independence-dar.yml
+      parameters:
+        platform: '${{parameters.name}}'
+        is_release: '${{parameters.is_release}}'
 
   - task: PublishBuildArtifacts@1
     condition: succeededOrFailed()
@@ -88,6 +90,9 @@ steps:
     env:
       DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
     name: publish
+    condition: and(succeeded(),
+                   eq(${{parameters.is_release}}, 'true'),
+                   eq(variables['Build.SourceBranchName'], 'main'))
   - task: PublishPipelineArtifact@0
     inputs:
       targetPath: $(Build.StagingDirectory)/release

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -79,7 +79,7 @@ jobs:
     - name: is_release
       value: $[ dependencies.check_for_release.outputs['out.is_release'] ]
     - template: job-variables.yml
-  timeoutInMinutes: 360
+  timeoutInMinutes: 180
   pool:
     name: 'ubuntu_20_04'
     demands: assignment -equals default
@@ -141,7 +141,7 @@ jobs:
       value: $[ and(eq(variables.is_release, 'true'),
                        eq(variables['Build.SourceBranchName'], 'main')) ]
     - template: job-variables.yml
-  timeoutInMinutes: 360
+  timeoutInMinutes: 180
   pool:
     name: 'windows-pool'
     demands: assignment -equals default
@@ -191,7 +191,7 @@ jobs:
 - job: Linux_oracle
   dependsOn:
   - build_canton
-  timeoutInMinutes: 360
+  timeoutInMinutes: 180
   pool:
     name: 'ubuntu_20_04'
     demands: assignment -equals default
@@ -336,7 +336,7 @@ jobs:
     - check_for_release
   condition: and(succeeded(),
                  not(eq(dependencies.check_for_release.outputs['out.is_release'], 'true')))
-  timeoutInMinutes: 360
+  timeoutInMinutes: 180
   pool:
     name: ubuntu_20_04
     demands: assignment -equals default
@@ -353,7 +353,7 @@ jobs:
     - check_for_release
     - compatibility_ts_libs
     - build_canton
-  timeoutInMinutes: 360
+  timeoutInMinutes: 180
   pool:
     name: ubuntu_20_04
     demands: assignment -equals default

--- a/ci/macOS.yml
+++ b/ci/macOS.yml
@@ -11,7 +11,7 @@ jobs:
   dependsOn:
     - check_for_release
     - build_canton
-  timeoutInMinutes: 360
+  timeoutInMinutes: 180
   pool:
     name: macOS-pool
     demands: assignment -equals ${{parameters.assignment}}
@@ -28,7 +28,9 @@ jobs:
       value: $[ dependencies.check_for_release.outputs['out.is_release'] ]
     - template: job-variables.yml
   steps:
-    - template: report-start.yml
+    # Do not record start/end times for m1
+    - ${{ if eq(parameters.name, 'macos') }}:
+      - template: report-start.yml
     - template: clear-shared-segments-macos.yml
     - checkout: self
     - bash: |
@@ -38,13 +40,19 @@ jobs:
       condition: and(succeeded(), eq(variables.is_release, 'true'))
     - template: get-local-canton.yml
     - template: clean-up.yml
-    - template: build-unix.yml
-      parameters:
-        release_tag: $(release_tag)
-        name: ${{parameters.name}}
-        is_release: variables.is_release
-    - template: upload-bazel-metrics.yml
+    # Do not build m1 on releases
+    - ${{ if or(eq(parameters.name, 'macos'), eq(variables.is_release, 'false')) }}:
+      - template: build-unix.yml
+        parameters:
+          release_tag: $(release_tag)
+          name: ${{parameters.name}}
+          is_release: variables.is_release
+    # Do not upload metrics for m1
+    - ${{ if eq(parameters.name, 'macos') }}:
+      - template: upload-bazel-metrics.yml
     - template: tell-slack-failed.yml
       parameters:
         trigger_sha: '$(trigger_sha)'
-    - template: report-end.yml
+    # Do not record start/end times for m1
+    - ${{ if eq(parameters.name, 'macos') }}:
+      - template: report-end.yml


### PR DESCRIPTION
This was spurred by the fact that the "report_end" task sometimes fails on m1 with the "install Bash lib" step just never finishing (and the whole job then times out after 6h).

Hopefully by running fewer things we get fewer chances of these kinds of weird issues.

Note that it's unclear if anything actually crashes on the m1 machines or if this is a loss of connection between Azure Pipelines and the machine. From what I've seen as soon as that job times out the machine is able to successfully pick up other jobs. Speaking of, I've also reduced the 6h timeouts to a more reasonable 3h.