### PR TITLE
Add LF2 support to interpreter/perf/explore

### DIFF
--- a/daml-lf/interpreter/perf/BUILD.bazel
+++ b/daml-lf/interpreter/perf/BUILD.bazel
@@ -16,6 +16,9 @@ da_scala_binary(
     name = "explore",
     srcs = glob(["src/main/**/Explore.scala"]),
     main_class = "com.daml.lf.speedy.explore.Explore",
+    scala_deps = [
+        "@maven//:com_github_scopt_scopt",
+    ],
     runtime_deps = [
         "@maven//:ch_qos_logback_logback_classic",
     ],

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
@@ -8,7 +8,6 @@ package explore
 import com.daml.bazeltools.BazelRunfiles.rlocation
 import com.daml.lf.archive.UniversalArchiveDecoder
 import com.daml.lf.data.Ref.{DefinitionRef, Identifier, QualifiedName}
-import com.daml.lf.language.LanguageMajorVersion
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.Speedy._
@@ -77,9 +76,10 @@ object PlaySpeedy {
     val packages = UniversalArchiveDecoder.assertReadFile(darFile)
 
     println(s"Compiling packages... ${config.stacktracing}")
-    // TODO(#17366): Add support for LF v2 if we keep this in daml3
     val compilerConfig =
-      Compiler.Config.Default(LanguageMajorVersion.V1).copy(stacktracing = config.stacktracing)
+      Compiler.Config
+        .Default(packages.main._2.languageVersion.major)
+        .copy(stacktracing = config.stacktracing)
     val compiledPackages =
       PureCompiledPackages.build(packages.all.toMap, compilerConfig) match {
         case Right(x) => x

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
@@ -24,10 +24,9 @@ object LoadDarFunction extends App {
 
     val packages = UniversalArchiveDecoder.assertReadFile(darFile)
 
-    // TODO(#17366): Add support for LF v2 if we keep this in daml3
     val compilerConfig =
       Compiler.Config
-        .Default(LanguageMajorVersion.V1)
+        .Default(packages.main._2.languageVersion.major)
         .copy(
           stacktracing = Compiler.NoStackTrace
         )

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
@@ -7,7 +7,6 @@ package explore
 
 import com.daml.lf.archive.UniversalArchiveDecoder
 import com.daml.lf.data.Ref.{DefinitionRef, Identifier, QualifiedName}
-import com.daml.lf.language.LanguageMajorVersion
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._


### PR DESCRIPTION
Not sure we'll use it with daml3 but it's easy to add and it might come in handy when we start changing the LF format or simplify the engine.
