### PR TITLE
Refactor ledger/error

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/ScalazEqual.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/ScalazEqual.scala
@@ -6,7 +6,7 @@ package com.daml.lf.data
 import scalaz.{@@, Equal, Order, Tag}
 import scalaz.syntax.order._
 
-private[daml] object ScalazEqual {
+object ScalazEqual {
   def withNatural[A](isNatural: Boolean)(c: (A, A) => Boolean): Equal[A] =
     if (isNatural) Equal.equalA else Equal.equal(c)
 

--- a/docs/resources/generated-error-pages/error-categories-inventory.rst.inc
+++ b/docs/resources/generated-error-pages/error-categories-inventory.rst.inc
@@ -96,7 +96,7 @@ SecurityAlert
 
     **Default log level**: WARN
 
-    **Description**: A potential attack or a faulty peer component has been detected.  This error is exposed on the API with grpc-status INVALID_ARGUMENT without any details for security reasons.
+    **Description**: A potential attack or a faulty peer component has been detected. This error is exposed on the API with grpc-status INVALID_ARGUMENT without any details for security reasons.
 
     **Resolution**: Expectation: this can be a severe issue that requires operator attention or intervention, and potentially vendor support. It means that the system has detected invalid information that can be attributed to either faulty or malicious manipulation of data coming from a peer source.
 

--- a/ledger/error/BUILD.bazel
+++ b/ledger/error/BUILD.bazel
@@ -35,6 +35,7 @@ da_scala_library(
     visibility = ["//:__subpackages__"],
     deps = [
         ":error",
+        "//ledger-api/grpc-definitions:ledger_api_proto_scala",
         "//libs-scala/contextualized-logging",
         "@maven//:com_google_api_grpc_proto_google_common_protos",
         "@maven//:com_google_protobuf_protobuf_java",
@@ -86,6 +87,7 @@ da_scala_test_suite(
         ":error",
         ":error-test-lib",
         ":error-test-utils",
+        "//ledger-api/grpc-definitions:ledger_api_proto_scala",
         "//libs-scala/contextualized-logging",
         "//libs-scala/logging-entries",
         "//test-common",

--- a/ledger/error/src/main/scala/com/daml/error/ContextualizedErrorLogger.scala
+++ b/ledger/error/src/main/scala/com/daml/error/ContextualizedErrorLogger.scala
@@ -7,6 +7,7 @@ package com.daml.error
 trait ContextualizedErrorLogger {
   def properties: Map[String, String]
   def correlationId: Option[String]
+  def traceId: Option[String]
   def logError(err: BaseError, extra: Map[String, String]): Unit
   def info(message: String): Unit
   def info(message: String, throwable: Throwable): Unit
@@ -30,16 +31,4 @@ object ContextualizedErrorLogger {
       .mkString(", ")
   }
 
-}
-
-object NoLogging extends ContextualizedErrorLogger {
-  override def properties: Map[String, String] = Map.empty
-  override def correlationId: Option[String] = None
-  override def logError(err: BaseError, extra: Map[String, String]): Unit = ()
-  override def info(message: String): Unit = ()
-  override def info(message: String, throwable: Throwable): Unit = ()
-  override def warn(message: String): Unit = ()
-  override def warn(message: String, throwable: Throwable): Unit = ()
-  override def error(message: String): Unit = ()
-  override def error(message: String, throwable: Throwable): Unit = ()
 }

--- a/ledger/error/src/main/scala/com/daml/error/DamlContextualizedErrorLogger.scala
+++ b/ledger/error/src/main/scala/com/daml/error/DamlContextualizedErrorLogger.scala
@@ -45,6 +45,8 @@ class DamlContextualizedErrorLogger(
     val correlationId: Option[String],
 ) extends ContextualizedErrorLogger {
 
+  override val traceId: Option[String] = None
+
   override def properties: Map[String, String] = {
     val a: MapView[LoggingKey, LoggingValue] = loggingContext.entries.contents.view
     a.map { case (key, value) =>

--- a/ledger/error/src/main/scala/com/daml/error/DamlError.scala
+++ b/ledger/error/src/main/scala/com/daml/error/DamlError.scala
@@ -1,11 +1,7 @@
 // Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.error.definitions
-
-import com.daml.error.{ContextualizedError, ContextualizedErrorLogger, ErrorCode}
-
-import scala.jdk.CollectionConverters._
+package com.daml.error
 
 class DamlError(
     override val cause: String,
@@ -21,18 +17,6 @@ class DamlError(
 
   override def context: Map[String, String] =
     super.context ++ extraContext.view.mapValues(_.toString)
-
-  def rpcStatus(): com.google.rpc.status.Status = {
-    val status0: com.google.rpc.Status = code.asGrpcStatus(this)
-    val details: Seq[com.google.protobuf.Any] = status0.getDetailsList.asScala.toSeq
-    val detailsScalapb = details.map(com.google.protobuf.any.Any.fromJavaProto)
-    com.google.rpc.status.Status(
-      status0.getCode,
-      status0.getMessage,
-      detailsScalapb,
-    )
-  }
-
 }
 
 /** @param definiteAnswer Determines the value of the `definite_answer` key in the error details

--- a/ledger/error/src/main/scala/com/daml/error/ErrorClass.scala
+++ b/ledger/error/src/main/scala/com/daml/error/ErrorClass.scala
@@ -8,7 +8,7 @@ package com.daml.error
   * @param docName The name that will appear in the generated documentation for the grouping.
   * @param fullClassName Full class name of the corresponding [[ErrorGroup]].
   */
-case class Grouping(
+final case class Grouping(
     docName: String,
     fullClassName: String,
 ) {
@@ -20,7 +20,7 @@ case class Grouping(
 
 /** Used to hierarchically structure error codes in the official documentation.
   */
-case class ErrorClass(groupings: List[Grouping]) {
+final case class ErrorClass(groupings: List[Grouping]) {
   def extend(grouping: Grouping): ErrorClass =
     ErrorClass(groupings :+ grouping)
 }

--- a/ledger/error/src/main/scala/com/daml/error/GrpcStatuses.scala
+++ b/ledger/error/src/main/scala/com/daml/error/GrpcStatuses.scala
@@ -1,15 +1,16 @@
 // Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.client
+package com.daml.error
 
 import com.google.rpc.error_details.ErrorInfo
 import com.google.rpc.status.{Status => StatusProto}
-import com.daml.error.ErrorCode
 
 import scala.util.Try
 
 object GrpcStatuses {
+  val DefiniteAnswerKey = "definite_answer"
+  val CompletionOffsetKey = "completion_offset"
 
   def isDefiniteAnswer(status: StatusProto): Boolean =
     status.details.exists { any =>
@@ -22,7 +23,5 @@ object GrpcStatuses {
     }
 
   private def isDefiniteAnswer(errorInfo: ErrorInfo): Boolean =
-    errorInfo.metadata
-      .get(ErrorCode.DefiniteAnswerKey)
-      .exists(value => java.lang.Boolean.valueOf(value))
+    errorInfo.metadata.get(DefiniteAnswerKey).exists(value => java.lang.Boolean.valueOf(value))
 }

--- a/ledger/error/src/main/scala/com/daml/error/NoLogging.scala
+++ b/ledger/error/src/main/scala/com/daml/error/NoLogging.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.error
+
+object NoLogging extends NoLogging(properties = Map.empty, correlationId = None, traceId = None) {}
+
+class NoLogging(
+    val properties: Map[String, String],
+    val correlationId: Option[String],
+    val traceId: Option[String] = None,
+) extends ContextualizedErrorLogger {
+  override def logError(err: BaseError, extra: Map[String, String]): Unit = ()
+  override def info(message: String): Unit = ()
+  override def info(message: String, throwable: Throwable): Unit = ()
+  override def warn(message: String): Unit = ()
+  override def warn(message: String, throwable: Throwable): Unit = ()
+  override def error(message: String): Unit = ()
+  override def error(message: String, throwable: Throwable): Unit = ()
+}

--- a/ledger/error/src/main/scala/com/daml/error/samples/Example.scala
+++ b/ledger/error/src/main/scala/com/daml/error/samples/Example.scala
@@ -5,7 +5,7 @@ package com.daml.error.samples
 
 import scala.concurrent.duration._
 
-import com.daml.error.definitions.DamlError
+import com.daml.error.DamlError
 
 object DummmyServer {
 

--- a/ledger/error/src/main/scala/com/daml/error/utils/ErrorDetails.scala
+++ b/ledger/error/src/main/scala/com/daml/error/utils/ErrorDetails.scala
@@ -3,10 +3,10 @@
 
 package com.daml.error.utils
 
-import com.daml.error.{BaseError, ErrorCode}
+import com.daml.error.ErrorCode
 import com.google.protobuf
 import com.google.rpc.{ErrorInfo, RequestInfo, ResourceInfo, RetryInfo}
-import io.grpc.{Status, StatusRuntimeException}
+import io.grpc.StatusRuntimeException
 import io.grpc.protobuf.StatusProto
 
 import scala.jdk.CollectionConverters._
@@ -95,20 +95,10 @@ object ErrorDetails {
     case any => throw new IllegalStateException(s"Could not unpack value of: |$any|")
   }
 
-  def isInternalError(t: Throwable): Boolean = t match {
-    case e: StatusRuntimeException => isInternalError(e)
-    case _ => false
-  }
-
-  def isInternalError(e: StatusRuntimeException): Boolean =
-    e.getStatus.getCode == Status.Code.INTERNAL && e.getStatus.getDescription.startsWith(
-      BaseError.SecuritySensitiveMessageOnApiPrefix
-    )
-
   /** @return whether a status runtime exception matches the error code.
     *
     * NOTE: This method is not suitable for:
-    * 1) security sensitive error codes (e.g. internal or authentication related) as they are stripped from all the details when being converted to instances of [[StatusRuntimeException]],
+    * 1) security sensitive error codes (e.g. internal or authentication related) as they are stripped from all the details when being converted to instances of [[io.grpc.StatusRuntimeException]],
     * 2) error codes that do not translate to gRPC level errors (i.e. error codes that don't have a corresponding gRPC status)
     */
   def matches(e: StatusRuntimeException, errorCode: ErrorCode): Boolean = {
@@ -125,7 +115,4 @@ object ErrorDetails {
     case e: StatusRuntimeException => matches(e, errorCode)
     case _ => false
   }
-
-  def matchesOneOf(t: Throwable, errorCodes: ErrorCode*): Boolean =
-    errorCodes.exists(matches(t, _))
 }

--- a/ledger/error/src/test/suite/scala/com/daml/error/ErrorCodeSpec.scala
+++ b/ledger/error/src/test/suite/scala/com/daml/error/ErrorCodeSpec.scala
@@ -198,7 +198,7 @@ class ErrorCodeSpec
         val expectedStatus = Status
           .newBuilder()
           .setMessage(
-            "An error occurred. Please contact the operator and inquire about the request 123correlationId"
+            "An error occurred. Please contact the operator and inquire about the request 123correlationId with tid <no-tid>"
           )
           .setCode(testedErrorCode.category.grpcCode.get.value())
           .addDetails(requestInfo.toRpcAny)
@@ -228,7 +228,7 @@ class ErrorCodeSpec
           actual = testedErrorCode.asGrpcError(testedError)(errorLoggerBig),
           expectedStatusCode = testedErrorCode.category.grpcCode.get,
           expectedMessage =
-            "An error occurred. Please contact the operator and inquire about the request 123correlationId",
+            "An error occurred. Please contact the operator and inquire about the request 123correlationId with tid <no-tid>",
           expectedDetails = Seq(requestInfo, retryInfo),
         )
       }

--- a/ledger/error/src/test/suite/scala/com/daml/error/GrpcStatusesSpec.scala
+++ b/ledger/error/src/test/suite/scala/com/daml/error/GrpcStatusesSpec.scala
@@ -1,10 +1,9 @@
 // Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.client
+package com.daml.error
 
-import com.daml.error.ErrorCode
-import com.daml.error.ErrorCode.DefiniteAnswerKey
+import com.daml.error.GrpcStatuses.DefiniteAnswerKey
 import com.google.protobuf.any
 import com.google.rpc.error_details.ErrorInfo
 import com.google.rpc.status.Status
@@ -20,7 +19,7 @@ class GrpcStatusesSpec extends AnyWordSpec with Matchers {
         ("Description", "Error Info", "Expected"),
         (
           "ErrorInfo contains definite answer key and its value is true",
-          Some(anErrorInfo.copy(metadata = Map(ErrorCode.DefiniteAnswerKey -> "true"))),
+          Some(anErrorInfo.copy(metadata = Map(DefiniteAnswerKey -> "true"))),
           true,
         ),
         (

--- a/ledger/ledger-api-auth/src/test/suite/scala/com/digitalasset/ledger/api/auth/AuthorizationInterceptorSpec.scala
+++ b/ledger/ledger-api-auth/src/test/suite/scala/com/digitalasset/ledger/api/auth/AuthorizationInterceptorSpec.scala
@@ -34,7 +34,7 @@ class AuthorizationInterceptorSpec
   it should "close the ServerCall with a V2 status code on decoding failure" in {
     testServerCloseError { case (actualStatus, actualMetadata) =>
       actualStatus.getCode shouldBe Status.Code.INTERNAL
-      actualStatus.getDescription shouldBe "An error occurred. Please contact the operator and inquire about the request <no-correlation-id>"
+      actualStatus.getDescription shouldBe "An error occurred. Please contact the operator and inquire about the request <no-correlation-id> with tid <no-tid>"
 
       val actualRpcStatus = StatusProto.fromStatusAndTrailers(actualStatus, actualMetadata)
       actualRpcStatus.getDetailsList.size() shouldBe 0

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
@@ -3,12 +3,11 @@
 
 package com.daml.ledger.client.services.commands.tracker
 
-import com.daml.error.{ContextualizedErrorLogger, ErrorCode}
+import com.daml.error.{ContextualizedErrorLogger, GrpcStatuses}
 import com.daml.error.definitions.CommonErrors
 import com.daml.grpc.GrpcStatus
 import com.daml.ledger.api.v1.command_completion_service.Checkpoint
 import com.daml.ledger.api.v1.completion.Completion
-import com.daml.ledger.client.GrpcStatuses
 import com.google.rpc.status.{Status => StatusProto}
 import com.google.rpc.{Status => StatusJavaProto}
 import io.grpc.Status.Code
@@ -24,7 +23,7 @@ object CompletionResponse {
     val commandId: String = completion.commandId
     val grpcStatus: StatusProto = completion.getStatus
     def metadata: Map[String, String] = Map(
-      ErrorCode.DefiniteAnswerKey -> GrpcStatuses.isDefiniteAnswer(grpcStatus).toString
+      GrpcStatuses.DefiniteAnswerKey -> GrpcStatuses.isDefiniteAnswer(grpcStatus).toString
     )
   }
   final case class TimeoutResponse(commandId: String) extends CompletionFailure

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponseTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponseTest.scala
@@ -3,7 +3,8 @@
 
 package com.daml.ledger.client.services.commands.tracker
 
-import com.daml.error.{ContextualizedErrorLogger, DamlContextualizedErrorLogger, ErrorCode}
+import com.daml.error.GrpcStatuses.DefiniteAnswerKey
+import com.daml.error.{ContextualizedErrorLogger, DamlContextualizedErrorLogger}
 import com.daml.grpc.GrpcStatus
 import com.daml.ledger.api.v1.completion.Completion
 import com.daml.ledger.client.services.commands.tracker.CompletionResponse._
@@ -112,12 +113,12 @@ class CompletionResponseTest extends AnyWordSpec with Matchers {
         )
         val status = protobuf.StatusProto.fromThrowable(exception)
         val packedErrorInfo = status.getDetails(0).unpack(classOf[JavaErrorInfo])
-        packedErrorInfo.getMetadataOrThrow(ErrorCode.DefiniteAnswerKey) shouldEqual "false"
+        packedErrorInfo.getMetadataOrThrow(DefiniteAnswerKey) shouldEqual "false"
       }
 
       "include metadata for status not ok" in {
         val errorInfo = ErrorInfo(
-          metadata = Map(ErrorCode.DefiniteAnswerKey -> "true")
+          metadata = Map(DefiniteAnswerKey -> "true")
         )
         val exception = CompletionResponse.toException(
           QueueCompletionFailure(
@@ -141,12 +142,12 @@ class CompletionResponseTest extends AnyWordSpec with Matchers {
         )
         val status = protobuf.StatusProto.fromThrowable(exception)
         val packedErrorInfo = status.getDetails(0).unpack(classOf[JavaErrorInfo])
-        packedErrorInfo.getMetadataOrThrow(ErrorCode.DefiniteAnswerKey) shouldEqual "true"
+        packedErrorInfo.getMetadataOrThrow(DefiniteAnswerKey) shouldEqual "true"
       }
 
       "merge metadata for status not ok" in {
         val errorInfo = ErrorInfo(
-          metadata = Map(ErrorCode.DefiniteAnswerKey -> "true")
+          metadata = Map(DefiniteAnswerKey -> "true")
         )
         val requestInfo = RequestInfo(requestId = "aRequestId")
         val exception = CompletionResponse.toException(
@@ -176,7 +177,7 @@ class CompletionResponseTest extends AnyWordSpec with Matchers {
         details.exists { detail =>
           detail.is(classOf[JavaErrorInfo]) && detail
             .unpack(classOf[JavaErrorInfo])
-            .getMetadataOrThrow(ErrorCode.DefiniteAnswerKey) == "true"
+            .getMetadataOrThrow(DefiniteAnswerKey) == "true"
         } shouldEqual true
         details.exists { detail =>
           detail.is(classOf[JavaRequestInfo]) && detail

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/ErrorFactoriesSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/ErrorFactoriesSpec.scala
@@ -9,11 +9,12 @@ import java.util.regex.Pattern
 
 import ch.qos.logback.classic.Level
 import com.daml.error.definitions.LedgerApiErrors.RequestValidation.InvalidDeduplicationPeriodField.ValidMaxDeduplicationFieldKey
-import com.daml.error.definitions.{CommonErrors, DamlError, IndexErrors, LedgerApiErrors}
+import com.daml.error.definitions.{CommonErrors, IndexErrors, LedgerApiErrors}
 import com.daml.error.utils.ErrorDetails
 import com.daml.error.{
   ContextualizedErrorLogger,
   DamlContextualizedErrorLogger,
+  DamlError,
   ErrorAssertionsWithLogCollectorAssertions,
   ErrorCode,
 }

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/ErrorFactoriesSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/ErrorFactoriesSpec.scala
@@ -52,7 +52,7 @@ class ErrorFactoriesSpec
   private val expectedLocationLogMarkerRegex =
     "\\{err-context: \"\\{location=ErrorFactoriesSpec.scala:\\d+\\}\"\\}"
   private val expectedInternalErrorMessage =
-    s"An error occurred. Please contact the operator and inquire about the request $originalCorrelationId"
+    s"An error occurred. Please contact the operator and inquire about the request $originalCorrelationId with tid <no-tid>"
   private val expectedInternalErrorDetails =
     Seq[ErrorDetails.ErrorDetail](expectedCorrelationIdRequestInfo)
 

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/AdminServices.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/AdminServices.scala
@@ -3,9 +3,16 @@
 
 package com.daml.error.definitions.groups
 
-import com.daml.error.definitions.{DamlErrorWithDefiniteAnswer, LedgerApiErrors}
+import com.daml.error.definitions.{LedgerApiErrors}
 import com.daml.error.definitions.groups
-import com.daml.error.{ContextualizedErrorLogger, ErrorCategory, ErrorCode, Explanation, Resolution}
+import com.daml.error.{
+  ContextualizedErrorLogger,
+  DamlErrorWithDefiniteAnswer,
+  ErrorCategory,
+  ErrorCode,
+  Explanation,
+  Resolution,
+}
 
 @Explanation("Errors raised by Ledger API admin services.")
 object AdminServices extends LedgerApiErrors.AdminServicesErrorGroup {

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/AuthorizationChecks.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/AuthorizationChecks.scala
@@ -3,9 +3,10 @@
 
 package com.daml.error.definitions.groups
 
-import com.daml.error.definitions.{DamlErrorWithDefiniteAnswer, LedgerApiErrors}
+import com.daml.error.definitions.{LedgerApiErrors}
 import com.daml.error.{
   ContextualizedErrorLogger,
+  DamlErrorWithDefiniteAnswer,
   ErrorCategory,
   ErrorCategoryRetry,
   ErrorCode,

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/CommandExecution.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/CommandExecution.scala
@@ -3,9 +3,10 @@
 
 package com.daml.error.definitions.groups
 
-import com.daml.error.definitions.{DamlErrorWithDefiniteAnswer, LedgerApiErrors}
+import com.daml.error.definitions.{LedgerApiErrors}
 import com.daml.error.{
   ContextualizedErrorLogger,
+  DamlErrorWithDefiniteAnswer,
   ErrorCategory,
   ErrorCode,
   ErrorGroup,

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/ConsistencyErrors.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/ConsistencyErrors.scala
@@ -3,9 +3,10 @@
 
 package com.daml.error.definitions.groups
 
-import com.daml.error.definitions.{ChangeId, DamlErrorWithDefiniteAnswer, LedgerApiErrors}
+import com.daml.error.definitions.{ChangeId, LedgerApiErrors}
 import com.daml.error.{
   ContextualizedErrorLogger,
+  DamlErrorWithDefiniteAnswer,
   ErrorCategory,
   ErrorCode,
   ErrorGroup,

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/IdentityProviderConfigServiceErrorGroup.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/IdentityProviderConfigServiceErrorGroup.scala
@@ -3,8 +3,7 @@
 
 package com.daml.error.definitions.groups
 
-import com.daml.error._
-import com.daml.error.definitions.{DamlError, DamlErrorWithDefiniteAnswer}
+import com.daml.error.{DamlError, DamlErrorWithDefiniteAnswer, _}
 
 object IdentityProviderConfigServiceErrorGroup
     extends AdminServices.IdentityProviderConfigServiceErrorGroup {

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/PartyManagementServiceErrorGroup.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/PartyManagementServiceErrorGroup.scala
@@ -5,13 +5,14 @@ package com.daml.error.definitions.groups
 
 import com.daml.error.{
   ContextualizedErrorLogger,
+  DamlError,
+  DamlErrorWithDefiniteAnswer,
   ErrorCategory,
   ErrorCode,
   ErrorResource,
   Explanation,
   Resolution,
 }
-import com.daml.error.definitions.{DamlError, DamlErrorWithDefiniteAnswer}
 
 object PartyManagementServiceErrorGroup extends AdminServices.PartyManagementServiceErrorGroup {
 

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/RequestValidation.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/RequestValidation.scala
@@ -6,9 +6,11 @@ package com.daml.error.definitions.groups
 import java.time.Duration
 
 import com.daml.error.definitions.LedgerApiErrors.EarliestOffsetMetadataKey
-import com.daml.error.definitions.{DamlError, DamlErrorWithDefiniteAnswer, LedgerApiErrors}
+import com.daml.error.definitions.{LedgerApiErrors}
 import com.daml.error.{
   ContextualizedErrorLogger,
+  DamlError,
+  DamlErrorWithDefiniteAnswer,
   ErrorCategory,
   ErrorCode,
   ErrorGroup,

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/UserManagementServiceErrorGroup.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/UserManagementServiceErrorGroup.scala
@@ -3,9 +3,10 @@
 
 package com.daml.error.definitions.groups
 
-import com.daml.error.definitions.{DamlError, DamlErrorWithDefiniteAnswer}
 import com.daml.error.{
   ContextualizedErrorLogger,
+  DamlError,
+  DamlErrorWithDefiniteAnswer,
   ErrorCategory,
   ErrorCode,
   ErrorResource,

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/WriteServiceRejections.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/WriteServiceRejections.scala
@@ -3,9 +3,10 @@
 
 package com.daml.error.definitions.groups
 
-import com.daml.error.definitions.{DamlErrorWithDefiniteAnswer, LedgerApiErrors}
+import com.daml.error.definitions.{LedgerApiErrors}
 import com.daml.error.{
   ContextualizedErrorLogger,
+  DamlErrorWithDefiniteAnswer,
   ErrorCategory,
   ErrorCode,
   ErrorGroup,


### PR DESCRIPTION
Refactoring `ledger/error` to be in line with `canton`s `daml-errors`.

In the future the `daml-errors` will be an autonomous minimal library which will contain the common files.
To this end the current PR helps towards this direction having the code in both repos aligned.

Until then it worths having the greatest similarity between the two repos.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
