### PR TITLE
Revert addition of derived fields (revert #17539)

### DIFF
--- a/buf-ledger-api.yaml
+++ b/buf-ledger-api.yaml
@@ -17,3 +17,7 @@ breaking:
     #
     # We rely in particular on fields not getting renamed in `UpdateXXX` calls that use a `FieldMask`
     # to select the fields to update, see https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/field_mask.proto
+  ignore_only:
+    FIELD_NO_DELETE:
+      - com/daml/ledger/api/v1/commands.proto
+      - com/daml/ledger/api/v1/event.proto

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
@@ -233,22 +233,4 @@ message DisclosedContract {
   // The contract metadata from the create event.
   // Required
   ContractMetadata metadata = 4;
-
-  // The signatories for this contract as specified by the template.
-  // Required
-  repeated string signatories = 6;
-
-  // The observers for this contract as specified explicitly by the template or implicitly as choice controllers.
-  // This field never contains parties that are signatories.
-  // Optional
-  repeated string observers = 7;
-
-  // The key of the created contract.
-  // This will be set if and only if ``create_arguments`` is set and ``template_id`` defines a contract key.
-  // Optional
-  Value contract_key = 8;
-
-  // Maintainers of the contract key, if defined.
-  // Optional
-  repeated string key_maintainers = 9;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
@@ -117,12 +117,6 @@ message CreatedEvent {
   // after the introduction of explicit disclosure.
   // Optional
   ContractMetadata metadata = 10;
-
-  // Maintainers of the contract key, if defined.
-  // This list is populated (if a key is specified for this contract) for
-  // contracts created starting with Canton 2.7.0
-  // Optional
-  repeated string key_maintainers = 13;
 }
 
 // View of a create event matched by an interface filter.

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/InterfaceSpec.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/InterfaceSpec.scala
@@ -311,7 +311,7 @@ object InterfaceSpec extends Matchers with Inside {
               transactionId,
               Seq(
                 Event(
-                  Created(CreatedEvent(_, _, Some(`templateId`), _, _, _, _, _, _, _, _, _, _))
+                  Created(CreatedEvent(_, _, Some(`templateId`), _, _, _, _, _, _, _, _, _))
                 )
               ),
             ) =>
@@ -325,9 +325,7 @@ object InterfaceSpec extends Matchers with Inside {
       inside(events) {
         case Seq(
               Event(
-                Created(
-                  CreatedEvent(_, _, Some(`templateId`), _, None, _, Seq(_), _, _, _, _, _, _)
-                )
+                Created(CreatedEvent(_, _, Some(`templateId`), _, None, _, Seq(_), _, _, _, _, _))
               )
             ) =>
           succeed
@@ -338,7 +336,7 @@ object InterfaceSpec extends Matchers with Inside {
         case Seq(
               Event(
                 Created(
-                  CreatedEvent(_, _, Some(`templateId`), _, Some(_), _, Seq(_), _, _, _, _, _, _)
+                  CreatedEvent(_, _, Some(`templateId`), _, Some(_), _, Seq(_), _, _, _, _, _)
                 )
               )
             ) =>
@@ -350,7 +348,7 @@ object InterfaceSpec extends Matchers with Inside {
         case Seq(
               Event(
                 Created(
-                  CreatedEvent(_, _, _, _, _, _, Seq(view), _, _, _, _, _, _)
+                  CreatedEvent(_, _, _, _, _, _, Seq(view), _, _, _, _, _)
                 )
               )
             ) =>


### PR DESCRIPTION
This PR reverts the recent addition of the derived fields (Complete contract data in DisclosedContract (https://github.com/digital-asset/daml/pull/17539)) in the explicit disclosure and paves the way for a clean addition of the opaque payload.