### PR TITLE
fix docs format

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
@@ -47,13 +47,13 @@ message InclusiveFilters {
   // SHOULD NOT contain duplicates.
   // All ``template_ids`` need to be valid: corresponding templates should be defined in one of
   // the available packages at the time of the query.
-  // Deprecated in favor of the `template_filters`. If the `template_filters` field is set,
-  // the `template_ids` field is ignored.
+  // Deprecated in favor of the ``template_filters``. If the ``template_filters`` field is set,
+  // the ``template_ids`` field is ignored.
   // Optional
   repeated Identifier template_ids = 1 [deprecated = true];
 
   // Include an ``InterfaceView`` for every ``InterfaceFilter`` matching a contract.
-  // The ``InterfaceFilter``s MUST use unique ``interface_id``s.
+  // The ``InterfaceFilter`` instances MUST each use a unique ``interface_id``.
   // Optional
   repeated InterfaceFilter interface_filters = 2;
 


### PR DESCRIPTION
Having a letter directly following the backticks is not valid RST.

Hopefully I didn't change the meaning here, please double-check.

Note: this is broken by [this change](https://github.com/digital-asset/daml/pull/17606/files#diff-bd749e6ba10cc644e517ea2592f798738ab24063cf525393bcc53247073e4bdbL55-L56) (cc @mziolekda), where the rest of the sentence is removed.

Also: single-backticks are not valid either, though that just looks bad, it doesn't fail the build.