### PR TITLE
Log the json string instead in json-api on failed response in json-api

### DIFF
--- a/language-support/ts/codegen/extract-ts-libs.sh
+++ b/language-support/ts/codegen/extract-ts-libs.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eou pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Expected exactly one argument."
+    echo "Usage: ./extract-ts-libs.sh path/to/canton-network-node/nix/vendored"
+    exit 1
+fi
+
+bazel run //language-support/ts/daml-types:npm_package.pack -- --pack-destination $1
+bazel run //language-support/ts/daml-ledger:npm_package.pack -- --pack-destination $1/

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -352,6 +352,24 @@ type LedgerError = {
   warnings: unknown | undefined;
 };
 
+export type CommandMeta = {
+  workflowId?: string;
+  disclosedContracts?: DisclosedContract[];
+};
+
+export type DisclosedContract = {
+  contractId: ContractId<any>;
+  templateId: string;
+  payload: unknown;
+  metadata: DisclosedContractMetadata;
+};
+
+export type DisclosedContractMetadata = {
+  createdAt: string;
+  keyHash: string; // base16
+  driverMetadata: string; // base64
+};
+
 /**
  * @internal
  */
@@ -1112,10 +1130,12 @@ class Ledger {
   async create<T extends object, K, I extends string>(
     template: Template<T, K, I>,
     payload: T,
+    meta?: CommandMeta,
   ): Promise<CreateEvent<T, K, I>> {
     const command = {
       templateId: template.templateId,
       payload: template.encode(payload),
+      meta,
     };
     const json = await this.submit("v1/create", command);
     return jtv.Result.withException(decodeCreateEvent(template).run(json));
@@ -1139,12 +1159,14 @@ class Ledger {
     choice: Choice<T, C, R, K>,
     contractId: ContractId<T>,
     argument: C,
+    meta?: CommandMeta,
   ): Promise<[R, Event<object>[]]> {
     const payload = {
       templateId: choice.template().templateId,
       contractId: ContractId(choice.template()).encode(contractId),
       choice: choice.choiceName,
       argument: choice.argumentEncode(argument),
+      meta,
     };
     const json = await this.submit("v1/exercise", payload);
     // Decode the server response into a tuple.

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -987,7 +987,7 @@ class Ledger {
   private async throwOnError(r: Response): Promise<void> {
     if (!r.ok) {
       const json = await r.json();
-      console.log(json);
+      console.log(JSON.stringify(json));
       throw decode(decodeLedgerError, json);
     }
   }


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
