### PR TITLE
Fixes issue with Ledger class in app-dev/bindings-ts/daml-ledger/

### DIFF
--- a/language-support/ts/daml-ledger/README.md
+++ b/language-support/ts/daml-ledger/README.md
@@ -34,7 +34,7 @@ base URL and a websocket base URL.
 
 An instance of the `Ledger` class provides the following methods to communicate with a Daml ledger.
 Please consult the
-[documentation](https://docs.daml.com/app-dev/bindings-ts/daml-ledger/classes/_index_.ledger.html)
+[documentation](https://docs.daml.com/app-dev/bindings-ts/daml-ledger/classes/Ledger.html)
 for their exact signatures.
 
 `create`

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -907,7 +907,7 @@ class QueryStreamsManager {
 /**
  * An object of type `Ledger` represents a handle to a Daml ledger.
  */
-class Ledger {
+export class Ledger {
   private readonly token: string;
   private readonly httpBaseUrl: string;
   private readonly wsBaseUrl: string;


### PR DESCRIPTION
Issue from Ben Minton says there is a broken link to the Ledger documentation in bindings-ts:
- Referring [link](https://discuss.daml.com/t/broken-link-to-daml-ledger-typescript-library-doc/6900/2).
- Missing [link](https://docs.daml.com/app-dev/bindings-ts/daml-ledger/classes/_index_.ledger.html).

The cause of the issue turns out to be `export default Ledger` - this only creates an entry for `default` in the docs. By adding an explicit export statement to Ledger's class declaration `export class Ledger` we add Ledger back to the sidebar. The link still needed fixing.