### PR TITLE
Fix proto_breaking_changes tests for LF

### DIFF
--- a/daml-lf/archive/BUILD.bazel
+++ b/daml-lf/archive/BUILD.bazel
@@ -182,7 +182,6 @@ SNASPSHOT_VERSIONS = [ver for ver in PROTO_LF_VERSIONS if ver != "1.dev"]
         data = [
             "buf.yaml",
             "proto_breaking_changes.sh",
-            "src/main/protobuf/com/daml/daml_lf_dev",
             ":daml_lf_%s_archive_proto_srcs" % version,
             ":daml_lf_1.dev_archive_proto_srcs",
             "@buf//:bin/buf",


### PR DESCRIPTION
After this change, the `buf` tool sees the files under `src/main/protobuf`. Without this change, it only sees an empty directory and the diff is trivially empty.

Note that even with this change, the `daml_lf.proto` are not being diffed, because their proto packages ([here](https://github.com/digital-asset/daml/blob/main/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf.proto#L5) and [here](https://github.com/digital-asset/daml/blob/main/daml-lf/archive/src/stable/protobuf/com/daml/daml_lf_1_14/daml_lf.proto#L5)) differ. So incompatible changes to that file will not be caught. I don't know how to work around this without rewriting the file with sed or similar before running `buf`. Fortunately the file that is being diffed contains the majority of the LF definition.