### PR TITLE
Add SharedGlobalKey

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/LossyValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/LossyValueTranslator.scala
@@ -1,0 +1,182 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package engine
+package preprocessing
+
+import com.daml.lf.data.Ref.IdString
+import com.daml.lf.data._
+import com.daml.lf.language.Ast._
+import com.daml.lf.speedy.{ArrayList, SValue}
+import com.daml.lf.value.Value
+import com.daml.lf.value.Value._
+
+/** This translator is only intended for use where a SValue is needed for error reporting but
+  * only a Value is available. This can be the case for [[com.daml.lf.transaction.SharedGlobalKey]]
+  * where the package-id may not be available. Once there are other ways to resolve missing package-ids,
+  * for example issue #17646, this will longer be necessary.
+  */
+object LossyValueTranslator {
+
+  private[preprocessing] val lossyConversionIdentifier: Ref.Identifier =
+    Ref.Identifier.assertFromString("Lossy:Conversion:Id")
+  private[preprocessing] val lossyConversionVariantRank: Int = -1
+  private[preprocessing] val lossyConversionFieldPrefix: String = "Lossy_Field_"
+
+  private final case class ValueTy(value: SValue, ty: Type)
+
+  @throws[Error.Preprocessing.Error]
+  def unsafeTranslate(lf: Value): (SValue, Type) = {
+    val ValueTy(value, ty) = translate(lf)
+    (value, ty)
+  }
+
+  private def translate(value: Value): ValueTy = {
+
+    def vty(value: SValue, ty: Type): ValueTy = ValueTy(value, ty)
+    def bty(value: SValue, bt: BuiltinType): ValueTy = ValueTy(value, TBuiltin(bt))
+
+    def go(value0: Value, nesting: Int = 0): ValueTy = {
+      if (nesting > Value.MAXIMUM_NESTING) {
+        throw Error.Preprocessing.ValueNesting(value)
+      } else {
+        val newNesting = nesting + 1
+
+        def typeError(msg: String = s"Unable to translate value: $value") =
+          throw Error.Preprocessing.Internal("LossyTranslate", msg, None)
+
+        value0 match {
+          case ValueUnit => bty(SValue.SUnit, BTUnit)
+          case ValueBool(b) => bty(if (b) SValue.SValue.True else SValue.SValue.False, BTBool)
+          case ValueInt64(i) => bty(SValue.SInt64(i), BTInt64)
+          case ValueTimestamp(t) => bty(SValue.STimestamp(t), BTTimestamp)
+          case ValueDate(t) => bty(SValue.SDate(t), BTDate)
+          case ValueText(t) => bty(SValue.SText(t), BTText)
+          case ValueParty(p) => bty(SValue.SParty(p), BTParty)
+
+          case ValueContractId(c) =>
+            vty(
+              SValue.SContractId(c),
+              TApp(TBuiltin(BTContractId), TTyCon(lossyConversionIdentifier)),
+            )
+
+          case ValueNumeric(d) =>
+            Numeric.fromBigDecimal(TNat.Decimal.n, d) match {
+              case Right(value) =>
+                vty(SValue.SNumeric(value), TApp(TBuiltin(BTNumeric), TNat.Decimal))
+              case Left(message) => typeError(message)
+            }
+
+          case ValueOptional(mbValue) =>
+            mbValue match {
+              case None =>
+                vty(SValue.SValue.None, TBuiltin(BTOptional))
+              case Some(x) =>
+                val vt = go(x, newNesting)
+                vty(SValue.SOptional(Some(vt.value)), TApp(TBuiltin(BTOptional), vt.ty))
+            }
+
+          case ValueList(ls) =>
+            val list = ls.map(go(_, newNesting))
+            list.iterator.nextOption() match {
+              case None => vty(SValue.SValue.EmptyList, TBuiltin(BTList))
+              case Some(ref) => vty(SValue.SList(list.map(_.value)), TApp(TBuiltin(BTList), ref.ty))
+            }
+
+          case ValueTextMap(entries) =>
+            entries.iterator.nextOption() match {
+              case None =>
+                vty(SValue.SValue.EmptyTextMap, TBuiltin(BTTextMap))
+              case Some((_, refVal)) =>
+                val refTy = go(refVal, newNesting).ty
+                vty(
+                  SValue.SMap(
+                    isTextMap = true,
+                    entries = entries.iterator.map { case (k, v) =>
+                      SValue.SText(k) -> go(v, newNesting).value
+                    },
+                  ),
+                  TApp(TBuiltin(BTTextMap), refTy),
+                )
+            }
+
+          case ValueGenMap(entries) =>
+            entries.iterator.nextOption() match {
+              case None =>
+                vty(
+                  SValue.SValue.EmptyGenMap,
+                  TBuiltin(BTGenMap),
+                )
+              case Some((kr, vr)) =>
+                val refK = go(kr, newNesting).ty
+                val refV = go(vr, newNesting).ty
+                vty(
+                  SValue.SMap(
+                    isTextMap = false,
+                    entries = entries.iterator.map { case (k, v) =>
+                      go(k, newNesting).value -> go(v, newNesting).value
+                    },
+                  ),
+                  TApp(TApp(TBuiltin(BTGenMap), refK), refV),
+                )
+            }
+
+          case ValueVariant(mbId, constructorName, val0) =>
+            val vt = go(val0, newNesting)
+            // This cannot work in the general case as there is no way to derive all the types that
+            // are involved in the variant as we only observer one instance
+            vty(
+              SValue.SVariant(
+                mbId.getOrElse(lossyConversionIdentifier),
+                constructorName,
+                lossyConversionVariantRank,
+                vt.value,
+              ),
+              TApp(TTyCon(lossyConversionIdentifier), vt.ty),
+            )
+
+          case ValueRecord(mTyCon, sourceElements) =>
+            val flatNames = sourceElements.iterator.flatMap(_._1).toList
+            val names = flatNames.length match {
+              case 0 =>
+                (1 to sourceElements.length).map(i =>
+                  IdString.Name.assertFromString(s"$lossyConversionFieldPrefix$i")
+                )
+              case sourceElements.length => flatNames
+              case _ => typeError()
+            }
+            val vts = sourceElements.iterator.map(_._2).map(go(_, newNesting)).toList
+            val types = vts.map(_.ty).foldLeft[Type](TTyCon(lossyConversionIdentifier)) {
+              case (it, t) => TApp(it, t)
+            }
+            vty(
+              SValue.SRecord(
+                mTyCon.getOrElse(lossyConversionIdentifier),
+                ImmArray.from(names),
+                vts.map(_.value).to(ArrayList),
+              ),
+              types,
+            )
+
+          case ValueEnum(mbId, constructor) =>
+            vty(
+              SValue.SEnum(
+                mbId.getOrElse(lossyConversionIdentifier),
+                constructor,
+                lossyConversionVariantRank,
+              ),
+              TTyCon(lossyConversionIdentifier),
+            )
+
+          case _ => typeError()
+        }
+
+      }
+    }
+
+    go(value)
+
+  }
+
+}

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LossyValueTranslatorSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LossyValueTranslatorSpec.scala
@@ -1,0 +1,162 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package engine
+package preprocessing
+
+import com.daml.lf.data._
+import com.daml.lf.engine.preprocessing.LossyValueTranslator.{
+  lossyConversionFieldPrefix,
+  lossyConversionIdentifier,
+  lossyConversionVariantRank,
+  unsafeTranslate,
+}
+import com.daml.lf.language.Ast.TTyCon
+import com.daml.lf.language.Util._
+import com.daml.lf.language.{Ast, LanguageMajorVersion}
+import com.daml.lf.speedy.ArrayList
+import com.daml.lf.speedy.SValue._
+import com.daml.lf.testing.parser.ParserParameters
+import com.daml.lf.value.Value
+import com.daml.lf.value.Value._
+import org.scalatest.Inside
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.{Failure, Success, Try}
+
+class LossyValueTranslatorSpec()
+    extends AnyWordSpec
+    with Inside
+    with Matchers
+    with TableDrivenPropertyChecks {
+
+  import com.daml.lf.testing.parser.Implicits.SyntaxHelper
+  import com.daml.lf.transaction.test.TransactionBuilder.Implicits.{defaultPackageId => _, _}
+
+  private[this] implicit val parserParameters
+      : ParserParameters[LossyValueTranslatorSpec.this.type] =
+    ParserParameters.defaultFor(LanguageMajorVersion.V2)
+
+  private[this] implicit val defaultPackageId: Ref.PackageId =
+    parserParameters.defaultPackageId
+
+  private[this] val aCid =
+    ContractId.V1.assertBuild(
+      crypto.Hash.hashPrivateKey("a Contract ID"),
+      Bytes.assertFromString("00"),
+    )
+
+  "translateValue" should {
+
+    val testCases = Table[Ast.Type, Value, speedy.SValue](
+      ("type", "value", "svalue"),
+      (TUnit, ValueUnit, SValue.Unit),
+      (TBool, ValueTrue, SValue.True),
+      (TInt64, ValueInt64(42), SInt64(42)),
+      (
+        TTimestamp,
+        ValueTimestamp(Time.Timestamp.assertFromString("1969-07-20T20:17:00Z")),
+        STimestamp(Time.Timestamp.assertFromString("1969-07-20T20:17:00Z")),
+      ),
+      (
+        TDate,
+        ValueDate(Time.Date.assertFromString("1879-03-14")),
+        SDate(Time.Date.assertFromString("1879-03-14")),
+      ),
+      (TText, ValueText("daml"), SText("daml")),
+      (
+        TNumeric(Ast.TNat(Decimal.scale)),
+        ValueNumeric(Numeric.assertFromString("10.")),
+        SNumeric(Numeric.assertFromString("10.0000000000")),
+      ),
+      (TParty, ValueParty("Alice"), SParty("Alice")),
+      (
+        TContractId(TTyCon(lossyConversionIdentifier)),
+        ValueContractId(aCid),
+        SContractId(aCid),
+      ),
+      (
+        TList(TText),
+        ValueList(FrontStack(ValueText("a"), ValueText("b"))),
+        SList(FrontStack(SText("a"), SText("b"))),
+      ),
+      (
+        TTextMap(TBool),
+        ValueTextMap(SortedLookupList(Map("0" -> ValueTrue, "1" -> ValueFalse))),
+        SMap(true, Iterator(SText("0") -> SValue.True, SText("1") -> SValue.False)),
+      ),
+      (
+        TGenMap(TInt64, TText),
+        ValueGenMap(ImmArray(ValueInt64(1) -> ValueText("1"), ValueInt64(42) -> ValueText("42"))),
+        SMap(false, Iterator(SInt64(1) -> SText("1"), SInt64(42) -> SText("42"))),
+      ),
+      (TOptional(TText), ValueOptional(Some(ValueText("text"))), SOptional(Some(SText("text")))),
+      (
+        t"'Lossy':Conversion:Id Int64 Text Bool",
+        ValueRecord(
+          "",
+          ImmArray("x" -> ValueInt64(33), "y" -> ValueText("a"), "z" -> ValueBool(true)),
+        ),
+        SRecord(
+          lossyConversionIdentifier,
+          ImmArray("x", "y", "z"),
+          ArrayList(SInt64(33), SText("a"), SBool(true)),
+        ),
+      ),
+      (
+        t"'Lossy':Conversion:Id Text",
+        ValueVariant("", "Right", ValueText("some test")),
+        SVariant(lossyConversionIdentifier, "Right", lossyConversionVariantRank, SText("some test")),
+      ),
+      (
+        Ast.TTyCon(lossyConversionIdentifier),
+        ValueEnum("", "blue"),
+        SEnum(lossyConversionIdentifier, "blue", lossyConversionVariantRank),
+      ),
+      (
+        Ast.TApp(Ast.TTyCon(lossyConversionIdentifier), Ast.TBuiltin(Ast.BTList)),
+        ValueRecord("", ImmArray("" -> ValueNil)),
+        SRecord(
+          lossyConversionIdentifier,
+          ImmArray(Ref.Name.assertFromString(s"${lossyConversionFieldPrefix}1")),
+          ArrayList(SValue.EmptyList),
+        ),
+      ),
+    )
+
+    "succeeds on well type values" in {
+      forAll(testCases) { (ty, value, sValue) =>
+        Try(
+          unsafeTranslate(value)
+        ) shouldBe Success((sValue, ty))
+      }
+    }
+
+    "fails on too deep values" in {
+
+      def mkMyList(n: Int) =
+        Iterator.range(0, n).foldLeft[Value](ValueVariant("", "MyNil", ValueUnit)) { case (v, n) =>
+          ValueVariant(
+            "",
+            "MyCons",
+            ValueRecord("", ImmArray("" -> ValueInt64(n.toLong), "" -> v)),
+          )
+        }
+      val notTooBig = mkMyList(49)
+      val tooBig = mkMyList(50)
+      val failure = Failure(Error.Preprocessing.ValueNesting(tooBig))
+
+      Try(
+        unsafeTranslate(notTooBig)
+      ) shouldBe a[Success[_]]
+      Try(
+        unsafeTranslate(tooBig)
+      ) shouldBe failure
+    }
+
+  }
+
+}

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -295,15 +295,33 @@ object Hash {
   def hashPrivateKey(s: String): Hash =
     builder(Purpose.PrivateKey, noCid2String).add(s).build
 
+  @throws[HashingError]
+  def assertHashContractKey(
+      packageId: Option[Ref.PackageId],
+      qualifiedName: Ref.QualifiedName,
+      key: Value,
+  ): Hash = {
+    val kb = builder(Purpose.ContractKey, noCid2String)
+    packageId.foreach(p => kb.add(p))
+    kb
+      .addQualifiedName(qualifiedName)
+      .addTypedValue(key)
+      .build
+  }
+
   // This function assumes that key is well typed, i.e. :
   // 1 - `templateId` is the identifier for a template with a key of type τ
   // 2 - `key` is a value of type τ
   @throws[HashingError]
   def assertHashContractKey(templateId: Ref.Identifier, key: Value): Hash =
-    builder(Purpose.ContractKey, noCid2String)
-      .addIdentifier(templateId)
-      .addTypedValue(key)
-      .build
+    assertHashContractKey(Some(templateId.packageId), templateId.qualifiedName, key)
+
+  def hashContractKey(
+      packageId: Option[Ref.PackageId],
+      qualifiedName: Ref.QualifiedName,
+      key: Value,
+  ): Either[HashingError, Hash] =
+    handleError(assertHashContractKey(packageId, qualifiedName, key))
 
   def hashContractKey(
       templateId: Ref.Identifier,

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
@@ -35,7 +35,8 @@ final class GlobalKey private (
   override def toString: String = s"GlobalKey($templateId, $key)"
 }
 
-// The target state for GlobalKey once all call sites support SharedGlobalKey (#14486)
+// TODO: https://github.com/digital-asset/daml/issues/17661 - the target state for GlobalKey
+//   once all call sites support SharedGlobalKey
 final case class SharedGlobalKey private (
     val packageId: Option[Ref.PackageId],
     val qualifiedName: Ref.QualifiedName,

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
@@ -9,6 +9,8 @@ import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.TypeConName
 import com.daml.lf.value.Value
 
+import scala.language.implicitConversions
+
 /** Useful in various circumstances -- basically this is what a ledger implementation must use as
   * a key. The 'hash' is guaranteed to be stable over time.
   */
@@ -25,10 +27,65 @@ final class GlobalKey private (
   // Ready for refactoring where packageId becomes optional (#14486)
   def packageId: Option[Ref.PackageId] = Some(templateId.packageId)
   def qualifiedName: Ref.QualifiedName = templateId.qualifiedName
+  def shared: SharedGlobalKey =
+    SharedGlobalKey(Some(templateId.packageId), templateId.qualifiedName, key, hash)
 
   override def hashCode(): Int = hash.hashCode()
 
   override def toString: String = s"GlobalKey($templateId, $key)"
+}
+
+// The target state for GlobalKey once all call sites support SharedGlobalKey (#14486)
+final case class SharedGlobalKey private (
+    val packageId: Option[Ref.PackageId],
+    val qualifiedName: Ref.QualifiedName,
+    val key: Value,
+    val hash: crypto.Hash,
+) extends data.NoCopy {
+
+  override def equals(obj: Any): Boolean = obj match {
+    case that: SharedGlobalKey => this.hash == that.hash
+    case _ => false
+  }
+
+  override def hashCode(): Int = hash.hashCode()
+
+  override def toString: String =
+    s"SharedGlobalKey($qualifiedName${packageId.fold("")(p => s"@$p")}, $key)"
+
+  def assertGlobalKey: GlobalKey =
+    GlobalKey.assertBuild(Ref.TypeConName(packageId.get, qualifiedName), key)
+}
+
+object SharedGlobalKey {
+
+  implicit def globalKeyToShared(gk: GlobalKey): SharedGlobalKey =
+    SharedGlobalKey(gk.packageId, gk.qualifiedName, gk.key, gk.hash)
+
+  def build(
+      packageId: Option[Ref.PackageId],
+      qualifiedName: Ref.QualifiedName,
+      key: Value,
+  ): Either[crypto.Hash.HashingError, SharedGlobalKey] = {
+    crypto.Hash
+      .hashContractKey(packageId, qualifiedName, key)
+      .map(new SharedGlobalKey(packageId, qualifiedName, key, _))
+  }
+
+  // Like `build` but,  in case of error, throws an exception instead of returning a message.
+  @throws[IllegalArgumentException]
+  def assertBuild(
+      packageId: Option[Ref.PackageId],
+      qualifiedName: Ref.QualifiedName,
+      key: Value,
+  ): SharedGlobalKey =
+    data.assertRight(build(packageId, qualifiedName, key).left.map(_.msg))
+
+  private[lf] def unapply(
+      globalKey: SharedGlobalKey
+  ): Some[(Option[Ref.PackageId], Ref.QualifiedName, Value)] =
+    Some((globalKey.packageId, globalKey.qualifiedName, globalKey.key))
+
 }
 
 object GlobalKey {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
@@ -4,7 +4,7 @@
 package com.daml.lf.engine.script.v2.ledgerinteraction
 
 import com.daml.lf.data.Ref._
-import com.daml.lf.transaction.{GlobalKey, TransactionVersion}
+import com.daml.lf.transaction.{GlobalKey, SharedGlobalKey, TransactionVersion}
 import com.daml.lf.value.Value.ContractId
 import com.daml.lf.value.ValueCoder
 import com.daml.lf.value.ValueCoder.CidDecoder
@@ -12,6 +12,7 @@ import com.daml.nonempty.NonEmpty
 import com.google.common.io.BaseEncoding
 import com.google.protobuf.ByteString
 import io.grpc.StatusRuntimeException
+
 import scala.reflect.ClassTag
 import scala.util.Try
 
@@ -86,11 +87,23 @@ object GrpcErrorParser {
       case "CONTRACT_KEY_NOT_FOUND" =>
         caseErr {
           case Seq(
-                (ErrorResource.TemplateId, tid),
+                (ErrorResource.PackageId, pid),
+                (ErrorResource.QualifiedName, name),
                 (ErrorResource.ContractKey, decodeValue.unlift(key)),
               ) =>
             SubmitError.ContractKeyNotFound(
-              GlobalKey.assertBuild(Identifier.assertFromString(tid), key)
+              SharedGlobalKey.assertBuild(
+                Some(PackageId.assertFromString(pid)),
+                QualifiedName.assertFromString(name),
+                key,
+              )
+            )
+          case Seq(
+                (ErrorResource.QualifiedName, name),
+                (ErrorResource.ContractKey, decodeValue.unlift(key)),
+              ) =>
+            SubmitError.ContractKeyNotFound(
+              SharedGlobalKey.assertBuild(None, QualifiedName.assertFromString(name), key)
             )
         }
       case "DAML_AUTHORIZATION_ERROR" => SubmitError.AuthorizationError(message)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
@@ -105,6 +105,20 @@ object GrpcErrorParser {
             SubmitError.ContractKeyNotFound(
               SharedGlobalKey.assertBuild(None, QualifiedName.assertFromString(name), key)
             )
+          // TODO https://github.com/digital-asset/daml/issues/17661 - this match is only needed for
+          //  temporary backward compatibility with Canton so can soon be removed
+          case Seq(
+                (ErrorResource.TemplateId, tid),
+                (ErrorResource.ContractKey, decodeValue.unlift(key)),
+              ) =>
+            val ident = Identifier.assertFromString(tid)
+            SubmitError.ContractKeyNotFound(
+              SharedGlobalKey.assertBuild(
+                Some(ident.packageId),
+                ident.qualifiedName,
+                key,
+              )
+            )
         }
       case "DAML_AUTHORIZATION_ERROR" => SubmitError.AuthorizationError(message)
       case "CONTRACT_NOT_ACTIVE" =>

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
@@ -10,13 +10,14 @@ import com.daml.lf.data.Ref.{Identifier, Name}
 import com.daml.lf.language.{Ast, StablePackagesV2}
 import com.daml.lf.speedy.SValue
 import com.daml.lf.speedy.SValue._
-import com.daml.lf.transaction.GlobalKey
+import com.daml.lf.transaction.{GlobalKey, SharedGlobalKey}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.nonempty.NonEmpty
 import com.daml.platform.participant.util.LfEngineToApi.toApiIdentifier
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.Time
+import com.daml.lf.engine.preprocessing.LossyValueTranslator
 
 import scala.util.control.NoStackTrace
 
@@ -56,10 +57,31 @@ object SubmitError {
       damlScriptVariant("SubmitError", name, rank, fields: _*)
   }
 
-  def globalKeyToAnyContractKey(env: Env, key: GlobalKey): SValue = {
-    val ty = env.lookupKeyTy(key.templateId).toOption.get
-    val sValue = env.translateValue(ty, key.key).toOption.get
-    fromAnyContractKey(AnyContractKey(key.templateId, ty, sValue))
+  private def globalKeyToAnyContractKey(env: Env, key: GlobalKey): SValue =
+    keyToAnyContractKey(env, key.templateId, key.key)
+
+  private def sharedKeyToAnyContractKey(env: Env, key: SharedGlobalKey): SValue = {
+    key.packageId match {
+      case Some(packageId) =>
+        keyToAnyContractKey(env, TypeConName(packageId, key.qualifiedName), key.key)
+      case None => sharedKeyToAnyContractKey(key.key, key.qualifiedName)
+    }
+  }
+
+  private val sharedKeyPackageId = PackageId.assertFromString("SharedKey")
+
+  /** TODO This is a workaround until the type can be established based on the qualified name alone,
+    * see issue #17646 for details of how this can be done.
+    */
+  private def sharedKeyToAnyContractKey(value: Value, qualifiedName: QualifiedName): SValue = {
+    val (sValue, ty) = LossyValueTranslator.unsafeTranslate(value)
+    fromAnyContractKey(AnyContractKey(TypeConName(sharedKeyPackageId, qualifiedName), ty, sValue))
+  }
+
+  private def keyToAnyContractKey(env: Env, templateId: TypeConName, key: Value): SValue = {
+    val ty = env.lookupKeyTy(templateId).toOption.get
+    val sValue = env.translateValue(ty, key).toOption.get
+    fromAnyContractKey(AnyContractKey(templateId, ty, sValue))
   }
 
   def fromNonEmptySet[A](set: NonEmpty[Seq[A]], conv: A => SValue): SValue = {
@@ -176,13 +198,15 @@ object SubmitError {
     }
   }
 
-  final case class ContractKeyNotFound(key: GlobalKey) extends SubmitError {
-    override def toDamlSubmitError(env: Env): SValue =
+  final case class ContractKeyNotFound(key: SharedGlobalKey) extends SubmitError {
+    override def toDamlSubmitError(env: Env): SValue = {
+      val contractKey = sharedKeyToAnyContractKey(env, key)
       SubmitErrorConverters(env).damlScriptError(
         "ContractKeyNotFound",
         1,
-        ("contractKey", globalKeyToAnyContractKey(env, key)),
+        ("contractKey", contractKey),
       )
+    }
   }
 
   final case class AuthorizationError(message: String) extends SubmitError {

--- a/ledger/error/src/main/scala/com/daml/error/ErrorResource.scala
+++ b/ledger/error/src/main/scala/com/daml/error/ErrorResource.scala
@@ -33,6 +33,8 @@ object ErrorResource {
     Parties,
     Party,
     TemplateId,
+    PackageId,
+    QualifiedName,
     TransactionId,
     User,
   )
@@ -59,6 +61,12 @@ object ErrorResource {
   }
   object TemplateId extends ErrorResource {
     def asString: String = "TEMPLATE_ID"
+  }
+  object PackageId extends ErrorResource {
+    def asString: String = "PACKAGE_ID"
+  }
+  object QualifiedName extends ErrorResource {
+    def asString: String = "QUALIFIED_NAME"
   }
   object InterfaceId extends ErrorResource {
     def asString: String = "INTERFACE_ID"

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/CommandExecution.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/CommandExecution.scala
@@ -3,7 +3,7 @@
 
 package com.daml.error.definitions.groups
 
-import com.daml.error.definitions.{LedgerApiErrors}
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.error.{
   ContextualizedErrorLogger,
   DamlErrorWithDefiniteAnswer,
@@ -18,7 +18,7 @@ import com.daml.lf.data.Ref.Identifier
 import com.daml.lf.engine.{Error => LfError}
 import com.daml.lf.interpretation.{Error => LfInterpretationError}
 import com.daml.lf.language.Ast
-import com.daml.lf.transaction.{GlobalKey, TransactionVersion}
+import com.daml.lf.transaction.{SharedGlobalKey, TransactionVersion}
 import com.daml.lf.value.ValueCoder.CidEncoder
 import com.daml.lf.value.{Value, ValueCoder}
 
@@ -111,7 +111,7 @@ object CommandExecution extends ErrorGroup()(LedgerApiErrors.errorClass) {
 
         final case class Reject(
             override val cause: String,
-            key: GlobalKey,
+            key: SharedGlobalKey,
         )(implicit
             loggingContext: ContextualizedErrorLogger
         ) extends DamlErrorWithDefiniteAnswer(
@@ -119,10 +119,13 @@ object CommandExecution extends ErrorGroup()(LedgerApiErrors.errorClass) {
             ) {
           override def resources: Seq[(ErrorResource, String)] =
             withEncodedValue(key.key) { encodedKey =>
-              Seq(
-                (ErrorResource.TemplateId, key.templateId.toString),
-                (ErrorResource.ContractKey, encodedKey),
-              )
+              key.packageId.fold[Seq[(ErrorResource, String)]](Seq.empty)(p =>
+                Seq((ErrorResource.PackageId, p))
+              ) ++
+                Seq(
+                  (ErrorResource.QualifiedName, key.qualifiedName.toString),
+                  (ErrorResource.ContractKey, encodedKey),
+                )
             }
         }
       }


### PR DESCRIPTION
This PR is part of a program of work to support shared contract keys. The first phase of this is making packageId optional inside contract keys, see https://github.com/DACH-NY/canton/issues/14486.

This PR introduces `SharedGlobalKey` that is the target structure for `GlobalKey` the difference being that the `packageId` is optional inside `SharedGlobalKey`.

In many cases the `packageId`, although not in the contract key will be available from the context in which the code is running. When it comes to error handling this is not the case.

An example of a problem is when the `GrpcErrorParser` gets passed a `SharedContractKey`. In this situation no `packageId` is available. For situations where the a conversion from value to SValue is needed for _error reporting_ a `LossyValueTranslator` has been added.

There are alternatives to doing this once we really have LF support for shared contract keys, see:
https://github.com/digital-asset/daml/issues/17646 
