### PR TITLE
LT-30: fix java codegen when uppercase enum data constructor clashes with type name

### DIFF
--- a/language-support/java/codegen/src/it/daml/Tests/EnumTest.daml
+++ b/language-support/java/codegen/src/it/daml/Tests/EnumTest.daml
@@ -1,0 +1,21 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+
+module Tests.EnumTest where
+
+data FooBar = Foo | Bar deriving (Eq, Show, Enum)
+
+-- In Java the data constructor names (enum values) are uppercased, so this tests the handling 
+-- of name clash between type name and uppercased data constructor.
+data ALLUPPERCASE = AllUpperCase | NotAllUpperCase deriving (Eq, Show, Enum)
+
+-- Not part of the test but the codegen filters out
+-- data definitions which are not used in a template
+template FooBarTemplate
+    with
+        owner : Party
+        foobarItem : FooBar
+        uppercaseItem : ALLUPPERCASE
+    where
+        signatory owner

--- a/language-support/java/codegen/src/it/java/com/daml/EnumTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/EnumTest.java
@@ -1,0 +1,45 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import tests.enumtest.ALLUPPERCASE;
+import tests.enumtest.FooBar;
+
+@RunWith(JUnitPlatform.class)
+public class EnumTest {
+
+  @Test
+  void roundtripFooValue() {
+    FooBar expected = FooBar.FOO;
+    FooBar actual = FooBar.fromValue(expected.toValue());
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void roundtripFoo() throws JsonLfDecoder.Error {
+    FooBar expected = FooBar.FOO;
+    FooBar actual = FooBar.fromJson(expected.toJson());
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void roundtripAllUpperCaseValue() {
+    ALLUPPERCASE expected = ALLUPPERCASE.ALLUPPERCASE;
+    ALLUPPERCASE actual = ALLUPPERCASE.fromValue(expected.toValue());
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void roundtripAllUpperCaseJson() throws JsonLfDecoder.Error {
+    ALLUPPERCASE expected = ALLUPPERCASE.ALLUPPERCASE;
+    ALLUPPERCASE actual = ALLUPPERCASE.fromJson(expected.toJson());
+    assertEquals(expected, actual);
+  }
+}

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/EnumClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/EnumClass.scala
@@ -34,7 +34,7 @@ private[inner] object EnumClass extends StrictLogging {
         .addField(generateEnumsMap(className))
         .addMethod(generateDeprecatedFromValue(className, enumeration))
         .addMethod(generateValueDecoder(className, enumeration))
-        .addMethod(generateToValue(className))
+        .addMethod(generateToValue)
         .addMethods(FromJsonGenerator.forEnum(className, "__enums$").asJava)
         .addMethods(ToJsonGenerator.forEnum(className).asJava)
       logger.debug("End")
@@ -69,7 +69,7 @@ private[inner] object EnumClass extends StrictLogging {
     FieldSpec
       .builder(mapType(className), "__enums$")
       .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
-      .initializer("$T.__buildEnumsMap$$()", className)
+      .initializer("__buildEnumsMap$$()")
       .build()
 
   private def generateEnumsMapBuilder(
@@ -127,12 +127,11 @@ private[inner] object EnumClass extends StrictLogging {
         s"Expected DamlEnum to build an instance of the Enum ${className.simpleName()}",
       )
       .addStatement(
-        "if (!$T.__enums$$.containsKey(constructor$$)) throw new $T($S + constructor$$)",
-        className,
+        "if (!__enums$$.containsKey(constructor$$)) throw new $T($S + constructor$$)",
         classOf[IllegalArgumentException],
         s"Expected a DamlEnum with ${className.simpleName()} constructor, found ",
       )
-      .addStatement("return $T.__enums$$.get(constructor$$)", className)
+      .addStatement("return __enums$$.get(constructor$$)")
 
     MethodSpec
       .methodBuilder("valueDecoder")
@@ -145,12 +144,12 @@ private[inner] object EnumClass extends StrictLogging {
       .build()
   }
 
-  private def generateToValue(className: ClassName): MethodSpec =
+  private def generateToValue: MethodSpec =
     MethodSpec
       .methodBuilder("toValue")
       .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
       .returns(classOf[javaapi.data.DamlEnum])
-      .addStatement("return $T.__values$$[ordinal()]", className)
+      .addStatement("return __values$$[ordinal()]")
       .build()
 
 }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToJsonGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToJsonGenerator.scala
@@ -107,7 +107,7 @@ private[inner] object ToJsonGenerator {
       .methodBuilder("jsonEncoder")
       .addModifiers(Modifier.PUBLIC)
       .addStatement(
-        "return $T.enumeration($T::getConstructor).apply(this)",
+        "return $T.enumeration(($T e$$) -> e$$.getConstructor()).apply(this)",
         encodersClass,
         className,
       )


### PR DESCRIPTION
Fixes https://github.com/digital-asset/daml/issues/17692

Fixes the error from the `jsonEncoder` method (which was about `javac` mis-interpreting a method reference), and the warnings in `toValue`, `valueDecoder` and the initialiser for `__enums$`, which did not need to qualify the static identifiers by class name.