### PR TITLE
LT-35: pull JsonLfDecoders out from JsonLfReader.Decoders

### DIFF
--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfDecoders.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfDecoders.java
@@ -1,0 +1,338 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data.codegen.json;
+
+import com.daml.ledger.javaapi.data.Unit;
+import com.daml.ledger.javaapi.data.codegen.ContractId;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/// Readers for built-in LF types. ///
+public class JsonLfDecoders {
+
+  public static final JsonLfDecoder<Unit> unit =
+      r -> {
+        r.readStartObject();
+        r.readEndObject();
+        return Unit.getInstance();
+      };
+
+  public static final JsonLfDecoder<Boolean> bool =
+      r -> {
+        r.expectIsAt("boolean", JsonToken.VALUE_TRUE, JsonToken.VALUE_FALSE);
+        Boolean value = null;
+        try {
+          value = Boolean.parseBoolean(r.currentText("boolean"));
+        } catch (IOException e) {
+          r.parseExpected("true or false", e);
+        }
+        r.moveNext();
+        return value;
+      };
+
+  public static final JsonLfDecoder<Long> int64 =
+      r -> {
+        r.expectIsAt("int64", JsonToken.VALUE_NUMBER_INT, JsonToken.VALUE_STRING);
+        Long value = null;
+        try {
+          value = Long.parseLong(r.currentText("int64"));
+        } catch (NumberFormatException e) {
+          r.parseExpected("int64", e);
+        }
+        r.moveNext();
+        return value;
+      };
+
+  public static JsonLfDecoder<BigDecimal> numeric(int scale) {
+    assert scale >= 0 : "negative numeric scale " + scale;
+    return r -> {
+      r.expectIsAt(
+          "numeric",
+          JsonToken.VALUE_NUMBER_INT,
+          JsonToken.VALUE_NUMBER_FLOAT,
+          JsonToken.VALUE_STRING);
+      BigDecimal value = null;
+      try {
+        value = new BigDecimal(r.currentText("numeric"));
+      } catch (NumberFormatException e) {
+        r.parseExpected("numeric", e);
+      }
+      int orderMag = MAX_NUMERIC_PRECISION - scale; // Available digits on lhs of decimal point
+      if (value.precision() - value.scale() > orderMag) {
+        r.parseExpected(String.format("numeric in range (-10^%s, 10^%s)", orderMag, orderMag));
+      }
+      if (value.scale() > scale) value = value.setScale(scale, RoundingMode.HALF_EVEN);
+      r.moveNext();
+      return value;
+    };
+  }
+
+  public static final JsonLfDecoder<Instant> timestamp =
+      r -> {
+        r.expectIsAt("timestamp", JsonToken.VALUE_STRING);
+        Instant value = null;
+        try {
+          value = Instant.parse(r.currentText("timestamp")).truncatedTo(ChronoUnit.MICROS);
+        } catch (DateTimeParseException e) {
+          r.parseExpected("valid ISO 8601 date and time in UTC", e);
+        }
+        r.moveNext();
+        return value;
+      };
+
+  public static final JsonLfDecoder<LocalDate> date =
+      r -> {
+        r.expectIsAt("date", JsonToken.VALUE_STRING);
+        LocalDate value = null;
+        try {
+          value = LocalDate.parse(r.currentText("date"));
+        } catch (DateTimeParseException e) {
+          r.parseExpected("valid ISO 8601 date", e);
+        }
+        r.moveNext();
+        return value;
+      };
+
+  public static final JsonLfDecoder<String> text =
+      r -> {
+        r.expectIsAt("text", JsonToken.VALUE_STRING);
+        String value = r.currentText("valid textual value");
+        r.moveNext();
+        return value;
+      };
+
+  public static final JsonLfDecoder<String> party = text;
+
+  public static <C extends ContractId<?>> JsonLfDecoder<C> contractId(Function<String, C> constr) {
+    return r -> {
+      String id = text.decode(r);
+      return constr.apply(id);
+    };
+  }
+
+  // Read an list with an unknown number of items of the same type.
+  public static <T> JsonLfDecoder<List<T>> list(JsonLfDecoder<T> decodeItem) {
+    return r -> {
+      List<T> list = new ArrayList<>();
+      r.readStartArray();
+      while (r.notEndArray()) {
+        T item = decodeItem.decode(r);
+        list.add(item);
+      }
+      r.readEndArray();
+      return list;
+    };
+  }
+
+  // Read a map with textual keys, and unknown number of items of the same type.
+  public static <V> JsonLfDecoder<Map<String, V>> textMap(JsonLfDecoder<V> decodeValue) {
+    return r -> {
+      Map<String, V> map = new LinkedHashMap<>();
+      r.readStartObject();
+      while (r.notEndObject()) {
+        String key = r.readFieldName().name;
+        V val = decodeValue.decode(r);
+        map.put(key, val);
+      }
+      r.readEndObject();
+      return map;
+    };
+  }
+
+  // Read a map with unknown number of items of the same types.
+  public static <K, V> JsonLfDecoder<Map<K, V>> genMap(
+      JsonLfDecoder<K> decodeKey, JsonLfDecoder<V> decodeVal) {
+    return r -> {
+      Map<K, V> map = new LinkedHashMap<>();
+      // Maps are represented as an array of 2-element arrays.
+      r.readStartArray();
+      while (r.notEndArray()) {
+        r.readStartArray();
+        K key = decodeKey.decode(r);
+        V val = decodeVal.decode(r);
+        r.readEndArray();
+        map.put(key, val);
+      }
+      r.readEndArray();
+      return map;
+    };
+  }
+
+  // The T type should not itself be Optional<?>. In that case use OptionalNested below.
+  public static <T> JsonLfDecoder<Optional<T>> optional(JsonLfDecoder<T> decodeVal) {
+    return r -> {
+      if (r.isNull()) {
+        r.moveNext();
+        return Optional.empty();
+      } else {
+        T some = decodeVal.decode(r);
+        assert (!(some instanceof Optional))
+            : "Used `optional` to decode a "
+                + some.getClass()
+                + " but `optionalNested` must be used for the outer decoders of nested"
+                + " Optional";
+        return Optional.of(some);
+      }
+    };
+  }
+
+  public static <T> JsonLfDecoder<Optional<Optional<T>>> optionalNested(
+      JsonLfDecoder<Optional<T>> decodeVal) {
+    return r -> {
+      if (r.isNull()) {
+        r.moveNext();
+        return Optional.empty();
+      } else {
+        r.readStartArray();
+        if (r.isNull()) r.parseExpected("] or item");
+        Optional<T> val = r.notEndArray() ? decodeVal.decode(r) : Optional.empty();
+        r.readEndArray();
+        return Optional.of(val);
+      }
+    };
+  }
+
+  public static <E extends Enum<E>> JsonLfDecoder<E> enumeration(Map<String, E> damlNameToEnum) {
+    return r -> r.readFromText(damlNameToEnum::get, new ArrayList<>(damlNameToEnum.keySet()));
+  }
+
+  // Provides a generic way to read a variant type, by specifying each tag.
+  public static <T> JsonLfDecoder<T> variant(
+      List<String> tagNames, Function<String, JsonLfDecoder<? extends T>> decoderByName) {
+    return r -> {
+      r.readStartObject();
+      T result = null;
+      JsonLfReader.FieldName field = r.readFieldName();
+      switch (field.name) {
+        case "tag":
+          {
+            var decoder = r.readFromText(decoderByName, tagNames);
+            JsonLfReader.FieldName valueField = r.readFieldName();
+            if (!valueField.name.equals("value")) {
+              r.parseExpected("field value", null, valueField.name, valueField.loc);
+            }
+            result = decoder.decode(r);
+            break;
+          }
+        case "value":
+          {
+            // Can't decode until we know the tag.
+            JsonLfReader.UnknownValue unknown = JsonLfReader.UnknownValue.read(r);
+            JsonLfReader.FieldName tagField = r.readFieldName();
+            if (!tagField.name.equals("tag")) {
+              r.parseExpected("field tag", null, tagField.name, tagField.loc);
+            }
+            var decoder = r.readFromText(decoderByName, tagNames);
+            result = unknown.decodeWith(decoder);
+            break;
+          }
+        default:
+          r.parseExpected("field tag or value", null, field.name, field.loc);
+      }
+      r.readEndObject();
+      return result;
+    };
+  }
+
+  // Provides a generic way to read a record type, with a constructor arg for each field.
+  // This is a little fragile, so is better used by code-gen. Specifically:
+  // - The constructor must cast the elements and pass them to the T's constructor appropriately.
+  // - The elements of argNames should all evaluate to non non-null when applied to
+  // argsByName.
+  // - The index field values should correspond to the args passed to the constructor.
+  //
+  // e.g.
+  //     r.record(
+  //        asList("i", "b"),
+  //        name -> {
+  //          switch (name) {
+  //            case "i":
+  //              return JsonLfReader.JavaArg.at(0, r.list(r.int64()));
+  //            case "b":
+  //              return JsonLfReader.JavaArg.at(1, r.bool(), false);
+  //            default:
+  //              return null;
+  //          }
+  //        },
+  //        args -> new Foo((List<Long>) args[0], (Boolean) args[1]))
+  //     )
+  public static <T> JsonLfDecoder<T> record(
+      List<String> argNames,
+      Function<String, JavaArg<? extends Object>> argsByName,
+      Function<Object[], T> constr) {
+    return r -> {
+      Object[] args = new Object[argNames.size()];
+      if (r.isStartObject()) {
+        r.readStartObject();
+        while (r.notEndObject()) {
+          JsonLfReader.FieldName field = r.readFieldName();
+          var constrArg = argsByName.apply(field.name);
+          if (constrArg == null) r.unknownField(field.name, argNames, field.loc);
+          else args[constrArg.index] = constrArg.decode.decode(r);
+        }
+        r.readEndObject();
+      } else if (r.isStartArray()) {
+        r.readStartArray();
+        for (String fieldName : argNames) {
+          var field = argsByName.apply(fieldName);
+          args[field.index] = field.decode.decode(r);
+        }
+        r.readEndArray();
+      } else {
+        r.parseExpected("object or array");
+      }
+
+      // Handle missing fields.
+      for (String argName : argNames) {
+        JavaArg<? extends Object> arg = argsByName.apply(argName);
+        if (args[arg.index] != null) continue;
+        if (arg.defaultVal == null) r.missingField(argName);
+        args[arg.index] = arg.defaultVal;
+      }
+
+      return constr.apply(args);
+    };
+  }
+
+  // Represents an argument to the constructor of the code-gen class.
+  public static class JavaArg<T> {
+    final int index;
+    final JsonLfDecoder<T> decode;
+    final T defaultVal; // If non-null, used to populate value of missing fields.
+
+    private JavaArg(int index, JsonLfDecoder<T> decode, T defaultVal) {
+      this.index = index;
+      this.decode = decode;
+      this.defaultVal = defaultVal;
+    }
+
+    public static <T> JavaArg<T> at(int index, JsonLfDecoder<T> decode, T defaultVal) {
+      return new JavaArg<T>(index, decode, defaultVal);
+    }
+
+    public static <T> JavaArg<T> at(int index, JsonLfDecoder<T> decode) {
+      return new JavaArg<T>(index, decode, null);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  // Can be used within the `constr` arg to `record`, to allow casting without producing warnings.
+  public static <T> T cast(Object o) {
+    return (T) o;
+  }
+
+  private static final int MAX_NUMERIC_PRECISION = 38;
+}

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReader.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfReader.java
@@ -3,25 +3,13 @@
 
 package com.daml.ledger.javaapi.data.codegen.json;
 
-import com.daml.ledger.javaapi.data.Unit;
-import com.daml.ledger.javaapi.data.codegen.ContractId;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.format.DateTimeParseException;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 
 // Reads LF-JSON data in a streaming fashion.
@@ -44,334 +32,6 @@ public class JsonLfReader {
       parser.nextToken();
     } catch (IOException e) {
       throw new JsonLfDecoder.Error("JSON parse error", locationStart(), e);
-    }
-  }
-
-  /// Readers for built-in LF types. ///
-  public static class Decoders {
-
-    public static final JsonLfDecoder<Unit> unit =
-        r -> {
-          r.readStartObject();
-          r.readEndObject();
-          return Unit.getInstance();
-        };
-
-    public static final JsonLfDecoder<Boolean> bool =
-        r -> {
-          r.expectIsAt("boolean", JsonToken.VALUE_TRUE, JsonToken.VALUE_FALSE);
-          Boolean value = null;
-          try {
-            value = r.parser.getBooleanValue();
-          } catch (IOException e) {
-            r.parseExpected("true or false", e);
-          }
-          r.moveNext();
-          return value;
-        };
-
-    public static final JsonLfDecoder<Long> int64 =
-        r -> {
-          r.expectIsAt("int64", JsonToken.VALUE_NUMBER_INT, JsonToken.VALUE_STRING);
-          Long value = null;
-          try {
-            value = Long.parseLong(r.parser.getText());
-          } catch (IOException e) {
-            r.parseExpected("int64", e);
-          } catch (NumberFormatException e) {
-            r.parseExpected("int64", e);
-          }
-          r.moveNext();
-          return value;
-        };
-
-    public static JsonLfDecoder<BigDecimal> numeric(int scale) {
-      assert scale >= 0 : "negative numeric scale " + scale;
-      return r -> {
-        r.expectIsAt(
-            "numeric",
-            JsonToken.VALUE_NUMBER_INT,
-            JsonToken.VALUE_NUMBER_FLOAT,
-            JsonToken.VALUE_STRING);
-        BigDecimal value = null;
-        try {
-          value = new BigDecimal(r.parser.getText());
-        } catch (NumberFormatException e) {
-          r.parseExpected("numeric", e);
-        } catch (IOException e) {
-          r.parseExpected("numeric", e);
-        }
-        int orderMag = MAX_NUMERIC_PRECISION - scale; // Available digits on lhs of decimal point
-        if (value.precision() - value.scale() > orderMag) {
-          r.parseExpected(String.format("numeric in range (-10^%s, 10^%s)", orderMag, orderMag));
-        }
-        if (value.scale() > scale) value = value.setScale(scale, RoundingMode.HALF_EVEN);
-        r.moveNext();
-        return value;
-      };
-    }
-
-    public static final JsonLfDecoder<Instant> timestamp =
-        r -> {
-          r.expectIsAt("timestamp", JsonToken.VALUE_STRING);
-          Instant value = null;
-          try {
-            value = Instant.parse(r.parser.getText()).truncatedTo(ChronoUnit.MICROS);
-          } catch (DateTimeParseException e) {
-            r.parseExpected("valid ISO 8601 date and time in UTC", e);
-          } catch (IOException e) {
-            r.parseExpected("timestamp", e);
-          }
-          r.moveNext();
-          return value;
-        };
-
-    public static final JsonLfDecoder<LocalDate> date =
-        r -> {
-          r.expectIsAt("date", JsonToken.VALUE_STRING);
-          LocalDate value = null;
-          try {
-            value = LocalDate.parse(r.parser.getText());
-          } catch (DateTimeParseException e) {
-            r.parseExpected("valid ISO 8601 date", e);
-          } catch (IOException e) {
-            r.parseExpected("date", e);
-          }
-          r.moveNext();
-          return value;
-        };
-
-    public static final JsonLfDecoder<String> text =
-        r -> {
-          r.expectIsAt("text", JsonToken.VALUE_STRING);
-          String value = null;
-          try {
-            value = r.parser.getText();
-          } catch (IOException e) {
-            r.parseExpected("valid textual value", e);
-          }
-          r.moveNext();
-          return value;
-        };
-
-    public static final JsonLfDecoder<String> party = text;
-
-    public static <C extends ContractId<?>> JsonLfDecoder<C> contractId(
-        Function<String, C> constr) {
-      return r -> {
-        String id = text.decode(r);
-        return constr.apply(id);
-      };
-    }
-
-    // Read an list with an unknown number of items of the same type.
-    public static <T> JsonLfDecoder<List<T>> list(JsonLfDecoder<T> decodeItem) {
-      return r -> {
-        List<T> list = new ArrayList<>();
-        r.readStartArray();
-        while (r.notEndArray()) {
-          T item = decodeItem.decode(r);
-          list.add(item);
-        }
-        r.readEndArray();
-        return list;
-      };
-    }
-
-    // Read a map with textual keys, and unknown number of items of the same type.
-    public static <V> JsonLfDecoder<Map<String, V>> textMap(JsonLfDecoder<V> decodeValue) {
-      return r -> {
-        Map<String, V> map = new LinkedHashMap<>();
-        r.readStartObject();
-        while (r.notEndObject()) {
-          String key = r.readFieldName().name;
-          V val = decodeValue.decode(r);
-          map.put(key, val);
-        }
-        r.readEndObject();
-        return map;
-      };
-    }
-
-    // Read a map with unknown number of items of the same types.
-    public static <K, V> JsonLfDecoder<Map<K, V>> genMap(
-        JsonLfDecoder<K> decodeKey, JsonLfDecoder<V> decodeVal) {
-      return r -> {
-        Map<K, V> map = new LinkedHashMap<>();
-        // Maps are represented as an array of 2-element arrays.
-        r.readStartArray();
-        while (r.notEndArray()) {
-          r.readStartArray();
-          K key = decodeKey.decode(r);
-          V val = decodeVal.decode(r);
-          r.readEndArray();
-          map.put(key, val);
-        }
-        r.readEndArray();
-        return map;
-      };
-    }
-
-    // The T type should not itself be Optional<?>. In that case use OptionalNested below.
-    public static <T> JsonLfDecoder<Optional<T>> optional(JsonLfDecoder<T> decodeVal) {
-      return r -> {
-        if (r.parser.currentToken() == JsonToken.VALUE_NULL) {
-          r.moveNext();
-          return Optional.empty();
-        } else {
-          T some = decodeVal.decode(r);
-          assert (!(some instanceof Optional))
-              : "Used `optional` to decode a "
-                  + some.getClass()
-                  + " but `optionalNested` must be used for the outer decoders of nested"
-                  + " Optional";
-          return Optional.of(some);
-        }
-      };
-    }
-
-    public static <T> JsonLfDecoder<Optional<Optional<T>>> optionalNested(
-        JsonLfDecoder<Optional<T>> decodeVal) {
-      return r -> {
-        if (r.parser.currentToken() == JsonToken.VALUE_NULL) {
-          r.moveNext();
-          return Optional.empty();
-        } else {
-          r.readStartArray();
-          if (r.parser.currentToken() == JsonToken.VALUE_NULL) r.parseExpected("] or item");
-          Optional<T> val = r.notEndArray() ? decodeVal.decode(r) : Optional.empty();
-          r.readEndArray();
-          return Optional.of(val);
-        }
-      };
-    }
-
-    public static <E extends Enum<E>> JsonLfDecoder<E> enumeration(Map<String, E> damlNameToEnum) {
-      return r -> r.readFromText(damlNameToEnum::get, new ArrayList<>(damlNameToEnum.keySet()));
-    }
-
-    // Provides a generic way to read a variant type, by specifying each tag.
-    public static <T> JsonLfDecoder<T> variant(
-        List<String> tagNames, Function<String, JsonLfDecoder<? extends T>> decoderByName) {
-      return r -> {
-        r.readStartObject();
-        T result = null;
-        FieldName field = r.readFieldName();
-        switch (field.name) {
-          case "tag":
-            {
-              var decoder = r.readFromText(decoderByName, tagNames);
-              FieldName valueField = r.readFieldName();
-              if (!valueField.name.equals("value")) {
-                r.parseExpected("field value", null, valueField.name, valueField.loc);
-              }
-              result = decoder.decode(r);
-              break;
-            }
-          case "value":
-            {
-              UnknownValue unknown = UnknownValue.read(r); // Can't decode until we know the tag.
-              FieldName tagField = r.readFieldName();
-              if (!tagField.name.equals("tag")) {
-                r.parseExpected("field tag", null, tagField.name, tagField.loc);
-              }
-              var decoder = r.readFromText(decoderByName, tagNames);
-              result = unknown.decodeWith(decoder);
-              break;
-            }
-          default:
-            r.parseExpected("field tag or value", null, field.name, field.loc);
-        }
-        r.readEndObject();
-        return result;
-      };
-    }
-
-    // Provides a generic way to read a record type, with a constructor arg for each field.
-    // This is a little fragile, so is better used by code-gen. Specifically:
-    // - The constructor must cast the elements and pass them to the T's constructor appropriately.
-    // - The elements of argNames should all evaluate to non non-null when applied to
-    // argsByName.
-    // - The index field values should correspond to the args passed to the constructor.
-    //
-    // e.g.
-    //     r.record(
-    //        asList("i", "b"),
-    //        name -> {
-    //          switch (name) {
-    //            case "i":
-    //              return JsonLfReader.JavaArg.at(0, r.list(r.int64()));
-    //            case "b":
-    //              return JsonLfReader.JavaArg.at(1, r.bool(), false);
-    //            default:
-    //              return null;
-    //          }
-    //        },
-    //        args -> new Foo((List<Long>) args[0], (Boolean) args[1]))
-    //     )
-    public static <T> JsonLfDecoder<T> record(
-        List<String> argNames,
-        Function<String, JavaArg<? extends Object>> argsByName,
-        Function<Object[], T> constr) {
-      return r -> {
-        Object[] args = new Object[argNames.size()];
-        if (r.isStartObject()) {
-          r.readStartObject();
-          while (r.notEndObject()) {
-            FieldName field = r.readFieldName();
-            var constrArg = argsByName.apply(field.name);
-            if (constrArg == null) r.unknownField(field.name, argNames, field.loc);
-            else args[constrArg.index] = constrArg.decode.decode(r);
-          }
-          r.readEndObject();
-        } else if (r.isStartArray()) {
-          r.readStartArray();
-          for (String fieldName : argNames) {
-            var field = argsByName.apply(fieldName);
-            args[field.index] = field.decode.decode(r);
-          }
-          r.readEndArray();
-        } else {
-          r.parseExpected("object or array");
-        }
-
-        // Handle missing fields.
-        for (String argName : argNames) {
-          JavaArg<? extends Object> arg = argsByName.apply(argName);
-          if (args[arg.index] != null) continue;
-          if (arg.defaultVal == null) r.missingField(argName);
-          args[arg.index] = arg.defaultVal;
-        }
-
-        return constr.apply(args);
-      };
-    }
-
-    // Represents an argument to the constructor of the code-gen class.
-    public static class JavaArg<T> {
-      final int index;
-      final JsonLfDecoder<T> decode;
-      final T defaultVal; // If non-null, used to populate value of missing fields.
-
-      private JavaArg(int index, JsonLfDecoder<T> decode, T defaultVal) {
-        this.index = index;
-        this.decode = decode;
-        this.defaultVal = defaultVal;
-      }
-
-      public static <T> JavaArg<T> at(int index, JsonLfDecoder<T> decode, T defaultVal) {
-        return new JavaArg<T>(index, decode, defaultVal);
-      }
-
-      public static <T> JavaArg<T> at(int index, JsonLfDecoder<T> decode) {
-        return new JavaArg<T>(index, decode, null);
-      }
-    }
-
-    @SuppressWarnings("unchecked")
-    // Can be used within the `constr` arg to `record`, to allow casting without producing warnings.
-    public static <T> T cast(Object o) {
-      return (T) o;
     }
   }
 
@@ -439,45 +99,49 @@ public class JsonLfReader {
 
   /// Used for branching and looping on objects and arrays. ///
 
-  private boolean isStartObject() {
+  boolean isStartObject() {
     return parser.currentToken() == JsonToken.START_OBJECT;
   }
 
-  private boolean notEndObject() {
+  boolean notEndObject() {
     return !parser.isClosed() && parser.currentToken() != JsonToken.END_OBJECT;
   }
 
-  private boolean isStartArray() {
+  boolean isStartArray() {
     return parser.currentToken() == JsonToken.START_ARRAY;
   }
 
-  private boolean notEndArray() {
+  boolean notEndArray() {
     return !parser.isClosed() && parser.currentToken() != JsonToken.END_ARRAY;
+  }
+
+  boolean isNull() {
+    return parser.currentToken() == JsonToken.VALUE_NULL;
   }
 
   /// Used for consuming the structural components of objects and arrays. ///
 
-  private void readStartObject() throws JsonLfDecoder.Error {
+  void readStartObject() throws JsonLfDecoder.Error {
     expectIsAt("{", JsonToken.START_OBJECT);
     moveNext();
   }
 
-  private void readEndObject() throws JsonLfDecoder.Error {
+  void readEndObject() throws JsonLfDecoder.Error {
     expectIsAt("}", JsonToken.END_OBJECT);
     moveNext();
   }
 
-  private void readStartArray() throws JsonLfDecoder.Error {
+  void readStartArray() throws JsonLfDecoder.Error {
     expectIsAt("[", JsonToken.START_ARRAY);
     moveNext();
   }
 
-  private void readEndArray() throws JsonLfDecoder.Error {
+  void readEndArray() throws JsonLfDecoder.Error {
     expectIsAt("]", JsonToken.END_ARRAY);
     moveNext();
   }
 
-  private class FieldName {
+  class FieldName {
     final String name;
     final Location loc;
 
@@ -487,7 +151,7 @@ public class JsonLfReader {
     }
   }
 
-  private FieldName readFieldName() throws JsonLfDecoder.Error {
+  FieldName readFieldName() throws JsonLfDecoder.Error {
     expectIsAt("field", JsonToken.FIELD_NAME);
     String name = null;
     try {
@@ -500,21 +164,27 @@ public class JsonLfReader {
     return new FieldName(name, loc);
   }
 
-  private <T> T readFromText(Function<String, T> interpreter, List<String> expected)
+  <T> T readFromText(Function<String, T> interpreter, List<String> expected)
       throws JsonLfDecoder.Error {
-    Location textLoc = locationStart();
-    String got = Decoders.text.decode(this);
+    expectIsAt("text", JsonToken.VALUE_STRING);
+    String got = null;
+    try {
+      got = parser.getText();
+    } catch (IOException e) {
+      parseExpected("valid textual value", e);
+    }
     T result = interpreter.apply(got);
-    if (result == null) parseExpected("one of " + expected, null, got, textLoc);
+    if (result == null) parseExpected("one of " + expected);
+    moveNext();
     return result;
   }
 
-  private Location locationStart() {
+  Location locationStart() {
     JsonLocation loc = parser.currentTokenLocation();
     return new Location(loc.getLineNr(), loc.getColumnNr(), (int) loc.getCharOffset());
   }
 
-  private Location locationEnd() {
+  Location locationEnd() {
     // First request the parser to retrieve the whole token.
     try {
       parser.finishToken();
@@ -524,30 +194,31 @@ public class JsonLfReader {
     return new Location(loc.getLineNr(), loc.getColumnNr(), (int) loc.getCharOffset());
   }
 
-  private String currentText() {
+  String currentText(String expected) throws JsonLfDecoder.Error {
+    String text = null;
     try {
-      String text = parser.getText();
-      return (text == null) ? "nothing" : text;
+      text = parser.getText();
     } catch (IOException e) {
-      return "? (" + e.getMessage() + ")";
+      parseExpected(expected, e, "nothing", locationStart());
     }
+    return text == null ? "nothing" : text;
   }
 
-  private void parseExpected(String expected) throws JsonLfDecoder.Error {
+  void parseExpected(String expected) throws JsonLfDecoder.Error {
     parseExpected(expected, null);
   }
 
-  private void parseExpected(String expected, Throwable cause) throws JsonLfDecoder.Error {
-    parseExpected(expected, cause, currentText(), locationStart());
+  void parseExpected(String expected, Throwable cause) throws JsonLfDecoder.Error {
+    parseExpected(expected, cause, currentText(expected), locationStart());
   }
 
-  private void parseExpected(String expected, Throwable cause, String actual, Location location)
+  void parseExpected(String expected, Throwable cause, String actual, Location location)
       throws JsonLfDecoder.Error {
     String message = String.format("Expected %s but was %s", expected, actual);
     throw new JsonLfDecoder.Error(message, location, cause);
   }
 
-  private void expectIsAt(String description, JsonToken... expected) throws JsonLfDecoder.Error {
+  void expectIsAt(String description, JsonToken... expected) throws JsonLfDecoder.Error {
     for (int i = 0; i < expected.length; i++) {
       if (parser.currentToken() == expected[i]) return;
     }
@@ -564,6 +235,4 @@ public class JsonLfReader {
       throw new JsonLfDecoder.Error(String.format("Read failed"), locationEnd(), e);
     }
   }
-
-  private static final int MAX_NUMERIC_PRECISION = 38;
 }

--- a/language-support/java/codegen/src/it/java/com/daml/ListTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/ListTest.java
@@ -11,7 +11,7 @@ import com.daml.ledger.javaapi.data.DamlRecord;
 import com.daml.ledger.javaapi.data.Text;
 import com.daml.ledger.javaapi.data.Unit;
 import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
-import com.daml.ledger.javaapi.data.codegen.json.JsonLfReader;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoders;
 import com.google.protobuf.Empty;
 import java.util.Arrays;
 import java.util.Collections;
@@ -306,7 +306,7 @@ public class ListTest {
     assertEquals(
         expected,
         ParameterizedListRecord.fromJson(
-            "{\"list\":[\"Element1\", \"Element2\"]}", JsonLfReader.Decoders.text));
+            "{\"list\":[\"Element1\", \"Element2\"]}", JsonLfDecoders.text));
   }
 
   @Test
@@ -399,6 +399,6 @@ public class ListTest {
         expected,
         ParameterizedListRecord.fromJson(
             "{\"list\": [[\"Element1\", \"Element2\"], [\"Element3\", \"Element4\"]]}",
-            JsonLfReader.Decoders.list(JsonLfReader.Decoders.text)));
+            JsonLfDecoders.list(JsonLfDecoders.text)));
   }
 }

--- a/language-support/java/codegen/src/it/java/com/daml/OptionalTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/OptionalTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.daml.ledger.api.v1.ValueOuterClass;
 import com.daml.ledger.javaapi.data.*;
 import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
-import com.daml.ledger.javaapi.data.codegen.json.JsonLfReader;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoders;
 import com.google.protobuf.Empty;
 import java.util.Arrays;
 import java.util.Optional;
@@ -200,8 +200,7 @@ public class OptionalTest {
     assertEquals(
         expected,
         OptionalVariant.fromJson(
-            "{\"tag\": \"OptionalParametricVariant\", \"value\": 42}",
-            JsonLfReader.Decoders.int64));
+            "{\"tag\": \"OptionalParametricVariant\", \"value\": 42}", JsonLfDecoders.int64));
   }
 
   @Test
@@ -222,6 +221,6 @@ public class OptionalTest {
     assertEquals(
         expected,
         OptionalVariant.fromJson(
-            "{\"tag\": \"OptionalPrimVariant\", \"value\": 42}", JsonLfReader.Decoders.int64));
+            "{\"tag\": \"OptionalPrimVariant\", \"value\": 42}", JsonLfDecoders.int64));
   }
 }

--- a/language-support/java/codegen/src/it/java/com/daml/RecordTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/RecordTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertTrue;
 import com.daml.ledger.api.v1.ValueOuterClass;
 import com.daml.ledger.javaapi.data.*;
 import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
-import com.daml.ledger.javaapi.data.codegen.json.JsonLfReader;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoders;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -261,8 +261,8 @@ public class RecordTest {
                 + " \"fieldInt\": 42}, "
                 + "\"innerFixed\":  {\"fieldX1\": \"42\", \"fieldX2\": \"69\","
                 + " \"fieldY\": \"Text2\", \"fieldInt\": 69} }",
-            JsonLfReader.Decoders.text,
-            JsonLfReader.Decoders.bool));
+            JsonLfDecoders.text,
+            JsonLfDecoders.bool));
   }
 
   Long int64Value = 1L;

--- a/language-support/java/codegen/src/it/java/com/daml/TextMapTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/TextMapTest.java
@@ -10,7 +10,7 @@ import com.daml.ledger.javaapi.data.DamlRecord;
 import com.daml.ledger.javaapi.data.Int64;
 import com.daml.ledger.javaapi.data.Variant;
 import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
-import com.daml.ledger.javaapi.data.codegen.json.JsonLfReader;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoders;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -332,8 +332,7 @@ public class TextMapTest {
     assertEquals(
         expected,
         MapVariant.fromJson(
-            "{\"tag\": \"TextVariant\", \"value\": {\"key\": \"value\"}}",
-            JsonLfReader.Decoders.unit));
+            "{\"tag\": \"TextVariant\", \"value\": {\"key\": \"value\"}}", JsonLfDecoders.unit));
   }
 
   @Test
@@ -385,7 +384,7 @@ public class TextMapTest {
         expected,
         MapVariant.fromJson(
             "{\"tag\": \"RecordVariant\", \"value\": {\"x\": {\"key\": 42}}}",
-            JsonLfReader.Decoders.unit));
+            JsonLfDecoders.unit));
   }
 
   @Test
@@ -430,8 +429,7 @@ public class TextMapTest {
     assertEquals(
         expected,
         MapVariant.fromJson(
-            "{\"tag\": \"ParameterizedVariant\", \"value\": {\"key\": 42}}",
-            JsonLfReader.Decoders.int64));
+            "{\"tag\": \"ParameterizedVariant\", \"value\": {\"key\": 42}}", JsonLfDecoders.int64));
   }
 
   @Test

--- a/language-support/java/codegen/src/it/java/com/daml/VariantTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/VariantTest.java
@@ -10,7 +10,7 @@ import com.daml.ledger.javaapi.data.Int64;
 import com.daml.ledger.javaapi.data.Unit;
 import com.daml.ledger.javaapi.data.Variant;
 import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
-import com.daml.ledger.javaapi.data.codegen.json.JsonLfReader;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoders;
 import com.google.protobuf.Empty;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -49,8 +49,7 @@ public class VariantTest {
     VariantItem<?> expected = new EmptyVariant<>(Unit.getInstance());
     assertEquals(
         expected,
-        VariantItem.fromJson(
-            "{\"tag\": \"EmptyVariant\", \"value\": {}}", JsonLfReader.Decoders.unit));
+        VariantItem.fromJson("{\"tag\": \"EmptyVariant\", \"value\": {}}", JsonLfDecoders.unit));
   }
 
   @Test
@@ -78,8 +77,7 @@ public class VariantTest {
     VariantItem<?> expected = new PrimVariant<>(42L);
     assertEquals(
         expected,
-        VariantItem.fromJson(
-            "{\"tag\": \"PrimVariant\", \"value\": 42}", JsonLfReader.Decoders.unit));
+        VariantItem.fromJson("{\"tag\": \"PrimVariant\", \"value\": 42}", JsonLfDecoders.unit));
   }
 
   @Test
@@ -116,7 +114,7 @@ public class VariantTest {
     assertEquals(
         expected,
         VariantItem.fromJson(
-            "{\"tag\": \"RecordVariant\", \"value\": {\"x\": 42}}", JsonLfReader.Decoders.unit));
+            "{\"tag\": \"RecordVariant\", \"value\": {\"x\": 42}}", JsonLfDecoders.unit));
   }
 
   @Test
@@ -147,8 +145,7 @@ public class VariantTest {
     VariantItem<?> expected = new CustomVariant<>(new Custom());
     assertEquals(
         expected,
-        VariantItem.fromJson(
-            "{\"tag\": \"CustomVariant\", \"value\": {}}", JsonLfReader.Decoders.unit));
+        VariantItem.fromJson("{\"tag\": \"CustomVariant\", \"value\": {}}", JsonLfDecoders.unit));
   }
 
   @Test
@@ -189,7 +186,7 @@ public class VariantTest {
         VariantItem.fromJson(
             "{\"tag\": \"CustomParametricVariant\", \"value\": {\"tag\": \"CustomParametricCons\","
                 + " \"value\": 42}}",
-            JsonLfReader.Decoders.int64));
+            JsonLfDecoders.int64));
   }
 
   @Test
@@ -237,7 +234,7 @@ public class VariantTest {
         VariantItem.fromJson(
             "{\"tag\": \"RecordVariantRecord\", \"value\": {\"y\": {\"tag\": \"EmptyVariant\","
                 + " \"value\": {}}}}",
-            JsonLfReader.Decoders.int64));
+            JsonLfDecoders.int64));
   }
 
   @Test
@@ -294,6 +291,6 @@ public class VariantTest {
         VariantItem.fromJson(
             "{\"tag\": \"ParameterizedRecordVariant\", \"value\": {\"x1\": 42, \"x2\": 69, \"x3\":"
                 + " [65536]}}",
-            JsonLfReader.Decoders.int64));
+            JsonLfDecoders.int64));
   }
 }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromJsonGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromJsonGenerator.scala
@@ -3,7 +3,7 @@
 
 package com.daml.lf.codegen.backend.java.inner
 
-import com.daml.ledger.javaapi.data.codegen.json.{JsonLfReader, JsonLfDecoder}
+import com.daml.ledger.javaapi.data.codegen.json.{JsonLfReader, JsonLfDecoder, JsonLfDecoders}
 import com.typesafe.scalalogging.StrictLogging
 import javax.lang.model.element.Modifier
 import com.squareup.javapoet.{
@@ -18,7 +18,7 @@ import com.squareup.javapoet.{
 import scala.jdk.CollectionConverters._
 
 private[inner] object FromJsonGenerator extends StrictLogging {
-  private def decodeClass = ClassName.get(classOf[JsonLfReader.Decoders])
+  private def decodeClass = ClassName.get(classOf[JsonLfDecoders])
 
   // JsonLfDecoder<T>
   private def decoderTypeName(t: TypeName) =
@@ -72,8 +72,9 @@ private[inner] object FromJsonGenerator extends StrictLogging {
         .beginControlFlow("switch (name)")
       fields.zipWithIndex.foreach { case (f, i) =>
         block.addStatement(
-          "case $S: return JsonLfReader.Decoders.JavaArg.at($L, $L)",
+          "case $S: return $T.at($L, $L)",
           f.javaName,
+          decodeClass.nestedClass("JavaArg"),
           i,
           jsonDecoderForType(f.damlType),
         )


### PR DESCRIPTION
Mostly mechanical change, pulling nested static class `JsonLfReader.Decoders` out into its own class `JsonLfDecoders`.

Previously the nested class could access private members of `JsonLfReader`. I've now made the relevant methods package-accessible, and the fully private components such as anything from the jackson library are properly private. `currentText()` becomes the single way for `JsonLfDecoders` to read the current value.

This change will mirror what we'll then do with the upcoming `JsonLfEncoders`.