### PR TITLE
infra: add Production tag to daml-ci

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -59,6 +59,9 @@ provider "azurerm" {
 resource "azurerm_resource_group" "daml-ci" {
   name     = "daml-ci"
   location = "East US"
+  tags = {
+    env = "Production"
+  }
 }
 
 data "google_project" "current" {


### PR DESCRIPTION
When routinely checking for conformance between Terraform files and deployed state, I noticed someone had added this tag. Adding it to the Terraform files so it doesn't get removed by future Terraform deploys.

cc @nycnewman @asangeethada as probable people who might know about when/why/who added that tag.