### PR TITLE
correct the documentation of the trace context in the streams

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/completion.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/completion.proto
@@ -75,12 +75,10 @@ message Completion {
   //
   // The trace context transported in this message corresponds to the trace context supplied
   // by the client application in a HTTP2 header of the original command submission.
-  // This field can only be populated if the original submission contained it.
-  // As the context is currently served from an in-memory buffer of recent transactions,
-  // it may be omitted if this message is being served from the database instead.
-  // This happens after a restart or when there is a long time elapsing between the arrival
-  // of the transaction at the participant and the moment this message is being created.
   // We typically use a header to transfer this type of information. Here we use message
   // body, because it is used in gRPC streams which do not support per message headers.
+  // This field will be populated with the trace context contained in the original submission.
+  // If that was not provided, a unique ledger-api-server generated trace context will be used
+  // instead.
   TraceContext trace_context = 10;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction.proto
@@ -57,13 +57,11 @@ message TransactionTree {
   //
   // The trace context transported in this message corresponds to the trace context supplied
   // by the client application in a HTTP2 header of the original command submission.
-  // This field can only be populated if the original submission contained it.
-  // As the context is currently served from an in-memory buffer of recent transactions,
-  // it may be omitted if this message is being served from the database instead.
-  // This happens after a restart or when there is a long time elapsing between the arrival
-  // of the transaction at the participant and the moment this message is being created.
   // We typically use a header to transfer this type of information. Here we use message
   // body, because it is used in gRPC streams which do not support per message headers.
+  // This field will be populated with the trace context contained in the original submission.
+  // If that was not provided, a unique ledger-api-server generated trace context will be used
+  // instead.
   TraceContext trace_context = 9;
 
 }
@@ -118,13 +116,11 @@ message Transaction {
   //
   // The trace context transported in this message corresponds to the trace context supplied
   // by the client application in a HTTP2 header of the original command submission.
-  // This field can only be populated if the original submission contained it.
-  // As the context is currently served from an in-memory buffer of recent transactions,
-  // it may be omitted if this message is being served from the database instead.
-  // This happens after a restart or when there is a long time elapsing between the arrival
-  // of the transaction at the participant and the moment this message is being created.
   // We typically use a header to transfer this type of information. Here we use message
   // body, because it is used in gRPC streams which do not support per message headers.
+  // This field will be populated with the trace context contained in the original submission.
+  // If that was not provided, a unique ledger-api-server generated trace context will be used
+  // instead.
   TraceContext trace_context = 7;
 
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v2/completion.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v2/completion.proto
@@ -72,12 +72,10 @@ message Completion {
   //
   // The trace context transported in this message corresponds to the trace context supplied
   // by the client application in a HTTP2 header of the original command submission.
-  // This field can only be populated if the original submission contained it.
-  // As the context is currently served from an in-memory buffer of recent transactions,
-  // it may be omitted if this message is being served from the database instead.
-  // This happens after a restart or when there is a long time elapsing between the arrival
-  // of the transaction at the participant and the moment this message is being created.
   // We typically use a header to transfer this type of information. Here we use message
   // body, because it is used in gRPC streams which do not support per message headers.
+  // This field will be populated with the trace context contained in the original submission.
+  // If that was not provided, a unique ledger-api-server generated trace context will be used
+  // instead.
   com.daml.ledger.api.v1.TraceContext trace_context = 9;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v2/reassignment.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v2/reassignment.proto
@@ -45,13 +45,11 @@ message Reassignment {
   //
   // The trace context transported in this message corresponds to the trace context supplied
   // by the client application in a HTTP2 header of the original command submission.
-  // This field can only be populated if the original submission contained it.
-  // As the context is currently served from an in-memory buffer of recent transactions,
-  // it may be omitted if this message is being served from the database instead.
-  // This happens after a restart or when there is a long time elapsing between the arrival
-  // of the transaction at the participant and the moment this message is being created.
   // We typically use a header to transfer this type of information. Here we use message
   // body, because it is used in gRPC streams which do not support per message headers.
+  // This field will be populated with the trace context contained in the original submission.
+  // If that was not provided, a unique ledger-api-server generated trace context will be used
+  // instead.
   com.daml.ledger.api.v1.TraceContext trace_context = 7;
 }
 

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v2/transaction.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v2/transaction.proto
@@ -61,13 +61,11 @@ message TransactionTree {
   //
   // The trace context transported in this message corresponds to the trace context supplied
   // by the client application in a HTTP2 header of the original command submission.
-  // This field can only be populated if the original submission contained it.
-  // As the context is currently served from an in-memory buffer of recent transactions,
-  // it may be omitted if this message is being served from the database instead.
-  // This happens after a restart or when there is a long time elapsing between the arrival
-  // of the transaction at the participant and the moment this message is being created.
   // We typically use a header to transfer this type of information. Here we use message
   // body, because it is used in gRPC streams which do not support per message headers.
+  // This field will be populated with the trace context contained in the original submission.
+  // If that was not provided, a unique ledger-api-server generated trace context will be used
+  // instead.
   com.daml.ledger.api.v1.TraceContext trace_context = 9;
 
 }
@@ -113,12 +111,10 @@ message Transaction {
   //
   // The trace context transported in this message corresponds to the trace context supplied
   // by the client application in a HTTP2 header of the original command submission.
-  // This field can only be populated if the original submission contained it.
-  // As the context is currently served from an in-memory buffer of recent transactions,
-  // it may be omitted if this message is being served from the database instead.
-  // This happens after a restart or when there is a long time elapsing between the arrival
-  // of the transaction at the participant and the moment this message is being created.
   // We typically use a header to transfer this type of information. Here we use message
   // body, because it is used in gRPC streams which do not support per message headers.
+  // This field will be populated with the trace context contained in the original submission.
+  // If that was not provided, a unique ledger-api-server generated trace context will be used
+  // instead.
   com.daml.ledger.api.v1.TraceContext trace_context = 8;
 }


### PR DESCRIPTION
Following the improvements on the canton side, the wording of the trace context documentation has been altered