### PR TITLE
Exclude `canton/` from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 
+exclude: '^canton/'
 repos:
 - repo: local
   hooks:
@@ -45,4 +46,3 @@ repos:
       pass_filenames: false
       entry: "dade-copyright-headers update"
       types: [text]
-


### PR DESCRIPTION
Today, the `javafmt` pre-commit hook complains about some files in the canton code drop, namely

* canton/community/common/src/test/java/com/digitalasset/canton/annotations/UnstableTest.java
* canton/community/lib/Blake2b/src/main/java/org/bouncycastle/crypto/digests/canton/Blake2bDigest.java
* canton/community/testing/src/main/java/com/digitalasset/canton/logging/BufferingLogger.java
* canton/community/testing/src/main/java/com/digitalasset/canton/logging/SuppressingLoggerDispatcher.java

Since these are not the responsibility of this repo, I'd rather exclude the entire `canton/` directory from our hooks