### PR TITLE
Run Damldoc test serially to avoid flake

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/DamlDocTest.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlDocTest.hs
@@ -17,9 +17,14 @@ import Development.IDE.Core.Service
 import Development.IDE.Core.Shake
 import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Location
+import System.Environment.Blank (setEnv)
 
 main :: IO ()
-main = withDamlScriptDep Nothing $ \scriptPackageData -> -- Install Daml.Script once at the start of the suite, rather than for each case
+main =
+  -- Install Daml.Script once at the start of the suite, rather than for each case
+  withDamlScriptDep Nothing $ \scriptPackageData -> do
+    -- Must run serially
+    setEnv "TASTY_NUM_THREADS" "1" True
     defaultMain $ testGroup "daml-doctest"
         [ generateTests scriptPackageData
         ]


### PR DESCRIPTION
Following #17111, we now know that damldoc test was failing because of
```
C:\Users\u\AppData\Local\Temp\extra-dir-922051839534\.daml\package-database\1.15\package.conf.d\package.cache.lock: openBinaryFile: resource busy (file is locked)
```
This is because we're spinning up the IDEState with the same package database multiple times concurrently.
This PR adds the flag to force TASTY to run the tests serially.