### PR TITLE
Error reporting fix for the Daml-LF parser

### DIFF
--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -149,7 +149,9 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
     }
 
   private lazy val eVariantOrEnumCon: Parser[Expr] =
-    fullIdentifier ~ (`:` ~> id) ~ rep1(argTyp) ~> err("enum type does not take type parameters") |
+    phrase(fullIdentifier ~ (`:` ~> id) ~ rep1(argTyp)) ~> err(
+      "enum type does not take type parameters"
+    ) |
       fullIdentifier ~ (`:` ~> id) ~ rep(argTyp) ~ opt(expr0) ^^ {
         case tName ~ vName ~ argsTyp ~ Some(arg) =>
           EVariantCon(TypeConApp(tName, argsTyp.to(ImmArray)), vName, arg)

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -149,14 +149,13 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
     }
 
   private lazy val eVariantOrEnumCon: Parser[Expr] =
-    fullIdentifier ~ (`:` ~> id) ~ rep(argTyp) ~ opt(expr0) ^^ {
-      case tName ~ vName ~ argsTyp ~ Some(arg) =>
-        EVariantCon(TypeConApp(tName, argsTyp.to(ImmArray)), vName, arg)
-      case _ ~ _ ~ argsTyp ~ None if argsTyp.nonEmpty =>
-        throw new java.lang.Error("enum type do not take type parameters")
-      case tName ~ vName ~ _ ~ None =>
-        EEnumCon(tName, vName)
-    }
+    fullIdentifier ~ (`:` ~> id) ~ rep1(argTyp) ~> err("enum type does not take type parameters") |
+      fullIdentifier ~ (`:` ~> id) ~ rep(argTyp) ~ opt(expr0) ^^ {
+        case tName ~ vName ~ argsTyp ~ Some(arg) =>
+          EVariantCon(TypeConApp(tName, argsTyp.to(ImmArray)), vName, arg)
+        case tName ~ vName ~ _ ~ None =>
+          EEnumCon(tName, vName)
+      }
 
   private lazy val eStructCon: Parser[Expr] =
     `<` ~> fieldInits <~ `>` ^^ EStructCon

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Parsers.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Parsers.scala
@@ -32,6 +32,8 @@ private[parser] object Parsers extends scala.util.parsing.combinator.Parsers {
     },
   )
   val text: Parser[String] = accept("Text", { case Text(s) => s })
+
+  // The lexer requires that package IDs wrapped by single quotes - e.g. '-my-package-id-'
   val pkgId: Parser[Ref.PackageId] = accept(
     "PackageId",
     Function unlift {
@@ -40,6 +42,7 @@ private[parser] object Parsers extends scala.util.parsing.combinator.Parsers {
     },
   )
 
+  // The lexer requires that package names wrapped by single quotes - e.g. '-my-package-name-'
   val pkgName: Parser[Ref.PackageName] = accept(
     "PackageName",
     Function unlift {
@@ -48,6 +51,7 @@ private[parser] object Parsers extends scala.util.parsing.combinator.Parsers {
     },
   )
 
+  // The lexer requires that package versions wrapped by single quotes - e.g. '-my-package-version-'
   val pkgVersion: Parser[Ref.PackageVersion] = accept(
     "PackageVersion",
     Function unlift {


### PR DESCRIPTION
Previously, throwing the `java.lang.Error` exception would not report on what input the parser was getting upset with. This PR fixes that by allowing the errors to be handled via `ParserResult`.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
