### PR TITLE
Make package optional in GlobalKey

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractKeySpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractKeySpec.scala
@@ -63,7 +63,7 @@ class ContractKeySpec
 
   val basicTestsSignatures = language.PackageInterface(Map(basicTestsPkgId -> basicTestsPkg))
 
-  val withKeyTemplate = "BasicTests:WithKey"
+  val withKeyTemplate: QualifiedName = "BasicTests:WithKey"
   val BasicTests_WithKey = Identifier(basicTestsPkgId, withKeyTemplate)
   val withKeyContractInst: VersionedContractInstance =
     assertAsVersionedContract(
@@ -120,7 +120,8 @@ class ContractKeySpec
   private[this] val lookupKey: PartialFunction[GlobalKeyWithMaintainers, ContractId] = {
     case GlobalKeyWithMaintainers(
           GlobalKey(
-            BasicTests_WithKey,
+            Some(`basicTestsPkgId`),
+            `withKeyTemplate`,
             ValueRecord(_, ImmArray((_, ValueParty(`alice`)), (_, ValueInt64(42)))),
           ),
           _,
@@ -264,7 +265,7 @@ class ContractKeySpec
         )
       )
       val (multiKeysPkgId, _, allMultiKeysPkgs) = loadPackage("daml-lf/tests/MultiKeys.dar")
-      val keyedId = Identifier(multiKeysPkgId, "MultiKeys:Keyed")
+      val keyedIdQName: QualifiedName = "MultiKeys:Keyed"
       val opsId = Identifier(multiKeysPkgId, "MultiKeys:KeyOperations")
       val let = Time.Timestamp.now()
       val submissionSeed = hash("multikeys")
@@ -280,7 +281,11 @@ class ContractKeySpec
       )
       val contracts = Map(cid1 -> keyedInst, cid2 -> keyedInst)
       val lookupKey: PartialFunction[GlobalKeyWithMaintainers, ContractId] = {
-        case GlobalKeyWithMaintainers(GlobalKey(`keyedId`, ValueParty(`party`)), _) => cid1
+        case GlobalKeyWithMaintainers(
+              GlobalKey(Some(`multiKeysPkgId`), `keyedIdQName`, ValueParty(`party`)),
+              _,
+            ) =>
+          cid1
       }
       def run(engine: Engine, choice: String, argument: Value) = {
         val cmd = ApiCommand.CreateAndExercise(

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -5,7 +5,6 @@ package com.daml.lf
 package engine
 
 import java.io.File
-
 import com.daml.lf.archive.UniversalArchiveDecoder
 import com.daml.lf.data.Ref._
 import com.daml.lf.data._
@@ -1389,7 +1388,8 @@ class EngineTest
     val lookupKey: PartialFunction[GlobalKeyWithMaintainers, ContractId] = {
       case GlobalKeyWithMaintainers(
             GlobalKey(
-              BasicTests_WithKey,
+              Some(`basicTestsPkgId`),
+              `withKeyTemplate`,
               ValueRecord(_, ImmArray((_, ValueParty(`alice`)), (_, ValueInt64(42)))),
             ),
             _,
@@ -1749,7 +1749,8 @@ class EngineTest
       val lookupKey: PartialFunction[GlobalKeyWithMaintainers, ContractId] = {
         case GlobalKeyWithMaintainers(
               GlobalKey(
-                BasicTests_WithKey,
+                Some(`basicTestsPkgId`),
+                `withKeyTemplate`,
                 ValueRecord(_, ImmArray((_, ValueParty(`alice`)), (_, ValueInt64(42)))),
               ),
               _,
@@ -1976,7 +1977,7 @@ class EngineTest
 
   "exceptions" should {
     val (exceptionsPkgId, _, allExceptionsPkgs) = loadPackage("daml-lf/tests/Exceptions.dar")
-    val kId = Identifier(exceptionsPkgId, "Exceptions:K")
+    val kIdQName: QualifiedName = "Exceptions:K"
     val tId = Identifier(exceptionsPkgId, "Exceptions:T")
     val let = Time.Timestamp.now()
     val submissionSeed = hash("rollback")
@@ -2000,7 +2001,8 @@ class EngineTest
     val lookupKey: PartialFunction[GlobalKeyWithMaintainers, ContractId] = {
       case GlobalKeyWithMaintainers(
             GlobalKey(
-              `kId`,
+              Some(`exceptionsPkgId`),
+              `kIdQName`,
               ValueRecord(_, ImmArray((_, ValueParty(`alice`)), (_, ValueInt64(0)))),
             ),
             _,
@@ -2123,7 +2125,7 @@ class EngineTest
 
   "action node seeds" should {
     val (exceptionsPkgId, _, allExceptionsPkgs) = loadPackage("daml-lf/tests/Exceptions.dar")
-    val kId = Identifier(exceptionsPkgId, "Exceptions:K")
+    val kIdQName: QualifiedName = "Exceptions:K"
     val seedId = Identifier(exceptionsPkgId, "Exceptions:NodeSeeds")
     val let = Time.Timestamp.now()
     val submissionSeed = hash("rollback")
@@ -2147,7 +2149,8 @@ class EngineTest
     val lookupKey: PartialFunction[GlobalKeyWithMaintainers, ContractId] = {
       case GlobalKeyWithMaintainers(
             GlobalKey(
-              `kId`,
+              Some(`exceptionsPkgId`),
+              `kIdQName`,
               ValueRecord(_, ImmArray((_, ValueParty(`party`)), (_, ValueInt64(0)))),
             ),
             _,
@@ -2198,7 +2201,8 @@ class EngineTest
 
   "global key lookups" should {
     val (exceptionsPkgId, _, allExceptionsPkgs) = loadPackage("daml-lf/tests/Exceptions.dar")
-    val kId = Identifier(exceptionsPkgId, "Exceptions:K")
+
+    val kIdQName: QualifiedName = "Exceptions:K"
     val tId = Identifier(exceptionsPkgId, "Exceptions:GlobalLookups")
     val let = Time.Timestamp.now()
     val submissionSeed = hash("global-keys")
@@ -2222,7 +2226,8 @@ class EngineTest
     val lookupKey: PartialFunction[GlobalKeyWithMaintainers, ContractId] = {
       case GlobalKeyWithMaintainers(
             GlobalKey(
-              `kId`,
+              Some(`exceptionsPkgId`),
+              `kIdQName`,
               ValueRecord(_, ImmArray((_, ValueParty(`party`)), (_, ValueInt64(0)))),
             ),
             _,
@@ -2409,7 +2414,7 @@ object EngineTest {
 
   val dummySuffix: Bytes = Bytes.assertFromString("00")
 
-  val withKeyTemplate = "BasicTests:WithKey"
+  val withKeyTemplate: QualifiedName = "BasicTests:WithKey"
   val BasicTests_WithKey: lf.data.Ref.ValueRef = Identifier(basicTestsPkgId, withKeyTemplate)
   val withKeyContractInst: VersionedContractInstance =
     assertAsVersionedContract(
@@ -2486,7 +2491,8 @@ object EngineTest {
   val lookupKey: PartialFunction[GlobalKeyWithMaintainers, ContractId] = {
     case GlobalKeyWithMaintainers(
           GlobalKey(
-            BasicTests_WithKey,
+            Some(`basicTestsPkgId`),
+            `withKeyTemplate`,
             ValueRecord(_, ImmArray((_, ValueParty(`alice`)), (_, ValueInt64(42)))),
           ),
           _,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1548,7 +1548,7 @@ private[lf] object SBuiltin {
       if (cachedKey.maintainers.isEmpty) {
         Control.Error(
           IE.FetchEmptyContractKeyMaintainers(
-            cachedKey.templateId,
+            templateId,
             cachedKey.lfValue,
           )
         )
@@ -2081,6 +2081,7 @@ private[lf] object SBuiltin {
             throw SErrorDamlException(IE.ContractIdInContractKey(keyValue.toUnnormalizedValue))
           )
         CachedKey(
+          templateId,
           GlobalKeyWithMaintainers(
             gkey,
             extractParties(NameOf.qualifiedNameOfCurrentFunc, vals.get(maintainerIdx)),

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -107,16 +107,20 @@ private[lf] object Speedy {
   sealed abstract class LedgerMode extends Product with Serializable
 
   final case class CachedKey(
+      templateId: TypeConName,
       globalKeyWithMaintainers: GlobalKeyWithMaintainers,
       key: SValue,
   ) {
     def globalKey: GlobalKey = globalKeyWithMaintainers.globalKey
-    def templateId: TypeConName = globalKey.templateId
     def maintainers: Set[Party] = globalKeyWithMaintainers.maintainers
     val lfValue: V = globalKey.key
     def renormalizedGlobalKeyWithMaintainers(version: TxVersion) = {
       globalKeyWithMaintainers.copy(
-        globalKey = GlobalKey.assertBuild(templateId, key.toNormalizedValue(version))
+        globalKey = GlobalKey.assertBuild(
+          globalKey.packageId,
+          globalKey.qualifiedName,
+          key.toNormalizedValue(version),
+        )
       )
     }
   }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExplicitDisclosureLib.scala
@@ -128,6 +128,7 @@ private[lf] class ExplicitDisclosureLib(evaluationOrder: EvaluationOrder) {
       if (withKey)
         Some(
           Speedy.CachedKey(
+            templateId,
             globalKeyWithMaintainers =
               GlobalKeyWithMaintainers(buildContractKey(maintainer, label), Set(maintainer)),
             key = buildContractSKey(maintainer),
@@ -245,6 +246,7 @@ private[lf] class ExplicitDisclosureLib(evaluationOrder: EvaluationOrder) {
       if (withKey)
         Some(
           CachedKey(
+            templateId,
             GlobalKeyWithMaintainers
               .assertBuild(templateId, contract.toUnnormalizedValue, Set(maintainer)),
             contract,

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -1798,6 +1798,7 @@ class SBuiltinTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
         val (disclosedContract, Some((key, keyWithMaintainers))) =
           buildDisclosedContract(contractId, alice, alice, templateId, withKey = true)
         val cachedKey = CachedKey(
+          templateId,
           GlobalKeyWithMaintainers.assertBuild(templateId, key.toUnnormalizedValue, Set(alice)),
           key,
         )

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -299,17 +299,28 @@ object Hash {
   // 1 - `templateId` is the identifier for a template with a key of type τ
   // 2 - `key` is a value of type τ
   @throws[HashingError]
-  def assertHashContractKey(templateId: Ref.Identifier, key: Value): Hash =
-    builder(Purpose.ContractKey, noCid2String)
-      .addIdentifier(templateId)
+  def assertHashContractKey(
+      packageId: Option[Ref.PackageId],
+      qualifiedName: Ref.QualifiedName,
+      key: Value,
+  ): Hash = {
+    val hashBuilder = builder(Purpose.ContractKey, noCid2String)
+    packageId.foreach(hashBuilder.add)
+    hashBuilder
+      .addQualifiedName(qualifiedName)
       .addTypedValue(key)
       .build
+  }
+
+  def assertHashContractKey(templateId: Ref.Identifier, key: Value): Hash =
+    assertHashContractKey(Some(templateId.packageId), templateId.qualifiedName, key)
 
   def hashContractKey(
-      templateId: Ref.Identifier,
+      packageId: Option[Ref.PackageId],
+      qualifiedName: Ref.QualifiedName,
       key: Value,
   ): Either[HashingError, Hash] =
-    handleError(assertHashContractKey(templateId, key))
+    handleError(assertHashContractKey(packageId, qualifiedName, key))
 
   // This function assumes that `arg` is well typed, i.e. :
   // 1 - `templateId` is the identifier for a template with a contract argument of type τ

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -201,7 +201,7 @@ object Node {
   }
 
   final case class LookupByKey(
-      override val templateId: TypeConName,
+      override val templateId: TypeConName, // The template that defines the lookup key type
       key: GlobalKeyWithMaintainers,
       result: Option[ContractId],
       // For the sake of consistency between types with a version field, keep this field the last.

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Normalization.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Normalization.scala
@@ -95,7 +95,7 @@ class Normalization {
     x match {
       case GlobalKeyWithMaintainers(key, maintainers) =>
         GlobalKeyWithMaintainers(
-          GlobalKey.assertBuild(key.templateId, normValue(version)(key.key)),
+          GlobalKey.assertBuild(key.packageId, key.qualifiedName, normValue(version)(key.key)),
           maintainers,
         )
     }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Util.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Util.scala
@@ -92,7 +92,9 @@ object Util {
       version: TransactionVersion,
   ): Either[String, GlobalKeyWithMaintainers] =
     normalizeValue(key.globalKey.key, version).map(normalized =>
-      key.copy(globalKey = GlobalKey.assertBuild(key.globalKey.templateId, normalized))
+      key.copy(globalKey =
+        GlobalKey.assertBuild(key.globalKey.packageId, key.globalKey.qualifiedName, normalized)
+      )
     )
 
   def normalizeOptKey(


### PR DESCRIPTION
As part of the upgrading story contract keys will no longer be scoped to the package but will be accessible from different packages providing the qualified template name matches.

The first task in doing this is to make package id optional in GlobalKey but to populate the package id in all cases (so effectively no change).

The main complication in doing this where there is a need to normalize (remove type info) or un-normalize (add type info) the value. To do this the type of the key value needs to be established and this could previously be done by looking up the template definition and from there the key type. Although no concrete template is associated with the key (in case where the package is not specified) this information needs to come from the context in which the value is being (un)normalized.

The design for shared cans can be [found here](https://docs.google.com/document/d/1wfoxfSVjDoHNNjRGsD7fHEN06dndPiR7H-T14HhKeb0/edit#heading=h.j1o9vy5fqmrz
)

