### PR TITLE
Testing for trigger service TLS clients

### DIFF
--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -274,6 +274,7 @@ da_scala_test_suite(
         "//libs-scala/postgresql-testing",
         "//libs-scala/resources",
         "//libs-scala/test-evidence/tag:test-evidence-tag",
+        "//libs-scala/timer-utils",
         "//triggers/runner:trigger-runner-lib",
         "//triggers/service/auth:middleware-api",
         "//triggers/service/auth:oauth2-test-server",

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestTls.scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestTls.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.engine.trigger
+
+import akka.http.scaladsl.model.Uri
+import com.daml.ledger.api.v1.value.Identifier
+import com.daml.timer.RetryStrategy
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+
+class TriggerServiceTestTls
+    extends AbstractTriggerServiceTest
+    with NoAuthFixture
+    with TriggerDaoInMemFixture
+    with Matchers {
+
+  override protected lazy val tlsEnable: Boolean = true
+
+  it should "successfully run Cat breeding trigger" in {
+    withTriggerService(List(dar)) { uri: Uri =>
+      for {
+        client <- defaultLedgerClient()
+        party <- allocateParty(client)
+        resp <- startTrigger(uri, s"$testPkgId:Cats:breedingTrigger", party, Some(applicationId))
+        catsTrigger <- parseTriggerId(resp)
+        _ <- assertTriggerIds(uri, party, Vector(catsTrigger))
+        _ <- assertTriggerStatus(catsTrigger, _.last shouldBe "running")
+        // Ensure at least one Cat contract is created
+        _ <- RetryStrategy.constant(10, 1.seconds) { (_, _) =>
+          getActiveContracts(client, party, Identifier(testPkgId, "Cats", "Cat"))
+            .map(_.length should be >= 1)
+        }
+      } yield succeed
+    }
+  }
+}

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -505,7 +505,7 @@ trait TriggerServiceFixture
                 encodedDars,
                 jdbcConfig,
                 false,
-                Cli.DefaultTlsConfiguration,
+                config.tlsClientConfig,
                 Compiler.Config.Dev,
                 triggerRunnerConfig.getOrElse(DefaultTriggerRunnerConfig),
                 logTriggerStatus,


### PR DESCRIPTION
Adds trigger service testing for trigger runners and TLS ledger clients (as part of resolving issue https://github.com/digital-asset/daml/issues/17182)

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
