### PR TITLE
[engine] allow disclosed contracts to be upgraded

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1105,6 +1105,12 @@ private[lf] object SBuiltin {
       } else {
         assert(actualTemplateId != templateId)
         val coid = getSContractId(args, 0)
+
+        println("WronglyTypedContract(from SBCastAnyContract)") // NICK
+        println(s"- coid = $coid")
+        println(s"- templateId = $templateId")
+        println(s"- actualTemplateId = $actualTemplateId")
+
         Control.Error(IE.WronglyTypedContract(coid, templateId, actualTemplateId))
       }
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1099,20 +1099,12 @@ private[lf] object SBuiltin {
         args: util.ArrayList[SValue],
         machine: Machine[Q],
     ): Control[Nothing] = {
+      val coid = getSContractId(args, 0)
       val (actualTemplateId, record) = getSAnyContract(args, 1)
-      if (actualTemplateId == templateId) {
+      if (actualTemplateId == templateId)
         Control.Value(record)
-      } else {
-        assert(actualTemplateId != templateId)
-        val coid = getSContractId(args, 0)
-
-        println("WronglyTypedContract(from SBCastAnyContract)") // NICK
-        println(s"- coid = $coid")
-        println(s"- templateId = $templateId")
-        println(s"- actualTemplateId = $actualTemplateId")
-
+      else
         Control.Error(IE.WronglyTypedContract(coid, templateId, actualTemplateId))
-      }
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -342,21 +342,37 @@ private[lf] object Speedy {
         )
       )
 
-    final private[speedy] def lookupContractOnLedger[Q](coid: V.ContractId)(
-        continue: V.ContractInstance => Control[Question.Update]
-    ): Control[Question.Update] =
-      contractsCache.get(coid) match {
-        case Some(contract) => continue(contract)
+
+    private[speedy] def lookupContract( coid: V.ContractId)(
+      f: V.ContractInstance => Control[Question.Update]
+    ): Control[Question.Update] = {
+
+      disclosedContracts.get(coid) match {
+        case Some(contractInfo) =>
+            markDisclosedcontractAsUsed(coid)
+            f(
+              V.ContractInstance(
+              contractInfo.templateId,
+              contractInfo.value.toUnnormalizedValue,
+            )
+            )
+
         case None =>
-          needContract(
-            NameOf.qualifiedNameOfCurrentFunc,
-            coid,
-            { res =>
-              contractsCache = contractsCache.updated(coid, res)
-              continue(res)
-            },
-          )
+          contractsCache.get(coid) match {
+            case Some(res) =>
+              f(res)
+            case None =>
+              needContract(
+                NameOf.qualifiedNameOfCurrentFunc,
+                coid,
+                { res =>
+                  contractsCache = contractsCache.updated(coid, res)
+                  f(res)
+                }
+              )
+          }
       }
+    }
 
     private[speedy] override def asUpdateMachine(location: String)(
         f: UpdateMachine => Control[Question.Update]
@@ -602,7 +618,7 @@ private[lf] object Speedy {
 
     // Track which disclosed contracts are used, so we can report events to the ledger
     private[this] var usedDiclosedContracts: Set[V.ContractId] = Set.empty
-    private[speedy] def markDisclosedcontractAsUsed(coid: V.ContractId): Unit = {
+    private[this] def markDisclosedcontractAsUsed(coid: V.ContractId): Unit = {
       usedDiclosedContracts = usedDiclosedContracts + coid
     }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -342,20 +342,19 @@ private[lf] object Speedy {
         )
       )
 
-
-    private[speedy] def lookupContract( coid: V.ContractId)(
-      f: V.ContractInstance => Control[Question.Update]
+    private[speedy] def lookupContract(coid: V.ContractId)(
+        f: V.ContractInstance => Control[Question.Update]
     ): Control[Question.Update] = {
 
       disclosedContracts.get(coid) match {
         case Some(contractInfo) =>
-            markDisclosedcontractAsUsed(coid)
-            f(
-              V.ContractInstance(
+          markDisclosedcontractAsUsed(coid)
+          f(
+            V.ContractInstance(
               contractInfo.templateId,
               contractInfo.value.toUnnormalizedValue,
             )
-            )
+          )
 
         case None =>
           contractsCache.get(coid) match {
@@ -368,7 +367,7 @@ private[lf] object Speedy {
                 { res =>
                   contractsCache = contractsCache.updated(coid, res)
                   f(res)
-                }
+                },
               )
           }
       }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
@@ -376,7 +376,7 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
 
       // This is the SValue equivalent of v1_base
       val sv1_base: SValue = {
-        def id: Identifier = parseTyCon(pid1, "M1:T1")
+        def id: Identifier = parseTyCon(pid1, "M1:T1") // NICK can make it diff in new code-path
         def fields: ImmArray[Name] = ImmArray(
           n"theSig", // This one get checked during contract-info computation.
           n"aNumber",
@@ -394,6 +394,34 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
       inside(res) { case Right((v, _)) =>
         v shouldBe v1_base
       }
+    }
+
+    "requires downgrade" in {
+
+      val sv1_base: SValue = {
+        def id: Identifier = parseTyCon(pid1, "M1:T1xx")
+        def fields: ImmArray[Name] = ImmArray(
+          n"theSig",
+          n"aNumber",
+          n"someText",
+          n"extraField",
+        )
+        def values: util.ArrayList[SValue] = ArrayList(
+          SValue.SParty(alice), // And it needs to be a party
+          SValue.SInt64(100),
+          SValue.SText("lala"),
+          // SValue.SText("extra-info-should-have-optional-type"),
+          // SValue.SOptional(Some(SValue.SText("Some cant be lost"))),
+          SValue.SOptional(None),
+        )
+        SValue.SRecord(id, fields, values)
+      }
+      val res = goDisclosed("M1:do_fetch", sv1_base)
+      // println(s"res=$res") // NICK
+      val _ = res // NICK
+      /*inside(res) { case Right((v, _)) => // NICK
+        v shouldBe v1_base
+      }*/
     }
 
   }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
@@ -4,8 +4,10 @@
 package com.daml.lf
 package speedy
 
+import java.util
+
 import com.daml.lf.data.ImmArray
-import com.daml.lf.data.Ref.{Identifier, PackageId, Party}
+import com.daml.lf.data.Ref.{Identifier, PackageId, Party, Name}
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.{LanguageMajorVersion}
 import com.daml.lf.speedy.SError.SError
@@ -147,6 +149,7 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
 
   type Success = (Value, List[UpgradeVerificationRequest])
 
+  // The given contractValue is wrapped as a contract available for ledger-fetch
   def go(entryPoint: String, contractValue: Value): Either[SError, Success] = {
 
     val e: Expr = parseExpr(pid1, entryPoint)
@@ -174,6 +177,40 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
       }
   }
 
+  // The given contractSValue is wrapped as a disclosedContract
+  def goDisclosed(entryPoint: String, contractSValue: SValue): Either[SError, Success] = {
+
+    val e: Expr = parseExpr(pid1, entryPoint)
+    val se: SExpr = pkgs.compiler.unsafeCompile(e)
+    val args: Array[SValue] = Array(SContractId(theCid))
+    val sexprToEval: SExpr = SEApp(se, args)
+
+    implicit def logContext: LoggingContext = LoggingContext.ForTesting
+    val seed = crypto.Hash.hashPrivateKey("seed")
+    val machine = Speedy.Machine.fromUpdateSExpr(pkgs, seed, sexprToEval, Set(alice, bob))
+
+    val contractInfo: Speedy.ContractInfo = {
+      // NICK: where does this contract-info even get used?
+      Speedy.ContractInfo(
+        version = VDev,
+        templateId = parseTyCon(pid1, "Myyy:Tyyy"),
+        value = contractSValue,
+        agreementText = "meh",
+        signatories = Set.empty,
+        observers = Set.empty,
+        keyOpt = None,
+      )
+    }
+    machine.addDisclosedContracts(theCid, contractInfo)
+
+    SpeedyTestLib
+      .runCollectRequests(machine)
+      .map { case (sv, _, uvs) => // ignoring any AuthRequest
+        val v = sv.toNormalizedValue(VDev)
+        (v, uvs)
+      }
+  }
+
   def makeRecord(fields: Value*): Value = {
     Value.ValueRecord(
       None,
@@ -181,17 +218,17 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
     )
   }
 
+  val v1_base =
+    makeRecord(
+      Value.ValueParty(alice),
+      Value.ValueInt64(100),
+      Value.ValueText("lala"),
+    )
+
   "downgrade attempted" - {
 
     // These tests check downgrade of differently shaped actual contracts
     // Always expecting a contract of type M1:T1
-
-    val v1_base =
-      makeRecord(
-        Value.ValueParty(alice),
-        Value.ValueInt64(100),
-        Value.ValueText("lala"),
-      )
 
     "correct fields" in {
 
@@ -333,4 +370,31 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
 
   }
 
+  "Dislosed contracts" - {
+
+    "correct fields" in {
+
+      // This is the SValue equivalent of v1_base
+      val sv1_base: SValue = {
+        def id: Identifier = parseTyCon(pid1, "M1:T1")
+        def fields: ImmArray[Name] = ImmArray(
+          n"theSig", // This one get checked during contract-info computation.
+          n"aNumber",
+          n"someText",
+        )
+        def values: util.ArrayList[SValue] = ArrayList(
+          SValue.SParty(alice), // And it needs to be a party
+          SValue.SInt64(100),
+          SValue.SText("lala"),
+        )
+        SValue.SRecord(id, fields, values)
+      }
+      val res = goDisclosed("M1:do_fetch", sv1_base)
+      // println(s"res=$res") // NICK
+      inside(res) { case Right((v, _)) =>
+        v shouldBe v1_base
+      }
+    }
+
+  }
 }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
@@ -390,7 +390,6 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
         SValue.SRecord(id, fields, values)
       }
       val res = goDisclosed("M1:do_fetch", sv1_base)
-      // println(s"res=$res") // NICK
       inside(res) { case Right((v, _)) =>
         v shouldBe v1_base
       }
@@ -410,18 +409,14 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
           SValue.SParty(alice), // And it needs to be a party
           SValue.SInt64(100),
           SValue.SText("lala"),
-          // SValue.SText("extra-info-should-have-optional-type"),
-          // SValue.SOptional(Some(SValue.SText("Some cant be lost"))),
           SValue.SOptional(None),
         )
         SValue.SRecord(id, fields, values)
       }
       val res = goDisclosed("M1:do_fetch", sv1_base)
-      // println(s"res=$res") // NICK
-      val _ = res // NICK
-      /*inside(res) { case Right((v, _)) => // NICK
+      inside(res) { case Right((v, _)) =>
         v shouldBe v1_base
-      }*/
+      }
     }
 
   }


### PR DESCRIPTION
Advances #17082 

WIP


It's quite odd that disclosed contracts have already been converted into _speedy_ values by the engine/preprocessor code, before speedy execution has even been started.

This is unlike contracts fetched from the ledger, where the conversion from _Value_ to _SValue_ in performed by `Machine.importValue` (in `Speedy.scala`), when called by `fetchAny` (in `SBuiltin.scala`) 

`importValue` is _the_ place where up/down-grading occurs, when given the `destTemplateId` provided by `fetchAny`.

I suspect that the current conversion by the preprocessor is at best pointless, and perhaps even an impediment to upgrading.
