### PR TITLE
LT-35: add codegen for json encoding

### DIFF
--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/DefinedDataType.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/DefinedDataType.java
@@ -4,6 +4,11 @@
 package com.daml.ledger.javaapi.data.codegen;
 
 import com.daml.ledger.javaapi.data.Value;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfEncoder;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfWriter;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
 
 /**
  * The codegen-decoded form of any of these:
@@ -22,4 +27,17 @@ import com.daml.ledger.javaapi.data.Value;
 public interface DefinedDataType<T> {
   /** Produce the encoded form. */
   Value toValue();
+
+  JsonLfEncoder jsonEncoder();
+
+  default String toJson() {
+    var w = new StringWriter();
+    try {
+      this.jsonEncoder().encode(new JsonLfWriter(w));
+    } catch (IOException e) {
+      // Not expected with StringWriter
+      throw new UncheckedIOException(e);
+    }
+    return w.toString();
+  }
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncoders.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncoders.java
@@ -6,7 +6,9 @@ package com.daml.ledger.javaapi.data.codegen.json;
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.time.temporal.ChronoUnit.SECONDS;
 
+import com.daml.ledger.javaapi.data.Unit;
 import com.daml.ledger.javaapi.data.codegen.ContractId;
+import com.daml.ledger.javaapi.data.codegen.DamlEnum;
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -14,6 +16,7 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -22,11 +25,12 @@ import java.util.function.Function;
 public class JsonLfEncoders {
   private static final JsonStringEncoder stringEncoder = JsonStringEncoder.getInstance();
 
-  public static final JsonLfEncoder unit =
-      w -> {
-        w.writeStartObject();
-        w.writeEndObject();
-      };
+  public static JsonLfEncoder unit(Unit _unit) {
+    return w -> {
+      w.writeStartObject();
+      w.writeEndObject();
+    };
+  }
 
   public static JsonLfEncoder bool(Boolean value) {
     return w -> w.write(String.valueOf(value));
@@ -65,17 +69,16 @@ public class JsonLfEncoders {
     return text(value);
   }
 
-  public static JsonLfEncoder contractId(ContractId<?> value) {
+  public static <Cid extends ContractId<?>> JsonLfEncoder contractId(Cid value) {
     return text(value.toValue().asContractId().get().getValue());
   }
 
-  public static <E extends Enum<E>> Function<E, JsonLfEncoder> enumeration(
+  public static <E extends DamlEnum<E>> Function<E, JsonLfEncoder> enumeration(
       Function<E, String> toDamlName) {
     return value -> text(toDamlName.apply(value));
   }
 
-  public static <T> Function<Iterable<T>, JsonLfEncoder> list(
-      Function<T, JsonLfEncoder> itemEncoder) {
+  public static <T> Function<List<T>, JsonLfEncoder> list(Function<T, JsonLfEncoder> itemEncoder) {
     return items -> {
       return w -> {
         w.writeStartArray();

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncoders.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncoders.java
@@ -207,6 +207,13 @@ public class JsonLfEncoders {
     };
   }
 
+  // This function is used as a static import within code-gen encoder implementations.
+  // It assists the type checker with type inference and unification,
+  // and unifies the call syntax by accepting both method references and Function's as f
+  public static <I, O> O apply(Function<I, O> f, I x) {
+    return f.apply(x);
+  }
+
   private static boolean isRoundTo(Instant value, ChronoUnit unit) {
     return value.truncatedTo(unit).equals(value);
   }

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncodersTest.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncodersTest.java
@@ -25,7 +25,7 @@ public class JsonLfEncodersTest {
 
   @Test
   void testUnit() throws IOException {
-    assertEquals("{}", intoString(JsonLfEncoders.unit));
+    assertEquals("{}", intoString(JsonLfEncoders.unit(Unit.getInstance())));
   }
 
   @Test
@@ -215,7 +215,7 @@ public class JsonLfEncodersTest {
                 return JsonLfEncoders.Field.of(
                     "Bar", JsonLfEncoders.int64(((SomeVariant.Bar) v).x));
               else if (v instanceof SomeVariant.Baz)
-                return JsonLfEncoders.Field.of("Baz", JsonLfEncoders.unit);
+                return JsonLfEncoders.Field.of("Baz", JsonLfEncoders.unit(((SomeVariant.Baz) v).x));
               else if (v instanceof SomeVariant.Quux)
                 return JsonLfEncoders.Field.of(
                     "Quux",

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/TestHelpers.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/TestHelpers.java
@@ -204,5 +204,9 @@ public class TestHelpers {
     public com.daml.ledger.javaapi.data.DamlEnum toValue() {
       return null;
     }
+
+    public JsonLfEncoder jsonEncoder() {
+      return null;
+    }
   }
 }

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/TestHelpers.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/TestHelpers.java
@@ -4,6 +4,8 @@
 package com.daml.ledger.javaapi.data.codegen.json;
 
 import com.daml.ledger.javaapi.data.Unit;
+import com.daml.ledger.javaapi.data.codegen.ContractId;
+import com.daml.ledger.javaapi.data.codegen.DamlEnum;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -160,14 +162,14 @@ public class TestHelpers {
   }
 
   static class Tmpl {
-    public static final class Cid extends com.daml.ledger.javaapi.data.codegen.ContractId<Tmpl> {
+    public static final class Cid extends ContractId<Tmpl> {
       public Cid(String id) {
         super(id);
       }
     }
   }
 
-  static enum Suit {
+  static enum Suit implements DamlEnum<Suit> {
     HEARTS,
     DIAMONDS,
     CLUBS,
@@ -197,5 +199,10 @@ public class TestHelpers {
             put("Spades", SPADES);
           }
         };
+
+    @Override
+    public com.daml.ledger.javaapi.data.DamlEnum toValue() {
+      return null;
+    }
   }
 }

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -431,7 +431,17 @@ da_scala_test(
 
 da_scala_benchmark_jmh(
     name = "from-json-bench",
-    srcs = glob(["src/bench/**/*.scala"]),
+    srcs = glob(["src/bench/**/FromJsonBench.scala"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":test-model-2.dev.jar",
+        "//language-support/java/bindings:bindings-java",
+    ],
+)
+
+da_scala_benchmark_jmh(
+    name = "to-json-bench",
+    srcs = glob(["src/bench/**/ToJsonBench.scala"]),
     visibility = ["//visibility:public"],
     deps = [
         ":test-model-2.dev.jar",

--- a/language-support/java/codegen/src/bench/com/daml/lf/codegen/java/FromJsonBench.scala
+++ b/language-support/java/codegen/src/bench/com/daml/lf/codegen/java/FromJsonBench.scala
@@ -8,7 +8,7 @@ import org.openjdk.jmh.annotations._
 
 @BenchmarkMode(Array(Mode.Throughput)) @OutputTimeUnit(TimeUnit.SECONDS)
 @Fork(value = 1)
-@Warmup(iterations = 3)
+@Warmup(iterations = 4)
 @Measurement(iterations = 10)
 class FromJsonBench {
 

--- a/language-support/java/codegen/src/bench/com/daml/lf/codegen/java/ToJsonBench.scala
+++ b/language-support/java/codegen/src/bench/com/daml/lf/codegen/java/ToJsonBench.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.codegen.java
+
+import com.daml.ledger.javaapi.data.Unit
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+
+@BenchmarkMode(Array(Mode.Throughput)) @OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@Warmup(iterations = 4)
+@Measurement(iterations = 10)
+class ToJsonBench {
+
+  @Benchmark
+  def enummodBox = Samples.enummodBox.toJson
+
+  @Benchmark
+  def enummodOptionalColor = Samples.enummodOptionalColor.toJson
+
+  @Benchmark
+  def enummodColoredTree = Samples.enummodColoredTree.toJson
+
+  @Benchmark
+  def genmapmodBox = Samples.genmapmodBox.toJson
+}
+
+object Samples {
+
+  val enummodOptionalColor = new test.enummod.optionalcolor.SomeColor(test.enummod.Color.GREEN)
+
+  val enummodBox = new test.enummod.Box(test.enummod.Color.RED, "party")
+
+  val enummodColoredTree = new test.enummod.coloredtree.Node(
+    test.enummod.Color.BLUE,
+    new test.enummod.coloredtree.Leaf(Unit.getInstance()),
+    new test.enummod.coloredtree.Leaf(Unit.getInstance()),
+  )
+
+  private def pair(i: Long, d: BigDecimal) =
+    new test.recordmod.Pair(java.lang.Long.valueOf(i), d.bigDecimal)
+  private def right(d: BigDecimal): test.variantmod.Either[java.lang.Long, java.math.BigDecimal] =
+    new test.variantmod.either.Right(d.bigDecimal)
+  private def left(i: Long): test.variantmod.Either[java.lang.Long, java.math.BigDecimal] =
+    new test.variantmod.either.Left(java.lang.Long.valueOf(i))
+
+  import scala.jdk.CollectionConverters._
+  val genmapmodBox = new test.genmapmod.Box(
+    Map(
+      pair(1L, BigDecimal("1.0000000000")) -> right(BigDecimal("1.0000000000")),
+      pair(2L, BigDecimal("-2.2222222222")) -> left(2L),
+      pair(3L, BigDecimal("3.3333333333")) -> right(BigDecimal("3.3333333333")),
+    ).asJava,
+    "alice",
+  )
+}

--- a/language-support/java/codegen/src/it/java/com/daml/ListTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/ListTest.java
@@ -12,6 +12,7 @@ import com.daml.ledger.javaapi.data.Text;
 import com.daml.ledger.javaapi.data.Unit;
 import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
 import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoders;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfEncoders;
 import com.google.protobuf.Empty;
 import java.util.Arrays;
 import java.util.Collections;
@@ -101,18 +102,14 @@ public class ListTest {
   }
 
   @Test
-  void fromJsonMyListRecord() throws JsonLfDecoder.Error {
+  void roundtripJsonMyListRecord() throws JsonLfDecoder.Error {
     MyListRecord expected =
         new MyListRecord(
             Arrays.asList(1L, 2L),
             Collections.singletonList(Unit.getInstance()),
             Arrays.asList(new Node<Long>(17L), new Node<Long>(42L)));
 
-    assertEquals(
-        expected,
-        MyListRecord.fromJson(
-            "{\"intList\": [1, 2], \"unitList\": [{}], \"itemList\": "
-                + "[{\"tag\": \"Node\", \"value\": 17}, {\"tag\": \"Node\", \"value\": 42}]}"));
+    assertEquals(expected, MyListRecord.fromJson(expected.toJson()));
   }
 
   @Test
@@ -200,18 +197,13 @@ public class ListTest {
   }
 
   @Test
-  void fromJsonMyListOfListRecord() throws JsonLfDecoder.Error {
+  void roundtripJsonMyListOfListRecord() throws JsonLfDecoder.Error {
     MyListOfListRecord expected =
         new MyListOfListRecord(
             Arrays.asList(
                 Arrays.asList(new Node<>(17L), new Node<>(42L)), Arrays.asList(new Node<>(1337L))));
 
-    assertEquals(
-        expected,
-        MyListOfListRecord.fromJson(
-            "{\"itemList\": ["
-                + "[{\"tag\": \"Node\", \"value\": 17}, {\"tag\": \"Node\", \"value\": 42}], "
-                + "[{\"tag\": \"Node\", \"value\": 1337}]]}"));
+    assertEquals(expected, MyListOfListRecord.fromJson(expected.toJson()));
   }
 
   @Test
@@ -253,10 +245,10 @@ public class ListTest {
   }
 
   @Test
-  void fromJsonColorListRecord() throws JsonLfDecoder.Error {
+  void roundtripJsonColorListRecord() throws JsonLfDecoder.Error {
     ColorListRecord expected = new ColorListRecord(Arrays.asList(Color.GREEN, Color.RED));
 
-    assertEquals(expected, ColorListRecord.fromJson("{\"colors\": [\"Green\", \"Red\"]}"));
+    assertEquals(expected, ColorListRecord.fromJson(expected.toJson()));
   }
 
   @Test
@@ -299,14 +291,14 @@ public class ListTest {
   }
 
   @Test
-  void fromJsonParameterizedListRecordWithString() throws JsonLfDecoder.Error {
+  void roundtripJsonParameterizedListRecordWithString() throws JsonLfDecoder.Error {
     ParameterizedListRecord<String> expected =
         new ParameterizedListRecord<>(Arrays.asList("Element1", "Element2"));
 
-    assertEquals(
-        expected,
-        ParameterizedListRecord.fromJson(
-            "{\"list\":[\"Element1\", \"Element2\"]}", JsonLfDecoders.text));
+    String json = expected.toJson(JsonLfEncoders::text);
+    var actual = ParameterizedListRecord.fromJson(json, JsonLfDecoders.text);
+
+    assertEquals(expected, actual);
   }
 
   @Test
@@ -389,16 +381,15 @@ public class ListTest {
   }
 
   @Test
-  void fromJsonParameterizedListRecordWithListOfString() throws JsonLfDecoder.Error {
+  void roundtripJsonParameterizedListRecordWithListOfString() throws JsonLfDecoder.Error {
     ParameterizedListRecord<List<String>> expected =
         new ParameterizedListRecord<>(
             Arrays.asList(
                 Arrays.asList("Element1", "Element2"), Arrays.asList("Element3", "Element4")));
 
-    assertEquals(
-        expected,
-        ParameterizedListRecord.fromJson(
-            "{\"list\": [[\"Element1\", \"Element2\"], [\"Element3\", \"Element4\"]]}",
-            JsonLfDecoders.list(JsonLfDecoders.text)));
+    String json = expected.toJson(JsonLfEncoders.list(JsonLfEncoders::text));
+    var actual = ParameterizedListRecord.fromJson(json, JsonLfDecoders.list(JsonLfDecoders.text));
+
+    assertEquals(expected, actual);
   }
 }

--- a/language-support/java/codegen/src/it/java/com/daml/OptionalTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/OptionalTest.java
@@ -9,6 +9,7 @@ import com.daml.ledger.api.v1.ValueOuterClass;
 import com.daml.ledger.javaapi.data.*;
 import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
 import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoders;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfEncoders;
 import com.google.protobuf.Empty;
 import java.util.Arrays;
 import java.util.Optional;
@@ -37,11 +38,11 @@ public class OptionalTest {
   }
 
   @Test
-  void fromJsonRecordWithOptionalFields() throws JsonLfDecoder.Error {
+  void roundtripJsonRecordWithOptionalFields() throws JsonLfDecoder.Error {
     MyOptionalRecord expected =
         new MyOptionalRecord(Optional.of(42L), Optional.of(Unit.getInstance()));
 
-    assertEquals(expected, MyOptionalRecord.fromJson("{\"intOpt\": 42, \"unitOpt\": {}}"));
+    assertEquals(expected, MyOptionalRecord.fromJson(expected.toJson()));
   }
 
   @Test
@@ -100,11 +101,11 @@ public class OptionalTest {
   }
 
   @Test
-  void fromJsonNestedOptional() throws JsonLfDecoder.Error {
+  void roundtripJsonNestedOptional() throws JsonLfDecoder.Error {
     NestedOptionalRecord expected =
         new NestedOptionalRecord(Optional.of(Optional.of(Optional.of(42L))));
 
-    assertEquals(expected, NestedOptionalRecord.fromJson("{\"outerOptional\": [[42]]}"));
+    assertEquals(expected, NestedOptionalRecord.fromJson(expected.toJson()));
   }
 
   @Test
@@ -137,10 +138,10 @@ public class OptionalTest {
   }
 
   @Test
-  void fromJsonOptionalListRecord() throws JsonLfDecoder.Error {
+  void roundtripJsonOptionalListRecord() throws JsonLfDecoder.Error {
     MyOptionalListRecord expected = new MyOptionalListRecord(Optional.of(Arrays.asList(42L)));
 
-    assertEquals(expected, MyOptionalListRecord.fromJson("{\"list\": [42]}"));
+    assertEquals(expected, MyOptionalListRecord.fromJson(expected.toJson()));
   }
 
   @Test
@@ -174,10 +175,10 @@ public class OptionalTest {
   }
 
   @Test
-  void fromJsonListOfOptionalsRecord() throws JsonLfDecoder.Error {
+  void roundtripJsonListOfOptionalsRecord() throws JsonLfDecoder.Error {
     MyListOfOptionalsRecord expected = new MyListOfOptionalsRecord(Arrays.asList(Optional.of(42L)));
 
-    assertEquals(expected, MyListOfOptionalsRecord.fromJson("{\"list\": [42]}"));
+    assertEquals(expected, MyListOfOptionalsRecord.fromJson(expected.toJson()));
   }
 
   @Test
@@ -194,13 +195,13 @@ public class OptionalTest {
   }
 
   @Test
-  void fromJsonOptionalParametricVariant() throws JsonLfDecoder.Error {
+  void roundtripJsonOptionalParametricVariant() throws JsonLfDecoder.Error {
     OptionalVariant<Long> expected = new OptionalParametricVariant<Long>(Optional.of(42L));
 
-    assertEquals(
-        expected,
-        OptionalVariant.fromJson(
-            "{\"tag\": \"OptionalParametricVariant\", \"value\": 42}", JsonLfDecoders.int64));
+    String json = expected.toJson(JsonLfEncoders::int64);
+    var actual = OptionalVariant.fromJson(json, JsonLfDecoders.int64);
+
+    assertEquals(expected, actual);
   }
 
   @Test
@@ -215,12 +216,12 @@ public class OptionalTest {
   }
 
   @Test
-  void fromJsonOptionalPrimVariant() throws JsonLfDecoder.Error {
+  void roundtripJsonOptionalPrimVariant() throws JsonLfDecoder.Error {
     OptionalVariant<Long> expected = new OptionalPrimVariant(Optional.of(42L));
 
-    assertEquals(
-        expected,
-        OptionalVariant.fromJson(
-            "{\"tag\": \"OptionalPrimVariant\", \"value\": 42}", JsonLfDecoders.int64));
+    String json = expected.toJson(JsonLfEncoders::int64);
+    var actual = OptionalVariant.fromJson(json, JsonLfDecoders.int64);
+
+    assertEquals(expected, actual);
   }
 }

--- a/language-support/java/codegen/src/it/java/com/daml/ParametrizedContractIdTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/ParametrizedContractIdTest.java
@@ -51,13 +51,14 @@ public class ParametrizedContractIdTest {
   }
 
   @Test
-  void fromJsonFixedContractId() throws JsonLfDecoder.Error {
-    FixedContractId expected =
+  void roundTripJson() throws JsonLfDecoder.Error {
+    FixedContractId fixed =
         new FixedContractId(new ParametrizedContractId<>(new Foo.ContractId("SomeID")));
-    assertEquals(
-        expected,
-        FixedContractId.fromJson(
-            "{\"fixedContractId\": {\"parametrizedContractId\": \"SomeID\"}}"));
+    FixedContractId parameterized =
+        new FixedContractId(new ParametrizedContractId<>(new ContractId<Foo>("SomeID")));
+
+    assertEquals(fixed, FixedContractId.fromJson(fixed.toJson()));
+    assertEquals(parameterized, FixedContractId.fromJson(parameterized.toJson()));
   }
 
   @Test

--- a/language-support/java/codegen/src/it/java/com/daml/RecordTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/RecordTest.java
@@ -10,6 +10,7 @@ import com.daml.ledger.api.v1.ValueOuterClass;
 import com.daml.ledger.javaapi.data.*;
 import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
 import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoders;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfEncoders;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -122,7 +123,7 @@ public class RecordTest {
   }
 
   @Test
-  void fromJsonMyRecord() throws JsonLfDecoder.Error {
+  void roundtripJsonMyRecord() throws JsonLfDecoder.Error {
     MyRecord expected =
         new MyRecord(
             int64Value,
@@ -139,24 +140,7 @@ public class RecordTest {
             nestedRecordValue,
             nestedVariantValue);
 
-    assertEquals(
-        expected,
-        MyRecord.fromJson(
-            "{"
-                + "\"int_\": 1, "
-                + "\"decimal\": 2, "
-                + "\"text\": \"text\", "
-                + "\"bool\": false, "
-                + "\"party\": \"myparty\", "
-                + "\"date\": \"1970-01-04\", "
-                + "\"time\": \"1970-01-01T00:00:00.004Z\", "
-                + "\"void$\": false, "
-                + "\"list\": [{}, {}], "
-                + "\"nestedList\": [[1,2,3], [1,2,3]], "
-                + "\"unit\": {}, "
-                + "\"nestedRecord\": {\"value\": 42}, "
-                + "\"nestedVariant\": {\"tag\": \"Nested\", \"value\": 42} "
-                + "}"));
+    assertEquals(expected, MyRecord.fromJson(expected.toJson()));
   }
 
   @Test
@@ -247,22 +231,16 @@ public class RecordTest {
   }
 
   @Test
-  void fromJsonOuterRecord() throws JsonLfDecoder.Error {
+  void roundtripJsonOuterRecord() throws JsonLfDecoder.Error {
     OuterRecord<String, Boolean> expected =
         new OuterRecord<>(
             new ParametricRecord<String, Boolean>("Text1", "Text2", true, 42L),
             new ParametricRecord<Long, String>(42L, 69L, "Text2", 69L));
 
-    assertEquals(
-        expected,
-        OuterRecord.fromJson(
-            "{"
-                + "\"inner\": {\"fieldX1\": \"Text1\", \"fieldX2\": \"Text2\", \"fieldY\": true,"
-                + " \"fieldInt\": 42}, "
-                + "\"innerFixed\":  {\"fieldX1\": \"42\", \"fieldX2\": \"69\","
-                + " \"fieldY\": \"Text2\", \"fieldInt\": 69} }",
-            JsonLfDecoders.text,
-            JsonLfDecoders.bool));
+    String json = expected.toJson(JsonLfEncoders::text, JsonLfEncoders::bool);
+    var actual = OuterRecord.fromJson(json, JsonLfDecoders.text, JsonLfDecoders.bool);
+
+    assertEquals(expected, actual);
   }
 
   Long int64Value = 1L;

--- a/language-support/java/codegen/src/it/java/com/daml/TextMapTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/TextMapTest.java
@@ -11,6 +11,7 @@ import com.daml.ledger.javaapi.data.Int64;
 import com.daml.ledger.javaapi.data.Variant;
 import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
 import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoders;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfEncoders;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -75,19 +76,9 @@ public class TextMapTest {
   }
 
   @Test
-  void fromJsonMapRecord() throws JsonLfDecoder.Error {
-    MapRecord expected =
-        new MapRecord(
-            new HashMap<>() {
-              {
-                put("key1", "value1");
-                put("key2", "value2");
-              }
-            });
-
-    assertEquals(
-        expected,
-        MapRecord.fromJson("{\"mapField\": {\"key1\": \"value1\", \"key2\": \"value2\"}}"));
+  void roundtripJsonMapRecord() throws JsonLfDecoder.Error {
+    MapRecord expected = new MapRecord(Map.of("key1", "value1", "key2", "value2"));
+    assertEquals(expected, MapRecord.fromJson(expected.toJson()));
   }
 
   @Test
@@ -260,37 +251,14 @@ public class TextMapTest {
   }
 
   @Test
-  void fromJsonMapItemMapRecord() throws JsonLfDecoder.Error {
+  void roundTripJsonMapItemMapRecord() throws JsonLfDecoder.Error {
     MapItemMapRecord expected =
         new MapItemMapRecord(
-            new HashMap<>() {
-              {
-                put(
-                    "outerkey1",
-                    new HashMap<>() {
-                      {
-                        put("key1", new MapItem<Long>(1L));
-                        put("key2", new MapItem<Long>(2L));
-                      }
-                    });
-                put(
-                    "outerkey2",
-                    new HashMap<>() {
-                      {
-                        put("key1", new MapItem<Long>(3L));
-                        put("key2", new MapItem<Long>(4L));
-                      }
-                    });
-              }
-            });
+            Map.of(
+                "outerkey1", Map.of("key1", new MapItem<Long>(1L), "key2", new MapItem<Long>(2L)),
+                "outerkey2", Map.of("key1", new MapItem<Long>(3L), "key2", new MapItem<Long>(4L))));
 
-    assertEquals(
-        expected,
-        MapItemMapRecord.fromJson(
-            "{\"field\": {"
-                + "\"outerkey1\": {\"key1\": {\"value\": 1}, \"key2\": {\"value\": 2} }, "
-                + "\"outerkey2\": {\"key1\": {\"value\": 3}, \"key2\": {\"value\": 4} } "
-                + "}}"));
+    assertEquals(expected, MapItemMapRecord.fromJson(expected.toJson()));
   }
 
   @Test
@@ -326,13 +294,13 @@ public class TextMapTest {
   }
 
   @Test
-  public void fromJsonTextVariant() throws JsonLfDecoder.Error {
-    MapVariant<?> expected = new TextVariant<>(Collections.singletonMap("key", "value"));
+  public void roundtripJsonTextVariant() throws JsonLfDecoder.Error {
+    MapVariant<Long> expected = new TextVariant<>(Collections.singletonMap("key", "value"));
 
-    assertEquals(
-        expected,
-        MapVariant.fromJson(
-            "{\"tag\": \"TextVariant\", \"value\": {\"key\": \"value\"}}", JsonLfDecoders.unit));
+    String json = expected.toJson(JsonLfEncoders::int64);
+    var actual = MapVariant.fromJson(json, JsonLfDecoders.int64);
+
+    assertEquals(expected, actual);
   }
 
   @Test
@@ -377,14 +345,13 @@ public class TextMapTest {
   }
 
   @Test
-  void fromJsonRecordVariant() throws JsonLfDecoder.Error {
-    MapVariant<?> expected = new RecordVariant<>(Collections.singletonMap("key", 42L));
+  void roundtripJsonRecordVariant() throws JsonLfDecoder.Error {
+    MapVariant<Long> expected = new RecordVariant<>(Collections.singletonMap("key", 42L));
 
-    assertEquals(
-        expected,
-        MapVariant.fromJson(
-            "{\"tag\": \"RecordVariant\", \"value\": {\"x\": {\"key\": 42}}}",
-            JsonLfDecoders.unit));
+    String json = expected.toJson(JsonLfEncoders::int64);
+    var actual = MapVariant.fromJson(json, JsonLfDecoders.int64);
+
+    assertEquals(expected, actual);
   }
 
   @Test
@@ -423,13 +390,13 @@ public class TextMapTest {
   }
 
   @Test
-  void fromJsonParameterizedVariant() throws JsonLfDecoder.Error {
+  void roundtripJsonParameterizedVariant() throws JsonLfDecoder.Error {
     MapVariant<Long> expected = new ParameterizedVariant<>(Collections.singletonMap("key", 42L));
 
-    assertEquals(
-        expected,
-        MapVariant.fromJson(
-            "{\"tag\": \"ParameterizedVariant\", \"value\": {\"key\": 42}}", JsonLfDecoders.int64));
+    String json = expected.toJson(JsonLfEncoders::int64);
+    var actual = MapVariant.fromJson(json, JsonLfDecoders.int64);
+
+    assertEquals(expected, actual);
   }
 
   @Test
@@ -475,10 +442,9 @@ public class TextMapTest {
   }
 
   @Test
-  void fromJsonTemplateWithMap() throws JsonLfDecoder.Error {
+  void roundtripJsonTemplateWithMap() throws JsonLfDecoder.Error {
     TemplateWithMap expected = new TemplateWithMap("party1", Collections.singletonMap("key", 42L));
 
-    assertEquals(
-        expected, TemplateWithMap.fromJson("{\"owner\": \"party1\", \"valueMap\": {\"key\": 42}}"));
+    assertEquals(expected, TemplateWithMap.fromJson(expected.toJson()));
   }
 }

--- a/language-support/java/codegen/src/it/java/com/daml/VariantTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/VariantTest.java
@@ -11,6 +11,7 @@ import com.daml.ledger.javaapi.data.Unit;
 import com.daml.ledger.javaapi.data.Variant;
 import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
 import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoders;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfEncoders;
 import com.google.protobuf.Empty;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -45,11 +46,13 @@ public class VariantTest {
   }
 
   @Test
-  void fromJsonEmptyVariant() throws JsonLfDecoder.Error {
-    VariantItem<?> expected = new EmptyVariant<>(Unit.getInstance());
-    assertEquals(
-        expected,
-        VariantItem.fromJson("{\"tag\": \"EmptyVariant\", \"value\": {}}", JsonLfDecoders.unit));
+  void roundtripJsonEmptyVariant() throws JsonLfDecoder.Error {
+    VariantItem<Unit> expected = new EmptyVariant<>(Unit.getInstance());
+
+    String json = expected.toJson(JsonLfEncoders::unit);
+    var actual = VariantItem.fromJson(json, JsonLfDecoders.unit);
+
+    assertEquals(expected, actual);
   }
 
   @Test
@@ -73,11 +76,13 @@ public class VariantTest {
   }
 
   @Test
-  void fromJsonPrimVariant() throws JsonLfDecoder.Error {
-    VariantItem<?> expected = new PrimVariant<>(42L);
-    assertEquals(
-        expected,
-        VariantItem.fromJson("{\"tag\": \"PrimVariant\", \"value\": 42}", JsonLfDecoders.unit));
+  void roundtripJsonPrimVariant() throws JsonLfDecoder.Error {
+    VariantItem<Long> expected = new PrimVariant<>(42L);
+
+    String json = expected.toJson(JsonLfEncoders::int64);
+    var actual = VariantItem.fromJson(json, JsonLfDecoders.int64);
+
+    assertEquals(expected, actual);
   }
 
   @Test
@@ -109,12 +114,13 @@ public class VariantTest {
   }
 
   @Test
-  void fromJsonRecordVariant() throws JsonLfDecoder.Error {
-    VariantItem<?> expected = new RecordVariant<Long>(42L);
-    assertEquals(
-        expected,
-        VariantItem.fromJson(
-            "{\"tag\": \"RecordVariant\", \"value\": {\"x\": 42}}", JsonLfDecoders.unit));
+  void roundtripJsonRecordVariant() throws JsonLfDecoder.Error {
+    VariantItem<Long> expected = new RecordVariant<Long>(42L);
+
+    String json = expected.toJson(JsonLfEncoders::int64);
+    var actual = VariantItem.fromJson(json, JsonLfDecoders.int64);
+
+    assertEquals(expected, actual);
   }
 
   @Test
@@ -141,11 +147,13 @@ public class VariantTest {
   }
 
   @Test
-  void fromJsonCustomVariant() throws JsonLfDecoder.Error {
-    VariantItem<?> expected = new CustomVariant<>(new Custom());
-    assertEquals(
-        expected,
-        VariantItem.fromJson("{\"tag\": \"CustomVariant\", \"value\": {}}", JsonLfDecoders.unit));
+  void roundtripJsonCustomVariant() throws JsonLfDecoder.Error {
+    VariantItem<Unit> expected = new CustomVariant<>(new Custom());
+
+    String json = expected.toJson(JsonLfEncoders::unit);
+    var actual = VariantItem.fromJson(json, JsonLfDecoders.unit);
+
+    assertEquals(expected, actual);
   }
 
   @Test
@@ -179,14 +187,13 @@ public class VariantTest {
   }
 
   @Test
-  void fromJsonCustomParametricVariant() throws JsonLfDecoder.Error {
-    VariantItem<?> expected = new CustomParametricVariant<>(new CustomParametricCons<>(42L));
-    assertEquals(
-        expected,
-        VariantItem.fromJson(
-            "{\"tag\": \"CustomParametricVariant\", \"value\": {\"tag\": \"CustomParametricCons\","
-                + " \"value\": 42}}",
-            JsonLfDecoders.int64));
+  void roundtripJsonCustomParametricVariant() throws JsonLfDecoder.Error {
+    VariantItem<Long> expected = new CustomParametricVariant<>(new CustomParametricCons<>(42L));
+
+    String json = expected.toJson(JsonLfEncoders::int64);
+    var actual = VariantItem.fromJson(json, JsonLfDecoders.int64);
+
+    assertEquals(expected, actual);
   }
 
   @Test
@@ -227,14 +234,13 @@ public class VariantTest {
   }
 
   @Test
-  void fromJsonRecordVariantRecord() throws JsonLfDecoder.Error {
-    VariantItem<?> expected = new RecordVariantRecord<>(new EmptyVariant<>(Unit.getInstance()));
-    assertEquals(
-        expected,
-        VariantItem.fromJson(
-            "{\"tag\": \"RecordVariantRecord\", \"value\": {\"y\": {\"tag\": \"EmptyVariant\","
-                + " \"value\": {}}}}",
-            JsonLfDecoders.int64));
+  void roundtripJsonRecordVariantRecord() throws JsonLfDecoder.Error {
+    VariantItem<Unit> expected = new RecordVariantRecord<>(new EmptyVariant<>(Unit.getInstance()));
+
+    String json = expected.toJson(JsonLfEncoders::unit);
+    var actual = VariantItem.fromJson(json, JsonLfDecoders.unit);
+
+    assertEquals(expected, actual);
   }
 
   @Test
@@ -283,14 +289,13 @@ public class VariantTest {
   }
 
   @Test
-  void fromJsonParameterizedRecordVariant() throws JsonLfDecoder.Error {
+  void roundtripJsonParameterizedRecordVariant() throws JsonLfDecoder.Error {
     VariantItem<Long> expected =
         new ParameterizedRecordVariant<>(42L, 69L, Collections.singletonList(65536L));
-    assertEquals(
-        expected,
-        VariantItem.fromJson(
-            "{\"tag\": \"ParameterizedRecordVariant\", \"value\": {\"x1\": 42, \"x2\": 69, \"x3\":"
-                + " [65536]}}",
-            JsonLfDecoders.int64));
+
+    String json = expected.toJson(JsonLfEncoders::int64);
+    var actual = VariantItem.fromJson(json, JsonLfDecoders.int64);
+
+    assertEquals(expected, actual);
   }
 }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/EnumClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/EnumClass.scala
@@ -36,6 +36,7 @@ private[inner] object EnumClass extends StrictLogging {
         .addMethod(generateValueDecoder(className, enumeration))
         .addMethod(generateToValue(className))
         .addMethods(FromJsonGenerator.forEnum(className, "__enums$").asJava)
+        .addMethods(ToJsonGenerator.forEnum(className).asJava)
       logger.debug("End")
       enumType.build()
     }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordClass.scala
@@ -21,10 +21,11 @@ private[inner] object RecordClass extends StrictLogging {
       record: Record.FWT,
   )(implicit
       packagePrefixes: PackagePrefixes
-  ): TypeSpec = {
+  ): (TypeSpec, Seq[(ClassName, String)]) = {
     TrackLineage.of("record", className.simpleName()) {
       logger.info("Start")
       val fields = getFieldsWithTypes(record.fields)
+      val (recordMethods, staticImports) = RecordMethods(fields, className, typeParameters)
       val recordType = TypeSpec
         .classBuilder(className)
         .addModifiers(Modifier.PUBLIC)
@@ -39,10 +40,11 @@ private[inner] object RecordClass extends StrictLogging {
         .addTypeVariables(typeParameters.map(TypeVariableName.get).asJava)
         .addFields(RecordFields(fields).asJava)
         .addField(createPackageIdField(packageId))
-        .addMethods(RecordMethods(fields, className, typeParameters).asJava)
+        .addMethods(recordMethods.asJava)
         .build()
       logger.debug("End")
-      recordType
+
+      (recordType, staticImports)
     }
   }
 }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordMethods.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordMethods.scala
@@ -11,7 +11,7 @@ private[inner] object RecordMethods {
 
   def apply(fields: Fields, className: ClassName, typeParameters: IndexedSeq[String])(implicit
       packagePrefixes: PackagePrefixes
-  ): Vector[MethodSpec] = {
+  ): (Vector[MethodSpec], Seq[(ClassName, String)]) = {
 
     val constructor = ConstructorGenerator.generateConstructor(fields)
 
@@ -44,13 +44,17 @@ private[inner] object RecordMethods {
       List(deprecatedFromValue, valueDecoder, toValue)
     }
 
+    val (jsonEncoders, staticImports) = ToJsonGenerator.forRecordLike(fields, typeParameters)
+
     val jsonConversionMethods = FromJsonGenerator.forRecordLike(
       fields,
       className,
       typeParameters,
-    ) ++ ToJsonGenerator.forRecordLike(fields, typeParameters)
+    ) ++ jsonEncoders
 
-    Vector(constructor) ++ conversionMethods ++ jsonConversionMethods ++
+    val methods = Vector(constructor) ++ conversionMethods ++ jsonConversionMethods ++
       ObjectMethods(className, typeParameters, fields.map(_.javaName))
+
+    (methods, staticImports)
   }
 }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordMethods.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordMethods.scala
@@ -48,7 +48,7 @@ private[inner] object RecordMethods {
       fields,
       className,
       typeParameters,
-    )
+    ) ++ ToJsonGenerator.forRecordLike(fields, typeParameters)
 
     Vector(constructor) ++ conversionMethods ++ jsonConversionMethods ++
       ObjectMethods(className, typeParameters, fields.map(_.javaName))

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateMethods.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateMethods.scala
@@ -14,7 +14,7 @@ private[inner] object TemplateMethods {
 
   def apply(fields: Fields, className: ClassName)(implicit
       packagePrefixes: PackagePrefixes
-  ): Vector[MethodSpec] = {
+  ): (Vector[MethodSpec], Seq[(ClassName, String)]) = {
     val constructor = ConstructorGenerator.generateConstructor(fields)
     val conversionMethods = distinctTypeVars(fields, IndexedSeq.empty[String]).flatMap { params =>
       val deprecatedFromValue = FromValueGenerator.generateDeprecatedFromValueForRecordLike(
@@ -61,15 +61,19 @@ private[inner] object TemplateMethods {
       .addStatement("return $T.of(COMPANION)", classOf[ContractFilter[_]])
       .build()
 
+    val (jsonEncoderMethods, staticImports) = ToJsonGenerator.forRecordLike(fields, IndexedSeq())
+
     val jsonConversionMethods = FromJsonGenerator.forRecordLike(
       fields,
       className,
       IndexedSeq(),
-    ) ++ ToJsonGenerator.forRecordLike(fields, IndexedSeq())
+    ) ++ jsonEncoderMethods
 
-    Vector(constructor) ++ conversionMethods ++ jsonConversionMethods ++ Vector(
+    val methods = Vector(constructor) ++ conversionMethods ++ jsonConversionMethods ++ Vector(
       contractFilterMethod
     ) ++
       ObjectMethods(className, IndexedSeq.empty[String], fields.map(_.javaName))
+
+    (methods, staticImports)
   }
 }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateMethods.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateMethods.scala
@@ -65,7 +65,7 @@ private[inner] object TemplateMethods {
       fields,
       className,
       IndexedSeq(),
-    )
+    ) ++ ToJsonGenerator.forRecordLike(fields, IndexedSeq())
 
     Vector(constructor) ++ conversionMethods ++ jsonConversionMethods ++ Vector(
       contractFilterMethod

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToJsonGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToJsonGenerator.scala
@@ -1,0 +1,283 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.codegen.backend.java.inner
+
+import com.daml.ledger.javaapi.data.codegen.json.{JsonLfEncoder, JsonLfEncoders, JsonLfWriter}
+import com.daml.lf.typesig.Type
+import com.squareup.javapoet.{
+  CodeBlock,
+  ClassName,
+  TypeName,
+  MethodSpec,
+  TypeVariableName,
+  ParameterizedTypeName,
+  ParameterSpec,
+}
+import java.io.{IOException, UncheckedIOException, StringWriter}
+import javax.lang.model.element.Modifier
+import scala.jdk.CollectionConverters._
+
+private[inner] object ToJsonGenerator {
+
+  private val encodersClass = classOf[JsonLfEncoders]
+  private val fieldClass = classOf[JsonLfEncoders.Field]
+
+  // Variants are encoded via a JsonLfEncoder.Field, which describes
+  // how to encode this particular instance.
+  // The definition of the Field is delegated out to the subclasses
+  // which each override a `fieldForJsonEncoder` method.
+  // For each type parameter to the variant, an encoder function
+  // will need to be passed in.
+  def forVariant(className: ClassName, typeParams: IndexedSeq[String]): Seq[MethodSpec] = {
+    def abstractFieldForJsonEncoder = MethodSpec
+      .methodBuilder("fieldForJsonEncoder")
+      .addModifiers(Modifier.PROTECTED, Modifier.ABSTRACT)
+      .addParameters(jsonEncoderParamsForTypeParams(typeParams))
+      .returns(fieldClass)
+      .build()
+
+    def jsonEncoder = MethodSpec
+      .methodBuilder("jsonEncoder")
+      .addModifiers(Modifier.PUBLIC)
+      .addParameters(jsonEncoderParamsForTypeParams(typeParams))
+      .addStatement {
+        val encoderFieldFunc =
+          if (typeParams.isEmpty) CodeBlock.of("$T::fieldForJsonEncoder", className)
+          else
+            CodeBlock.of(
+              "($T _x) -> _x.fieldForJsonEncoder($L)",
+              className.parameterized(typeParams),
+              jsonEncoderArgsForTypeParams(typeParams),
+            )
+        CodeBlock.of("return $T.variant($L).apply(this)", encodersClass, encoderFieldFunc)
+      }
+      .returns(classOf[JsonLfEncoder])
+      .build()
+    Seq(abstractFieldForJsonEncoder, jsonEncoder, toJson(typeParams))
+  }
+
+  // A different code-gen strategy is employed for "simple" variants vs "record" variants, i.e.
+  // data Foo = SimpleFoo Int | RecordFoo with x: Int, y: Text
+
+  // In this case, the encoder is simply the one for the single data arg.
+  def forVariantSimple(
+      constructorName: String,
+      typeParams: IndexedSeq[String],
+      fieldName: String,
+      damlType: Type,
+  )(implicit
+      packagePrefixes: PackagePrefixes
+  ): Seq[MethodSpec] = {
+    val encoder = CodeBlock.of("apply($L, $L)", encoderOf(damlType), fieldName)
+    Seq(apply, fieldForJsonEncoder(constructorName, typeParams, encoder))
+  }
+
+  // Encoding a record is more involved, so we pull that out into its own method,
+  // and reference that method when building the Field encoder.
+  def forVariantRecord(constructorName: String, fields: Fields, typeParams: IndexedSeq[String])(
+      implicit packagePrefixes: PackagePrefixes
+  ): Seq[MethodSpec] = {
+    val recordEncoderMethodName = s"jsonEncoder${constructorName}"
+    val fieldEncoder = CodeBlock.of(
+      "this.$L($L)",
+      recordEncoderMethodName,
+      jsonEncoderArgsForTypeParams(typeParams),
+    )
+    Seq(
+      apply,
+      jsonEncoderForRecordLike(recordEncoderMethodName, Modifier.PRIVATE, typeParams, fields),
+      fieldForJsonEncoder(constructorName, typeParams, fieldEncoder),
+    )
+  }
+
+  def forEnum(className: ClassName): Seq[MethodSpec] = {
+    val getConstructor = MethodSpec
+      .methodBuilder("getConstructor")
+      .addModifiers(Modifier.PUBLIC)
+      .addStatement("return toValue().getConstructor()", className)
+      .returns(classOf[String])
+      .build()
+
+    val jsonEncoder = MethodSpec
+      .methodBuilder("jsonEncoder")
+      .addModifiers(Modifier.PUBLIC)
+      .addStatement(
+        "return $T.enumeration($T::getConstructor).apply(this)",
+        encodersClass,
+        className,
+      )
+      .returns(classOf[JsonLfEncoder])
+      .build()
+
+    Seq(getConstructor, jsonEncoder, toJson(IndexedSeq()))
+  }
+
+  def forRecordLike(fields: Fields, typeParams: IndexedSeq[String])(implicit
+      packagePrefixes: PackagePrefixes
+  ): Seq[MethodSpec] = {
+    Seq(
+      apply,
+      jsonEncoderForRecordLike("jsonEncoder", Modifier.PUBLIC, typeParams, fields),
+      toJson(typeParams),
+    )
+  }
+
+  // When a type has type parameters (generic classes), we need to tell
+  // the encoder how to encode that type argument,
+  // e.g. if encoding a List<T>, we need to tell it how to encode a T.
+  // This is done by passing functions for each type parameter as arguments to the encoding methods.
+  // These functions can create a JsonLfEncoder for each value of the relevant type.
+  // These arguments are given a name based on the type param, defined here.
+  private def makeEncoderParamName(t: String): String = s"makeEncoder_${t}"
+
+  // Argument names, used when calling method.
+  private def jsonEncoderArgsForTypeParams(typeParams: IndexedSeq[String]) =
+    CodeBlock.join(typeParams.map(t => CodeBlock.of(makeEncoderParamName(t))).asJava, ",$W")
+
+  // ParameterSpec's, used when defining method.
+  private def jsonEncoderParamsForTypeParams(
+      typeParams: IndexedSeq[String]
+  ): java.util.List[ParameterSpec] = {
+    def makeEncoderParamType(t: String): TypeName =
+      ParameterizedTypeName.get(
+        ClassName.get(classOf[java.util.function.Function[_, _]]),
+        TypeVariableName.get(t),
+        ClassName.get(classOf[JsonLfEncoder]),
+      )
+
+    typeParams.map { t =>
+      ParameterSpec
+        .builder(makeEncoderParamType(t), makeEncoderParamName(t))
+        .build()
+    }.asJava
+  }
+
+  private def toJson(typeParams: IndexedSeq[String]): MethodSpec = MethodSpec
+    .methodBuilder("toJson")
+    .addModifiers(Modifier.PUBLIC)
+    .addParameters(jsonEncoderParamsForTypeParams(typeParams))
+    .addStatement("var w = new $T()", classOf[StringWriter])
+    .beginControlFlow("try")
+    .addStatement(
+      "this.jsonEncoder($L).encode(new $T(w))",
+      jsonEncoderArgsForTypeParams(typeParams),
+      classOf[JsonLfWriter],
+    )
+    .nextControlFlow("catch ($T e)", classOf[IOException])
+    .addComment("Not expected with StringWriter")
+    .addStatement("throw new $T(e)", classOf[UncheckedIOException])
+    .endControlFlow()
+    .addStatement("return w.toString()")
+    .returns(ClassName.get(classOf[String]))
+    .build()
+
+  private def jsonEncoderForRecordLike(
+      methodName: String,
+      modifier: Modifier,
+      typeParams: IndexedSeq[String],
+      fields: Fields,
+  )(implicit
+      packagePrefixes: PackagePrefixes
+  ): MethodSpec = {
+    val encoderFields = fields.map { f =>
+      val encoder = CodeBlock.of("apply($L, $L)", encoderOf(f.damlType), f.javaName)
+      CodeBlock.of(
+        "$T.of($S, $L)",
+        fieldClass,
+        f.damlName,
+        encoder,
+      )
+    }
+    MethodSpec
+      .methodBuilder(methodName)
+      .addModifiers(modifier)
+      .addParameters(jsonEncoderParamsForTypeParams(typeParams))
+      .returns(classOf[JsonLfEncoder])
+      .addStatement(
+        "return $T.record($Z$L)",
+        encodersClass,
+        CodeBlock.join(encoderFields.asJava, ",$Z"),
+      )
+      .build()
+  }
+
+  // Assists the type checker with type inference and unification,
+  // and unifies the call syntax across method references and functions.
+  private def apply = {
+    val inputType = TypeVariableName.get("I")
+    val outputType = TypeVariableName.get("O")
+    val functionType = ParameterizedTypeName.get(
+      ClassName.get(classOf[java.util.function.Function[_, _]]),
+      inputType,
+      outputType,
+    )
+    MethodSpec
+      .methodBuilder("apply")
+      .addModifiers(Modifier.PRIVATE)
+      .addTypeVariable(inputType)
+      .addTypeVariable(outputType)
+      .addParameter(functionType, "f")
+      .addParameter(inputType, "x")
+      .addStatement("return f.apply(x)")
+      .returns(outputType)
+      .build()
+  }
+
+  private def fieldForJsonEncoder(
+      constructorName: String,
+      typeParams: IndexedSeq[String],
+      encoder: CodeBlock,
+  ) = MethodSpec
+    .methodBuilder("fieldForJsonEncoder")
+    .addModifiers(Modifier.PROTECTED)
+    .addParameters(jsonEncoderParamsForTypeParams(typeParams))
+    .addAnnotation(classOf[Override])
+    .addStatement("return $T.of($S,$W$L)", fieldClass, constructorName, encoder)
+    .returns(fieldClass)
+    .build()
+
+  private def encoderOf(
+      damlType: Type,
+      nesting: Int = 0, // Used to avoid clashing argument identifiers in nested encoder definitions
+  )(implicit packagePrefixes: PackagePrefixes): CodeBlock = {
+    import com.daml.lf.typesig._
+
+    def typeEncoders(types: Iterable[Type]): CodeBlock =
+      CodeBlock.join(types.map(t => encoderOf(t, nesting + 1)).asJava, ", ")
+
+    damlType match {
+      case TypeCon(TypeConName(ident), IndexedSeq()) =>
+        CodeBlock.of("$T::jsonEncoder", guessClass(ident))
+      case TypeCon(TypeConName(_), typeParams) => {
+        // We are introducing identifiers into the namespace, so try to make them unique.
+        val argName = CodeBlock.of("_x$L", nesting)
+        CodeBlock.of("$L -> $L.jsonEncoder($L)", argName, argName, typeEncoders(typeParams))
+      }
+      case TypePrim(PrimTypeUnit, _) => CodeBlock.of("$T::unit", encodersClass)
+      case TypePrim(PrimTypeBool, _) => CodeBlock.of("$T::bool", encodersClass)
+      case TypePrim(PrimTypeInt64, _) => CodeBlock.of("$T::int64", encodersClass)
+      case TypeNumeric(_) => CodeBlock.of("$T::numeric", encodersClass)
+      case TypePrim(PrimTypeText, _) => CodeBlock.of("$T::text", encodersClass)
+      case TypePrim(PrimTypeDate, _) => CodeBlock.of("$T::date", encodersClass)
+      case TypePrim(PrimTypeTimestamp, _) => CodeBlock.of("$T::timestamp", encodersClass)
+      case TypePrim(PrimTypeParty, _) => CodeBlock.of("$T::party", encodersClass)
+      case TypePrim(PrimTypeContractId, _) => CodeBlock.of("$T::contractId", encodersClass)
+      case TypePrim(PrimTypeList, Seq(typ)) =>
+        CodeBlock.of("$T.list($L)", encodersClass, encoderOf(typ, nesting + 1))
+      case TypePrim(PrimTypeOptional, Seq(typ)) =>
+        CodeBlock.of("$T.optional($L)", encodersClass, encoderOf(typ, nesting + 1))
+      case TypePrim(PrimTypeTextMap, Seq(valType)) =>
+        CodeBlock.of("$T.textMap($L)", encodersClass, encoderOf(valType, nesting + 1))
+      case TypePrim(PrimTypeGenMap, Seq(keyType, valType)) =>
+        CodeBlock.of(
+          "$T.genMap($L, $L)",
+          encodersClass,
+          encoderOf(keyType, nesting + 1),
+          encoderOf(valType, nesting + 1),
+        )
+      case TypeVar(t) => CodeBlock.of(makeEncoderParamName(t))
+      case _ => throw new IllegalArgumentException(s"Invalid Daml datatype: $damlType")
+    }
+  }
+}

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantClass.scala
@@ -50,6 +50,9 @@ private[inner] object VariantClass extends StrictLogging {
           FromJsonGenerator.forVariant(variantClassName, typeArguments, constructorInfo).asJava
         )
         .addMethods(
+          ToJsonGenerator.forVariant(variantClassName, typeArguments).asJava
+        )
+        .addMethods(
           VariantValueDecodersMethods(
             typeArguments,
             variant,

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantConstructorClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantConstructorClass.scala
@@ -26,7 +26,7 @@ object VariantConstructorClass extends StrictLogging {
       body: Type,
   )(implicit
       packagePrefixes: PackagePrefixes
-  ): TypeSpec = {
+  ): (TypeSpec, Seq[(ClassName, String)]) = {
     TrackLineage.of("variant constructor", constructorName) {
       logger.info("Start")
 
@@ -59,6 +59,9 @@ object VariantConstructorClass extends StrictLogging {
           )
       }
 
+      val (jsonEncoderMethods, staticImports) =
+        ToJsonGenerator.forVariantSimple(javaName, typeArgs, variantFieldName, body)
+
       val typeSpec =
         TypeSpec
           .classBuilder(javaName)
@@ -70,13 +73,11 @@ object VariantConstructorClass extends StrictLogging {
           .addMethod(constructor)
           .addMethods(conversionMethods.asJava)
           .addMethods(ObjectMethods(className.rawType, typeArgs, Vector(variantFieldName)).asJava)
-          .addMethods(
-            ToJsonGenerator.forVariantSimple(javaName, typeArgs, variantFieldName, body).asJava
-          )
+          .addMethods(jsonEncoderMethods.asJava)
           .build()
 
       logger.info("End")
-      typeSpec
+      (typeSpec, staticImports)
     }
   }
 

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantConstructorClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantConstructorClass.scala
@@ -70,6 +70,9 @@ object VariantConstructorClass extends StrictLogging {
           .addMethod(constructor)
           .addMethods(conversionMethods.asJava)
           .addMethods(ObjectMethods(className.rawType, typeArgs, Vector(variantFieldName)).asJava)
+          .addMethods(
+            ToJsonGenerator.forVariantSimple(javaName, typeArgs, variantFieldName, body).asJava
+          )
           .build()
 
       logger.info("End")

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantRecordClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantRecordClass.scala
@@ -20,27 +20,27 @@ private[inner] object VariantRecordClass extends StrictLogging {
       superclass: TypeName,
   )(implicit
       packagePrefixes: PackagePrefixes
-  ): TypeSpec =
+  ): (TypeSpec, Seq[(ClassName, String)]) =
     TrackLineage.of("variant-record", name) {
       logger.info("Start")
       val className = ClassName.bestGuess(name)
+      val (methods, staticImports) = VariantRecordMethods(
+        name,
+        fields,
+        superclass,
+        className.parameterized(typeParameters),
+        typeParameters,
+      )
+
       val typeSpec = TypeSpec
         .classBuilder(name)
         .addModifiers(Modifier.PUBLIC)
         .superclass(superclass)
         .addTypeVariables(typeParameters.map(TypeVariableName.get).asJava)
         .addFields((createPackageIdField(packageId) +: RecordFields(fields)).asJava)
-        .addMethods(
-          VariantRecordMethods(
-            name,
-            fields,
-            superclass,
-            className.parameterized(typeParameters),
-            typeParameters,
-          ).asJava
-        )
+        .addMethods(methods.asJava)
         .build()
       logger.debug("End")
-      typeSpec
+      (typeSpec, staticImports)
     }
 }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantRecordMethods.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantRecordMethods.scala
@@ -22,7 +22,7 @@ private[inner] object VariantRecordMethods extends StrictLogging {
       typeParameters: IndexedSeq[String],
   )(implicit
       packagePrefixes: PackagePrefixes
-  ): Vector[MethodSpec] = {
+  ): (Vector[MethodSpec], Seq[(ClassName, String)]) = {
     val constructor = ConstructorGenerator.generateConstructor(fields)
 
     val conversionMethods = distinctTypeVars(fields, typeParameters) match {
@@ -41,10 +41,13 @@ private[inner] object VariantRecordMethods extends StrictLogging {
         )
     }
 
-    val toJsonMethods = ToJsonGenerator.forVariantRecord(constructorName, fields, typeParameters)
+    val (toJsonMethods, staticImports) =
+      ToJsonGenerator.forVariantRecord(constructorName, fields, typeParameters)
 
-    Vector(constructor) ++ conversionMethods ++
+    val methods: Vector[MethodSpec] = Vector(constructor) ++ conversionMethods ++
       ObjectMethods(className.rawType, typeParameters, fields.map(_.javaName)) ++ toJsonMethods
+
+    (methods, staticImports)
   }
 
   private def toValue(constructorName: String, params: IndexedSeq[String], fields: Fields)(implicit

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantRecordMethods.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantRecordMethods.scala
@@ -41,8 +41,10 @@ private[inner] object VariantRecordMethods extends StrictLogging {
         )
     }
 
+    val toJsonMethods = ToJsonGenerator.forVariantRecord(constructorName, fields, typeParameters)
+
     Vector(constructor) ++ conversionMethods ++
-      ObjectMethods(className.rawType, typeParameters, fields.map(_.javaName))
+      ObjectMethods(className.rawType, typeParameters, fields.map(_.javaName)) ++ toJsonMethods
   }
 
   private def toValue(constructorName: String, params: IndexedSeq[String], fields: Fields)(implicit

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/DecimalTestForAll.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/DecimalTestForAll.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.daml.ledger.javaapi.data.DamlRecord;
 import com.daml.ledger.javaapi.data.Numeric;
 import com.daml.ledger.javaapi.data.Party;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
 import java.io.IOException;
 import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,14 @@ public class DecimalTestForAll {
     for (String s : goodValues) {
       Box b = new Box(new BigDecimal(s), "alice");
       assertEquals(Box.fromValue(b.toValue()), b);
+    }
+  }
+
+  @Test
+  void decimal2Value2DecimalJson() throws JsonLfDecoder.Error {
+    for (String s : goodValues) {
+      Box b = new Box(new BigDecimal(s), "alice");
+      assertEquals(Box.fromJson(b.toJson()), b);
     }
   }
 

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/EnumTestForForAll.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/EnumTestForForAll.java
@@ -10,6 +10,7 @@ import com.daml.ledger.javaapi.data.DamlRecord;
 import com.daml.ledger.javaapi.data.Party;
 import com.daml.ledger.javaapi.data.Unit;
 import com.daml.ledger.javaapi.data.Variant;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -32,6 +33,20 @@ public class EnumTestForForAll {
       assertEquals(Box.fromValue(record.toValue()), record);
       assertEquals(OptionalColor.fromValue(variant.toValue()), variant);
       assertEquals(ColoredTree.fromValue(variantRecord.toValue()), variantRecord);
+    }
+  }
+
+  @Test
+  void enum2Value2EnumJson() throws JsonLfDecoder.Error {
+    for (Color c : new Color[] {Color.RED, Color.GREEN, Color.BLUE}) {
+      Box record = new Box(c, "party");
+      OptionalColor variant = new SomeColor(c);
+      ColoredTree variantRecord =
+          new Node(Color.RED, new Leaf(Unit.getInstance()), new Leaf(Unit.getInstance()));
+      assertEquals(Color.fromJson(c.toJson()), c);
+      assertEquals(Box.fromJson(record.toJson()), record);
+      assertEquals(OptionalColor.fromJson(variant.toJson()), variant);
+      assertEquals(ColoredTree.fromJson(variantRecord.toJson()), variantRecord);
     }
   }
 

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/GenMapTestFor1_11AndFor1_12ndFor1_13AndFor1_14AndFor1_15AndFor1_devAndFor2_dev.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/GenMapTestFor1_11AndFor1_12ndFor1_13AndFor1_14AndFor1_15AndFor1_devAndFor2_dev.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.daml.ledger.javaapi.data.*;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.LinkedHashMap;
@@ -58,6 +59,12 @@ public class GenMapTestFor1_11AndFor1_12ndFor1_13AndFor1_14AndFor1_15AndFor1_dev
   void genMap2Value2GenMap() {
     Box b = box();
     assertEquals(Box.fromValue(b.toValue()), b);
+  }
+
+  @Test
+  void genMap2Value2GenMapJson() throws JsonLfDecoder.Error {
+    Box b = box();
+    assertEquals(Box.fromJson(b.toJson()), b);
   }
 
   @Test

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/NumericTestForAll.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/NumericTestForAll.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.daml.ledger.javaapi.data.DamlRecord;
 import com.daml.ledger.javaapi.data.Numeric;
 import com.daml.ledger.javaapi.data.Party;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
 import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -28,6 +29,18 @@ public class NumericTestForAll {
             new BigDecimal("0.37"),
             "alice");
     assertEquals(Box.fromValue(b.toValue()), b);
+  }
+
+  @Test
+  void numeric2Value2NumericJson() throws JsonLfDecoder.Error {
+    Box b =
+        new Box(
+            new BigDecimal(0),
+            new BigDecimal(10),
+            new BigDecimal(17),
+            new BigDecimal("0.37"),
+            "alice");
+    assertEquals(Box.fromJson(b.toJson()), b);
   }
 
   @Test

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordLikeMethodsSpec.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordLikeMethodsSpec.scala
@@ -47,6 +47,14 @@ final class RecordLikeMethodsSpec
     constructor.annotations shouldBe empty
   }
 
+  behavior of "RecordMethods.staticImports"
+
+  import com.daml.ledger.javaapi.data.codegen.json.JsonLfEncoders
+
+  it should "have the apply method" in {
+    staticImports shouldBe Seq((ClassName.get(classOf[JsonLfEncoders]), "apply"))
+  }
+
   behavior of "RecordMethods.toValueSpec"
 
   it should "be correctly named" in {
@@ -137,7 +145,7 @@ final class RecordLikeMethodsSpec
   }
 
   private val name = ClassName.bestGuess("Test")
-  private val methods = {
+  private val (methods, staticImports) = {
     implicit val packagePrefixes: PackagePrefixes = PackagePrefixes(Map.empty)
     RecordMethods(
       getFieldsWithTypes(


### PR DESCRIPTION
To avoid excess duplicate code-gen, I put the implementation of `toJson` into the parent interface `DefinedDataType`, and leverage the `jsonEncoder()` in each generated subclasses. However custom datatypes with type parameters have a different signature of `toJson(...)` as they need to pass in arguments for encoders for each type arg, so we generate a custom `toJson(...)` for those classes. I also do a static import of the `JsonLfEncoder.apply` method, as a useful uniform syntax for calling either `Function` objects or method references (e.g. `JsonLfEncoder::bool`). That required propagating the static imports up from the various methods that need them, and adding them at the `JavaFile.Builder` level.

I changed all the integration tests that did `fromJson` from a hard-coded string, into round-trip tests a la `Foo.fromJson(foo.toJson())`, now that we have `toJson`.

Also add a benchmark, which can be run with
```
bazel run //language-support/java/codegen:to-json-bench
```
Locally I currently get these results.
```
# Run complete. Total time: 00:00:56

Benchmark                          Mode  Cnt         Score        Error  Units
ToJsonBench.enummodBox            thrpt   10   8138043.644 ± 197223.048  ops/s
ToJsonBench.enummodColoredTree    thrpt   10   3132500.885 ±  23677.832  ops/s
ToJsonBench.enummodOptionalColor  thrpt   10  10762883.904 ± 116865.102  ops/s
ToJsonBench.genmapmodBox          thrpt   10   1554965.578 ±   4956.210  ops/s
```
 The `Score` is the number of times the sample values can be converted to json per second.