### PR TITLE
Revert "bump canton to 2.8.0-snapshot.20230914.11170.0.v3bc03a0c (#17404)

### DIFF
--- a/canton/BUILD.bazel
+++ b/canton/BUILD.bazel
@@ -66,8 +66,8 @@ if [ "{local}" = "true" ]; then
     exit 0
 fi
 
-CANTON_ENTERPRISE_VERSION=2.8.0-snapshot.20230914.11170.0.v3bc03a0c
-CANTON_ENTERPRISE_SHA=6f041102eb604d9a8fe7f043513bb113974c38d8b4c223ab701602967f19a7d3
+CANTON_ENTERPRISE_VERSION=2.8.0-snapshot.20230913.11166.0.v590556d1
+CANTON_ENTERPRISE_SHA=3cd7bd2c6864dfdd697be04af90717ba14fc13f50ba7bd28a12e41618c96f68e
 
 url=https://digitalasset.jfrog.io/artifactory/canton-enterprise/canton-enterprise-$$CANTON_ENTERPRISE_VERSION.tar.gz
 

--- a/canton_dep.bzl
+++ b/canton_dep.bzl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 canton = {
-    "sha": "cd72960040e3a231f4b922ae8a88bff9a2775ea1df218d1d4b01361acd6e4f54",
-    "url": "https://www.canton.io/releases/canton-open-source-2.8.0-snapshot.20230914.11170.0.v3bc03a0c.tar.gz",
+    "sha": "3572c35c67ec944d545517747de50496093f3c8e22482b934897045aa3be1f21",
+    "url": "https://www.canton.io/releases/canton-open-source-2.8.0-snapshot.20230913.11166.0.v590556d1.tar.gz",
     "local": False,
 }


### PR DESCRIPTION
Because artifacts have been overwritten. 

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
