### PR TITLE
[engine] call: ResultNeedUpgradeVerification

### DIFF
--- a/canton/it-lib/src/main/com/daml/CantonFixture.scala
+++ b/canton/it-lib/src/main/com/daml/CantonFixture.scala
@@ -68,7 +68,7 @@ trait CantonFixtureWithResource[A]
   //   - temporary file are not deleted (this requires "--test_tmpdir=/tmp/" or similar for bazel builds)
   //   - some debug info are logged.
   //   - output from the canton process is sent to stdout
-  protected val cantonFixtureDebugMode = true // NICK
+  protected val cantonFixtureDebugMode = false
 
   final protected val logger = org.slf4j.LoggerFactory.getLogger(getClass)
 

--- a/canton/it-lib/src/main/com/daml/CantonFixture.scala
+++ b/canton/it-lib/src/main/com/daml/CantonFixture.scala
@@ -68,7 +68,7 @@ trait CantonFixtureWithResource[A]
   //   - temporary file are not deleted (this requires "--test_tmpdir=/tmp/" or similar for bazel builds)
   //   - some debug info are logged.
   //   - output from the canton process is sent to stdout
-  protected val cantonFixtureDebugMode = false
+  protected val cantonFixtureDebugMode = true // NICK
 
   final protected val logger = org.slf4j.LoggerFactory.getLogger(getClass)
 

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -466,7 +466,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
               // println(s"interpretLoop: NeedUpgradeVerification...")
               // println(s"- src = $src")
               // println(s"- dest = $dest")
-              if (src == dest) {
+              if (src == dest) { // NICK: move this logic back into speedy
                 // dont ask question to ledger
                 println("interpretLoop: NeedUpgradeVerification, src==dest, not asking ledger")
                 callback()

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -460,10 +460,6 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
                   keyOpt,
                   callback,
                 ) =>
-              println("interpretLoop: NeedUpgradeVerification, asking ledger...")
-              // println(s"- signatories = $signatories")
-              // println(s"- observers = $observers")
-              // println(s"- keyOpt = $keyOpt")
               ResultNeedUpgradeVerification(
                 coid,
                 signatories,
@@ -472,18 +468,16 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
                 { failureMessageOpt: Option[String] =>
                   failureMessageOpt match {
                     case None =>
-                      println("interpretLoop: NeedUpgradeVerification, ledger says ALL OK")
                       callback()
                       loopOuter(cache)
                     case Some(mes) =>
-                      println(s"interpretLoop: NeedUpgradeVerification, message-from-ledger=$mes")
                       // TODO: https://github.com/digital-asset/daml/issues/17082
                       // - we need a new interpretation.Error for this
                       ResultError(
                         Error.Interpretation.Internal(
                           NameOf.qualifiedNameOfCurrentFunc,
                           s"Ledger refused upgrade verification with message: $mes",
-                          None
+                          None,
                         )
                       )
                   }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -463,21 +463,19 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
                   callback,
                 ) =>
               // NICK -- check and remove all debug prints
-
-              println(
-                s"**interpretLoop: Question.Update.NeedUpgradeVerification, \n- src=$src\n- dest=$dest"
-              )
+              // println(s"interpretLoop: NeedUpgradeVerification...")
+              // println(s"- src = $src")
+              // println(s"- dest = $dest")
               if (src == dest) {
                 // dont ask question to ledger
-                println(
-                  "**interpretLoop: Question.Update.NeedUpgradeVerification, src==dest, not asking ledger"
-                )
+                println("interpretLoop: NeedUpgradeVerification, src==dest, not asking ledger")
                 callback()
                 loop(cache)
               } else {
-                println(
-                  "**interpretLoop: Question.Update.NeedUpgradeVerification, asking ledger..."
-                )
+                println("interpretLoop: NeedUpgradeVerification, asking ledger...")
+                // println(s"- signatories = $signatories")
+                // println(s"- observers = $observers")
+                // println(s"- keyOpt = $keyOpt")
                 ResultNeedUpgradeVerification(
                   coid,
                   signatories,
@@ -486,17 +484,12 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
                   { failureMessageOpt: Option[String] =>
                     failureMessageOpt match {
                       case None =>
-                        println(
-                          "**interpretLoop: Question.Update.NeedUpgradeVerification, ledger says ALL OK"
-                        )
+                        println("interpretLoop: NeedUpgradeVerification, ledger says ALL OK")
                         callback()
                         loopOuter(cache)
                       case Some(mes) =>
-                        println(
-                          s"**interpretLoop: Question.Update.NeedUpgradeVerification, message-from-ledger=$mes"
-                        )
+                        println(s"interpretLoop: NeedUpgradeVerification, message-from-ledger=$mes")
                         // NICK, the correct behaviour is to fail here (model on NeedAuthority)
-                        // NICK: but ir dev lets continue...
                         callback()
                         loopOuter(cache)
                     }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -454,48 +454,35 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
               }
 
             case Question.Update.NeedUpgradeVerification(
-                  src,
-                  dest,
                   coid,
                   signatories,
                   observers,
                   keyOpt,
                   callback,
                 ) =>
-              // NICK -- check and remove all debug prints
-              // println(s"interpretLoop: NeedUpgradeVerification...")
-              // println(s"- src = $src")
-              // println(s"- dest = $dest")
-              if (src == dest) { // NICK: move this logic back into speedy
-                // dont ask question to ledger
-                println("interpretLoop: NeedUpgradeVerification, src==dest, not asking ledger")
-                callback()
-                loop(cache)
-              } else {
-                println("interpretLoop: NeedUpgradeVerification, asking ledger...")
-                // println(s"- signatories = $signatories")
-                // println(s"- observers = $observers")
-                // println(s"- keyOpt = $keyOpt")
-                ResultNeedUpgradeVerification(
-                  coid,
-                  signatories,
-                  observers,
-                  keyOpt,
-                  { failureMessageOpt: Option[String] =>
-                    failureMessageOpt match {
-                      case None =>
-                        println("interpretLoop: NeedUpgradeVerification, ledger says ALL OK")
-                        callback()
-                        loopOuter(cache)
-                      case Some(mes) =>
-                        println(s"interpretLoop: NeedUpgradeVerification, message-from-ledger=$mes")
-                        // NICK, the correct behaviour is to fail here (model on NeedAuthority)
-                        callback()
-                        loopOuter(cache)
-                    }
-                  },
-                )
-              }
+              println("interpretLoop: NeedUpgradeVerification, asking ledger...")
+              // println(s"- signatories = $signatories")
+              // println(s"- observers = $observers")
+              // println(s"- keyOpt = $keyOpt")
+              ResultNeedUpgradeVerification(
+                coid,
+                signatories,
+                observers,
+                keyOpt,
+                { failureMessageOpt: Option[String] =>
+                  failureMessageOpt match {
+                    case None =>
+                      println("interpretLoop: NeedUpgradeVerification, ledger says ALL OK")
+                      callback()
+                      loopOuter(cache)
+                    case Some(mes) =>
+                      println(s"interpretLoop: NeedUpgradeVerification, message-from-ledger=$mes")
+                      // NICK, the correct behaviour is to fail here (model on NeedAuthority)
+                      callback()
+                      loopOuter(cache)
+                  }
+                },
+              )
 
             case Question.Update.NeedKey(gk, _, callback) =>
               ResultNeedKey(

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -477,9 +477,15 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
                       loopOuter(cache)
                     case Some(mes) =>
                       println(s"interpretLoop: NeedUpgradeVerification, message-from-ledger=$mes")
-                      // NICK, the correct behaviour is to fail here (model on NeedAuthority)
-                      callback()
-                      loopOuter(cache)
+                      // TODO: https://github.com/digital-asset/daml/issues/17082
+                      // - we need a new interpretation.Error for this
+                      ResultError(
+                        Error.Interpretation.Internal(
+                          NameOf.qualifiedNameOfCurrentFunc,
+                          s"Ledger refused upgrade verification with message: $mes",
+                          None
+                        )
+                      )
                   }
                 },
               )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -2228,8 +2228,8 @@ private[lf] object SBuiltin {
                   getContractInfo(machine, coid, destTemplateId, templateArg, keyOpt) { contract =>
                     ensureContractActive(machine, coid, contract.templateId) {
 
-                      machine.enforceLimitAddInputContract()
                       machine.checkContractVisibility(coid, contract)
+                      machine.enforceLimitAddInputContract()
                       machine.enforceLimitSignatoriesAndObservers(coid, contract)
 
                       val src: TypeConName = srcTemplateId

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -29,10 +29,8 @@ object Question {
         callback: Value.ContractInstance => Unit,
     ) extends Update
 
-    /** Contract info needs verification by ledger in case of upgrade */
+    /** Contract info for upgraded contract needs verification by ledger */
     final case class NeedUpgradeVerification(
-        src: TypeConName,
-        dest: TypeConName,
         coid: ContractId,
         signatories: Set[Party],
         observers: Set[Party],

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -29,6 +29,17 @@ object Question {
         callback: Value.ContractInstance => Unit,
     ) extends Update
 
+    // NICK : comment here
+    final case class NeedUpgradeVerification(
+        src: Int, // NICK -- idea, pass src/dest packageId, do can only dispatch when diff
+        dest: Int,
+        coid: ContractId,
+        signatories: Set[Party],
+        observers: Set[Party],
+        keyOpt: Option[GlobalKeyWithMaintainers],
+        callback: () => Unit,
+    ) extends Update
+
     /** Machine needs a definition that was not present when the machine was
       * initialized. The caller must retrieve the definition and fill it in
       * the packages cache it had provided to initialize the machine.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -29,10 +29,10 @@ object Question {
         callback: Value.ContractInstance => Unit,
     ) extends Update
 
-    // NICK : comment here
+    /** Contract info needs verification by ledger in case of upgrade */
     final case class NeedUpgradeVerification(
-        src: Int, // NICK -- idea, pass src/dest packageId, do can only dispatch when diff
-        dest: Int,
+        src: TypeConName,
+        dest: TypeConName,
         coid: ContractId,
         signatories: Set[Party],
         observers: Set[Party],

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
@@ -124,6 +124,8 @@ private[speedy] object SpeedyTestLib {
           case None =>
             throw UnknownContract(contractId)
         }
+      case Question.Update.NeedUpgradeVerification(_, _, _, _, _, _, callback) =>
+        callback() // NICK
 
       case Question.Update.NeedPackage(pkg, _, callback) =>
         getPkg.lift(pkg) match {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
@@ -125,7 +125,7 @@ private[speedy] object SpeedyTestLib {
             throw UnknownContract(contractId)
         }
       case Question.Update.NeedUpgradeVerification(_, _, _, _, _, _, callback) =>
-        callback() // NICK
+        callback()
 
       case Question.Update.NeedPackage(pkg, _, callback) =>
         getPkg.lift(pkg) match {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
@@ -124,7 +124,7 @@ private[speedy] object SpeedyTestLib {
           case None =>
             throw UnknownContract(contractId)
         }
-      case Question.Update.NeedUpgradeVerification(_, _, _, _, _, _, callback) =>
+      case Question.Update.NeedUpgradeVerification(_, _, _, _, callback) =>
         callback()
 
       case Question.Update.NeedPackage(pkg, _, callback) =>

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -463,6 +463,9 @@ private[lf] object ScenarioRunner {
                 case Left(err) => SubmissionError(err, enrich(ledgerMachine.incompleteTransaction))
                 case Right(_) => go()
               }
+            case Question.Update.NeedUpgradeVerification(_, _, _, _, _, _, callback) =>
+              callback() // NICK
+              go()
             case Question.Update.NeedKey(keyWithMaintainers, committers, callback) =>
               ledger.lookupKey(
                 keyWithMaintainers.globalKey,

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -464,7 +464,7 @@ private[lf] object ScenarioRunner {
                 case Right(_) => go()
               }
             case Question.Update.NeedUpgradeVerification(_, _, _, _, _, _, callback) =>
-              callback() // NICK
+              callback()
               go()
             case Question.Update.NeedKey(keyWithMaintainers, committers, callback) =>
               ledger.lookupKey(

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -463,7 +463,7 @@ private[lf] object ScenarioRunner {
                 case Left(err) => SubmissionError(err, enrich(ledgerMachine.incompleteTransaction))
                 case Right(_) => go()
               }
-            case Question.Update.NeedUpgradeVerification(_, _, _, _, _, _, callback) =>
+            case Question.Update.NeedUpgradeVerification(_, _, _, _, callback) =>
               callback()
               go()
             case Question.Update.NeedKey(keyWithMaintainers, committers, callback) =>


### PR DESCRIPTION
Advances #17082

Engine calls `ResultNeedUpgradeVerification` when both:
- (a) the upgrading feature flag is enabled
- (b) the source/destination template types differ (i.e. an upgrade or downgrade has occurred)

