### PR TITLE
Fix complexity of SMap deserialization

### DIFF
--- a/daml-lf/data/BUILD.bazel
+++ b/daml-lf/data/BUILD.bazel
@@ -3,6 +3,7 @@
 
 load(
     "//bazel_tools:scala.bzl",
+    "da_scala_benchmark_jmh",
     "da_scala_library",
     "da_scala_test",
     "kind_projector_plugin",
@@ -51,4 +52,10 @@ da_scala_test(
         "//daml-lf/data-scalacheck",
         "//libs-scala/scalatest-utils",
     ],
+)
+
+da_scala_benchmark_jmh(
+    name = "treemap-bench",
+    srcs = ["src/bench/scala/com/daml/lf/TreeMapBench.scala"],
+    deps = ["//daml-lf/data"],
 )

--- a/daml-lf/data/src/bench/scala/com/daml/lf/TreeMapBench.scala
+++ b/daml-lf/data/src/bench/scala/com/daml/lf/TreeMapBench.scala
@@ -1,0 +1,93 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package data
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+import scala.collection.immutable
+import scala.util.Random
+
+@State(Scope.Benchmark)
+class TreeMapBench {
+
+  type TreeMap[K, V] = collection.immutable.TreeMap[K, V]
+
+  val AnyMapOrdering: Ordering[TreeMap[Any, Any]] = new Ordering[TreeMap[Any, Any]] {
+    override def compare(x: TreeMap[Any, Any], y: TreeMap[Any, Any]): Int = {
+      assert(x.ordering == y.ordering)
+
+      @annotation.tailrec
+      def loop(keys1: List[Any], keys2: List[Any]): Int =
+        (keys1, keys2) match {
+          case (k1 :: ks1, k2 :: ks2) =>
+            val c = x.ordering.compare(k1, k2)
+            // if the first elements are equal, compare the rest of the lists recursively
+            if (c == 0) loop(ks1, ks2)
+            // otherwise, return the comparison result of the first elements
+            else c
+          case (Nil, Nil) => 0
+          case (Nil, _) => -1
+          case (_, Nil) => 1
+        }
+
+      loop(x.keys.toList, y.keys.toList)
+    }
+  }
+
+  implicit def mapOrdering[K, V]: Ordering[TreeMap[K, V]] =
+    AnyMapOrdering.asInstanceOf[Ordering[TreeMap[K, V]]]
+
+  val seed = getClass.getName.iterator.toSeq.hashCode()
+
+  val random = new Random(seed)
+
+  def examples0(n: Int): Iterator[(Long, Long)] =
+    Iterator.fill(n)(random.nextLong(n * n.toLong) -> random.nextLong(n.toLong))
+
+  def example1(n: Int): Iterator[(TreeMap[Long, Long], Long)] =
+    Iterator
+      .iterate(immutable.TreeMap.empty[Long, Long], n)(
+        _.updated(random.nextLong(n * n.toLong), random.nextLong(n.toLong))
+      )
+      .map(_ -> random.nextLong(n.toLong))
+
+  @Param(Array("1", "2", "4", "8", "16", "32", "64", "128", "1024", "2048", "4096"))
+  var n: Int = _
+
+  var smallEntries: Array[(Long, Long)] = _
+  var bigEntries: Array[(TreeMap[Long, Long], Long)] = _
+
+  @Setup(Level.Trial)
+  def init(): Unit = {
+    smallEntries = examples0(n).toArray.sorted
+    assert(TreeMap.fromOrderedEntries(smallEntries) == immutable.TreeMap.from(smallEntries))
+    bigEntries = example1(n).toArray.sorted
+    assert(TreeMap.fromOrderedEntries(bigEntries) == immutable.TreeMap.from(bigEntries))
+    remy.log(
+      n -> TreeMap.fromOrderedEntries(smallEntries).size -> TreeMap
+        .fromOrderedEntries(bigEntries)
+        .size
+    )
+  }
+
+  @Benchmark @BenchmarkMode(Array(Mode.AverageTime)) @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  def smallBenchN(blackhole: Blackhole): Unit =
+    blackhole.consume(TreeMap.fromOrderedEntries(smallEntries))
+
+  @Benchmark @BenchmarkMode(Array(Mode.AverageTime)) @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  def smallBenchNLogN(blackhole: Blackhole): Unit =
+    blackhole.consume(immutable.TreeMap.from(smallEntries))
+
+  @Benchmark @BenchmarkMode(Array(Mode.AverageTime)) @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  def bigBenchN(blackhole: Blackhole): Unit =
+    blackhole.consume(TreeMap.fromOrderedEntries(bigEntries))
+
+  @Benchmark @BenchmarkMode(Array(Mode.AverageTime)) @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  def bigBenchNLogN(blackhole: Blackhole): Unit =
+    blackhole.consume(immutable.TreeMap.from(bigEntries))
+
+}

--- a/daml-lf/data/src/bench/scala/com/daml/lf/TreeMapBench.scala
+++ b/daml-lf/data/src/bench/scala/com/daml/lf/TreeMapBench.scala
@@ -67,11 +67,6 @@ class TreeMapBench {
     assert(TreeMap.fromOrderedEntries(smallEntries) == immutable.TreeMap.from(smallEntries))
     bigEntries = example1(n).toArray.sorted
     assert(TreeMap.fromOrderedEntries(bigEntries) == immutable.TreeMap.from(bigEntries))
-    remy.log(
-      n -> TreeMap.fromOrderedEntries(smallEntries).size -> TreeMap
-        .fromOrderedEntries(bigEntries)
-        .size
-    )
   }
 
   @Benchmark @BenchmarkMode(Array(Mode.AverageTime)) @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/daml-lf/data/src/main/scala/com/daml/TreeMap.scala
+++ b/daml-lf/data/src/main/scala/com/daml/TreeMap.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package data
+
+object TreeMap {
+
+  import Ordering.Implicits._
+
+  // Linear time builder for immutable TreeMap.
+  // Requires the entries to be strictly ordered, crashes if not.
+  // Relies on the fact that collection.immutable.TreeMap.from is linear when
+  // its argument is a SortedMap with the same ordering.
+  @throws[IllegalArgumentException]
+  def fromOrderedEntries[K: Ordering, V](
+      entries: Iterable[(K, V)]
+  ): collection.immutable.TreeMap[K, V] =
+    if (entries.isEmpty)
+      collection.immutable.TreeMap.empty
+    else {
+
+      val _ = entries.tail.foldLeft(entries.head._1) { case (previousKey, (k, _)) =>
+        require(previousKey < k, "the entries are not strictly ordered")
+        k
+      }
+
+      val fakeSortedMap = new collection.immutable.SortedMap[K, V] {
+        override def ordering: Ordering[K] = implicitly
+        override val iterator: Iterator[(K, V)] = entries.iterator
+        override def size: Int = entries.size
+
+        // As for scala 2.12.10 collection.immutable.TreeMap.from does not use the following methods
+        override def removed(key: K): Nothing = ???
+        override def updated[V1 >: V](key: K, value: V1): Nothing = ???
+        override def iteratorFrom(start: K): Nothing = ???
+        override def keysIteratorFrom(start: K): Nothing = ???
+        override def rangeImpl(from: Option[K], until: Option[K]): Nothing = ???
+        override def get(key: K): Nothing = ???
+      }
+
+      collection.immutable.TreeMap.from(fakeSortedMap)
+    }
+}

--- a/daml-lf/data/src/main/scala/com/daml/TreeMap.scala
+++ b/daml-lf/data/src/main/scala/com/daml/TreeMap.scala
@@ -27,10 +27,9 @@ object TreeMap {
       val it = entries.iterator
       var previous = it.next()
 
-      while (it.hasNext) {
-        val next = it.next()
-        order.compare(previous._1, next._1) match {
-          case i if i < 0 =>
+      it.foreach { next =>
+        order.compare(previous._1, next._1).sign match {
+          case -1 =>
             val _ = buffer.addOne(previous)
           case 0 =>
           case _ =>

--- a/daml-lf/data/src/main/scala/com/daml/TreeMap.scala
+++ b/daml-lf/data/src/main/scala/com/daml/TreeMap.scala
@@ -5,30 +5,43 @@ package com.daml.lf
 package data
 
 import scala.collection.immutable
+import scala.collection.mutable.ArrayBuffer
 
 object TreeMap {
 
-  import Ordering.Implicits._
-
   // Linear time builder for immutable TreeMap.
-  // Requires the entries to be strictly ordered, crashes if not.
+  // Requires the entries to be ordered, crashes if not.
+  // Like Normal TreeMap builder, in case of duplicate key, the last wins
   // Relies on the fact that immutable.TreeMap.from is linear when its argument
   // is a SortedMap with the same ordering.
   @throws[IllegalArgumentException]
-  def fromOrderedEntries[K: Ordering, V](entries: Iterable[(K, V)]): immutable.TreeMap[K, V] =
+  def fromOrderedEntries[K, V](entries: Iterable[(K, V)])(implicit order: Ordering[K]): immutable.TreeMap[K, V] =
     if (entries.isEmpty)
       immutable.TreeMap.empty
     else {
 
-      val _ = entries.tail.foldLeft(entries.head._1) { case (previousKey, (k, _)) =>
-        require(previousKey < k, "the entries are not strictly ordered")
-        k
+      val buffer = new ArrayBuffer[(K, V)]()
+      buffer.sizeHint(entries.knownSize)
+      val it = entries.iterator
+      var previous = it.next()
+
+      while(it.hasNext) {
+        val next = it.next()
+        order.compare(previous._1, next._1) match {
+          case i if i < 0 =>
+            val _ = buffer.addOne(previous)
+          case 0 =>
+          case _ =>
+            throw new IllegalArgumentException("the entries are not ordered")
+        }
+        previous = next
       }
+      val _ = buffer.addOne(previous)
 
       val fakeSortedMap = new immutable.SortedMap[K, V] {
-        override def ordering: Ordering[K] = implicitly
-        override def iterator: Iterator[(K, V)] = entries.iterator
-        override def size: Int = entries.size
+        override def ordering: Ordering[K] = order
+        override def iterator: Iterator[(K, V)] = buffer.iterator
+        override val size: Int = buffer.size
 
         // As for scala 2.12.10 immutable.TreeMap.from does not use the following methods
         override def removed(key: K): Nothing = ???

--- a/daml-lf/data/src/main/scala/com/daml/TreeMap.scala
+++ b/daml-lf/data/src/main/scala/com/daml/TreeMap.scala
@@ -4,20 +4,20 @@
 package com.daml.lf
 package data
 
+import scala.collection.immutable
+
 object TreeMap {
 
   import Ordering.Implicits._
 
   // Linear time builder for immutable TreeMap.
   // Requires the entries to be strictly ordered, crashes if not.
-  // Relies on the fact that collection.immutable.TreeMap.from is linear when
-  // its argument is a SortedMap with the same ordering.
+  // Relies on the fact that immutable.TreeMap.from is linear when its argument
+  // is a SortedMap with the same ordering.
   @throws[IllegalArgumentException]
-  def fromOrderedEntries[K: Ordering, V](
-      entries: Iterable[(K, V)]
-  ): collection.immutable.TreeMap[K, V] =
+  def fromOrderedEntries[K: Ordering, V](entries: Iterable[(K, V)]): immutable.TreeMap[K, V] =
     if (entries.isEmpty)
-      collection.immutable.TreeMap.empty
+      immutable.TreeMap.empty
     else {
 
       val _ = entries.tail.foldLeft(entries.head._1) { case (previousKey, (k, _)) =>
@@ -25,12 +25,12 @@ object TreeMap {
         k
       }
 
-      val fakeSortedMap = new collection.immutable.SortedMap[K, V] {
+      val fakeSortedMap = new immutable.SortedMap[K, V] {
         override def ordering: Ordering[K] = implicitly
         override val iterator: Iterator[(K, V)] = entries.iterator
         override def size: Int = entries.size
 
-        // As for scala 2.12.10 collection.immutable.TreeMap.from does not use the following methods
+        // As for scala 2.12.10 immutable.TreeMap.from does not use the following methods
         override def removed(key: K): Nothing = ???
         override def updated[V1 >: V](key: K, value: V1): Nothing = ???
         override def iteratorFrom(start: K): Nothing = ???
@@ -39,6 +39,6 @@ object TreeMap {
         override def get(key: K): Nothing = ???
       }
 
-      collection.immutable.TreeMap.from(fakeSortedMap)
+      immutable.TreeMap.from(fakeSortedMap)
     }
 }

--- a/daml-lf/data/src/main/scala/com/daml/TreeMap.scala
+++ b/daml-lf/data/src/main/scala/com/daml/TreeMap.scala
@@ -15,7 +15,9 @@ object TreeMap {
   // Relies on the fact that immutable.TreeMap.from is linear when its argument
   // is a SortedMap with the same ordering.
   @throws[IllegalArgumentException]
-  def fromOrderedEntries[K, V](entries: Iterable[(K, V)])(implicit order: Ordering[K]): immutable.TreeMap[K, V] =
+  def fromOrderedEntries[K, V](
+      entries: Iterable[(K, V)]
+  )(implicit order: Ordering[K]): immutable.TreeMap[K, V] =
     if (entries.isEmpty)
       immutable.TreeMap.empty
     else {
@@ -25,7 +27,7 @@ object TreeMap {
       val it = entries.iterator
       var previous = it.next()
 
-      while(it.hasNext) {
+      while (it.hasNext) {
         val next = it.next()
         order.compare(previous._1, next._1) match {
           case i if i < 0 =>

--- a/daml-lf/data/src/main/scala/com/daml/TreeMap.scala
+++ b/daml-lf/data/src/main/scala/com/daml/TreeMap.scala
@@ -16,15 +16,14 @@ object TreeMap {
   // is a SortedMap with the same ordering.
   @throws[IllegalArgumentException]
   def fromOrderedEntries[K, V](
-      entries: Iterable[(K, V)]
-  )(implicit order: Ordering[K]): immutable.TreeMap[K, V] =
-    if (entries.isEmpty)
+      entries: IterableOnce[(K, V)]
+  )(implicit order: Ordering[K]): immutable.TreeMap[K, V] = {
+    val it = entries.iterator
+    if (it.isEmpty)
       immutable.TreeMap.empty
     else {
-
       val buffer = new ArrayBuffer[(K, V)]()
       buffer.sizeHint(entries.knownSize)
-      val it = entries.iterator
       var previous = it.next()
 
       it.foreach { next =>
@@ -55,4 +54,5 @@ object TreeMap {
 
       immutable.TreeMap.from(fakeSortedMap)
     }
+  }
 }

--- a/daml-lf/data/src/main/scala/com/daml/TreeMap.scala
+++ b/daml-lf/data/src/main/scala/com/daml/TreeMap.scala
@@ -27,7 +27,7 @@ object TreeMap {
 
       val fakeSortedMap = new immutable.SortedMap[K, V] {
         override def ordering: Ordering[K] = implicitly
-        override val iterator: Iterator[(K, V)] = entries.iterator
+        override def iterator: Iterator[(K, V)] = entries.iterator
         override def size: Int = entries.size
 
         // As for scala 2.12.10 immutable.TreeMap.from does not use the following methods

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TreeMapSpec.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TreeMapSpec.scala
@@ -26,12 +26,9 @@ class TreeMapSpec extends AnyWordSpec with Matchers with TableDrivenPropertyChec
       List("1" -> 1, "0" -> 2),
       List("1" -> 1, "2" -> 2, "3" -> 3, "1" -> 2),
       List("2" -> 2, "3" -> 3, "1" -> 1),
-
     )
 
-    forAll(negativeTestCases)( l =>
-     TreeMap.fromOrderedEntries(l) shouldBe l.toMap
-    )
+    forAll(negativeTestCases)(l => TreeMap.fromOrderedEntries(l) shouldBe l.toMap)
 
     forAll(positiveTestCases)(l =>
       a[IllegalArgumentException] shouldBe thrownBy(TreeMap.fromOrderedEntries(l))

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TreeMapSpec.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TreeMapSpec.scala
@@ -17,6 +17,8 @@ class TreeMapSpec extends AnyWordSpec with Matchers with TableDrivenPropertyChec
         List.empty,
         List("1" -> 1),
         List("1" -> 1, "2" -> 2, "3" -> 3),
+        List("1" -> 1, "1" -> 2),
+        List("1" -> 1, "2" -> 2, "3" -> 3, "3" -> 2),
       )
 
     val positiveTestCases = Table(
@@ -24,14 +26,12 @@ class TreeMapSpec extends AnyWordSpec with Matchers with TableDrivenPropertyChec
       List("1" -> 1, "0" -> 2),
       List("1" -> 1, "2" -> 2, "3" -> 3, "1" -> 2),
       List("2" -> 2, "3" -> 3, "1" -> 1),
-      List("1" -> 1, "1" -> 2),
-      List("1" -> 1, "2" -> 2, "3" -> 3, "3" -> 2),
+
     )
 
-    forAll(negativeTestCases) { l =>
-      val treeMap = TreeMap.fromOrderedEntries(l)
-      assert(treeMap.iterator sameElements l)
-    }
+    forAll(negativeTestCases)( l =>
+     TreeMap.fromOrderedEntries(l) shouldBe l.toMap
+    )
 
     forAll(positiveTestCases)(l =>
       a[IllegalArgumentException] shouldBe thrownBy(TreeMap.fromOrderedEntries(l))

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TreeMapSpec.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TreeMapSpec.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.data
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.wordspec.AnyWordSpec
+
+class TreeMapSpec extends AnyWordSpec with Matchers with TableDrivenPropertyChecks {
+
+  "TreeMap.fromOrderedEntries should fails if the input list is not sorted" in {
+
+    val negativeTestCases =
+      Table(
+        "list",
+        List.empty,
+        List("1" -> 1),
+        List("1" -> 1, "2" -> 2, "3" -> 3),
+      )
+
+    val positiveTestCases = Table(
+      "list",
+      List("1" -> 1, "0" -> 2),
+      List("1" -> 1, "2" -> 2, "3" -> 3, "1" -> 2),
+      List("2" -> 2, "3" -> 3, "1" -> 1),
+      List("1" -> 1, "1" -> 2),
+      List("1" -> 1, "2" -> 2, "3" -> 3, "3" -> 2),
+    )
+
+    forAll(negativeTestCases) { l =>
+      val treeMap = TreeMap.fromOrderedEntries(l)
+      assert(treeMap.iterator sameElements l)
+    }
+
+    forAll(positiveTestCases)(l =>
+      a[IllegalArgumentException] shouldBe thrownBy(TreeMap.fromOrderedEntries(l))
+    )
+  }
+
+}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -263,49 +263,8 @@ object SValue {
       */
     def fromOrderedEntries(
         isTextMap: Boolean,
-        entries: IndexedSeqView[(SValue, SValue)],
-    ): SMap = {
-      require(
-        entries
-          .foldLeft[(Boolean, Option[SValue])]((true, None)) {
-            case ((result, previousKey), (currentKey, _)) =>
-              (result && previousKey.forall(`SMap Ordering`.lteq(_, currentKey)), Some(currentKey))
-          }
-          ._1,
-        "The entries are not in descending order",
-      )
-
-      val sortedEntryMap: SortedMap[SValue, SValue] = new SortedMap[SValue, SValue] {
-        private[this] val encapsulatedSortedMap = SortedMap.from(entries)
-
-        override def iterator: Iterator[(SValue, SValue)] = entries.iterator
-
-        override def size: Int = entries.size
-
-        override def ordering: Ordering[SValue] = `SMap Ordering`
-
-        override def updated[V1 >: SValue](key: SValue, value: V1): SortedMap[SValue, V1] =
-          encapsulatedSortedMap.updated(key, value)
-
-        override def removed(key: SValue): SortedMap[SValue, SValue] =
-          encapsulatedSortedMap.removed(key)
-
-        override def iteratorFrom(start: SValue): Iterator[(SValue, SValue)] =
-          encapsulatedSortedMap.iteratorFrom(start)
-
-        override def keysIteratorFrom(start: SValue): Iterator[SValue] =
-          encapsulatedSortedMap.keysIteratorFrom(start)
-
-        override def rangeImpl(
-            from: Option[SValue],
-            until: Option[SValue],
-        ): SortedMap[SValue, SValue] = encapsulatedSortedMap.rangeImpl(from, until)
-
-        override def get(key: SValue): Option[SValue] = encapsulatedSortedMap.get(key)
-      }
-
-      SMap(isTextMap, TreeMap.from(sortedEntryMap))
-    }
+        entries: Iterable[(SValue, SValue)],
+    ): SMap = SMap(isTextMap, data.TreeMap.fromOrderedEntries(entries))
 
     /** Build an SMap from an iterator over SValue key/value pairs.
       *

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -5,7 +5,7 @@ package com.daml.lf
 package speedy
 
 import java.util
-import com.daml.lf.data._
+import com.daml.lf.data.{TreeMap => _, _}
 import com.daml.lf.data.Ref._
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SExpr.SExpr
@@ -15,9 +15,8 @@ import com.daml.lf.value.{Value => V}
 import com.daml.scalautil.Statement.discard
 import com.daml.nameof.NameOf
 
-import scala.collection.IndexedSeqView
 import scala.jdk.CollectionConverters._
-import scala.collection.immutable.{SortedMap, TreeMap}
+import scala.collection.immutable.TreeMap
 import scala.util.hashing.MurmurHash3
 
 /** Speedy values. These are the value types recognized by the
@@ -269,6 +268,7 @@ object SValue {
     /** Build an SMap from an iterator over SValue key/value pairs.
       *
       * SValue keys are not assumed to be ordered - hence the SMap will be built in time O(n log(n)).
+      * If keys are duplicate, the last overrides the firsts
       */
     def apply(isTextMap: Boolean, entries: Iterator[(SValue, SValue)]): SMap =
       SMap(

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SValueTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SValueTest.scala
@@ -74,7 +74,7 @@ class SValueTest extends AnyWordSpec with Inside with Matchers with TableDrivenP
         val result = Try(SMap.fromOrderedEntries(isTextMap, entries))
 
         inside(result) { case Failure(error: IllegalArgumentException) =>
-          error.getMessage shouldBe "requirement failed: The entries are not in descending order"
+          error.getMessage shouldBe "The entries are not in descending order"
         }
       }
     }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SValueTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SValueTest.scala
@@ -74,7 +74,7 @@ class SValueTest extends AnyWordSpec with Inside with Matchers with TableDrivenP
         val result = Try(SMap.fromOrderedEntries(isTextMap, entries))
 
         inside(result) { case Failure(error: IllegalArgumentException) =>
-          error.getMessage shouldBe "The entries are not in descending order"
+          error.getMessage shouldBe "the entries are not ordered"
         }
       }
     }


### PR DESCRIPTION
No noticiable slowdown for small map 
Provide a 8x factor for building a map with 100 entries 

Benchmark                      (n)  Mode  Cnt        Score        Error  Units

// optimize log n implementation with cheap comparison
TreeMapBench.smallBenchN         1  avgt   20        0.069 ±      0.006  us/op
TreeMapBench.smallBenchN         2  avgt   20        0.124 ±      0.001  us/op
TreeMapBench.smallBenchN         4  avgt   20        0.200 ±      0.004  us/op
TreeMapBench.smallBenchN         8  avgt   20        0.301 ±      0.002  us/op
TreeMapBench.smallBenchN        16  avgt   20        0.655 ±      0.003  us/op
TreeMapBench.smallBenchN        32  avgt   20        1.325 ±      0.026  us/op
TreeMapBench.smallBenchN        64  avgt   20        2.467 ±      0.020  us/op
TreeMapBench.smallBenchN       128  avgt   20        5.611 ±      0.051  us/op
TreeMapBench.smallBenchN      1024  avgt   20       41.861 ±      0.176  us/op
TreeMapBench.smallBenchN      2048  avgt   20       88.466 ±      0.483  us/op
TreeMapBench.smallBenchN      4096  avgt   20      167.988 ±      1.473  us/op
// / original n.log n implementation with cheap comparison
TreeMapBench.smallBenchNLogN     1  avgt   20        0.075 ±      0.001  us/op
TreeMapBench.smallBenchNLogN     2  avgt   20        0.105 ±      0.001  us/op
TreeMapBench.smallBenchNLogN     4  avgt   20        0.203 ±      0.001  us/op
TreeMapBench.smallBenchNLogN     8  avgt   20        0.488 ±      0.004  us/op
TreeMapBench.smallBenchNLogN    16  avgt   20        1.206 ±      0.013  us/op
TreeMapBench.smallBenchNLogN    32  avgt   20        3.197 ±      0.030  us/op
TreeMapBench.smallBenchNLogN    64  avgt   20        8.311 ±      0.252  us/op
TreeMapBench.smallBenchNLogN   128  avgt   20       25.233 ±      0.397  us/op
TreeMapBench.smallBenchNLogN  1024  avgt   20      341.476 ±      3.334  us/op
TreeMapBench.smallBenchNLogN  2048  avgt   20      759.253 ±      5.363  us/op
TreeMapBench.smallBenchNLogN  4096  avgt   20     1557.377 ±     14.372  us/op
// optimize log n implementation with expensive comparison
TreeMapBench.bigBenchN           1  avgt   20        0.068 ±      0.001  us/op
TreeMapBench.bigBenchN           2  avgt   20        0.156 ±      0.001  us/op
TreeMapBench.bigBenchN           4  avgt   20        0.490 ±      0.003  us/op
TreeMapBench.bigBenchN           8  avgt   20        2.081 ±      0.337  us/op
TreeMapBench.bigBenchN          16  avgt   20        5.526 ±      0.921  us/op
TreeMapBench.bigBenchN          32  avgt   20       24.051 ±      3.825  us/op
TreeMapBench.bigBenchN          64  avgt   20       87.623 ±      3.150  us/op
TreeMapBench.bigBenchN         128  avgt   20      440.156 ±     43.163  us/op
TreeMapBench.bigBenchN        1024  avgt   20    29722.161 ±   4540.973  us/op
TreeMapBench.bigBenchN        2048  avgt   20   101022.168 ±   8031.037  us/op
TreeMapBench.bigBenchN        4096  avgt   20   412135.813 ±  37063.802  us/op
// original n.log n implementation with expensive comparison
TreeMapBench.bigBenchNLogN       1  avgt   20        0.080 ±      0.005  us/op
TreeMapBench.bigBenchNLogN       2  avgt   20        0.142 ±      0.004  us/op
TreeMapBench.bigBenchNLogN       4  avgt   20        0.713 ±      0.040  us/op
TreeMapBench.bigBenchNLogN       8  avgt   20        4.371 ±      0.236  us/op
TreeMapBench.bigBenchNLogN      16  avgt   20       19.403 ±      0.905  us/op
TreeMapBench.bigBenchNLogN      32  avgt   20      116.205 ±      9.356  us/op
TreeMapBench.bigBenchNLogN      64  avgt   20      659.754 ±    100.593  us/op
TreeMapBench.bigBenchNLogN     128  avgt   20     2145.517 ±     50.427  us/op
TreeMapBench.bigBenchNLogN    1024  avgt   20   236622.521 ±   3860.775  us/op
TreeMapBench.bigBenchNLogN    2048  avgt   20  1200165.768 ±  11779.846  us/op
TreeMapBench.bigBenchNLogN    4096  avgt   20  5834790.537 ± 141100.189  us/op


<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
