### PR TITLE
[engine] Final wiring of enable-contract-upgrading feature flag

### DIFF
--- a/canton/it-lib/src/main/com/daml/CantonRunner.scala
+++ b/canton/it-lib/src/main/com/daml/CantonRunner.scala
@@ -98,6 +98,7 @@ object CantonRunner {
          |      storage.type = memory
          |      parameters = {
          |        enable-engine-stack-traces = true
+         |        enable-contract-upgrading = ${config.enableUpgrade}
          |        dev-version-support = ${config.devMode}
          |      }
          |      ${timeType.fold("")(x => "testing-time.type = " + x)}
@@ -162,9 +163,7 @@ object CantonRunner {
         Process(
           cmd,
           None,
-          // TODO: https://github.com/digital-asset/daml/issues/17082
-          // Workaround to allow DevIT tests to pass.
-          ("enableContractUpgrading", if (config.enableUpgrade) "true" else "false"),
+          // env-vars here
         ).run(ProcessLogger { str =>
           if (config.debug) println(str)
           outputBuffer += str

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -51,13 +51,6 @@ final case class EngineConfig(
     enableContractUpgrading: Boolean = false,
 ) {
 
-  // TODO: https://github.com/digital-asset/daml/issues/17082
-  // Workaround while we wait for: https://github.com/digital-asset/daml/pull/17126
-  // And a canton PR to support enableContractUpgrading in canton-config.
-  // Until then we set enableContractUpgrading via env-var.
-
-  val enableContractUpgradingEV = sys.env.get("enableContractUpgrading").exists(_ == "true")
-
   private[lf] def getCompilerConfig: speedy.Compiler.Config =
     speedy.Compiler.Config(
       allowedLanguageVersions,
@@ -76,7 +69,7 @@ final case class EngineConfig(
           speedy.Compiler.FullProfile
         else
           speedy.Compiler.NoProfile,
-      enableContractUpgrading = enableContractUpgradingEV,
+      enableContractUpgrading = enableContractUpgrading,
     )
 
   private[lf] def authorizationChecker: AuthorizationChecker =


### PR DESCRIPTION
Advances #17082

- `Engineconfig`: kill env-var hack & use feature flag `enableContractUpgrading`
- `CantonRunner`: set participant config `enable-contract-upgrading` as required