### PR TITLE
Check script output in damlc integration tests

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -122,6 +122,7 @@
     - DA.Daml.Desugar.Tests
     - DA.Daml.Doc.Tests
     - DA.Test.DamlRenamer
+    - DA.Test.DamlcIntegration
     - DA.Signals
     - Development.IDE.Core.Compile
     - Development.IDE.GHC.Compat

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -109,10 +109,14 @@ da_haskell_test(
 da_haskell_library(
     name = "integration-lib",
     srcs = ["src/DA/Test/DamlcIntegration.hs"],
+    compiler_flags = [
+        "-DPOSIX_DIFF=\"$(POSIX_DIFF)\"",
+    ],
     hackage_deps = [
         "aeson-pretty",
         "base",
         "bytestring",
+        "containers",
         "data-default",
         "deepseq",
         "directory",
@@ -129,10 +133,15 @@ da_haskell_library(
         "shake",
         "tagged",
         "tasty",
+        "tasty-golden",
         "tasty-hunit",
         "text",
         "time",
         "unordered-containers",
+        "vector",
+    ],
+    toolchains = [
+        "@rules_sh//sh/posix:make_variables",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -146,6 +155,7 @@ da_haskell_library(
         "//compiler/damlc/daml-opts",
         "//compiler/damlc/daml-opts:daml-opts-types",
         "//compiler/damlc/daml-package-config",
+        "//compiler/damlc/daml-rule-types",
         "//compiler/scenario-service/client",
         "//daml-assistant:daml-project-config",
         "//daml-lf/archive:daml_lf_dev_archive_haskell_proto",

--- a/compiler/damlc/tests/daml-test-files/LedgerTestException.EXPECTED.ledger
+++ b/compiler/damlc/tests/daml-test-files/LedgerTestException.EXPECTED.ledger
@@ -1,0 +1,8 @@
+Script execution failed:
+  Unhandled exception:  DA.Exception.GeneralError:GeneralError with
+                          message = "ohno"
+
+Ledger time: 1970-01-01T00:00:00Z
+
+Trace: 
+  hello world

--- a/compiler/damlc/tests/daml-test-files/LedgerTestException.daml
+++ b/compiler/damlc/tests/daml-test-files/LedgerTestException.daml
@@ -1,0 +1,13 @@
+-- Copyright (c) 2023, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+module LedgerTestException where
+
+import Daml.Script
+
+-- @ERROR ohno
+-- @LEDGER test LedgerTestException.EXPECTED.ledger
+test : Script (Int, Bool)
+test = do
+  debugRaw "hello world"
+  error "ohno"

--- a/compiler/damlc/tests/daml-test-files/LedgerTestOk.EXPECTED.ledger
+++ b/compiler/damlc/tests/daml-test-files/LedgerTestOk.EXPECTED.ledger
@@ -1,0 +1,22 @@
+Transactions: 
+  TX 0 1970-01-01T00:00:00Z (LedgerTestOk:23:5)
+  #0:0
+  │   referenced by #1:0
+  │   disclosed to (since): 'alice' (0)
+  └─> 'alice' creates LedgerTestOk:T
+              with
+                p = 'alice'
+  
+  TX 1 1970-01-01T00:00:00Z (LedgerTestOk:27:5)
+  #1:0
+  │   disclosed to (since): 'alice' (1)
+  └─> 'alice' exercises Noop on #0:0 (LedgerTestOk:T)
+
+Active contracts:  #0:0
+
+Return value:
+  DA.Types:Tuple2 with
+    _1 = 42; _2 = false
+
+Trace: 
+  hello world

--- a/compiler/damlc/tests/daml-test-files/LedgerTestOk.daml
+++ b/compiler/damlc/tests/daml-test-files/LedgerTestOk.daml
@@ -1,0 +1,29 @@
+-- Copyright (c) 2023, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+module LedgerTestOk where
+
+import Daml.Script
+
+template T
+  with
+    p : Party
+  where
+    signatory p
+    nonconsuming choice Noop : ()
+      controller p
+      do pure ()
+
+-- @LEDGER test LedgerTestOk.EXPECTED.ledger
+test : Script (Int, Bool)
+test = do
+  debugRaw "hello world"
+  alice <- allocateParty "alice"
+  cid <-
+    alice `submit`
+      createCmd T with
+        p = alice
+  () <-
+    alice `submit`
+      exerciseCmd cid Noop
+  pure (42, False)

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -383,7 +383,6 @@ withLog action = do
 
 testCase :: LF.Version -> IsScriptV2Opt -> EvaluationOrder -> IO IdeState -> FilePath -> (TODO -> IO ()) -> DamlTestInput -> TestTree
 testCase version (IsScriptV2Opt isScriptV2Opt) evalOrderOpt getService outdir registerTODO input = singleTest name . TestCase $ \log -> do
-  service <- getService
   if any (`notElem` supportedOutputVersions) [v | UntilLF v <- anns] then
     pure (testFailed "Unsupported Daml-LF version in UNTIL-LF annotation")
   else if any (ignoreVersion version) anns
@@ -395,6 +394,7 @@ testCase version (IsScriptV2Opt isScriptV2Opt) evalOrderOpt getService outdir re
       , resultDetailsPrinter = noResultDetails
       }
     else do
+      service <- getService
       -- FIXME: Use of unsafeClearDiagnostics is only because we don't naturally lose them when we change setFilesOfInterest
       unsafeClearDiagnostics service
       ex <- try $ mainProj service outdir log (toNormalizedFilePath' path) :: IO (Either SomeException (Package, FilePath))

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -78,8 +78,7 @@ import qualified Test.Tasty.HUnit as HUnit
 import Test.Tasty.HUnit ((@?=))
 import Test.Tasty.Options
 import Test.Tasty.Providers
-import Test.Tasty.Providers.ConsoleFormat (noResultDetails)
-import Test.Tasty.Runners (Outcome(..), Result(..))
+import Test.Tasty.Runners (Result(..))
 
 import DA.Daml.Package.Config (PackageSdkVersion (..))
 import DA.Cli.Damlc.DependencyDb (installDependencies)
@@ -386,13 +385,7 @@ testCase version (IsScriptV2Opt isScriptV2Opt) evalOrderOpt getService outdir re
   if any (`notElem` supportedOutputVersions) [v | UntilLF v <- anns] then
     pure (testFailed "Unsupported Daml-LF version in UNTIL-LF annotation")
   else if any (ignoreVersion version) anns
-    then pure $ Result
-      { resultOutcome = Success
-      , resultDescription = ""
-      , resultShortDescription = "IGNORE"
-      , resultTime = 0
-      , resultDetailsPrinter = noResultDetails
-      }
+    then pure (testPassed "") { resultShortDescription = "IGNORE" }
     else do
       service <- getService
       -- FIXME: Use of unsafeClearDiagnostics is only because we don't naturally lose them when we change setFilesOfInterest

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -135,7 +135,7 @@ type ScriptPackageData = (FilePath, [PackageFlag])
 -- | Creates a temp directory with daml script v1 installed, gives the database db path and package flag
 withDamlScriptDep :: Maybe Version -> (ScriptPackageData -> IO a) -> IO a
 withDamlScriptDep mLfVer =
-  let 
+  let
     lfVerStr = maybe "" (\lfVer -> "-" <> renderVersion lfVer) mLfVer
     darPath = "daml-script" </> "daml" </> "daml-script" <> lfVerStr <> ".dar"
   in withVersionedDamlScriptDep ("daml-script-" <> sdkPackageVersion) darPath mLfVer []
@@ -146,7 +146,7 @@ withDamlScriptV2Dep =
     darPath = "daml-script" </> "daml3" </> "daml3-script.dar"
   in withVersionedDamlScriptDep
        ("daml3-script-" <> sdkPackageVersion)
-       darPath 
+       darPath
        (Just version2_dev) -- daml-script only supports 2.dev for now
        scriptV2ExternalPackages
 

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -381,14 +381,15 @@ withLog action = do
   pure (f (unlines (DList.toList msgs)))
 
 testCase :: LF.Version -> IsScriptV2Opt -> EvaluationOrder -> IO IdeState -> FilePath -> (TODO -> IO ()) -> DamlTestInput -> TestTree
-testCase version (IsScriptV2Opt isScriptV2Opt) evalOrderOpt getService outdir registerTODO input =
-  if any (`notElem` supportedOutputVersions) [v | UntilLF v <- anns] then
+testCase version (IsScriptV2Opt isScriptV2Opt) evalOrderOpt getService outdir registerTODO input
+  | any (`notElem` supportedOutputVersions) [v | UntilLF v <- anns] =
     singleTest name $ TestCase \_ ->
       pure $ testFailed "Unsupported Daml-LF version in UNTIL-LF annotation"
-  else if any (ignoreVersion version) anns
-    then singleTest name $ TestCase \_ ->
-            pure (testPassed "") { resultShortDescription = "IGNORE" }
-    else singleTest name $ TestCase \log -> do
+  | any (ignoreVersion version) anns =
+    singleTest name $ TestCase \_ ->
+      pure (testPassed "") { resultShortDescription = "IGNORE" }
+  | otherwise =
+    singleTest name $ TestCase \log -> do
       service <- getService
       -- FIXME: Use of unsafeClearDiagnostics is only because we don't naturally lose them when we change setFilesOfInterest
       unsafeClearDiagnostics service


### PR DESCRIPTION
This PR Extends the damlc integration tests to support `-- @LEDGER <script-name> <expected-ledger-file>` annotations.
For daml test files with such annotations, this checks that the output of running `<script-name>` matches the contents of `<expected-ledger-file>`. 

The script output is produced with `PrettyLevel (-1)` (equivalent to `daml test --detail=-1 ...`) in order to remove package ids - this should remove the need to update the golden files every time a package id changes because of a change elsewhere.

Note that this PR also changes the `TestTree` structure generated. Previously, each `.daml` file under `compiler/damlc/tests/daml-test-files/` corresponded to a `singleTest` that built the project and then performed all the checks in a single IO computation. Now, each `.daml` file corresponds to a test tree where the `damlc` output is shared using `withResource`, with this more granular structure:

* test tree for file <xyz>.daml
    * dummy `singleTest` that always succeeds; its purpose is to log `TODO`s and the timing stats from the build step, sometimes useful for debugging.
    * check diagnostics (`singleTest`)
    * check `jq` queries 
        * one `singleTest` per `-- @QUERY-LF(-STREAM)` annotation
    * check script output
        * one `goldenVsStringDiff` per `-- @LEDGER` annotation - switching to a `TestTree` allows us to reuse `goldenVsStringDiff` from `tasty-golden`.

The golden files can be updated with

```
bazel run //compiler/damlc/tests:integration-v114 -- --accept
bazel run //compiler/damlc/tests:integration-v115 -- --accept
bazel run //compiler/damlc/tests:integration-v1dev -- --accept
```

TODO:
* [x] rebase on `main` after https://github.com/digital-asset/daml/pull/17399 gets merged
* [x] ~document changes~ => https://github.com/digital-asset/daml/issues/17460