### PR TITLE
Run daml script tests using both evaluation orders

### DIFF
--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -8,6 +8,7 @@ module DA.Daml.Options.Types
     ( Options(..)
     , EnableScenarioService(..)
     , EnableScenarios(..)
+    , EvaluationOrder(..)
     , AllowLargeTuples(..)
     , StudioAutorunAllScenarios(..)
     , SkipScenarioValidation(..)
@@ -184,6 +185,11 @@ newtype AllowLargeTuples = AllowLargeTuples { getAllowLargeTuples :: Bool }
 
 newtype StudioAutorunAllScenarios = StudioAutorunAllScenarios { getStudioAutorunAllScenarios :: Bool }
     deriving Show
+
+data EvaluationOrder
+  = LeftToRight
+  | RightToLeft
+  deriving (Read, Show, Eq)
 
 damlArtifactDir :: FilePath
 damlArtifactDir = ".daml"

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -163,9 +163,10 @@ da_haskell_library(
     da_haskell_test(
         # NOTE(MH): For some reason, ghc-pkg gets very unhappy if we separate
         # the components of the version number by dot, dash or underscore.
-        name = "integration{skip}-v{version}".format(
+        name = "integration{skip}{order}-v{version}".format(
             version = version.replace(".", ""),
             skip = "-unvalidated" if skip_validation else "",
+            order = "-r2l" if eval_order == "RightToLeft" else "",
         ),
         size = "large",
         srcs = ["src/DA/Test/DamlcIntegrationMain.hs"],
@@ -176,6 +177,8 @@ da_haskell_library(
             "true" if skip_validation else "false",
             "--daml-script-v2",
             "false",
+            "--evaluation-order",
+            eval_order,
         ],
         data = [
             ":bond-trading",
@@ -199,54 +202,71 @@ da_haskell_library(
             ":integration-lib",
         ],
     )
-    for version, skip_validation in [(version, False) for version in COMPILER_LF_VERSIONS] + [
+    for version, skip_validation, eval_order in [(version, False, "LeftToRight") for version in COMPILER_LF_VERSIONS] + [
         (
             lf_version_configuration.get("default"),
             True,
+            "LeftToRight",
         ),
         (
             lf_version_configuration.get("dev"),
             True,
+            "LeftToRight",
+        ),
+        (
+            lf_version_configuration.get("dev"),
+            False,
+            "RightToLeft",
         ),
     ]
 ]
 
-da_haskell_test(
-    name = "integration-v1dev-script2",
-    size = "large",
-    srcs = ["src/DA/Test/DamlcIntegrationMain.hs"],
-    args = [
-        "--daml-lf-version",
-        "1.dev",
-        "--skip-validation",
-        "false",
-        "--daml-script-v2",
-        "true",
-    ],
-    data = [
-        ":bond-trading",
-        ":cant-skip-preprocessor",
-        ":daml-test-files",
-        ":package-vetting-package-a.dar",
-        ":package-vetting-package-b.dar",
-        ":query-lf-lib",
-        "//compiler/damlc/pkg-db",
-        "//compiler/damlc/stable-packages",
-        "//compiler/scenario-service/server:scenario_service_jar",
-        "//daml-script/daml3:daml3-script.dar",
-        "@jq_dev_env//:jq",
-        ghc_pkg,
-    ],
-    hackage_deps = [
-        "base",
-    ],
-    main_function = "DA.Test.DamlcIntegrationMain.main",
-    src_strip_prefix = "src",
-    visibility = ["//visibility:public"],
-    deps = [
-        ":integration-lib",
-    ],
-)
+[
+    da_haskell_test(
+        name = "integration{order}-v1dev-script2".format(
+            order = "-r2l" if eval_order == "RightToLeft" else "",
+        ),
+        size = "large",
+        srcs = ["src/DA/Test/DamlcIntegrationMain.hs"],
+        args = [
+            "--daml-lf-version",
+            "1.dev",
+            "--skip-validation",
+            "false",
+            "--daml-script-v2",
+            "true",
+            "--evaluation-order",
+            eval_order,
+        ],
+        data = [
+            ":bond-trading",
+            ":cant-skip-preprocessor",
+            ":daml-test-files",
+            ":package-vetting-package-a.dar",
+            ":package-vetting-package-b.dar",
+            ":query-lf-lib",
+            "//compiler/damlc/pkg-db",
+            "//compiler/damlc/stable-packages",
+            "//compiler/scenario-service/server:scenario_service_jar",
+            "//daml-script/daml3:daml3-script.dar",
+            "@jq_dev_env//:jq",
+            ghc_pkg,
+        ],
+        hackage_deps = [
+            "base",
+        ],
+        main_function = "DA.Test.DamlcIntegrationMain.main",
+        src_strip_prefix = "src",
+        visibility = ["//visibility:public"],
+        deps = [
+            ":integration-lib",
+        ],
+    )
+    for eval_order in [
+        "LeftToRight",
+        "RightToLeft",
+    ]
+]
 
 # Tests for daml-doc
 da_haskell_test(

--- a/compiler/damlc/tests/daml-test-files/SemanticsEvalOrderRightToLeft.daml
+++ b/compiler/damlc/tests/daml-test-files/SemanticsEvalOrderRightToLeft.daml
@@ -13,9 +13,9 @@
 {-# OPTIONS_GHC -Wno-controller-can #-}
 {-# LANGUAGE ApplicativeDo #-}
 
-module SemanticsEvalOrder where
+module SemanticsEvalOrderRightToLeft where
 
--- @EVALUATION-ORDER LeftToRight
+-- @EVALUATION-ORDER RightToLeft
 
 import Daml.Script
 import ScriptAssertHelpers
@@ -30,15 +30,15 @@ evTyAbsErasableErr = script do
 -- @ERROR overApply OK
 overApply : Script ()
 overApply = script do
-  let f x = error "overApply OK"
-  let _ = f 1 (error "overApply Failed")
+  let f x = error "overApply Failed"
+  let _ = f 1 (error "overApply OK")
   let _ = f 1 2
   pure ()
 
 -- @ERROR EvExpAppErr1 OK
 evExpAppErr1 : Script ()
 evExpAppErr1 = script do
-  let _ = (error "EvExpAppErr1 OK") (error "EvExpAppErr1 failed")
+  let _ = (error "EvExpAppErr1 failed") (error "EvExpAppErr1 OK")
   pure ()
 
 -- @ERROR EvExpAppErr2 OK
@@ -87,21 +87,21 @@ evExpCase_2 = script do
 -- @ERROR EvExpConsErr1 OK
 evExpConsErr1 : Script [Int]
 evExpConsErr1 = script do
-  pure ( error "EvExpConsErr1 OK"
+  pure ( error "EvExpConsErr1 failed"
       :: error "EvExpConsErr1 failed"
-      :: error "EvExpConsErr1 failed")
+      :: error "EvExpConsErr1 OK")
 
 -- @ERROR EvExpConsErr2 OK
 evExpConsErr2 : Script [Int]
 evExpConsErr2 = script do
   pure ( 10
-      :: error "EvExpConsErr2 OK"
-      :: error "EvExpConsErr2 failed")
+      :: error "EvExpConsErr2 failed"
+      :: error "EvExpConsErr2 OK")
 
 -- @ERROR EvExpBuiltinErr OK
 evExpBuiltinErr : Script ()
 evExpBuiltinErr = script do
-  let _ : Int = error "EvExpBuiltinErr OK" + error "EvExpBuiltinErr failed"
+  let _ : Int = error "EvExpBuiltinErr failed" + error "EvExpBuiltinErr OK"
   pure ()
 
 
@@ -110,12 +110,12 @@ data R1 = R1 { a: Int, b: Int }
 -- @ERROR EvExpRecConErr_1 OK
 evExpRecConErr_1 : Script R1
 evExpRecConErr_1 = script do
-  pure R1 { a = error "EvExpRecConErr_1 OK", b = error "EvExpRecConErr_1 failed" }
+  pure R1 { a = error "EvExpRecConErr_1 failed", b = error "EvExpRecConErr_1 OK" }
 
 -- @ERROR EvExpRecConErr_2 OK
 evExpRecConErr_2 : Script R1
 evExpRecConErr_2 = script do
-  pure R1 { b = error "EvExpRecConErr_2 failed", a = error "EvExpRecConErr_2 OK" }
+  pure R1 { b = error "EvExpRecConErr_2 OK", a = error "EvExpRecConErr_2 failed" }
 
 data R2 = R2 { d: Int, c: Int }
   -- ^ Checking that there isn't a dependence on the field names.
@@ -124,30 +124,30 @@ data R2 = R2 { d: Int, c: Int }
 -- @ERROR EvExpRecConErr_3 OK
 evExpRecConErr_3 : Script R2
 evExpRecConErr_3 = script do
-  pure R2 { d = error "EvExpRecConErr_3 OK", c = error "EvExpRecConErr_3 failed" }
+  pure R2 { d = error "EvExpRecConErr_3 failed", c = error "EvExpRecConErr_3 OK" }
 
 -- @ERROR EvExpRecConErr_4 OK
 evExpRecConErr_4 : Script R2
 evExpRecConErr_4 = script do
-  pure R2 { c = error "EvExpRecConErr_4 failed", d = error "EvExpRecConErr_4 OK"  }
+  pure R2 { c = error "EvExpRecConErr_4 OK", d = error "EvExpRecConErr_4 failed"  }
 
 -- @ERROR EvExpRecUpdErr1 OK
 evExpRecUpdErr1 : Script R1
 evExpRecUpdErr1 = script do
-  pure (error "EvExpRecUpdErr1 OK" : R1)
-    { a = error "EvExpRecUpdErr1 failed", b = error "EvExpRecUpdErr1 failed" }
+  pure (error "EvExpRecUpdErr1 failed" : R1)
+    { a = error "EvExpRecUpdErr1 failed", b = error "EvExpRecUpdErr1 OK" }
 
 -- @ERROR EvExpRecUpdErr2_1 OK
 evExpRecUpdErr2_1 : Script R1
 evExpRecUpdErr2_1 = script do
   pure (R1 {a=0, b=0})
-    { a = error "EvExpRecUpdErr2_1 OK", b = error "EvExpRecUpdErr2_1 failed" }
+    { a = error "EvExpRecUpdErr2_1 failed", b = error "EvExpRecUpdErr2_1 OK" }
 
 -- @ERROR EvExpRecUpdErr2_2 OK
 evExpRecUpdErr2_2 : Script R1
 evExpRecUpdErr2_2 = script do
   pure (R1 {a=0, b=0})
-    { b = error "EvExpRecUpdErr2_2 OK", a = error "EvExpRecUpdErr2_2 failed" }
+    { b = error "EvExpRecUpdErr2_2 failed", a = error "EvExpRecUpdErr2_2 OK" }
   -- ^ Note that record update depends on the order the fields appear in
   -- code, rather than the order in which fields were defined.
 
@@ -157,7 +157,7 @@ evExpRecUpdErr2_2 = script do
 evExpRecUpdErr2_3 : Script R1
 evExpRecUpdErr2_3 = script do
   pure (R1 {a=0, b=0})
-    { a = error "EvExpRecUpdErr2_3 OK", a = error "EvExpRecUpdErr2_3 failed" }
+    { a = error "EvExpRecUpdErr2_3 failed", a = error "EvExpRecUpdErr2_3 OK" }
 
 -- Can't test LF struct evaluation order from Daml, since we purposely avoid
 -- evaluation of struct fields during typeclass desugaring, and we don't have
@@ -182,10 +182,10 @@ evExpFoldrErr2 = script do
 -- @ERROR EvExpFoldrErr3 OK
 evExpFoldrErr3 : Script Int
 evExpFoldrErr3 = script do
-  pure (foldr f identity [1] (error "EvExpFoldrErr3 failed"))
+  pure (foldr f identity [1] (error "EvExpFoldrErr3 OK"))
   where
     f: Int -> (Int -> Int) -> (Int -> Int)
-    f _ _ = error "EvExpFoldrErr3 OK"
+    f _ _ = error "EvExpFoldrErr3 failed"
 
 -- @ERROR EvExpFoldlErr1 OK
 evExpFoldlErr1 : Script Int
@@ -206,10 +206,10 @@ evExpFoldlErr2 = script do
 -- @ERROR EvExpFoldlErr3 OK
 evExpFoldlErr3 : Script Int
 evExpFoldlErr3 = script do
-  pure (foldl f identity [1] (error "EvExpFoldlErr3 failed"))
+  pure (foldl f identity [1] (error "EvExpFoldlErr3 OK"))
   where
     f: (Int -> Int) -> Int -> (Int -> Int)
-    f _ _ = error "EvExpFoldlErr3 OK"
+    f _ _ = error "EvExpFoldlErr3 failed"
 
 -- @ERROR EvExpUpPureErr OK
 evExpUpPureErr : Script ()
@@ -415,7 +415,7 @@ choiceControllerDoesntAddObserver = script do
 
 -- | Verify that contract inactivity is checked before interpreting
 -- the rest of the update.
--- @ERROR Attempt to exercise a contract that was consumed in same transaction. Contract: #0:0 (SemanticsEvalOrder:T_DoubleArchive)
+-- @ERROR Attempt to exercise a contract that was consumed in same transaction. Contract: #0:0 (SemanticsEvalOrderRightToLeft:T_DoubleArchive)
 template T_DoubleArchive
   with
     p : Party
@@ -434,7 +434,7 @@ doubleArchive = script do
 
 -- | Verify that a consuming choice's update is interpreted with a
 -- ledger state where the template has already been consumed.
--- @ERROR Attempt to exercise a contract that was consumed in same transaction. Contract: #0:0 (SemanticsEvalOrder:T_EvUpdExercConsumErr_1)
+-- @ERROR Attempt to exercise a contract that was consumed in same transaction. Contract: #0:0 (SemanticsEvalOrderRightToLeft:T_EvUpdExercConsumErr_1)
 template T_EvUpdExercConsumErr_1
   with
     p : Party
@@ -454,7 +454,7 @@ evUpdExercConsumErr_1 = script do
 
 
 -- | Similar to `T_EvUpdExercConsumErr_1` but using fetch instead of archive.
--- @ERROR Attempt to exercise a contract that was consumed in same transaction. Contract: #0:0 (SemanticsEvalOrder:T_EvUpdExercConsumErr_2)
+-- @ERROR Attempt to exercise a contract that was consumed in same transaction. Contract: #0:0 (SemanticsEvalOrderRightToLeft:T_EvUpdExercConsumErr_2)
 template T_EvUpdExercConsumErr_2
   with
     p : Party

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
@@ -44,7 +44,7 @@ import qualified Data.Set as S
 import qualified Data.Text as T
 import System.Directory
 
-import DA.Daml.Options.Types (EnableScenarioService(..), EnableScenarios(..))
+import DA.Daml.Options.Types (EnableScenarioService(..), EnableScenarios(..), EvaluationOrder (..))
 import DA.Daml.Project.Config
 import DA.Daml.Project.Consts
 import DA.Daml.Project.Types
@@ -75,6 +75,7 @@ toLowLevelOpts optDamlLfVersion Options{..} =
         optEvaluationTimeout = fromMaybe 60 $ cnfEvaluationTimeout optScenarioServiceConfig
         optGrpcMaxMessageSize = cnfGrpcMaxMessageSize optScenarioServiceConfig
         optJvmOptions = cnfJvmOptions optScenarioServiceConfig
+        optEvaluationOrder = cnfEvaluationOrder optScenarioServiceConfig
 
 data Handle = Handle
   { hLowLevelHandle :: LowLevel.Handle
@@ -163,6 +164,7 @@ data ScenarioServiceConfig = ScenarioServiceConfig
     , cnfGrpcTimeout :: Maybe LowLevel.TimeoutSeconds
     , cnfEvaluationTimeout :: Maybe LowLevel.TimeoutSeconds
     , cnfJvmOptions :: [String]
+    , cnfEvaluationOrder :: EvaluationOrder
     } deriving Show
 
 defaultScenarioServiceConfig :: ScenarioServiceConfig
@@ -171,6 +173,7 @@ defaultScenarioServiceConfig = ScenarioServiceConfig
     , cnfGrpcTimeout = Nothing
     , cnfEvaluationTimeout = Nothing
     , cnfJvmOptions = []
+    , cnfEvaluationOrder = LeftToRight
     }
 
 readScenarioServiceConfig :: IO ScenarioServiceConfig
@@ -188,6 +191,7 @@ parseScenarioServiceConfig conf = do
     cnfGrpcTimeout <- queryOpt "grpc-timeout"
     cnfEvaluationTimeout <- queryOpt "evaluation-timeout"
     cnfJvmOptions <- fromMaybe [] <$> queryOpt "jvm-options"
+    let cnfEvaluationOrder = LeftToRight
     pure ScenarioServiceConfig {..}
   where queryOpt opt = do
             a <- queryProjectConfig ["script-service", opt] conf

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -48,7 +48,7 @@ import Control.Exception
 import Control.Monad
 import Control.Monad.IO.Class
 import DA.Daml.LF.Mangling
-import DA.Daml.Options.Types (EnableScenarios (..))
+import DA.Daml.Options.Types (EnableScenarios (..), EvaluationOrder (..))
 import qualified DA.Daml.LF.Proto3.EncodeV1 as EncodeV1
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
@@ -88,6 +88,7 @@ data Options = Options
   , optLogError :: String -> IO ()
   , optDamlLfVersion :: LF.Version
   , optEnableScenarios :: EnableScenarios
+  , optEvaluationOrder :: EvaluationOrder
   }
 
 type TimeoutSeconds = Int64
@@ -227,6 +228,7 @@ withScenarioService opts@Options{..} f = do
     , ["-jar" , optServerJar]
     , ["--max-inbound-message-size=" <> show size | Just size <- [optGrpcMaxMessageSize]]
     , ["--enable-scenarios=" <> show b | EnableScenarios b <- [optEnableScenarios]]
+    , ["--evaluation-order=" <> show optEvaluationOrder]
     ]
 
   exitExpected <- newIORef False

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
@@ -6,6 +6,7 @@ package com.daml.lf.scenario
 import akka.actor.ActorSystem
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import akka.stream.Materializer
+
 import java.net.{InetAddress, InetSocketAddress}
 import java.util.logging.{Level, Logger}
 import scalaz.std.option._
@@ -15,17 +16,19 @@ import com.daml.lf.archive
 import com.daml.lf.data.ImmArray
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.ModuleName
+import com.daml.lf.language.LanguageDevConfig.{EvaluationOrder, LeftToRight, RightToLeft}
 import com.daml.lf.language.LanguageVersion
 import com.daml.lf.scenario.api.v1.{Map => _, _}
 import com.daml.logging.LoggingContext
 import io.grpc.stub.StreamObserver
 import io.grpc.{Status, StatusRuntimeException}
 import io.grpc.netty.NettyServerBuilder
+import scopt.Read
 
 import java.time.Instant
 import scala.util.Random
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Success, Failure}
+import scala.util.{Failure, Success}
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
@@ -34,6 +37,7 @@ import scala.util.control.NonFatal
 private final case class ScenarioServiceConfig(
     maxInboundMessageSize: Int,
     enableScenarios: Boolean,
+    evaluationOrder: EvaluationOrder,
 )
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
@@ -57,6 +61,18 @@ private object ScenarioServiceConfig {
       .text(
         "Enable/disable support for running scenarios. Defaults to true."
       )
+
+    val evaluationOrderRead: Read[EvaluationOrder] = Read.reads {
+      case "LeftToRight" => LeftToRight
+      case "RightToLeft" => RightToLeft
+      case s => throw new IllegalArgumentException(s"$s is not an EvaluationOrder")
+    }
+    opt[EvaluationOrder]("evaluation-order")(evaluationOrderRead)
+      .optional()
+      .action((x, c) => c.copy(evaluationOrder = x))
+      .text(
+        "The evaluation order of expressions: LeftToRight or RightToLeft. Defaults to LeftToRight."
+      )
   }
 
   def parse(args: Array[String]): Option[ScenarioServiceConfig] =
@@ -65,6 +81,7 @@ private object ScenarioServiceConfig {
       ScenarioServiceConfig(
         maxInboundMessageSize = DefaultMaxInboundMessageSize,
         enableScenarios = true,
+        evaluationOrder = LeftToRight,
       ),
     )
 }
@@ -84,7 +101,7 @@ object ScenarioServiceMain extends App {
         val server =
           NettyServerBuilder
             .forAddress(new InetSocketAddress(InetAddress.getLoopbackAddress, 0)) // any free port
-            .addService(new ScenarioService(config.enableScenarios))
+            .addService(new ScenarioService(config.enableScenarios, config.evaluationOrder))
             .maxInboundMessageSize(config.maxInboundMessageSize)
             .build
         server.start()
@@ -180,7 +197,8 @@ object ScriptStream {
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class ScenarioService(
-    enableScenarios: Boolean
+    enableScenarios: Boolean,
+    evaluationOrder: EvaluationOrder,
 )(implicit
     ec: ExecutionContext,
     esf: ExecutionSequencerFactory,
@@ -371,7 +389,7 @@ class ScenarioService(
       LanguageVersion.Major.V1,
       LanguageVersion.Minor(req.getLfMinor),
     )
-    val ctx = Context.newContext(lfVersion, req.getEvaluationTimeout.seconds)
+    val ctx = Context.newContext(lfVersion, req.getEvaluationTimeout.seconds, evaluationOrder)
     contexts += (ctx.contextId -> ctx)
     val response = NewContextResponse.newBuilder.setContextId(ctx.contextId).build
     respObs.onNext(response)


### PR DESCRIPTION
This is the continuation of PR #17253 and part of ticket #11669.

PR #17253 introduces a right-to-left evaluation order behind an interpreter feature flag. It also modifies every scala test that uses the interpreter to test both evaluation orders and documents any divergence as a new test case.

In this PR we do the same for Daml script tests (`compiler/damlc/tests/daml-test-files/...`). We introduce a new file annotation for Daml script tests: `@EVALUATION-ORDER (LeftToRight|RightToLeft)`. A test that uses this annotation will be ignored when  run with an evaluation order that differs from the specified one. The BUILD file is modified to run every test twice: once in left-to-right order, and once in right-to-left order.

The only test for which the evaluation orders disagree is `SemanticsEvalOrder.daml`. So we mark it as left-to-right only, and we introduce `SemanticsEvalOrderRightToLeft.daml`, which is right-to-left only and documents the new behavior. All the other existing tests are run using both modes and do not diverge.

The evaluation order flag is passed from the BUILD file to the interpreter as follows:
 - The BUILD file passes the evaluation order to `DamlcIntegration.hs` as a new commandline flag
 - `DamlcIntegration.hs` passes the evaluation order to `ScenarioServiceClient.hs` using a new `ScenarioServiceConfig` flag.
 - `ScenarioServiceClient.hs` in turn launches the scenario grpc service via `LowLevel.hs`, which introduces a new low-level flag.
 - `ScenarioServiceMain.scala` is updated to accept a new commandline flag on startup. It forwards the flag to the interpreter when building the Context.
 
