### PR TITLE
[engine] Refuse to downgrade optional field values which are not None 

### DIFF
--- a/canton/it-lib/src/main/com/daml/CantonFixture.scala
+++ b/canton/it-lib/src/main/com/daml/CantonFixture.scala
@@ -66,6 +66,7 @@ trait CantonFixtureWithResource[A]
   //  If `true`
   //   - temporary file are not deleted (this requires "--test_tmpdir=/tmp/" or similar for bazel builds)
   //   - some debug info are logged.
+  //   - output from the canton process is sent to stdout
   protected val cantonFixtureDebugMode = false
 
   final protected val logger = org.slf4j.LoggerFactory.getLogger(getClass)

--- a/canton/it-lib/src/main/com/daml/CantonRunner.scala
+++ b/canton/it-lib/src/main/com/daml/CantonRunner.scala
@@ -150,7 +150,10 @@ object CantonRunner {
             "-c" ::
             files.configFile.toString ::
             debugOptions
-        ).run(ProcessLogger(str => outputBuffer += str))
+        ).run(ProcessLogger { str =>
+          if (config.debug) println(str)
+          outputBuffer += str
+        })
       )
       size <- RetryStrategy.constant(attempts = 240, waitTime = 1.seconds) { (_, _) =>
         info("waiting for Canton to start")

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureLib.scala
@@ -196,19 +196,33 @@ object ExplicitDisclosureLib {
       owner: Party,
       maintainer: Party,
       templateId: Ref.Identifier = houseTemplateId,
-  ): Versioned[ContractInstance] = Versioned(
-    TransactionVersion.minExplicitDisclosure,
-    Value.ContractInstance(
-      templateId,
-      Value.ValueRecord(
-        None,
+  ): Versioned[ContractInstance] = {
+    val contractFields = templateId match {
+      case `caveTemplateId` =>
+        ImmArray(
+          None -> Value.ValueParty(owner)
+        )
+
+      case `houseTemplateId` =>
         ImmArray(
           None -> Value.ValueParty(owner),
           None -> Value.ValueParty(maintainer),
-        ),
+        )
+
+      case _ =>
+        throw new RuntimeException(
+          s"Unknown template ID $templateId - unable to determine the contract fields"
+        )
+    }
+
+    Versioned(
+      TransactionVersion.minExplicitDisclosure,
+      Value.ContractInstance(
+        templateId,
+        Value.ValueRecord(None, contractFields),
       ),
-    ),
-  )
+    )
+  }
 
   def buildHouseCachedContract(
       signatory: Party,

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureTest.scala
@@ -34,7 +34,7 @@ class ExplicitDisclosureTest extends ExplicitDisclosureTestMethods {
         }
       }
 
-      "ledger queried when contract ID is not disclosed" in {
+      "ledger queried when contract ID is not disclosed" ignore { // NICK
         ledgerQueriedWhenContractNotDisclosed(
           SBFetchAny(None)(SEValue(SContractId(contractId)), SEValue.None),
           getContract = Map(contractId -> ledgerCaveContract),
@@ -76,7 +76,7 @@ class ExplicitDisclosureTest extends ExplicitDisclosureTestMethods {
       }
 
       "contract IDs that are inactive" - {
-        "ledger query fails when contract ID is not disclosed" in {
+        "ledger query fails when contract ID is not disclosed" ignore { // NICK
           ledgerQueryFailsWhenContractNotDisclosed(
             SBFetchAny(None)(SEValue(SContractId(contractId)), SEValue.None),
             contractId,

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureTest.scala
@@ -34,7 +34,7 @@ class ExplicitDisclosureTest extends ExplicitDisclosureTestMethods {
         }
       }
 
-      "ledger queried when contract ID is not disclosed" ignore { // NICK
+      "ledger queried when contract ID is not disclosed" in {
         ledgerQueriedWhenContractNotDisclosed(
           SBFetchAny(None)(SEValue(SContractId(contractId)), SEValue.None),
           getContract = Map(contractId -> ledgerCaveContract),
@@ -76,7 +76,7 @@ class ExplicitDisclosureTest extends ExplicitDisclosureTestMethods {
       }
 
       "contract IDs that are inactive" - {
-        "ledger query fails when contract ID is not disclosed" ignore { // NICK
+        "ledger query fails when contract ID is not disclosed" in {
           ledgerQueryFailsWhenContractNotDisclosed(
             SBFetchAny(None)(SEValue(SContractId(contractId)), SEValue.None),
             contractId,

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/DevIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/DevIT.scala
@@ -139,9 +139,7 @@ final class DevIT extends AsyncWordSpec with AbstractScriptTest with Inside with
       } yield r shouldBe SUnit
     }
 
-    // TODO: https://github.com/digital-asset/daml/issues/17082
-    // enable this test when it works!
-    "fail when given a contract id of a non-predecessor type of Coin V1, Coin V2 (with new field = Some _) -- refuse Downgrade/drop-Some" ignore {
+    "fail when given a contract id of a non-predecessor type of Coin V1, Coin V2 (with new field = Some _) -- refuse Downgrade/drop-Some" in {
       for {
         clients <- scriptClients()
         r <-


### PR DESCRIPTION
Advances #17082

- Principled recode of `importValue`/`SRecord` to handle UPGRADE/DOWNGRADE
- Refuse to downgrade optional field values which are not None
- Fix buglets in `ExplicitDisclosureTest` which triggered illegal downgrade case (thanks Carl)
