### PR TITLE
Revert "Add ResultNeedCreate (#17243)"

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
@@ -7,7 +7,7 @@ package engine
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{BackStack, FrontStack, ImmArray}
 import com.daml.lf.language.Ast._
-import com.daml.lf.transaction.{GlobalKeyWithMaintainers, Node}
+import com.daml.lf.transaction.GlobalKeyWithMaintainers
 import com.daml.lf.value.Value._
 import scalaz.Monad
 
@@ -24,8 +24,6 @@ sealed trait Result[+A] extends Product with Serializable {
     case ResultError(err) => ResultError(err)
     case ResultNeedContract(acoid, resume) =>
       ResultNeedContract(acoid, mbContract => resume(mbContract).map(f))
-    case ResultNeedCreate(acoid, resume) =>
-      ResultNeedCreate(acoid, create => resume(create).map(f))
     case ResultNeedPackage(pkgId, resume) =>
       ResultNeedPackage(pkgId, mbPkg => resume(mbPkg).map(f))
     case ResultNeedKey(gk, resume) =>
@@ -42,8 +40,6 @@ sealed trait Result[+A] extends Product with Serializable {
     case ResultError(err) => ResultError(err)
     case ResultNeedContract(acoid, resume) =>
       ResultNeedContract(acoid, mbContract => resume(mbContract).flatMap(f))
-    case ResultNeedCreate(acoid, resume) =>
-      ResultNeedCreate(acoid, create => resume(create).flatMap(f))
     case ResultNeedPackage(pkgId, resume) =>
       ResultNeedPackage(pkgId, mbPkg => resume(mbPkg).flatMap(f))
     case ResultNeedKey(gk, resume) =>
@@ -59,7 +55,6 @@ sealed trait Result[+A] extends Product with Serializable {
       pkgs: PartialFunction[PackageId, Package] = PartialFunction.empty,
       keys: PartialFunction[GlobalKeyWithMaintainers, ContractId] = PartialFunction.empty,
       grantNeedAuthority: Boolean = false,
-      creates: PartialFunction[ContractId, Node.Create] = PartialFunction.empty,
   ): Either[Error, A] = {
     @tailrec
     def go(res: Result[A]): Either[Error, A] =
@@ -68,7 +63,6 @@ sealed trait Result[+A] extends Product with Serializable {
         case ResultInterruption(continue) => go(continue())
         case ResultError(err) => Left(err)
         case ResultNeedContract(acoid, resume) => go(resume(pcs.lift(acoid)))
-        case ResultNeedCreate(acoid, resume) => go(resume(creates.lift(acoid)))
         case ResultNeedPackage(pkgId, resume) => go(resume(pkgs.lift(pkgId)))
         case ResultNeedKey(key, resume) => go(resume(keys.lift(key)))
         case ResultNeedAuthority(_, _, resume) => go(resume(grantNeedAuthority))
@@ -118,32 +112,6 @@ object ResultError {
 final case class ResultNeedContract[A](
     acoid: ContractId,
     resume: Option[VersionedContractInstance] => Result[A],
-) extends Result[A]
-
-/** Intermediate result indicating that a [[Node.Create]] is required to complete the computation.
-  * To resume the computation, the caller must invoke `resume` with the following argument:
-  * <ul>
-  * <li>`Some(create)`, if the caller can dereference `acoid` to `create`</li>
-  * <li>`None`, if the caller is unable to dereference `acoid`</li>
-  * </ul>
-  *
-  * The caller of `resume` has to ensure that the create passed to `resume` is a create that
-  * has previously been associated with `acoid` by the engine.
-  *
-  * The engine will verify that details provided in the create match the recomputed values based on the
-  * target package template (that may or may not be the package originally associated with the create).
-  *
-  * The details that should be checked are:
-  *
-  *  - signatories
-  *  - observers
-  *  - contract key
-  *  - maintainers
-  *  - agreement
-  */
-final case class ResultNeedCreate[A](
-    acoid: ContractId,
-    resume: Option[Node.Create] => Result[A],
 ) extends Result[A]
 
 /** Intermediate result indicating that a [[Package]] is required to complete the computation.
@@ -285,16 +253,6 @@ object Result {
               )
             case ResultNeedContract(acoid, resume) =>
               ResultNeedContract(
-                acoid,
-                coinst =>
-                  resume(coinst).flatMap(x =>
-                    Result
-                      .sequence(results_)
-                      .map(otherResults => (okResults :+ x) :++ otherResults)
-                  ),
-              )
-            case ResultNeedCreate(acoid, resume) =>
-              ResultNeedCreate(
                 acoid,
                 coinst =>
                   resume(coinst).flatMap(x =>


### PR DESCRIPTION
Support for this engine callback is not easily possible until we retire divulged contracts (Daml 3.0).

The approach for upgrading has been to switch to `ResultNeedUpgradeVerification`.

This reverts commit 7ba1e6754c08b145366c80f3af1c293e017b45c7.

