### PR TITLE
Json-LF decoding: numeric bounds checking, timestamp truncation and error reporting

### DIFF
--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfDecoder.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfDecoder.java
@@ -10,12 +10,21 @@ public interface JsonLfDecoder<T> {
   public T decode(JsonLfReader r) throws Error;
 
   public static class Error extends IOException {
-    public Error(String message) {
-      super(message);
+    public final JsonLfReader.Location location;
+    private final String msg;
+
+    public Error(String message, JsonLfReader.Location loc) {
+      this(message, loc, null);
     }
 
-    public Error(String message, Throwable cause) {
-      super(message, cause);
+    public Error(String message, JsonLfReader.Location loc, Throwable cause) {
+      super(String.format("%s at line: %d, column: %d", message, loc.line, loc.column), cause);
+      this.msg = message;
+      this.location = loc;
+    }
+
+    public Error fromStartLocation(JsonLfReader.Location start) {
+      return new Error(this.msg, start.advance(this.location), this.getCause());
     }
   }
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReader.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReader.java
@@ -34,7 +34,6 @@ public class JsonLfReader {
   private static final JsonFactory jsonFactory = new JsonFactory();
   private final JsonParser parser;
 
-  @SuppressWarnings("deprecation")
   public JsonLfReader(String json) throws JsonLfDecoder.Error {
     this.json = json;
     try {

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReader.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReader.java
@@ -80,10 +80,11 @@ public class JsonLfReader {
           return value;
         };
 
-    public static JsonLfDecoder<BigDecimal> decimal(int scale) {
+    public static JsonLfDecoder<BigDecimal> numeric(int scale) {
+      assert scale >= 0 : "negative numeric scale " + scale;
       return r -> {
         r.expectIsAt(
-            "decimal",
+            "numeric",
             JsonToken.VALUE_NUMBER_INT,
             JsonToken.VALUE_NUMBER_FLOAT,
             JsonToken.VALUE_STRING);
@@ -92,9 +93,9 @@ public class JsonLfReader {
           value = new BigDecimal(r.parser.getText());
           if (value.scale() > scale) value = value.setScale(scale, RoundingMode.HALF_EVEN);
         } catch (NumberFormatException e) {
-          r.parseExpected("decimal", e);
+          r.parseExpected("numeric", e);
         } catch (IOException e) {
-          r.parseExpected("decimal", e);
+          r.parseExpected("numeric", e);
         }
         r.moveNext();
         return value;
@@ -210,13 +211,11 @@ public class JsonLfReader {
           return Optional.empty();
         } else {
           T some = decodeVal.decode(r);
-          if (some instanceof Optional) {
-            throw new IllegalArgumentException(
+          assert (!(some instanceof Optional)) :
                 "Used `optional` to decode a "
                     + some.getClass()
                     + " but `optionalNested` must be used for the outer decoders of nested"
-                    + " Optional");
-          }
+                    + " Optional";
           return Optional.of(some);
         }
       };

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReaderTest.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReaderTest.java
@@ -58,7 +58,7 @@ public class JsonLfReaderTest {
   @Test
   void testDecimal() throws IOException {
     checkReadAll(
-        Decoders.decimal(12),
+        Decoders.numeric(10),
         cmpEq("42", dec("42")),
         cmpEq("42.0", dec("42")),
         cmpEq("\"42\"", dec("42")),

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromJsonGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromJsonGenerator.scala
@@ -230,7 +230,7 @@ private[inner] object FromJsonGenerator extends StrictLogging {
         CodeBlock.of("$T.jsonDecoder($L)", guessClass(ident), typeReaders(typeParams))
       case TypePrim(PrimTypeBool, _) => CodeBlock.of("$T.bool", decodeClass)
       case TypePrim(PrimTypeInt64, _) => CodeBlock.of("$T.int64", decodeClass)
-      case TypeNumeric(scale) => CodeBlock.of("$T.decimal($L)", decodeClass, scale)
+      case TypeNumeric(scale) => CodeBlock.of("$T.numeric($L)", decodeClass, scale)
       case TypePrim(PrimTypeText, _) => CodeBlock.of("$T.text", decodeClass)
       case TypePrim(PrimTypeDate, _) => CodeBlock.of("$T.date", decodeClass)
       case TypePrim(PrimTypeTimestamp, _) => CodeBlock.of("$T.timestamp", decodeClass)


### PR DESCRIPTION
Also renamed `decimal` decoder to `numeric` and added a bunch of unit tests, especially the error cases.