### PR TITLE
FIX: Propagate client-side termination of websockets to infinite substreams

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -848,7 +848,6 @@ class WebSocketService(
           InvalidUserInput("Multiple requests over the same WebSocket connection are not allowed.")
         )
       )
-      // flatMapMerge only completes when all consumed substreams complete, hence the kill-switch for otherwise infinite streams
       .flatMapMerge(
         2, // 2 streams max, the 2nd is to be able to send an error back
         _.map { case (offPrefix, rq: ResolvedQueryRequest[q]) =>
@@ -861,6 +860,7 @@ class WebSocketService(
             rq.q: q,
           )
             .via(logTermination("getTransactionSourceForParty"))
+            // flatMapMerge only completes when all consumed substreams complete, hence the kill-switch for otherwise infinite streams
             .via(killSwitch.flow)
         }.valueOr(e => Source.single(-\/(e))): Source[Error \/ Message, NotUsed],
       )


### PR DESCRIPTION
This PR is the implementation of a bugfix tracked down and identified by @raphael-speyer-da. It does not currently include any tests.

The correct behaviour has been verified experimentally at this stage.

The problem was that upstream completion (i.e. termination on the client-side of WebSocket streams) does not propagate to infinitely-running substreams created inside a `flatMapMerge` operator. Similar operators such as `flatMapConcat` have the same behavior.

> [flatMapMerge](https://doc.akka.io/docs/akka/current/stream/operators/Source-or-Flow/flatMapMerge.html): completes when upstream completes **and all consumed substreams complete**

This could lead to the situation where the server would never gracefully terminate the WebSocket connection by sending a `close frame`, and connections would remain open indefinitely (unless closed forcefully).

A simple solution is to propagate the upstream completion explicitly using a kill-switch.

A new `killSwitch` is created for each WebSocket HTTP request, so there is no risk of accidental re-use of the same kill-switch across multiple requests.