### PR TITLE
Upgrades typecheck

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
@@ -12,7 +12,7 @@ module DA.Daml.LF.Ast.World(
     initWorldSelf,
     extendWorldSelf,
     ExternalPackage(..),
-    LookupError,
+    LookupError(..),
     lookupTemplate,
     lookupException,
     lookupTypeSyn,

--- a/compiler/daml-lf-tools/BUILD.bazel
+++ b/compiler/daml-lf-tools/BUILD.bazel
@@ -9,6 +9,7 @@ da_haskell_library(
     hackage_deps = [
         "base",
         "containers",
+        "deepseq",
         "either",
         "extra",
         "ghcide",

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -4,6 +4,7 @@
 module DA.Daml.LF.TypeChecker.Error(
     Context(..),
     Error(..),
+    UpgradeError(..),
     TemplatePart(..),
     InterfacePart(..),
     UnserializabilityReason(..),
@@ -162,24 +163,28 @@ data Error
   | EMissingMethodInInterfaceInstance !MethodName
   | EUnknownMethodInInterfaceInstance { eumiiIface :: !(Qualified TypeConName), eumiiTpl :: !(Qualified TypeConName), eumiiMethodName :: !MethodName }
   | EWrongInterfaceRequirement !(Qualified TypeConName) !(Qualified TypeConName)
-  | EUpgradeMissingModule !ModuleName
-  | EUpgradeMissingTemplate !TypeConName
-  | EUpgradeMissingChoice !ChoiceName
-  | EUpgradeMissingDataCon !TypeConName
-  | EUpgradeMismatchDataConsVariety !TypeConName
-  | EUpgradeRecordFieldsMissing !UpgradedRecordOrigin
-  | EUpgradeRecordFieldsExistingChanged !UpgradedRecordOrigin
-  | EUpgradeRecordFieldsNewNonOptional !UpgradedRecordOrigin
-  | EUpgradeRecordChangedOrigin !TypeConName !UpgradedRecordOrigin !UpgradedRecordOrigin
-  | EUpgradeTemplateChangedPrecondition !TypeConName
-  | EUpgradeTemplateChangedSignatories !TypeConName
-  | EUpgradeTemplateChangedObservers !TypeConName
-  | EUpgradeTemplateChangedAgreement !TypeConName
-  | EUpgradeChoiceChangedControllers !ChoiceName
-  | EUpgradeChoiceChangedObservers !ChoiceName
-  | EUpgradeChoiceChangedAuthorizers !ChoiceName
-  | EUpgradeChoiceChangedReturnType !ChoiceName
+  | EUpgradeError !UpgradeError
   | EUnknownExperimental !T.Text !Type
+
+data UpgradeError
+  = MissingModule !ModuleName
+  | MissingTemplate !TypeConName
+  | MissingChoice !ChoiceName
+  | MissingDataCon !TypeConName
+  | MismatchDataConsVariety !TypeConName
+  | RecordFieldsMissing !UpgradedRecordOrigin
+  | RecordFieldsExistingChanged !UpgradedRecordOrigin
+  | RecordFieldsNewNonOptional !UpgradedRecordOrigin
+  | RecordChangedOrigin !TypeConName !UpgradedRecordOrigin !UpgradedRecordOrigin
+  | TemplateChangedPrecondition !TypeConName
+  | TemplateChangedSignatories !TypeConName
+  | TemplateChangedObservers !TypeConName
+  | TemplateChangedAgreement !TypeConName
+  | ChoiceChangedControllers !ChoiceName
+  | ChoiceChangedObservers !ChoiceName
+  | ChoiceChangedAuthorizers !ChoiceName
+  | ChoiceChangedReturnType !ChoiceName
+  deriving (Eq, Ord, Show)
 
 data UpgradedRecordOrigin
   = TemplateBody TypeConName
@@ -553,25 +558,29 @@ instance Pretty Error where
       text "Tried to implement method " <> quotes (pretty eumiiMethodName) <> text ", but interface " <> pretty eumiiIface <> text " does not have a method with that name."
     EWrongInterfaceRequirement requiringIface requiredIface ->
       "Interface " <> pretty requiringIface <> " does not require interface " <> pretty requiredIface
-    EUpgradeMissingModule moduleName -> "Module " <> pPrint moduleName <> " appears in package that is being upgraded, but does not appear in this package."
-    EUpgradeMissingTemplate templateName -> "Template " <> pPrint templateName <> " appears in package that is being upgraded, but does not appear in this package."
-    EUpgradeMissingChoice templateName -> "Choice " <> pPrint templateName <> " appears in package that is being upgraded, but does not appear in this package."
-    EUpgradeMissingDataCon dataConName -> "Data type " <> pPrint dataConName <> " appears in package that is being upgraded, but does not appear in this package."
-    EUpgradeMismatchDataConsVariety dataConName -> "EUpgradeMismatchDataConsVariety " <> pretty dataConName
-    EUpgradeRecordFieldsMissing origin -> "The upgraded " <> pPrint origin <> " is missing some of its original fields."
-    EUpgradeRecordFieldsExistingChanged origin -> "The upgraded " <> pPrint origin <> " has changed the types of some of its original fields."
-    EUpgradeRecordFieldsNewNonOptional origin -> "The upgraded " <> pPrint origin <> " has added new fields, but those fields are not Optional."
-    EUpgradeRecordChangedOrigin dataConName past present -> "The record " <> pPrint dataConName <> " has changed origin from " <> pPrint past <> " to " <> pPrint present
-    EUpgradeTemplateChangedPrecondition template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its precondition."
-    EUpgradeTemplateChangedSignatories template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its signatories."
-    EUpgradeTemplateChangedObservers template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its observers."
-    EUpgradeTemplateChangedAgreement template -> "The upgraded template " <> pPrint template <> " cannot change the definition of agreement."
-    EUpgradeChoiceChangedControllers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of controllers."
-    EUpgradeChoiceChangedObservers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of observers."
-    EUpgradeChoiceChangedAuthorizers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of authorizers."
-    EUpgradeChoiceChangedReturnType choice -> "The upgraded choice " <> pPrint choice <> " cannot change its return type."
+    EUpgradeError upgradeError -> pPrint upgradeError
     EUnknownExperimental name ty ->
       "Unknown experimental primitive " <> string (show name) <> " : " <> pretty ty
+
+instance Pretty UpgradeError where
+  pPrint = \case
+    MissingModule moduleName -> "Module " <> pPrint moduleName <> " appears in package that is being upgraded, but does not appear in this package."
+    MissingTemplate templateName -> "Template " <> pPrint templateName <> " appears in package that is being upgraded, but does not appear in this package."
+    MissingChoice templateName -> "Choice " <> pPrint templateName <> " appears in package that is being upgraded, but does not appear in this package."
+    MissingDataCon dataConName -> "Data type " <> pPrint dataConName <> " appears in package that is being upgraded, but does not appear in this package."
+    MismatchDataConsVariety dataConName -> "EUpgradeMismatchDataConsVariety " <> pretty dataConName
+    RecordFieldsMissing origin -> "The upgraded " <> pPrint origin <> " is missing some of its original fields."
+    RecordFieldsExistingChanged origin -> "The upgraded " <> pPrint origin <> " has changed the types of some of its original fields."
+    RecordFieldsNewNonOptional origin -> "The upgraded " <> pPrint origin <> " has added new fields, but those fields are not Optional."
+    RecordChangedOrigin dataConName past present -> "The record " <> pPrint dataConName <> " has changed origin from " <> pPrint past <> " to " <> pPrint present
+    TemplateChangedPrecondition template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its precondition."
+    TemplateChangedSignatories template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its signatories."
+    TemplateChangedObservers template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its observers."
+    TemplateChangedAgreement template -> "The upgraded template " <> pPrint template <> " cannot change the definition of agreement."
+    ChoiceChangedControllers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of controllers."
+    ChoiceChangedObservers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of observers."
+    ChoiceChangedAuthorizers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of authorizers."
+    ChoiceChangedReturnType choice -> "The upgraded choice " <> pPrint choice <> " cannot change its return type."
 
 instance Pretty UpgradedRecordOrigin where
   pPrint = \case

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -189,7 +189,6 @@ data UpgradeError
 data UpgradedRecordOrigin
   = TemplateBody TypeConName
   | TemplateChoiceInput TypeConName ChoiceName
-  | TemplateChoiceOutput TypeConName ChoiceName TypeConName
   | TopLevel
   deriving (Eq, Ord, Show)
 
@@ -586,7 +585,6 @@ instance Pretty UpgradedRecordOrigin where
   pPrint = \case
     TemplateBody tpl -> "template " <> pPrint tpl
     TemplateChoiceInput tpl chcName -> "input type of choice " <> pPrint chcName <> " on template " <> pPrint tpl
-    TemplateChoiceOutput tpl chcName rec -> "record " <> pPrint tpl <> " (used in output type of choice " <> pPrint chcName <> " on template " <> pPrint rec <> ")"
     TopLevel -> "record"
 
 instance Pretty Context where

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -178,11 +178,13 @@ data Error
   | EUpgradeChoiceChangedControllers !ChoiceName
   | EUpgradeChoiceChangedObservers !ChoiceName
   | EUpgradeChoiceChangedAuthorizers !ChoiceName
+  | EUpgradeChoiceChangedReturnType !ChoiceName
   | EUnknownExperimental !T.Text !Type
 
 data UpgradedRecordOrigin
   = TemplateBody TypeConName
   | TemplateChoiceInput TypeConName ChoiceName
+  | TemplateChoiceOutput TypeConName ChoiceName TypeConName
   | TopLevel
   deriving (Eq, Ord, Show)
 
@@ -567,13 +569,15 @@ instance Pretty Error where
     EUpgradeChoiceChangedControllers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of controllers."
     EUpgradeChoiceChangedObservers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of observers."
     EUpgradeChoiceChangedAuthorizers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of authorizers."
+    EUpgradeChoiceChangedReturnType choice -> "The upgraded choice " <> pPrint choice <> " cannot change its return type."
     EUnknownExperimental name ty ->
       "Unknown experimental primitive " <> string (show name) <> " : " <> pretty ty
 
 instance Pretty UpgradedRecordOrigin where
   pPrint = \case
-    TemplateBody tcon -> "template " <> pPrint tcon
-    TemplateChoiceInput tcon chcName -> "type of choice " <> pPrint chcName <> " on template " <> pPrint tcon
+    TemplateBody tpl -> "template " <> pPrint tpl
+    TemplateChoiceInput tpl chcName -> "input type of choice " <> pPrint chcName <> " on template " <> pPrint tpl
+    TemplateChoiceOutput tpl chcName rec -> "record " <> pPrint tpl <> " (used in output type of choice " <> pPrint chcName <> " on template " <> pPrint rec <> ")"
     TopLevel -> "record"
 
 instance Pretty Context where

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -161,6 +161,11 @@ data Error
   | EMissingMethodInInterfaceInstance !MethodName
   | EUnknownMethodInInterfaceInstance { eumiiIface :: !(Qualified TypeConName), eumiiTpl :: !(Qualified TypeConName), eumiiMethodName :: !MethodName }
   | EWrongInterfaceRequirement !(Qualified TypeConName) !(Qualified TypeConName)
+  | EUpgradeMissing
+  | EUpgradeMismatchDataConsVariety !TypeConName
+  | EUpgradeRecordFieldsMissing
+  | EUpgradeRecordFieldsExistingChanged
+  | EUpgradeRecordFieldsNewNonOptional
   | EUnknownExperimental !T.Text !Type
 
 contextLocation :: Context -> Maybe SourceLoc
@@ -528,6 +533,11 @@ instance Pretty Error where
       text "Tried to implement method " <> quotes (pretty eumiiMethodName) <> text ", but interface " <> pretty eumiiIface <> text " does not have a method with that name."
     EWrongInterfaceRequirement requiringIface requiredIface ->
       "Interface " <> pretty requiringIface <> " does not require interface " <> pretty requiredIface
+    EUpgradeMissing {} -> "EUpgradeMissing"
+    EUpgradeMismatchDataConsVariety dataConName -> "EUpgradeMismatchDataConsVariety " <> pretty dataConName
+    EUpgradeRecordFieldsMissing {} -> "EUpgradeRecordFieldsMissing"
+    EUpgradeRecordFieldsExistingChanged {} -> "EUpgradeRecordFieldsExistingChanged"
+    EUpgradeRecordFieldsNewNonOptional {} -> "EUpgradeRecordFieldsNewNonOptional"
     EUnknownExperimental name ty ->
       "Unknown experimental primitive " <> string (show name) <> " : " <> pretty ty
 

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module DA.Daml.LF.TypeChecker.Upgrade (checkUpgrade, Upgrading(..)) where
 
 --import           DA.Daml.LF.TypeChecker.Env
@@ -29,6 +30,18 @@ data Upgrading a = Upgrading
 instance Functor Upgrading where
     fmap f Upgrading{..} = Upgrading (f past) (f present)
 
+instance Foldable Upgrading where
+    foldMap f Upgrading{..} = f past <> f present
+
+instance Traversable Upgrading where
+    traverse f Upgrading{..} = Upgrading <$> f past <*> f present
+
+zipU :: Upgrading a -> Upgrading b -> (a -> b -> c) -> Upgrading c
+zipU a b f = Upgrading { past = f (past a) (past b), present = f (present a) (present b) }
+
+foldU :: (a -> a -> b) -> Upgrading a -> b
+foldU f u = f (past u) (present u)
+
 checkUpgrade :: Version -> Upgrading LF.Package -> [Diagnostic]
 checkUpgrade version package =
     let result =
@@ -43,7 +56,7 @@ checkUpgrade version package =
 
 checkUpgradeM :: MonadGamma m => Upgrading LF.Package -> m ()
 checkUpgradeM package = do
-    (upgradedModules, _new) <- checkDeleted (const EUpgradeMissing) $ NM.toHashMap . packageModules <$> package
+    (upgradedModules, _new) <- checkDeleted (EUpgradeMissingModule . NM.name) $ NM.toHashMap . packageModules <$> package
     forM_ upgradedModules checkModule
 
 extractDelExistNew
@@ -69,31 +82,65 @@ checkDeleted handle upgrade = do
 
 checkModule :: MonadGamma m => Upgrading LF.Module -> m ()
 checkModule module_ = do
-    (existingDefDataTypes, _new) <- checkDeleted (const EUpgradeMissing) $ NM.toHashMap . moduleDataTypes <$> module_
-    forM_ existingDefDataTypes $ \dt ->
+    --(existingDefDataTypes, _new) <- checkDeleted (EUpgradeMissingDataCon . LF.dataTypeCon) $ NM.toHashMap . moduleDataTypes <$> module_
+    --forM_ existingDefDataTypes $ \dt ->
+    --    withContext
+    --        (ContextDefDataType (present module_) (present dt))
+    --        (checkDefDataType dt)
+    (existingTemplates, _new) <- checkDeleted (EUpgradeMissingTemplate . NM.name) $ NM.toHashMap . moduleTemplates <$> module_
+    forM_ existingTemplates $ \template ->
         withContext
-            (ContextDefDataType (present module_) (present dt))
-            (checkDefDataType dt)
+            (ContextTemplate (present module_) (present template) TPWhole)
+            (checkTemplate module_ template)
+    pure ()
 
-checkDefDataType :: MonadGamma m => Upgrading LF.DefDataType -> m ()
-checkDefDataType datatype = do
+lookupDataTypeInMod :: MonadGamma m => Module -> LF.TypeConName -> m DefDataType
+lookupDataTypeInMod module_ typeConName =
+    let mbDatatype = typeConName `NM.lookup` moduleDataTypes module_
+    in
+    case mbDatatype of
+      Nothing -> throwWithContext (EUnknownDefinition (LEDataType (Qualified PRSelf (moduleName module_) typeConName)))
+      Just dt -> pure dt
+
+checkTemplate :: MonadGamma m => Upgrading Module -> Upgrading LF.Template -> m ()
+checkTemplate module_ template = do
+    definition <- sequence $ zipU module_ template $ \module_ template -> lookupDataTypeInMod module_ (tplTypeCon template)
+    checkDefDataType (TemplateBody (tplTypeCon (present template))) definition
+    (existingChoices, _new) <- checkDeleted (EUpgradeMissingChoice . NM.name) $ NM.toHashMap . LF.tplChoices <$> template
+    forM_ existingChoices $ \choice ->
+        withContext (ContextTemplate (present module_) (present template) (TPChoice (present choice))) $ do
+            checkCompatibleType (TemplateChoiceInput (chcName (present choice))) module_ (fmap (snd . chcArgBinder) choice)
+            checkCompatibleType (TemplateChoiceOutput (chcName (present choice))) module_ (fmap chcReturnType choice)
+    pure ()
+
+checkCompatibleType :: MonadGamma m => (LF.TypeConName -> UpgradedRecordOrigin) -> Upgrading Module -> Upgrading LF.Type -> m ()
+checkCompatibleType origin module_ type_ = do
+    case type_ of
+      Upgrading { past = TCon pastName, present = TCon presentName } -> do
+          dt <- sequence (zipU module_ (Upgrading { past = qualObject pastName, present = qualObject presentName }) lookupDataTypeInMod)
+          checkDefDataType (origin (qualObject presentName)) dt
+      -- TODO: Fill out check for more types than zero-argument datatypes
+      _ -> pure ()
+
+checkDefDataType :: MonadGamma m => UpgradedRecordOrigin -> Upgrading LF.DefDataType -> m ()
+checkDefDataType origin datatype = do
     case fmap dataCons datatype of
-      Upgrading { past = DataRecord past, present = DataRecord present } -> checkFields (Upgrading {..})
+      Upgrading { past = DataRecord past, present = DataRecord present } -> checkFields origin (Upgrading {..})
       Upgrading { past = DataVariant {}, present = DataVariant {} } -> pure ()
       Upgrading { past = DataEnum {}, present = DataEnum {} } -> pure ()
       Upgrading { past = DataInterface {}, present = DataInterface {} } -> pure ()
       _ -> throwWithContext (EUpgradeMismatchDataConsVariety (dataTypeCon (past datatype)))
 
-checkFields :: MonadGamma m => Upgrading [(FieldName, Type)] -> m ()
-checkFields fields = do
-    (existing, new) <- checkDeleted (const EUpgradeRecordFieldsMissing) $ HMS.fromList <$> fields
+checkFields :: MonadGamma m => UpgradedRecordOrigin -> Upgrading [(FieldName, Type)] -> m ()
+checkFields origin fields = do
+    (existing, new) <- checkDeleted (const (EUpgradeRecordFieldsMissing origin)) $ HMS.fromList <$> fields
 
     -- If a field from the upgraded package has had its type changed
     let matchingFieldDifferentType Upgrading{..} = past /= present
-    when (any matchingFieldDifferentType existing) $ throwWithContext EUpgradeRecordFieldsExistingChanged
+    when (any matchingFieldDifferentType existing) $ throwWithContext (EUpgradeRecordFieldsExistingChanged origin)
 
     -- If a new field has a non-optional type
     let newFieldOptionalType (TOptional _) = True
         newFieldOptionalType _ = False
-    when (not (all newFieldOptionalType new)) $ throwWithContext EUpgradeRecordFieldsNewNonOptional
+    when (not (all newFieldOptionalType new)) $ throwWithContext (EUpgradeRecordFieldsNewNonOptional origin)
 

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -1,0 +1,97 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE DeriveAnyClass #-}
+module DA.Daml.LF.TypeChecker.Upgrade (checkUpgrade, Upgrading(..)) where
+
+--import           DA.Daml.LF.TypeChecker.Env
+--import           DA.Daml.LF.TypeChecker.Error
+import           DA.Daml.LF.Ast as LF
+import           DA.Daml.LF.TypeChecker.Env
+import           DA.Daml.LF.TypeChecker.Error
+import qualified Data.NameMap as NM
+import qualified Data.HashMap.Strict as HMS
+
+import Control.Monad
+import Data.Data
+import GHC.Generics(Generic)
+import Control.DeepSeq
+
+import Development.IDE.Types.Diagnostics
+
+data Upgrading a = Upgrading
+    { past :: a
+    , present :: a
+    }
+    deriving (Eq, Data, Generic, NFData, Show, Functor)
+
+instance Functor Upgrading where
+    fmap f Upgrading{..} = Upgrading (f past) (f present)
+
+checkUpgrade :: Version -> Upgrading LF.Package -> [Diagnostic]
+checkUpgrade version package =
+    let result =
+            runGamma
+                (initWorldSelf [] (present package))
+                version
+                (checkUpgradeM package)
+    in
+    case result of
+      Left err -> [toDiagnostic DsError err]
+      Right () -> []
+
+checkUpgradeM :: MonadGamma m => Upgrading LF.Package -> m ()
+checkUpgradeM package = do
+    upgradedModules <- checkDeleted packageModules package
+    forM_ upgradedModules checkModule
+
+extractDeleted :: NM.Named a => (b -> NM.NameMap a) -> Upgrading b -> HMS.HashMap (NM.Name a) a
+extractDeleted extract Upgrading{..} =
+    NM.toHashMap (extract past) `HMS.difference` NM.toHashMap (extract present)
+
+extractExisting :: NM.Named a => (b -> NM.NameMap a) -> Upgrading b -> HMS.HashMap (NM.Name a) (Upgrading a)
+extractExisting extract Upgrading{..} =
+    HMS.intersectionWith Upgrading (NM.toHashMap (extract past)) (NM.toHashMap (extract present))
+
+checkDeleted :: (NM.Named a, MonadGamma m) => (b -> NM.NameMap a) -> Upgrading b -> m (HMS.HashMap (NM.Name a) (Upgrading a))
+checkDeleted extract upgrade = do
+    let deleted = extractDeleted extract upgrade
+    let existing = extractExisting extract upgrade
+    if HMS.null deleted
+       then pure existing
+       else throwWithContext EUpgradeMissing
+
+checkModule :: MonadGamma m => Upgrading LF.Module -> m ()
+checkModule module_ = do
+    existingDefDataTypes <- checkDeleted moduleDataTypes module_
+    forM_ existingDefDataTypes checkDefDataType
+
+checkDefDataType :: MonadGamma m => Upgrading LF.DefDataType -> m ()
+checkDefDataType datatype = do
+    case fmap dataCons datatype of
+      Upgrading { past = DataRecord past, present = DataRecord present } -> checkFields (Upgrading {..})
+      Upgrading { past = DataVariant {}, present = DataVariant {} } -> pure ()
+      Upgrading { past = DataEnum {}, present = DataEnum {} } -> pure ()
+      Upgrading { past = DataInterface {}, present = DataInterface {} } -> pure ()
+      _ -> throwWithContext (EUpgradeMismatchDataConsVariety (dataTypeCon (past datatype)))
+
+checkFields :: MonadGamma m => Upgrading [(FieldName, Type)] -> m ()
+checkFields fields = do
+    let pastMap = HMS.fromList (past fields)
+    let presentMap = HMS.fromList (present fields)
+    let deletedFields = pastMap `HMS.difference` presentMap
+    let matchingFields = HMS.intersectionWith Upgrading pastMap presentMap
+    let newFields = presentMap `HMS.difference` pastMap
+
+    -- If a field from the upgraded package is missing
+    when (not (HMS.null deletedFields)) $ throwWithContext EUpgradeRecordFieldsMissing
+
+    -- If a field from the upgraded package has had its type changed
+    let matchingFieldDifferentType Upgrading{..} = past /= present
+    when (any matchingFieldDifferentType matchingFields) $ throwWithContext EUpgradeRecordFieldsExistingChanged
+
+    -- If a new field has a non-optional type
+    let newFieldOptionalType (TOptional _) = True
+        newFieldOptionalType _ = False
+    when (not (all newFieldOptionalType newFields)) $ throwWithContext EUpgradeRecordFieldsNewNonOptional
+

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -106,7 +106,7 @@ checkModule module_ = do
         deriveChoiceInfo module_ = HMS.fromList $ do
             template <- NM.toList (moduleTemplates module_)
             choice <- NM.toList (tplChoices template)
-            TCon dtName <- [snd (chcArgBinder choice)] -- Choice inputs should always be a list
+            TCon dtName <- [snd (chcArgBinder choice)] -- Choice inputs should always be type constructors
             pure (qualObject dtName, (template, choice))
         allChoiceReturnTCons :: LF.Module -> HMS.HashMap LF.TypeConName (LF.Template, LF.TemplateChoice)
         allChoiceReturnTCons module_ = HMS.fromList $ do

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -11,6 +11,7 @@ import           DA.Daml.LF.TypeChecker.Env
 import           DA.Daml.LF.TypeChecker.Error
 import qualified Data.NameMap as NM
 import qualified Data.HashMap.Strict as HMS
+import Data.Hashable
 
 import Control.Monad
 import Data.Data
@@ -23,7 +24,7 @@ data Upgrading a = Upgrading
     { past :: a
     , present :: a
     }
-    deriving (Eq, Data, Generic, NFData, Show, Functor)
+    deriving (Eq, Data, Generic, NFData, Show)
 
 instance Functor Upgrading where
     fmap f Upgrading{..} = Upgrading (f past) (f present)
@@ -42,28 +43,33 @@ checkUpgrade version package =
 
 checkUpgradeM :: MonadGamma m => Upgrading LF.Package -> m ()
 checkUpgradeM package = do
-    upgradedModules <- checkDeleted packageModules package
+    (upgradedModules, _new) <- checkDeleted (const EUpgradeMissing) $ NM.toHashMap . packageModules <$> package
     forM_ upgradedModules checkModule
 
-extractDeleted :: NM.Named a => (b -> NM.NameMap a) -> Upgrading b -> HMS.HashMap (NM.Name a) a
-extractDeleted extract Upgrading{..} =
-    NM.toHashMap (extract past) `HMS.difference` NM.toHashMap (extract present)
+extractDelExistNew
+    :: (Eq k, Hashable k)
+    => Upgrading (HMS.HashMap k a)
+    -> (HMS.HashMap k a, HMS.HashMap k (Upgrading a), HMS.HashMap k a)
+extractDelExistNew Upgrading{..} =
+    ( past `HMS.difference` present
+    , HMS.intersectionWith Upgrading past present
+    , present `HMS.difference` past
+    )
 
-extractExisting :: NM.Named a => (b -> NM.NameMap a) -> Upgrading b -> HMS.HashMap (NM.Name a) (Upgrading a)
-extractExisting extract Upgrading{..} =
-    HMS.intersectionWith Upgrading (NM.toHashMap (extract past)) (NM.toHashMap (extract present))
-
-checkDeleted :: (NM.Named a, MonadGamma m) => (b -> NM.NameMap a) -> Upgrading b -> m (HMS.HashMap (NM.Name a) (Upgrading a))
-checkDeleted extract upgrade = do
-    let deleted = extractDeleted extract upgrade
-    let existing = extractExisting extract upgrade
-    if HMS.null deleted
-       then pure existing
-       else throwWithContext EUpgradeMissing
+checkDeleted
+    :: (Eq k, Hashable k, MonadGamma m)
+    => (a -> Error)
+    -> Upgrading (HMS.HashMap k a)
+    -> m (HMS.HashMap k (Upgrading a), HMS.HashMap k a)
+checkDeleted handle upgrade = do
+    let (deleted, existing, new) = extractDelExistNew upgrade
+    case HMS.toList deleted of
+      ((_, head):_) -> throwWithContext $ handle head
+      _ -> pure (existing, new)
 
 checkModule :: MonadGamma m => Upgrading LF.Module -> m ()
 checkModule module_ = do
-    existingDefDataTypes <- checkDeleted moduleDataTypes module_
+    (existingDefDataTypes, _new) <- checkDeleted (const EUpgradeMissing) $ NM.toHashMap . moduleDataTypes <$> module_
     forM_ existingDefDataTypes checkDefDataType
 
 checkDefDataType :: MonadGamma m => Upgrading LF.DefDataType -> m ()
@@ -77,21 +83,14 @@ checkDefDataType datatype = do
 
 checkFields :: MonadGamma m => Upgrading [(FieldName, Type)] -> m ()
 checkFields fields = do
-    let pastMap = HMS.fromList (past fields)
-    let presentMap = HMS.fromList (present fields)
-    let deletedFields = pastMap `HMS.difference` presentMap
-    let matchingFields = HMS.intersectionWith Upgrading pastMap presentMap
-    let newFields = presentMap `HMS.difference` pastMap
-
-    -- If a field from the upgraded package is missing
-    when (not (HMS.null deletedFields)) $ throwWithContext EUpgradeRecordFieldsMissing
+    (existing, new) <- checkDeleted (const EUpgradeRecordFieldsMissing) $ HMS.fromList <$> fields
 
     -- If a field from the upgraded package has had its type changed
     let matchingFieldDifferentType Upgrading{..} = past /= present
-    when (any matchingFieldDifferentType matchingFields) $ throwWithContext EUpgradeRecordFieldsExistingChanged
+    when (any matchingFieldDifferentType existing) $ throwWithContext EUpgradeRecordFieldsExistingChanged
 
     -- If a new field has a non-optional type
     let newFieldOptionalType (TOptional _) = True
         newFieldOptionalType _ = False
-    when (not (all newFieldOptionalType newFields)) $ throwWithContext EUpgradeRecordFieldsNewNonOptional
+    when (not (all newFieldOptionalType new)) $ throwWithContext EUpgradeRecordFieldsNewNonOptional
 

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -70,7 +70,10 @@ checkDeleted handle upgrade = do
 checkModule :: MonadGamma m => Upgrading LF.Module -> m ()
 checkModule module_ = do
     (existingDefDataTypes, _new) <- checkDeleted (const EUpgradeMissing) $ NM.toHashMap . moduleDataTypes <$> module_
-    forM_ existingDefDataTypes checkDefDataType
+    forM_ existingDefDataTypes $ \dt ->
+        withContext
+            (ContextDefDataType (present module_) (present dt))
+            (checkDefDataType dt)
 
 checkDefDataType :: MonadGamma m => Upgrading LF.DefDataType -> m ()
 checkDefDataType datatype = do

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -2,24 +2,21 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 module DA.Daml.LF.TypeChecker.Upgrade (checkUpgrade, Upgrading(..)) where
 
---import           DA.Daml.LF.TypeChecker.Env
---import           DA.Daml.LF.TypeChecker.Error
+import           Control.DeepSeq
+import           Control.Monad (unless, forM_)
 import           DA.Daml.LF.Ast as LF
+import           DA.Daml.LF.Ast.Alpha (alphaExpr)
 import           DA.Daml.LF.TypeChecker.Env
 import           DA.Daml.LF.TypeChecker.Error
-import qualified Data.NameMap as NM
+import           Data.Data
+import           Data.Hashable
 import qualified Data.HashMap.Strict as HMS
-import Data.Hashable
-
-import Control.Monad
-import Data.Data
-import GHC.Generics(Generic)
-import Control.DeepSeq
-
-import Development.IDE.Types.Diagnostics
+import qualified Data.NameMap as NM
+import qualified Data.Text as T
+import           Development.IDE.Types.Diagnostics
+import           GHC.Generics (Generic)
 
 data Upgrading a = Upgrading
     { past :: a
@@ -36,8 +33,9 @@ instance Foldable Upgrading where
 instance Traversable Upgrading where
     traverse f Upgrading{..} = Upgrading <$> f past <*> f present
 
-zipU :: Upgrading a -> Upgrading b -> (a -> b -> c) -> Upgrading c
-zipU a b f = Upgrading { past = f (past a) (past b), present = f (present a) (present b) }
+instance Applicative Upgrading where
+    pure a = Upgrading a a
+    (<*>) f a = Upgrading { past = past f (past a), present = present f (present a) }
 
 foldU :: (a -> a -> b) -> Upgrading a -> b
 foldU f u = f (past u) (present u)
@@ -82,65 +80,156 @@ checkDeleted handle upgrade = do
 
 checkModule :: MonadGamma m => Upgrading LF.Module -> m ()
 checkModule module_ = do
-    --(existingDefDataTypes, _new) <- checkDeleted (EUpgradeMissingDataCon . LF.dataTypeCon) $ NM.toHashMap . moduleDataTypes <$> module_
-    --forM_ existingDefDataTypes $ \dt ->
-    --    withContext
-    --        (ContextDefDataType (present module_) (present dt))
-    --        (checkDefDataType dt)
     (existingTemplates, _new) <- checkDeleted (EUpgradeMissingTemplate . NM.name) $ NM.toHashMap . moduleTemplates <$> module_
     forM_ existingTemplates $ \template ->
         withContext
             (ContextTemplate (present module_) (present template) TPWhole)
             (checkTemplate module_ template)
-    pure ()
 
-lookupDataTypeInMod :: MonadGamma m => Module -> LF.TypeConName -> m DefDataType
-lookupDataTypeInMod module_ typeConName =
-    let mbDatatype = typeConName `NM.lookup` moduleDataTypes module_
-    in
-    case mbDatatype of
-      Nothing -> throwWithContext (EUnknownDefinition (LEDataType (Qualified PRSelf (moduleName module_) typeConName)))
-      Just dt -> pure dt
+    -- TODO: Handle deleted datatypes (not belonging to templates or choices)
+    let (_dtDel, dtExisting, _dtNew) = extractDelExistNew $ NM.toHashMap . moduleDataTypes <$> module_
+
+    -- For a datatype, derive its context
+    let deriveChoiceInfo :: LF.Module -> HMS.HashMap LF.TypeConName (LF.Template, LF.TemplateChoice)
+        deriveChoiceInfo module_ = HMS.fromList $ do
+            template <- NM.toList (moduleTemplates module_)
+            choice <- NM.toList (tplChoices template)
+            TCon dtName <- [snd (chcArgBinder choice)] -- Choice inputs should always be a list
+            pure (qualObject dtName, (template, choice))
+        dataTypeOrigin
+            :: DefDataType -> Module
+            -> (UpgradedRecordOrigin, Context)
+        dataTypeOrigin dt module_
+            | Just template <- NM.name dt `NM.lookup` moduleTemplates module_ =
+                ( TemplateBody (NM.name dt)
+                , ContextTemplate module_ template TPWhole
+                )
+            | Just (template, choice) <- NM.name dt `HMS.lookup` deriveChoiceInfo module_ =
+                ( TemplateChoiceInput (NM.name template) (NM.name choice)
+                , ContextTemplate module_ template (TPChoice choice)
+                )
+            | otherwise = (TopLevel, ContextDefDataType module_ dt)
+
+    forM_ dtExisting $ \dt ->
+        -- Get origin/context for each datatype in both past and present
+        let origin = dataTypeOrigin <$> dt <*> module_
+        in
+        -- If origins don't match, record has changed origin
+        if foldU (/=) (fst <$> origin) then
+            withContext (ContextDefDataType (present module_) (present dt)) $
+                throwWithContext (EUpgradeRecordChangedOrigin (dataTypeCon (present dt)) (fst (past origin)) (fst (present origin)))
+        else
+            case present origin of
+              (TopLevel, _) -> pure () -- Ignore top level datatypes
+              (otherOrigin, context) ->
+                  case checkDefDataType otherOrigin dt of
+                    Nothing -> pure ()
+                    Just e -> withContext context $ throwWithContext e
 
 checkTemplate :: MonadGamma m => Upgrading Module -> Upgrading LF.Template -> m ()
 checkTemplate module_ template = do
-    definition <- sequence $ zipU module_ template $ \module_ template -> lookupDataTypeInMod module_ (tplTypeCon template)
-    checkDefDataType (TemplateBody (tplTypeCon (present template))) definition
-    (existingChoices, _new) <- checkDeleted (EUpgradeMissingChoice . NM.name) $ NM.toHashMap . LF.tplChoices <$> template
-    forM_ existingChoices $ \choice ->
+    -- Check that no choices have been removed
+    (existingChoices, _existingNew) <- checkDeleted (EUpgradeMissingChoice . NM.name) $ NM.toHashMap . tplChoices <$> template
+    forM_ existingChoices $ \choice -> do
         withContext (ContextTemplate (present module_) (present template) (TPChoice (present choice))) $ do
-            checkCompatibleType (TemplateChoiceInput (chcName (present choice))) module_ (fmap (snd . chcArgBinder) choice)
-            checkCompatibleType (TemplateChoiceOutput (chcName (present choice))) module_ (fmap chcReturnType choice)
+            throwIfDifferent "controllers" (extractFuncFromFuncThisArg . chcControllers <$> choice) $
+                EUpgradeChoiceChangedControllers $ NM.name $ present choice
+
+            let observersErr = EUpgradeChoiceChangedObservers $ NM.name $ present choice
+            case fmap (mapENilToNothing . chcObservers) choice of
+               Upgrading { past = Nothing, present = Nothing } -> do
+                   pure ()
+               Upgrading { past = Just past, present = Just present } -> do
+                   throwIfDifferent "observers" (extractFuncFromFuncThisArg <$> Upgrading past present) observersErr
+               _ -> do
+                   throwWithContext observersErr
+
+            let authorizersErr = EUpgradeChoiceChangedAuthorizers $ NM.name $ present choice
+            case fmap (mapENilToNothing . chcAuthorizers) choice of
+               Upgrading { past = Nothing, present = Nothing } -> pure ()
+               Upgrading { past = Just past, present = Just present } ->
+                   throwIfDifferent "authorizers" (extractFuncFromFuncThisArg <$> Upgrading past present) authorizersErr
+               _ -> throwWithContext authorizersErr
+        pure choice
+
+    -- This check assumes that we encode signatories etc. on a template as
+    -- $<uniquename> this, where $<uniquename> is a function that contains the
+    -- actual definition. We resolve this function and check that it is
+    -- identical.
+    withContext (ContextTemplate (present module_) (present template) TPPrecondition) $
+        throwIfDifferent "precondition" (extractFuncFromCaseFuncThis . tplPrecondition <$> template) $
+            EUpgradeTemplateChangedPrecondition $ NM.name $ present template
+    withContext (ContextTemplate (present module_) (present template) TPSignatories) $
+        throwIfDifferent "signatories" (extractFuncFromFuncThis . tplSignatories <$> template) $
+            EUpgradeTemplateChangedSignatories $ NM.name $ present template
+    withContext (ContextTemplate (present module_) (present template) TPObservers) $
+        throwIfDifferent "observers" (extractFuncFromFuncThis . tplObservers <$> template) $
+            EUpgradeTemplateChangedObservers $ NM.name $ present template
+    withContext (ContextTemplate (present module_) (present template) TPAgreement) $
+        throwIfDifferent "agreement" (extractFuncFromFuncThis . tplAgreement <$> template) $
+            EUpgradeTemplateChangedAgreement $ NM.name $ present template
+    -- TODO: Check that return type of a choice is compatible
     pure ()
+    where
+        extractFuncFromFuncThis expr
+            | ETmApp{..} <- expr
+            , EVal qualEvn <- tmappFun
+            , EVar (ExprVarName "this") <- tmappArg
+            = Just (qualObject qualEvn)
+            | otherwise
+            = Nothing
+        extractFuncFromFuncThisArg expr
+            | outer@ETmApp{} <- expr
+            , EVar (ExprVarName "arg") <- tmappArg outer
+            , inner@ETmApp{} <- tmappFun outer
+            , EVar (ExprVarName "this") <- tmappArg inner
+            , EVal qualEvn <- tmappFun inner
+            = Just (qualObject qualEvn)
+            | otherwise
+            = Nothing
+        extractFuncFromCaseFuncThis expr
+            | ECase{..} <- expr
+            = extractFuncFromFuncThis casScrutinee
+            | otherwise
+            = Nothing
+        resolveExpression field expr module_ =
+            case expr of
+              Nothing -> error ("checkTemplate: Could not extract a proper " ++ field ++ ", the structure of the expression must be wrong.")
+              Just evn ->
+                case NM.lookup evn (moduleValues module_) of
+                    Nothing -> error ("checkTemplate: Trying to get definition of " ++ T.unpack (unExprValName evn) ++ " but it is not defined!")
+                    Just defValue -> dvalBody defValue
+        throwIfDifferent field exprs err = do
+            let resolvedExprs = resolveExpression field <$> exprs <*> module_
+            let exprsMatch = foldU alphaExpr $ fmap removeLocations resolvedExprs
+            unless exprsMatch (throwWithContext err)
+        mapENilToNothing (Just (LF.ENil (LF.TBuiltin LF.BTParty))) = Nothing
+        mapENilToNothing e = e
 
-checkCompatibleType :: MonadGamma m => (LF.TypeConName -> UpgradedRecordOrigin) -> Upgrading Module -> Upgrading LF.Type -> m ()
-checkCompatibleType origin module_ type_ = do
-    case type_ of
-      Upgrading { past = TCon pastName, present = TCon presentName } -> do
-          dt <- sequence (zipU module_ (Upgrading { past = qualObject pastName, present = qualObject presentName }) lookupDataTypeInMod)
-          checkDefDataType (origin (qualObject presentName)) dt
-      -- TODO: Fill out check for more types than zero-argument datatypes
-      _ -> pure ()
-
-checkDefDataType :: MonadGamma m => UpgradedRecordOrigin -> Upgrading LF.DefDataType -> m ()
+checkDefDataType :: UpgradedRecordOrigin -> Upgrading LF.DefDataType -> Maybe Error
 checkDefDataType origin datatype = do
     case fmap dataCons datatype of
       Upgrading { past = DataRecord past, present = DataRecord present } -> checkFields origin (Upgrading {..})
-      Upgrading { past = DataVariant {}, present = DataVariant {} } -> pure ()
-      Upgrading { past = DataEnum {}, present = DataEnum {} } -> pure ()
-      Upgrading { past = DataInterface {}, present = DataInterface {} } -> pure ()
-      _ -> throwWithContext (EUpgradeMismatchDataConsVariety (dataTypeCon (past datatype)))
+      Upgrading { past = DataVariant {}, present = DataVariant {} } -> Nothing
+      Upgrading { past = DataEnum {}, present = DataEnum {} } -> Nothing
+      Upgrading { past = DataInterface {}, present = DataInterface {} } -> Nothing
+      _ -> Just (EUpgradeMismatchDataConsVariety (dataTypeCon (past datatype)))
 
-checkFields :: MonadGamma m => UpgradedRecordOrigin -> Upgrading [(FieldName, Type)] -> m ()
-checkFields origin fields = do
-    (existing, new) <- checkDeleted (const (EUpgradeRecordFieldsMissing origin)) $ HMS.fromList <$> fields
-
+checkFields :: UpgradedRecordOrigin -> Upgrading [(FieldName, Type)] -> Maybe Error
+checkFields origin fields =
+    let (deleted, existing, new) = extractDelExistNew $ HMS.fromList <$> fields
+    in
+    if not (HMS.null deleted) then
+        Just (EUpgradeRecordFieldsMissing origin)
     -- If a field from the upgraded package has had its type changed
-    let matchingFieldDifferentType Upgrading{..} = past /= present
-    when (any matchingFieldDifferentType existing) $ throwWithContext (EUpgradeRecordFieldsExistingChanged origin)
-
+    else if any matchingFieldDifferentType existing then
+        Just (EUpgradeRecordFieldsExistingChanged origin)
     -- If a new field has a non-optional type
-    let newFieldOptionalType (TOptional _) = True
+    else if not (all newFieldOptionalType new) then
+        Just (EUpgradeRecordFieldsNewNonOptional origin)
+    else
+        Nothing
+    where
+        matchingFieldDifferentType Upgrading{..} = past /= present
+        newFieldOptionalType (TOptional _) = True
         newFieldOptionalType _ = False
-    when (not (all newFieldOptionalType new)) $ throwWithContext (EUpgradeRecordFieldsNewNonOptional origin)
-

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -2,7 +2,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 module DA.Daml.LF.TypeChecker.Upgrade (checkUpgrade, Upgrading(..)) where
 
 import           Control.DeepSeq

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -156,12 +156,13 @@ buildDar service PackageConfigFields {..} ifDir dalfInput = do
                      Nothing -> mergePkgs pMeta lfVersion . map fst <$> usesE GeneratePackage files
                      Just _ -> generateSerializedPackage pName pVersion pMeta files
 
-                 case mbUpgradedPackage of
-                    Just (_, upgradedPackage) ->
-                      MaybeT $ do
-                        let upgradePair = Upgrading { past = upgradedPackage, present = pkg }
-                        runDiagnosticCheck $ diagsToIdeResult (toNormalizedFilePath' pSrc) $ TypeChecker.Upgrade.checkUpgrade lfVersion upgradePair
-                    _ -> pure ()
+                 when pTypecheckUpgrades $
+                     case mbUpgradedPackage of
+                        Just (_, upgradedPackage) ->
+                          MaybeT $ do
+                            let upgradePair = Upgrading { past = upgradedPackage, present = pkg }
+                            runDiagnosticCheck $ diagsToIdeResult (toNormalizedFilePath' pSrc) $ TypeChecker.Upgrade.checkUpgrade lfVersion upgradePair
+                        _ -> pure ()
                  MaybeT $ finalPackageCheck (toNormalizedFilePath' pSrc) pkg
 
                  let pkgModuleNames = map (Ghc.mkModuleName . T.unpack) $ LF.packageModuleNames pkg

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -202,10 +202,13 @@ ideErrorPretty :: Pretty.Pretty e => NormalizedFilePath -> e -> FileDiagnostic
 ideErrorPretty fp = ideErrorText fp . T.pack . HughesPJPretty.prettyShow
 
 finalPackageCheck :: NormalizedFilePath -> LF.Package -> Action (Maybe ())
-finalPackageCheck fp pkg = do
+finalPackageCheck fp pkg =
+    runDiagnosticCheck $ diagsToIdeResult fp (LF.nameCheckPackage pkg)
+
+runDiagnosticCheck :: IdeResult a -> Action (Maybe a)
+runDiagnosticCheck (diags, r) = do
     sendFileDiagnostics diags
     pure r
-    where (diags, r) = diagsToIdeResult fp (LF.nameCheckPackage pkg)
 
 diagsToIdeResult :: NormalizedFilePath -> [Diagnostic] -> IdeResult ()
 diagsToIdeResult fp diags = (map (fp, ShowDiag,) diags, r)

--- a/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
+++ b/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
@@ -56,6 +56,7 @@ data PackageConfigFields = PackageConfigFields
     -- under the given prefix.
     , pSdkVersion :: PackageSdkVersion
     , pUpgradedPackagePath :: Maybe String
+    , pTypecheckUpgrades :: Bool
     }
 
 -- | SDK version for package.
@@ -77,6 +78,7 @@ parseProjectConfig project = do
     pModulePrefixes <- fromMaybe Map.empty <$> queryProjectConfig ["module-prefixes"] project
     pSdkVersion <- queryProjectConfigRequired ["sdk-version"] project
     pUpgradedPackagePath <- queryProjectConfig ["upgrades"] project
+    pTypecheckUpgrades <- fromMaybe False <$> queryProjectConfig ["typecheck-upgrades"] project
     Right PackageConfigFields {..}
 
 checkPkgConfig :: PackageConfigFields -> [T.Text]

--- a/compiler/damlc/daml-package-config/test/DA/Daml/Package/ConfigTest.hs
+++ b/compiler/damlc/daml-package-config/test/DA/Daml/Package/ConfigTest.hs
@@ -38,5 +38,6 @@ checkPkgConfigTests = testGroup "checkPkgConfig"
       , pModulePrefixes = Map.empty
       , pSdkVersion = PackageSdkVersion "0.0.0"
       , pUpgradedPackagePath = Nothing
+      , pTypecheckUpgrades = False
       }
 

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -1406,6 +1406,7 @@ execPackage projectOpts filePath opts mbOutFile dalfInput =
                               , pSdkVersion = PackageSdkVersion SdkVersion.sdkVersion
                               , pModulePrefixes = Map.empty
                               , pUpgradedPackagePath = Nothing
+                              , pTypecheckUpgrades = False
                               -- execPackage is deprecated so it doesn't need to support upgrades
                               }
                             (toNormalizedFilePath' $ fromMaybe ifaceDir $ optIfaceDir opts)

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -450,6 +450,39 @@ da_haskell_test(
     ],
 )
 
+# Tests for upgrades
+da_haskell_test(
+    name = "upgrades",
+    srcs = ["src/DA/Test/DamlcUpgrades.hs"],
+    data = [
+        "//compiler/damlc",
+        "//daml-script/daml:daml-script.dar",
+        "//daml-script/runner:daml-script-binary",
+    ],
+    hackage_deps = [
+        "base",
+        "containers",
+        "directory",
+        "extra",
+        "filepath",
+        "process",
+        "regex-tdfa",
+        "tasty",
+        "tasty-hunit",
+        "text",
+    ],
+    main_function = "DA.Test.DamlcUpgrades.main",
+    src_strip_prefix = "src",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:sdk-version-hs-lib",
+        "//compiler/damlc/daml-opts:daml-opts-types",
+        "//libs-haskell/bazel-runfiles",
+        "//libs-haskell/test-utils",
+        "//compiler/daml-lf-ast",
+    ],
+)
+
 # Tests for packaging
 da_haskell_test(
     name = "packaging",

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -476,10 +476,10 @@ da_haskell_test(
     visibility = ["//visibility:public"],
     deps = [
         "//:sdk-version-hs-lib",
+        "//compiler/daml-lf-ast",
         "//compiler/damlc/daml-opts:daml-opts-types",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/test-utils",
-        "//compiler/daml-lf-ast",
     ],
 )
 

--- a/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -164,5 +164,5 @@ tests damlc =
           , "typecheck-upgrades: true"
           , "build-options:"
           , "- --target=" <> renderVersion (featureMinVersion featurePackageUpgrades)
-          ] ++ ["upgrades: \"" <> path <> "\"" | Just path <- pure upgradedFile]
+          ] ++ ["upgrades: '" <> path <> "'" | Just path <- pure upgradedFile]
         )

--- a/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -29,95 +29,412 @@ tests damlc =
     testGroup
         "Upgrade"
         [ test
-              "Fails when new field is added without Optional type"
-              (Just "Message: \n\ESC\\[0;91merror type checking data type MyLib.A:\n  EUpgradeRecordFieldsNewNonOptional")
+              "Fails when template changes signatories"
+              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A signatories:\n  The upgraded template A cannot change the definition of its signatories.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
-                      , "data A = A"
-                      , "  { existing1 : Int"
-                      , "  , existing2 : Int"
-                      , "  }"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where signatory [p]"
                       ]
                 )
               ]
               [ ("daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
-                      , "data A = A"
-                      , "  { existing1 : Int"
-                      , "  , existing2 : Int"
-                      , "  , new : Int"
-                      , "  }"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where signatory [p, q]"
                       ]
                 )
               ]
         , test
-              "Fails when old field is deleted"
-              (Just "Message: \n\ESC\\[0;91merror type checking data type MyLib.A:\n  EUpgradeRecordFieldsMissing")
+              "Fails when template changes observers"
+              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A observers:\n  The upgraded template A cannot change the definition of its observers.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
-                      , "data A = A"
-                      , "  { existing1 : Int"
-                      , "  , existing2 : Int"
-                      , "  }"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    observer p"
                       ]
                 )
               ]
               [ ("daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
-                      , "data A = A"
-                      , "  { existing2 : Int"
-                      , "  }"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    observer p, q"
                       ]
                 )
               ]
         , test
-              "Fails when existing field is changed"
-              (Just "Message: \n\ESC\\[0;91merror type checking data type MyLib.A:\n  EUpgradeRecordFieldsExistingChanged")
+              "Fails when template changes ensure"
+              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A precondition:\n  The upgraded template A cannot change the definition of its precondition.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
-                      , "data A = A"
-                      , "  { existing1 : Int"
-                      , "  , existing2 : Int"
-                      , "  }"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    ensure True"
                       ]
                 )
               ]
               [ ("daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
-                      , "data A = A"
-                      , "  { existing1 : Text"
-                      , "  , existing2 : Int"
-                      , "  }"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    ensure True == True"
                       ]
                 )
               ]
         , test
-              "Succeeds when new field is added with optional type"
+              "Fails when template changes agreement"
+              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A agreement:\n  The upgraded template A cannot change the definition of agreement.")
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    agreement \"agreement1\""
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    agreement \"agreement2\""
+                      ]
+                )
+              ]
+        , test
+              "Fails when new field is added to template without Optional type"
+              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A :\n  The upgraded template A has added new fields, but those fields are not Optional.")
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    existing1 : Int"
+                      , "    existing2 : Int"
+                      , "  where signatory p"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    existing1 : Int"
+                      , "    existing2 : Int"
+                      , "    new : Int"
+                      , "  where signatory p"
+                      ]
+                )
+              ]
+        , test
+              "Fails when old field is deleted from template"
+              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A :\n  The upgraded template A is missing some of its original fields.")
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    existing1 : Int"
+                      , "    existing2 : Int"
+                      , "  where signatory p"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    existing2 : Int"
+                      , "  where signatory p"
+                      ]
+                )
+              ]
+        , test
+              "Fails when existing field in template is changed"
+              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A :\n  The upgraded template A has changed the types of some of its original fields.")
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    existing1 : Int"
+                      , "    existing2 : Int"
+                      , "  where signatory p"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    existing1 : Text"
+                      , "    existing2 : Int"
+                      , "  where signatory p"
+                      ]
+                )
+              ]
+        , test
+              "Succeeds when new field with optional type is added to template"
               Nothing
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
-                      , "data A = A"
-                      , "  { existing1 : Int"
-                      , "  , existing2 : Int"
-                      , "  }"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    existing1 : Int"
+                      , "    existing2 : Int"
+                      , "  where signatory p"
                       ]
                 )
               ]
               [ ("daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
-                      , "data A = A"
-                      , "  { existing1 : Int"
-                      , "  , existing2 : Int"
-                      , "  , new : Optional Int"
-                      , "  }"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    existing1 : Int"
+                      , "    existing2 : Int"
+                      , "    new : Optional Int"
+                      , "  where signatory p"
+                      ]
+                )
+              ]
+        , test
+              "Fails when new field is added to template choice without Optional type"
+              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded type of choice C on template A has added new fields, but those fields are not Optional.")
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : ()"
+                      , "      with"
+                      , "        existing1 : Int"
+                      , "        existing2 : Int"
+                      , "      controller p"
+                      , "      do pure ()"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : ()"
+                      , "      with"
+                      , "        existing1 : Int"
+                      , "        existing2 : Int"
+                      , "        new : Int"
+                      , "      controller p"
+                      , "      do pure ()"
+                      ]
+                )
+              ]
+        , test
+              "Fails when old field is deleted from template choice"
+              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded type of choice C on template A is missing some of its original fields.")
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : ()"
+                      , "      with"
+                      , "        existing1 : Int"
+                      , "        existing2 : Int"
+                      , "      controller p"
+                      , "      do pure ()"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : ()"
+                      , "      with"
+                      , "        existing2 : Int"
+                      , "      controller p"
+                      , "      do pure ()"
+                      ]
+                )
+              ]
+        , test
+              "Fails when existing field in template choice is changed"
+              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded type of choice C on template A has changed the types of some of its original fields.")
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : ()"
+                      , "      with"
+                      , "        existing1 : Int"
+                      , "        existing2 : Int"
+                      , "      controller p"
+                      , "      do pure ()"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : ()"
+                      , "      with"
+                      , "        existing1 : Text"
+                      , "        existing2 : Int"
+                      , "      controller p"
+                      , "      do pure ()"
+                      ]
+                )
+              ]
+        , test
+              "Fails when controllers of template choice are changed"
+              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded choice C cannot change the definition of controllers.")
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : ()"
+                      , "      controller p"
+                      , "      do pure ()"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : ()"
+                      , "      controller p, q"
+                      , "      do pure ()"
+                      ]
+                )
+              ]
+        , test
+              "Fails when observers of template choice are changed"
+              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded choice C cannot change the definition of observers.")
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : ()"
+                      , "      observer p"
+                      , "      controller p"
+                      , "      do pure ()"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : ()"
+                      , "      observer p, q"
+                      , "      controller p"
+                      , "      do pure ()"
+                      ]
+                )
+              ]
+        , test
+              "Succeeds when new field with optional type is added to template choice"
+              Nothing
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : ()"
+                      , "      with"
+                      , "        existing1 : Int"
+                      , "        existing2 : Int"
+                      , "      controller p"
+                      , "      do pure ()"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : ()"
+                      , "      with"
+                      , "        existing1 : Int"
+                      , "        existing2 : Int"
+                      , "        new : Optional Int"
+                      , "      controller p"
+                      , "      do pure ()"
                       ]
                 )
               ]

--- a/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -31,9 +31,9 @@ tests damlc =
         [ test
               "Fails when new field is added without Optional type"
               (Just "Message: \n\ESC\\[0;91merror type checking <none>:\n  EUpgradeRecordFieldsNewNonOptional")
-              [ ( "daml/Foo.daml"
+              [ ( "daml/MyLib.daml"
                 , unlines
-                      [ "module Foo where"
+                      [ "module MyLib where"
                       , "data A = A"
                       , "  { existing1 : Int"
                       , "  , existing2 : Int"
@@ -41,9 +41,9 @@ tests damlc =
                       ]
                 )
               ]
-              [ ("daml/Foo.daml"
+              [ ("daml/MyLib.daml"
                 , unlines
-                      [ "module Foo where"
+                      [ "module MyLib where"
                       , "data A = A"
                       , "  { existing1 : Int"
                       , "  , existing2 : Int"
@@ -55,9 +55,9 @@ tests damlc =
         , test
               "Fails when old field is deleted"
               (Just "Message: \n\ESC\\[0;91merror type checking <none>:\n  EUpgradeRecordFieldsMissing")
-              [ ( "daml/Foo.daml"
+              [ ( "daml/MyLib.daml"
                 , unlines
-                      [ "module Foo where"
+                      [ "module MyLib where"
                       , "data A = A"
                       , "  { existing1 : Int"
                       , "  , existing2 : Int"
@@ -65,9 +65,9 @@ tests damlc =
                       ]
                 )
               ]
-              [ ("daml/Foo.daml"
+              [ ("daml/MyLib.daml"
                 , unlines
-                      [ "module Foo where"
+                      [ "module MyLib where"
                       , "data A = A"
                       , "  { existing2 : Int"
                       , "  }"
@@ -77,9 +77,9 @@ tests damlc =
         , test
               "Fails when existing field is changed"
               (Just "Message: \n\ESC\\[0;91merror type checking <none>:\n  EUpgradeRecordFieldsExistingChanged")
-              [ ( "daml/Foo.daml"
+              [ ( "daml/MyLib.daml"
                 , unlines
-                      [ "module Foo where"
+                      [ "module MyLib where"
                       , "data A = A"
                       , "  { existing1 : Int"
                       , "  , existing2 : Int"
@@ -87,9 +87,9 @@ tests damlc =
                       ]
                 )
               ]
-              [ ("daml/Foo.daml"
+              [ ("daml/MyLib.daml"
                 , unlines
-                      [ "module Foo where"
+                      [ "module MyLib where"
                       , "data A = A"
                       , "  { existing1 : Text"
                       , "  , existing2 : Int"
@@ -100,9 +100,9 @@ tests damlc =
         , test
               "Succeeds when new field is added with optional type"
               Nothing
-              [ ( "daml/Foo.daml"
+              [ ( "daml/MyLib.daml"
                 , unlines
-                      [ "module Foo where"
+                      [ "module MyLib where"
                       , "data A = A"
                       , "  { existing1 : Int"
                       , "  , existing2 : Int"
@@ -110,9 +110,9 @@ tests damlc =
                       ]
                 )
               ]
-              [ ("daml/Foo.daml"
+              [ ("daml/MyLib.daml"
                 , unlines
-                      [ "module Foo where"
+                      [ "module MyLib where"
                       , "data A = A"
                       , "  { existing1 : Int"
                       , "  , existing2 : Int"
@@ -135,8 +135,8 @@ tests damlc =
             let depDir = dir </> "oldVersion"
             let dar = dir </> "out.dar"
             let depDar = dir </> "oldVersion" </> "dep.dar"
-            writeFiles dir (projectFile "foo-v2" (Just depDar) : newVersion)
-            writeFiles depDir (projectFile "foo-v1" Nothing : oldVersion)
+            writeFiles dir (projectFile "mylib-v2" (Just depDar) : newVersion)
+            writeFiles depDir (projectFile "mylib-v1" Nothing : oldVersion)
             callProcessSilent damlc ["build", "--project-root", depDir, "-o", depDar]
             case expectedError of
               Nothing ->

--- a/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -161,6 +161,7 @@ tests damlc =
           , "dependencies:"
           , "  - daml-prim"
           , "  - daml-stdlib"
+          , "typecheck-upgrades: true"
           , "build-options:"
           , "- --target=" <> renderVersion (featureMinVersion featurePackageUpgrades)
           ] ++ ["upgrades: \"" <> path <> "\"" | Just path <- pure upgradedFile]

--- a/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -235,7 +235,7 @@ tests damlc =
               ]
         , test
               "Fails when new field is added to template choice without Optional type"
-              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded type of choice C on template A has added new fields, but those fields are not Optional.")
+              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded input type of choice C on template A has added new fields, but those fields are not Optional.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -271,7 +271,7 @@ tests damlc =
               ]
         , test
               "Fails when old field is deleted from template choice"
-              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded type of choice C on template A is missing some of its original fields.")
+              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded input type of choice C on template A is missing some of its original fields.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -305,7 +305,7 @@ tests damlc =
               ]
         , test
               "Fails when existing field in template choice is changed"
-              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded type of choice C on template A has changed the types of some of its original fields.")
+              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded input type of choice C on template A has changed the types of some of its original fields.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -399,6 +399,41 @@ tests damlc =
                       , "      observer p, q"
                       , "      controller p"
                       , "      do pure ()"
+                      ]
+                )
+              ]
+        , test
+              "Fails when template choice changes its return type"
+              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded choice C cannot change its return type.")
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : ()"
+                      , "      with"
+                      , "        existing1 : Int"
+                      , "        existing2 : Int"
+                      , "      controller p"
+                      , "      do pure ()"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : Int"
+                      , "      with"
+                      , "        existing1 : Int"
+                      , "        existing2 : Int"
+                      , "      controller p"
+                      , "      do pure 1"
                       ]
                 )
               ]

--- a/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -18,6 +18,7 @@ import SdkVersion
 import DA.Daml.LF.Ast.Version
 import Text.Regex.TDFA
 import qualified Data.Text as T
+import Data.Maybe (fromMaybe)
 
 main :: IO ()
 main = do
@@ -515,6 +516,10 @@ tests damlc =
           , "  - daml-stdlib"
           , "typecheck-upgrades: true"
           , "build-options:"
-          , "- --target=" <> renderVersion (featureMinVersion featurePackageUpgrades)
+          , "- --target=" <>
+                renderVersion
+                  (fromMaybe
+                    (error "DamlcUpgrades: featureMinVersion should be defined over featurePackageUpgrades")
+                    (featureMinVersion featurePackageUpgrades V1))
           ] ++ ["upgrades: '" <> path <> "'" | Just path <- pure upgradedFile]
         )

--- a/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -1,0 +1,167 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DA.Test.DamlcUpgrades (main) where
+
+{- HLINT ignore "locateRunfiles/package_app" -}
+
+import Control.Monad.Extra
+import DA.Bazel.Runfiles
+import Data.Foldable
+import System.Directory.Extra
+import System.FilePath
+import System.IO.Extra
+import DA.Test.Process
+import Test.Tasty
+import Test.Tasty.HUnit
+import SdkVersion
+import DA.Daml.LF.Ast.Version
+import Text.Regex.TDFA
+import qualified Data.Text as T
+
+main :: IO ()
+main = do
+    damlc <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> exe "damlc")
+    defaultMain $ tests damlc
+
+tests :: FilePath -> TestTree
+tests damlc =
+    testGroup
+        "Upgrade"
+        [ test
+              "Fails when new field is added without Optional type"
+              (Just "Message: \n\ESC\\[0;91merror type checking <none>:\n  EUpgradeRecordFieldsNewNonOptional")
+              [ ( "daml/Foo.daml"
+                , unlines
+                      [ "module Foo where"
+                      , "data A = A"
+                      , "  { existing1 : Int"
+                      , "  , existing2 : Int"
+                      , "  }"
+                      ]
+                )
+              ]
+              [ ("daml/Foo.daml"
+                , unlines
+                      [ "module Foo where"
+                      , "data A = A"
+                      , "  { existing1 : Int"
+                      , "  , existing2 : Int"
+                      , "  , new : Int"
+                      , "  }"
+                      ]
+                )
+              ]
+        , test
+              "Fails when old field is deleted"
+              (Just "Message: \n\ESC\\[0;91merror type checking <none>:\n  EUpgradeRecordFieldsMissing")
+              [ ( "daml/Foo.daml"
+                , unlines
+                      [ "module Foo where"
+                      , "data A = A"
+                      , "  { existing1 : Int"
+                      , "  , existing2 : Int"
+                      , "  }"
+                      ]
+                )
+              ]
+              [ ("daml/Foo.daml"
+                , unlines
+                      [ "module Foo where"
+                      , "data A = A"
+                      , "  { existing2 : Int"
+                      , "  }"
+                      ]
+                )
+              ]
+        , test
+              "Fails when existing field is changed"
+              (Just "Message: \n\ESC\\[0;91merror type checking <none>:\n  EUpgradeRecordFieldsExistingChanged")
+              [ ( "daml/Foo.daml"
+                , unlines
+                      [ "module Foo where"
+                      , "data A = A"
+                      , "  { existing1 : Int"
+                      , "  , existing2 : Int"
+                      , "  }"
+                      ]
+                )
+              ]
+              [ ("daml/Foo.daml"
+                , unlines
+                      [ "module Foo where"
+                      , "data A = A"
+                      , "  { existing1 : Text"
+                      , "  , existing2 : Int"
+                      , "  }"
+                      ]
+                )
+              ]
+        , test
+              "Succeeds when new field is added with optional type"
+              Nothing
+              [ ( "daml/Foo.daml"
+                , unlines
+                      [ "module Foo where"
+                      , "data A = A"
+                      , "  { existing1 : Int"
+                      , "  , existing2 : Int"
+                      , "  }"
+                      ]
+                )
+              ]
+              [ ("daml/Foo.daml"
+                , unlines
+                      [ "module Foo where"
+                      , "data A = A"
+                      , "  { existing1 : Int"
+                      , "  , existing2 : Int"
+                      , "  , new : Optional Int"
+                      , "  }"
+                      ]
+                )
+              ]
+        ]
+  where
+    test ::
+           String
+        -> Maybe T.Text
+        -> [(FilePath, String)]
+        -> [(FilePath, String)]
+        -> TestTree
+    test name expectedError oldVersion newVersion =
+        testCase name $
+        withTempDir $ \dir -> do
+            let depDir = dir </> "oldVersion"
+            let dar = dir </> "out.dar"
+            let depDar = dir </> "oldVersion" </> "dep.dar"
+            writeFiles dir (projectFile "foo-v2" (Just depDar) : newVersion)
+            writeFiles depDir (projectFile "foo-v1" Nothing : oldVersion)
+            callProcessSilent damlc ["build", "--project-root", depDir, "-o", depDar]
+            case expectedError of
+              Nothing ->
+                  callProcessSilent damlc ["build", "--project-root", dir, "-o", dar]
+              Just regex -> do
+                  stderr <- callProcessForStderr damlc ["build", "--project-root", dir, "-o", dar]
+                  unless (matchTest (makeRegex regex :: Regex) stderr) $
+                      assertFailure ("Regex '" <> show regex <> "' did not match stderr:\n" <> show stderr)
+
+    writeFiles dir fs =
+        for_ fs $ \(file, content) -> do
+            createDirectoryIfMissing True (takeDirectory $ dir </> file)
+            writeFileUTF8 (dir </> file) content
+
+    projectFile name upgradedFile =
+        ( "daml.yaml"
+        , unlines $
+          [ "sdk-version: " <> sdkVersion
+          , "name: " <> name
+          , "source: daml"
+          , "version: 0.0.1"
+          , "dependencies:"
+          , "  - daml-prim"
+          , "  - daml-stdlib"
+          , "build-options:"
+          , "- --target=" <> renderVersion (featureMinVersion featurePackageUpgrades)
+          ] ++ ["upgrades: \"" <> path <> "\"" | Just path <- pure upgradedFile]
+        )

--- a/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -439,6 +439,70 @@ tests damlc =
                 )
               ]
         , test
+              "Succeeds when template choice returns a template which has changed"
+              Nothing
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : A"
+                      , "      controller p"
+                      , "      do pure (A p)"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Optional Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : A"
+                      , "      controller p"
+                      , "      do pure (A p (Just p))"
+                      ]
+                )
+              ]
+        , test
+              "Succeeds when template choice input argument has changed"
+              Nothing
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : ()"
+                      , "      with"
+                      , "        tpl : A"
+                      , "      controller p"
+                      , "      do pure ()"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Optional Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    choice C : ()"
+                      , "      with"
+                      , "        tpl : A"
+                      , "      controller p"
+                      , "      do pure ()"
+                      ]
+                )
+              ]
+        , test
               "Succeeds when new field with optional type is added to template choice"
               Nothing
               [ ( "daml/MyLib.daml"

--- a/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -30,7 +30,7 @@ tests damlc =
         "Upgrade"
         [ test
               "Fails when new field is added without Optional type"
-              (Just "Message: \n\ESC\\[0;91merror type checking <none>:\n  EUpgradeRecordFieldsNewNonOptional")
+              (Just "Message: \n\ESC\\[0;91merror type checking data type MyLib.A:\n  EUpgradeRecordFieldsNewNonOptional")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -54,7 +54,7 @@ tests damlc =
               ]
         , test
               "Fails when old field is deleted"
-              (Just "Message: \n\ESC\\[0;91merror type checking <none>:\n  EUpgradeRecordFieldsMissing")
+              (Just "Message: \n\ESC\\[0;91merror type checking data type MyLib.A:\n  EUpgradeRecordFieldsMissing")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -76,7 +76,7 @@ tests damlc =
               ]
         , test
               "Fails when existing field is changed"
-              (Just "Message: \n\ESC\\[0;91merror type checking <none>:\n  EUpgradeRecordFieldsExistingChanged")
+              (Just "Message: \n\ESC\\[0;91merror type checking data type MyLib.A:\n  EUpgradeRecordFieldsExistingChanged")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"


### PR DESCRIPTION
Proof of concept for typechecking for upgrades - not complete, but should cover the fundamentals for modules and templates, that is

- Checks that for relevant datatypes with same name and module in a package
  - Don't remove a field
  - Don't change a field's return type
  - Don't add a field without an `Optional` return type
  
  Relevant datatypes are those used in the definition of a template, i.e. its body, the inputs of its choices, and the outputs of its choices.

- Definition of signatories, observers, etc. remain unchanged

For those with access, a reference: https://docs.google.com/document/d/18XKYP-PvrhgaDRPnG30H2JZvBawqz5nBpa7gIFsYOwE/edit

After this PR goes in, TODOs:
- [ ] Resolve type synonyms in choice return types to find datatypes that are upgraded poorly.
- [ ] Improve error messages
- [ ] Determine what to do with datatypes that aren't in templates/choices
- [ ] Check dependencies have changed