### PR TITLE
Revert "[LF] make Timestamp parsing consistent accross Java versions …

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
@@ -4,7 +4,8 @@
 package com.daml.lf.data
 
 import java.time.format.DateTimeFormatter
-import java.time.temporal.{ChronoField, ChronoUnit}
+import java.time.temporal.ChronoField
+import java.time.temporal.ChronoUnit.MICROS
 import java.time.{Duration, Instant, LocalDate, ZoneId}
 import java.util.concurrent.TimeUnit
 
@@ -12,20 +13,14 @@ import scalaz.std.anyVal._
 import scalaz.syntax.order._
 import scalaz.{Order, Ordering}
 
+import scala.util.Try
+
 object Time {
 
-  class Date private (val days: Int) extends Ordered[Date] {
+  case class Date private (days: Int) extends Ordered[Date] {
 
     override def toString: String =
       Date.formatter.format(LocalDate.ofEpochDay(days.toLong))
-
-    override def equals(obj: Any): Boolean =
-      obj match {
-        case that: Date => this.days == that.days
-        case _ => false
-      }
-
-    override def hashCode(): Int = days + Date.seed
 
     override def compare(that: Date): Int =
       days.compareTo(that.days)
@@ -33,36 +28,43 @@ object Time {
 
   object Date {
 
-    private val seed: Int = getClass.getName.hashCode
+    type T = Date
 
     private val formatter: DateTimeFormatter =
       DateTimeFormatter.ISO_DATE.withZone(ZoneId.of("Z"))
 
-    // throws if cannot parse
-    private[this] def assertDaysFromString(str: String) =
-      Math.toIntExact(formatter.parse(str).getLong(ChronoField.EPOCH_DAY))
+    private def assertDaysFromString(str: String) = {
+      asInt(formatter.parse(str).getLong(ChronoField.EPOCH_DAY)).fold(sys.error, identity)
+    }
 
-    val MinValue: Date = new Date(assertDaysFromString("0001-01-01"))
+    private[lf] def asInt(days: Long): Either[String, Int] = {
+      val daysI = days.toInt
+      if (daysI.toLong == days) Right(daysI)
+      else Left(s"out of bound Date $days")
+    }
 
-    val MaxValue: Date = new Date(assertDaysFromString("9999-12-31"))
+    val MinValue: Date =
+      Date(assertDaysFromString("0001-01-01"))
 
-    val Epoch: Date = assertFromDaysSinceEpoch(0)
+    val MaxValue: Date =
+      Date(assertDaysFromString("9999-12-31"))
+
+    val Epoch: Date =
+      Date(0)
 
     def fromDaysSinceEpoch(days: Int): Either[String, Date] =
       if (MinValue.days <= days && days <= MaxValue.days)
-        Right(new Date(days))
+        Right(Date(days))
       else
         Left(s"out of bound Date $days")
 
     def fromString(str: String): Either[String, Date] =
-      try {
-        fromDaysSinceEpoch(assertDaysFromString(str))
-      } catch {
-        case scala.util.control.NonFatal(_) => Left(s"cannot interpret $str as Date")
-      }
+      Try(assertDaysFromString(str)).toEither.left
+        .map(_ => s"cannot interpret $str as Date")
+        .flatMap(fromDaysSinceEpoch)
 
     @throws[IllegalArgumentException]
-    final def assertFromString(s: String): Date =
+    final def assertFromString(s: String): T =
       assertRight(fromString(s))
 
     def assertFromDaysSinceEpoch(days: Int): Date =
@@ -78,18 +80,10 @@ object Time {
 
   }
 
-  class Timestamp private (val micros: Long) extends Ordered[Timestamp] {
+  case class Timestamp private (micros: Long) extends Ordered[Timestamp] {
 
     override def toString: String =
       Timestamp.formatter.format(toInstant)
-
-    override def equals(obj: Any): Boolean =
-      obj match {
-        case that: Timestamp => this.micros == that.micros
-        case _ => false
-      }
-
-    override def hashCode(): Int = micros.hashCode() + Timestamp.seed
 
     def compare(that: Timestamp): Int =
       micros.compareTo(that.micros)
@@ -118,113 +112,62 @@ object Time {
 
   object Timestamp {
 
-    private val seed: Int = getClass.getName.hashCode
+    type T = Timestamp
 
-    private lazy val formatter: DateTimeFormatter =
+    private val formatter: DateTimeFormatter =
       DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.of("Z"))
 
-    // throws if cannot parse
-    private[this] def parseToInstant(str: String): Instant = {
-      // The following enforces constituency of parsing between java 8 and java 11
-      // See https://bugs.openjdk.org/browse/JDK-8166138
-      if (str.last.toUpper != 'Z') throw new IllegalArgumentException
-      Instant.from(formatter.parse(str))
-    }
-
-    private def microsOfInstant(i: Instant): Long =
+    private def assertMicrosFromInstant(i: Instant): Long =
       TimeUnit.SECONDS.toMicros(i.getEpochSecond) + TimeUnit.NANOSECONDS.toMicros(i.getNano.toLong)
 
+    private def assertMicrosFromString(str: String): Long =
+      assertMicrosFromInstant(Instant.parse(str))
+
     val MinValue: Timestamp =
-      new Timestamp(microsOfInstant(parseToInstant("0001-01-01T00:00:00.000000Z")))
+      Timestamp(assertMicrosFromString("0001-01-01T00:00:00.000000Z"))
 
     val MaxValue: Timestamp =
-      new Timestamp(microsOfInstant(parseToInstant("9999-12-31T23:59:59.999999Z")))
+      Timestamp(assertMicrosFromString("9999-12-31T23:59:59.999999Z"))
 
-    val Resolution: Duration = Duration.of(1L, ChronoUnit.MICROS)
+    val Resolution: Duration = Duration.of(1L, MICROS)
 
-    val Epoch: Timestamp = assertFromLong(0)
+    val Epoch: Timestamp =
+      Timestamp(0)
 
-    def now(): Timestamp = assertLenientFromInstant(Instant.now())
+    def now(): Timestamp =
+      assertFromLong(assertMicrosFromInstant(Instant.now()))
 
     def fromLong(micros: Long): Either[String, Timestamp] =
       if (MinValue.micros <= micros && micros <= MaxValue.micros)
-        Right(new Timestamp(micros))
+        Right(Timestamp(micros))
       else
         Left(s"out of bound Timestamp $micros")
 
     @throws[IllegalArgumentException]
-    def assertFromLong(micros: Long): Timestamp = assertRight(fromLong(micros))
+    def assertFromLong(micros: Long): Timestamp =
+      assertRight(fromLong(micros))
 
-    // Truncate nanoseconds
-    def lenientFromInstant(i: Instant): Either[String, Timestamp] =
-      fromLong(microsOfInstant(i))
-
-    @throws[IllegalArgumentException]
-    def assertLenientFromInstant(i: Instant): Timestamp = assertRight(lenientFromInstant(i))
-
-    private val nanosInOneMicros: Long =
-      TimeUnit.MICROSECONDS.toNanos(1)
-
-    // reject if cannot be converted without loss of precision
-    def strictFromInstant(i: Instant): Either[String, Timestamp] =
-      if (i.getNano % nanosInOneMicros == 0)
-        lenientFromInstant(i)
-      else
-        Left(s"cannot interpret $i as Timestamp")
+    def fromString(str: String): Either[String, Timestamp] =
+      Try(assertMicrosFromString(str)).toEither.left
+        .map(_ => s"cannot interpret $str as Timestamp")
+        .flatMap(fromLong)
 
     @throws[IllegalArgumentException]
-    def assertStrictFromInstant(i: Instant): Timestamp =
-      assertRight(strictFromInstant(i))
+    final def assertFromString(s: String): T =
+      assertRight(fromString(s))
 
-    @deprecated(
-      "use lenientFromInstant or strictFromInstant, legacy behavior is lenient, preferred is strict",
-      since = "2.7.0",
-    )
-    def fromInstant(i: Instant): Either[String, Timestamp] = lenientFromInstant(i)
+    def fromInstant(i: Instant): Either[String, Timestamp] =
+      Try(assertMicrosFromInstant(i)).toEither.left
+        .map(_ => s"cannot interpret $i as Timestamp")
+        .flatMap(fromLong)
 
-    @deprecated(
-      "use lenientFromInstant or strictFromInstant, legacy behavior is lenient, preferred is strict",
-      since = "2.7.0",
-    )
-    def assertFromInstant(i: Instant): Timestamp = assertLenientFromInstant(i)
-
-    private def instantFromString(str: String): Either[String, Instant] =
-      try {
-        Right(parseToInstant(str))
-      } catch {
-        case scala.util.control.NonFatal(_) => Left(s"cannot interpret $str as Timestamp")
-      }
-
-    def lenientFromString(str: String): Either[String, Timestamp] =
-      instantFromString(str).flatMap(lenientFromInstant)
-
-    @throws[IllegalArgumentException]
-    def assertLenientFromString(str: String): Timestamp =
-      assertRight(lenientFromString(str))
-
-    def strictFromString(str: String): Either[String, Timestamp] =
-      instantFromString(str).flatMap(strictFromInstant)
-
-    @throws[IllegalArgumentException]
-    def assertStrictFromString(str: String): Timestamp =
-      assertRight(strictFromString(str))
-
-    @deprecated(
-      "use lenientFromString or strictFromString, legacy behavior is lenient, preferred is strict",
-      since = "2.7.0",
-    )
-    def fromString(str: String): Either[String, Timestamp] = lenientFromString(str)
-
-    @deprecated(
-      "use lenientFromString or strictFromString, legacy behavior is lenient, preferred is strict",
-      since = "2.7.0",
-    )
-    def assertFromString(str: String): Timestamp = assertLenientFromString(str)
+    def assertFromInstant(i: Instant): Timestamp =
+      assertFromLong(assertMicrosFromInstant(i))
 
     implicit val `Time.Timestamp Order`: Order[Timestamp] = new Order[Timestamp] {
       override def equalIsNatural = true
 
-      override def equal(x: Timestamp, y: Timestamp): Boolean = x.micros == y.micros
+      override def equal(x: Timestamp, y: Timestamp): Boolean = x == y
 
       override def order(x: Timestamp, y: Timestamp): Ordering = x.micros ?|? y.micros
     }

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -1033,7 +1033,7 @@ class EngineTest
     val originalCoid = toContractId("BasicTests:CallablePayout:1")
     val templateId = Identifier(basicTestsPkgId, "BasicTests:CallablePayout")
     // we need to fix time as cid are depending on it
-    val let = Time.Timestamp.assertStrictFromString("1969-07-20T20:17:00Z")
+    val let = Time.Timestamp.assertFromString("1969-07-20T20:17:00Z")
     val command = ApiCommand.Exercise(
       templateId,
       originalCoid,

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValueTranslatorSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValueTranslatorSpec.scala
@@ -75,8 +75,8 @@ class ValueTranslatorSpec
       (TInt64, ValueInt64(42), SInt64(42)),
       (
         TTimestamp,
-        ValueTimestamp(Time.Timestamp.assertStrictFromString("1969-07-20T20:17:00Z")),
-        STimestamp(Time.Timestamp.assertStrictFromString("1969-07-20T20:17:00Z")),
+        ValueTimestamp(Time.Timestamp.assertFromString("1969-07-20T20:17:00Z")),
+        STimestamp(Time.Timestamp.assertFromString("1969-07-20T20:17:00Z")),
       ),
       (
         TDate,

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -1350,9 +1350,9 @@ class SBuiltinTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
 
         forEvery(testCases) { (date, int) =>
           eval(e"DATE_TO_UNIX_DAYS $date") shouldBe Right(SInt64(int))
-          eval(e"UNIX_DAYS_TO_DATE $int") shouldBe Right(
-            SDate(Time.Date.assertFromDaysSinceEpoch(int.toInt))
-          )
+          eval(e"UNIX_DAYS_TO_DATE $int") shouldBe Time.Date
+            .asInt(int)
+            .map(i => SDate(Time.Date.assertFromDaysSinceEpoch(i)))
           eval(e"EQUAL @Date (UNIX_DAYS_TO_DATE $int) $date") shouldBe Right(SBool(true))
         }
       }

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
@@ -93,7 +93,7 @@ private[parser] object Lexer extends RegexParsers {
 
   private def toTimestamp(s: String): Parser[Timestamp] =
     (in: Input) =>
-      Time.Timestamp.strictFromString(s) match {
+      Time.Timestamp.fromString(s) match {
         case Right(x) => Success(Timestamp(x), in)
         case Left(_) =>
           Error(s"cannot interpret $s as a Timestamp", in)

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -176,7 +176,7 @@ object TransactionBuilder {
       Ref.Identifier(defaultPackageId, s)
 
     implicit def toTimestamp(s: String): Time.Timestamp =
-      Time.Timestamp.assertStrictFromString(s)
+      Time.Timestamp.assertFromString(s)
 
     implicit def toDate(s: String): Time.Date =
       Time.Date.assertFromString(s)

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
@@ -364,8 +364,8 @@ class HashSpec extends AnyWordSpec with Matchers {
       val timestamps =
         List(
           Time.Timestamp.assertFromLong(0),
-          Time.Timestamp.assertStrictFromString("1969-07-21T02:56:15.000000Z"),
-          Time.Timestamp.assertStrictFromString("2019-12-16T11:17:54.940779Z"),
+          Time.Timestamp.assertFromString("1969-07-21T02:56:15.000000Z"),
+          Time.Timestamp.assertFromString("2019-12-16T11:17:54.940779363Z"),
         ).map(VA.timestamp.inj(_))
       val parties =
         List(

--- a/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
@@ -501,7 +501,7 @@ object TreeUtils {
   }
 
   def timestampFromTree(tree: TransactionTree): Timestamp = {
-    Timestamp.assertStrictFromInstant(
+    Timestamp.assertFromInstant(
       Instant.ofEpochSecond(tree.getEffectiveAt.seconds, tree.getEffectiveAt.nanos.toLong)
     )
   }

--- a/daml-script/export/src/test/scala/com/daml/script/export/ActionsFromTreesSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/ActionsFromTreesSpec.scala
@@ -16,7 +16,7 @@ class ActionsFromTreesSpec extends AnyFreeSpec with Matchers {
         Action.fromTrees(Seq.empty, setTime = true) shouldBe empty
       }
       "single transaction" in {
-        val t1 = Timestamp.assertStrictFromString("1990-01-01T01:00:00Z")
+        val t1 = Timestamp.assertFromString("1990-01-01T01:00:00Z")
         val trees = Seq(
           TestData
             .Tree(
@@ -33,7 +33,7 @@ class ActionsFromTreesSpec extends AnyFreeSpec with Matchers {
         actions(1) shouldBe a[SubmitSimpleSingle]
       }
       "multipe transaction at same time" in {
-        val t1 = Timestamp.assertStrictFromString("1990-01-01T01:00:00Z")
+        val t1 = Timestamp.assertFromString("1990-01-01T01:00:00Z")
         val trees = Seq(
           TestData
             .Tree(
@@ -59,8 +59,8 @@ class ActionsFromTreesSpec extends AnyFreeSpec with Matchers {
         actions(2) shouldBe a[SubmitSimpleSingle]
       }
       "multipe transaction at different times" in {
-        val t1 = Timestamp.assertStrictFromString("1990-01-01T01:00:00Z")
-        val t2 = Timestamp.assertStrictFromString("1990-01-02T01:00:00Z")
+        val t1 = Timestamp.assertFromString("1990-01-01T01:00:00Z")
+        val t2 = Timestamp.assertFromString("1990-01-02T01:00:00Z")
         val trees = Seq(
           TestData
             .Tree(
@@ -89,8 +89,8 @@ class ActionsFromTreesSpec extends AnyFreeSpec with Matchers {
     }
     "setTime disabled" - {
       "multipe transaction at different times" in {
-        val t1 = Timestamp.assertStrictFromString("1990-01-01T01:00:00Z")
-        val t2 = Timestamp.assertStrictFromString("1990-01-02T01:00:00Z")
+        val t1 = Timestamp.assertFromString("1990-01-01T01:00:00Z")
+        val t2 = Timestamp.assertFromString("1990-01-02T01:00:00Z")
         val trees = Seq(
           TestData
             .Tree(

--- a/daml-script/export/src/test/scala/com/daml/script/export/EncodeSetTimeSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/EncodeSetTimeSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.matchers.should.Matchers
 class EncodeSetTimeSpec extends AnyFreeSpec with Matchers {
   import Encode._
   "encodeSetTime" in {
-    encodeSetTime(Timestamp.assertStrictFromString("1990-11-09T04:30:23.123456Z"))
-      .render(80) shouldBe
+    encodeSetTime(Timestamp.assertFromString("1990-11-09T04:30:23.123456Z")).render(80) shouldBe
       """setTime (DA.Time.time (DA.Date.date 1990 DA.Date.Nov 9) 4 30 23)"""
   }
 }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ScriptF.scala
@@ -424,7 +424,7 @@ object ScriptF {
           }
           case ScriptTimeMode.WallClock =>
             Future {
-              Timestamp.assertLenientFromInstant(env.utcClock.instant())
+              Timestamp.assertFromInstant(env.utcClock.instant())
             }
         }
       } yield SEAppAtomic(SEValue(continue), Array(SEValue(STimestamp(time))))

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/JsonLedgerClient.scala
@@ -3,6 +3,7 @@
 
 package com.daml.lf.engine.script.v1.ledgerinteraction
 
+import java.time.Instant
 import akka.util.ByteString
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
@@ -382,7 +383,7 @@ class JsonLedgerClient(
       mat: Materializer,
   ): Future[Time.Timestamp] = {
     // There is no time service in the JSON API so we default to the Unix epoch.
-    Future { Time.Timestamp.Epoch }
+    Future { Time.Timestamp.assertFromInstant(Instant.EPOCH) }
   }
 
   override def setStaticTime(time: Time.Timestamp)(implicit

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
@@ -434,7 +434,7 @@ object ScriptF {
           }
           case ScriptTimeMode.WallClock =>
             Future {
-              Timestamp.assertLenientFromInstant(env.utcClock.instant())
+              Timestamp.assertFromInstant(env.utcClock.instant())
             }
         }
       } yield SEValue(STimestamp(time))

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/JsonLedgerClient.scala
@@ -3,6 +3,7 @@
 
 package com.daml.lf.engine.script.v2.ledgerinteraction
 
+import java.time.Instant
 import akka.util.ByteString
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
@@ -382,7 +383,7 @@ class JsonLedgerClient(
       mat: Materializer,
   ): Future[Time.Timestamp] = {
     // There is no time service in the JSON API so we default to the Unix epoch.
-    Future { Time.Timestamp.Epoch }
+    Future { Time.Timestamp.assertFromInstant(Instant.EPOCH) }
   }
 
   override def setStaticTime(time: Time.Timestamp)(implicit

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/FuncStaticTimeIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/FuncStaticTimeIT.scala
@@ -26,8 +26,8 @@ final class FuncStaticTimeIT extends AbstractFuncIT {
         assert(vals.size == 2)
         val t0 = assertSTimestamp(vals.get(0))
         val t1 = assertSTimestamp(vals.get(1))
-        assert(t0 == Timestamp.assertStrictFromString("1970-01-01T00:00:00Z"))
-        assert(t1 == Timestamp.assertStrictFromString("2000-02-02T00:01:02Z"))
+        assert(t0 == Timestamp.assertFromString("1970-01-01T00:00:00Z"))
+        assert(t1 == Timestamp.assertFromString("2000-02-02T00:01:02Z"))
       }
     }
   }

--- a/language-support/java/json/src/main/scala/com/daml/lf/codegen/json/ValueConversion.scala
+++ b/language-support/java/json/src/main/scala/com/daml/lf/codegen/json/ValueConversion.scala
@@ -73,7 +73,7 @@ object ValueConversion {
     case text: JData.Text => LfValue.ValueText(text.getValue)
     case timestamp: JData.Timestamp =>
       LfValue.ValueTimestamp(
-        Time.Timestamp.assertLenientFromInstant(timestamp.getValue)
+        Time.Timestamp.assertFromInstant(timestamp.getValue)
       )
     case date: JData.Date =>
       LfValue.ValueDate(Time.Date.assertFromDaysSinceEpoch(date.getValue.toEpochDay.toInt))

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/api/util/util/TimeProvider.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/api/util/util/TimeProvider.scala
@@ -12,7 +12,7 @@ trait TimeProvider { self =>
 
   def getCurrentTime: Instant
 
-  def getCurrentTimestamp: Timestamp = Timestamp.assertLenientFromInstant(getCurrentTime)
+  def getCurrentTimestamp: Timestamp = Timestamp.assertFromInstant(getCurrentTime)
 
   def map(transform: Instant => Instant): TimeProvider = MappedTimeProvider(this, transform)
 }

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/api/util/util/TimestampConversion.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/api/util/util/TimestampConversion.scala
@@ -47,7 +47,7 @@ object TimestampConversion {
 
   def toLf(protoTimestamp: ProtoTimestamp, mode: ConversionMode): LfTimestamp = {
     val instant = roundToMicros(toInstant(protoTimestamp), mode)
-    LfTimestamp.assertStrictFromInstant(instant)
+    LfTimestamp.assertFromInstant(instant)
   }
 
   def fromLf(timestamp: LfTimestamp): ProtoTimestamp = {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/MeteringReportEndpoint.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/MeteringReportEndpoint.scala
@@ -47,9 +47,7 @@ private[http] object MeteringReportEndpoint {
   private val startOfDay = LocalTime.of(0, 0, 0)
 
   private[endpoints] def toTimestamp(ts: LocalDate): Timestamp = {
-    Timestamp.assertStrictFromInstant(
-      Instant.ofEpochSecond(ts.toEpochSecond(startOfDay, ZoneOffset.UTC))
-    )
+    Timestamp.assertFromInstant(Instant.ofEpochSecond(ts.toEpochSecond(startOfDay, ZoneOffset.UTC)))
   }
 
   private[endpoints] def toPbTimestamp(ts: Timestamp): protobuf.timestamp.Timestamp = {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -54,7 +54,7 @@ object JsonProtocol extends JsonProtocolLow {
     taggedJsonFormat
 
   private implicit val TimestampFormat: JsonFormat[Time.Timestamp] =
-    xemapStringJsonFormat(Time.Timestamp.lenientFromString)(_.toString)
+    xemapStringJsonFormat(Time.Timestamp.fromString)(_.toString)
 
   implicit def NonEmptyListFormat[A: JsonReader: JsonWriter]: JsonFormat[NonEmptyList[A]] =
     jsonFormatFromReaderWriter(NonEmptyListReader, NonEmptyListWriter)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/query/ValuePredicate.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/query/ValuePredicate.scala
@@ -373,7 +373,7 @@ object ValuePredicate {
   )(V.ValueDate)
   private[this] val TimestampRangeExpr = RangeExpr(
     { case JsString(q) =>
-      Time.Timestamp.lenientFromString(q).fold(predicateParseError(_), identity)
+      Time.Timestamp.fromString(q).fold(predicateParseError(_), identity)
     },
     { case V.ValueTimestamp(v) => v },
   )(V.ValueTimestamp)

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/endpoints/MeteringReportEndpointTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/endpoints/MeteringReportEndpointTest.scala
@@ -36,7 +36,7 @@ class MeteringReportEndpointTest extends AnyFreeSpec with Matchers {
     }
 
     "should convert to timestamp to protobuf timestamp" in {
-      val expected = Timestamp.assertStrictFromString("2022-02-03T00:00:00Z")
+      val expected = Timestamp.assertFromString("2022-02-03T00:00:00Z")
       val actual = toTimestamp(LocalDate.of(2022, 2, 3))
       actual shouldBe expected
     }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
@@ -341,7 +341,7 @@ class JsonProtocolTest
         domain.ContractTypeId.Template(Option.empty[String], "Mod", "Tmpl"),
         argumentsDecoded,
         DisclosedContract.Metadata(
-          Time.Timestamp.assertStrictFromString("2023-03-21T18:00:33.246813Z"),
+          Time.Timestamp.assertFromString("2023-03-21T18:00:33.246813Z"),
           Some(domain.Base16(ByteString.copyFrom("well hello", utf8))),
           Some(domain.Base64(ByteString.copyFrom("there reader", utf8))),
         ),

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
@@ -140,7 +140,7 @@ class ValuePredicateTest
         true,
       ),
       c("""{"%gte": "1980-01-01T00:00:00Z", "%lt": "2000-01-01T00:00:00Z"}""", VA.timestamp)(
-        Time.Timestamp assertStrictFromString "1986-06-21T00:00:00Z",
+        Time.Timestamp assertFromString "1986-06-21T00:00:00Z",
         true,
       ),
     )

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
@@ -135,7 +135,7 @@ class ApiCodecCompressed(val encodeDecimalAsString: Boolean, val encodeInt64AsSt
       }
       case Model.DamlLfPrimType.Unit => { case JsObject(_) => V.ValueUnit }
       case Model.DamlLfPrimType.Timestamp => { case JsString(v) =>
-        V.ValueTimestamp(assertDE(Time.Timestamp lenientFromString v))
+        V.ValueTimestamp(assertDE(Time.Timestamp fromString v))
       }
       case Model.DamlLfPrimType.Date => { case JsString(v) =>
         try {

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiValueImplicits.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiValueImplicits.scala
@@ -27,10 +27,9 @@ object ApiValueImplicits {
   // Timestamp has microsecond resolution
   implicit final class `ApiTimestamp.type additions`(private val it: V.ValueTimestamp.type)
       extends AnyVal {
-    def fromIso8601(t: String): V.ValueTimestamp =
-      fromInstant(Instant.parse(t))
+    def fromIso8601(t: String): V.ValueTimestamp = fromInstant(Instant.parse(t))
     def fromInstant(t: Instant): V.ValueTimestamp =
-      V.ValueTimestamp(Time.Timestamp.assertLenientFromInstant(t))
+      V.ValueTimestamp(Time.Timestamp.assertFromInstant(t))
     def fromMillis(t: Long): V.ValueTimestamp =
       V.ValueTimestamp(Time.Timestamp.assertFromLong(micros = t * 1000L))
   }

--- a/ledger-service/lf-value-json/src/test/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressedSpec.scala
+++ b/ledger-service/lf-value-json/src/test/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressedSpec.scala
@@ -123,7 +123,7 @@ class ApiCodecCompressedSpec
         fListOfText = Vector("foo", "bar"),
         fListOfUnit = Vector((), ()),
         fDate = Time.Date assertFromString "2019-01-28",
-        fTimestamp = Time.Timestamp assertStrictFromString "2019-01-28T12:44:33.22Z",
+        fTimestamp = Time.Timestamp assertFromString "2019-01-28T12:44:33.22Z",
         fOptionalText = None,
         fOptionalUnit = Some(()),
         fOptOptText = Some(Some("foo")),
@@ -309,7 +309,7 @@ class ApiCodecCompressedSpec
         "\"0.12345123445001\"",
       ),
       c("\"1990-11-09T04:30:23.123456Z\"", VA.timestamp)(
-        Time.Timestamp assertStrictFromString "1990-11-09T04:30:23.123456Z",
+        Time.Timestamp assertFromString "1990-11-09T04:30:23.123456Z",
         "\"1990-11-09T04:30:23.1234569Z\"",
       ),
       c("\"1970-01-01T00:00:00Z\"", VA.timestamp)(Time.Timestamp assertFromLong 0),

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -1136,7 +1136,7 @@ private[lf] class Runner private (
       }
 
       val clientTime: Timestamp =
-        Timestamp.assertLenientFromInstant(Runner.getTimeProvider(timeProviderType).getCurrentTime)
+        Timestamp.assertFromInstant(Runner.getTimeProvider(timeProviderType).getCurrentTime)
       val stateFun = Machine
         .stepToValue(compiledPackages, makeAppD(updateStateLambda, messageVal.value))
         .expect(
@@ -1225,7 +1225,7 @@ private[lf] class Runner private (
     triggerContext.logInfo("Trigger starting")
 
     val clientTime: Timestamp =
-      Timestamp.assertLenientFromInstant(Runner.getTimeProvider(timeProviderType).getCurrentTime)
+      Timestamp.assertFromInstant(Runner.getTimeProvider(timeProviderType).getCurrentTime)
     val hardLimitKillSwitch = KillSwitches.shared("hard-limit")
 
     import UnfoldState.{flatMapConcatNodeOps, toSourceOps}

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/TriggerRuleSimulationLib.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/TriggerRuleSimulationLib.scala
@@ -780,7 +780,7 @@ final class TriggerRuleSimulationLib private[simulation] (
           import GraphDSL.Implicits._
 
           val clientTime: Timestamp =
-            Timestamp.assertLenientFromInstant(
+            Timestamp.assertFromInstant(
               Runner.getTimeProvider(RunnerConfig.DefaultTimeProviderType).getCurrentTime
             )
           val killSwitch = KillSwitches.shared("init-state-simulation")


### PR DESCRIPTION
…(#17053)"

This reverts commit db7a5b36530fe80c95ae5e3b9b2a297f4fca65fe.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
