### PR TITLE
[DEPRECATED] Proto changes to support explicit disclosure in conjunction with template subscriptions

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
@@ -219,15 +219,16 @@ message DisclosedContract {
   // Required
   string contract_id = 2;
 
-  // The contract arguments as typed Record
+  // The contract arguments
   // Required
-  Record create_arguments = 3;
+  oneof arguments {
+    // The contract arguments as typed Record
+    Record create_arguments = 3;
 
-  // The contract arguments specified using an opaque blob extracted from the ``create_arguments_blob`` field
-  // of a ``com.daml.ledger.api.v1.CreatedEvent``. Ledger API server validates this data in conjunction with
-  // the ``create_arguments`` record and returns a comprehensive error when any inconsistency is found.
-  // Required
-  google.protobuf.Any create_arguments_blob = 5;
+    // The contract arguments specified using an opaque blob extracted from the ``create_arguments_blob`` field
+    // of a ``com.daml.ledger.api.v1.CreatedEvent``.
+    google.protobuf.Any create_arguments_blob = 5;
+  }
 
   // The contract metadata from the create event.
   // Required
@@ -250,4 +251,16 @@ message DisclosedContract {
   // Maintainers of the contract key, if defined.
   // Optional
   repeated string key_maintainers = 9;
+
+  // The contract arguments as a typed record. The fields comprising the create arguments are cross-validated
+  // with the contents of the ``contract_create_arguments_blob``. If any inconsistency is determined,
+  // the command submission is rejected. It can be left unset.
+  // Optional
+  Record contract_create_arguments = 10;
+
+  // The contract arguments specified using an opaque blob extracted from the ``create_arguments_blob`` field
+  // of a ``com.daml.ledger.api.v1.CreatedEvent``.
+  // Required
+  google.protobuf.Any contract_create_arguments_blob = 11;
+
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
@@ -223,11 +223,13 @@ message DisclosedContract {
   // Required
   oneof arguments {
     // The contract arguments as typed Record
-    Record create_arguments = 3;
+    // Deprecated in favor of `contract_create_arguments`
+    Record create_arguments = 3 [deprecated = true];
 
     // The contract arguments specified using an opaque blob extracted from the ``create_arguments_blob`` field
     // of a ``com.daml.ledger.api.v1.CreatedEvent``.
-    google.protobuf.Any create_arguments_blob = 5;
+    // Deprecated in favor of `contract_create_arguments_blob`
+    google.protobuf.Any create_arguments_blob = 5 [deprecated = true];
   }
 
   // The contract metadata from the create event.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
@@ -219,16 +219,15 @@ message DisclosedContract {
   // Required
   string contract_id = 2;
 
-  // The contract arguments
+  // The contract arguments as typed Record
   // Required
-  oneof arguments {
-    // The contract arguments as typed Record
-    Record create_arguments = 3;
+  Record create_arguments = 3;
 
-    // The contract arguments specified using an opaque blob extracted from the ``create_arguments_blob`` field
-    // of a ``com.daml.ledger.api.v1.CreatedEvent``.
-    google.protobuf.Any create_arguments_blob = 5;
-  }
+  // The contract arguments specified using an opaque blob extracted from the ``create_arguments_blob`` field
+  // of a ``com.daml.ledger.api.v1.CreatedEvent``. Ledger API server validates this data in conjunction with
+  // the ``create_arguments`` record and returns a comprehensive error when any inconsistency is found.
+  // Required
+  google.protobuf.Any create_arguments_blob = 5;
 
   // The contract metadata from the create event.
   // Required

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
@@ -56,6 +56,16 @@ message InclusiveFilters {
   // the available packages at the time of the query.
   // Optional
   repeated InterfaceFilter interface_filters = 2;
+
+  // A collection of templates for which the payload will be included in the
+  // ``create_arguments`` of a matching ``CreatedEvent``.
+  // SHOULD NOT contain duplicates.
+  // In contrast to the ``template_ids`` field, one can specify whether the blob should be provided
+  // alongside the create arguments.
+  // All ``template_id`` inside need to be valid: corresponding template should be defined in one of
+  // the available packages at the time of the query.
+  // Optional
+  repeated TemplateFilter template_flters = 3;
 }
 
 // This filter matches contracts that implement a specific interface.
@@ -69,6 +79,21 @@ message InterfaceFilter {
   // Use this to access contract data in a uniform manner in your API client.
   // Optional
   bool include_interface_view = 2;
+
+  // Whether to include a ``create_arguments_blob`` in the returned
+  // ``CreateEvent``.
+  // Use this to access the complete contract data in your API client
+  // for submitting it as a disclosed contract with future commands.
+  // Optional
+  bool include_create_arguments_blob = 3;
+}
+
+// This filter matches contracts that implement a specific interface.
+message TemplateFilter {
+
+  // A template for which the payload should be included in the response.
+  // Required
+  Identifier template_id = 1;
 
   // Whether to include a ``create_arguments_blob`` in the returned
   // ``CreateEvent``.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
@@ -62,10 +62,12 @@ message InclusiveFilters {
   // SHOULD NOT contain duplicates.
   // In contrast to the ``template_ids`` field, one can specify whether the blob should be provided
   // alongside the create arguments.
+  // If a contract is simultaneously selected by a template filter and one or more interface filters,
+  // the corresponding ``include_create_arguments_blob`` are consolidated using an OR operation.
   // All ``template_id`` inside need to be valid: corresponding template should be defined in one of
   // the available packages at the time of the query.
   // Optional
-  repeated TemplateFilter template_flters = 3;
+  repeated TemplateFilter template_filters = 3;
 }
 
 // This filter matches contracts that implement a specific interface.
@@ -80,10 +82,11 @@ message InterfaceFilter {
   // Optional
   bool include_interface_view = 2;
 
-  // Whether to include a ``create_arguments_blob`` in the returned
-  // ``CreateEvent``.
-  // Use this to access the complete contract data in your API client
-  // for submitting it as a disclosed contract with future commands.
+  // Whether to include a ``create_arguments_blob`` in the returned ``CreateEvent``.
+  // Use this to access the complete contract data in your API client for submitting it as a disclosed
+  // contract with future commands.
+  // If a contract is simultaneously selected by a template filter and one or more interface filters,
+  // the corresponding ``include_create_arguments_blob`` are consolidated using an OR operation.
   // Optional
   bool include_create_arguments_blob = 3;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
@@ -47,8 +47,10 @@ message InclusiveFilters {
   // SHOULD NOT contain duplicates.
   // All ``template_ids`` needs to be valid: corresponding template should be defined in one of
   // the available packages at the time of the query.
+  // Deprecated in favor of the `template_filters`.
+  // If the `template_filters` field are set, the `template_ids` field is ignored.
   // Optional
-  repeated Identifier template_ids = 1;
+  repeated Identifier template_ids = 1 [deprecated=true];
 
   // Include an ``InterfaceView`` for every ``InterfaceFilter`` matching a contract.
   // The ``InterfaceFilter``s MUST use unique ``interface_id``s.
@@ -91,7 +93,7 @@ message InterfaceFilter {
   bool include_create_arguments_blob = 3;
 }
 
-// This filter matches contracts that implement a specific interface.
+// This filter matches contracts of a specific template.
 message TemplateFilter {
 
   // A template for which the payload should be included in the response.


### PR DESCRIPTION
Two changes to the proto definitions

- Make the blob mandatory on the command submission
- Extend template filter to allow for requesting blobs when subscribing for templates

Why is this change necessary:

- Either a publisher or a client in a typical explicit-disclosure scenario may be based on an old package version that is missing a couple of fields. As a result some of the create-arguments may be dropped in the communication. This would render the subsequent command submission a failure. This is why a blob MUST be a required field.
- The typed arguments on the other hand CAN be an optional filed. A client needs to trust the publisher of the data that the contract it has received off ledger is legit. Alas, there is no way of validating of what is in the blob and that the blob and the typed arguments match. The only one that can verify that is ledger api server. It can do it when validating the submission message.