### PR TITLE
Add temporary internal setContractUpgradingEnabled flag to daml-script

### DIFF
--- a/daml-script/daml3/Daml/Script/Questions/Upgrading/Internal.daml
+++ b/daml-script/daml3/Daml/Script/Questions/Upgrading/Internal.daml
@@ -5,9 +5,9 @@ module Daml.Script.Questions.Upgrading.Internal where
 
 import Daml.Script.Internal
 
-data SetContractUpgradingEnabled = SetContractUpgradingEnabled with
-  enabled : Bool
-instance IsQuestion SetContractUpgradingEnabled () where command = "SetContractUpgradingEnabled"
+data SetProvidePackageId = SetProvidePackageId with
+  shouldProvide : Bool
+instance IsQuestion SetProvidePackageId () where command = "SetProvidePackageId"
 
-setContractUpgradingEnabled : Bool -> Script ()
-setContractUpgradingEnabled = lift . SetContractUpgradingEnabled
+setProvidePackageId : Bool -> Script ()
+setProvidePackageId = lift . SetProvidePackageId

--- a/daml-script/daml3/Daml/Script/Questions/Upgrading/Internal.daml
+++ b/daml-script/daml3/Daml/Script/Questions/Upgrading/Internal.daml
@@ -1,0 +1,13 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Script.Questions.Upgrading.Internal where
+
+import Daml.Script.Internal
+
+data SetContractUpgradingEnabled = SetContractUpgradingEnabled with
+  enabled : Bool
+instance IsQuestion SetContractUpgradingEnabled () where command = "SetContractUpgradingEnabled"
+
+setContractUpgradingEnabled : Bool -> Script ()
+setContractUpgradingEnabled = lift . SetContractUpgradingEnabled

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
@@ -778,7 +778,7 @@ object ScriptF {
       )
   }
 
-  final case class SetContractUpgradingEnabled(enabled: Boolean) extends Cmd {
+  final case class SetProvidePackageId(shouldProvide: Boolean) extends Cmd {
     override def execute(env: Env)(implicit
         ec: ExecutionContext,
         mat: Materializer,
@@ -786,10 +786,10 @@ object ScriptF {
     ): Future[SExpr] =
       for {
         _ <- env.clients.default_participant.fold(Future.unit)(
-          _.setContractUpgradingEnabled(enabled)
+          _.setProvidePackageId(shouldProvide)
         )
         _ <- Future.traverse(env.clients.participants.toList) { case (_, v) =>
-          v.setContractUpgradingEnabled(enabled)
+          v.setProvidePackageId(shouldProvide)
         }
       } yield SEValue(SUnit)
   }
@@ -1070,13 +1070,13 @@ object ScriptF {
     }
   }
 
-  private def parseSetContractUpgradingEnabled(
+  private def parseSetProvidePackageId(
       v: SValue
-  ): Either[String, SetContractUpgradingEnabled] =
+  ): Either[String, SetProvidePackageId] =
     v match {
       case SRecord(_, _, ArrayList(SBool(enabled))) =>
-        Right(SetContractUpgradingEnabled(enabled))
-      case _ => Left(s"Expected SetContractUpgradingEnabled payload but got $v")
+        Right(SetProvidePackageId(enabled))
+      case _ => Left(s"Expected SetProvidePackageId payload but got $v")
     }
 
   def parse(
@@ -1115,9 +1115,12 @@ object ScriptF {
       case ("UnvetPackages", 1) => parseChangePackages(v).map(UnvetPackages)
       case ("ListVettedPackages", 1) => parseEmpty(ListVettedPackages())(v)
       case ("ListAllPackages", 1) => parseEmpty(ListAllPackages())(v)
-      case ("SetContractUpgradingEnabled", 1) => parseSetContractUpgradingEnabled(v)
+      case ("SetProvidePackageId", 1) => parseSetProvidePackageId(v)
       case _ => Left(s"Unknown command $commandName - Version $version")
     }
+
+  // TODO: Update SetProvidePackageId to `SetProvidePackageId`, which should only change whether the packageID is given, so for translation of commands and query template filter
+  // Translation of results is always enabled if the flag is
 
   private def toOneAndSet[F[_], A](x: OneAnd[F, A])(implicit fF: Foldable[F]): OneAnd[Set, A] =
     OneAnd(x.head, x.tail.toSet - x.head)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -884,9 +884,9 @@ class IdeLedgerClient(
   ): Future[List[ScriptLedgerClient.ReadablePackageId]] =
     Future.successful(getPackageIdMap().keys.toList)
 
-  override def setContractUpgradingEnabled(enabled: Boolean)(implicit
+  override def setProvidePackageId(shouldProvide: Boolean)(implicit
       ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
       mat: Materializer,
-  ): Future[Unit] = unsupportedOn("setContractUpgradingEnabled")
+  ): Future[Unit] = unsupportedOn("setProvidePackageId")
 }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -883,4 +883,10 @@ class IdeLedgerClient(
       mat: Materializer,
   ): Future[List[ScriptLedgerClient.ReadablePackageId]] =
     Future.successful(getPackageIdMap().keys.toList)
+
+  override def setContractUpgradingEnabled(enabled: Boolean)(implicit
+      ec: ExecutionContext,
+      esf: ExecutionSequencerFactory,
+      mat: Materializer,
+  ): Future[Unit] = unsupportedOn("setContractUpgradingEnabled")
 }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/JsonLedgerClient.scala
@@ -722,11 +722,11 @@ class JsonLedgerClient(
       mat: Materializer,
   ): Future[List[ScriptLedgerClient.ReadablePackageId]] = unsupportedOn("listAllPackages")
 
-  override def setContractUpgradingEnabled(enabled: Boolean)(implicit
+  override def setProvidePackageId(shouldProvide: Boolean)(implicit
       ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
       mat: Materializer,
-  ): Future[Unit] = unsupportedOn("setContractUpgradingEnabled")
+  ): Future[Unit] = unsupportedOn("setProvidePackageId")
 }
 
 object JsonLedgerClient {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/JsonLedgerClient.scala
@@ -721,6 +721,12 @@ class JsonLedgerClient(
       esf: ExecutionSequencerFactory,
       mat: Materializer,
   ): Future[List[ScriptLedgerClient.ReadablePackageId]] = unsupportedOn("listAllPackages")
+
+  override def setContractUpgradingEnabled(enabled: Boolean)(implicit
+      ec: ExecutionContext,
+      esf: ExecutionSequencerFactory,
+      mat: Materializer,
+  ): Future[Unit] = unsupportedOn("setContractUpgradingEnabled")
 }
 
 object JsonLedgerClient {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
@@ -90,7 +90,7 @@ trait ScriptLedgerClient {
 
   protected def transport: String
 
-  def enableContractUpgrading: Boolean = false
+  val enableContractUpgrading: Boolean = false
 
   final protected def unsupportedOn(what: String) =
     Future.failed(
@@ -269,7 +269,7 @@ trait ScriptLedgerClient {
 
   // TEMPORARY AND INTERNAL - once we have decided on a proper daml3-script upgrading interface for users, we will update this to be
   // specified per command
-  def setContractUpgradingEnabled(enabled: Boolean)(implicit
+  def setProvidePackageId(shouldProvide: Boolean)(implicit
       ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
       mat: Materializer,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
@@ -90,7 +90,7 @@ trait ScriptLedgerClient {
 
   protected def transport: String
 
-  val enableContractUpgrading: Boolean = false
+  def enableContractUpgrading: Boolean = false
 
   final protected def unsupportedOn(what: String) =
     Future.failed(
@@ -266,4 +266,12 @@ trait ScriptLedgerClient {
       esf: ExecutionSequencerFactory,
       mat: Materializer,
   ): Future[List[ScriptLedgerClient.ReadablePackageId]]
+
+  // TEMPORARY AND INTERNAL - once we have decided on a proper daml3-script upgrading interface for users, we will update this to be
+  // specified per command
+  def setContractUpgradingEnabled(enabled: Boolean)(implicit
+      ec: ExecutionContext,
+      esf: ExecutionSequencerFactory,
+      mat: Materializer,
+  ): Future[Unit]
 }


### PR DESCRIPTION
For the daml-script upgrades tests, I need the ability to query the ledger either providing or not providing the package-id.
The first PR that added upgrades support has all submits/queries always omitting the package-id.

Later down the road, we will implement a proper in language interface to allow the user to decide if they want to provide the package-id, with different named commands, and piping the enableUpgrades flag through the Questions data types.

For now however, I just need the functionality quickly, so I've implemented a simply stateful setter so i can easily turn the features on and off for the internal tests.
The setter is internal and temporary, I'll create a ticket after merging this to update it to something better
