### PR TITLE
Fix version caching

### DIFF
--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -100,8 +100,8 @@ commandWantsProjectPath cmd = LookForProjectPath $
 -- versions are out of date with the latest known release.
 versionChecks :: Env -> IO ()
 versionChecks Env{..} = do
-    envLatestStableSdkVersion <- envLatestStableSdkVersion
-    whenJust envLatestStableSdkVersion $ \latestVersion -> do
+    envFreshStableSdkVersionForCheck <- envFreshStableSdkVersionForCheck
+    whenJust envFreshStableSdkVersionForCheck $ \latestVersion -> do
         let isHead = maybe False isHeadVersion envSdkVersion
             projectSdkVersionIsOld = isJust envProjectPath && envSdkVersion < Just latestVersion
             assistantVersionIsOld = isJust envDamlAssistantSdkVersion &&

--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -18,6 +18,7 @@ import DA.Daml.Assistant.Command
 import DA.Daml.Assistant.Version
 import DA.Daml.Assistant.Install
 import DA.Daml.Assistant.Util
+import DA.Daml.Assistant.Cache
 import System.Environment (getArgs, lookupEnv)
 import System.FilePath
 import System.Directory
@@ -196,7 +197,7 @@ runCommand env@Env{..} = \case
               UseCache
                 { cachePath = envCachePath
                 , damlPath = envDamlPath
-                , forceReload = vForceRefresh
+                , overrideTimeout = if vForceRefresh then Just (CacheTimeout 1) else Nothing
                 }
         installedVersionsE <- tryAssistant $ getInstalledSdkVersions envDamlPath
         snapshotVersionsEUnfiltered <- tryAssistant $ fst <$> getAvailableSdkSnapshotVersions useCache

--- a/daml-assistant/src/DA/Daml/Assistant/Cache.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Cache.hs
@@ -67,10 +67,12 @@ cacheAvailableSdkVersions UseCache { overrideTimeout, cachePath, damlPath } getV
     damlConfigE <- tryConfig $ readDamlConfig damlPath
     let configUpdateCheckM = join $ eitherToMaybe (queryDamlConfig ["update-check"] =<< damlConfigE)
         (allowExistingStaleCache, timeout)
+            -- A few different things can override the timeout behaviour in
+            -- daml-config.yaml, chiefly `daml install latest` and `daml version --force-reload yes`
           | Just timeout <- overrideTimeout = (False, timeout)
           | Just updateCheck <- configUpdateCheckM =
               case updateCheck of
-                -- When UpdateCheckNever, still refresh the cache if it's completely empty
+                -- When UpdateCheckNever, still refresh the cache if it doesn't exist
                 UpdateCheckNever -> (True, CacheTimeout (1000 * 365 * 86400))
                 UpdateCheckEvery timeout -> (False, timeout)
           | otherwise = (False, CacheTimeout 86400)

--- a/daml-assistant/src/DA/Daml/Assistant/Env.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Env.hs
@@ -48,7 +48,7 @@ envUseCache Env {..} =
 
 mkUseCache :: CachePath -> DamlPath -> UseCache
 mkUseCache cachePath damlPath =
-  UseCache { cachePath, damlPath, forceReload = False }
+  UseCache { cachePath, damlPath, overrideTimeout = Nothing }
 
 -- | (internal) Override function with environment variable
 -- if it is available.

--- a/daml-assistant/src/DA/Daml/Assistant/Env.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Env.hs
@@ -39,7 +39,7 @@ getDamlEnv envDamlPath lookForProjectPath = do
     envProjectPath <- getProjectPath lookForProjectPath
     (envSdkVersion, envSdkPath) <- getSdk envDamlPath envProjectPath
     envCachePath <- getCachePath
-    envLatestStableSdkVersion <- getLatestStableSdkVersion (mkUseCache envCachePath envDamlPath)
+    envFreshStableSdkVersionForCheck <- getFreshStableSdkVersionForCheck (mkUseCache envCachePath envDamlPath)
     pure Env {..}
 
 envUseCache :: Env -> UseCache
@@ -83,8 +83,8 @@ overrideWithEnvVarMaybe envVar normalize parse calculate = do
 
 -- | Get the latest stable SDK version. Can be overriden with
 -- DAML_SDK_LATEST_VERSION environment variable.
-getLatestStableSdkVersion :: UseCache -> IO (IO (Maybe SdkVersion))
-getLatestStableSdkVersion useCache = do
+getFreshStableSdkVersionForCheck :: UseCache -> IO (IO (Maybe SdkVersion))
+getFreshStableSdkVersionForCheck useCache = do
   val <- getEnv sdkVersionLatestEnvVar
   case val of
     Nothing -> pure (freshMaximumOfVersions (getAvailableReleaseVersions useCache))
@@ -234,14 +234,14 @@ getSdk damlPath projectPathM =
 getDispatchEnv :: Env -> IO [(String, String)]
 getDispatchEnv Env{..} = do
     originalEnv <- getEnvironment
-    envLatestStableSdkVersion <- envLatestStableSdkVersion
+    envFreshStableSdkVersionForCheck <- envFreshStableSdkVersionForCheck
     pure $ filter ((`notElem` damlEnvVars) . fst) originalEnv
         ++ [ (damlPathEnvVar, unwrapDamlPath envDamlPath)
            , (damlCacheEnvVar, unwrapCachePath envCachePath)
            , (projectPathEnvVar, maybe "" unwrapProjectPath envProjectPath)
            , (sdkPathEnvVar, maybe "" unwrapSdkPath envSdkPath)
            , (sdkVersionEnvVar, maybe "" versionToString envSdkVersion)
-           , (sdkVersionLatestEnvVar, maybe "" versionToString envLatestStableSdkVersion)
+           , (sdkVersionLatestEnvVar, maybe "" versionToString envFreshStableSdkVersionForCheck)
            , (damlAssistantEnvVar, unwrapDamlAssistantPath envDamlAssistantPath)
            , (damlAssistantVersionEnvVar, maybe ""
                (versionToString . unwrapDamlAssistantSdkVersion)

--- a/daml-assistant/src/DA/Daml/Assistant/Env.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Env.hs
@@ -87,7 +87,7 @@ getLatestStableSdkVersion :: UseCache -> IO (IO (Maybe SdkVersion))
 getLatestStableSdkVersion useCache = do
   val <- getEnv sdkVersionLatestEnvVar
   case val of
-    Nothing -> pure (getLatestSdkVersion useCache)
+    Nothing -> pure (freshMaximumOfVersions (getAvailableReleaseVersions useCache))
     Just "" -> pure (pure Nothing)
     Just value -> do
       parsed <- requiredE

--- a/daml-assistant/src/DA/Daml/Assistant/Install.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install.hs
@@ -22,6 +22,7 @@ import qualified DA.Daml.Assistant.Install.Github as Github
 import DA.Daml.Assistant.Install.Path
 import DA.Daml.Assistant.Install.Completion
 import DA.Daml.Assistant.Version (getLatestSdkSnapshotVersion, getLatestReleaseVersion, UseCache (..))
+import DA.Daml.Assistant.Cache (CacheTimeout (..))
 import DA.Daml.Project.Consts
 import DA.Daml.Project.Config
 import Safe
@@ -418,6 +419,9 @@ versionInstall env@InstallEnv{..} version = withInstallLock env $ do
 latestInstall :: InstallEnv -> IO ()
 latestInstall env@InstallEnv{..} = do
     version1 <- getLatestReleaseVersion useCache
+        -- override the cache if it's older than 1 day, even if daml-config.yaml says otherwise
+        { overrideTimeout = Just (CacheTimeout 86400)
+        }
     version2M <- if iSnapshots options
         then tryAssistantM $ getLatestSdkSnapshotVersion useCache
         else pure Nothing

--- a/daml-assistant/src/DA/Daml/Assistant/Install.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install.hs
@@ -419,7 +419,7 @@ latestInstall :: InstallEnv -> IO ()
 latestInstall env@InstallEnv{..} = do
     version1 <- getLatestReleaseVersion useCache
     version2M <- if iSnapshots options
-        then getLatestSdkSnapshotVersion useCache
+        then tryAssistantM $ getLatestSdkSnapshotVersion useCache
         else pure Nothing
     let version = maybe version1 (max version1) version2M
     versionInstall env version

--- a/daml-assistant/src/DA/Daml/Assistant/Types.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Types.hs
@@ -58,7 +58,7 @@ data EnvF f = Env
     , envProjectPath   :: Maybe ProjectPath
     , envSdkPath       :: Maybe SdkPath
     , envSdkVersion    :: Maybe SdkVersion
-    , envLatestStableSdkVersion :: f (Maybe SdkVersion)
+    , envFreshStableSdkVersionForCheck :: f (Maybe SdkVersion)
     }
 
 deriving instance Eq (f (Maybe SdkVersion)) => Eq (EnvF f)
@@ -68,7 +68,7 @@ type Env = EnvF IO
 
 forceEnv :: Monad m => EnvF m -> m (EnvF Identity)
 forceEnv Env{..} = do
-  envLatestStableSdkVersion <- fmap Identity envLatestStableSdkVersion
+  envFreshStableSdkVersionForCheck <- fmap Identity envFreshStableSdkVersionForCheck
   pure Env{..}
 
 data BuiltinCommand

--- a/daml-assistant/src/DA/Daml/Assistant/Version.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Version.hs
@@ -276,7 +276,7 @@ maximumOfNonEmptyVersions :: IO ([SdkVersion], CacheAge) -> IO SdkVersion
 maximumOfNonEmptyVersions getVersions = do
     (versions, _cacheAge) <- getVersions
     case maximumMay versions of
-      Nothing -> throwIO $ assistantError $ pack $ "Version list is empty."
+      Nothing -> throwIO $ assistantError $ pack "Version list is empty."
       Just m -> pure m
 
 -- | Get the latest released SDK version

--- a/daml-assistant/src/DA/Daml/Assistant/Version.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Version.hs
@@ -9,7 +9,6 @@ module DA.Daml.Assistant.Version
     , getAssistantSdkVersion
     , getDefaultSdkVersion
     , getAvailableReleaseVersions
-    , getLatestSdkVersion
     , getAvailableSdkSnapshotVersions
     , getAvailableSdkSnapshotVersionsUncached
     , findAvailableSdkSnapshotVersion
@@ -18,6 +17,7 @@ module DA.Daml.Assistant.Version
     , isReleaseVersion
     , extractReleasesFromSnapshots
     , UseCache (..)
+    , freshMaximumOfVersions
     ) where
 
 import DA.Daml.Assistant.Types
@@ -272,25 +272,26 @@ instance FromJSON ParsedSdkVersion where
         Left (InvalidVersion src msg) -> fail $ "Invalid version string `" <> unpack src <> "` for reason: " <> msg
         Right sdkVersion -> pure ParsedSdkVersion { unParsedSdkVersion = sdkVersion, isPrerelease }
 
+maximumOfNonEmptyVersions :: IO ([SdkVersion], CacheAge) -> IO SdkVersion
+maximumOfNonEmptyVersions getVersions = do
+    (versions, _cacheAge) <- getVersions
+    case maximumMay versions of
+      Nothing -> throwIO $ assistantError $ pack $ "Version list is empty."
+      Just m -> pure m
+
 -- | Get the latest released SDK version
-getLatestSdkVersion :: UseCache -> IO (Maybe SdkVersion)
-getLatestSdkVersion useCache = do
-    versionE <- tryAssistant (getAvailableReleaseVersions useCache)
-    pure $ do
-      (versions, _cacheAge) <- eitherToMaybe versionE
-      maximumMay versions
+freshMaximumOfVersions :: IO ([SdkVersion], CacheAge) -> IO (Maybe SdkVersion)
+freshMaximumOfVersions getVersions = do
+    (versions, cacheAge) <- getVersions
+    case cacheAge of
+      Stale -> pure Nothing
+      Fresh -> pure (maximumMay versions)
 
 -- | Get the latest snapshot SDK version.
-getLatestSdkSnapshotVersion :: UseCache -> IO (Maybe SdkVersion)
+getLatestSdkSnapshotVersion :: UseCache -> IO SdkVersion
 getLatestSdkSnapshotVersion useCache = do
-    versionE <- tryAssistant (getAvailableSdkSnapshotVersions useCache)
-    pure $ do
-      (versions, _cacheAge) <- eitherToMaybe versionE
-      maximumMay versions
+    maximumOfNonEmptyVersions (getAvailableSdkSnapshotVersions useCache)
 
 getLatestReleaseVersion :: UseCache -> IO SdkVersion
-getLatestReleaseVersion useCache = do
-    mbReleaseVersion <- getLatestSdkVersion useCache
-    case mbReleaseVersion of
-      Nothing -> throwIO $ assistantError (pack "Failed to get latest release version from github.com")
-      Just rv -> pure rv
+getLatestReleaseVersion useCache =
+    maximumOfNonEmptyVersions (getAvailableReleaseVersions useCache)

--- a/daml-assistant/src/DA/Daml/Assistant/Version.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Version.hs
@@ -205,6 +205,10 @@ searchSnapshotsUntil pred SnapshotsList { versions, next } = do
 -- | Get the list of available snapshot versions, until finding a version of
 -- interest. This will fetch https://api.github.com/repos/digital-asset/daml/releases
 -- and parse the obtained JSON.
+-- We do *not* use
+-- https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release
+-- because it sorts by time of upload, so a minor version bump like 2.5.15 may
+-- supersede 2.7.2 if the minor release on 2.5.12 was released later
 getAvailableSdkSnapshotVersionsUncached :: IO SnapshotsList
 getAvailableSdkSnapshotVersionsUncached = do
   requestReleasesSnapshotsList "https://api.github.com/repos/digital-asset/daml/releases"

--- a/daml-assistant/test/DA/Daml/Assistant/Tests.hs
+++ b/daml-assistant/test/DA/Daml/Assistant/Tests.hs
@@ -292,7 +292,7 @@ testGetDispatchEnv = Tasty.testGroup "DA.Daml.Assistant.Env.getDispatchEnv"
                     , envDamlAssistantPath = DamlAssistantPath (base </> ".daml" </> "bin" </> "strange-daml")
                     , envDamlAssistantSdkVersion = Just $ DamlAssistantSdkVersion version
                     , envSdkVersion = Just version
-                    , envLatestStableSdkVersion = pure (Just version)
+                    , envFreshStableSdkVersionForCheck = pure (Just version)
                     , envSdkPath = Just $ SdkPath (base </> "sdk")
                     , envProjectPath = Just $ ProjectPath (base </> "proj")
                     }
@@ -309,7 +309,7 @@ testGetDispatchEnv = Tasty.testGroup "DA.Daml.Assistant.Env.getDispatchEnv"
                     , envDamlAssistantPath = DamlAssistantPath (base </> ".daml" </> "bin" </> "strange-daml")
                     , envDamlAssistantSdkVersion = Just $ DamlAssistantSdkVersion version
                     , envSdkVersion = Just version
-                    , envLatestStableSdkVersion = pure (Just version)
+                    , envFreshStableSdkVersionForCheck = pure (Just version)
                     , envSdkPath = Just $ SdkPath (base </> "sdk")
                     , envProjectPath = Just $ ProjectPath (base </> "proj")
                     }
@@ -327,7 +327,7 @@ testGetDispatchEnv = Tasty.testGroup "DA.Daml.Assistant.Env.getDispatchEnv"
                     , envDamlAssistantPath = DamlAssistantPath (base </> ".daml" </> "bin" </> "strange-daml")
                     , envDamlAssistantSdkVersion = Nothing
                     , envSdkVersion = Nothing
-                    , envLatestStableSdkVersion = pure Nothing
+                    , envFreshStableSdkVersionForCheck = pure Nothing
                     , envSdkPath = Nothing
                     , envProjectPath = Nothing
                     }


### PR DESCRIPTION
`daml install latest` does not retrieve a list of versions to install from because of the default `update-check: never` in `$HOME/.daml/daml-config.yaml`, which interacts incorrectly with version retrieval in `daml-assistant/src/DA/Daml/Assistant/Version.hs` and `daml-assistant/src/DA/Daml/Assistant/Cache.hs`, which was added in https://github.com/digital-asset/daml/pull/17029

We change this now:
- When `daml install latest` or `daml version --force-reload` is invoked, it overrides the caching behaviour specified in `.daml/daml-config.yaml`. This preserves the original behaviour before seen.
- When any function requests a list of versions, the list is at least retrieved once, regardless of caching in `.daml/daml-config.yaml`
- Clarify which functions should and shouldn't fail when a list is not available from Github 