### PR TITLE
Add support for querying upgraded contracts to daml-script

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
@@ -345,13 +345,22 @@ private[lf] final class ValueTranslator(
 
   // This does not try to pull missing packages, return an error instead.
   // TODO: https://github.com/digital-asset/daml/issues/17082
-  //  This is used by script and trigger, this should problaby use ValueTranslator.Config.Legacy
+  //  This is used by script and trigger, this should problaby use ValueTranslator.Config.Strict
   def strictTranslateValue(
       ty: Type,
       value: Value,
   ): Either[Error.Preprocessing.Error, SValue] =
     safelyRun(
       unsafeTranslateValue(ty, value, Config.Legacy)
+    )
+
+  def translateValue(
+      ty: Type,
+      value: Value,
+      config: Config,
+  ): Either[Error.Preprocessing.Error, SValue] =
+    safelyRun(
+      unsafeTranslateValue(ty, value, config)
     )
 
 }
@@ -374,6 +383,9 @@ object ValueTranslator {
     // Lenient Legacy config, i.e. pre-upgrade
     val Legacy =
       Config(allowFieldReordering = true, ignorePackageId = false, enableUpgrade = false)
+
+    val Upgradeable =
+      Config(allowFieldReordering = false, ignorePackageId = true, enableUpgrade = true)
   }
 
 }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -126,10 +126,16 @@ abstract class ConverterMethods(stablePackages: StablePackages) {
       translator: preprocessing.ValueTranslator,
       templateId: Identifier,
       argument: Value,
+      enableContractUpgrading: Boolean = false,
   ): Either[String, SValue] = {
     for {
       translated <- translator
-        .strictTranslateValue(TTyCon(templateId), argument)
+        .translateValue(
+          TTyCon(templateId),
+          argument,
+          if (enableContractUpgrading) preprocessing.ValueTranslator.Config.Upgradeable
+          else preprocessing.ValueTranslator.Config.Strict,
+        )
         .left
         .map(err => s"Failed to translate create argument: $err")
     } yield record(

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -396,6 +396,7 @@ object Runner {
       warningLog: WarningLog = Speedy.Machine.newWarningLog,
       profile: Profile = Speedy.Machine.newProfile,
       canceled: () => Option[RuntimeException] = () => None,
+      enableContractUpgrading: Boolean = false,
   )(implicit
       ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
@@ -412,6 +413,7 @@ object Runner {
       warningLog,
       profile,
       canceled,
+      enableContractUpgrading,
     )._1
 
   // Same as run above but requires use of IdeLedgerClient, gives additional context back
@@ -458,6 +460,7 @@ object Runner {
       warningLog: WarningLog,
       profile: Profile,
       canceled: () => Option[RuntimeException],
+      enableContractUpgrading: Boolean = false,
   )(implicit
       ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
@@ -483,7 +486,7 @@ object Runner {
       case (_: Script.Function, None) =>
         throw new RuntimeException(s"The script ${scriptId} requires an argument.")
     }
-    val runner = new Runner(compiledPackages, scriptAction, timeMode)
+    val runner = new Runner(compiledPackages, scriptAction, timeMode, enableContractUpgrading)
     runner.runWithClients(initialClients, traceLog, warningLog, profile, canceled)
   }
 }
@@ -492,6 +495,7 @@ private[lf] class Runner(
     val compiledPackages: CompiledPackages,
     val script: Script.Action,
     val timeMode: ScriptTimeMode,
+    val enableContractUpgrading: Boolean = false,
 ) extends StrictLogging {
 
   // We overwrite the definition of 'fromLedgerValue' with an identity function.
@@ -557,6 +561,8 @@ private[lf] class Runner(
       throw new IllegalArgumentException("Couldn't get daml script package name")
     ) match {
       case "daml-script" =>
+        if (enableContractUpgrading)
+          throw new IllegalArgumentException("daml2-script does not support Upgrades natively.")
         new v1.Runner(this).runWithClients(initialClients, traceLog, warningLog, profile, canceled)
       case "daml3-script" =>
         new v2.Runner(this, initialClients, traceLog, warningLog, profile, canceled).getResult()

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Converter.scala
@@ -138,7 +138,9 @@ object Converter extends script.ConverterMethods(StablePackagesV2) {
   def fromContract(
       translator: preprocessing.ValueTranslator,
       contract: ScriptLedgerClient.ActiveContract,
-  ): Either[String, SValue] = fromAnyTemplate(translator, contract.templateId, contract.argument)
+      enableContractUpgrading: Boolean = false,
+  ): Either[String, SValue] =
+    fromAnyTemplate(translator, contract.templateId, contract.argument, enableContractUpgrading)
 
   // Convert a Created event to a pair of (ContractId (), AnyTemplate)
   def fromCreated(

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Runner.scala
@@ -38,6 +38,7 @@ private[lf] class Runner(
       unversionedRunner.timeMode,
       initialClientsV1,
       unversionedRunner.extendedCompiledPackages,
+      unversionedRunner.enableContractUpgrading,
     )
 
   private val ideLedgerContext: Option[IdeLedgerContext] =

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
@@ -70,6 +70,7 @@ object ScriptF {
       val timeMode: ScriptTimeMode,
       private var _clients: Participants[ScriptLedgerClient],
       compiledPackages: CompiledPackages,
+      val enableContractUpgrading: Boolean,
   ) {
     def clients = _clients
     val valueTranslator = new ValueTranslator(
@@ -313,8 +314,10 @@ object ScriptF {
     ): Future[SExpr] =
       for {
         client <- Converter.toFuture(env.clients.getPartiesParticipant(parties))
-        optR <- client.queryContractId(parties, tplId, cid)
-        optR <- Converter.toFuture(optR.traverse(Converter.fromContract(env.valueTranslator, _)))
+        optR <- client.queryContractId(parties, tplId, cid, env.enableContractUpgrading)
+        optR <- Converter.toFuture(
+          optR.traverse(Converter.fromContract(env.valueTranslator, _, env.enableContractUpgrading))
+        )
       } yield SEValue(SOptional(optR))
   }
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -111,7 +111,11 @@ class IdeLedgerClient(
 
   private val userManagementStore = new InMemoryUserManagementStore(createAdmin = false)
 
-  override def query(parties: OneAnd[Set, Ref.Party], templateId: Identifier)(implicit
+  override def query(
+      parties: OneAnd[Set, Ref.Party],
+      templateId: Identifier,
+      enableContractUpgrading: Boolean = false,
+  )(implicit
       ec: ExecutionContext,
       mat: Materializer,
   ): Future[Seq[ScriptLedgerClient.ActiveContract]] = {
@@ -162,6 +166,7 @@ class IdeLedgerClient(
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,
       cid: ContractId,
+      enableContractUpgrading: Boolean = false,
   )(implicit
       ec: ExecutionContext,
       mat: Materializer,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/JsonLedgerClient.scala
@@ -161,7 +161,11 @@ class JsonLedgerClient(
       case SuccessResponse(result, _) => Future.successful(result)
     }
 
-  override def query(parties: OneAnd[Set, Ref.Party], templateId: Identifier)(implicit
+  override def query(
+      parties: OneAnd[Set, Ref.Party],
+      templateId: Identifier,
+      enableContractUpgrading: Boolean = false,
+  )(implicit
       ec: ExecutionContext,
       mat: Materializer,
   ) = {
@@ -190,6 +194,7 @@ class JsonLedgerClient(
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,
       cid: ContractId,
+      enableContractUpgrading: Boolean = false,
   )(implicit ec: ExecutionContext, mat: Materializer) = {
     for {
       parties <- validateTokenParties(parties, "queryContractId")

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
@@ -73,7 +73,11 @@ object ScriptLedgerClient {
 // us to plug in something that interacts with the JSON API as well as
 // something that works against the gRPC API.
 trait ScriptLedgerClient {
-  def query(parties: OneAnd[Set, Ref.Party], templateId: Identifier)(implicit
+  def query(
+      parties: OneAnd[Set, Ref.Party],
+      templateId: Identifier,
+      enableContractUpgrading: Boolean = false,
+  )(implicit
       ec: ExecutionContext,
       mat: Materializer,
   ): Future[Seq[ScriptLedgerClient.ActiveContract]]
@@ -87,8 +91,12 @@ trait ScriptLedgerClient {
       )
     )
 
-  def queryContractId(parties: OneAnd[Set, Ref.Party], templateId: Identifier, cid: ContractId)(
-      implicit
+  def queryContractId(
+      parties: OneAnd[Set, Ref.Party],
+      templateId: Identifier,
+      cid: ContractId,
+      enableContractUpgrading: Boolean = false,
+  )(implicit
       ec: ExecutionContext,
       mat: Materializer,
   ): Future[Option[ScriptLedgerClient.ActiveContract]]


### PR DESCRIPTION
To be used by https://github.com/digital-asset/daml/pull/17610 in testing upgrades.
As such, I've only verified this behaviour works locally (since its behind a flag)
Proper tests for it will be included in the PR linked above once this is merged.