### PR TITLE
Fix da-ghcid

### DIFF
--- a/bazel_tools/haskell.bzl
+++ b/bazel_tools/haskell.bzl
@@ -258,6 +258,7 @@ def da_haskell_repl(**kwargs):
             "//nix/...",
         ],
         repl_ghci_args = [
+            "-fobject-code",
             "-fexternal-interpreter",
             "-j",
             "+RTS",


### PR DESCRIPTION
@paulbrauner-da and @dylant-da were having problems with `da-ghci[d]` reporting an error and dying at launch:

```
ghc-iserv: mmap 4096 bytes at (nil): Cannot allocate memory
ghc-iserv: Try specifying an address with +RTS -xm<addr> -RTS
...
ghc: ghc-iserv terminated (-11)
...
<no location info>: error: ghc: ghc-iserv terminated (-11)
```

A few troubleshots:
https://discourse.haskell.org/t/facing-mmap-4096-bytes-at-nil-cannot-allocate-memory-youre-not-alone/6259/21
https://gitlab.haskell.org/ghc/ghc/-/issues/18911

In the end, adding `-fobject-code` fixed it.

Pending review by @paulbrauner-da to check if it's working on his machine.