### PR TITLE
ci: compress results on failure

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -58,9 +58,13 @@ steps:
   - bash: |
       set -euo pipefail
       cd '$(Build.StagingDirectory)/logs'
-      gzip -9 *
+      find . -type f | xargs gzip -9
+      cd -
+      cd bazel-testlogs
+      find . -type f | xargs gzip -9
 
     displayName: compress logs
+    condition: succeededOrFailed()
 
   - task: PublishBuildArtifacts@1
     condition: succeededOrFailed()

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -40,6 +40,17 @@ steps:
       platform: 'windows'
       is_release: '${{parameters.is_release}}'
 
+  - bash: |
+      set -euo pipefail
+      cd '$(Build.StagingDirectory)/logs'
+      find . -type f | xargs gzip -9
+      cd -
+      cd bazel-testlogs
+      find . -type f | xargs gzip -9
+
+    displayName: compress logs
+    condition: succeededOrFailed()
+
   - task: PublishBuildArtifacts@1
     condition: failed()
     displayName: 'Publish the bazel test logs'


### PR DESCRIPTION
Right now logs only get compressed on successful runs, which is not necessarily when they are smallest.