### PR TITLE
HOTFIX: try using path java_test_suite targets in Bazel

### DIFF
--- a/bazel_tools/java_testing/java_test_suite.bzl
+++ b/bazel_tools/java_testing/java_test_suite.bzl
@@ -19,7 +19,7 @@ def _junit_class_name(test_file, strip):
     return c
 
 # Similar to https://github.com/bazelbuild/rules_scala/blob/2676400bed17b03fdd0fe13a8794eb0ff0129284/scala/scala.bzl#L425
-def java_test_suite(name, srcs = [], strip = "", visibility = None, **kwargs):
+def java_test_suite(name, srcs = [], strip = "", visibility = None, use_short_names = False, **kwargs):
     """Define a Java test-suite.
 
     Generates a java_test for each given source file and bundles them in a
@@ -37,8 +37,10 @@ def java_test_suite(name, srcs = [], strip = "", visibility = None, **kwargs):
       kwargs: Remaining arguments are forwarded to each java_test rule.
     """
     ts = []
+    i = 0
     for test_file in srcs:
-        n = "%s_test_suite_%s" % (name, _sanitize_string_for_usage(test_file))
+        i = i + 1
+        n = ("%s_%s" % (name, i)) if use_short_names else "%s_test_suite_%s" % (name, _sanitize_string_for_usage(test_file))
         native.java_test(
             name = n,
             test_class = _junit_class_name(test_file, strip),

--- a/language-support/java/bindings/BUILD.bazel
+++ b/language-support/java/bindings/BUILD.bazel
@@ -9,6 +9,7 @@ load(
 load("//bazel_tools:proto.bzl", "proto_gen")
 load("//bazel_tools:java.bzl", "da_java_library")
 load("//language-support/java:javaopts.bzl", "da_java_bindings_javacopts")
+load("//bazel_tools/java_testing:java_test_suite.bzl", "java_test_suite")
 
 proto_gen(
     name = "ledger-api-java",
@@ -83,10 +84,10 @@ da_java_library(
     ],
 )
 
-java_test(
+java_test_suite(
     name = "java-tests",
     srcs = glob(["src/test/java/**/*.java"]),
-    test_class = "com.daml.ledger.javaapi.data.codegen.json.JsonLfReaderTest",
+    strip = "src/test/java/",
     deps = [
         ":bindings-java",
         "@maven//:com_google_protobuf_protobuf_java",

--- a/language-support/java/bindings/BUILD.bazel
+++ b/language-support/java/bindings/BUILD.bazel
@@ -10,6 +10,7 @@ load("//bazel_tools:proto.bzl", "proto_gen")
 load("//bazel_tools:java.bzl", "da_java_library")
 load("//language-support/java:javaopts.bzl", "da_java_bindings_javacopts")
 load("//bazel_tools/java_testing:java_test_suite.bzl", "java_test_suite")
+load("@os_info//:os_info.bzl", "is_windows")
 
 proto_gen(
     name = "ledger-api-java",
@@ -88,6 +89,7 @@ java_test_suite(
     name = "java-tests",
     srcs = glob(["src/test/java/**/*Test.java"]),
     strip = "src/test/java/",
+    use_short_names = is_windows,
     deps = [
         ":bindings-java",
         ":bindings-java-test-helpers",

--- a/language-support/java/bindings/BUILD.bazel
+++ b/language-support/java/bindings/BUILD.bazel
@@ -86,15 +86,23 @@ da_java_library(
 
 java_test_suite(
     name = "java-tests",
-    srcs = glob(["src/test/java/**/*.java"]),
+    srcs = glob(["src/test/java/**/*Test.java"]),
     strip = "src/test/java/",
     deps = [
         ":bindings-java",
+        ":bindings-java-test-helpers",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_junit_jupiter_junit_jupiter_api",
         "@maven//:org_junit_jupiter_junit_jupiter_engine",
         "@maven//:org_junit_platform_junit_platform_runner",
     ],
+)
+
+java_library(
+    name = "bindings-java-test-helpers",
+    testonly = True,
+    srcs = glob(["src/test/java/**/TestHelpers.java"]),
+    deps = [":bindings-java"],
 )
 
 da_scala_library(

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfDecoders.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfDecoders.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-/// Readers for built-in LF types. ///
+/// Decoders for built-in LF types. ///
 public class JsonLfDecoders {
 
   public static final JsonLfDecoder<Unit> unit =

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncoder.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncoder.java
@@ -1,0 +1,11 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data.codegen.json;
+
+import java.io.IOException;
+
+@FunctionalInterface
+public interface JsonLfEncoder {
+  public void encode(JsonLfWriter w) throws IOException;
+}

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncoders.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncoders.java
@@ -6,7 +6,9 @@ package com.daml.ledger.javaapi.data.codegen.json;
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.time.temporal.ChronoUnit.SECONDS;
 
+import com.daml.ledger.javaapi.data.Unit;
 import com.daml.ledger.javaapi.data.codegen.ContractId;
+import com.daml.ledger.javaapi.data.codegen.DamlEnum;
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -14,6 +16,7 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -22,11 +25,12 @@ import java.util.function.Function;
 public class JsonLfEncoders {
   private static final JsonStringEncoder stringEncoder = JsonStringEncoder.getInstance();
 
-  public static final JsonLfEncoder unit =
-      w -> {
-        w.writeStartObject();
-        w.writeEndObject();
-      };
+  public static JsonLfEncoder unit(Unit _unit) {
+    return w -> {
+      w.writeStartObject();
+      w.writeEndObject();
+    };
+  }
 
   public static JsonLfEncoder bool(Boolean value) {
     return w -> w.write(String.valueOf(value));
@@ -65,17 +69,16 @@ public class JsonLfEncoders {
     return text(value);
   }
 
-  public static JsonLfEncoder contractId(ContractId<?> value) {
+  public static <Cid extends ContractId<?>> JsonLfEncoder contractId(Cid value) {
     return text(value.toValue().asContractId().get().getValue());
   }
 
-  public static <E extends Enum<E>> Function<E, JsonLfEncoder> enumeration(
+  public static <E extends DamlEnum<E>> Function<E, JsonLfEncoder> enumeration(
       Function<E, String> toDamlName) {
     return value -> text(toDamlName.apply(value));
   }
 
-  public static <T> Function<Iterable<T>, JsonLfEncoder> list(
-      Function<T, JsonLfEncoder> itemEncoder) {
+  public static <T> Function<List<T>, JsonLfEncoder> list(Function<T, JsonLfEncoder> itemEncoder) {
     return items -> {
       return w -> {
         w.writeStartArray();

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncoders.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncoders.java
@@ -132,7 +132,15 @@ public class JsonLfEncoders {
     return opt -> {
       return w -> {
         if (opt.isEmpty()) w.write("null");
-        else valueEncoder.apply(opt.get()).encode(w);
+        else {
+          T value = opt.get();
+          assert (!(value instanceof Optional))
+              : "Using `optional` to encode a "
+                  + value.getClass()
+                  + " but `optionalNested` must be used for the outer encoders of nested"
+                  + " Optional";
+          valueEncoder.apply(value).encode(w);
+        }
       };
     };
   }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncoders.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncoders.java
@@ -1,0 +1,202 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data.codegen.json;
+
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+import com.daml.ledger.javaapi.data.codegen.ContractId;
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/// Encoders for built-in LF types. ///
+public class JsonLfEncoders {
+  private static final JsonStringEncoder stringEncoder = JsonStringEncoder.getInstance();
+
+  public static final JsonLfEncoder unit =
+      w -> {
+        w.writeStartObject();
+        w.writeEndObject();
+      };
+
+  public static JsonLfEncoder bool(Boolean value) {
+    return w -> w.write(String.valueOf(value));
+  }
+
+  public static JsonLfEncoder int64(Long value) {
+    return w -> w.write(String.valueOf(value));
+  }
+
+  public static JsonLfEncoder text(String value) {
+    return w -> {
+      String escaped = String.valueOf(stringEncoder.quoteAsString(value));
+      w.write("\"" + escaped + "\"");
+    };
+  }
+
+  public static JsonLfEncoder numeric(BigDecimal value) {
+    return w -> w.write(value.toString());
+  }
+
+  public static JsonLfEncoder timestamp(Instant t) {
+    return w -> {
+      String subsecPat = isRoundTo(t, SECONDS) ? "" : (isRoundTo(t, MILLIS) ? ".SSS" : ".SSSSSS");
+      var formatter =
+          DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss" + subsecPat + "X")
+              .withZone(ZoneOffset.UTC);
+      w.write("\"" + formatter.format(t) + "\"");
+    };
+  }
+
+  public static JsonLfEncoder date(LocalDate d) {
+    return text(d.toString());
+  }
+
+  public static JsonLfEncoder party(String value) {
+    return text(value);
+  }
+
+  public static JsonLfEncoder contractId(ContractId<?> value) {
+    return text(value.toValue().asContractId().get().getValue());
+  }
+
+  public static <E extends Enum<E>> Function<E, JsonLfEncoder> enumeration(
+      Function<E, String> toDamlName) {
+    return value -> text(toDamlName.apply(value));
+  }
+
+  public static <T> Function<Iterable<T>, JsonLfEncoder> list(
+      Function<T, JsonLfEncoder> itemEncoder) {
+    return items -> {
+      return w -> {
+        w.writeStartArray();
+        boolean first = true;
+        for (var item : items) {
+          if (!first) w.writeComma();
+          itemEncoder.apply(item).encode(w);
+          first = false;
+        }
+        w.writeEndArray();
+      };
+    };
+  }
+
+  public static <T> Function<Map<String, T>, JsonLfEncoder> textMap(
+      Function<T, JsonLfEncoder> valueEncoder) {
+    return map -> {
+      return w -> {
+        w.writeStartObject();
+        boolean first = true;
+        for (var entry : map.entrySet()) {
+          if (!first) w.writeComma();
+          w.writeFieldName(entry.getKey());
+          valueEncoder.apply(entry.getValue()).encode(w);
+          first = false;
+        }
+        w.writeEndObject();
+      };
+    };
+  }
+
+  public static <K, V> Function<Map<K, V>, JsonLfEncoder> genMap(
+      Function<K, JsonLfEncoder> keyEncoder, Function<V, JsonLfEncoder> valueEncoder) {
+    return map -> {
+      return w -> {
+        w.writeStartArray();
+        boolean first = true;
+        for (var entry : map.entrySet()) {
+          if (!first) w.writeComma();
+          w.writeStartArray();
+          keyEncoder.apply(entry.getKey()).encode(w);
+          w.writeComma();
+          valueEncoder.apply(entry.getValue()).encode(w);
+          w.writeEndArray();
+          first = false;
+        }
+        w.writeEndArray();
+      };
+    };
+  }
+
+  public static <T> Function<Optional<T>, JsonLfEncoder> optional(
+      Function<T, JsonLfEncoder> valueEncoder) {
+    return opt -> {
+      return w -> {
+        if (opt.isEmpty()) w.write("null");
+        else valueEncoder.apply(opt.get()).encode(w);
+      };
+    };
+  }
+
+  public static <T> Function<Optional<Optional<T>>, JsonLfEncoder> optionalNested(
+      Function<Optional<T>, JsonLfEncoder> valueEncoder) {
+    return optOpt -> {
+      return w -> {
+        if (optOpt.isEmpty()) w.write("null");
+        else {
+          var opt = optOpt.get();
+          w.writeStartArray();
+          if (!opt.isEmpty()) valueEncoder.apply(opt).encode(w);
+          w.writeEndArray();
+        }
+      };
+    };
+  }
+
+  public static <T> Function<T, JsonLfEncoder> variant(Function<T, Field> getField) {
+    return v -> {
+      return w -> {
+        var field = getField.apply(v);
+        assert field != null;
+        w.writeStartObject();
+        w.writeFieldName("tag");
+        w.write("\"" + field.name + "\"");
+        w.writeComma();
+        w.writeFieldName("value");
+        field.encoder.encode(w);
+        w.writeEndObject();
+      };
+    };
+  }
+
+  public static class Field {
+    public final String name;
+    public final JsonLfEncoder encoder;
+
+    private Field(String name, JsonLfEncoder encoder) {
+      this.name = name;
+      this.encoder = encoder;
+    }
+
+    public static Field of(String name, JsonLfEncoder encoder) {
+      return new Field(name, encoder);
+    }
+  }
+
+  public static JsonLfEncoder record(Field... fields) {
+    return w -> {
+      w.writeStartObject();
+      boolean first = true;
+      for (var field : fields) {
+        if (!first) w.writeComma();
+        w.writeFieldName(field.name);
+        field.encoder.encode(w);
+        first = false;
+      }
+      w.writeEndObject();
+    };
+  }
+
+  private static boolean isRoundTo(Instant value, ChronoUnit unit) {
+    return value.truncatedTo(unit).equals(value);
+  }
+}

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfWriter.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfWriter.java
@@ -1,0 +1,43 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data.codegen.json;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public class JsonLfWriter {
+  private final Writer writer;
+
+  public JsonLfWriter(Writer w) {
+    this.writer = w;
+  }
+
+  void writeStartObject() throws IOException {
+    write("{");
+  }
+
+  void writeEndObject() throws IOException {
+    write("}");
+  }
+
+  void writeFieldName(String name) throws IOException {
+    write("\"" + name + "\": ");
+  }
+
+  void writeStartArray() throws IOException {
+    write("[");
+  }
+
+  void writeEndArray() throws IOException {
+    write("]");
+  }
+
+  void writeComma() throws IOException {
+    write(", ");
+  }
+
+  void write(String value) throws IOException {
+    writer.write(value);
+  }
+}

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfDecodersTest.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfDecodersTest.java
@@ -28,7 +28,7 @@ import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
 @RunWith(JUnitPlatform.class)
-public class JsonLfReaderTest {
+public class JsonLfDecodersTest {
 
   @Test
   void testUnit() throws JsonLfDecoder.Error {

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfDecodersTest.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfDecodersTest.java
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.javaapi.data.codegen.json;
 
+import static com.daml.ledger.javaapi.data.codegen.json.TestHelpers.*;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -10,17 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.daml.ledger.javaapi.data.Unit;
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.Month;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
@@ -631,166 +624,6 @@ public class JsonLfDecodersTest {
                 .moveNext(), // Skip "hello"
         JsonLfDecoders.list(JsonLfDecoders.bool),
         "Expected boolean but was 42 at line: 5, column: 7");
-  }
-
-  private BigDecimal dec(String s) {
-    return new BigDecimal(s);
-  }
-
-  private Instant timestampUTC(
-      int year, Month month, int day, int hour, int minute, int second, int micros) {
-    return LocalDateTime.of(year, month, day, hour, minute, second, micros * 1000)
-        .toInstant(ZoneOffset.UTC);
-  }
-
-  private LocalDate date(int year, Month month, int day) {
-    return LocalDate.of(year, month, day);
-  }
-
-  class SomeRecord {
-    private final List<Long> i;
-    private final Boolean b;
-
-    public SomeRecord(List<Long> i, Boolean b) {
-      this.i = i;
-      this.b = b;
-    }
-
-    public String toString() {
-      return String.format("SomeRecord{i=%s,b=%s}", i, b);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      return o != null
-          && (o instanceof SomeRecord)
-          && ((SomeRecord) o).i.equals(i)
-          && (((SomeRecord) o).b.equals(b));
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(i, b);
-    }
-  }
-
-  abstract static class SomeVariant {
-    static class Bar extends SomeVariant {
-      private final Long x;
-
-      public Bar(Long x) {
-        this.x = x;
-      }
-
-      @Override
-      public boolean equals(Object o) {
-        return o != null && (o instanceof Bar) && x == ((Bar) o).x;
-      }
-
-      @Override
-      public int hashCode() {
-        return Objects.hash(x);
-      }
-
-      @Override
-      public String toString() {
-        return String.format("Bar(%s)", x);
-      }
-    }
-
-    static class Baz extends SomeVariant {
-      private final Unit x;
-
-      public Baz(Unit x) {
-        this.x = x;
-      }
-      // All units are the same, and thus so are all Baz's
-      @Override
-      public boolean equals(Object o) {
-        return o != null && (o instanceof Baz);
-      }
-
-      @Override
-      public int hashCode() {
-        return 1;
-      }
-
-      @Override
-      public String toString() {
-        return "Baz()";
-      }
-    }
-
-    static class Quux extends SomeVariant {
-      private final Optional<Long> x;
-
-      public Quux(Optional<Long> x) {
-        this.x = x;
-      }
-
-      @Override
-      public boolean equals(Object o) {
-        return o != null && (o instanceof Quux) && x.equals(((Quux) o).x);
-      }
-
-      @Override
-      public int hashCode() {
-        return Objects.hash(x);
-      }
-
-      @Override
-      public String toString() {
-        return String.format("Quux(%s)", x);
-      }
-    }
-
-    static class Flarp extends SomeVariant {
-      private final List<Long> x;
-
-      public Flarp(List<Long> x) {
-        this.x = x;
-      }
-
-      @Override
-      public boolean equals(Object o) {
-        return o != null && (o instanceof Flarp) && x.equals(((Flarp) o).x);
-      }
-
-      @Override
-      public int hashCode() {
-        return Objects.hash(x);
-      }
-
-      @Override
-      public String toString() {
-        return String.format("Flarp(%s)", x);
-      }
-    }
-  }
-
-  static class Tmpl {
-    public static final class Cid extends com.daml.ledger.javaapi.data.codegen.ContractId<Tmpl> {
-      public Cid(String id) {
-        super(id);
-      }
-    }
-  }
-
-  enum Suit {
-    HEARTS,
-    DIAMONDS,
-    CLUBS,
-    SPADES;
-
-    static final Map<String, Suit> damlNames =
-        new HashMap<>() {
-          {
-            put("Hearts", HEARTS);
-            put("Diamonds", DIAMONDS);
-            put("Clubs", CLUBS);
-            put("Spades", SPADES);
-          }
-        };
   }
 
   private <T> void checkReadAll(JsonLfDecoder<T> decoder, TestCase<T>... testCases)

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncodersTest.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncodersTest.java
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.javaapi.data.codegen.json;
 
+import static com.daml.ledger.javaapi.data.codegen.json.TestHelpers.*;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -11,17 +12,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.daml.ledger.javaapi.data.Unit;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.math.BigDecimal;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.Month;
-import java.time.ZoneOffset;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -249,187 +242,6 @@ public class JsonLfEncodersTest {
                 JsonLfEncoders.Field.of("b", JsonLfEncoders.bool(r.b))),
         Case.of(new SomeRecord(asList(), true), "{\"i\": [], \"b\": true}"),
         Case.of(new SomeRecord(asList(1L, 2L), true), "{\"i\": [1, 2], \"b\": true}"));
-  }
-
-  private BigDecimal dec(String s) {
-    return new BigDecimal(s);
-  }
-
-  private Instant timestampUTC(
-      int year, Month month, int day, int hour, int minute, int second, int micros) {
-    return LocalDateTime.of(year, month, day, hour, minute, second, micros * 1000)
-        .toInstant(ZoneOffset.UTC);
-  }
-
-  private Instant timestampUTC(
-      int year, Month month, int day, int hour, int minute, int second, int micros, int nanos) {
-    return LocalDateTime.of(year, month, day, hour, minute, second, micros * 1000 + nanos)
-        .toInstant(ZoneOffset.UTC);
-  }
-
-  private LocalDate date(int year, Month month, int day) {
-    return LocalDate.of(year, month, day);
-  }
-
-  class SomeRecord {
-    private final List<Long> i;
-    private final Boolean b;
-
-    public SomeRecord(List<Long> i, Boolean b) {
-      this.i = i;
-      this.b = b;
-    }
-
-    public String toString() {
-      return String.format("SomeRecord{i=%s,b=%s}", i, b);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      return o != null
-          && (o instanceof SomeRecord)
-          && ((SomeRecord) o).i.equals(i)
-          && (((SomeRecord) o).b.equals(b));
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(i, b);
-    }
-  }
-
-  abstract static class SomeVariant {
-    static class Bar extends SomeVariant {
-      private final Long x;
-
-      public Bar(Long x) {
-        this.x = x;
-      }
-
-      @Override
-      public boolean equals(Object o) {
-        return o != null && (o instanceof Bar) && x == ((Bar) o).x;
-      }
-
-      @Override
-      public int hashCode() {
-        return Objects.hash(x);
-      }
-
-      @Override
-      public String toString() {
-        return String.format("Bar(%s)", x);
-      }
-    }
-
-    static class Baz extends SomeVariant {
-      private final Unit x;
-
-      public Baz(Unit x) {
-        this.x = x;
-      }
-      // All units are the same, and thus so are all Baz's
-      @Override
-      public boolean equals(Object o) {
-        return o != null && (o instanceof Baz);
-      }
-
-      @Override
-      public int hashCode() {
-        return 1;
-      }
-
-      @Override
-      public String toString() {
-        return "Baz()";
-      }
-    }
-
-    static class Quux extends SomeVariant {
-      private final Optional<Long> x;
-
-      public Quux(Optional<Long> x) {
-        this.x = x;
-      }
-
-      @Override
-      public boolean equals(Object o) {
-        return o != null && (o instanceof Quux) && x.equals(((Quux) o).x);
-      }
-
-      @Override
-      public int hashCode() {
-        return Objects.hash(x);
-      }
-
-      @Override
-      public String toString() {
-        return String.format("Quux(%s)", x);
-      }
-    }
-
-    static class Flarp extends SomeVariant {
-      private final List<Long> x;
-
-      public Flarp(List<Long> x) {
-        this.x = x;
-      }
-
-      @Override
-      public boolean equals(Object o) {
-        return o != null && (o instanceof Flarp) && x.equals(((Flarp) o).x);
-      }
-
-      @Override
-      public int hashCode() {
-        return Objects.hash(x);
-      }
-
-      @Override
-      public String toString() {
-        return String.format("Flarp(%s)", x);
-      }
-    }
-  }
-
-  static class Tmpl {
-    public static final class Cid extends com.daml.ledger.javaapi.data.codegen.ContractId<Tmpl> {
-      public Cid(String id) {
-        super(id);
-      }
-    }
-  }
-
-  enum Suit {
-    HEARTS,
-    DIAMONDS,
-    CLUBS,
-    SPADES;
-
-    String toDamlName() {
-      switch (this) {
-        case HEARTS:
-          return "Hearts";
-        case DIAMONDS:
-          return "Diamonds";
-        case CLUBS:
-          return "Clubs";
-        case SPADES:
-          return "Spades";
-        default:
-          return null;
-      }
-    }
-
-    static final Map<String, Suit> damlNames =
-        new HashMap<>() {
-          {
-            put("Hearts", HEARTS);
-            put("Diamonds", DIAMONDS);
-            put("Clubs", CLUBS);
-            put("Spades", SPADES);
-          }
-        };
   }
 
   String intoString(JsonLfEncoder encoder) throws IOException {

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncodersTest.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncodersTest.java
@@ -25,7 +25,7 @@ public class JsonLfEncodersTest {
 
   @Test
   void testUnit() throws IOException {
-    assertEquals("{}", intoString(JsonLfEncoders.unit));
+    assertEquals("{}", intoString(JsonLfEncoders.unit(Unit.getInstance())));
   }
 
   @Test
@@ -215,7 +215,7 @@ public class JsonLfEncodersTest {
                 return JsonLfEncoders.Field.of(
                     "Bar", JsonLfEncoders.int64(((SomeVariant.Bar) v).x));
               else if (v instanceof SomeVariant.Baz)
-                return JsonLfEncoders.Field.of("Baz", JsonLfEncoders.unit);
+                return JsonLfEncoders.Field.of("Baz", JsonLfEncoders.unit(((SomeVariant.Baz) v).x));
               else if (v instanceof SomeVariant.Quux)
                 return JsonLfEncoders.Field.of(
                     "Quux",

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncodersTest.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/JsonLfEncodersTest.java
@@ -1,0 +1,462 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data.codegen.json;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.daml.ledger.javaapi.data.Unit;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+public class JsonLfEncodersTest {
+
+  @Test
+  void testUnit() throws IOException {
+    assertEquals("{}", intoString(JsonLfEncoders.unit));
+  }
+
+  @Test
+  void testBool() throws IOException {
+    checkWriteAll(JsonLfEncoders::bool, Case.of(true, "true"), Case.of(false, "false"));
+  }
+
+  @Test
+  void testInt64() throws IOException {
+    checkWriteAll(
+        JsonLfEncoders::int64,
+        Case.of(42L, "42"),
+        Case.of(-42L, "-42"),
+        Case.of(0L, "0"),
+        Case.of(-0L, "0"),
+        Case.of(9223372036854775807L, "9223372036854775807"),
+        Case.of(-9223372036854775808L, "-9223372036854775808"));
+  }
+
+  @Test
+  void testNumeric() throws IOException {
+    checkWriteAll(
+        JsonLfEncoders::numeric,
+        Case.of(dec("42"), "42"),
+        Case.of(dec("-42"), "-42"),
+        Case.of(dec("0"), "0"),
+        Case.of(dec("-0"), "0"),
+        Case.of(dec("0.3"), "0.3"),
+        Case.of(
+            dec("-9999999999999999999999999999.9999999999"),
+            "-9999999999999999999999999999.9999999999"),
+        Case.of(
+            dec("9999999999999999999999999999.9999999999"),
+            "9999999999999999999999999999.9999999999"));
+  }
+
+  @Test
+  void testTimestamp() throws IOException {
+    checkWriteAll(
+        JsonLfEncoders::timestamp,
+        Case.of(
+            timestampUTC(1990, Month.NOVEMBER, 9, 4, 30, 23, 123400),
+            "\"1990-11-09T04:30:23.123400Z\""),
+        Case.of(
+            timestampUTC(1990, Month.NOVEMBER, 9, 4, 30, 23, 123456),
+            "\"1990-11-09T04:30:23.123456Z\""),
+        Case.of(
+            timestampUTC(9999, Month.DECEMBER, 31, 23, 59, 59, 999999),
+            "\"9999-12-31T23:59:59.999999Z\""),
+        Case.of(
+            timestampUTC(1990, Month.NOVEMBER, 9, 4, 30, 23, 123456, 900),
+            "\"1990-11-09T04:30:23.123456Z\""),
+        Case.of(timestampUTC(1990, Month.NOVEMBER, 9, 4, 30, 23, 0), "\"1990-11-09T04:30:23Z\""),
+        Case.of(
+            timestampUTC(1990, Month.NOVEMBER, 9, 4, 30, 23, 123000),
+            "\"1990-11-09T04:30:23.123Z\""),
+        Case.of(
+            timestampUTC(1990, Month.NOVEMBER, 9, 4, 30, 23, 120000),
+            "\"1990-11-09T04:30:23.120Z\""),
+        Case.of(timestampUTC(1, Month.JANUARY, 1, 0, 0, 0, 0), "\"0001-01-01T00:00:00Z\""));
+  }
+
+  @Test
+  void testDate() throws IOException {
+    checkWriteAll(
+        JsonLfEncoders::date,
+        Case.of(date(2019, Month.JUNE, 18), "\"2019-06-18\""),
+        Case.of(date(9999, Month.DECEMBER, 31), "\"9999-12-31\""),
+        Case.of(date(1, Month.JANUARY, 1), "\"0001-01-01\""));
+  }
+
+  @Test
+  void testParty() throws IOException {
+    checkWriteAll(JsonLfEncoders::party, Case.of("Alice", "\"Alice\""));
+  }
+
+  @Test
+  void testText() throws IOException {
+    checkWriteAll(
+        JsonLfEncoders::text,
+        Case.of("", "\"\""),
+        Case.of("\\", "\"\\\\\""),
+        Case.of(" ", "\" \""),
+        Case.of("hello", "\"hello\""));
+  }
+
+  @Test
+  void testContractId() throws IOException {
+    checkWriteAll(JsonLfEncoders::contractId, Case.of(new Tmpl.Cid("deadbeef"), "\"deadbeef\""));
+  }
+
+  @Test
+  void testEnum() throws IOException {
+    checkWriteAll(
+        JsonLfEncoders.enumeration(Suit::toDamlName),
+        Case.of(Suit.HEARTS, "\"Hearts\""),
+        Case.of(Suit.DIAMONDS, "\"Diamonds\""),
+        Case.of(Suit.CLUBS, "\"Clubs\""),
+        Case.of(Suit.SPADES, "\"Spades\""));
+  }
+
+  @Test
+  void testList() throws IOException {
+    checkWriteAll(
+        JsonLfEncoders.list(JsonLfEncoders::int64),
+        Case.of(emptyList(), "[]"),
+        Case.of(asList(1L, 2L), "[1, 2]"));
+  }
+
+  @Test
+  void testListNested() throws IOException {
+    checkWriteAll(
+        JsonLfEncoders.list(JsonLfEncoders.list(JsonLfEncoders::int64)),
+        Case.of(emptyList(), "[]"),
+        Case.of(asList(asList(1L), emptyList(), asList(2L, 3L)), "[[1], [], [2, 3]]"));
+  }
+
+  <K, V> Map<K, V> orderedMap(K key1, V val1, K key2, V val2) {
+    Map<K, V> map = new LinkedHashMap<>();
+    map.put(key1, val1);
+    map.put(key2, val2);
+    return map;
+  }
+
+  @Test
+  void testTextMap() throws IOException {
+    checkWriteAll(
+        JsonLfEncoders.textMap(JsonLfEncoders::int64),
+        Case.of(emptyMap(), "{}"),
+        Case.of(orderedMap("foo", 1L, "bar", 2L), "{\"foo\": 1, \"bar\": 2}"));
+  }
+
+  @Test
+  void testGenMap() throws IOException {
+    checkWriteAll(
+        JsonLfEncoders.genMap(JsonLfEncoders::text, JsonLfEncoders::int64),
+        Case.of(emptyMap(), "[]"),
+        Case.of(orderedMap("foo", 1L, "bar", 2L), "[[\"foo\", 1], [\"bar\", 2]]"));
+  }
+
+  @Test
+  void testOptionalNonNested() throws IOException {
+    checkWriteAll(
+        JsonLfEncoders.optional(JsonLfEncoders::int64),
+        Case.of(Optional.empty(), "null"),
+        Case.of(Optional.of(42L), "42"));
+  }
+
+  @Test
+  void testOptionalNested() throws IOException {
+    checkWriteAll(
+        JsonLfEncoders.optionalNested(JsonLfEncoders.optional(JsonLfEncoders::int64)),
+        Case.of(Optional.empty(), "null"),
+        Case.of(Optional.of(Optional.empty()), "[]"),
+        Case.of(Optional.of(Optional.of(42L)), "[42]"));
+  }
+
+  @Test
+  void testOptionalNestedDeeper() throws IOException {
+    checkWriteAll(
+        JsonLfEncoders.optionalNested(
+            JsonLfEncoders.optionalNested(
+                JsonLfEncoders.optionalNested(JsonLfEncoders.optional(JsonLfEncoders::int64)))),
+        Case.of(Optional.empty(), "null"),
+        Case.of(Optional.of(Optional.empty()), "[]"),
+        Case.of(Optional.of(Optional.of(Optional.empty())), "[[]]"),
+        Case.of(Optional.of(Optional.of(Optional.of(Optional.empty()))), "[[[]]]"),
+        Case.of(Optional.of(Optional.of(Optional.of(Optional.of(42L)))), "[[[42]]]"));
+  }
+
+  @Test
+  void testOptionalLists() throws IOException {
+    checkWriteAll(
+        JsonLfEncoders.optional(JsonLfEncoders.list(JsonLfEncoders.list(JsonLfEncoders::int64))),
+        Case.of(Optional.empty(), "null"),
+        Case.of(Optional.of(emptyList()), "[]"),
+        Case.of(Optional.of(asList(emptyList())), "[[]]"),
+        Case.of(Optional.of(asList(asList(42L))), "[[42]]"));
+  }
+
+  @Test
+  void testVariant() throws IOException {
+    checkWriteAll(
+        JsonLfEncoders.variant(
+            v -> {
+              if (v instanceof SomeVariant.Bar)
+                return JsonLfEncoders.Field.of(
+                    "Bar", JsonLfEncoders.int64(((SomeVariant.Bar) v).x));
+              else if (v instanceof SomeVariant.Baz)
+                return JsonLfEncoders.Field.of("Baz", JsonLfEncoders.unit);
+              else if (v instanceof SomeVariant.Quux)
+                return JsonLfEncoders.Field.of(
+                    "Quux",
+                    JsonLfEncoders.optional(JsonLfEncoders::int64).apply(((SomeVariant.Quux) v).x));
+              else if (v instanceof SomeVariant.Flarp)
+                return JsonLfEncoders.Field.of(
+                    "Flarp",
+                    JsonLfEncoders.list(JsonLfEncoders::int64).apply(((SomeVariant.Flarp) v).x));
+              else return null;
+            }),
+        Case.of(new SomeVariant.Bar(42L), "{\"tag\": \"Bar\", \"value\": 42}"),
+        Case.of(new SomeVariant.Baz(Unit.getInstance()), "{\"tag\": \"Baz\", \"value\": {}}"),
+        Case.of(new SomeVariant.Quux(Optional.empty()), "{\"tag\": \"Quux\", \"value\": null}"),
+        Case.of(new SomeVariant.Quux(Optional.of(42L)), "{\"tag\": \"Quux\", \"value\": 42}"),
+        Case.of(new SomeVariant.Flarp(asList(42L)), "{\"tag\": \"Flarp\", \"value\": [42]}"));
+  }
+
+  @Test
+  void testRecord() throws IOException {
+    checkWriteAll(
+        r ->
+            JsonLfEncoders.record(
+                JsonLfEncoders.Field.of("i", JsonLfEncoders.list(JsonLfEncoders::int64).apply(r.i)),
+                JsonLfEncoders.Field.of("b", JsonLfEncoders.bool(r.b))),
+        Case.of(new SomeRecord(asList(), true), "{\"i\": [], \"b\": true}"),
+        Case.of(new SomeRecord(asList(1L, 2L), true), "{\"i\": [1, 2], \"b\": true}"));
+  }
+
+  private BigDecimal dec(String s) {
+    return new BigDecimal(s);
+  }
+
+  private Instant timestampUTC(
+      int year, Month month, int day, int hour, int minute, int second, int micros) {
+    return LocalDateTime.of(year, month, day, hour, minute, second, micros * 1000)
+        .toInstant(ZoneOffset.UTC);
+  }
+
+  private Instant timestampUTC(
+      int year, Month month, int day, int hour, int minute, int second, int micros, int nanos) {
+    return LocalDateTime.of(year, month, day, hour, minute, second, micros * 1000 + nanos)
+        .toInstant(ZoneOffset.UTC);
+  }
+
+  private LocalDate date(int year, Month month, int day) {
+    return LocalDate.of(year, month, day);
+  }
+
+  class SomeRecord {
+    private final List<Long> i;
+    private final Boolean b;
+
+    public SomeRecord(List<Long> i, Boolean b) {
+      this.i = i;
+      this.b = b;
+    }
+
+    public String toString() {
+      return String.format("SomeRecord{i=%s,b=%s}", i, b);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o != null
+          && (o instanceof SomeRecord)
+          && ((SomeRecord) o).i.equals(i)
+          && (((SomeRecord) o).b.equals(b));
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(i, b);
+    }
+  }
+
+  abstract static class SomeVariant {
+    static class Bar extends SomeVariant {
+      private final Long x;
+
+      public Bar(Long x) {
+        this.x = x;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+        return o != null && (o instanceof Bar) && x == ((Bar) o).x;
+      }
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(x);
+      }
+
+      @Override
+      public String toString() {
+        return String.format("Bar(%s)", x);
+      }
+    }
+
+    static class Baz extends SomeVariant {
+      private final Unit x;
+
+      public Baz(Unit x) {
+        this.x = x;
+      }
+      // All units are the same, and thus so are all Baz's
+      @Override
+      public boolean equals(Object o) {
+        return o != null && (o instanceof Baz);
+      }
+
+      @Override
+      public int hashCode() {
+        return 1;
+      }
+
+      @Override
+      public String toString() {
+        return "Baz()";
+      }
+    }
+
+    static class Quux extends SomeVariant {
+      private final Optional<Long> x;
+
+      public Quux(Optional<Long> x) {
+        this.x = x;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+        return o != null && (o instanceof Quux) && x.equals(((Quux) o).x);
+      }
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(x);
+      }
+
+      @Override
+      public String toString() {
+        return String.format("Quux(%s)", x);
+      }
+    }
+
+    static class Flarp extends SomeVariant {
+      private final List<Long> x;
+
+      public Flarp(List<Long> x) {
+        this.x = x;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+        return o != null && (o instanceof Flarp) && x.equals(((Flarp) o).x);
+      }
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(x);
+      }
+
+      @Override
+      public String toString() {
+        return String.format("Flarp(%s)", x);
+      }
+    }
+  }
+
+  static class Tmpl {
+    public static final class Cid extends com.daml.ledger.javaapi.data.codegen.ContractId<Tmpl> {
+      public Cid(String id) {
+        super(id);
+      }
+    }
+  }
+
+  enum Suit {
+    HEARTS,
+    DIAMONDS,
+    CLUBS,
+    SPADES;
+
+    String toDamlName() {
+      switch (this) {
+        case HEARTS:
+          return "Hearts";
+        case DIAMONDS:
+          return "Diamonds";
+        case CLUBS:
+          return "Clubs";
+        case SPADES:
+          return "Spades";
+        default:
+          return null;
+      }
+    }
+
+    static final Map<String, Suit> damlNames =
+        new HashMap<>() {
+          {
+            put("Hearts", HEARTS);
+            put("Diamonds", DIAMONDS);
+            put("Clubs", CLUBS);
+            put("Spades", SPADES);
+          }
+        };
+  }
+
+  String intoString(JsonLfEncoder encoder) throws IOException {
+    StringWriter writer = new StringWriter();
+    encoder.encode(new JsonLfWriter(writer));
+    return writer.toString();
+  }
+
+  static class Case<T> {
+    public final T input;
+    public final String output;
+
+    private Case(T input, String output) {
+      this.input = input;
+      this.output = output;
+    }
+
+    static <T> Case<T> of(T input, String output) {
+      return new Case(input, output);
+    }
+  }
+
+  <T> void checkWriteAll(java.util.function.Function<T, JsonLfEncoder> encoderFor, Case<T>... cases)
+      throws IOException {
+    for (Case<T> c : cases) {
+      JsonLfEncoder encoder = encoderFor.apply(c.input);
+      assertEquals(c.output, intoString(encoder));
+    }
+  }
+}

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/TestHelpers.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/TestHelpers.java
@@ -1,0 +1,201 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data.codegen.json;
+
+import com.daml.ledger.javaapi.data.Unit;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class TestHelpers {
+
+  static BigDecimal dec(String s) {
+    return new BigDecimal(s);
+  }
+
+  static Instant timestampUTC(
+      int year, Month month, int day, int hour, int minute, int second, int micros) {
+    return LocalDateTime.of(year, month, day, hour, minute, second, micros * 1000)
+        .toInstant(ZoneOffset.UTC);
+  }
+
+  static Instant timestampUTC(
+      int year, Month month, int day, int hour, int minute, int second, int micros, int nanos) {
+    return LocalDateTime.of(year, month, day, hour, minute, second, micros * 1000 + nanos)
+        .toInstant(ZoneOffset.UTC);
+  }
+
+  static LocalDate date(int year, Month month, int day) {
+    return LocalDate.of(year, month, day);
+  }
+
+  static class SomeRecord {
+    final List<Long> i;
+    final Boolean b;
+
+    public SomeRecord(List<Long> i, Boolean b) {
+      this.i = i;
+      this.b = b;
+    }
+
+    public String toString() {
+      return String.format("SomeRecord{i=%s,b=%s}", i, b);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o != null
+          && (o instanceof SomeRecord)
+          && ((SomeRecord) o).i.equals(i)
+          && (((SomeRecord) o).b.equals(b));
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(i, b);
+    }
+  }
+
+  abstract static class SomeVariant {
+    static class Bar extends SomeVariant {
+      final Long x;
+
+      public Bar(Long x) {
+        this.x = x;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+        return o != null && (o instanceof Bar) && x == ((Bar) o).x;
+      }
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(x);
+      }
+
+      @Override
+      public String toString() {
+        return String.format("Bar(%s)", x);
+      }
+    }
+
+    static class Baz extends SomeVariant {
+      final Unit x;
+
+      public Baz(Unit x) {
+        this.x = x;
+      }
+      // All units are the same, and thus so are all Baz's
+      @Override
+      public boolean equals(Object o) {
+        return o != null && (o instanceof Baz);
+      }
+
+      @Override
+      public int hashCode() {
+        return 1;
+      }
+
+      @Override
+      public String toString() {
+        return "Baz()";
+      }
+    }
+
+    static class Quux extends SomeVariant {
+      final Optional<Long> x;
+
+      public Quux(Optional<Long> x) {
+        this.x = x;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+        return o != null && (o instanceof Quux) && x.equals(((Quux) o).x);
+      }
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(x);
+      }
+
+      @Override
+      public String toString() {
+        return String.format("Quux(%s)", x);
+      }
+    }
+
+    static class Flarp extends SomeVariant {
+      final List<Long> x;
+
+      public Flarp(List<Long> x) {
+        this.x = x;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+        return o != null && (o instanceof Flarp) && x.equals(((Flarp) o).x);
+      }
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(x);
+      }
+
+      @Override
+      public String toString() {
+        return String.format("Flarp(%s)", x);
+      }
+    }
+  }
+
+  static class Tmpl {
+    public static final class Cid extends com.daml.ledger.javaapi.data.codegen.ContractId<Tmpl> {
+      public Cid(String id) {
+        super(id);
+      }
+    }
+  }
+
+  static enum Suit {
+    HEARTS,
+    DIAMONDS,
+    CLUBS,
+    SPADES;
+
+    String toDamlName() {
+      switch (this) {
+        case HEARTS:
+          return "Hearts";
+        case DIAMONDS:
+          return "Diamonds";
+        case CLUBS:
+          return "Clubs";
+        case SPADES:
+          return "Spades";
+        default:
+          return null;
+      }
+    }
+
+    static final Map<String, Suit> damlNames =
+        new HashMap<>() {
+          {
+            put("Hearts", HEARTS);
+            put("Diamonds", DIAMONDS);
+            put("Clubs", CLUBS);
+            put("Spades", SPADES);
+          }
+        };
+  }
+}

--- a/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/TestHelpers.java
+++ b/language-support/java/bindings/src/test/java/com/daml/ledger/javaapi/data/codegen/json/TestHelpers.java
@@ -4,6 +4,8 @@
 package com.daml.ledger.javaapi.data.codegen.json;
 
 import com.daml.ledger.javaapi.data.Unit;
+import com.daml.ledger.javaapi.data.codegen.ContractId;
+import com.daml.ledger.javaapi.data.codegen.DamlEnum;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -160,14 +162,14 @@ public class TestHelpers {
   }
 
   static class Tmpl {
-    public static final class Cid extends com.daml.ledger.javaapi.data.codegen.ContractId<Tmpl> {
+    public static final class Cid extends ContractId<Tmpl> {
       public Cid(String id) {
         super(id);
       }
     }
   }
 
-  static enum Suit {
+  static enum Suit implements DamlEnum<Suit> {
     HEARTS,
     DIAMONDS,
     CLUBS,
@@ -197,5 +199,10 @@ public class TestHelpers {
             put("Spades", SPADES);
           }
         };
+
+    @Override
+    public com.daml.ledger.javaapi.data.DamlEnum toValue() {
+      return null;
+    }
   }
 }

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -431,7 +431,17 @@ da_scala_test(
 
 da_scala_benchmark_jmh(
     name = "from-json-bench",
-    srcs = glob(["src/bench/**/*.scala"]),
+    srcs = glob(["src/bench/**/FromJsonBench.scala"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":test-model-2.dev.jar",
+        "//language-support/java/bindings:bindings-java",
+    ],
+)
+
+da_scala_benchmark_jmh(
+    name = "to-json-bench",
+    srcs = glob(["src/bench/**/ToJsonBench.scala"]),
     visibility = ["//visibility:public"],
     deps = [
         ":test-model-2.dev.jar",

--- a/language-support/java/codegen/src/bench/com/daml/lf/codegen/java/FromJsonBench.scala
+++ b/language-support/java/codegen/src/bench/com/daml/lf/codegen/java/FromJsonBench.scala
@@ -8,7 +8,7 @@ import org.openjdk.jmh.annotations._
 
 @BenchmarkMode(Array(Mode.Throughput)) @OutputTimeUnit(TimeUnit.SECONDS)
 @Fork(value = 1)
-@Warmup(iterations = 3)
+@Warmup(iterations = 4)
 @Measurement(iterations = 10)
 class FromJsonBench {
 

--- a/language-support/java/codegen/src/bench/com/daml/lf/codegen/java/ToJsonBench.scala
+++ b/language-support/java/codegen/src/bench/com/daml/lf/codegen/java/ToJsonBench.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.codegen.java
+
+import com.daml.ledger.javaapi.data.Unit
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+
+@BenchmarkMode(Array(Mode.Throughput)) @OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@Warmup(iterations = 4)
+@Measurement(iterations = 10)
+class ToJsonBench {
+
+  @Benchmark
+  def enummodBox = Samples.enummodBox.toJson
+
+  @Benchmark
+  def enummodOptionalColor = Samples.enummodOptionalColor.toJson
+
+  @Benchmark
+  def enummodColoredTree = Samples.enummodColoredTree.toJson
+
+  @Benchmark
+  def genmapmodBox = Samples.genmapmodBox.toJson
+}
+
+object Samples {
+
+  val enummodOptionalColor = new test.enummod.optionalcolor.SomeColor(test.enummod.Color.GREEN)
+
+  val enummodBox = new test.enummod.Box(test.enummod.Color.RED, "party")
+
+  val enummodColoredTree = new test.enummod.coloredtree.Node(
+    test.enummod.Color.BLUE,
+    new test.enummod.coloredtree.Leaf(Unit.getInstance()),
+    new test.enummod.coloredtree.Leaf(Unit.getInstance()),
+  )
+
+  private def pair(i: Long, d: BigDecimal) =
+    new test.recordmod.Pair(java.lang.Long.valueOf(i), d.bigDecimal)
+  private def right(d: BigDecimal): test.variantmod.Either[java.lang.Long, java.math.BigDecimal] =
+    new test.variantmod.either.Right(d.bigDecimal)
+  private def left(i: Long): test.variantmod.Either[java.lang.Long, java.math.BigDecimal] =
+    new test.variantmod.either.Left(java.lang.Long.valueOf(i))
+
+  import scala.jdk.CollectionConverters._
+  val genmapmodBox = new test.genmapmod.Box(
+    Map(
+      pair(1L, BigDecimal("1.0000000000")) -> right(BigDecimal("1.0000000000")),
+      pair(2L, BigDecimal("-2.2222222222")) -> left(2L),
+      pair(3L, BigDecimal("3.3333333333")) -> right(BigDecimal("3.3333333333")),
+    ).asJava,
+    "alice",
+  )
+}

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/EnumClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/EnumClass.scala
@@ -36,6 +36,7 @@ private[inner] object EnumClass extends StrictLogging {
         .addMethod(generateValueDecoder(className, enumeration))
         .addMethod(generateToValue(className))
         .addMethods(FromJsonGenerator.forEnum(className, "__enums$").asJava)
+        .addMethods(ToJsonGenerator.forEnum(className).asJava)
       logger.debug("End")
       enumType.build()
     }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordMethods.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordMethods.scala
@@ -48,7 +48,7 @@ private[inner] object RecordMethods {
       fields,
       className,
       typeParameters,
-    )
+    ) ++ ToJsonGenerator.forRecordLike(fields, typeParameters)
 
     Vector(constructor) ++ conversionMethods ++ jsonConversionMethods ++
       ObjectMethods(className, typeParameters, fields.map(_.javaName))

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateMethods.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateMethods.scala
@@ -65,7 +65,7 @@ private[inner] object TemplateMethods {
       fields,
       className,
       IndexedSeq(),
-    )
+    ) ++ ToJsonGenerator.forRecordLike(fields, IndexedSeq())
 
     Vector(constructor) ++ conversionMethods ++ jsonConversionMethods ++ Vector(
       contractFilterMethod

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToJsonGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToJsonGenerator.scala
@@ -1,0 +1,283 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.codegen.backend.java.inner
+
+import com.daml.ledger.javaapi.data.codegen.json.{JsonLfEncoder, JsonLfEncoders, JsonLfWriter}
+import com.daml.lf.typesig.Type
+import com.squareup.javapoet.{
+  CodeBlock,
+  ClassName,
+  TypeName,
+  MethodSpec,
+  TypeVariableName,
+  ParameterizedTypeName,
+  ParameterSpec,
+}
+import java.io.{IOException, UncheckedIOException, StringWriter}
+import javax.lang.model.element.Modifier
+import scala.jdk.CollectionConverters._
+
+private[inner] object ToJsonGenerator {
+
+  private val encodersClass = classOf[JsonLfEncoders]
+  private val fieldClass = classOf[JsonLfEncoders.Field]
+
+  // Variants are encoded via a JsonLfEncoder.Field, which describes
+  // how to encode this particular instance.
+  // The definition of the Field is delegated out to the subclasses
+  // which each override a `fieldForJsonEncoder` method.
+  // For each type parameter to the variant, an encoder function
+  // will need to be passed in.
+  def forVariant(className: ClassName, typeParams: IndexedSeq[String]): Seq[MethodSpec] = {
+    def abstractFieldForJsonEncoder = MethodSpec
+      .methodBuilder("fieldForJsonEncoder")
+      .addModifiers(Modifier.PROTECTED, Modifier.ABSTRACT)
+      .addParameters(jsonEncoderParamsForTypeParams(typeParams))
+      .returns(fieldClass)
+      .build()
+
+    def jsonEncoder = MethodSpec
+      .methodBuilder("jsonEncoder")
+      .addModifiers(Modifier.PUBLIC)
+      .addParameters(jsonEncoderParamsForTypeParams(typeParams))
+      .addStatement {
+        val encoderFieldFunc =
+          if (typeParams.isEmpty) CodeBlock.of("$T::fieldForJsonEncoder", className)
+          else
+            CodeBlock.of(
+              "($T _x) -> _x.fieldForJsonEncoder($L)",
+              className.parameterized(typeParams),
+              jsonEncoderArgsForTypeParams(typeParams),
+            )
+        CodeBlock.of("return $T.variant($L).apply(this)", encodersClass, encoderFieldFunc)
+      }
+      .returns(classOf[JsonLfEncoder])
+      .build()
+    Seq(abstractFieldForJsonEncoder, jsonEncoder, toJson(typeParams))
+  }
+
+  // A different code-gen strategy is employed for "simple" variants vs "record" variants, i.e.
+  // data Foo = SimpleFoo Int | RecordFoo with x: Int, y: Text
+
+  // In this case, the encoder is simply the one for the single data arg.
+  def forVariantSimple(
+      constructorName: String,
+      typeParams: IndexedSeq[String],
+      fieldName: String,
+      damlType: Type,
+  )(implicit
+      packagePrefixes: PackagePrefixes
+  ): Seq[MethodSpec] = {
+    val encoder = CodeBlock.of("apply($L, $L)", encoderOf(damlType), fieldName)
+    Seq(apply, fieldForJsonEncoder(constructorName, typeParams, encoder))
+  }
+
+  // Encoding a record is more involved, so we pull that out into its own method,
+  // and reference that method when building the Field encoder.
+  def forVariantRecord(constructorName: String, fields: Fields, typeParams: IndexedSeq[String])(
+      implicit packagePrefixes: PackagePrefixes
+  ): Seq[MethodSpec] = {
+    val recordEncoderMethodName = s"jsonEncoder${constructorName}"
+    val fieldEncoder = CodeBlock.of(
+      "this.$L($L)",
+      recordEncoderMethodName,
+      jsonEncoderArgsForTypeParams(typeParams),
+    )
+    Seq(
+      apply,
+      jsonEncoderForRecordLike(recordEncoderMethodName, Modifier.PRIVATE, typeParams, fields),
+      fieldForJsonEncoder(constructorName, typeParams, fieldEncoder),
+    )
+  }
+
+  def forEnum(className: ClassName): Seq[MethodSpec] = {
+    val getConstructor = MethodSpec
+      .methodBuilder("getConstructor")
+      .addModifiers(Modifier.PUBLIC)
+      .addStatement("return toValue().getConstructor()", className)
+      .returns(classOf[String])
+      .build()
+
+    val jsonEncoder = MethodSpec
+      .methodBuilder("jsonEncoder")
+      .addModifiers(Modifier.PUBLIC)
+      .addStatement(
+        "return $T.enumeration($T::getConstructor).apply(this)",
+        encodersClass,
+        className,
+      )
+      .returns(classOf[JsonLfEncoder])
+      .build()
+
+    Seq(getConstructor, jsonEncoder, toJson(IndexedSeq()))
+  }
+
+  def forRecordLike(fields: Fields, typeParams: IndexedSeq[String])(implicit
+      packagePrefixes: PackagePrefixes
+  ): Seq[MethodSpec] = {
+    Seq(
+      apply,
+      jsonEncoderForRecordLike("jsonEncoder", Modifier.PUBLIC, typeParams, fields),
+      toJson(typeParams),
+    )
+  }
+
+  // When a type has type parameters (generic classes), we need to tell
+  // the encoder how to encode that type argument,
+  // e.g. if encoding a List<T>, we need to tell it how to encode a T.
+  // This is done by passing functions for each type parameter as arguments to the encoding methods.
+  // These functions can create a JsonLfEncoder for each value of the relevant type.
+  // These arguments are given a name based on the type param, defined here.
+  private def makeEncoderParamName(t: String): String = s"makeEncoder_${t}"
+
+  // Argument names, used when calling method.
+  private def jsonEncoderArgsForTypeParams(typeParams: IndexedSeq[String]) =
+    CodeBlock.join(typeParams.map(t => CodeBlock.of(makeEncoderParamName(t))).asJava, ",$W")
+
+  // ParameterSpec's, used when defining method.
+  private def jsonEncoderParamsForTypeParams(
+      typeParams: IndexedSeq[String]
+  ): java.util.List[ParameterSpec] = {
+    def makeEncoderParamType(t: String): TypeName =
+      ParameterizedTypeName.get(
+        ClassName.get(classOf[java.util.function.Function[_, _]]),
+        TypeVariableName.get(t),
+        ClassName.get(classOf[JsonLfEncoder]),
+      )
+
+    typeParams.map { t =>
+      ParameterSpec
+        .builder(makeEncoderParamType(t), makeEncoderParamName(t))
+        .build()
+    }.asJava
+  }
+
+  private def toJson(typeParams: IndexedSeq[String]): MethodSpec = MethodSpec
+    .methodBuilder("toJson")
+    .addModifiers(Modifier.PUBLIC)
+    .addParameters(jsonEncoderParamsForTypeParams(typeParams))
+    .addStatement("var w = new $T()", classOf[StringWriter])
+    .beginControlFlow("try")
+    .addStatement(
+      "this.jsonEncoder($L).encode(new $T(w))",
+      jsonEncoderArgsForTypeParams(typeParams),
+      classOf[JsonLfWriter],
+    )
+    .nextControlFlow("catch ($T e)", classOf[IOException])
+    .addComment("Not expected with StringWriter")
+    .addStatement("throw new $T(e)", classOf[UncheckedIOException])
+    .endControlFlow()
+    .addStatement("return w.toString()")
+    .returns(ClassName.get(classOf[String]))
+    .build()
+
+  private def jsonEncoderForRecordLike(
+      methodName: String,
+      modifier: Modifier,
+      typeParams: IndexedSeq[String],
+      fields: Fields,
+  )(implicit
+      packagePrefixes: PackagePrefixes
+  ): MethodSpec = {
+    val encoderFields = fields.map { f =>
+      val encoder = CodeBlock.of("apply($L, $L)", encoderOf(f.damlType), f.javaName)
+      CodeBlock.of(
+        "$T.of($S, $L)",
+        fieldClass,
+        f.damlName,
+        encoder,
+      )
+    }
+    MethodSpec
+      .methodBuilder(methodName)
+      .addModifiers(modifier)
+      .addParameters(jsonEncoderParamsForTypeParams(typeParams))
+      .returns(classOf[JsonLfEncoder])
+      .addStatement(
+        "return $T.record($Z$L)",
+        encodersClass,
+        CodeBlock.join(encoderFields.asJava, ",$Z"),
+      )
+      .build()
+  }
+
+  // Assists the type checker with type inference and unification,
+  // and unifies the call syntax across method references and functions.
+  private def apply = {
+    val inputType = TypeVariableName.get("I")
+    val outputType = TypeVariableName.get("O")
+    val functionType = ParameterizedTypeName.get(
+      ClassName.get(classOf[java.util.function.Function[_, _]]),
+      inputType,
+      outputType,
+    )
+    MethodSpec
+      .methodBuilder("apply")
+      .addModifiers(Modifier.PRIVATE)
+      .addTypeVariable(inputType)
+      .addTypeVariable(outputType)
+      .addParameter(functionType, "f")
+      .addParameter(inputType, "x")
+      .addStatement("return f.apply(x)")
+      .returns(outputType)
+      .build()
+  }
+
+  private def fieldForJsonEncoder(
+      constructorName: String,
+      typeParams: IndexedSeq[String],
+      encoder: CodeBlock,
+  ) = MethodSpec
+    .methodBuilder("fieldForJsonEncoder")
+    .addModifiers(Modifier.PROTECTED)
+    .addParameters(jsonEncoderParamsForTypeParams(typeParams))
+    .addAnnotation(classOf[Override])
+    .addStatement("return $T.of($S,$W$L)", fieldClass, constructorName, encoder)
+    .returns(fieldClass)
+    .build()
+
+  private def encoderOf(
+      damlType: Type,
+      nesting: Int = 0, // Used to avoid clashing argument identifiers in nested encoder definitions
+  )(implicit packagePrefixes: PackagePrefixes): CodeBlock = {
+    import com.daml.lf.typesig._
+
+    def typeEncoders(types: Iterable[Type]): CodeBlock =
+      CodeBlock.join(types.map(t => encoderOf(t, nesting + 1)).asJava, ", ")
+
+    damlType match {
+      case TypeCon(TypeConName(ident), IndexedSeq()) =>
+        CodeBlock.of("$T::jsonEncoder", guessClass(ident))
+      case TypeCon(TypeConName(_), typeParams) => {
+        // We are introducing identifiers into the namespace, so try to make them unique.
+        val argName = CodeBlock.of("_x$L", nesting)
+        CodeBlock.of("$L -> $L.jsonEncoder($L)", argName, argName, typeEncoders(typeParams))
+      }
+      case TypePrim(PrimTypeUnit, _) => CodeBlock.of("$T::unit", encodersClass)
+      case TypePrim(PrimTypeBool, _) => CodeBlock.of("$T::bool", encodersClass)
+      case TypePrim(PrimTypeInt64, _) => CodeBlock.of("$T::int64", encodersClass)
+      case TypeNumeric(_) => CodeBlock.of("$T::numeric", encodersClass)
+      case TypePrim(PrimTypeText, _) => CodeBlock.of("$T::text", encodersClass)
+      case TypePrim(PrimTypeDate, _) => CodeBlock.of("$T::date", encodersClass)
+      case TypePrim(PrimTypeTimestamp, _) => CodeBlock.of("$T::timestamp", encodersClass)
+      case TypePrim(PrimTypeParty, _) => CodeBlock.of("$T::party", encodersClass)
+      case TypePrim(PrimTypeContractId, _) => CodeBlock.of("$T::contractId", encodersClass)
+      case TypePrim(PrimTypeList, Seq(typ)) =>
+        CodeBlock.of("$T.list($L)", encodersClass, encoderOf(typ, nesting + 1))
+      case TypePrim(PrimTypeOptional, Seq(typ)) =>
+        CodeBlock.of("$T.optional($L)", encodersClass, encoderOf(typ, nesting + 1))
+      case TypePrim(PrimTypeTextMap, Seq(valType)) =>
+        CodeBlock.of("$T.textMap($L)", encodersClass, encoderOf(valType, nesting + 1))
+      case TypePrim(PrimTypeGenMap, Seq(keyType, valType)) =>
+        CodeBlock.of(
+          "$T.genMap($L, $L)",
+          encodersClass,
+          encoderOf(keyType, nesting + 1),
+          encoderOf(valType, nesting + 1),
+        )
+      case TypeVar(t) => CodeBlock.of(makeEncoderParamName(t))
+      case _ => throw new IllegalArgumentException(s"Invalid Daml datatype: $damlType")
+    }
+  }
+}

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantClass.scala
@@ -50,6 +50,9 @@ private[inner] object VariantClass extends StrictLogging {
           FromJsonGenerator.forVariant(variantClassName, typeArguments, constructorInfo).asJava
         )
         .addMethods(
+          ToJsonGenerator.forVariant(variantClassName, typeArguments).asJava
+        )
+        .addMethods(
           VariantValueDecodersMethods(
             typeArguments,
             variant,

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantConstructorClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantConstructorClass.scala
@@ -70,6 +70,9 @@ object VariantConstructorClass extends StrictLogging {
           .addMethod(constructor)
           .addMethods(conversionMethods.asJava)
           .addMethods(ObjectMethods(className.rawType, typeArgs, Vector(variantFieldName)).asJava)
+          .addMethods(
+            ToJsonGenerator.forVariantSimple(javaName, typeArgs, variantFieldName, body).asJava
+          )
           .build()
 
       logger.info("End")

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantRecordMethods.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantRecordMethods.scala
@@ -41,8 +41,10 @@ private[inner] object VariantRecordMethods extends StrictLogging {
         )
     }
 
+    val toJsonMethods = ToJsonGenerator.forVariantRecord(constructorName, fields, typeParameters)
+
     Vector(constructor) ++ conversionMethods ++
-      ObjectMethods(className.rawType, typeParameters, fields.map(_.javaName))
+      ObjectMethods(className.rawType, typeParameters, fields.map(_.javaName)) ++ toJsonMethods
   }
 
   private def toValue(constructorName: String, params: IndexedSeq[String], fields: Fields)(implicit

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/DecimalTestForAll.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/DecimalTestForAll.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.daml.ledger.javaapi.data.DamlRecord;
 import com.daml.ledger.javaapi.data.Numeric;
 import com.daml.ledger.javaapi.data.Party;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
 import java.io.IOException;
 import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,14 @@ public class DecimalTestForAll {
     for (String s : goodValues) {
       Box b = new Box(new BigDecimal(s), "alice");
       assertEquals(Box.fromValue(b.toValue()), b);
+    }
+  }
+
+  @Test
+  void decimal2Value2DecimalJson() throws JsonLfDecoder.Error {
+    for (String s : goodValues) {
+      Box b = new Box(new BigDecimal(s), "alice");
+      assertEquals(Box.fromJson(b.toJson()), b);
     }
   }
 

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/EnumTestForForAll.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/EnumTestForForAll.java
@@ -10,6 +10,7 @@ import com.daml.ledger.javaapi.data.DamlRecord;
 import com.daml.ledger.javaapi.data.Party;
 import com.daml.ledger.javaapi.data.Unit;
 import com.daml.ledger.javaapi.data.Variant;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -32,6 +33,20 @@ public class EnumTestForForAll {
       assertEquals(Box.fromValue(record.toValue()), record);
       assertEquals(OptionalColor.fromValue(variant.toValue()), variant);
       assertEquals(ColoredTree.fromValue(variantRecord.toValue()), variantRecord);
+    }
+  }
+
+  @Test
+  void enum2Value2EnumJson() throws JsonLfDecoder.Error {
+    for (Color c : new Color[] {Color.RED, Color.GREEN, Color.BLUE}) {
+      Box record = new Box(c, "party");
+      OptionalColor variant = new SomeColor(c);
+      ColoredTree variantRecord =
+          new Node(Color.RED, new Leaf(Unit.getInstance()), new Leaf(Unit.getInstance()));
+      assertEquals(Color.fromJson(c.toJson()), c);
+      assertEquals(Box.fromJson(record.toJson()), record);
+      assertEquals(OptionalColor.fromJson(variant.toJson()), variant);
+      assertEquals(ColoredTree.fromJson(variantRecord.toJson()), variantRecord);
     }
   }
 

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/GenMapTestFor1_11AndFor1_12ndFor1_13AndFor1_14AndFor1_15AndFor1_devAndFor2_dev.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/GenMapTestFor1_11AndFor1_12ndFor1_13AndFor1_14AndFor1_15AndFor1_devAndFor2_dev.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.daml.ledger.javaapi.data.*;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.LinkedHashMap;
@@ -58,6 +59,12 @@ public class GenMapTestFor1_11AndFor1_12ndFor1_13AndFor1_14AndFor1_15AndFor1_dev
   void genMap2Value2GenMap() {
     Box b = box();
     assertEquals(Box.fromValue(b.toValue()), b);
+  }
+
+  @Test
+  void genMap2Value2GenMapJson() throws JsonLfDecoder.Error {
+    Box b = box();
+    assertEquals(Box.fromJson(b.toJson()), b);
   }
 
   @Test

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/NumericTestForAll.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/NumericTestForAll.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.daml.ledger.javaapi.data.DamlRecord;
 import com.daml.ledger.javaapi.data.Numeric;
 import com.daml.ledger.javaapi.data.Party;
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
 import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -28,6 +29,18 @@ public class NumericTestForAll {
             new BigDecimal("0.37"),
             "alice");
     assertEquals(Box.fromValue(b.toValue()), b);
+  }
+
+  @Test
+  void numeric2Value2NumericJson() throws JsonLfDecoder.Error {
+    Box b =
+        new Box(
+            new BigDecimal(0),
+            new BigDecimal(10),
+            new BigDecimal(17),
+            new BigDecimal("0.37"),
+            "alice");
+    assertEquals(Box.fromJson(b.toJson()), b);
   }
 
   @Test


### PR DESCRIPTION
In the grandparent [PR](https://github.com/digital-asset/daml/pull/17603) I got this error on Windows

```
ERROR(tools/test/windows/tw.cc:471) value: 206 (0x000000ce), arg: C:\users\u\_bazel_u\vvgx3zjt\execroot\com_github_digital_asset_daml\bazel-out\x64_windows-opt\bin\language-support\java\bindings\java-tests_test_suite_src_test_java_com_daml_ledger_javaapi_data_codegen_json_JsonLfEncodersTest.java.exe.runfiles\com_github_digital_asset_daml: Could not chdir
```

Apparently Windows doesn't like long paths, so I'm trying using a somewhat shorter one to see whether it helps.