### PR TITLE
LT-30: add benchmark of JSON decoding for Java code-gen types

### DIFF
--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReader.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReader.java
@@ -300,9 +300,9 @@ public class JsonLfReader {
     //        name -> {
     //          switch (name) {
     //            case "i":
-    //              return JsonLfReader.ConstrArg.at(0, r.list(r.int64()));
+    //              return JsonLfReader.JavaArg.at(0, r.list(r.int64()));
     //            case "b":
-    //              return JsonLfReader.ConstrArg.at(1, r.bool(), false);
+    //              return JsonLfReader.JavaArg.at(1, r.bool(), false);
     //            default:
     //              return null;
     //          }
@@ -311,7 +311,7 @@ public class JsonLfReader {
     //     )
     public static <T> JsonLfDecoder<T> record(
         List<String> argNames,
-        Function<String, ConstrArg<? extends Object>> argsByName,
+        Function<String, JavaArg<? extends Object>> argsByName,
         Function<Object[], T> constr) {
       return r -> {
         Object[] args = new Object[argNames.size()];
@@ -337,7 +337,7 @@ public class JsonLfReader {
 
         // Handle missing fields.
         for (String argName : argNames) {
-          ConstrArg<? extends Object> arg = argsByName.apply(argName);
+          JavaArg<? extends Object> arg = argsByName.apply(argName);
           if (args[arg.index] != null) continue;
           if (arg.defaultVal == null) r.missingField(argName);
           args[arg.index] = arg.defaultVal;
@@ -347,24 +347,24 @@ public class JsonLfReader {
       };
     }
 
-    // Represents an argument to the code-gen constructor.
-    public static class ConstrArg<T> {
+    // Represents an argument to the constructor of the code-gen class.
+    public static class JavaArg<T> {
       final int index;
       final JsonLfDecoder<T> decode;
       final T defaultVal; // If non-null, used to populate value of missing fields.
 
-      private ConstrArg(int index, JsonLfDecoder<T> decode, T defaultVal) {
+      private JavaArg(int index, JsonLfDecoder<T> decode, T defaultVal) {
         this.index = index;
         this.decode = decode;
         this.defaultVal = defaultVal;
       }
 
-      public static <T> ConstrArg<T> at(int index, JsonLfDecoder<T> decode, T defaultVal) {
-        return new ConstrArg<T>(index, decode, defaultVal);
+      public static <T> JavaArg<T> at(int index, JsonLfDecoder<T> decode, T defaultVal) {
+        return new JavaArg<T>(index, decode, defaultVal);
       }
 
-      public static <T> ConstrArg<T> at(int index, JsonLfDecoder<T> decode) {
-        return new ConstrArg<T>(index, decode, null);
+      public static <T> JavaArg<T> at(int index, JsonLfDecoder<T> decode) {
+        return new JavaArg<T>(index, decode, null);
       }
     }
 

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReaderTest.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReaderTest.java
@@ -519,9 +519,9 @@ public class JsonLfReaderTest {
             name -> {
               switch (name) {
                 case "i":
-                  return Decoders.ConstrArg.at(0, Decoders.list(Decoders.int64));
+                  return Decoders.JavaArg.at(0, Decoders.list(Decoders.int64));
                 case "b":
-                  return Decoders.ConstrArg.at(1, Decoders.bool, false);
+                  return Decoders.JavaArg.at(1, Decoders.bool, false);
                 default:
                   return null;
               }
@@ -542,9 +542,9 @@ public class JsonLfReaderTest {
             name -> {
               switch (name) {
                 case "i":
-                  return Decoders.ConstrArg.at(0, Decoders.list(Decoders.int64));
+                  return Decoders.JavaArg.at(0, Decoders.list(Decoders.int64));
                 case "b":
-                  return Decoders.ConstrArg.at(1, Decoders.bool, false);
+                  return Decoders.JavaArg.at(1, Decoders.bool, false);
                 default:
                   return null;
               }

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReaderTest.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReaderTest.java
@@ -469,9 +469,9 @@ public class JsonLfReaderTest {
                   return null;
               }
             }),
-        errors("{}", "Expected field tag or value but was } at line: 1, column: 2"),
+        errors("{}", "Expected field but was } at line: 1, column: 2"),
         errors("{\"Bar\": 1}", "Expected field tag or value but was Bar at line: 1, column: 2"),
-        errors("{\"value\": 1}", "Expected field tag but was } at line: 1, column: 12"),
+        errors("{\"value\": 1}", "Expected field but was } at line: 1, column: 12"),
         errors(
             "{\"tag\": \"What\"}",
             "Expected one of [Bar, Baz, Quux, Flarp] but was What at line: 1, column: 9"),
@@ -519,9 +519,9 @@ public class JsonLfReaderTest {
             name -> {
               switch (name) {
                 case "i":
-                  return Decoders.Field.at(0, Decoders.list(Decoders.int64));
+                  return Decoders.ConstrArg.at(0, Decoders.list(Decoders.int64));
                 case "b":
-                  return Decoders.Field.at(1, Decoders.bool, false);
+                  return Decoders.ConstrArg.at(1, Decoders.bool, false);
                 default:
                   return null;
               }
@@ -542,9 +542,9 @@ public class JsonLfReaderTest {
             name -> {
               switch (name) {
                 case "i":
-                  return Decoders.Field.at(0, Decoders.list(Decoders.int64));
+                  return Decoders.ConstrArg.at(0, Decoders.list(Decoders.int64));
                 case "b":
-                  return Decoders.Field.at(1, Decoders.bool, false);
+                  return Decoders.ConstrArg.at(1, Decoders.bool, false);
                 default:
                   return null;
               }
@@ -568,6 +568,9 @@ public class JsonLfReaderTest {
   @Test
   void testUnknownValue() throws JsonLfDecoder.Error {
     JsonLfReader.UnknownValue.read(new JsonLfReader("1")).decodeWith(Decoders.int64);
+    JsonLfReader.UnknownValue.read(new JsonLfReader("\"88\"")).decodeWith(Decoders.numeric(2));
+    JsonLfReader.UnknownValue.read(new JsonLfReader("[\"hi\", \"there\"]"))
+        .decodeWith(Decoders.list(Decoders.text));
 
     JsonLfReader.UnknownValue.read(
             new JsonLfReader("[1,2]").moveNext() // Skip [
@@ -593,6 +596,11 @@ public class JsonLfReaderTest {
             )
         .decodeWith(
             Decoders.optionalNested(Decoders.optionalNested(Decoders.optional(Decoders.int64))));
+
+    JsonLfReader.UnknownValue.read(
+            new JsonLfReader("[ \"hello\", \"world\" ]").moveNext() // Skip [
+            )
+        .decodeWith(Decoders.text);
   }
 
   @Test

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -3,6 +3,7 @@
 
 load(
     "//bazel_tools:scala.bzl",
+    "da_scala_benchmark_jmh",
     "da_scala_binary",
     "da_scala_library",
     "da_scala_test",
@@ -426,6 +427,16 @@ da_scala_test(
         "@maven//:io_grpc_grpc_stub",
         "@maven//:io_reactivex_rxjava2_rxjava",
         "@maven//:org_scalatest_scalatest_compatible",
+    ],
+)
+
+da_scala_benchmark_jmh(
+    name = "from-json-bench",
+    srcs = glob(["src/bench/**/*.scala"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":test-model-2.dev.jar",
+        "//language-support/java/bindings:bindings-java",
     ],
 )
 

--- a/language-support/java/codegen/src/bench/com/daml/lf/codegen/java/FromJsonBench.scala
+++ b/language-support/java/codegen/src/bench/com/daml/lf/codegen/java/FromJsonBench.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.codegen.java
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+
+@BenchmarkMode(Array(Mode.Throughput)) @OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 10)
+class FromJsonBench {
+
+  @Benchmark
+  def enummodBox = test.enummod.Box.fromJson(JsonSamples.enummodBox)
+
+  @Benchmark
+  def enummodOptionalColor = test.enummod.OptionalColor.fromJson(JsonSamples.enummodOptionalColor)
+
+  @Benchmark
+  def enummodOptionalColor_ValueBeforeTag =
+    test.enummod.OptionalColor.fromJson(JsonSamples.enummodOptionalColor_ValueBeforeTag)
+
+  @Benchmark
+  def enummodColoredTree = test.enummod.ColoredTree.fromJson(JsonSamples.enummodColoredTree)
+
+  @Benchmark
+  def genmapmodBox = test.genmapmod.Box.fromJson(JsonSamples.genmapmodBox)
+}
+
+object JsonSamples {
+
+  val enummodOptionalColor = """{"tag": "SomeColor", "value": "Green"}"""
+
+  val enummodOptionalColor_ValueBeforeTag = """{"value": "Green", "tag": "SomeColor"}"""
+
+  val enummodBox = """{"x": "Red", "party":"party"}"""
+
+  val enummodColoredTree =
+    """{
+       |  "tag": "Node",
+       |  "value": {
+       |    "color": "Blue",
+       |    "left": {"tag": "Leaf", "value": {}},
+       |    "right": {"tag": "Leaf", "value": {}}
+       |  }
+       |}""".stripMargin
+
+  val genmapmodBox =
+    """{
+       |  "party": "alice",
+       |  "x": [
+       |    [ [1, "1.0000000000"], {"tag": "Right", "value": "1.0000000000"} ],
+       |    [ [2, "-2.2222222222"], {"tag": "Left", "value": 2} ],
+       |    [ [3, "3.3333333333"], {"tag": "Right", "value": "3.3333333333" } ]
+       |  ]
+       |}""".stripMargin
+}

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromJsonGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromJsonGenerator.scala
@@ -60,20 +60,19 @@ private[inner] object FromJsonGenerator extends StrictLogging {
   )(implicit packagePrefixes: PackagePrefixes): MethodSpec = {
     val typeName = className.parameterized(typeParams)
 
-    val fieldNames = {
+    val argNames = {
       val names = fields.map(f => CodeBlock.of("$S", f.javaName))
       CodeBlock.of("$T.asList($L)", classOf[java.util.Arrays], CodeBlock.join(names.asJava, ", "))
     }
 
-    val fieldsByName = {
+    val argsByName = {
       val block = CodeBlock
         .builder()
         .beginControlFlow("name ->")
         .beginControlFlow("switch (name)")
       fields.zipWithIndex.foreach { case (f, i) =>
-        // We generate `JsonLfReader.Field` as a literal as $T seems to always use fully qualified name.
         block.addStatement(
-          "case $S: return JsonLfReader.Decoders.Field.at($L, $L)",
+          "case $S: return JsonLfReader.Decoders.ConstrArg.at($L, $L)",
           f.javaName,
           i,
           jsonDecoderForType(f.damlType),
@@ -101,8 +100,8 @@ private[inner] object FromJsonGenerator extends StrictLogging {
       .addStatement(
         "return $T.record($L, $L, $L)",
         decodeClass,
-        fieldNames,
-        fieldsByName.toString(),
+        argNames,
+        argsByName.toString(),
         constr,
       )
       .build()

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromJsonGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromJsonGenerator.scala
@@ -72,7 +72,7 @@ private[inner] object FromJsonGenerator extends StrictLogging {
         .beginControlFlow("switch (name)")
       fields.zipWithIndex.foreach { case (f, i) =>
         block.addStatement(
-          "case $S: return JsonLfReader.Decoders.ConstrArg.at($L, $L)",
+          "case $S: return JsonLfReader.Decoders.JavaArg.at($L, $L)",
           f.javaName,
           i,
           jsonDecoderForType(f.damlType),


### PR DESCRIPTION
In doing so:
- `JsonLfReader::readFieldName` now also returns the location, as that is needed for error reporting
- Renamed `JsonLfReader::Field` to `JsonLfReader::JavaArg` as for our purposes it really represents an argument to the constructor of the Java class, and this avoids confusion with the new `FieldName` class, which refers to JSON object fields.
- Fix `locationEnd` so that it always does return the end location of the current token.

As for the benchmarks, on my laptop `bazel run language-support/java/codegen:from-json-bench` currently gives me
```
# Run complete. Total time: 00:01:06

Benchmark                                           Mode  Cnt        Score        Error  Units
FromJsonBench.enummodBox                           thrpt   10  4412899.724 ± 456030.906  ops/s
FromJsonBench.enummodColoredTree                   thrpt   10  1429975.211 ±  72853.649  ops/s
FromJsonBench.enummodOptionalColor                 thrpt   10  4696006.017 ± 267894.386  ops/s
FromJsonBench.enummodOptionalColor_ValueBeforeTag  thrpt   10  1293112.352 ±  29469.946  ops/s
FromJsonBench.genmapmodBox                         thrpt   10   714561.743 ±  55421.006  ops/s
```

i.e. depending on the data itself, throughput can be in the order of millions per second.

Simple stack profiling with
`bazel run language-support/java/codegen:from-json-bench -- -prof stack`
can also provide some insight into where time is spent while decoding.