### PR TITLE
Use feature names instead of explicit mentions to 1.dev

### DIFF
--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -1520,7 +1520,7 @@ private[archive] class DecodeV1(minor: LV.Minor) {
           }
 
         case PLF.Expr.SumCase.EXPERIMENTAL =>
-          assertSince(LV.v1_dev, "Expr.experimental")
+          assertSince(LV.Features.unstable, "Expr.experimental")
           val experimental = lfExpr.getExperimental
           decodeType(experimental.getType) { typ =>
             Ret(EExperimental(experimental.getName, typ))
@@ -1717,7 +1717,7 @@ private[archive] class DecodeV1(minor: LV.Minor) {
             decodeExpr(exercise.getArg, definition) { argE =>
               bindWork(
                 if (exercise.hasGuard) {
-                  assertSince(LV.v1_dev, "exerciseInterface.guard")
+                  assertSince(LV.Features.extendedInterfaces, "exerciseInterface.guard")
                   decodeExpr(exercise.getGuard, definition) { e =>
                     Ret(Some(e))
                   }

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -1118,7 +1118,7 @@ class DecodeV1Spec
       }
     }
 
-    s"decode extended TypeRep iff version < ${LV.v1_dev}" in {
+    s"decode extended TypeRep iff version < ${LV.Features.templateTypeRepToText}" in {
       val testCases = {
         val typeRepTyConName = DamlLf1.Expr
           .newBuilder()
@@ -1136,7 +1136,7 @@ class DecodeV1Spec
       forEveryVersion { version =>
         forEvery(testCases) { (proto, scala) =>
           val result = Try(interfacePrimitivesDecoder(version).decodeExprForTest(proto, "test"))
-          if (version < LV.v1_dev)
+          if (version < LV.Features.templateTypeRepToText)
             inside(result) { case Failure(error) => error shouldBe a[Error.Parsing] }
           else
             result shouldBe Success(scala)
@@ -1204,7 +1204,7 @@ class DecodeV1Spec
       }
     }
 
-    s"translate interface exercise guard iff version >= ${LV.v1_dev}" in {
+    s"translate interface exercise guard iff version >= ${LV.Features.extendedInterfaces}" in {
 
       val unit = DamlLf1.Unit.newBuilder().build()
       val pkgRef = DamlLf1.PackageRef.newBuilder().setSelf(unit).build
@@ -1233,7 +1233,7 @@ class DecodeV1Spec
         Some(EUnit),
       )
 
-      forEveryVersionSuchThat(_ >= LV.v1_dev) { version =>
+      forEveryVersionSuchThat(_ >= LV.Features.extendedInterfaces) { version =>
         val decoder =
           moduleDecoder(version, ImmArraySeq("Choice"), interfaceDottedNameTable, typeTable)
         val proto = DamlLf1.Expr.newBuilder().setUpdate(exerciseInterfaceProto).build()
@@ -1811,7 +1811,7 @@ class DecodeV1Spec
     }
   }
 
-  s"reject experiment expression if LF version < ${LV.v1_dev}" in {
+  s"reject experiment expression if LF version < ${LV.Features.unstable}" in {
 
     val expr = DamlLf1.Expr
       .newBuilder()
@@ -1829,7 +1829,7 @@ class DecodeV1Spec
       )
       .build()
 
-    forEveryVersionSuchThat(_ < LV.v1_dev) { version =>
+    forEveryVersionSuchThat(_ < LV.Features.unstable) { version =>
       val decoder = moduleDecoder(version)
       an[Error.Parsing] shouldBe thrownBy(decoder.decodeExprForTest(expr, "test"))
     }

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -402,7 +402,7 @@ private[daml] class EncodeV1(minor: LV.Minor) {
           b.setArg(arg)
           builder.setSoftExercise(b)
         case UpdateDynamicExercise(templateId, choice, cid, arg) =>
-          assertSince(LV.v1_dev, "DynamicExercise")
+          assertSince(LV.Features.dynamicExercise, "DynamicExercise")
           val b = PLF.Update.DynamicExercise.newBuilder()
           b.setTemplate(templateId)
           setInternedString(choice, b.setChoiceInternedStr)
@@ -416,7 +416,7 @@ private[daml] class EncodeV1(minor: LV.Minor) {
           b.setCid(cid)
           b.setArg(arg)
           guard.foreach { g =>
-            assertSince(LV.v1_dev, "ExerciseInterface.guard")
+            assertSince(LV.Features.extendedInterfaces, "ExerciseInterface.guard")
             b.setGuard(g)
           }
           builder.setExerciseInterface(b)
@@ -791,7 +791,7 @@ private[daml] class EncodeV1(minor: LV.Minor) {
           setInternedString(choiceName, b.setChoiceInternedStr)
           builder.setChoiceObserver(b)
         case EExperimental(name, ty) =>
-          assertSince(LV.v1_dev, "Expr.experimental")
+          assertSince(LV.Features.unstable, "Expr.experimental")
           builder.setExperimental(PLF.Expr.Experimental.newBuilder().setName(name).setType(ty))
 
         case ECallInterface(ty, methodName, expr) =>

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -59,6 +59,13 @@ object LanguageVersion {
     val choiceAuthority = v1_dev
     val natTypeErasure = v1_dev
     val packageUpgrades = v1_dev
+    val dynamicExercise = v1_dev
+
+    /** TYPE_REP_TYCON_NAME builtin */
+    val templateTypeRepToText = v1_dev
+
+    /** Guards in interfaces */
+    val extendedInterfaces = v1_dev
 
     /** Unstable, experimental features. This should stay in 1.dev forever.
       * Features implemented with this flag should be moved to a separate


### PR DESCRIPTION
Context: #17366

Removing as many explicit mentions of v1_dev as possible because at some point some features will be available in both v1_dev and v2_dev, some others only 1_dev only, and some others in v2_dev only.

I've reused the feature names from https://github.com/digital-asset/daml/blob/main/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs with a comment when their name wasn't obvious.