### PR TITLE
align java deps versions with canton

### DIFF
--- a/bazel-java-deps.bzl
+++ b/bazel-java-deps.bzl
@@ -46,8 +46,8 @@ version_specific = {
 # need to be updated with careful consideration.
 
 netty_tcnative_version = "2.0.46.Final"
-netty_version = "4.1.72.Final"
-grpc_version = "1.44.0"
+netty_version = "4.1.100.Final"
+grpc_version = "1.59.0"
 protobuf_version = "3.19.6"
 akka_version = "2.6.21"
 akka_http_version = "10.2.10"


### PR DESCRIPTION
https://github.com/DACH-NY/canton/pull/15129 bumps the version number of some java deps. We bump the subset that our repo depends on accordingly.