### PR TITLE
[engine] Restore array based representation for speedy record values

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -562,7 +562,7 @@ private[lf] object Pretty {
               text("$update")
             case _: SBRecUpdMulti =>
               text("$updateMulti")
-            case SBRecProj(id, field) =>
+            case SBRecProj(id, _, field) =>
               text("$project") + char('[') + text(id.qualifiedName.toString) + char(':') + str(
                 field
               ) + char(']')

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -790,37 +790,37 @@ private[lf] object SBuiltin {
   }
 
   /** $rupd[R, field] :: R -> a -> R */
-  final case class SBRecUpd(id: Identifier, field: Name) extends SBuiltinPure(2) {
+  final case class SBRecUpd(id: Identifier, field: Name, fieldNum: Int) extends SBuiltinPure(2) {
     override private[speedy] def executePure(args: util.ArrayList[SValue]): SRecord = {
       val record = getSRecord(args, 0)
       if (record.id != id) {
         crash(s"type mismatch on record update: expected $id, got record of type ${record.id}")
       }
       val value = args.get(1)
-      record.updateField(field, value)
+      record.updateField(fieldNum, field, value)
     }
   }
 
   /** $rupdmulti[R, [field_1, ..., field_n]] :: R -> a_1 -> ... -> a_n -> R */
-  final case class SBRecUpdMulti(id: Identifier, fields: List[Name])
+  final case class SBRecUpdMulti(id: Identifier, fields: List[(Name, Int)])
       extends SBuiltinPure(1 + fields.length) {
     override private[speedy] def executePure(args: util.ArrayList[SValue]): SRecord = {
       val record = getSRecord(args, 0)
       if (record.id != id) {
         crash(s"type mismatch on record update: expected $id, got record of type ${record.id}")
       }
-      fields.zipWithIndex.foldLeft(record) { case (r, (field, i)) =>
+      fields.zipWithIndex.foldLeft(record) { case (r, ((field, fieldNum), i)) =>
         val value = args.get(i + 1)
-        r.updateField(field, value)
+        r.updateField(fieldNum, field, value)
       }
     }
   }
 
   /** $rproj[R, field] :: R -> a */
-  final case class SBRecProj(id: Identifier, field: Name) extends SBuiltinPure(1) {
+  final case class SBRecProj(id: Identifier, field: Name, fieldNum: Int) extends SBuiltinPure(1) {
     override private[speedy] def executePure(args: util.ArrayList[SValue]): SValue = {
       val record: SRecord = getSRecord(args, 0)
-      record.lookupField(field)
+      record.lookupField(fieldNum, field)
     }
   }
 
@@ -1818,7 +1818,7 @@ private[lf] object SBuiltin {
       val exception = getSAnyException(args, 0)
       exception.id match {
         case ValueArithmeticError.tyCon =>
-          Control.Value(exception.lookupField(field))
+          Control.Value(exception.lookupField(fieldNum = 0, field))
         case tyCon =>
           val e = SEApp(SEVal(ExceptionMessageDefRef(tyCon)), Array(exception))
           Control.Expression(e)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -83,7 +83,7 @@ private[lf] object SExpr {
       /* special case for nullary record constructors */
       b match {
         case SBRecCon(id, fields) if b.arity == 0 =>
-          SRecordRep(id, fields, Map.empty)
+          SRecordRep(id, fields, ArrayList.empty)
         case _ =>
           SPAP(PBuiltin(b), ArrayList.empty, b.arity)
       }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SValueIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SValueIterable.scala
@@ -12,7 +12,7 @@ private[speedy] object SValueIterable {
   that =>
   private[iterable] def iterator(v: SValue): Iterator[SValue] = v match {
     case SValue.SPAP(prim, actuals, _) => iterator(prim) ++ actuals.asScala.iterator
-    case SValue.SRecordRep(_, _, dict) => dict.iterator.flatMap({ case (_, v) => Iterator(v) })
+    case SValue.SRecordRep(_, _, values) => values.asScala.iterator
     case SValue.SStruct(_, values) => values.asScala.iterator
     case SValue.SVariant(_, _, _, value) => Iterator(value)
     case SValue.SEnum(_, _, _) => Iterator.empty

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -319,7 +319,7 @@ class SpeedyTest extends AnyFreeSpec with Matchers with Inside {
                 SELet1General(
                   SEVal(LfDefRef(qualify("M:origin"))),
                   SEAppAtomicSaturatedBuiltin(
-                    SBRecUpd(qualify("M:Point"), Name.assertFromString("x")),
+                    SBRecUpd(qualify("M:Point"), Name.assertFromString("x"), 0),
                     Array(SELocS(1), SEValue(SInt64(1))),
                   ),
                 )
@@ -349,7 +349,7 @@ class SpeedyTest extends AnyFreeSpec with Matchers with Inside {
                   SEAppAtomicSaturatedBuiltin(
                     SBRecUpdMulti(
                       qualify("M:Point"),
-                      List(Name.assertFromString("x"), Name.assertFromString("y")),
+                      List(Name.assertFromString("x"), Name.assertFromString("y")).zipWithIndex,
                     ),
                     Array(
                       SELocS(1),
@@ -394,7 +394,7 @@ class SpeedyTest extends AnyFreeSpec with Matchers with Inside {
                     SEAppAtomicSaturatedBuiltin(
                       SBRecUpdMulti(
                         qualify("M:Point"),
-                        List(Name.assertFromString("x"), Name.assertFromString("y")),
+                        List(Name.assertFromString("x"), Name.assertFromString("y")).zipWithIndex,
                       ),
                       Array(
                         SELocS(1),
@@ -435,7 +435,10 @@ class SpeedyTest extends AnyFreeSpec with Matchers with Inside {
                         SEAppAtomicSaturatedBuiltin(
                           SBRecUpdMulti(
                             qualify("M:Point"),
-                            List(Name.assertFromString("x"), Name.assertFromString("y")),
+                            List(
+                              Name.assertFromString("x"),
+                              Name.assertFromString("y"),
+                            ).zipWithIndex,
                           ),
                           Array(
                             SELocS(5),
@@ -465,7 +468,10 @@ class SpeedyTest extends AnyFreeSpec with Matchers with Inside {
                         SEAppAtomicSaturatedBuiltin(
                           SBRecUpdMulti(
                             qualify("M:Point"),
-                            List(Name.assertFromString("x"), Name.assertFromString("y")),
+                            List(
+                              Name.assertFromString("x"),
+                              Name.assertFromString("y"),
+                            ).zipWithIndex,
                           ),
                           Array(SELocS(1), SELocS(2), SELocS(4)),
                         ),
@@ -505,9 +511,9 @@ class SpeedyTest extends AnyFreeSpec with Matchers with Inside {
                     SBRecUpdMulti(
                       qualify("M:Point"),
                       List(
-                        Name.assertFromString("x"),
-                        Name.assertFromString("y"),
-                        Name.assertFromString("x"),
+                        (Name.assertFromString("x"), 0),
+                        (Name.assertFromString("y"), 1),
+                        (Name.assertFromString("x"), 0),
                       ),
                     ),
                     Array(


### PR DESCRIPTION
Address the performance regression reported against: #17054

Revert to the original array based representation for speedy record values:
- Use `util.ArrayList` instead of `Map` for `SRecordRep`
- Pre-compute the index for lookup/update field.

### Note:

I do not support the changes in this PR (despite being the author).
I think it a step in the wrong direction. It makes trade-offs which I don't agree with.

It trades:
- `(-)` clarity and debugability (which we ought to care about more)
- `(+)` for micro efficiency (which we shouldn't care about here)


Clarify will become increasingly important as we move towards upgrade support. When supporting upgrades, the runtime data representation will no longer be locked to a specific (version of) a type definition: The potential for bugs caused by this _optimised_ array based representation, which disregards the field names in favour of pre-computed field indexes, will be even higher.

