### PR TITLE
[DEPRECATED] Explicit disclosure API changes for upgrading

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
@@ -222,12 +222,13 @@ message DisclosedContract {
   // The contract arguments
   // Required
   oneof arguments {
-    // The contract arguments as typed Record
+    // The contract arguments as typed record.
+    // The record passed must be exactly the same as the one retrieved in the ``create_arguments`` field
+    // of the ``com.daml.ledger.api.v1.CreatedEvent`` message.
     Record create_arguments = 3;
 
-    // The contract arguments specified using an opaque blob extracted from the ``create_arguments_blob`` field
-    // of a ``com.daml.ledger.api.v1.CreatedEvent``.
-    google.protobuf.Any create_arguments_blob = 5;
+    // Deprecated, use ``create_arguments`` instead.
+    google.protobuf.Any create_arguments_blob = 5 [deprecated = true];
   }
 
   // The contract metadata from the create event.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
@@ -68,11 +68,10 @@ message CreatedEvent {
   // Optional
   Record create_arguments = 4;
 
-  // Opaque representation of contract payload intended for forwarding
-  // to an API server as a contract disclosed as part of a command
-  // submission.
+  // Deprecated. Use the data retrieved in ``create_arguments`` field
+  // for submitting as a disclosed contract with future commands.
   // Optional
-  google.protobuf.Any create_arguments_blob = 12;
+  google.protobuf.Any create_arguments_blob = 12 [deprecated = true];
 
   // Interface views specified in the transaction filter.
   // Includes an ``InterfaceView`` for each interface for which there is a ``InterfaceFilter`` with

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
@@ -70,10 +70,8 @@ message InterfaceFilter {
   // Optional
   bool include_interface_view = 2;
 
-  // Whether to include a ``create_arguments_blob`` in the returned
-  // ``CreateEvent``.
-  // Use this to access the complete contract data in your API client
-  // for submitting it as a disclosed contract with future commands.
+  // Deprecated. Use the data retrieved in ``create_arguments`` field of the ``CreatedEvent``
+  // for submitting as a disclosed contract with future commands.
   // Optional
-  bool include_create_arguments_blob = 3;
+  bool include_create_arguments_blob = 3 [deprecated = true];
 }


### PR DESCRIPTION
An alternative approach to supporting the upgrading in the explicit disclosure proposed in #17546.

The blobs have been removed. Instead, the explicit disclosure will rely on verbatim transfer of the `create_argument` record retrieved by the publisher in the `CreatedEvents` into the `DisclosedContract` of the command submission by the target client. 
