### PR TITLE
Publish akka-http-metrics JAR

### DIFF
--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -259,3 +259,5 @@
   type: jar-scala
 - target: //observability/telemetry:telemetry
   type: jar-scala
+- target: //observability/akka-http-metrics:akka-http-metrics
+  type: jar-scala


### PR DESCRIPTION
The copy of the JSON API in Canton depends on this so without publishing this you can't build Canton without the Daml submodule which causes issues for CN.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
