### PR TITLE
delete old logs before starting

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -34,6 +34,13 @@ steps:
 
   - bash: |
       set -euo pipefail
+      if [ -e bazel-testlogs ]; then
+          rm -rf bazel-testlogs/
+      fi
+    displayName: delete old logs
+
+  - bash: |
+      set -euo pipefail
       p="_${{parameters.name}}"
       a="_$(System.JobAttempt)"
       if [ "$p" == "_m1" ]; then

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -18,6 +18,13 @@ steps:
   - powershell: '.\ci\windows-diagnostics.ps1'
     displayName: 'Agent diagnostics'
 
+  - bash: |
+      set -euo pipefail
+      if [ -e bazel-testlogs ]; then
+          rm -rf bazel-testlogs/
+      fi
+    displayName: delete old logs
+
   - powershell: '.\build.ps1'
     displayName: 'Build'
     env:


### PR DESCRIPTION
Bazel "testlogs" are stored in a directory that does not get cleaned up by Azure Pipelines automatically, so on subsequent runs on the same machine some files are already compressed and gzip is sad.

(I think.)