### PR TITLE
canton-ee tests are run only on Unix and disable locally by default.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -139,3 +139,7 @@ build -c opt
 try-import %workspace%/.bazelrc.local
 build --build_tag_filters=-canton-ee
 test --test_tag_filters=-canton-ee
+
+# Set flag --config=canton-ee to run tests which depend on Canton Enterprise Edition
+build:canton-ee --build_tag_filters=canton-ee
+test:canton-ee --test_tag_filters=canton-ee

--- a/build.sh
+++ b/build.sh
@@ -90,7 +90,8 @@ $bazel test //... \
   --experimental_profile_include_target_label \
   --build_event_json_file test-events.json \
   --build_event_publish_all_actions \
-  --experimental_execution_log_file "$ARTIFACT_DIRS/logs/test_execution${execution_log_postfix}.log"
+  --experimental_execution_log_file "$ARTIFACT_DIRS/logs/test_execution${execution_log_postfix}.log" \
+  --config=canton-ee
 
 # Make sure that Bazel query works.
 $bazel query 'deps(//...)' >/dev/null

--- a/canton/README.md
+++ b/canton/README.md
@@ -61,16 +61,12 @@ open-source repository so we cannot assume every contributor will have a Canton
 EE license key.
 
 Tests that require Canton EE **must** be tagged with `"canton-ee"`, which is
-disabled by default through `.bazelrc`. To run those tests locally, either
-explicitly target them or add `--build_tag_filters=` or `--test_tag_filters=`
-as appropriate (yes, these are the full options: by setting the "running"
-filters to empty for the current run, you overwrite the `-canton-ee` set in
-`.bazelrc` which excludes the Canton EE tests, thereby removing the exclusion
-and including the tests).
+disabled by default through `.bazelrc`. To run those tests locally, add
+`--config=canton-ee`, thereby removing the exclusion and including the tests.
 
 Those tests are run on CI.
 
 If you're using a local build of canton (setting `local` to `True` per above)
-_and_ you are explicitly overwriting the `*_tag_filters` to run the Canton EE
+_and_ you are explicitly using `--config=canton-ee` to run the Canton EE
 tests, they will be run using your provided `canton-ee.jar` (which therefore
 needs to be an EE jar at that point).

--- a/compatibility/.bazelrc
+++ b/compatibility/.bazelrc
@@ -139,3 +139,7 @@ build -c opt
 try-import %workspace%/.bazelrc.local
 build --build_tag_filters=-canton-ee
 test --test_tag_filters=-canton-ee
+
+# Set flag --config=canton-ee to run tests which depend on Canton Enterprise Edition
+build:canton-ee --build_tag_filters=canton-ee
+test:canton-ee --test_tag_filters=canton-ee


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
