### PR TITLE
Hardcode the canton version in BuildInfo for now

### DIFF
--- a/canton/BUILD.bazel
+++ b/canton/BUILD.bazel
@@ -15,6 +15,8 @@ load(
 
 ### build-info ###
 
+# TODO(https://github.com/DACH-NY/canton/issues/15106): read 'version' from the canton repository
+#  once it is exposed in some file.
 genrule(
     name = "community_buildinfo_src",
     outs = ["BuildInfo.scala"],
@@ -23,7 +25,7 @@ cat << EOF > $@
 package com.digitalasset.canton.buildinfo
 
 case object BuildInfo {{
-  val version: String = "{sdk_version}"
+  val version: String = "2.7.0-SNAPSHOT"
   val scalaVersion: String = "{scala_version}"
   val sbtVersion: String = "bazel"
   val damlLibrariesVersion: String = "2.7.0-SNAPSHOT"
@@ -35,10 +37,7 @@ case object BuildInfo {{
   }}
 }}
 EOF
-""".format(
-        scala_version = scala_version,
-        sdk_version = sdk_version,
-    ),
+""".format(scala_version = scala_version),
 )
 
 scala_library(

--- a/canton/BUILD.bazel
+++ b/canton/BUILD.bazel
@@ -28,7 +28,7 @@ case object BuildInfo {{
   val version: String = "2.7.0-SNAPSHOT"
   val scalaVersion: String = "{scala_version}"
   val sbtVersion: String = "bazel"
-  val damlLibrariesVersion: String = "2.7.0-SNAPSHOT"
+  val damlLibrariesVersion: String = "{sdk_version}"
   val protocolVersions = List("3", "4", "5")
   override val toString: String = {{
     "version: %s, scalaVersion: %s, sbtVersion: %s, damlLibrariesVersion: %s, protocolVersions: %s".format(
@@ -37,7 +37,10 @@ case object BuildInfo {{
   }}
 }}
 EOF
-""".format(scala_version = scala_version),
+""".format(
+        scala_version = scala_version,
+        sdk_version = sdk_version,
+    ),
 )
 
 scala_library(


### PR DESCRIPTION
Until https://github.com/DACH-NY/canton/issues/15106 is resolved, hardcode the canton version in the BuildInfo synthetized by our genrule when building canton with bazel. We currently set it to `0.0.0` in our development environment, which is not a valid canton version.