### PR TITLE
[Speedy] Ensure continuation of Update questions do not throw

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -626,6 +626,9 @@ private[lf] object Pretty {
         case SEPreventCatch(body) =>
           text("prevent_catch") + char('(') + prettySExpr(index)(body) + text(")")
 
+        case SEDelayedCrash(location, reason) =>
+          text("delayed_crash") + char('(') + text(location) + text(",") + text(reason) + text(")")
+
         case x: SEImportValue => str(x)
         case x: SELabelClosure => str(x)
       }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -51,6 +51,11 @@ private[lf] object SExpr {
     }
   }
 
+  private[speedy] final case class SEDelayedCrash(location: String, reason: String) extends SExpr {
+    override def execute[Q](machine: Machine[Q]): Control[Nothing] =
+      throw SError.SErrorCrash(location, reason)
+  }
+
   /** Reference to a value. On first lookup the evaluated expression is
     * stored in 'cached'.
     */

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -51,7 +51,7 @@ private[lf] object SExpr {
     }
   }
 
-  // This is used to delay error happing during evaluation of question continuations
+  // This is used to delay errors happening during evaluation of question continuations
   private[speedy] final case class SEDelayedCrash(location: String, reason: String) extends SExpr {
     override def execute[Q](machine: Machine[Q]): Control[Nothing] =
       throw SError.SErrorCrash(location, reason)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -51,6 +51,7 @@ private[lf] object SExpr {
     }
   }
 
+  // This is used to delay error happing during evaluation of question continuations
   private[speedy] final case class SEDelayedCrash(location: String, reason: String) extends SExpr {
     override def execute[Q](machine: Machine[Q]): Control[Nothing] =
       throw SError.SErrorCrash(location, reason)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -188,10 +188,10 @@ private[lf] object Speedy {
     private[this] var contractsCache = Map.empty[V.ContractId, V.ContractInstance]
 
     // To handle continuation exceptions, as continuations run outside the interpreter loop.
-    // Here we delay the throw to the interpreter loop, but it would be probably better 
+    // Here we delay the throw to the interpreter loop, but it would be probably better
     // to delay the whole execution. This would work for all continuation (which have type
     // `X => Unit`)  except `NeedKey` (which have type `X => Bool`) that need to be run
-    // strait away.  
+    // strait away.
     private[this] def safelyContinue(
         location: => String,
         question: => String,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -35,7 +35,7 @@ import com.daml.nameof.NameOf
 import com.daml.scalautil.Statement.discard
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 
-import scala.annotation.{tailrec, nowarn}
+import scala.annotation.{nowarn, tailrec}
 import scala.util.control.NonFatal
 
 private[lf] object Speedy {
@@ -1022,8 +1022,8 @@ private[lf] object Speedy {
     }
 
     /** Reuse an existing speedy machine to evaluate a new expression.
-      * Do not use if the machine is partway though an existing evaluation.
-      * i.e. run() has returned an `SResult` requiring a callback.
+      *      Do not use if the machine is partway though an existing evaluation.
+      *      i.e. run() has returned an `SResult` requiring a callback.
       */
     final def setExpressionToEvaluate(expr: SExpr): Unit = {
       setControl(Control.Expression(expr))
@@ -1072,7 +1072,6 @@ private[lf] object Speedy {
             }
           }
         }
-
         loop()
       } catch {
         case serr: SError => // TODO: prefer Control over throw for SError
@@ -1120,7 +1119,7 @@ private[lf] object Speedy {
     }
 
     /** This function is used to enter an ANF application.  The function has been evaluated to
-      * a value, and so have the arguments - they just need looking up
+      *      a value, and so have the arguments - they just need looking up
       */
     // TODO: share common code with executeApplication
     private[speedy] final def enterApplication(
@@ -1228,11 +1227,11 @@ private[lf] object Speedy {
     }
 
     /** Evaluate the first 'n' arguments in 'args'.
-      * 'args' will contain at least 'n' expressions, but it may contain more(!)
+      *      'args' will contain at least 'n' expressions, but it may contain more(!)
       *
-      * This is because, in the call from 'executeApplication' below, although over-applied
-      * arguments are pushed into a continuation, they are not removed from the original array
-      * which is passed here as 'args'.
+      *      This is because, in the call from 'executeApplication' below, although over-applied
+      *      arguments are pushed into a continuation, they are not removed from the original array
+      *      which is passed here as 'args'.
       */
     private[speedy] final def evaluateArguments(
         actuals: util.ArrayList[SValue],

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -188,7 +188,7 @@ private[lf] object Speedy {
     private[this] var contractsCache = Map.empty[V.ContractId, V.ContractInstance]
 
     // To handle continuation exceptions, as continuation are run outside the interpreter loop.
-    protected def safelyContinue(
+    private[this] def safelyContinue(
         location: => String,
         question: => String,
         continue: => Control[Question.Update],
@@ -211,7 +211,7 @@ private[lf] object Speedy {
     // The following needXXXX methods take care to emit question while ensuring no exceptions are
     // thrown during the question callbacks execution
 
-    final def needTime(): Control[Question.Update] = {
+    final private[speedy] def needTime(): Control[Question.Update] = {
       setDependsOnTime()
       Control.Question(
         Question.Update.NeedTime(time =>
@@ -224,7 +224,7 @@ private[lf] object Speedy {
       )
     }
 
-    final def needContract(
+    final private[speedy] def needContract(
         location: => String,
         contractId: V.ContractId,
         continue: V.ContractInstance => Control[Question.Update],
@@ -237,7 +237,7 @@ private[lf] object Speedy {
         )
       )
 
-    final def needUpgradeVerification(
+    final private[speedy] def needUpgradeVerification(
         location: => String,
         coid: V.ContractId,
         signatories: Set[Party],
@@ -255,7 +255,7 @@ private[lf] object Speedy {
         )
       )
 
-    final def needPackage(
+    final private[speedy] def needPackage(
         location: => String,
         packageId: PackageId,
         context: language.Reference,
@@ -278,7 +278,7 @@ private[lf] object Speedy {
         )
       )
 
-    final def needKey(
+    final private[speedy] def needKey(
         location: => String,
         key: GlobalKeyWithMaintainers,
         continue: Option[V.ContractId] => (Control[Question.Update], Boolean),
@@ -309,7 +309,7 @@ private[lf] object Speedy {
         )
       )
 
-    final def needAuthority(
+    final private[speedy] def needAuthority(
         location: => String,
         holding: Set[Party],
         requesting: Set[Party],
@@ -324,7 +324,7 @@ private[lf] object Speedy {
         )
       )
 
-    final def needPackageId(
+    final private[speedy] def needPackageId(
         location: => String,
         module: ModuleName,
         pid0: PackageId,
@@ -338,7 +338,7 @@ private[lf] object Speedy {
         )
       )
 
-    def lookupContractOnLedger[Q](coid: V.ContractId)(
+    final private[speedy] def lookupContractOnLedger[Q](coid: V.ContractId)(
         continue: V.ContractInstance => Control[Question.Update]
     ): Control[Question.Update] =
       contractsCache.get(coid) match {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -187,7 +187,11 @@ private[lf] object Speedy {
 
     private[this] var contractsCache = Map.empty[V.ContractId, V.ContractInstance]
 
-    // To handle continuation exceptions, as continuation are run outside the interpreter loop.
+    // To handle continuation exceptions, as continuations run outside the interpreter loop.
+    // Here we delay the throw to the interpreter loop, but it would be probably better 
+    // to delay the whole execution. This would work for all continuation (which have type
+    // `X => Unit`)  except `NeedKey` (which have type `X => Bool`) that need to be run
+    // strait away.  
     private[this] def safelyContinue(
         location: => String,
         question: => String,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -187,7 +187,7 @@ private[lf] object Speedy {
 
     private[this] var contractsCache = Map.empty[V.ContractId, V.ContractInstance]
 
-    // To hanle continuation exceptions, as continuation are un outside the interpreter loop.
+    // To handle continuation exceptions, as continuation are run outside the interpreter loop.
     protected def safelyContinue(
         location: => String,
         question: => String,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
@@ -34,6 +34,7 @@ private[speedy] object SExprIterable {
     case SExpr.SELocS(_) => Iterator.empty
     case SExpr.SEValue(v) => iterator(v)
     case SExpr.SELocF(_) => Iterator.empty
+    case SExpr.SEDelayedCrash(_, _) => Iterator.empty
   }
   private[this] def iterator(v: SValue): Iterator[SExpr] = v match {
     case SValue.SPAP(prim, actuals, _) =>


### PR DESCRIPTION
It is important continuations of Engine Result does not throw exceptions, as we cannot ensure those are properly caught.

Until now, we have to carefully review the code we write never throws exceptions. However as the code in continuation grows, I think this is not possible to do it anymore. For this reason, this PR systematically caught any possible exception thrown during continuation evaluation, and delay the error reporting to the next Speedy iteration.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
