### PR TITLE
Sw/daml script upgrades

### DIFF
--- a/daml-script/daml3/Daml/Script.daml
+++ b/daml-script/daml3/Daml/Script.daml
@@ -86,6 +86,9 @@ module Daml.Script
   , unvetPackages
   , listVettedPackages
   , listAllPackages
+
+  , transformTemplate
+  , transformAnyTemplate
   ) where
 
 import Daml.Script.Internal

--- a/daml-script/daml3/Daml/Script/Questions.daml
+++ b/daml-script/daml3/Daml/Script/Questions.daml
@@ -10,6 +10,7 @@ module Daml.Script.Questions
   , module Daml.Script.Questions.Submit
   , module Daml.Script.Questions.Time
   , module Daml.Script.Questions.TransactionTree
+  , module Daml.Script.Questions.Upgrades
   , module Daml.Script.Questions.UserManagement
   , module Daml.Script.Questions.Util
   ) where
@@ -22,5 +23,6 @@ import Daml.Script.Questions.Query
 import Daml.Script.Questions.Submit
 import Daml.Script.Questions.Time
 import Daml.Script.Questions.TransactionTree
+import Daml.Script.Questions.Upgrades
 import Daml.Script.Questions.UserManagement
 import Daml.Script.Questions.Util

--- a/daml-script/daml3/Daml/Script/Questions/Upgrades.daml
+++ b/daml-script/daml3/Daml/Script/Questions/Upgrades.daml
@@ -10,12 +10,14 @@ data TransformTemplate = TransformTemplate with
   desiredTplId : TemplateTypeRep
 instance IsQuestion TransformTemplate (Either Text LedgerValue) where command = "TransformTemplate"
 
-transformTemplate : forall t t'. (Template t, HasAgreement t, Template t', HasAgreement t') => t -> Script (Either Text t')
-transformTemplate t = fmap fromLedgerValue <$> lift TransformTemplate with
-  tpl = toAnyTemplate t
-  desiredTplId = templateTypeRep @t'
+transformTemplate : forall t' t. (Template t, HasAgreement t, Template t', HasAgreement t') => t -> Script (Either Text t')
+transformTemplate = transformAnyTemplate . toAnyTemplate
 
--- transformAnyTemplate : forall t. (Template t, HasAgreement t) => AnyTemplate -> Script (Either Text t)
+transformAnyTemplate : forall t. (Template t, HasAgreement t) => AnyTemplate -> Script (Either Text t)
+transformAnyTemplate t = fmap fromLedgerValue <$> lift TransformTemplate with
+  tpl = t
+  desiredTplId = templateTypeRep @t
+
 -- Consider if theres a way to "tag" an AnyTemplate with the name without package id
 -- akin to `EquivilentTemplate "Main:MyTemplate"`, we can bring the name down to value level using generated typeclasses
 -- but for type level, we'd need to share a data type between the multiple definitions, essentially fool the type system into thinking they're the same

--- a/daml-script/daml3/Daml/Script/Questions/Upgrades.daml
+++ b/daml-script/daml3/Daml/Script/Questions/Upgrades.daml
@@ -1,0 +1,22 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Script.Questions.Upgrades where
+
+import Daml.Script.Internal
+
+data TransformTemplate = TransformTemplate with
+  tpl : AnyTemplate
+  desiredTplId : TemplateTypeRep
+instance IsQuestion TransformTemplate (Either Text LedgerValue) where command = "TransformTemplate"
+
+transformTemplate : forall t t'. (Template t, HasAgreement t, Template t', HasAgreement t') => t -> Script (Either Text t')
+transformTemplate t = fmap fromLedgerValue <$> lift TransformTemplate with
+  tpl = toAnyTemplate t
+  desiredTplId = templateTypeRep @t'
+
+-- transformAnyTemplate : forall t. (Template t, HasAgreement t) => AnyTemplate -> Script (Either Text t)
+-- Consider if theres a way to "tag" an AnyTemplate with the name without package id
+-- akin to `EquivilentTemplate "Main:MyTemplate"`, we can bring the name down to value level using generated typeclasses
+-- but for type level, we'd need to share a data type between the multiple definitions, essentially fool the type system into thinking they're the same
+-- I dont think this is possible without symbols

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -118,10 +118,11 @@ trait ConverterMethods {
       translator: preprocessing.ValueTranslator,
       templateId: Identifier,
       argument: Value,
+      soft: Boolean = false,
   ): Either[String, SValue] = {
     for {
       translated <- translator
-        .translateValue(TTyCon(templateId), argument)
+        .translateValue(TTyCon(templateId), argument, soft)
         .left
         .map(err => s"Failed to translate create argument: $err")
     } yield record(

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Converter.scala
@@ -138,7 +138,9 @@ object Converter extends script.ConverterMethods {
   def fromContract(
       translator: preprocessing.ValueTranslator,
       contract: ScriptLedgerClient.ActiveContract,
-  ): Either[String, SValue] = fromAnyTemplate(translator, contract.templateId, contract.argument)
+      soft: Boolean = false,
+  ): Either[String, SValue] =
+    fromAnyTemplate(translator, contract.templateId, contract.argument, soft)
 
   // Convert a Created event to a pair of (ContractId (), AnyTemplate)
   def fromCreated(

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Runner.scala
@@ -38,6 +38,7 @@ private[lf] class Runner(
       unversionedRunner.timeMode,
       initialClientsV1,
       unversionedRunner.extendedCompiledPackages,
+      unversionedRunner.enableContractUpgrading,
     )
 
   private val ideLedgerContext: Option[IdeLedgerContext] =

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
@@ -315,8 +315,10 @@ object ScriptF {
     ): Future[SExpr] =
       for {
         client <- Converter.toFuture(env.clients.getPartiesParticipant(parties))
-        optR <- client.queryContractId(parties, tplId, cid)
-        optR <- Converter.toFuture(optR.traverse(Converter.fromContract(env.valueTranslator, _)))
+        optR <- client.queryContractId(parties, tplId, cid, true)
+        optR <- Converter.toFuture(
+          optR.traverse(Converter.fromContract(env.valueTranslator, _, true))
+        )
       } yield SEValue(SOptional(optR))
   }
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcLedgerClient.scala
@@ -56,11 +56,15 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
     extends ScriptLedgerClient {
   override val transport = "gRPC API"
 
-  override def query(parties: OneAnd[Set, Ref.Party], templateId: Identifier)(implicit
+  override def query(
+      parties: OneAnd[Set, Ref.Party],
+      templateId: Identifier,
+      soft: Boolean = false,
+  )(implicit
       ec: ExecutionContext,
       mat: Materializer,
   ): Future[Vector[ScriptLedgerClient.ActiveContract]] = {
-    queryWithKey(parties, templateId).map(_.map(_._1))
+    queryWithKey(parties, templateId, soft).map(_.map(_._1))
   }
 
   private def templateFilter(
@@ -71,6 +75,16 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
     TransactionFilter(parties.toList.map(p => (p, filters)).toMap)
   }
 
+  // Template filter with the package id removed, for upgrades
+  private def softTemplateFilter(
+      parties: OneAnd[Set, Ref.Party],
+      templateId: Identifier,
+  ): TransactionFilter = {
+    val filters = Filters(
+      Some(InclusiveFilters(Seq(toApiIdentifier(templateId).copy(packageId = ""))))
+    )
+    TransactionFilter(parties.toList.map(p => (p, filters)).toMap)
+  }
   private def interfaceFilter(
       parties: OneAnd[Set, Ref.Party],
       interfaceId: Identifier,
@@ -88,11 +102,16 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
   }
 
   // Helper shared by query, queryContractId and queryContractKey
-  private def queryWithKey(parties: OneAnd[Set, Ref.Party], templateId: Identifier)(implicit
+  private def queryWithKey(
+      parties: OneAnd[Set, Ref.Party],
+      templateId: Identifier,
+      soft: Boolean = false,
+  )(implicit
       ec: ExecutionContext,
       mat: Materializer,
   ): Future[Vector[(ScriptLedgerClient.ActiveContract, Option[Value])]] = {
-    val filter = templateFilter(parties, templateId)
+    val filter =
+      if (soft) softTemplateFilter(parties, templateId) else templateFilter(parties, templateId)
     val acsResponses =
       grpcClient.activeContractSetClient
         .getActiveContracts(filter, verbose = false)
@@ -128,13 +147,14 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,
       cid: ContractId,
+      soft: Boolean = false,
   )(implicit
       ec: ExecutionContext,
       mat: Materializer,
   ): Future[Option[ScriptLedgerClient.ActiveContract]] = {
     // We cannot do better than a linear search over query here.
     for {
-      activeContracts <- query(parties, templateId)
+      activeContracts <- query(parties, templateId, soft)
     } yield {
       activeContracts.find(c => c.contractId == cid)
     }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -110,7 +110,11 @@ class IdeLedgerClient(
 
   private val userManagementStore = new InMemoryUserManagementStore(createAdmin = false)
 
-  override def query(parties: OneAnd[Set, Ref.Party], templateId: Identifier)(implicit
+  override def query(
+      parties: OneAnd[Set, Ref.Party],
+      templateId: Identifier,
+      soft: Boolean = false,
+  )(implicit
       ec: ExecutionContext,
       mat: Materializer,
   ): Future[Seq[ScriptLedgerClient.ActiveContract]] = {
@@ -161,6 +165,7 @@ class IdeLedgerClient(
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,
       cid: ContractId,
+      soft: Boolean = false,
   )(implicit
       ec: ExecutionContext,
       mat: Materializer,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/JsonLedgerClient.scala
@@ -160,7 +160,11 @@ class JsonLedgerClient(
       case SuccessResponse(result, _) => Future.successful(result)
     }
 
-  override def query(parties: OneAnd[Set, Ref.Party], templateId: Identifier)(implicit
+  override def query(
+      parties: OneAnd[Set, Ref.Party],
+      templateId: Identifier,
+      soft: Boolean = false,
+  )(implicit
       ec: ExecutionContext,
       mat: Materializer,
   ) = {
@@ -189,6 +193,7 @@ class JsonLedgerClient(
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,
       cid: ContractId,
+      soft: Boolean = false,
   )(implicit ec: ExecutionContext, mat: Materializer) = {
     for {
       parties <- validateTokenParties(parties, "queryContractId")

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
@@ -73,7 +73,7 @@ object ScriptLedgerClient {
 // us to plug in something that interacts with the JSON API as well as
 // something that works against the gRPC API.
 trait ScriptLedgerClient {
-  def query(parties: OneAnd[Set, Ref.Party], templateId: Identifier)(implicit
+  def query(parties: OneAnd[Set, Ref.Party], templateId: Identifier, soft: Boolean = false)(implicit
       ec: ExecutionContext,
       mat: Materializer,
   ): Future[Seq[ScriptLedgerClient.ActiveContract]]
@@ -87,8 +87,12 @@ trait ScriptLedgerClient {
       )
     )
 
-  def queryContractId(parties: OneAnd[Set, Ref.Party], templateId: Identifier, cid: ContractId)(
-      implicit
+  def queryContractId(
+      parties: OneAnd[Set, Ref.Party],
+      templateId: Identifier,
+      cid: ContractId,
+      soft: Boolean = false,
+  )(implicit
       ec: ExecutionContext,
       mat: Materializer,
   ): Future[Option[ScriptLedgerClient.ActiveContract]]


### PR DESCRIPTION
First version of casting logic, implements the same compatibility logic in value translator, but also keeps the existing capability of reordering fields (including with respect to upgrades)
Currently only supported for `queryContractId` in daml3-script