### PR TITLE
Replace `cd .. && pwd` with `readlink -f`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -16,4 +16,6 @@ HOOK_TYPES=(pre-commit pre-merge-commit pre-push prepare-commit-msg commit-msg p
 for HOOK_TYPE in ${HOOK_TYPES[@]}; do pre-commit uninstall -t "$HOOK_TYPE" > /dev/null; done
 
 # install pre-commit hook (opt-out by setting `DADE_NO_PRE_COMMIT`, set the hook type with `DADE_PRE_COMMIT_HOOK_TYPE` -- defaults to 'pre-push')
-test "x$DADE_NO_PRE_COMMIT" = x && pre-commit install -t "$DADE_PRE_COMMIT_HOOK_TYPE" > /dev/null
+if [[ -z "${DADE_NO_PRE_COMMIT:-}" ]]; then
+    pre-commit install -t "$DADE_PRE_COMMIT_HOOK_TYPE" > /dev/null
+fi

--- a/dev-env/bin/da-hls
+++ b/dev-env/bin/da-hls
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
 cd $DADE_CURRENT_SCRIPT_DIR
 cd ../..
 

--- a/dev-env/bin/da-test-haskell-update-expected
+++ b/dev-env/bin/da-test-haskell-update-expected
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+THIS_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
 ####################################################################
 
 cd $THIS_DIR/../..

--- a/dev-env/bin/dade
+++ b/dev-env/bin/dade
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
 source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
-DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
 
 if [ $# -lt 1 ]; then
    "$DADE_CURRENT_SCRIPT_DIR"/dade-help

--- a/dev-env/bin/dade-assist
+++ b/dev-env/bin/dade-assist
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
 source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
 
 linkTool java out "${DADE_DEVENV_DIR}/jdk"

--- a/dev-env/bin/dade-closure-size
+++ b/dev-env/bin/dade-closure-size
@@ -2,7 +2,7 @@
 #
 # Compute the size of the development environment closure
 #
-DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
 PATHS=$DADE_CURRENT_SCRIPT_DIR/../var/gc-roots/*/
 
 for bin in $PATHS; do

--- a/dev-env/bin/dade-collect-garbage
+++ b/dev-env/bin/dade-collect-garbage
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
 BASEL_CACHE_DIR="${DADE_CURRENT_SCRIPT_DIR}/../../.bazel-cache"
 source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
 

--- a/dev-env/bin/dade-env
+++ b/dev-env/bin/dade-env
@@ -11,7 +11,7 @@ EOF
   exit 1
 fi
 
-DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
 eval "$("${DADE_CURRENT_SCRIPT_DIR}/../lib/dade-dump-profile")"
 
 exec "$@"

--- a/dev-env/bin/dade-freeze
+++ b/dev-env/bin/dade-freeze
@@ -2,7 +2,7 @@
 
 set -Eeuo pipefail
 
-DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
 
 if [[ "$DADE_CURRENT_SCRIPT_DIR" =~ ^/nix/store/.* ]]; then
     echo "Unable to release dev-env from Nix store. Are you running this from another repository than `da`?"

--- a/dev-env/bin/dade-init
+++ b/dev-env/bin/dade-init
@@ -4,7 +4,7 @@
 # Installs nix and prepares some common tools
 #
 
-DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
 
 if [[ "$DADE_CURRENT_SCRIPT_DIR" =~ ^/nix/store/.* ]]; then
     echo "Unable to init dev-env from Nix store. Are you running this from another repository than `da`?"

--- a/dev-env/bin/dade-list
+++ b/dev-env/bin/dade-list
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #set -e
 
-DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
 source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
 
 # run 'buildTool' on each of the tools.

--- a/dev-env/bin/dade-preload
+++ b/dev-env/bin/dade-preload
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #set -e
 
-DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
 PATH=$DADE_CURRENT_SCRIPT_DIR:$PATH
 source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
 

--- a/dev-env/bin/dade-release-tool
+++ b/dev-env/bin/dade-release-tool
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BIN_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
 source "$BIN_DIR/../lib/dade-common"
 cd $BIN_DIR/../../
 execTool da-hs-release-tool out da-hs-release-tool "$@"

--- a/dev-env/lib/dade-common
+++ b/dev-env/lib/dade-common
@@ -9,8 +9,8 @@ if [[ -n "${DADE_DEBUG+x}" ]]; then
     set -x
 fi
 
-DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-DADE_BASE_ROOT="$( cd "${DADE_CURRENT_SCRIPT_DIR}/../../" && pwd)"
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
+DADE_BASE_ROOT="$( readlink -f "${DADE_CURRENT_SCRIPT_DIR}/../../" )"
 
 errcho() {
   >&2 echo "[dev-env] $@"

--- a/dev-env/lib/dade-dump-profile
+++ b/dev-env/lib/dade-dump-profile
@@ -65,7 +65,7 @@ nix_tool() {
 # TODO(gleber): Compatibility mode until JBH is ugraded.
 DADE_DEVENV_DIR="${DADE_DEVENV_DIR:-${DADE_BASE:-}}"
 if [ -z "$DADE_DEVENV_DIR" ]; then
-    DADE_DEVENV_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+    DADE_DEVENV_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
 fi
 export DADE_DEVENV_DIR="${DADE_DEVENV_DIR}"
 export DADE_REPO_ROOT="${DADE_REPO_ROOT:-${DADE_DEVENV_DIR}/..}"

--- a/dev-env/lib/dade-exec-nix-bin-tool
+++ b/dev-env/lib/dade-exec-nix-bin-tool
@@ -3,7 +3,7 @@
 # tool. Execute a Nix tool from a derivation that creates a `result-bin`
 # directory.
 
-DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
 source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
 base=$(basename $0)
 execTool $base bin $base "$@"

--- a/dev-env/lib/dade-exec-nix-tool
+++ b/dev-env/lib/dade-exec-nix-tool
@@ -2,7 +2,7 @@
 # Meant to be linked to from `dev-env/bin`, symlink should be named after the
 # tool. Execute a Nix tool from a derivation that creates a `result` directory.
 
-DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
 source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
 base=$(basename $0)
 execTool $base out $base "$@"


### PR DESCRIPTION
The output of `cd` might be altered by `CDPATH` set on a system, leading to `dade` being broken because it cannot read the current path. Instead, using `readlink -f` seem to get the job done without side effects.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
