### PR TITLE
Implement daml clean --all

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -189,6 +189,10 @@ multiPackageLocationOpt =
       <> value MPLCurrent
       )
 
+newtype MultiPackageCleanAll = MultiPackageCleanAll {getMultiPackageCleanAll :: Bool}
+multiPackageCleanAllOpt :: Parser MultiPackageCleanAll
+multiPackageCleanAllOpt = MultiPackageCleanAll <$> switch (long "all" <> help "Clean all packages in multi-package.daml" <> internal)
+
 data Telemetry
     = TelemetryOptedIn -- ^ User has explicitly opted in
     | TelemetryOptedOut -- ^ User has explicitly opted out


### PR DESCRIPTION
Uses the same gate flag as daml multi build (`enable-multi-package=yes`), and the same flags for multi-package discovery (`multi-package-path` and `multi-package-search`).
Adds `--all` which runs the same code as single project across each project.
We assume that the structure of the daml.yaml and the implementation of `clean` is static enough to not bother invoking daml clean through the assistant for each project.
