### PR TITLE
infra: let CI nodes sleep at night

### DIFF
--- a/infra/ubuntu.tf
+++ b/infra/ubuntu.tf
@@ -21,7 +21,7 @@ locals {
       {
         name       = "du1",
         disk_size  = 400,
-        size       = 15,
+        size       = 10,
         assignment = "default",
       },
       {

--- a/infra/windows.tf
+++ b/infra/windows.tf
@@ -23,7 +23,7 @@ locals {
     azure = [
       {
         name       = "dw1",
-        size       = 6,
+        size       = 5,
         assignment = "default",
         disk_size  = 400,
       },


### PR DESCRIPTION
Instead of always having all the nodes up, this tweaks the CI infrastructure to reduce the number of nodes "at night" and over the weekend.