### PR TITLE
Remove warning that prevents canton tests from passing

### DIFF
--- a/daml-lf/language/BUILD.bazel
+++ b/daml-lf/language/BUILD.bazel
@@ -21,7 +21,6 @@ da_scala_library(
     deps = [
         "//daml-lf/data",
         "//libs-scala/nameof",
-        "@maven//:org_slf4j_slf4j_api",
     ],
 )
 

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -117,14 +117,6 @@ object LanguageVersion {
     }
   }
 
-  // To temporarily preserve compatibility with Canton which creates an engine
-  // for the range (1.14, DevVersions.max) when running in dev mode and doesn't
-  // distinguish between LF1 and LF2. Usage in the daml repository is forbidden.
-  // TODO(#17366): delete and get Canton to use AllVersions.
-  @deprecated("use LanguageVersion.AllVersions", since = "2.8.0")
-  def DevVersions: VersionRange[LanguageVersion] =
-    VersionRange(v1_dev, v2_dev)
-
   // This refers to the default output LF version in the compiler
   val default: LanguageVersion = v1_14
 }
@@ -135,10 +127,10 @@ object LanguageVersionRangeOps {
 
   implicit class LanguageVersionRange(val range: VersionRange[LanguageVersion]) {
     def majorVersion: LanguageMajorVersion = {
-      // TODO(#17366): turn this into a precondition once Canton stops using DevVersions.
-      if (range.min.major != range.max.major) {
-        logger.warn(s"version range ${range} spans over multiple version LF versions")
-      }
+      // TODO(#17366): uncomment once Canton stops using (1.14, 2.dev) as the version range for dev.
+      // require(
+      //  range.min.major == range.max.major,
+      //  s"version range ${range} spans over multiple version LF versions")
       range.max.major
     }
   }

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -115,6 +115,14 @@ object LanguageVersion {
     }
   }
 
+// To temporarily preserve compatibility with Canton which creates an engine
+  // for the range (1.14, DevVersions.max) when running in dev mode and doesn't
+  // distinguish between LF1 and LF2. Usage in the daml repository is forbidden.
+  // TODO(#17366): delete and get Canton to use AllVersions.
+  @deprecated("use LanguageVersion.AllVersions", since = "2.8.0")
+  def DevVersions: VersionRange[LanguageVersion] =
+    VersionRange(v1_dev, v2_dev)
+
   // This refers to the default output LF version in the compiler
   val default: LanguageVersion = v1_14
 }

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -4,8 +4,6 @@
 package com.daml.lf
 package language
 
-import org.slf4j.LoggerFactory
-
 import scala.annotation.nowarn
 
 final case class LanguageVersion(major: LanguageMajorVersion, minor: LanguageMinorVersion) {
@@ -123,8 +121,6 @@ object LanguageVersion {
 
 /** Operations on [[VersionRange]] that only make sense for ranges of [[LanguageVersion]]. */
 object LanguageVersionRangeOps {
-  private[this] val logger = LoggerFactory.getLogger(this.getClass)
-
   implicit class LanguageVersionRange(val range: VersionRange[LanguageVersion]) {
     def majorVersion: LanguageMajorVersion = {
       // TODO(#17366): uncomment once Canton stops using (1.14, 2.dev) as the version range for dev.


### PR DESCRIPTION
Some canton tests will fail if the log contains any warning. Having an engine with a version range spanning two major versions is necessary at the moment (see https://github.com/digital-asset/daml/pull/17492) so we turn this warning into a precondition but leave it commented out at the moment.

`DevVersions` is no longer used by Canton so we remove it.