### PR TITLE
Add '--detail=LEVEL' option for `daml test` and `daml ide`

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -3,8 +3,12 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# LANGUAGE FlexibleInstances  #-}
-module DA.Daml.LF.Ast.Pretty(
-    (<:>)
+module DA.Daml.LF.Ast.Pretty
+    ( levelHasTypes
+    , levelHasKinds
+    , levelHasPackageIds
+    , levelHasLocations
+    , (<:>)
     ) where
 
 import qualified Data.Ratio                 as Ratio

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
@@ -39,6 +39,7 @@ import Development.IDE.Types.Options
 import DA.Daml.Options.Types
 import qualified DA.Daml.LF.Ast as LF
 import qualified DA.Daml.LF.ScenarioServiceClient as SS
+import DA.Pretty (PrettyLevel)
 
 data DamlEnv = DamlEnv
   { envScenarioService :: Maybe SS.Handle
@@ -58,6 +59,7 @@ data DamlEnv = DamlEnv
   , envAllowLargeTuples :: AllowLargeTuples
   , envStudioAutorunAllScenarios :: StudioAutorunAllScenarios
   , envTestFilter :: T.Text -> Bool
+  , envDetailLevel :: PrettyLevel
   }
 
 instance IsIdeGlobal DamlEnv
@@ -78,6 +80,7 @@ mkDamlEnv opts autorunAllScenarios scenarioService = do
         , envAllowLargeTuples = optAllowLargeTuples opts
         , envStudioAutorunAllScenarios = autorunAllScenarios
         , envTestFilter = optTestFilter opts
+        , envDetailLevel = optDetailLevel opts
         }
 
 getDamlServiceEnv :: Action DamlEnv

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -82,6 +82,8 @@ data Options = Options
     -- ^ The target Daml-LF version
   , optLogLevel :: Logger.Priority
     -- ^ Min log level that we display
+  , optDetailLevel :: PrettyLevel
+    -- ^ Level of detail in pretty printed output
   , optGhcCustomOpts :: [String]
     -- ^ custom options, parsed by GHC option parser, overriding DynFlags
   , optScenarioService :: EnableScenarioService
@@ -251,6 +253,7 @@ defaultOptions mbVersion =
         , optThreads = 1
         , optDamlLfVersion = fromMaybe LF.versionDefault mbVersion
         , optLogLevel = Logger.Info
+        , optDetailLevel = DA.Pretty.prettyNormal
         , optGhcCustomOpts = []
         , optScenarioService = EnableScenarioService True
         , optEnableScenarios = EnableScenarios False

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -26,6 +26,7 @@ import DA.Cli.Options (Debug(..),
                        ProjectOpts(..),
                        Style(..),
                        Telemetry(..),
+                       cliOptDetailLevel,
                        debugOpt,
                        disabledDlintUsageParser,
                        enabledDlintUsageParser,
@@ -432,10 +433,7 @@ cmdInspect =
     <> fullDesc
   where
     jsonOpt = switch $ long "json" <> help "Output the raw Protocol Buffer structures as JSON"
-    detailOpt =
-        fmap (maybe DA.Pretty.prettyNormal DA.Pretty.PrettyLevel) $
-            optional $ optionOnce auto $ long "detail" <> metavar "LEVEL" <> help "Detail level of the pretty printed output (default: 0)"
-    cmd = execInspect <$> inputFileOptWithExt ".dalf or .dar" <*> outputFileOpt <*> jsonOpt <*> detailOpt
+    cmd = execInspect <$> inputFileOptWithExt ".dalf or .dar" <*> outputFileOpt <*> jsonOpt <*> cliOptDetailLevel
 
 cmdBuild :: Int -> Mod CommandFields Command
 cmdBuild numProcessors =

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -350,6 +350,10 @@ cliOptLogLevel =
         "error" -> Just Logger.Error
         _ -> Nothing
 
+cliOptDetailLevel :: Parser Pretty.PrettyLevel
+cliOptDetailLevel =
+  fmap (maybe Pretty.prettyNormal Pretty.PrettyLevel) $
+    optional $ optionOnce auto $ long "detail" <> metavar "LEVEL" <> help "Detail level of the pretty printed output (default: 0)"
 
 optPackageName :: Parser (Maybe GHC.UnitId)
 optPackageName = optional $ fmap GHC.stringToUnitId $ strOptionOnce $
@@ -377,6 +381,7 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
     optThreads <- optShakeThreads
     optDamlLfVersion <- lfVersionOpt
     optLogLevel <- cliOptLogLevel
+    optDetailLevel <- cliOptDetailLevel
     optGhcCustomOpts <- optGhcCustomOptions
     let optScenarioService = enableScenarioService
     let optSkipScenarioValidation = SkipScenarioValidation False

--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -1219,8 +1219,8 @@ runScripts service fileContent = bracket getIdeState shutdown $ \ideState -> do
     prettyResult world (Left err) = case err of
       SS.BackendError err -> assertFailure $ "Unexpected result " <> show err
       SS.ExceptionError err -> assertFailure $ "Unexpected result " <> show err
-      SS.ScenarioError err -> pure $ Left $ renderPlain (prettyScenarioError world err)
-    prettyResult world (Right r) = pure $ Right $ renderPlain (prettyScenarioResult world (S.fromList (V.toList (SS.scenarioResultActiveContracts r))) r)
+      SS.ScenarioError err -> pure $ Left $ renderPlain (prettyScenarioError prettyNormal world err)
+    prettyResult world (Right r) = pure $ Right $ renderPlain (prettyScenarioResult prettyNormal world (S.fromList (V.toList (SS.scenarioResultActiveContracts r))) r)
     file = toNormalizedFilePath' "Test.daml"
     getIdeState = do
       vfs <- makeVFSHandle

--- a/compiler/damlc/tests/src/DA/Test/ScriptService_1_15.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService_1_15.hs
@@ -254,8 +254,8 @@ runScripts service fileContent = bracket getIdeState shutdown $ \ideState -> do
     prettyResult world (Left err) = case err of
       SS.BackendError err -> assertFailure $ "Unexpected result " <> show err
       SS.ExceptionError err -> assertFailure $ "Unexpected result " <> show err
-      SS.ScenarioError err -> pure $ Left $ renderPlain (prettyScenarioError world err)
-    prettyResult world (Right r) = pure $ Right $ renderPlain (prettyScenarioResult world (S.fromList (V.toList (SS.scenarioResultActiveContracts r))) r)
+      SS.ScenarioError err -> pure $ Left $ renderPlain (prettyScenarioError prettyNormal world err)
+    prettyResult world (Right r) = pure $ Right $ renderPlain (prettyScenarioResult prettyNormal world (S.fromList (V.toList (SS.scenarioResultActiveContracts r))) r)
     file = toNormalizedFilePath' "Test.daml"
     getIdeState = do
       vfs <- makeVFSHandle

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -157,16 +157,12 @@ prettyScenarioResult world activeContracts (ScenarioResult steps nodes retValue 
 
       ppTrace = vcat $ map prettyTraceMessage (V.toList traceLog)
       ppWarnings = vcat $ map prettyWarningMessage (V.toList warnings)
-  in vsep
-    [ label_ "Transactions: " ppSteps
-    , label_ "Active contracts: " ppActive
-    , maybe mempty (\v -> label_ "Return value:" (prettyValue' True 0 world v)) retValue
-    , if V.null traceLog
-      then text ""
-      else text "Trace: " $$ nest 2 ppTrace
-    , if V.null warnings
-      then text ""
-      else text "Warnings: " $$ nest 2 ppWarnings
+  in vsep $ concat
+    [ [label_ "Transactions: " ppSteps]
+    , [label_ "Active contracts: " ppActive]
+    , [label_ "Return value:" (prettyValue' True 0 world v) | Just v <- [retValue]]
+    , [text "Trace: " $$ nest 2 ppTrace | not (V.null traceLog)]
+    , [text "Warnings: " $$ nest 2 ppWarnings | not (V.null warnings)]
     ]
 
 prettyBriefScenarioError


### PR DESCRIPTION
This came up while working on https://github.com/digital-asset/daml/pull/17380. There, we want to add golden files for the final ledger state, but currently that output is littered with package ids. While we could follow the approach of the scenario-based tests in `//daml-lf/tests/scenario` and censor the output with `sed` or similar, it seems more principled to instead never produce those package ids in the first place.