### PR TITLE
[Speedy] Test node seeds are maintained properly in aborted rollback

### DIFF
--- a/daml-lf/engine/BUILD.bazel
+++ b/daml-lf/engine/BUILD.bazel
@@ -46,6 +46,7 @@ ENGINE_TEST_FILES = \
     [
         "BasicTests",
         "AuthTests",
+        "Demonstrator",
     ]
 
 [

--- a/daml-lf/engine/src/test/daml/Demonstrator.daml
+++ b/daml-lf/engine/src/test/daml/Demonstrator.daml
@@ -1,0 +1,52 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Demonstrator where
+
+template RegistrarRole
+  with
+    operator : Party
+  where
+    signatory operator
+
+    choice AcceptTransfer : ()
+      with
+        transferCid : ContractId TransferRequest
+      controller operator
+      do
+        try do
+          exercise transferCid AcceptTransferRequest
+          return ()
+        catch
+          (ex : AnyException) -> do
+            exercise transferCid CancelTransferRequest
+            return ()
+
+template TransferRequest
+  with
+    operator : Party
+    investor : Party
+  where
+    signatory operator
+    observer investor
+
+    choice AcceptTransferRequest : ()
+      controller operator
+      do
+        assert False
+
+    choice CancelTransferRequest : ContractId CancelledTransfer
+      controller operator
+      do
+        create CancelledTransfer with ..
+
+template CancelledTransfer
+  with
+    operator : Party
+    investor : Party
+  where
+    signatory operator
+    observer investor
+
+    key operator : Party
+    maintainer key

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/NodeSeedsTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/NodeSeedsTest.scala
@@ -1,0 +1,170 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+
+import com.daml.bazeltools.BazelRunfiles
+import com.daml.lf.archive.UniversalArchiveDecoder
+import com.daml.lf.data.{Ref, ImmArray, Time}
+import com.daml.lf.engine.Engine
+import com.daml.lf.transaction.Transaction.ChildrenRecursion
+import com.daml.lf.transaction.{Versioned, Node, NodeId}
+import com.daml.lf.value.Value
+import com.daml.logging.LoggingContext
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.File
+
+class NodeSeedsTest extends AnyWordSpec with Matchers {
+
+  // Test for https://github.com/DACH-NY/canton/issues/14712
+
+  val (mainPkgId, packages) = {
+    val packages = UniversalArchiveDecoder.assertReadFile(
+      new File(BazelRunfiles.rlocation("daml-lf/engine/Demonstrator.dar"))
+    )
+    (packages.main._1, packages.all.toMap)
+  }
+
+  val engine = Engine.DevEngine()
+
+  val operator = Ref.Party.assertFromString("operator")
+  val investor = Ref.Party.assertFromString("investor")
+  val time = Time.Timestamp.now()
+
+  val requestTmplId =
+    Ref.Identifier(mainPkgId, Ref.QualifiedName.assertFromString("Demonstrator:TransferRequest"))
+  val requestCid: Value.ContractId = Value.ContractId.V1.assertFromString(
+    "001000000000000000000000000000000000000000000000000000000000000000"
+  )
+  val requestContract =
+    Versioned(
+      transaction.TransactionVersion.VDev,
+      Value.ContractInstance(
+        requestTmplId,
+        Value.ValueRecord(
+          None,
+          ImmArray(None -> Value.ValueParty(operator), None -> Value.ValueParty(investor)),
+        ),
+      ),
+    )
+  val roleTmplId =
+    Ref.Identifier(mainPkgId, Ref.QualifiedName.assertFromString("Demonstrator:RegistrarRole"))
+  val roleCid: Value.ContractId = Value.ContractId.V1.assertFromString(
+    "002000000000000000000000000000000000000000000000000000000000000000"
+  )
+  val roleContract = Versioned(
+    transaction.TransactionVersion.VDev,
+    Value.ContractInstance(
+      roleTmplId,
+      Value.ValueRecord(None, ImmArray(None -> Value.ValueParty(operator))),
+    ),
+  )
+  val contracts = Map(requestCid -> requestContract, roleCid -> roleContract)
+
+  implicit val loggingContext = LoggingContext.empty
+
+  val Right((tx, metaData)) =
+    engine
+      .submit(
+        Set(operator),
+        Set.empty,
+        command.ApiCommands(
+          ImmArray(
+            command.ApiCommand.Exercise(
+              roleTmplId,
+              roleCid,
+              Ref.ChoiceName.assertFromString("AcceptTransfer"),
+              Value.ValueRecord(None, ImmArray(None -> Value.ValueContractId(requestCid))),
+            )
+          ),
+          time,
+          "some ref",
+        ),
+        participantId = Ref.ParticipantId.assertFromString("participant"),
+        submissionSeed = crypto.Hash.hashPrivateKey(getClass.getName + time.toString),
+      )
+      .consume(pcs = contracts, pkgs = packages)
+
+  val nodeSeeds = metaData.nodeSeeds.iterator.toMap
+
+  // return the create nodes under node `rootId`.
+  def projectCreates(rootId: NodeId) =
+    tx.foldInExecutionOrder((false, Set.empty[Node.Create]))(
+      exerciseBegin = { case ((collecting, creates), nodeId, _) =>
+        ((collecting || nodeId == rootId, creates), ChildrenRecursion.DoRecurse)
+      },
+      rollbackBegin = { case ((collecting, creates), nodeId, _) =>
+        ((collecting || nodeId == rootId, creates), ChildrenRecursion.DoRecurse)
+      },
+      leaf = {
+        case ((collecting, creates), nodeId, create: Node.Create)
+            if collecting || nodeId == rootId =>
+          (collecting, creates + create)
+        case (state, _, _) => state
+      },
+      exerciseEnd = { case ((collecting, creates), nodeId, _) =>
+        (collecting && rootId != nodeId, creates)
+      },
+      rollbackEnd = { case ((collecting, creates), nodeId, _) =>
+        (collecting && rootId != nodeId, creates)
+      },
+    )._2
+
+  def replay(nodeId: NodeId) = {
+    val cmd = tx.nodes(nodeId) match {
+      case exe: Node.Exercise =>
+        command.ReplayCommand.Exercise(
+          exe.templateId,
+          None,
+          exe.targetCoid,
+          exe.choiceId,
+          exe.chosenValue,
+        )
+      case create: Node.Create =>
+        command.ReplayCommand.Create(
+          create.templateId,
+          create.arg,
+        )
+      case fetch: Node.Fetch if fetch.byKey =>
+        command.ReplayCommand.FetchByKey(
+          fetch.templateId,
+          fetch.keyOpt.get.value,
+        )
+      case fetch: Node.Fetch =>
+        command.ReplayCommand.Fetch(
+          fetch.templateId,
+          fetch.coid,
+        )
+      case lookup: Node.LookupByKey =>
+        command.ReplayCommand.LookupByKey(
+          lookup.templateId,
+          lookup.key.value,
+        )
+      case _ =>
+        sys.error("unexpected node")
+    }
+    val Right((rTx, _)) =
+      engine
+        .reinterpret(
+          Set(operator),
+          cmd,
+          nodeSeeds.get(nodeId),
+          time,
+          time,
+        )(LoggingContext.empty)
+        .consume(pcs = contracts, pkgs = packages)
+    rTx.nodes.values.collect { case create: Node.Create => create }.toSet
+  }
+
+  val n = tx.nodes.iterator.collect { case (nid, _: Node.Action) =>
+    s"when run with $nid" in {
+      replay(nid) shouldBe projectCreates(nid)
+    }
+  }.size
+
+  // We double check we have exactly 4 action nodes in the transaction
+  assert(n == 4)
+
+}


### PR DESCRIPTION
Test for the bug DACH-NY/canton#14712 fixed in #16422

This is adapted from a test designed by @simonmaxen-da to reproduce the bug.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
