### PR TITLE
Implement tryCommands for internal testing

### DIFF
--- a/compiler/damlc/tests/daml-test-files/TryCommands.daml
+++ b/compiler/damlc/tests/daml-test-files/TryCommands.daml
@@ -1,0 +1,64 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @ SCRIPT-V2
+
+{-# LANGUAGE ApplicativeDo #-}
+
+module TryCommands where
+
+import Daml.Script
+import Daml.Script.Questions.Testing.Internal
+import DA.Assert
+import DA.Text
+
+template Name
+  with
+    party : Party
+  where
+    signatory party
+
+-- Throws the failed auth error, a script we use for testing
+-- Takes a unit to avoid it being run directly
+failedAuthScript : () -> Script ()
+failedAuthScript _ = do
+  a <- allocateParty "alice"
+  b <- allocateParty "bob"
+  a `submit` createCmd Name with party = b
+  pure ()
+
+-- The error we expect to be thrown from the above script
+failedAuthError : FailedCmd
+failedAuthError =
+  FailedCmd with
+    commandName = CommandName "Submit"
+    errorClassName = ErrorClassName "FailedAuthorization"
+    errorMessage = ErrorMessage "Error: node NodeId(0) (-homePackageId-:TryCommands:Name) requires authorizers bob, but only alice were given"
+
+-- Tests an error that is nested into SError
+tryCommandsAuthorizationFailure : Script ()
+tryCommandsAuthorizationFailure = do
+  res <- tryCommands $ failedAuthScript ()
+  res === Left failedAuthError
+
+tryCommandsContractNotActive : Script ()
+tryCommandsContractNotActive = do
+  res <- tryCommands $ do
+    a <- allocateParty "alice"
+    cid <- a `submit` createCmd Name with party = a
+    a `submit` archiveCmd cid
+    a `submit` archiveCmd cid
+  case res of
+    Left cmd
+      | cmd.commandName == CommandName "Submit"
+      , cmd.errorClassName == ErrorClassName "ContractNotActive"
+      , "The contract had been consumed in transaction" `isInfixOf` cmd.errorMessage.getErrorMessage
+      -> pure ()
+    _ -> assertFail $ "Expected ContractNotActive error but got " <> show res
+
+-- Check that the lifted error can be caught
+liftedFailedCmdException : Script ()
+liftedFailedCmdException = do
+  try
+    liftFailedCommandToException $ failedAuthScript ()
+  catch (e : FailedCmd) -> e === failedAuthError

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/StablePackage.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/StablePackage.scala
@@ -39,6 +39,7 @@ private[daml] trait StablePackages {
   val AnyView: Ref.TypeConName
   val NonEmpty: Ref.TypeConName
   val Tuple2: Ref.TypeConName
+  val Tuple3: Ref.TypeConName
   val Either: Ref.TypeConName
 }
 
@@ -267,6 +268,7 @@ private[daml] object StablePackagesV1 extends StablePackages {
     DA_Internal_Interface_AnyView_Types.assertIdentifier("AnyView")
   override val NonEmpty: Ref.TypeConName = DA_NonEmpty_Types.assertIdentifier("NonEmpty")
   override val Tuple2: Ref.TypeConName = DA_Types.assertIdentifier("Tuple2")
+  override val Tuple3: Ref.TypeConName = DA_Types.assertIdentifier("Tuple3")
   override val Either: Ref.TypeConName = GHC_Tuple.assertIdentifier("Either")
 }
 
@@ -470,5 +472,6 @@ private[daml] object StablePackagesV2 extends StablePackages {
     DA_Internal_Interface_AnyView_Types.assertIdentifier("AnyView")
   override val NonEmpty: Ref.TypeConName = DA_NonEmpty_Types.assertIdentifier("NonEmpty")
   override val Tuple2: Ref.TypeConName = DA_Types.assertIdentifier("Tuple2")
+  override val Tuple3: Ref.TypeConName = DA_Types.assertIdentifier("Tuple3")
   override val Either: Ref.TypeConName = GHC_Tuple.assertIdentifier("Either")
 }

--- a/daml-script/daml3/Daml/Script/Questions/Testing/Internal.daml
+++ b/daml-script/daml3/Daml/Script/Questions/Testing/Internal.daml
@@ -1,0 +1,47 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Script.Questions.Testing.Internal where
+
+import Daml.Script.Internal
+import Daml.Script.Questions.Exceptions ()
+import DA.Bifunctor
+import DA.Exception
+
+newtype CommandName = CommandName
+  with getCommandName : Text
+  deriving (Eq, Show)
+
+newtype ErrorClassName = ErrorClassName
+  with getErrorClassName : Text
+  deriving (Eq, Show)
+
+newtype ErrorMessage = ErrorMessage
+  with getErrorMessage : Text
+  deriving (Eq, Show)
+
+data TryCommands = TryCommands with
+  act : LedgerValue
+instance IsQuestion TryCommands (Either (Text, Text, Text) x) where command = "TryCommands"
+
+tupleToFailedCmd : (Text, Text, Text) -> FailedCmd
+tupleToFailedCmd (cmdName, errName, msg) =
+  FailedCmd with
+    commandName = CommandName cmdName
+    errorClassName = ErrorClassName errName
+    errorMessage = ErrorMessage msg
+
+-- Internal testing tool that allows us to catch FailedCmds in the daml language
+tryCommands : Script a -> Script (Either FailedCmd a)
+tryCommands = fmap (first tupleToFailedCmd) . lift . TryCommands . toLedgerValue
+
+exception FailedCmd with
+    commandName : CommandName
+    errorClassName : ErrorClassName
+    errorMessage : ErrorMessage
+  where
+    message getErrorMessage errorMessage
+
+-- Runs a script and lifts FailedCmd scala exceptions into the FailedCmd daml exception, which can be caught via try-catch
+liftFailedCommandToException : Script a -> Script a
+liftFailedCommandToException act = tryCommands act >>= either throw pure

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
@@ -794,6 +794,54 @@ object ScriptF {
       } yield SEValue(SUnit)
   }
 
+  final case class TryCommands(act: SValue) extends Cmd {
+    override def executeWithRunner(env: Env, runner: v2.Runner)(implicit
+        ec: ExecutionContext,
+        mat: Materializer,
+        esf: ExecutionSequencerFactory,
+    ): Future[SExpr] =
+      runner.run(SEValue(act)).transformWith {
+        case Success(v) =>
+          Future.successful(SEAppAtomic(right, Array(SEValue(v))))
+        case Failure(
+              Script.FailedCmd(cmdName, _, err)
+            ) =>
+          import com.daml.lf.scenario.{Pretty, Error}
+          val msg = err match {
+            case e: Error => Pretty.prettyError(e).render(10000)
+            case e => e.getMessage
+          }
+
+          val name = err match {
+            case Error.RunnerException(speedy.SError.SErrorDamlException(iErr)) =>
+              iErr.getClass.getSimpleName
+            case e => e.getClass.getSimpleName
+          }
+
+          import com.daml.script.converter.Converter.record
+          Future.successful(
+            SEApp(
+              left,
+              Array(
+                record(
+                  StablePackagesV2.Tuple3,
+                  ("_1", SText(cmdName)),
+                  ("_2", SText(name)),
+                  ("_3", SText(msg)),
+                )
+              ),
+            )
+          )
+        case Failure(e) => Future.failed(e)
+      }
+
+    override def execute(env: Env)(implicit
+        ec: ExecutionContext,
+        mat: Materializer,
+        esf: ExecutionSequencerFactory,
+    ): Future[SExpr] = Future.failed(new NotImplementedError)
+  }
+
   // Shared between Submit, SubmitMustFail and SubmitTree
   final case class SubmitData(
       actAs: OneAnd[Set, Party],
@@ -1079,6 +1127,12 @@ object ScriptF {
       case _ => Left(s"Expected SetProvidePackageId payload but got $v")
     }
 
+  private def parseTryCommands(v: SValue): Either[String, TryCommands] =
+    v match {
+      case SRecord(_, _, ArrayList(act)) => Right(TryCommands(act))
+      case _ => Left(s"Expected TryCommands payload but got $v")
+    }
+
   def parse(
       commandName: String,
       version: Long,
@@ -1116,6 +1170,7 @@ object ScriptF {
       case ("ListVettedPackages", 1) => parseEmpty(ListVettedPackages())(v)
       case ("ListAllPackages", 1) => parseEmpty(ListAllPackages())(v)
       case ("SetProvidePackageId", 1) => parseSetProvidePackageId(v)
+      case ("TryCommands", 1) => parseTryCommands(v)
       case _ => Left(s"Unknown command $commandName - Version $version")
     }
 


### PR DESCRIPTION
Implements `tryCommands : Script a -> Script (Either FailedCmd a)`, which pulls scala level FailedCmd errors into daml, and `liftFailedCommandToException : Script a -> Script a`, which uses the above to re-throw these errors as daml errors, that can be caught just as any other exception.
Note that `FailedCmd` only holds basic string information, so this cannot replace `trySubmit`

This is intended for internal testing only, and as such can only be used if you explicitly import `Daml.Script.Questions.Testing.Internal`

This PR gets us a little closer to using daml3-script for all integration tests