### PR TITLE
Update daml-assistant to support new versioning

### DIFF
--- a/daml-assistant/src/DA/Daml/Assistant/Install.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install.hs
@@ -320,7 +320,7 @@ httpInstall env@InstallEnv{..} releaseVersion = do
         getLocation sdkVersion = case artifactoryApiKeyM of
             Nothing -> Github.versionLocation releaseVersion sdkVersion
             Just apiKey
-              | releaseVersion >= firstEEVersion -> Artifactory.versionLocation releaseVersion sdkVersion apiKey
+              | releaseVersion >= firstEEVersion -> Artifactory.versionLocation sdkVersion apiKey
               | otherwise -> Github.versionLocation releaseVersion sdkVersion
         !firstEEVersion =
             let verStr = "1.12.0-snapshot.20210312.6498.0.707c86aa"

--- a/daml-assistant/src/DA/Daml/Assistant/Install/Artifactory.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install/Artifactory.hs
@@ -26,7 +26,7 @@ queryArtifactoryApiKey damlConfig =
      eitherToMaybe (queryDamlConfigRequired ["artifactory-api-key"] damlConfig)
 
 -- | Install location for particular version.
--- NOTE THIS TAKES THE SDK VERSION, not the release version that `Github.versionLocation`
+-- NOTE THIS TAKES THE SDK VERSION, not the release version that `Github.versionLocation` uses
 versionLocation :: SdkVersion -> ArtifactoryApiKey -> InstallLocation
 versionLocation sdkVersion apiKey = InstallLocation
     { ilUrl = T.concat

--- a/daml-assistant/src/DA/Daml/Assistant/Install/Artifactory.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install/Artifactory.hs
@@ -26,11 +26,12 @@ queryArtifactoryApiKey damlConfig =
      eitherToMaybe (queryDamlConfigRequired ["artifactory-api-key"] damlConfig)
 
 -- | Install location for particular version.
-versionLocation :: SdkVersion -> SdkVersion -> ArtifactoryApiKey -> InstallLocation
-versionLocation releaseVersion sdkVersion apiKey = InstallLocation
+-- NOTE THIS TAKES THE SDK VERSION, not the release version that `Github.versionLocation`
+versionLocation :: SdkVersion -> ArtifactoryApiKey -> InstallLocation
+versionLocation sdkVersion apiKey = InstallLocation
     { ilUrl = T.concat
         [ "https://digitalasset.jfrog.io/artifactory/sdk-ee/"
-        , versionToText releaseVersion
+        , versionToText sdkVersion
         , "/daml-sdk-"
         , versionToText sdkVersion
         , "-"

--- a/daml-assistant/src/DA/Daml/Assistant/Install/Artifactory.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install/Artifactory.hs
@@ -26,13 +26,13 @@ queryArtifactoryApiKey damlConfig =
      eitherToMaybe (queryDamlConfigRequired ["artifactory-api-key"] damlConfig)
 
 -- | Install location for particular version.
-versionLocation :: SdkVersion -> ArtifactoryApiKey -> InstallLocation
-versionLocation v apiKey = InstallLocation
+versionLocation :: SdkVersion -> SdkVersion -> ArtifactoryApiKey -> InstallLocation
+versionLocation releaseVersion sdkVersion apiKey = InstallLocation
     { ilUrl = T.concat
         [ "https://digitalasset.jfrog.io/artifactory/sdk-ee/"
-        , versionToText v
+        , versionToText releaseVersion
         , "/daml-sdk-"
-        , versionToText v
+        , versionToText sdkVersion
         , "-"
         , osName
         , "-ee.tar.gz"

--- a/daml-assistant/src/DA/Daml/Assistant/Install/Github.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install/Github.hs
@@ -86,4 +86,3 @@ getSdkVersionFromEnterpriseVersion v = do
           T.stripPrefix "daml-sdk-" withoutExt
       sdkVersionStr = fromMaybe (error "Failed to find linux sdk in release") mSdkVersionStr
   either throwIO pure $ parseVersion sdkVersionStr
-  


### PR DESCRIPTION
Since ~2.8.snapshot, the version of the daml sdk can differ from the version of the release (sometimes called the enterprise release)
As such, the path to the sdk is no longer `releases/tags/v$VERSION/daml-sdk-$VERSION-$OS.tar.gz`, but instead
`releases/tags/v$RELEASE_VERSION/daml-sdk-$SDK_VERSION-$OS.tar.gz`

We still work with release versions via the assistant, so now we discover the sdk version by listing the files in the release and searching for the daml-sdk linux tarfile.

Related to: https://github.com/digital-asset/daml/pull/17550/files
Verified working via both github and artifactory.
