### PR TITLE
HOTFIX: JSON API: make the bootstrap script block until the setting taken effect

### DIFF
--- a/ledger-service/http-json-testing/src/main/scala/com/daml/http/util/SandboxTestLedger.scala
+++ b/ledger-service/http-json-testing/src/main/scala/com/daml/http/util/SandboxTestLedger.scala
@@ -26,9 +26,11 @@ trait SandboxTestLedger extends CantonFixture {
   override lazy protected val darFiles = packageFiles.map(_.toPath)
   override lazy protected val tlsEnable = useTls
   override lazy protected val enableDisclosedContracts: Boolean = true
-  override lazy protected val bootstrapScript = Some(
-    "local.service.set_reconciliation_interval(1.seconds)"
-  )
+  override lazy protected val bootstrapScript = Some("""
+    |local.service.set_reconciliation_interval(1.second)
+    |// now block until the setting has taken effect
+    |utils.retry_until_true { local.service.get_reconciliation_interval == 1.second }
+    |""".stripMargin)
 
   def usingLedger[A](token: Option[String] = None)(
       testFn: (Port, DamlLedgerClient, LedgerId) => Future[A]

--- a/ledger-service/http-json/src/it/edition/ee/com/daml/http/PruningTest.scala
+++ b/ledger-service/http-json/src/it/edition/ee/com/daml/http/PruningTest.scala
@@ -30,7 +30,7 @@ final class PruningTest
       )
 
       // prune, at an offset that is later than the last cache refresh.
-      _ <- RetryStrategy.constant(20, 1.second) { case (_, _) =>
+      _ <- RetryStrategy.constant(10, 1.second) { case (_, _) =>
         for {
           // Add artificial ledger activity to advance the safe prune offset. Repeated on failure.
           _ <- postCreateCommand(iouCreateCommand(alice), fixture, aliceHeaders)


### PR DESCRIPTION
Unfortunately the PruningTest still needs to retry, but this should make the behaviour a little more synchronous