### PR TITLE
[engine] Calls to ResultNeedUpgradeValidation are mode dependent

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -2220,7 +2220,15 @@ private[lf] object SBuiltin {
                     val src: TypeConName = srcTemplateId
                     val dest: TypeConName = destTemplateId
 
-                    if (upgradingIsEnabled && src != dest) {
+                    // In Validation mode, we always call validateContractInfo
+                    // In Submission mode, we only call validateContractInfo when src != dest
+                    val needValidationCall: Boolean =
+                      if (machine.validating) {
+                        upgradingIsEnabled
+                      } else {
+                        upgradingIsEnabled && (src != dest)
+                      }
+                    if (needValidationCall) {
 
                       validateContractInfo(machine, coid, contract) { () =>
                         f(contract.any)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -166,7 +166,7 @@ private[lf] object Speedy {
       override var compiledPackages: CompiledPackages,
       override val profile: Profile,
       override val iterationsBetweenInterruptions: Long,
-      val validating: Boolean,
+      val validating: Boolean, // TODO: Better: Mode = SubmissionMode | ValidationMode
       val submissionTime: Time.Timestamp,
       val contractKeyUniqueness: ContractKeyUniquenessMode,
       /* The current partial transaction */


### PR DESCRIPTION
Advances #17082

To make live easier for the ledger, the engine should be aware of whether it is being used in Submission mode or Validation mode, and vary it's behaviour (slightly) w.r.t the calls to `ResultNeedUpgradeVerification` (RNUV)

- In validation mode, the engine should call RNUV every time a contract instance is referenced at a specific template type.
- In submission mode, the engine should only call RNUV if the type of the contract instance differs from the template type it is being used at, i.e an upgrade/downgrade is actually occurring.

(Prior to this change, the engine behaviour was fixed to be what is wanted for submission mode.)
