### PR TITLE
Backport #16491 (Add `internal` to errorIfTwiceParser) to 2.5.x

### DIFF
--- a/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
+++ b/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
@@ -75,7 +75,7 @@ optionOnce' :: String -> ReadM a -> Mod OptionFields a -> Parser a
 optionOnce' errMsg reader options = const <$> actualParser <*> errorIfTwiceParser
     where
     actualParser = option reader options
-    errorIfTwiceParser = option (readerError errMsg) (options <> hidden <> value (error "optionOnce: should not happen"))
+    errorIfTwiceParser = option (readerError errMsg) (options <> internal <> value (error "optionOnce: should not happen"))
 
 strOptionOnce :: IsString a => Mod OptionFields a -> Parser a
 strOptionOnce = optionOnce str


### PR DESCRIPTION
Backport #16491 to 2.5.x

Sibling PR: https://github.com/digital-asset/daml/pull/17178