### PR TITLE
LF-30: add JsonLfReader and unit tests for happy cases

### DIFF
--- a/language-support/java/bindings/BUILD.bazel
+++ b/language-support/java/bindings/BUILD.bazel
@@ -67,6 +67,7 @@ da_java_library(
         "//visibility:public",
     ],
     deps = [
+        "@maven//:com_fasterxml_jackson_core_jackson_core",
         "@maven//:com_google_api_grpc_proto_google_common_protos",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
@@ -78,6 +79,19 @@ da_java_library(
         "@maven//:io_grpc_grpc_stub",
         "@maven//:javax_annotation_javax_annotation_api",
         "@maven//:org_checkerframework_checker_qual",
+    ],
+)
+
+java_test(
+    name = "java-tests",
+    srcs = glob(["src/test/java/**/*.java"]),
+    test_class = "com.daml.ledger.javaapi.data.codegen.json.JsonLfReaderTest",
+    deps = [
+        ":bindings-java",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:org_junit_jupiter_junit_jupiter_api",
+        "@maven//:org_junit_jupiter_junit_jupiter_engine",
+        "@maven//:org_junit_platform_junit_platform_runner",
     ],
 )
 

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/FromJson.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/FromJson.java
@@ -6,15 +6,15 @@ package com.daml.ledger.javaapi.data.codegen.json;
 import java.io.IOException;
 
 // Functional interface, that can be used to either read a value of the given type directly
-// (using .read()), or can be used to build a FromJson for types with generic arguments,
+// (using .read(r)), or can be used to build a FromJson for types with generic arguments,
 // to tell them how to read that argument type.
 //
 // e.g.
-//   String str = reader.text().read();
+//   String str = JsonLfReader.text.read(reader);
 // or
-//   List<String> = reader.list(reader::text).read();
+//   List<String> = JsonLfReader.list(JsonLfReader.text).read(reader);
 public interface FromJson<T> {
-  public T read() throws Error;
+  public T read(JsonLfReader r) throws Error;
 
   public static class Error extends IOException {
     public Error(String msg) {

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/FromJson.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/FromJson.java
@@ -14,11 +14,11 @@ import java.io.IOException;
 // or
 //   List<String> = reader.list(reader::text).read();
 public interface FromJson<T> {
+  public T read() throws Error;
+
   public class Error extends IOException {
     public Error(String msg) {
       super(msg);
     }
   }
-
-  public T read() throws Error;
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/FromJson.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/FromJson.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 public interface FromJson<T> {
   public T read() throws Error;
 
-  public class Error extends IOException {
+  public static class Error extends IOException {
     public Error(String msg) {
       super(msg);
     }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/FromJson.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/FromJson.java
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data.codegen.json;
+
+import java.io.IOException;
+
+// Functional interface, that can be used to either read a value of the given type directly
+// (using .read()), or can be used to build a FromJson for types with generic arguments,
+// to tell them how to read that argument type.
+//
+// e.g.
+//   String str = reader.text().read();
+// or
+//   List<String> = reader.list(reader::text).read();
+public interface FromJson<T> {
+  public class Error extends IOException {
+    public Error(String msg) {
+      super(msg);
+    }
+  }
+
+  public T read() throws Error;
+}

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReader.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReader.java
@@ -1,0 +1,414 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data.codegen.json;
+
+import com.daml.ledger.javaapi.data.Unit;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+// Utility to read LF-JSON data in a streaming fashion. Can be used by code-gen.
+public class JsonLfReader {
+  private static final JsonFactory jsonFactory = new JsonFactory();
+  private final JsonParser parser;
+
+  private void parseExpected(String expected) throws FromJson.Error {
+    throw new FromJson.Error(
+        String.format("Expected %s but was %s at %s", expected, currentText(), location()));
+  }
+
+  // Can override these two for different handling of these cases.
+  public void missingField(Object obj, String fieldName) throws FromJson.Error {
+    throw new FromJson.Error(
+        String.format(
+            "Missing field %s.%s at %s", obj.getClass().getCanonicalName(), fieldName, location()));
+  }
+
+  public void unknownFields(Object obj, List<String> fieldNames) throws FromJson.Error {
+    throw new FromJson.Error(
+        String.format(
+            "Unknown fields %s.%s at %s",
+            obj.getClass().getCanonicalName(), fieldNames.toString(), location()));
+  }
+
+  public JsonLfReader(String text) throws IOException {
+    parser = jsonFactory.createParser(text);
+    parser.nextToken();
+  }
+
+  /// Used for branching and looping on objects and arrays. ///
+
+  public boolean isStartObject() {
+    return parser.currentToken() == JsonToken.START_OBJECT;
+  }
+
+  public boolean notEndObject() {
+    return !parser.isClosed() && parser.currentToken() != JsonToken.END_OBJECT;
+  }
+
+  public boolean isStartArray() {
+    return parser.currentToken() == JsonToken.START_ARRAY;
+  }
+
+  public boolean notEndArray() {
+    return !parser.isClosed() && parser.currentToken() != JsonToken.END_ARRAY;
+  }
+
+  /// Used for consuming the structural components of objects and arrays. ///
+
+  public void readStartObject() throws FromJson.Error {
+    expectIsAt("{", JsonToken.START_OBJECT);
+    moveNext();
+  }
+
+  public void readEndObject() throws FromJson.Error {
+    expectIsAt("}", JsonToken.END_OBJECT);
+    moveNext();
+  }
+
+  public void readStartArray() throws FromJson.Error {
+    expectIsAt("[", JsonToken.START_ARRAY);
+    moveNext();
+  }
+
+  public void readEndArray() throws FromJson.Error {
+    expectIsAt("]", JsonToken.END_ARRAY);
+    moveNext();
+  }
+
+  public String readFieldName() throws FromJson.Error {
+    expectIsAt("field name", JsonToken.FIELD_NAME);
+    String fieldName = null;
+    try {
+      fieldName = parser.getText();
+    } catch (IOException e) {
+      parseExpected("textual field name");
+    }
+    moveNext();
+    return fieldName;
+  }
+
+  /// Readers for built-in LF types. ///
+
+  public FromJson<Unit> unit() {
+    return () -> {
+      readStartObject();
+      readEndObject();
+      return Unit.getInstance();
+    };
+  }
+
+  public FromJson<Boolean> bool() {
+    return () -> {
+      expectIsAt("boolean", JsonToken.VALUE_TRUE, JsonToken.VALUE_FALSE);
+      Boolean value = null;
+      try {
+        value = parser.getBooleanValue();
+      } catch (IOException e) {
+        parseExpected("true or false");
+      }
+      moveNext();
+      return value;
+    };
+  }
+
+  public FromJson<Long> int64() {
+    return () -> {
+      expectIsAt("int64", JsonToken.VALUE_NUMBER_INT, JsonToken.VALUE_STRING);
+      Long value = null;
+      try {
+        value = Long.parseLong(parser.getText());
+      } catch (IOException e) {
+        parseExpected("int64");
+      } catch (NumberFormatException e) {
+        parseExpected("int64");
+      }
+      moveNext();
+      return value;
+    };
+  }
+
+  public FromJson<BigDecimal> decimal() {
+    return () -> {
+      expectIsAt(
+          "decimal",
+          JsonToken.VALUE_NUMBER_INT,
+          JsonToken.VALUE_NUMBER_FLOAT,
+          JsonToken.VALUE_STRING);
+      BigDecimal value = null;
+      try {
+        value = new BigDecimal(parser.getText());
+      } catch (NumberFormatException e) {
+        parseExpected("decimal");
+      } catch (IOException e) {
+        parseExpected("decimal");
+      }
+      moveNext();
+      return value;
+    };
+  }
+
+  public FromJson<Instant> timestamp() {
+    return () -> {
+      expectIsAt("timestamp", JsonToken.VALUE_STRING);
+      Instant value = null;
+      try {
+        value = Instant.parse(parser.getText());
+      } catch (DateTimeParseException e) {
+        parseExpected("timestamp");
+      } catch (IOException e) {
+        parseExpected("timestamp");
+      }
+      moveNext();
+      return value;
+    };
+  }
+
+  public FromJson<LocalDate> date() {
+    return () -> {
+      expectIsAt("date", JsonToken.VALUE_STRING);
+      LocalDate value = null;
+      try {
+        value = LocalDate.parse(parser.getText());
+      } catch (DateTimeParseException e) {
+        parseExpected("date");
+      } catch (IOException e) {
+        parseExpected("date");
+      }
+      moveNext();
+      return value;
+    };
+  }
+
+  public FromJson<String> party() {
+    return text();
+  }
+
+  public FromJson<String> contractId() {
+    return text();
+  }
+
+  public FromJson<String> text() {
+    return () -> {
+      expectIsAt("text", JsonToken.VALUE_STRING);
+      String value = null;
+      try {
+        value = parser.getText();
+      } catch (IOException e) {
+        parseExpected("valid textual value");
+      }
+      moveNext();
+      return value;
+    };
+  }
+
+  // Read an list with an unknown number of items of the same type.
+  public <T> FromJson<List<T>> list(FromJson<T> readItem) {
+    return () -> {
+      List<T> list = new java.util.ArrayList<>();
+      readStartArray();
+      while (notEndArray()) {
+        T item = readItem.read();
+        list.add(item);
+      }
+      readEndArray();
+      return list;
+    };
+  }
+
+  // Read a map with textual keys, and unknown number of items of the same type.
+  public <V> FromJson<Map<String, V>> textMap(FromJson<V> readValue) {
+    return () -> {
+      Map<String, V> map = new java.util.TreeMap<>();
+      readStartObject();
+      while (notEndObject()) {
+        String key = readFieldName();
+        V val = readValue.read();
+        map.put(key, val);
+      }
+      ;
+      readEndObject();
+      return map;
+    };
+  }
+
+  // Read a map with unknown number of items of the same types.
+  public <K, V> FromJson<Map<K, V>> genMap(FromJson<K> readKey, FromJson<V> readValue) {
+    return () -> {
+      Map<K, V> map = new java.util.TreeMap<>();
+      // Maps are represented as an array of 2-element arrays.
+      readStartArray();
+      while (notEndArray()) {
+        readStartArray();
+        K key = readKey.read();
+        V val = readValue.read();
+        readEndArray();
+        map.put(key, val);
+      }
+      ;
+      readEndArray();
+      return map;
+    };
+  }
+
+  // The T type should not itself be Optional<?>. In that case use OptionalNested below.
+  public <T> FromJson<Optional<T>> optional(FromJson<T> readValue) {
+    return () -> {
+      if (parser.currentToken() == JsonToken.VALUE_NULL) {
+        moveNext();
+        return Optional.empty();
+      } else {
+        return Optional.of(readValue.read());
+      }
+    };
+  }
+
+  public <T> FromJson<Optional<Optional<T>>> optionalNested(FromJson<Optional<T>> readValue) {
+    return () -> {
+      if (parser.currentToken() == JsonToken.VALUE_NULL) {
+        moveNext();
+        return Optional.empty();
+      } else {
+        readStartArray();
+        Optional<T> val = notEndArray() ? readValue.read() : Optional.empty();
+        readEndArray();
+        return Optional.of(val);
+      }
+    };
+  }
+
+  public FromJson<String> enumeration(Set<String> values) {
+    return () -> {
+      String value = text().read();
+      if (!values.contains(value))
+        parseExpected(String.format("one of %s", String.join(" or ", values)));
+      return value;
+    };
+  }
+
+  // Provides a generic way to read a variant type, by specifying each tag.
+  public <T> FromJson<T> variant(List<String> tagNames, TagReader<T> readTag) {
+    return () -> {
+      readStartObject();
+      if (!readFieldName().equals("tag")) parseExpected("tag field");
+      String tagName = text().read();
+      if (!readFieldName().equals("value")) parseExpected("value field");
+      T result = readTag.get(tagName);
+      readEndObject();
+      if (result == null) parseExpected(String.format("tag of %s", String.join(" or ", tagNames)));
+      return result;
+    };
+  }
+
+  public interface TagReader<T> {
+    T get(String tagName) throws FromJson.Error;
+  }
+
+  // Provides a generic way to read a record type, by specifying each field.
+  // This is a little fragile, so is better built by code-gen. Specifically:
+  // - The elements of fieldNames should all evaluate to non non-null when applied to fieldsByName
+  // - The argIndex field values should be dense and unique.
+  // - The record type must have a constructor which takes an Object[] and appropriately casts
+  //   and populates its own fields, as per the argIndex of the fields provided.
+  public <T> FromJson<T> record(
+      Function<Object[], T> constr,
+      List<String> fieldNames,
+      Function<String, Field<? extends Object>> fieldsByName) {
+    return () -> {
+      List<String> missingFields = new java.util.ArrayList<>();
+      List<String> unknownFields = new java.util.ArrayList<>();
+
+      Object[] args = new Object[fieldNames.size()];
+      if (isStartObject()) {
+        readStartObject();
+        while (notEndObject()) {
+          String fieldName = readFieldName();
+          var field = fieldsByName.apply(fieldName);
+          if (field == null) unknownFields.add(fieldName);
+          else args[field.argIndex] = field.fromJson.read();
+        }
+        readEndObject();
+      } else if (isStartArray()) {
+        readStartArray();
+        for (String fieldName : fieldNames) {
+          var field = fieldsByName.apply(fieldName);
+          args[field.argIndex] = field.fromJson.read();
+        }
+        readEndArray();
+      } else {
+        parseExpected("object or array");
+      }
+
+      // Handle missing and unknown fields.
+      for (String fieldName : fieldNames) {
+        Field<? extends Object> field = fieldsByName.apply(fieldName);
+        if (args[field.argIndex] != null) continue;
+        if (field.defaultVal == null) missingFields.add(fieldName);
+        args[field.argIndex] = field.defaultVal;
+      }
+      T result = constr.apply(args);
+      for (String f : missingFields) missingField(result, f);
+      if (!unknownFields.isEmpty()) unknownFields(result, unknownFields);
+
+      return result;
+    };
+  }
+
+  public static class Field<T> {
+    final int argIndex;
+    final FromJson<T> fromJson;
+    final T defaultVal;
+
+    private Field(int argIndex, FromJson<T> fromJson, T defaultVal) {
+      this.argIndex = argIndex;
+      this.fromJson = fromJson;
+      this.defaultVal = defaultVal;
+    }
+
+    public static <T extends Object> Field<T> of(int argIndex, FromJson<T> fromJson, T defaultVal) {
+      return new Field<T>(argIndex, fromJson, defaultVal);
+    }
+
+    public static <T extends Object> Field<T> of(int argIndex, FromJson<T> fromJson) {
+      return of(argIndex, fromJson, null);
+    }
+  }
+
+  private String location() {
+    return parser.currentTokenLocation().offsetDescription();
+  }
+
+  private String currentText() {
+    try {
+      return parser.getText();
+    } catch (IOException e) {
+      return "? (" + e.getMessage() + ")";
+    }
+  }
+
+  private void expectIsAt(String description, JsonToken... expected) throws FromJson.Error {
+    for (int i = 0; i < expected.length; i++) {
+      if (parser.currentToken() == expected[i]) return;
+    }
+    parseExpected(description);
+  }
+
+  private void moveNext() throws FromJson.Error {
+    try {
+      parser.nextToken();
+    } catch (IOException e) {
+      parseExpected("more input");
+    }
+  }
+}

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReader.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReader.java
@@ -15,7 +15,6 @@ import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 
 // Utility to read LF-JSON data in a streaming fashion. Can be used by code-gen.
@@ -288,12 +287,15 @@ public class JsonLfReader {
     };
   }
 
-  public FromJson<String> enumeration(Set<String> values) {
+  public <E extends Enum<E>> FromJson<E> enumeration(Class<E> enumClass) {
     return () -> {
       String value = text().read();
-      if (!values.contains(value))
-        parseExpected(String.format("one of %s", String.join(" or ", values)));
-      return value;
+      try {
+        return Enum.valueOf(enumClass, value);
+      } catch (IllegalArgumentException e) {
+        parseExpected(String.format("constant of %s", enumClass.getName()));
+      }
+      return null;
     };
   }
 

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReader.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReader.java
@@ -228,7 +228,14 @@ public class JsonLfReader {
         moveNext();
         return Optional.empty();
       } else {
-        return Optional.of(readValue.read());
+        T some = readValue.read();
+        if (some instanceof Optional) {
+          throw new IllegalArgumentException(
+              "Used `optional` to decode a "
+                  + some.getClass()
+                  + " but `optionalNested` must be used for the outer decoders of nested Optional");
+        }
+        return Optional.of(some);
       }
     };
   }

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReaderTest.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReaderTest.java
@@ -156,6 +156,23 @@ public class JsonLfReaderTest {
         eq("[[42]]", Optional.of(Optional.of(Optional.of(42L)))));
   }
 
+  enum Suit {
+    Hearts,
+    Diamonds,
+    Clubs,
+    Spades
+  }
+
+  @Test
+  void testEnum() throws IOException {
+    checkReadAll(
+        r -> r.enumeration(Suit.class),
+        eq("\"Hearts\"", Suit.Hearts),
+        eq("\"Diamonds\"", Suit.Diamonds),
+        eq("\"Clubs\"", Suit.Clubs),
+        eq("\"Spades\"", Suit.Spades));
+  }
+
   @Test
   void testVariant() throws IOException, FromJson.Error {
     checkReadAll(

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReaderTest.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReaderTest.java
@@ -172,6 +172,16 @@ public class JsonLfReaderTest {
   }
 
   @Test
+  void testOptionalLists() throws IOException {
+    checkReadAll(
+        r -> r.optional(r.list(r.list(r.int64()))),
+        eq("null", Optional.empty()),
+        eq("[]", Optional.of(emptyList())),
+        eq("[[]]", Optional.of(asList(emptyList()))),
+        eq("[[42]]", Optional.of(asList(asList(42L)))));
+  }
+
+  @Test
   void testVariant() throws IOException, FromJson.Error {
     checkReadAll(
         r ->

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReaderTest.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReaderTest.java
@@ -1,0 +1,359 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data.codegen.json;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.daml.ledger.javaapi.data.Unit;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneOffset;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+public class JsonLfReaderTest {
+
+  private class TestCase<T> {
+    public final String input;
+    public final T expected;
+
+    public TestCase(String input, T expected) {
+      this.input = input;
+      this.expected = expected;
+    }
+
+    public String toString() {
+      return String.format("input=%s, expected=%s", input, expected);
+    }
+  }
+
+  private <T> TestCase<T> test(String input, T expected) {
+    return new TestCase(input, expected);
+  }
+
+  @Test
+  void testUnit() throws IOException {
+    testAll(
+        JsonLfReader::unit, test("{}", Unit.getInstance()), test("\t{\n} ", Unit.getInstance()));
+  }
+
+  @Test
+  void testBool() throws IOException {
+    testAll(JsonLfReader::bool, test("false", false), test("true", true));
+  }
+
+  @Test
+  void testInt64() throws IOException {
+    testAll(
+        JsonLfReader::int64,
+        test("42", 42L),
+        test("\"+42\"", 42L),
+        test("-42", -42L),
+        test("0", 0L),
+        test("-0", -0L),
+        test("9223372036854775807", 9223372036854775807L),
+        test("\"9223372036854775807\"", 9223372036854775807L),
+        test("-9223372036854775808", -9223372036854775808L),
+        test("\"-9223372036854775808\"", -9223372036854775808L));
+  }
+
+  @Test
+  void testDecimal() throws IOException {
+    testAllByComparison(
+        JsonLfReader::decimal,
+        test("42", dec("42")),
+        test("42.0", dec("42")),
+        test("\"42\"", dec("42")),
+        test("-42", dec("-42")),
+        test("\"-42\"", dec("-42")),
+        test("0", dec("0")),
+        test("-0", dec("-0")),
+        //            test("0.30000000000000004", dec("0.3")), // TODO(raphael-speyer-da):
+        // Appropriate rounding
+        test("2e3", dec("2000")),
+        test(
+            "9999999999999999999999999999.9999999999",
+            dec("9999999999999999999999999999.9999999999")));
+  }
+
+  @Test
+  void testTimestamp() throws IOException {
+    testAll(
+        JsonLfReader::timestamp,
+        test(
+            "\"1990-11-09T04:30:23.123456Z\"",
+            timestampUTC(1990, Month.NOVEMBER, 9, 4, 30, 23, 123456)),
+        test(
+            "\"9999-12-31T23:59:59.999999Z\"",
+            timestampUTC(9999, Month.DECEMBER, 31, 23, 59, 59, 999999)),
+        //            test("\"1990-11-09T04:30:23.1234569Z\"", timestampUTC(1990, Month.NOVEMBER,
+        // 9,  4, 30, 23, 123457)), // TODO(raphael-speyer-da): Appropriate rounding
+        test("\"1990-11-09T04:30:23Z\"", timestampUTC(1990, Month.NOVEMBER, 9, 4, 30, 23, 0)),
+        test(
+            "\"1990-11-09T04:30:23.123Z\"",
+            timestampUTC(1990, Month.NOVEMBER, 9, 4, 30, 23, 123000)),
+        test("\"0001-01-01T00:00:00Z\"", timestampUTC(1, Month.JANUARY, 1, 0, 0, 0, 0)));
+  }
+
+  @Test
+  void testDate() throws IOException {
+    testAll(
+        JsonLfReader::date,
+        test("\"2019-06-18\"", date(2019, Month.JUNE, 18)),
+        test("\"9999-12-31\"", date(9999, Month.DECEMBER, 31)),
+        test("\"0001-01-01\"", date(1, Month.JANUARY, 1)));
+  }
+
+  @Test
+  void testParty() throws IOException {
+    testAll(JsonLfReader::party, test("\"Alice\"", "Alice"));
+  }
+
+  @Test
+  void testText() throws IOException {
+    testAll(JsonLfReader::text, test("\"\"", ""), test("\" \"", " "), test("\"hello\"", "hello"));
+  }
+
+  @Test
+  void testList() throws IOException {
+    testAll(r -> r.list(r.int64()), test("[]", emptyList()), test("[1,2]", asList(1L, 2L)));
+  }
+
+  @Test
+  void testTextMap() throws IOException {
+    testAll(
+        r -> r.textMap(r.int64()),
+        test("{}", emptyMap()),
+        test("{\"foo\":1, \"bar\": 2}", java.util.Map.of("foo", 1L, "bar", 2L)));
+  }
+
+  @Test
+  void testGenMap() throws IOException {
+    testAll(
+        r -> r.genMap(r.text(), r.int64()),
+        test("[]", emptyMap()),
+        test("[[\"foo\", 1], [\"bar\", 2]]", java.util.Map.of("foo", 1L, "bar", 2L)));
+  }
+
+  @Test
+  void testOptionalNonNested() throws IOException {
+    testAll(
+        r -> r.optional(r.int64()), test("null", Optional.empty()), test("42", Optional.of(42L)));
+  }
+
+  @Test
+  void testOptionalNested() throws IOException {
+    testAll(
+        r -> r.optionalNested(r.optional(r.int64())),
+        test("null", Optional.empty()),
+        test("[]", Optional.of(Optional.empty())),
+        test("[42]", Optional.of(Optional.of(42L))));
+  }
+
+  @Test
+  void testOptionalNestedDeeper() throws IOException {
+    testAll(
+        r -> r.optionalNested(r.optionalNested(r.optional(r.int64()))),
+        test("null", Optional.empty()),
+        test("[]", Optional.of(Optional.empty())),
+        test("[[]]", Optional.of(Optional.of(Optional.empty()))),
+        test("[[42]]", Optional.of(Optional.of(Optional.of(42L)))));
+  }
+
+  @Test
+  void testVariant() throws IOException, FromJson.Error {
+    testAll(
+        r ->
+            r.variant(
+                asList("Bar", "Baz", "Quux"),
+                tagName -> {
+                  switch (tagName) {
+                    case "Bar":
+                      return new SomeVariant.Bar(r.int64().read());
+                    case "Baz":
+                      return new SomeVariant.Baz(r.unit().read());
+                    case "Quux":
+                      return new SomeVariant.Quux(r.optional(r.int64()).read());
+                    default:
+                      return null;
+                  }
+                }),
+        test("{\"tag\": \"Bar\", \"value\": 42}", new SomeVariant.Bar(42L)),
+        test("{\"tag\": \"Baz\", \"value\": {}}", new SomeVariant.Baz(Unit.getInstance())),
+        test("{\"tag\": \"Quux\", \"value\": null}", new SomeVariant.Quux(Optional.empty())),
+        test("{\"tag\": \"Quux\", \"value\": 42}", new SomeVariant.Quux(Optional.of(42L))));
+  }
+
+  @Test
+  void testRecord() throws IOException {
+    testAll(
+        r ->
+            r.record(
+                SomeRecord::new,
+                asList("i", "b"),
+                fieldName -> {
+                  switch (fieldName) {
+                    case "i":
+                      return JsonLfReader.Field.of(0, r.int64());
+                    case "b":
+                      return JsonLfReader.Field.of(
+                          1, r.bool(), false); // Note a default value here when missing.
+                    default:
+                      return null;
+                  }
+                }),
+        test("[1,true]", new SomeRecord(1L, true)),
+        test("{\"i\":1,\"b\":true}", new SomeRecord(1L, true)),
+        test("{\"b\":true,\"i\":1}", new SomeRecord(1L, true)),
+        test("{\"i\":1}", new SomeRecord(1L, false)));
+  }
+
+  private BigDecimal dec(String s) {
+    return new BigDecimal(s);
+  }
+
+  private Instant timestampUTC(
+      int year, Month month, int day, int hour, int minute, int second, int micros) {
+    return LocalDateTime.of(year, month, day, hour, minute, second, micros * 1000)
+        .toInstant(ZoneOffset.UTC);
+  }
+
+  private LocalDate date(int year, Month month, int day) {
+    return LocalDate.of(year, month, day);
+  }
+
+  class SomeRecord {
+    private final long i;
+    private final boolean b;
+
+    public SomeRecord(long i, boolean b) {
+      this.i = i;
+      this.b = b;
+    }
+
+    public SomeRecord(Object... args) {
+      this((Long) args[0], (Boolean) args[1]);
+    }
+
+    public String toString() {
+      return String.format("SomeRecord{i=%s,b=%s}", i, b);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o != null
+          && (o instanceof SomeRecord)
+          && ((SomeRecord) o).i == i
+          && (((SomeRecord) o).b == b);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(i, b);
+    }
+  }
+
+  abstract static class SomeVariant {
+    static class Bar extends SomeVariant {
+      private final Long x;
+
+      public Bar(Long x) {
+        this.x = x;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+        return o != null && (o instanceof Bar) && x == ((Bar) o).x;
+      }
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(x);
+      }
+
+      @Override
+      public String toString() {
+        return String.format("Bar(%s)", x);
+      }
+    }
+
+    static class Baz extends SomeVariant {
+      private final Unit x;
+
+      public Baz(Unit x) {
+        this.x = x;
+      }
+      // All units are the same, and thus so are all Baz's
+      @Override
+      public boolean equals(Object o) {
+        return o != null && (o instanceof Baz);
+      }
+
+      @Override
+      public int hashCode() {
+        return 1;
+      }
+
+      @Override
+      public String toString() {
+        return "Baz()";
+      }
+    }
+
+    static class Quux extends SomeVariant {
+      private final Optional<Long> x;
+
+      public Quux(Optional<Long> x) {
+        this.x = x;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+        return o != null && (o instanceof Quux) && x.equals(((Quux) o).x);
+      }
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(x);
+      }
+
+      @Override
+      public String toString() {
+        return String.format("Quux(%s)", x);
+      }
+    }
+  }
+
+  private <T> void testAll(
+      Function<JsonLfReader, FromJson<T>> readT, TestCase<? extends T>... testCases)
+      throws IOException {
+    for (var tc : testCases) {
+      var fromJson = readT.apply(new JsonLfReader(tc.input));
+      assertEquals(tc.expected, fromJson.read(), tc.toString());
+    }
+  }
+
+  private <T extends Comparable> void testAllByComparison(
+      Function<JsonLfReader, FromJson<T>> readT, TestCase<T>... testCases) throws IOException {
+    for (var tc : testCases) {
+      var fromJson = readT.apply(new JsonLfReader(tc.input));
+      assertEquals(
+          0,
+          tc.expected.compareTo(fromJson.read()),
+          "unequal by ordering comparison, when reading " + tc.toString());
+    }
+  }
+}

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReaderTest.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReaderTest.java
@@ -16,6 +16,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -199,6 +200,8 @@ public class JsonLfReaderTest {
                 case "Quux":
                   return r ->
                       new SomeVariant.Quux(JsonLfReader.optional(JsonLfReader.int64).read(r));
+                case "Flarp":
+                  return r -> new SomeVariant.Flarp(JsonLfReader.list(JsonLfReader.int64).read(r));
                 default:
                   return null;
               }
@@ -206,7 +209,9 @@ public class JsonLfReaderTest {
         eq("{\"tag\": \"Bar\", \"value\": 42}", new SomeVariant.Bar(42L)),
         eq("{\"tag\": \"Baz\", \"value\": {}}", new SomeVariant.Baz(Unit.getInstance())),
         eq("{\"tag\": \"Quux\", \"value\": null}", new SomeVariant.Quux(Optional.empty())),
-        eq("{\"tag\": \"Quux\", \"value\": 42}", new SomeVariant.Quux(Optional.of(42L))));
+        eq("{\"tag\": \"Quux\", \"value\": 42}", new SomeVariant.Quux(Optional.of(42L))),
+        eq("{\"value\": 42, \"tag\": \"Quux\"}", new SomeVariant.Quux(Optional.of(42L))),
+        eq("{\"value\": [42], \"tag\": \"Flarp\"}", new SomeVariant.Flarp(asList(42L))));
   }
 
   @Test
@@ -339,6 +344,29 @@ public class JsonLfReaderTest {
       @Override
       public String toString() {
         return String.format("Quux(%s)", x);
+      }
+    }
+
+    static class Flarp extends SomeVariant {
+      private final List<Long> x;
+
+      public Flarp(List<Long> x) {
+        this.x = x;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+        return o != null && (o instanceof Flarp) && x.equals(((Flarp) o).x);
+      }
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(x);
+      }
+
+      @Override
+      public String toString() {
+        return String.format("Flarp(%s)", x);
       }
     }
   }


### PR DESCRIPTION
Provide initial implementation of `JsonLfReader`, which can be used by Java code-gen to build the Java objects from a JSON LF formatted string, as specified here https://docs.daml.com/json-api/lf-value-specification.html

Not done yet:
* the actual code-gen to produces the `fromJson` methods on custom types
* unit tests for failure cases on parsing
* some corner-cases of rounding
* a `JsonLfWriter`