### PR TITLE
Revert "Disable temporary windows build"

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -85,8 +85,6 @@ jobs:
     assignment: m1-builds
 
 - job: Windows
-  # temporary disable windows
-  condition: eq(1,2)
   dependsOn:
     - check_for_release
     - build_canton


### PR DESCRIPTION
Windows nodes are back ! 

This reverts commit 908a39e55a5ec2e96c58bf35bc6e320ec696b42e.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
