### PR TITLE
[engine] unit test ResultNeedUpgradeVerification

### DIFF
--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ChoiceAuthorityTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ChoiceAuthorityTest.scala
@@ -97,7 +97,9 @@ class ChoiceAuthorityTest extends AnyFreeSpec with Inside {
           ),
         )
         val machine = Speedy.Machine.fromUpdateSExpr(pkgs, transactionSeed, example, committers)
-        SpeedyTestLib.buildTransactionCollectAuthRequests(machine)
+        SpeedyTestLib
+          .buildTransactionCollectRequests(machine)
+          .map { case (x, ars, _) => (x, ars) } // ignoring any UpgradeVerificationRequest
       }
 
       "Happy" - {


### PR DESCRIPTION
Advances #17082

Unit test speedy calls to `NeedUpgradeVerification`
- extending `SpeedyTestLib` as necessary.