### PR TITLE
Explicit disclosure based on blobs only

### DIFF
--- a/buf-ledger-api.yaml
+++ b/buf-ledger-api.yaml
@@ -17,7 +17,3 @@ breaking:
     #
     # We rely in particular on fields not getting renamed in `UpdateXXX` calls that use a `FieldMask`
     # to select the fields to update, see https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/field_mask.proto
-  ignore_only:
-    FIELD_NO_DELETE:
-      - com/daml/ledger/api/v1/commands.proto
-      - com/daml/ledger/api/v1/event.proto

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/TransactionsClientImplTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/TransactionsClientImplTest.scala
@@ -20,6 +20,8 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.jdk.CollectionConverters._
 
+// Allows using deprecated Protobuf fields for testing
+@annotation.nowarn("cat=deprecation&origin=com\\.daml\\.ledger\\.api\\.v1\\..*")
 final class TransactionsClientImplTest
     extends AnyFlatSpec
     with ScalaCheckDrivenPropertyChecks

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
@@ -246,6 +246,7 @@ object TransactionGenerator {
         contractKey.map(_._1),
         Some(scalaRecord),
         Some(com.google.protobuf.any.Any.fromJavaProto(createArgumentsBlob)),
+        ByteString.EMPTY,
         interfaceViews.map(_._1),
         signatories ++ observers,
         signatories,

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CreatedEvent.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CreatedEvent.java
@@ -273,6 +273,7 @@ public final class CreatedEvent implements Event, TreeEvent {
         + '}';
   }
 
+  @SuppressWarnings("deprecation")
   public EventOuterClass.@NonNull CreatedEvent toProto() {
     EventOuterClass.CreatedEvent.Builder builder =
         EventOuterClass.CreatedEvent.newBuilder()
@@ -311,6 +312,7 @@ public final class CreatedEvent implements Event, TreeEvent {
                     .build());
   }
 
+  @SuppressWarnings("deprecation")
   public static CreatedEvent fromProto(EventOuterClass.CreatedEvent createdEvent) {
     var splitInterfaceViews =
         createdEvent.getInterfaceViewsList().stream()

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DisclosedContract.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DisclosedContract.java
@@ -35,6 +35,7 @@ public final class DisclosedContract {
       this.arguments = arguments;
     }
 
+    @SuppressWarnings("deprecation")
     public CommandsOuterClass.DisclosedContract.Builder toProto(
         CommandsOuterClass.DisclosedContract.Builder builder) {
       return builder.setCreateArguments(arguments.toProtoRecord());
@@ -48,6 +49,7 @@ public final class DisclosedContract {
       this.createArgumentsBlob = createArgumentsBlob;
     }
 
+    @SuppressWarnings("deprecation")
     public CommandsOuterClass.DisclosedContract.Builder toProto(
         CommandsOuterClass.DisclosedContract.Builder builder) {
       return builder.setCreateArgumentsBlob(createArgumentsBlob);
@@ -55,6 +57,7 @@ public final class DisclosedContract {
   }
 
   public CommandsOuterClass.DisclosedContract toProto() {
+    @SuppressWarnings("deprecation")
     var builder =
         CommandsOuterClass.DisclosedContract.newBuilder()
             .setTemplateId(this.templateId.toProto())

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/InclusiveFilter.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/InclusiveFilter.java
@@ -49,6 +49,7 @@ public final class InclusiveFilter extends Filter {
     return interfaceIds;
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public TransactionFilterOuterClass.Filters toProto() {
     ArrayList<ValueOuterClass.Identifier> templateIds = new ArrayList<>(this.templateIds.size());
@@ -66,6 +67,7 @@ public final class InclusiveFilter extends Filter {
     return TransactionFilterOuterClass.Filters.newBuilder().setInclusive(inclusiveFilter).build();
   }
 
+  @SuppressWarnings("deprecation")
   public static InclusiveFilter fromProto(
       TransactionFilterOuterClass.InclusiveFilters inclusiveFilters) {
     HashSet<Identifier> templateIds = new HashSet<>(inclusiveFilters.getTemplateIdsCount());

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
@@ -11,6 +11,8 @@ import Arbitrary.arbitrary
 
 import scala.jdk.CollectionConverters._
 
+// Allows using deprecated Protobuf fields for testing
+@annotation.nowarn("cat=deprecation&origin=com\\.daml\\.ledger\\.api\\.v1\\..*")
 object Generators {
 
   def valueGen: Gen[ValueOuterClass.Value] =

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
@@ -226,14 +226,19 @@ message DisclosedContract {
     // Deprecated in favor of `contract_create_payload`
     Record create_arguments = 3 [deprecated = true];
 
-    // Opaque byte string containing the complete payload required by the Daml engine
-    // to reconstruct a contract not known to the receiving participant.
-    // Required
-    google.protobuf.Any contract_create_payload = 5;
+    // The contract arguments specified using an opaque blob extracted from the ``create_arguments_blob`` field
+    // of a ``com.daml.ledger.api.v1.CreatedEvent``.
+    // Deprecated in favor of `contract_create_payload`
+    google.protobuf.Any create_arguments_blob = 5 [deprecated = true];
   }
 
   // The contract metadata from the create event.
   // Deprecated in favor of `contract_create_payload`
   // Optional
   ContractMetadata metadata = 4 [deprecated = true];
+
+  // Opaque byte string containing the complete payload required by the Daml engine
+  // to reconstruct a contract not known to the receiving participant.
+  // Required
+  bytes contract_create_payload = 6;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
@@ -223,14 +223,17 @@ message DisclosedContract {
   // Required
   oneof arguments {
     // The contract arguments as typed Record
-    Record create_arguments = 3;
+    // Deprecated in favor of `contract_create_data`
+    Record create_arguments = 3 [deprecated = true];
 
-    // The contract arguments specified using an opaque blob extracted from the ``create_arguments_blob`` field
-    // of a ``com.daml.ledger.api.v1.CreatedEvent``.
-    google.protobuf.Any create_arguments_blob = 5;
+    // Opaque byte string containing the complete payload required by the Daml engine
+    // to reconstruct a contract not known to the receiving participant.
+    // Required
+    google.protobuf.Any contract_create_payload = 5;
   }
 
   // The contract metadata from the create event.
-  // Required
-  ContractMetadata metadata = 4;
+  // Deprecated in favor of `contract_create_data`
+  // Optional
+  ContractMetadata metadata = 4 [deprecated = true];
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
@@ -223,7 +223,7 @@ message DisclosedContract {
   // Required
   oneof arguments {
     // The contract arguments as typed Record
-    // Deprecated in favor of `contract_create_data`
+    // Deprecated in favor of `contract_create_payload`
     Record create_arguments = 3 [deprecated = true];
 
     // Opaque byte string containing the complete payload required by the Daml engine
@@ -233,7 +233,7 @@ message DisclosedContract {
   }
 
   // The contract metadata from the create event.
-  // Deprecated in favor of `contract_create_data`
+  // Deprecated in favor of `contract_create_payload`
   // Optional
   ContractMetadata metadata = 4 [deprecated = true];
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
@@ -223,22 +223,22 @@ message DisclosedContract {
   // Required
   oneof arguments {
     // The contract arguments as typed Record
-    // Deprecated in favor of `contract_create_payload`
+    // Deprecated in favor of `create_event_payload`
     Record create_arguments = 3 [deprecated = true];
 
     // The contract arguments specified using an opaque blob extracted from the ``create_arguments_blob`` field
     // of a ``com.daml.ledger.api.v1.CreatedEvent``.
-    // Deprecated in favor of `contract_create_payload`
+    // Deprecated in favor of `create_event_payload`
     google.protobuf.Any create_arguments_blob = 5 [deprecated = true];
   }
 
   // The contract metadata from the create event.
-  // Deprecated in favor of `contract_create_payload`
+  // Deprecated in favor of `create_event_payload`
   // Optional
   ContractMetadata metadata = 4 [deprecated = true];
 
   // Opaque byte string containing the complete payload required by the Daml engine
   // to reconstruct a contract not known to the receiving participant.
   // Required
-  bytes contract_create_payload = 6;
+  bytes create_event_payload = 6;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
@@ -71,15 +71,15 @@ message CreatedEvent {
   // Opaque representation of contract create argument data intended for forwarding
   // to an API server as a contract disclosed as part of a command
   // submission.
-  // Deprecated in favor of ``contract_create_payload``.
+  // Deprecated in favor of ``create_event_payload``.
   // Optional
   google.protobuf.Any create_arguments_blob = 12 [deprecated = true];
 
-  // Opaque representation of complete contract create payload intended for forwarding
+  // Opaque representation of contract create event payload intended for forwarding
   // to an API server as a contract disclosed as part of a command
   // submission.
   // Optional
-  bytes contract_create_payload = 13;
+  bytes create_event_payload = 13;
 
   // Interface views specified in the transaction filter.
   // Includes an ``InterfaceView`` for each interface for which there is a ``InterfaceFilter`` with
@@ -122,6 +122,7 @@ message CreatedEvent {
 
   // Metadata of the contract. Required for contracts created
   // after the introduction of explicit disclosure.
+  // Deprecated in favor of ``create_event_payload``.
   // Optional
 
   ContractMetadata metadata = 10 [deprecated = true];

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
@@ -72,7 +72,7 @@ message CreatedEvent {
   // to an API server as a contract disclosed as part of a command
   // submission.
   // Optional
-  google.protobuf.Any create_arguments_blob = 12;
+  google.protobuf.Any contract_create_payload = 12;
 
   // Interface views specified in the transaction filter.
   // Includes an ``InterfaceView`` for each interface for which there is a ``InterfaceFilter`` with
@@ -116,7 +116,8 @@ message CreatedEvent {
   // Metadata of the contract. Required for contracts created
   // after the introduction of explicit disclosure.
   // Optional
-  ContractMetadata metadata = 10;
+
+  ContractMetadata metadata = 10 [deprecated = true];
 }
 
 // View of a create event matched by an interface filter.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
@@ -68,11 +68,18 @@ message CreatedEvent {
   // Optional
   Record create_arguments = 4;
 
-  // Opaque representation of contract payload intended for forwarding
+  // Opaque representation of contract create argument data intended for forwarding
+  // to an API server as a contract disclosed as part of a command
+  // submission.
+  // Deprecated in favor of ``contract_create_payload``.
+  // Optional
+  google.protobuf.Any create_arguments_blob = 12 [deprecated = true];
+
+  // Opaque representation of complete contract create payload intended for forwarding
   // to an API server as a contract disclosed as part of a command
   // submission.
   // Optional
-  google.protobuf.Any contract_create_payload = 12;
+  bytes contract_create_payload = 13;
 
   // Interface views specified in the transaction filter.
   // Includes an ``InterfaceView`` for each interface for which there is a ``InterfaceFilter`` with

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
@@ -45,29 +45,25 @@ message InclusiveFilters {
   // A collection of templates for which the data will be included in the
   // ``create_arguments`` of a matching ``CreatedEvent``.
   // SHOULD NOT contain duplicates.
-  // All ``template_ids`` needs to be valid: corresponding template should be defined in one of
+  // All ``template_ids`` need to be valid: corresponding templates should be defined in one of
   // the available packages at the time of the query.
-  // Deprecated in favor of the `template_filters`.
-  // If the `template_filters` field is set, the `template_ids` field is ignored.
+  // Deprecated in favor of the `template_filters`. If the `template_filters` field is set,
+  // the `template_ids` field is ignored.
   // Optional
   repeated Identifier template_ids = 1 [deprecated = true];
 
   // Include an ``InterfaceView`` for every ``InterfaceFilter`` matching a contract.
   // The ``InterfaceFilter``s MUST use unique ``interface_id``s.
-  // All ``interface_id`` needs to be valid: corresponding interface should be defined in one of
-  // the available packages at the time of the query.
   // Optional
   repeated InterfaceFilter interface_filters = 2;
 
   // A collection of templates for which the data will be included in the
   // ``create_arguments`` of a matching ``CreatedEvent``.
   // SHOULD NOT contain duplicates.
-  // In contrast to the ``template_ids`` field, one can specify whether the create payload should be provided
-  // alongside the create arguments.
+  // In contrast to the ``template_ids`` field, one can specify whether the create payload
+  // should be provided alongside the create arguments.
   // If a contract is simultaneously selected by a template filter and one or more interface filters,
   // the corresponding ``include_contract_create_payload`` are consolidated using an OR operation.
-  // All ``template_id`` inside need to be valid: corresponding template should be defined in one of
-  // the available packages at the time of the query.
   // Optional
   repeated TemplateFilter template_filters = 3;
 }
@@ -76,6 +72,8 @@ message InclusiveFilters {
 message InterfaceFilter {
 
   // The interface that a matching contract must implement.
+  // The ``interface_id`` needs to be valid: corresponding interface should be defined in
+  // one of the available packages at the time of the query.
   // Required
   Identifier interface_id = 1;
 
@@ -84,18 +82,29 @@ message InterfaceFilter {
   // Optional
   bool include_interface_view = 2;
 
+  // Whether to include a ``create_arguments_blob`` in the returned
+  // ``CreateEvent``.
+  // Use this to access the complete contract create argument data in your API client
+  // for submitting it as a disclosed contract with future commands.
+  // Deprecated in favor of ``include_contract_create_payload``. If the latter field
+  // is set, ``include_create_arguments_blob`` is ignored.
+  // Optional
+  bool include_create_arguments_blob = 3 [deprecated = true];
+
   // Whether to include a ``contract_create_payload`` in the returned
   // ``CreateEvent``.
-  // Use this to access the complete contract payload in your API client
+  // Use this to access the complete contract create payload in your API client
   // for submitting it as a disclosed contract with future commands.
   // Optional
-  bool include_contract_create_payload = 3;
+  bool include_contract_create_payload = 4;
 }
 
 // This filter matches contracts of a specific template.
 message TemplateFilter {
 
   // A template for which the payload should be included in the response.
+  // The ``template_id`` needs to be valid: corresponding template should be defined in
+  // one of the available packages at the time of the query.
   // Required
   Identifier template_id = 1;
 

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
@@ -59,11 +59,11 @@ message InclusiveFilters {
 
   // A collection of templates for which the data will be included in the
   // ``create_arguments`` of a matching ``CreatedEvent``.
-  // SHOULD NOT contain duplicates.
-  // In contrast to the ``template_ids`` field, one can specify whether the create payload
+  // SHOULD NOT contain duplicate templates.
+  // In contrast to the ``template_ids`` field, one can specify whether the create event payloads
   // should be provided alongside the create arguments.
   // If a contract is simultaneously selected by a template filter and one or more interface filters,
-  // the corresponding ``include_contract_create_payload`` are consolidated using an OR operation.
+  // the corresponding ``include_create_event_payload`` are consolidated using an OR operation.
   // Optional
   repeated TemplateFilter template_filters = 3;
 }
@@ -86,17 +86,16 @@ message InterfaceFilter {
   // ``CreateEvent``.
   // Use this to access the complete contract create argument data in your API client
   // for submitting it as a disclosed contract with future commands.
-  // Deprecated in favor of ``include_contract_create_payload``. If the latter field
+  // Deprecated in favor of ``include_create_event_payload``. If the latter field
   // is set, ``include_create_arguments_blob`` is ignored.
   // Optional
   bool include_create_arguments_blob = 3 [deprecated = true];
 
-  // Whether to include a ``contract_create_payload`` in the returned
-  // ``CreateEvent``.
-  // Use this to access the complete contract create payload in your API client
+  // Whether to include a ``create_event_payload`` in the returned ``CreateEvent``.
+  // Use this to access the contract create event payload in your API client
   // for submitting it as a disclosed contract with future commands.
   // Optional
-  bool include_contract_create_payload = 4;
+  bool include_create_event_payload = 4;
 }
 
 // This filter matches contracts of a specific template.
@@ -108,10 +107,9 @@ message TemplateFilter {
   // Required
   Identifier template_id = 1;
 
-  // Whether to include a ``contract_create_payload`` in the returned
-  // ``CreateEvent``.
-  // Use this to access the complete contract payload in your API client
+  // Whether to include a ``create_event_payload`` in the returned ``CreateEvent``.
+  // Use this to access the contract event payload in your API client
   // for submitting it as a disclosed contract with future commands.
   // Optional
-  bool include_contract_create_payload = 2;
+  bool include_create_event_payload = 2;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
@@ -42,7 +42,7 @@ message Filters {
 // the ``template_ids`` or that match one of the ``interface_filters``.
 message InclusiveFilters {
 
-  // A collection of templates for which the payload will be included in the
+  // A collection of templates for which the data will be included in the
   // ``create_arguments`` of a matching ``CreatedEvent``.
   // SHOULD NOT contain duplicates.
   // All ``template_ids`` needs to be valid: corresponding template should be defined in one of
@@ -50,7 +50,7 @@ message InclusiveFilters {
   // Deprecated in favor of the `template_filters`.
   // If the `template_filters` field is set, the `template_ids` field is ignored.
   // Optional
-  repeated Identifier template_ids = 1;
+  repeated Identifier template_ids = 1 [deprecated = true];
 
   // Include an ``InterfaceView`` for every ``InterfaceFilter`` matching a contract.
   // The ``InterfaceFilter``s MUST use unique ``interface_id``s.
@@ -59,13 +59,13 @@ message InclusiveFilters {
   // Optional
   repeated InterfaceFilter interface_filters = 2;
 
-  // A collection of templates for which the payload will be included in the
+  // A collection of templates for which the data will be included in the
   // ``create_arguments`` of a matching ``CreatedEvent``.
   // SHOULD NOT contain duplicates.
-  // In contrast to the ``template_ids`` field, one can specify whether the create data should be provided
+  // In contrast to the ``template_ids`` field, one can specify whether the create payload should be provided
   // alongside the create arguments.
   // If a contract is simultaneously selected by a template filter and one or more interface filters,
-  // the corresponding ``include_contract_create_data`` are consolidated using an OR operation.
+  // the corresponding ``include_contract_create_payload`` are consolidated using an OR operation.
   // All ``template_id`` inside need to be valid: corresponding template should be defined in one of
   // the available packages at the time of the query.
   // Optional

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
@@ -47,6 +47,8 @@ message InclusiveFilters {
   // SHOULD NOT contain duplicates.
   // All ``template_ids`` needs to be valid: corresponding template should be defined in one of
   // the available packages at the time of the query.
+  // Deprecated in favor of the `template_filters`.
+  // If the `template_filters` field is set, the `template_ids` field is ignored.
   // Optional
   repeated Identifier template_ids = 1;
 
@@ -56,6 +58,18 @@ message InclusiveFilters {
   // the available packages at the time of the query.
   // Optional
   repeated InterfaceFilter interface_filters = 2;
+
+  // A collection of templates for which the payload will be included in the
+  // ``create_arguments`` of a matching ``CreatedEvent``.
+  // SHOULD NOT contain duplicates.
+  // In contrast to the ``template_ids`` field, one can specify whether the create data should be provided
+  // alongside the create arguments.
+  // If a contract is simultaneously selected by a template filter and one or more interface filters,
+  // the corresponding ``include_contract_create_data`` are consolidated using an OR operation.
+  // All ``template_id`` inside need to be valid: corresponding template should be defined in one of
+  // the available packages at the time of the query.
+  // Optional
+  repeated TemplateFilter template_filters = 3;
 }
 
 // This filter matches contracts that implement a specific interface.
@@ -70,10 +84,25 @@ message InterfaceFilter {
   // Optional
   bool include_interface_view = 2;
 
-  // Whether to include a ``create_arguments_blob`` in the returned
+  // Whether to include a ``contract_create_payload`` in the returned
   // ``CreateEvent``.
-  // Use this to access the complete contract data in your API client
+  // Use this to access the complete contract payload in your API client
   // for submitting it as a disclosed contract with future commands.
   // Optional
-  bool include_create_arguments_blob = 3;
+  bool include_contract_create_payload = 3;
+}
+
+// This filter matches contracts of a specific template.
+message TemplateFilter {
+
+  // A template for which the payload should be included in the response.
+  // Required
+  Identifier template_id = 1;
+
+  // Whether to include a ``contract_create_payload`` in the returned
+  // ``CreateEvent``.
+  // Use this to access the complete contract payload in your API client
+  // for submitting it as a disclosed contract with future commands.
+  // Optional
+  bool include_contract_create_payload = 2;
 }

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -1085,6 +1085,8 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           atdCtMetadata: DC.Metadata,
       )
 
+      // Allows using deprecated Protobuf fields for testing
+      @annotation.nowarn("cat=deprecation&origin=com\\.daml\\.ledger\\.api\\.v1\\..*")
       def contractsToDisclose(
           fixture: HttpServiceTestFixtureData,
           junkMessage: String,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -300,7 +300,7 @@ package domain {
     sealed abstract class Arguments[+LfV] extends Product with Serializable {
       import lav1.commands.DisclosedContract.Arguments.{CreateArguments, CreateArgumentsBlob}
 
-      // Allows using deprecated Protobuf fields for testing
+      // Allows using deprecated Protobuf fields
       @annotation.nowarn("cat=deprecation&origin=com\\.daml\\.ledger\\.api\\.v1\\..*")
       def toLedgerApi(implicit
           LfV: LfV <:< lav1.value.Record

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -299,6 +299,9 @@ package domain {
 
     sealed abstract class Arguments[+LfV] extends Product with Serializable {
       import lav1.commands.DisclosedContract.Arguments.{CreateArguments, CreateArgumentsBlob}
+
+      // Allows using deprecated Protobuf fields for testing
+      @annotation.nowarn("cat=deprecation&origin=com\\.daml\\.ledger\\.api\\.v1\\..*")
       def toLedgerApi(implicit
           LfV: LfV <:< lav1.value.Record
       ): lav1.commands.DisclosedContract.Arguments = this match {

--- a/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/ExplicitDisclosureIT.scala
+++ b/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/ExplicitDisclosureIT.scala
@@ -48,6 +48,8 @@ import java.util.regex.Pattern
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Success, Try}
 
+// Allows using deprecated Protobuf fields in tests
+@annotation.nowarn("cat=deprecation&origin=com\\.daml\\.ledger\\.api\\.v1\\..*")
 final class ExplicitDisclosureIT extends LedgerTestSuite {
   import ExplicitDisclosureIT._
 
@@ -1073,6 +1075,8 @@ object ExplicitDisclosureIT {
     )
   )
 
+  // Allows using deprecated Protobuf fields for testing
+  @annotation.nowarn("cat=deprecation&origin=com\\.daml\\.ledger\\.api\\.v1\\..*")
   private def createEventToDisclosedContract(ev: CreatedEvent): DisclosedContract = {
     val arguments = (ev.createArguments, ev.createArgumentsBlob) match {
       case (Some(createArguments), _) =>

--- a/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/InterfaceSubscriptionsIT.scala
+++ b/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/InterfaceSubscriptionsIT.scala
@@ -41,6 +41,8 @@ import scalaz.Tag
 import java.util.regex.Pattern
 import scala.concurrent.duration._
 
+// Allows using deprecated Protobuf fields for testing
+@annotation.nowarn("cat=deprecation&origin=com\\.daml\\.ledger\\.api\\.v1\\..*")
 class InterfaceSubscriptionsIT extends LedgerTestSuite {
 
   test(

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -2025,6 +2025,8 @@ object Runner {
     implicit def `SValue to LoggingValue`: ToLoggingValue[SValue] = value =>
       PrettyPrint.prettySValue(value).render(80)
 
+    // Allows using deprecated Protobuf fields
+    @annotation.nowarn("cat=deprecation&origin=com\\.daml\\.ledger\\.api\\.v1\\..*")
     implicit def `TransactionFilter to LoggingValue`: ToLoggingValue[TransactionFilter] = filter =>
       LoggingValue.Nested(LoggingEntries(filter.filtersByParty.view.mapValues { value =>
         LoggingValue.Nested(

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/InterfaceSpec.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/InterfaceSpec.scala
@@ -311,7 +311,7 @@ object InterfaceSpec extends Matchers with Inside {
               transactionId,
               Seq(
                 Event(
-                  Created(CreatedEvent(_, _, Some(`templateId`), _, _, _, _, _, _, _, _, _))
+                  Created(CreatedEvent(_, _, Some(`templateId`), _, _, _, _, _, _, _, _, _, _))
                 )
               ),
             ) =>
@@ -325,7 +325,9 @@ object InterfaceSpec extends Matchers with Inside {
       inside(events) {
         case Seq(
               Event(
-                Created(CreatedEvent(_, _, Some(`templateId`), _, None, _, Seq(_), _, _, _, _, _))
+                Created(
+                  CreatedEvent(_, _, Some(`templateId`), _, None, _, _, Seq(_), _, _, _, _, _)
+                )
               )
             ) =>
           succeed
@@ -336,7 +338,7 @@ object InterfaceSpec extends Matchers with Inside {
         case Seq(
               Event(
                 Created(
-                  CreatedEvent(_, _, Some(`templateId`), _, Some(_), _, Seq(_), _, _, _, _, _)
+                  CreatedEvent(_, _, Some(`templateId`), _, Some(_), _, _, Seq(_), _, _, _, _, _)
                 )
               )
             ) =>
@@ -348,7 +350,7 @@ object InterfaceSpec extends Matchers with Inside {
         case Seq(
               Event(
                 Created(
-                  CreatedEvent(_, _, _, _, _, _, Seq(view), _, _, _, _, _)
+                  CreatedEvent(_, _, _, _, _, _, _, Seq(view), _, _, _, _, _)
                 )
               )
             ) =>


### PR DESCRIPTION
Few changes to the proto definitions

- Command service
  - Make the payload blob mandatory on the command submission and rename it to `contract_create_payload` to emphasize the fact that it is not just about the create arguments
  - Introduce a new field of type `bytes` to represent the payload in contrast to the old `Any` field
  - Deprecate the create arguments passed as typed value as well as the old `Any` blob.
  - Deprecate the contract metadata field that is folded into the `contract_create_payload`
  - Eliminate all derived fields added recently, they too are folded into `contract_create_payload`
- Transaction service
  - Extend template filter to allow for requesting create payloads when subscribing for templates
  - Deprecate the old blob passed as `Any` in favor of new payload passed as `bytes`
  - Deprecate metadata passed alongside the contract arguments in the CreatedEvent. This information is folded into `contract_create_payload` 
  
  
Why is this change necessary:

We need to make the explicit disclosure compatible with the upcoming upgrading feature where the client application(s) and participants operate in the environment where the exact package with which a contract has been created is unknown. Also we want to reserve the right to evolve the format of the payload data associated with explicitly disclosed contract without needing to change the client applications.

This change is breaking at two levels

- it deliberately breaks compatibility with the recently published snapshot versions that contain the derived contract fields. We don't want these fields to ever be released to the customers, so all traces of them must be expunged.
- The old fields associated with the blob called `*create_arguments_blob` are deprecated in favor of their  `*contract_create_payload` counterparts. After client-side software will have been updated to the changed api, the corresponding `deprecated` fields will be made `reserved` instead.