### PR TITLE
Warn instead of errors for expression changes in templates

### DIFF
--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -341,7 +341,8 @@ liftClosedExpr e = do
             world <- gets sWorldExtended
             version <- gets sVersion
             case runGamma world version (typeOf' e) of
-                Right ty -> do
+                -- ignore warnings, they should have been caught prior and are not relevant here
+                Right (ty, _warnings) -> do
                     name <- freshExprVarNameFor e
                     addDefValue DefValue
                         { dvalBinder = (name, ty)

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker.hs
@@ -41,8 +41,8 @@ checkPackage world version = concatMap (checkModuleInWorld world version) module
 checkModuleInWorld :: World -> Version -> Module -> [Diagnostic]
 checkModuleInWorld world version m =
     case typeCheckResult of
-        Left err -> toDiagnostic DsError err : collisionDiags
-        Right () -> collisionDiags
+        Left err -> toDiagnostic err : collisionDiags
+        Right ((), warnings) -> map toDiagnostic warnings ++ collisionDiags
   where
     collisionDiags = NameCollision.runCheckModuleDeps world m
     typeCheckResult = runGamma world version $ do

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -648,7 +648,7 @@ instance Pretty Warning where
     WChoiceChangedAuthorizers choice -> "The upgraded choice " <> pPrint choice <> " has changed the definition of authorizers."
     WTemplateChangedKeyExpression template -> "The upgraded template " <> pPrint template <> " has changed the expression for computing its key."
     WTemplateChangedKeyMaintainers template -> "The upgraded template " <> pPrint template <> " has changed the maintainers for its key."
-    WTemplateAddedKeyDefinition template _key -> "The upgraded template " <> pPrint template <> " has added a key if it didn't have one previously."
+    WTemplateAddedKeyDefinition template _key -> "The upgraded template " <> pPrint template <> " has added a key where it didn't have one previously."
     WCouldNotExtractForUpgradeChecking attribute mbExtra -> "Could not check if the upgrade of " <> text attribute <> " is valid because its expression is the not the right shape." <> foldMap (const " Extra context: " <> text) mbExtra
 
 instance ToDiagnostic Warning where

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -570,7 +570,7 @@ instance Pretty UpgradeError where
     RecordChangedOrigin dataConName past present -> "The record " <> pPrint dataConName <> " has changed origin from " <> pPrint past <> " to " <> pPrint present
     ChoiceChangedReturnType choice -> "The upgraded choice " <> pPrint choice <> " cannot change its return type."
     TemplateChangedKeyType templateName -> "The upgraded template " <> pPrint templateName <> " cannot change its key type."
-    TemplateRemovedKey templateName key -> "The upgraded template " <> pPrint templateName <> " cannot remove its key " <> pPrint (tplKeyType key) <> "."
+    TemplateRemovedKey templateName _key -> "The upgraded template " <> pPrint templateName <> " cannot remove its key."
 
 instance Pretty UpgradedRecordOrigin where
   pPrint = \case
@@ -644,7 +644,7 @@ instance Pretty Warning where
     WChoiceChangedAuthorizers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of authorizers."
     WTemplateChangedKeyExpression template -> "The upgraded template " <> pPrint template <> " cannot change the expression for computing its key."
     WTemplateChangedKeyMaintainers template -> "The upgraded template " <> pPrint template <> " cannot change the maintainers for its key."
-    WTemplateAddedKeyDefinition template key -> "The upgraded template " <> pPrint template <> " cannot add a key " <> pPrint (tplKeyType key) <> " if it didn't have one previously."
+    WTemplateAddedKeyDefinition template _key -> "The upgraded template " <> pPrint template <> " cannot add a key if it didn't have one previously."
 
 instance ToDiagnostic Warning where
   toDiagnostic warning = Diagnostic

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -177,13 +177,6 @@ data UpgradeError
   | RecordFieldsExistingChanged !UpgradedRecordOrigin
   | RecordFieldsNewNonOptional !UpgradedRecordOrigin
   | RecordChangedOrigin !TypeConName !UpgradedRecordOrigin !UpgradedRecordOrigin
-  | TemplateChangedPrecondition !TypeConName
-  | TemplateChangedSignatories !TypeConName
-  | TemplateChangedObservers !TypeConName
-  | TemplateChangedAgreement !TypeConName
-  | ChoiceChangedControllers !ChoiceName
-  | ChoiceChangedObservers !ChoiceName
-  | ChoiceChangedAuthorizers !ChoiceName
   | ChoiceChangedReturnType !ChoiceName
   deriving (Eq, Ord, Show)
 
@@ -573,13 +566,6 @@ instance Pretty UpgradeError where
     RecordFieldsExistingChanged origin -> "The upgraded " <> pPrint origin <> " has changed the types of some of its original fields."
     RecordFieldsNewNonOptional origin -> "The upgraded " <> pPrint origin <> " has added new fields, but those fields are not Optional."
     RecordChangedOrigin dataConName past present -> "The record " <> pPrint dataConName <> " has changed origin from " <> pPrint past <> " to " <> pPrint present
-    TemplateChangedPrecondition template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its precondition."
-    TemplateChangedSignatories template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its signatories."
-    TemplateChangedObservers template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its observers."
-    TemplateChangedAgreement template -> "The upgraded template " <> pPrint template <> " cannot change the definition of agreement."
-    ChoiceChangedControllers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of controllers."
-    ChoiceChangedObservers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of observers."
-    ChoiceChangedAuthorizers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of authorizers."
     ChoiceChangedReturnType choice -> "The upgraded choice " <> pPrint choice <> " cannot change its return type."
 
 instance Pretty UpgradedRecordOrigin where
@@ -621,7 +607,13 @@ instance ToDiagnostic Error where
 
 data Warning
   = WContext !Context !Warning
-  | WarnChangingEnsure !TypeConName
+  | WTemplateChangedPrecondition !TypeConName
+  | WTemplateChangedSignatories !TypeConName
+  | WTemplateChangedObservers !TypeConName
+  | WTemplateChangedAgreement !TypeConName
+  | WChoiceChangedControllers !ChoiceName
+  | WChoiceChangedObservers !ChoiceName
+  | WChoiceChangedAuthorizers !ChoiceName
   deriving (Show)
 
 warningLocation :: Warning -> Maybe SourceLoc
@@ -632,7 +624,13 @@ warningLocation = \case
 instance Pretty Warning where
   pPrint = \case
     WContext _ w -> pPrint w
-    WarnChangingEnsure template -> "Ensure clause in template " <> pPrint template <> " has changed."
+    WTemplateChangedPrecondition template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its precondition."
+    WTemplateChangedSignatories template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its signatories."
+    WTemplateChangedObservers template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its observers."
+    WTemplateChangedAgreement template -> "The upgraded template " <> pPrint template <> " cannot change the definition of agreement."
+    WChoiceChangedControllers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of controllers."
+    WChoiceChangedObservers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of observers."
+    WChoiceChangedAuthorizers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of authorizers."
 
 instance ToDiagnostic Warning where
   toDiagnostic warning = Diagnostic

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -177,7 +177,9 @@ data UpgradeError
   | RecordFieldsExistingChanged !UpgradedRecordOrigin
   | RecordFieldsNewNonOptional !UpgradedRecordOrigin
   | RecordChangedOrigin !TypeConName !UpgradedRecordOrigin !UpgradedRecordOrigin
+  | TemplateChangedKeyType !TypeConName
   | ChoiceChangedReturnType !ChoiceName
+  | TemplateRemovedKey !TypeConName !TemplateKey
   deriving (Eq, Ord, Show)
 
 data UpgradedRecordOrigin
@@ -567,6 +569,8 @@ instance Pretty UpgradeError where
     RecordFieldsNewNonOptional origin -> "The upgraded " <> pPrint origin <> " has added new fields, but those fields are not Optional."
     RecordChangedOrigin dataConName past present -> "The record " <> pPrint dataConName <> " has changed origin from " <> pPrint past <> " to " <> pPrint present
     ChoiceChangedReturnType choice -> "The upgraded choice " <> pPrint choice <> " cannot change its return type."
+    TemplateChangedKeyType templateName -> "The upgraded template " <> pPrint templateName <> " cannot change its key type."
+    TemplateRemovedKey templateName key -> "The upgraded template " <> pPrint templateName <> " cannot remove its key " <> pPrint (tplKeyType key) <> "."
 
 instance Pretty UpgradedRecordOrigin where
   pPrint = \case
@@ -614,6 +618,9 @@ data Warning
   | WChoiceChangedControllers !ChoiceName
   | WChoiceChangedObservers !ChoiceName
   | WChoiceChangedAuthorizers !ChoiceName
+  | WTemplateChangedKeyExpression !TypeConName
+  | WTemplateChangedKeyMaintainers !TypeConName
+  | WTemplateAddedKeyDefinition !TypeConName !TemplateKey
   deriving (Show)
 
 warningLocation :: Warning -> Maybe SourceLoc
@@ -631,6 +638,9 @@ instance Pretty Warning where
     WChoiceChangedControllers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of controllers."
     WChoiceChangedObservers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of observers."
     WChoiceChangedAuthorizers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of authorizers."
+    WTemplateChangedKeyExpression template -> "The upgraded template " <> pPrint template <> " cannot change the expression for computing its key."
+    WTemplateChangedKeyMaintainers template -> "The upgraded template " <> pPrint template <> " cannot change the maintainers for its key."
+    WTemplateAddedKeyDefinition template key -> "The upgraded template " <> pPrint template <> " cannot add a key " <> pPrint (tplKeyType key) <> " if it didn't have one previously."
 
 instance ToDiagnostic Warning where
   toDiagnostic warning = Diagnostic

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -630,7 +630,11 @@ warningLocation = \case
 
 instance Pretty Warning where
   pPrint = \case
-    WContext _ w -> pPrint w
+    WContext ctx err ->
+      vcat
+      [ "warning while type checking " <> pretty ctx <> ":"
+      , nest 2 (pretty err)
+      ]
     WTemplateChangedPrecondition template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its precondition."
     WTemplateChangedSignatories template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its signatories."
     WTemplateChangedObservers template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its observers."

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -621,6 +621,10 @@ data Warning
   | WTemplateChangedKeyExpression !TypeConName
   | WTemplateChangedKeyMaintainers !TypeConName
   | WTemplateAddedKeyDefinition !TypeConName !TemplateKey
+  | WCouldNotExtractForUpgradeChecking !T.Text !(Maybe T.Text)
+    -- ^ When upgrading, we extract relevant expressions for things like
+    -- signatories. If the expression changes shape so that we can't get the
+    -- underlying expression that has changed, this warning is emitted.
   deriving (Show)
 
 warningLocation :: Warning -> Maybe SourceLoc
@@ -645,6 +649,7 @@ instance Pretty Warning where
     WTemplateChangedKeyExpression template -> "The upgraded template " <> pPrint template <> " cannot change the expression for computing its key."
     WTemplateChangedKeyMaintainers template -> "The upgraded template " <> pPrint template <> " cannot change the maintainers for its key."
     WTemplateAddedKeyDefinition template _key -> "The upgraded template " <> pPrint template <> " cannot add a key if it didn't have one previously."
+    WCouldNotExtractForUpgradeChecking attribute mbExtra -> "Could not check if the upgrade of " <> text attribute <> " is valid because its expression is the wrong shape." <> foldMap (const " Extra context: " <> text) mbExtra
 
 instance ToDiagnostic Warning where
   toDiagnostic warning = Diagnostic

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -639,17 +639,17 @@ instance Pretty Warning where
       [ "warning while type checking " <> pretty ctx <> ":"
       , nest 2 (pretty err)
       ]
-    WTemplateChangedPrecondition template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its precondition."
-    WTemplateChangedSignatories template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its signatories."
-    WTemplateChangedObservers template -> "The upgraded template " <> pPrint template <> " cannot change the definition of its observers."
-    WTemplateChangedAgreement template -> "The upgraded template " <> pPrint template <> " cannot change the definition of agreement."
-    WChoiceChangedControllers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of controllers."
-    WChoiceChangedObservers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of observers."
-    WChoiceChangedAuthorizers choice -> "The upgraded choice " <> pPrint choice <> " cannot change the definition of authorizers."
-    WTemplateChangedKeyExpression template -> "The upgraded template " <> pPrint template <> " cannot change the expression for computing its key."
-    WTemplateChangedKeyMaintainers template -> "The upgraded template " <> pPrint template <> " cannot change the maintainers for its key."
-    WTemplateAddedKeyDefinition template _key -> "The upgraded template " <> pPrint template <> " cannot add a key if it didn't have one previously."
-    WCouldNotExtractForUpgradeChecking attribute mbExtra -> "Could not check if the upgrade of " <> text attribute <> " is valid because its expression is the wrong shape." <> foldMap (const " Extra context: " <> text) mbExtra
+    WTemplateChangedPrecondition template -> "The upgraded template " <> pPrint template <> " has changed the definition of its precondition."
+    WTemplateChangedSignatories template -> "The upgraded template " <> pPrint template <> " has changed the definition of its signatories."
+    WTemplateChangedObservers template -> "The upgraded template " <> pPrint template <> " has changed the definition of its observers."
+    WTemplateChangedAgreement template -> "The upgraded template " <> pPrint template <> " has changed the definition of agreement."
+    WChoiceChangedControllers choice -> "The upgraded choice " <> pPrint choice <> " has changed the definition of controllers."
+    WChoiceChangedObservers choice -> "The upgraded choice " <> pPrint choice <> " has changed the definition of observers."
+    WChoiceChangedAuthorizers choice -> "The upgraded choice " <> pPrint choice <> " has changed the definition of authorizers."
+    WTemplateChangedKeyExpression template -> "The upgraded template " <> pPrint template <> " has changed the expression for computing its key."
+    WTemplateChangedKeyMaintainers template -> "The upgraded template " <> pPrint template <> " has changed the maintainers for its key."
+    WTemplateAddedKeyDefinition template _key -> "The upgraded template " <> pPrint template <> " has added a key if it didn't have one previously."
+    WCouldNotExtractForUpgradeChecking attribute mbExtra -> "Could not check if the upgrade of " <> text attribute <> " is valid because its expression is the not the right shape." <> foldMap (const " Extra context: " <> text) mbExtra
 
 instance ToDiagnostic Warning where
   toDiagnostic warning = Diagnostic

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
@@ -157,7 +157,7 @@ addName name (NCState nameMap)
         Right . NCState $ M.insert frName (name : oldNames) nameMap
     | otherwise =
         let err = EForbiddenNameCollision (displayName name) (map displayName badNames)
-            diag = toDiagnostic DsError err
+            diag = toDiagnostic err
         in Left diag
   where
     frName = fullyResolve name

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -52,8 +52,8 @@ checkUpgrade version package =
                 (checkUpgradeM package)
     in
     case result of
-      Left err -> [toDiagnostic DsError err]
-      Right () -> []
+      Left err -> [toDiagnostic err]
+      Right ((), warnings) -> map toDiagnostic warnings
 
 checkUpgradeM :: MonadGamma m => Upgrading LF.Package -> m ()
 checkUpgradeM package = do

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -240,7 +240,7 @@ checkTemplate module_ template = do
             , EVar (ExprVarName "this") <- tmappArg
             = lookupInModule module_ (qualObject qualEvn)
             | otherwise
-            = Left $ "extractFuncFromFuncThis: Wrong shape"
+            = Left "extractFuncFromFuncThis: Wrong shape"
 
         extractFuncFromFuncThisArg :: Expr -> Module -> Either String Expr
         extractFuncFromFuncThisArg expr module_
@@ -251,14 +251,14 @@ checkTemplate module_ template = do
             , EVal qualEvn <- tmappFun inner
             = lookupInModule module_ (qualObject qualEvn)
             | otherwise
-            = Left $ "extractFuncFromFuncThisArg: Wrong shape"
+            = Left "extractFuncFromFuncThisArg: Wrong shape"
 
         extractFuncFromCaseFuncThis :: Expr -> Module -> Either String Expr
         extractFuncFromCaseFuncThis expr module_
             | ECase{..} <- expr
             = extractFuncFromFuncThis casScrutinee module_
             | otherwise
-            = Left $ "extractFuncFromCaseFuncThis: No ECase found"
+            = Left "extractFuncFromCaseFuncThis: No ECase found"
 
         extractFuncFromTyAppNil :: Expr -> Module -> Either String Expr
         extractFuncFromTyAppNil expr module_
@@ -271,7 +271,7 @@ checkTemplate module_ template = do
                 definition <- lookupInModule module_ (qualObject qualEvn)
                 extractFuncFromProxyApp definition module_
             | otherwise
-            = Left $ "extractFuncFromTyAppNil: Wrong shape"
+            = Left "extractFuncFromTyAppNil: Wrong shape"
 
         extractFuncFromProxyApp :: Expr -> Module -> Either String Expr
         extractFuncFromProxyApp expr module_
@@ -282,7 +282,7 @@ checkTemplate module_ template = do
             , EVal qualEvn <- tmlamBody inner
             = lookupInModule module_ (qualObject qualEvn)
             | otherwise
-            = Left $ "extractFuncFromProxyApp: Wrong shape"
+            = Left "extractFuncFromProxyApp: Wrong shape"
 
         lookupInModule :: Module -> ExprValName -> Either String Expr
         lookupInModule module_ evn =

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -178,6 +178,7 @@ envLookupDepClass synName env =
 expandSynonyms :: LF.World -> LF.Type -> Either LF.Error ExpandedType
 expandSynonyms world ty =
     fmap ExpandedType $
+    fmap fst $ -- Ignore warnings from runGamma
     LF.runGamma world (worldLfVersion world) $
     LF.expandTypeSynonyms ty
 
@@ -603,7 +604,7 @@ generateSrcFromLf env = noLoc mod
         genInstanceBinds :: DFunSig -> Gen (LHsBinds GhcPs)
         genInstanceBinds DFunSig{..}
             | DFunHeadNormal{..} <- dfsHead
-            , Right (LF.TStruct fields) <-
+            , Right (LF.TStruct fields, _warnings) <-
                 LF.runGamma (envWorld env) (envLfVersion env) $
                     LF.introTypeVars dfsBinders $ LF.expandSynApp dfhName dfhArgs
             = listToBag <$> sequence

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -177,8 +177,7 @@ envLookupDepClass synName env =
 
 expandSynonyms :: LF.World -> LF.Type -> Either LF.Error ExpandedType
 expandSynonyms world ty =
-    fmap ExpandedType $
-    fmap fst $ -- Ignore warnings from runGamma
+    fmap (ExpandedType . fst) $ -- Ignore warnings from runGamma
     LF.runGamma world (worldLfVersion world) $
     LF.expandTypeSynonyms ty
 

--- a/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -31,7 +31,7 @@ tests damlc =
         "Upgrade"
         [ test
               "Warns when template changes signatories"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A signatories:\n  The upgraded template A cannot change the definition of its signatories.")
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A signatories:\n  The upgraded template A has changed the definition of its signatories.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -54,7 +54,7 @@ tests damlc =
               ]
         , test
               "Warns when template changes observers"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A observers:\n  The upgraded template A cannot change the definition of its observers.")
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A observers:\n  The upgraded template A has changed the definition of its observers.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -81,7 +81,7 @@ tests damlc =
               ]
         , test
               "Warns when template changes ensure"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A precondition:\n  The upgraded template A cannot change the definition of its precondition.")
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A precondition:\n  The upgraded template A has changed the definition of its precondition.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -108,7 +108,7 @@ tests damlc =
               ]
         , test
               "Warns when template changes agreement"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A agreement:\n  The upgraded template A cannot change the definition of agreement.")
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A agreement:\n  The upgraded template A has changed the definition of agreement.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -135,7 +135,7 @@ tests damlc =
               ]
         , test
               "Warns when template changes key expression"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A key:\n  The upgraded template A cannot change the expression for computing its key.")
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A key:\n  The upgraded template A has changed the expression for computing its key.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -164,7 +164,7 @@ tests damlc =
               ]
         , test
               "Warns when template changes key maintainers"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A key:\n  The upgraded template A cannot change the maintainers for its key.")
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A key:\n  The upgraded template A has changed the maintainers for its key.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -249,7 +249,7 @@ tests damlc =
               ]
         , test
               "Fails when template adds key type"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A key:\n  The upgraded template A cannot add a key if it didn't have one previously.")
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A key:\n  The upgraded template A has added a key where it didn't have one previously.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -482,7 +482,7 @@ tests damlc =
               ]
         , test
               "Warns when controllers of template choice are changed"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A choice C:\n  The upgraded choice C cannot change the definition of controllers.")
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A choice C:\n  The upgraded choice C has changed the definition of controllers.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -513,7 +513,7 @@ tests damlc =
               ]
         , test
               "Warns when observers of template choice are changed"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A choice C:\n  The upgraded choice C cannot change the definition of observers.")
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A choice C:\n  The upgraded choice C has changed the definition of observers.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"

--- a/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -134,6 +134,93 @@ tests damlc =
                 )
               ]
         , test
+              "Warns when template changes key expression"
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A key:\n  The upgraded template A cannot change the expression for computing its key.")
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    key (p, \"example\") : (Party, Text)"
+                      , "    maintainer (fst key)"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    key (q, \"example\") : (Party, Text)"
+                      , "    maintainer (fst key)"
+                      ]
+                )
+              ]
+        , test
+              "Warns when template changes key maintainers"
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A key:\n  The upgraded template A cannot change the maintainers for its key.")
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    key (p, q) : (Party, Party)"
+                      , "    maintainer (fst key)"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    key (p, q) : (Party, Party)"
+                      , "    maintainer (snd key)"
+                      ]
+                )
+              ]
+        , test
+              "Fails when template changes key type"
+              (FailWithError "\ESC\\[0;91merror type checking template MyLib.A key:\n  The upgraded template A cannot change its key type.")
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    key (p, \"text\") : (Party, Text)"
+                      , "    maintainer (fst key)"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    key (p, 1) : (Party, Int)"
+                      , "    maintainer (fst key)"
+                      ]
+                )
+              ]
+        , test
               "Fails when new field is added to template without Optional type"
               (FailWithError "\ESC\\[0;91merror type checking template MyLib.A :\n  The upgraded template A has added new fields, but those fields are not Optional.")
               [ ( "daml/MyLib.daml"

--- a/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -221,6 +221,60 @@ tests damlc =
                 )
               ]
         , test
+              "Fails when template removes key type"
+              (FailWithError "\ESC\\[0;91merror type checking template MyLib.A key:\n  The upgraded template A cannot remove its key.")
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    key (p, \"text\") : (Party, Text)"
+                      , "    maintainer (fst key)"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      ]
+                )
+              ]
+        , test
+              "Fails when template adds key type"
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A key:\n  The upgraded template A cannot add a key if it didn't have one previously.")
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template A with"
+                      , "    p : Party"
+                      , "    q : Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    key (p, \"text\") : (Party, Text)"
+                      , "    maintainer (fst key)"
+                      ]
+                )
+              ]
+        , test
               "Fails when new field is added to template without Optional type"
               (FailWithError "\ESC\\[0;91merror type checking template MyLib.A :\n  The upgraded template A has added new fields, but those fields are not Optional.")
               [ ( "daml/MyLib.daml"

--- a/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -30,8 +30,8 @@ tests damlc =
     testGroup
         "Upgrade"
         [ test
-              "Fails when template changes signatories"
-              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A signatories:\n  The upgraded template A cannot change the definition of its signatories.")
+              "Warns when template changes signatories"
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A signatories:\n  The upgraded template A cannot change the definition of its signatories.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -53,8 +53,8 @@ tests damlc =
                 )
               ]
         , test
-              "Fails when template changes observers"
-              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A observers:\n  The upgraded template A cannot change the definition of its observers.")
+              "Warns when template changes observers"
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A observers:\n  The upgraded template A cannot change the definition of its observers.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -80,8 +80,8 @@ tests damlc =
                 )
               ]
         , test
-              "Fails when template changes ensure"
-              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A precondition:\n  The upgraded template A cannot change the definition of its precondition.")
+              "Warns when template changes ensure"
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A precondition:\n  The upgraded template A cannot change the definition of its precondition.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -107,8 +107,8 @@ tests damlc =
                 )
               ]
         , test
-              "Fails when template changes agreement"
-              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A agreement:\n  The upgraded template A cannot change the definition of agreement.")
+              "Warns when template changes agreement"
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A agreement:\n  The upgraded template A cannot change the definition of agreement.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -135,7 +135,7 @@ tests damlc =
               ]
         , test
               "Fails when new field is added to template without Optional type"
-              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A :\n  The upgraded template A has added new fields, but those fields are not Optional.")
+              (FailWithError "\ESC\\[0;91merror type checking template MyLib.A :\n  The upgraded template A has added new fields, but those fields are not Optional.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -161,7 +161,7 @@ tests damlc =
               ]
         , test
               "Fails when old field is deleted from template"
-              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A :\n  The upgraded template A is missing some of its original fields.")
+              (FailWithError "\ESC\\[0;91merror type checking template MyLib.A :\n  The upgraded template A is missing some of its original fields.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -185,7 +185,7 @@ tests damlc =
               ]
         , test
               "Fails when existing field in template is changed"
-              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A :\n  The upgraded template A has changed the types of some of its original fields.")
+              (FailWithError "\ESC\\[0;91merror type checking template MyLib.A :\n  The upgraded template A has changed the types of some of its original fields.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -210,7 +210,7 @@ tests damlc =
               ]
         , test
               "Succeeds when new field with optional type is added to template"
-              Nothing
+              Succeed
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -236,7 +236,7 @@ tests damlc =
               ]
         , test
               "Fails when new field is added to template choice without Optional type"
-              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded input type of choice C on template A has added new fields, but those fields are not Optional.")
+              (FailWithError "\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded input type of choice C on template A has added new fields, but those fields are not Optional.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -272,7 +272,7 @@ tests damlc =
               ]
         , test
               "Fails when old field is deleted from template choice"
-              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded input type of choice C on template A is missing some of its original fields.")
+              (FailWithError "\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded input type of choice C on template A is missing some of its original fields.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -306,7 +306,7 @@ tests damlc =
               ]
         , test
               "Fails when existing field in template choice is changed"
-              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded input type of choice C on template A has changed the types of some of its original fields.")
+              (FailWithError "\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded input type of choice C on template A has changed the types of some of its original fields.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -340,8 +340,8 @@ tests damlc =
                 )
               ]
         , test
-              "Fails when controllers of template choice are changed"
-              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded choice C cannot change the definition of controllers.")
+              "Warns when controllers of template choice are changed"
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A choice C:\n  The upgraded choice C cannot change the definition of controllers.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -371,8 +371,8 @@ tests damlc =
                 )
               ]
         , test
-              "Fails when observers of template choice are changed"
-              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded choice C cannot change the definition of observers.")
+              "Warns when observers of template choice are changed"
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A choice C:\n  The upgraded choice C cannot change the definition of observers.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -405,7 +405,7 @@ tests damlc =
               ]
         , test
               "Fails when template choice changes its return type"
-              (Just "Message: \n\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded choice C cannot change its return type.")
+              (FailWithError "\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded choice C cannot change its return type.")
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -440,7 +440,7 @@ tests damlc =
               ]
         , test
               "Succeeds when template choice returns a template which has changed"
-              Nothing
+              Succeed
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -470,7 +470,7 @@ tests damlc =
               ]
         , test
               "Succeeds when template choice input argument has changed"
-              Nothing
+              Succeed
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -504,7 +504,7 @@ tests damlc =
               ]
         , test
               "Succeeds when new field with optional type is added to template choice"
-              Nothing
+              Succeed
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -542,11 +542,11 @@ tests damlc =
   where
     test ::
            String
-        -> Maybe T.Text
+        -> Expectation
         -> [(FilePath, String)]
         -> [(FilePath, String)]
         -> TestTree
-    test name expectedError oldVersion newVersion =
+    test name expectation oldVersion newVersion =
         testCase name $
         withTempDir $ \dir -> do
             let depDir = dir </> "oldVersion"
@@ -555,13 +555,19 @@ tests damlc =
             writeFiles dir (projectFile "mylib-v2" (Just depDar) : newVersion)
             writeFiles depDir (projectFile "mylib-v1" Nothing : oldVersion)
             callProcessSilent damlc ["build", "--project-root", depDir, "-o", depDar]
-            case expectedError of
-              Nothing ->
+            case expectation of
+              Succeed ->
                   callProcessSilent damlc ["build", "--project-root", dir, "-o", dar]
-              Just regex -> do
+              FailWithError regex -> do
                   stderr <- callProcessForStderr damlc ["build", "--project-root", dir, "-o", dar]
-                  unless (matchTest (makeRegex regex :: Regex) stderr) $
-                      assertFailure ("Regex '" <> show regex <> "' did not match stderr:\n" <> show stderr)
+                  let regexWithSeverity = "Severity: DsError\nMessage: \n" <> regex
+                  unless (matchTest (makeRegex regexWithSeverity :: Regex) stderr) $
+                      assertFailure ("`daml build` failed as expected, but did not give an error matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
+              SucceedWithWarning regex -> do
+                  stderr <- callProcessForSuccessfulStderr damlc ["build", "--project-root", dir, "-o", dar]
+                  let regexWithSeverity = "Severity: DsWarning\nMessage: \n" <> regex
+                  unless (matchTest (makeRegex regexWithSeverity :: Regex) stderr) $
+                      assertFailure ("`daml build` succeeded, but did not give a warning matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
 
     writeFiles dir fs =
         for_ fs $ \(file, content) -> do
@@ -587,3 +593,9 @@ tests damlc =
                     (featureMinVersion featurePackageUpgrades V1))
           ] ++ ["upgrades: '" <> path <> "'" | Just path <- pure upgradedFile]
         )
+
+data Expectation
+  = Succeed
+  | FailWithError T.Text
+  | SucceedWithWarning T.Text
+  deriving (Show, Eq, Ord)

--- a/libs-haskell/test-utils/DA/Test/Process.hs
+++ b/libs-haskell/test-utils/DA/Test/Process.hs
@@ -7,6 +7,7 @@ module DA.Test.Process
   , callProcessSilentError
   , callProcessForStdout
   , callProcessForStderr
+  , callProcessForSuccessfulStderr
   , callCommandSilent
   , callCommandSilentIn
   , callCommandSilentWithEnvIn
@@ -37,6 +38,10 @@ callProcessForStdout cmd args =
 callProcessForStderr :: FilePath -> [String] -> IO String
 callProcessForStderr cmd args =
   snd <$> run (ShouldSucceed False) (proc cmd args)
+
+callProcessForSuccessfulStderr :: FilePath -> [String] -> IO String
+callProcessForSuccessfulStderr cmd args =
+  snd <$> run (ShouldSucceed True) (proc cmd args)
 
 callCommandSilent :: String -> IO ()
 callCommandSilent cmd =


### PR DESCRIPTION
When expressions for things like signatories change, we should warn instead of throwing an error, because some of those changes are legitimate

Following on from https://github.com/digital-asset/daml/pull/17220, specifically https://github.com/digital-asset/daml/pull/17220#discussion_r1363921056