### PR TITLE
include the concrete ContractId type in Java codegen `create`'s type

### DIFF
--- a/language-support/java/codegen/src/it/java/com/daml/TemplateMethodTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/TemplateMethodTest.java
@@ -6,6 +6,8 @@ package com.daml;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.daml.ledger.javaapi.data.*;
+import com.daml.ledger.javaapi.data.codegen.Created;
+import com.daml.ledger.javaapi.data.codegen.Update;
 import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -26,8 +28,8 @@ public class TemplateMethodTest {
 
   @Test
   void templateHasCreateMethods() {
-    var fromStatic = SimpleTemplate.create("Bob");
-    var fromInstance = new SimpleTemplate("Bob").create();
+    Update<Created<SimpleTemplate.ContractId>> fromStatic = SimpleTemplate.create("Bob");
+    Update<Created<SimpleTemplate.ContractId>> fromInstance = new SimpleTemplate("Bob").create();
 
     assertEquals(
         1, fromStatic.commands().size(), "There are not exactly one command from static method");

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -8,7 +8,7 @@ import ClassGenUtils.{companionFieldName, templateIdFieldName, generateGetCompan
 import com.daml.lf.codegen.TypeWithContext
 import com.daml.lf.data.Ref
 import Ref.{ChoiceName, PackageId, QualifiedName}
-import com.daml.ledger.javaapi.data.codegen.{Choice, ContractId, Created, Exercised, Update}
+import com.daml.ledger.javaapi.data.codegen.{Choice, Created, Exercised, Update}
 import com.daml.lf.codegen.backend.java.inner.ToValueGenerator.generateToValueConverter
 import com.daml.lf.typesig
 import typesig._
@@ -108,7 +108,6 @@ private[inner] object TemplateClass extends StrictLogging {
       templateType.build()
     }
 
-  private val ctIdClassName = ClassName get classOf[ContractId[_]]
   private val updateClassName = ClassName get classOf[Update[_]]
   private val createUpdateClassName = ClassName get classOf[Update.CreateUpdate[_, _]]
   private val createdClassName = ClassName get classOf[Created[_]]
@@ -116,29 +115,24 @@ private[inner] object TemplateClass extends StrictLogging {
   private def parameterizedTypeName(raw: ClassName, arg: TypeName*) =
     ParameterizedTypeName.get(raw, arg: _*)
 
-  private def generateCreateMethod(name: ClassName): MethodSpec =
+  private def generateCreateMethod(name: ClassName): MethodSpec = {
+    val createdType = parameterizedTypeName(createdClassName, name nestedClass "ContractId")
     MethodSpec
       .methodBuilder("create")
       .addModifiers(Modifier.PUBLIC)
       .addAnnotation(classOf[Override])
       .returns(
-        parameterizedTypeName(
-          updateClassName,
-          parameterizedTypeName(createdClassName, parameterizedTypeName(ctIdClassName, name)),
-        )
+        parameterizedTypeName(updateClassName, createdType)
       )
       .addStatement(
         "return new $T(new $T($T.$N, this.toValue()), x -> x, ContractId::new)",
-        parameterizedTypeName(
-          createUpdateClassName,
-          parameterizedTypeName(ctIdClassName, name),
-          parameterizedTypeName(createdClassName, parameterizedTypeName(ctIdClassName, name)),
-        ),
+        parameterizedTypeName(createUpdateClassName, name nestedClass "ContractId", createdType),
         classOf[javaapi.data.CreateCommand],
         name,
         templateIdFieldName,
       )
       .build()
+  }
 
   private def generateStaticCreateMethod(fields: Fields, name: ClassName): MethodSpec =
     fields
@@ -149,7 +143,7 @@ private[inner] object TemplateClass extends StrictLogging {
           .returns(
             parameterizedTypeName(
               updateClassName,
-              parameterizedTypeName(createdClassName, parameterizedTypeName(ctIdClassName, name)),
+              parameterizedTypeName(createdClassName, name nestedClass "ContractId"),
             )
           )
       ) { case (b, FieldInfo(_, _, escapedName, tpe)) =>


### PR DESCRIPTION
Fixes #15602. The test change illustrates type annotations that would not compile prior to this change:

https://github.com/digital-asset/daml/blob/8158962392af6bdf3b22e6f23050351edbb26dcd/language-support/java/codegen/src/it/java/com/daml/TemplateMethodTest.java#L31-L32