### PR TITLE
LT-36: add DisclosedContracts and thread it through CommandsSubmission

### DIFF
--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CommandsSubmission.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CommandsSubmission.java
@@ -39,6 +39,7 @@ public final class CommandsSubmission {
   private Optional<Duration> minLedgerTimeRel;
   private Optional<Duration> deduplicationTime;
   private Optional<String> accessToken;
+  private List<DisclosedContract> disclosedContracts;
 
   protected CommandsSubmission(
       String applicationId,
@@ -50,7 +51,8 @@ public final class CommandsSubmission {
       Optional<Instant> minLedgerTimeAbs,
       Optional<Duration> minLedgerTimeRel,
       Optional<Duration> deduplicationTime,
-      Optional<String> accessToken) {
+      Optional<String> accessToken,
+      List<@NonNull DisclosedContract> disclosedContracts) {
     this.workflowId = workflowId;
     this.applicationId = applicationId;
     this.commandId = commandId;
@@ -61,6 +63,7 @@ public final class CommandsSubmission {
     this.deduplicationTime = deduplicationTime;
     this.commands = commands;
     this.accessToken = accessToken;
+    this.disclosedContracts = disclosedContracts;
   }
 
   public static CommandsSubmission create(
@@ -75,7 +78,8 @@ public final class CommandsSubmission {
         empty(),
         Optional.empty(),
         empty(),
-        empty());
+        empty(),
+        emptyList());
   }
 
   public Optional<String> getWorkflowId() {
@@ -118,6 +122,10 @@ public final class CommandsSubmission {
     return accessToken;
   }
 
+  public List<DisclosedContract> getDisclosedContracts() {
+    return unmodifiableList(disclosedContracts);
+  }
+
   public CommandsSubmission withWorkflowId(String workflowId) {
     return new CommandsSubmission(
         applicationId,
@@ -129,7 +137,8 @@ public final class CommandsSubmission {
         minLedgerTimeAbs,
         minLedgerTimeRel,
         deduplicationTime,
-        accessToken);
+        accessToken,
+        disclosedContracts);
   }
 
   public CommandsSubmission withActAs(String actAs) {
@@ -143,7 +152,8 @@ public final class CommandsSubmission {
         minLedgerTimeAbs,
         minLedgerTimeRel,
         deduplicationTime,
-        accessToken);
+        accessToken,
+        disclosedContracts);
   }
 
   public CommandsSubmission withActAs(List<@NonNull String> actAs) {
@@ -157,7 +167,8 @@ public final class CommandsSubmission {
         minLedgerTimeAbs,
         minLedgerTimeRel,
         deduplicationTime,
-        accessToken);
+        accessToken,
+        disclosedContracts);
   }
 
   public CommandsSubmission withReadAs(List<@NonNull String> readAs) {
@@ -171,7 +182,8 @@ public final class CommandsSubmission {
         minLedgerTimeAbs,
         minLedgerTimeRel,
         deduplicationTime,
-        accessToken);
+        accessToken,
+        disclosedContracts);
   }
 
   public CommandsSubmission withMinLedgerTimeAbs(Optional<Instant> minLedgerTimeAbs) {
@@ -185,7 +197,8 @@ public final class CommandsSubmission {
         minLedgerTimeAbs,
         minLedgerTimeRel,
         deduplicationTime,
-        accessToken);
+        accessToken,
+        disclosedContracts);
   }
 
   public CommandsSubmission withMinLedgerTimeRel(Optional<Duration> minLedgerTimeRel) {
@@ -199,7 +212,8 @@ public final class CommandsSubmission {
         minLedgerTimeAbs,
         minLedgerTimeRel,
         deduplicationTime,
-        accessToken);
+        accessToken,
+        disclosedContracts);
   }
 
   public CommandsSubmission withDeduplicationTime(Optional<Duration> deduplicationTime) {
@@ -213,7 +227,8 @@ public final class CommandsSubmission {
         minLedgerTimeAbs,
         minLedgerTimeRel,
         deduplicationTime,
-        accessToken);
+        accessToken,
+        disclosedContracts);
   }
 
   public CommandsSubmission withCommands(List<@NonNull ? extends HasCommands> commands) {
@@ -227,7 +242,8 @@ public final class CommandsSubmission {
         minLedgerTimeAbs,
         minLedgerTimeRel,
         deduplicationTime,
-        accessToken);
+        accessToken,
+        disclosedContracts);
   }
 
   public CommandsSubmission withAccessToken(Optional<String> accessToken) {
@@ -241,6 +257,22 @@ public final class CommandsSubmission {
         minLedgerTimeAbs,
         minLedgerTimeRel,
         deduplicationTime,
-        accessToken);
+        accessToken,
+        disclosedContracts);
+  }
+
+  public CommandsSubmission withDisclosedContracts(List<DisclosedContract> disclosedContracts) {
+    return new CommandsSubmission(
+        applicationId,
+        commandId,
+        commands,
+        actAs,
+        readAs,
+        workflowId,
+        minLedgerTimeAbs,
+        minLedgerTimeRel,
+        deduplicationTime,
+        accessToken,
+        disclosedContracts);
   }
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DisclosedContract.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DisclosedContract.java
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data;
+
+import com.daml.ledger.api.v1.CommandsOuterClass;
+import com.google.protobuf.Any;
+
+public final class DisclosedContract {
+  public final Identifier templateId;
+  public final String contractId;
+  public final Arguments arguments;
+  public final ContractMetadata contractMetadata;
+
+  public DisclosedContract(
+      Identifier templateId,
+      String contractId,
+      Arguments arguments,
+      ContractMetadata contractMetadata) {
+    this.templateId = templateId;
+    this.contractId = contractId;
+    this.arguments = arguments;
+    this.contractMetadata = contractMetadata;
+  }
+
+  public static interface Arguments {
+    public CommandsOuterClass.DisclosedContract.Builder toProto(
+        CommandsOuterClass.DisclosedContract.Builder builder);
+  }
+
+  public static final class CreateArguments implements Arguments {
+    public final DamlRecord arguments;
+
+    public CreateArguments(DamlRecord arguments) {
+      this.arguments = arguments;
+    }
+
+    public CommandsOuterClass.DisclosedContract.Builder toProto(
+        CommandsOuterClass.DisclosedContract.Builder builder) {
+      return builder.setCreateArguments(arguments.toProtoRecord());
+    }
+  }
+
+  public static final class CreateArgumentsBlob implements Arguments {
+    public final Any createArgumentsBlob;
+
+    public CreateArgumentsBlob(Any createArgumentsBlob) {
+      this.createArgumentsBlob = createArgumentsBlob;
+    }
+
+    public CommandsOuterClass.DisclosedContract.Builder toProto(
+        CommandsOuterClass.DisclosedContract.Builder builder) {
+      return builder.setCreateArgumentsBlob(createArgumentsBlob);
+    }
+  }
+
+  public CommandsOuterClass.DisclosedContract toProto() {
+    var builder =
+        CommandsOuterClass.DisclosedContract.newBuilder()
+            .setTemplateId(this.templateId.toProto())
+            .setContractId(this.contractId)
+            .setMetadata(this.contractMetadata.toProto());
+    return this.arguments.toProto(builder).build();
+  }
+}

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/SubmitCommandsRequest.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/SubmitCommandsRequest.java
@@ -328,7 +328,7 @@ public final class SubmitCommandsRequest {
 
   public static CommandsOuterClass.Commands toProto(
       @NonNull String ledgerId, @NonNull CommandsSubmission submission) {
-    return toProto(ledgerId, submission.getWorkflowId(), submission);
+    return toProto(ledgerId, Optional.empty(), submission);
   }
 
   /** @deprecated since 2.5. Please use {@link #toProto(String, CommandsSubmission)} */

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/SubmitCommandsRequest.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/SubmitCommandsRequest.java
@@ -212,7 +212,7 @@ public final class SubmitCommandsRequest {
 
   // TODO: Refactor this to take CommmandsSubmission when deprecated methods using it below are
   // removed
-  private static CommandsOuterClass.Commands toProto(
+  private static CommandsOuterClass.Commands deprecatedToProto(
       @NonNull String ledgerId,
       @NonNull String workflowId,
       @NonNull String applicationId,
@@ -274,6 +274,10 @@ public final class SubmitCommandsRequest {
     List<Command> commands = toCommands(submission.getCommands());
     List<CommandsOuterClass.Command> commandsConverted =
         commands.stream().map(Command::toProtoCommand).collect(Collectors.toList());
+    List<CommandsOuterClass.DisclosedContract> disclosedContracts =
+        submission.getDisclosedContracts().stream()
+            .map(DisclosedContract::toProto)
+            .collect(Collectors.toList());
 
     CommandsOuterClass.Commands.Builder builder =
         CommandsOuterClass.Commands.newBuilder()
@@ -283,7 +287,8 @@ public final class SubmitCommandsRequest {
             .setParty(submission.getActAs().get(0))
             .addAllActAs(submission.getActAs())
             .addAllReadAs(submission.getReadAs())
-            .addAllCommands(commandsConverted);
+            .addAllCommands(commandsConverted)
+            .addAllDisclosedContracts(disclosedContracts);
 
     submission
         .getMinLedgerTimeAbs()
@@ -323,18 +328,7 @@ public final class SubmitCommandsRequest {
 
   public static CommandsOuterClass.Commands toProto(
       @NonNull String ledgerId, @NonNull CommandsSubmission submission) {
-    return toProto(
-        ledgerId,
-        submission.getWorkflowId().orElse(""),
-        submission.getApplicationId(),
-        submission.getCommandId(),
-        submission.getActAs(),
-        submission.getReadAs(),
-        submission.getMinLedgerTimeAbs(),
-        submission.getMinLedgerTimeRel(),
-        submission.getDeduplicationTime(),
-        Optional.empty(),
-        toCommands(submission.getCommands()));
+    return toProto(ledgerId, submission.getWorkflowId(), submission);
   }
 
   /** @deprecated since 2.5. Please use {@link #toProto(String, CommandsSubmission)} */
@@ -350,7 +344,7 @@ public final class SubmitCommandsRequest {
       @NonNull Optional<Duration> minLedgerTimeRelative,
       @NonNull Optional<Duration> deduplicationTime,
       @NonNull List<@NonNull Command> commands) {
-    return toProto(
+    return deprecatedToProto(
         ledgerId,
         workflowId,
         applicationId,
@@ -368,18 +362,7 @@ public final class SubmitCommandsRequest {
       @NonNull String ledgerId,
       @NonNull String submissionId,
       @NonNull CommandsSubmission submission) {
-    return toProto(
-        ledgerId,
-        submission.getWorkflowId().orElse(""),
-        submission.getApplicationId(),
-        submission.getCommandId(),
-        submission.getActAs(),
-        submission.getReadAs(),
-        submission.getMinLedgerTimeAbs(),
-        submission.getMinLedgerTimeRel(),
-        submission.getDeduplicationTime(),
-        Optional.of(submissionId),
-        toCommands(submission.getCommands()));
+    return toProto(ledgerId, Optional.of(submissionId), submission);
   }
 
   /** @deprecated since 2.5. Please use {@link #toProto(String, String, CommandsSubmission)} */
@@ -396,7 +379,7 @@ public final class SubmitCommandsRequest {
       @NonNull Optional<Duration> minLedgerTimeRelative,
       @NonNull Optional<Duration> deduplicationTime,
       @NonNull List<@NonNull Command> commands) {
-    return toProto(
+    return deprecatedToProto(
         ledgerId,
         workflowId,
         applicationId,
@@ -426,7 +409,7 @@ public final class SubmitCommandsRequest {
     List<String> empty_read_as = new ArrayList<>();
     List<String> act_as = new ArrayList<>();
     act_as.add(party);
-    return toProto(
+    return deprecatedToProto(
         ledgerId,
         workflowId,
         applicationId,
@@ -455,7 +438,7 @@ public final class SubmitCommandsRequest {
     List<String> empty_read_as = new ArrayList<>();
     List<String> act_as = new ArrayList<>();
     act_as.add(party);
-    return toProto(
+    return deprecatedToProto(
         ledgerId,
         workflowId,
         applicationId,

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/UpdateSubmission.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/UpdateSubmission.java
@@ -241,6 +241,7 @@ public final class UpdateSubmission<U> {
         minLedgerTimeAbs,
         minLedgerTimeRel,
         deduplicationTime,
-        accessToken);
+        accessToken,
+        emptyList());
   }
 }


### PR DESCRIPTION
Also rename the private `SubmitCommandsRequest.toProto` method which is used by the deprecated but public `toProto` overloads, to `deprecatedToProto`. The passing of disclosed contracts is not supported by these deprecated overloads.

This PR does not provide facilities for building a `DisclosedContract`, either as read from Scribe or from whatever format it may have been published or shared.