### PR TITLE
Port daml repl to LF2

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -595,9 +595,9 @@ EOF
       $(location //compiler/damlc) build --project-root=$$TMP_DIR --target={lf_version} --ghc-option=-Werror -o $$PWD/$(location repl-test-indirect-v{major}.dar)
       rm -rf $$TMP_DIR
     """.format(
-                sdk = sdk_version,
                 lf_version = lf_version,
-                major = major
+                major = major,
+                sdk = sdk_version,
             ),
             tools = ["//compiler/damlc"],
             visibility = ["//visibility:public"],
@@ -631,9 +631,9 @@ EOF
       $(location //compiler/damlc) build --project-root=$$TMP_DIR --target={lf_version} --ghc-option=-Werror -o $$PWD/$(location repl-test-v{major}.dar)
       rm -rf $$TMP_DIR
     """.format(
-                sdk = sdk_version,
                 lf_version = lf_version,
-                major = major
+                major = major,
+                sdk = sdk_version,
             ),
             tools = ["//compiler/damlc"],
             visibility = ["//visibility:public"],
@@ -662,9 +662,9 @@ EOF
       $(location //compiler/damlc) build --project-root=$$TMP_DIR --target={lf_version} --ghc-option=-Werror -o $$PWD/$(location repl-test-two-v{major}.dar)
       rm -rf $$TMP_DIR
     """.format(
-                sdk = sdk_version,
                 lf_version = lf_version,
-                major = major
+                major = major,
+                sdk = sdk_version,
             ),
             tools = ["//compiler/damlc"],
             visibility = ["//visibility:public"],
@@ -700,9 +700,9 @@ EOF
       $(location //compiler/damlc) build --project-root=$$TMP_DIR --target={lf_version} --ghc-option=-Werror -o $$PWD/$(location repl-multi-test-v{major}.dar)
       rm -rf $$TMP_DIR
   """.format(
-                sdk = sdk_version,
                 lf_version = lf_version,
-                major = major
+                major = major,
+                sdk = sdk_version,
             ),
             tools = ["//compiler/damlc"],
             visibility = ["//visibility:public"],
@@ -748,9 +748,9 @@ da_haskell_test(
     tags = ["cpu:4"],
     visibility = ["//visibility:public"],
     deps = [
+        "//compiler/daml-lf-ast",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
-        "//compiler/daml-lf-ast",
         "//libs-haskell/test-utils",
     ],
 )

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -768,6 +768,7 @@ da_haskell_test(
             "//compiler/damlc/stable-packages",
             "//compiler/repl-service/server:repl_service_jar",
             "//daml-script/daml:daml-script.dar",
+            "//daml-script/daml3:daml3-script.dar",
         ] + (["@sysctl_nix//:bin/sysctl"] if is_darwin else []),
     hackage_deps = [
         "async",

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -6,7 +6,7 @@ load("@os_info//:os_info.bzl", "is_darwin", "is_windows")
 load(":util.bzl", "damlc_compile_test")
 load("//rules_daml:daml.bzl", "daml_build_test", "daml_compile", "daml_compile_with_dalf", "daml_test")
 load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
-load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS", "LF_DEV_VERSIONS", "lf_version_configuration")
+load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS", "LF_DEV_VERSIONS", "LF_MAJOR_VERSIONS", "lf_version_configuration", "lf_version_latest")
 load("//compiler/damlc:util.bzl", "ghc_pkg")
 
 # Tests for the lax CLI parser
@@ -569,13 +569,15 @@ da_haskell_test(
     ],
 )
 
-genrule(
-    name = "repl-test-indirect",
-    srcs = [
-        "ReplTestIndirect.daml",
-    ],
-    outs = ["repl-test-indirect.dar"],
-    cmd = """
+[
+    [
+        genrule(
+            name = "repl-test-indirect-v{}".format(major),
+            srcs = [
+                "ReplTestIndirect.daml",
+            ],
+            outs = ["repl-test-indirect-v{}.dar".format(major)],
+            cmd = """
       set -eou pipefail
       TMP_DIR=$$(mktemp -d)
       mkdir -p $$TMP_DIR/daml
@@ -590,28 +592,31 @@ dependencies:
   - daml-prim
 build-options: ["--ghc-option", "-Werror"]
 EOF
-      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location repl-test-indirect.dar)
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR --target={lf_version} --ghc-option=-Werror -o $$PWD/$(location repl-test-indirect-v{major}.dar)
       rm -rf $$TMP_DIR
-    """.format(sdk = sdk_version),
-    tools = ["//compiler/damlc"],
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "repl-test",
-    srcs = [
-        "ReplTest.daml",
-        "Colliding.daml",
-        "repl-test-indirect.dar",
-    ],
-    outs = ["repl-test.dar"],
-    cmd = """
+    """.format(
+                sdk = sdk_version,
+                lf_version = lf_version,
+                major = major
+            ),
+            tools = ["//compiler/damlc"],
+            visibility = ["//visibility:public"],
+        ),
+        genrule(
+            name = "repl-test-v{}".format(major),
+            srcs = [
+                "ReplTest.daml",
+                "Colliding.daml",
+                "repl-test-indirect-v{}.dar".format(major),
+            ],
+            outs = ["repl-test-v{}.dar".format(major)],
+            cmd = """
       set -eou pipefail
       TMP_DIR=$$(mktemp -d)
       mkdir -p $$TMP_DIR/daml
       cp -L $(location ReplTest.daml) $$TMP_DIR/daml
       cp -L $(location Colliding.daml) $$TMP_DIR/daml
-      cp -L $(location repl-test-indirect.dar) $$TMP_DIR
+      cp -L $(location repl-test-indirect-v{major}.dar) $$TMP_DIR
       cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: {sdk}
 name: repl-test
@@ -620,23 +625,26 @@ version: 0.1.0
 dependencies:
   - daml-stdlib
   - daml-prim
-  - repl-test-indirect.dar
+  - repl-test-indirect-v{major}.dar
 build-options: ["--ghc-option", "-Werror"]
 EOF
-      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location repl-test.dar)
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR --target={lf_version} --ghc-option=-Werror -o $$PWD/$(location repl-test-v{major}.dar)
       rm -rf $$TMP_DIR
-    """.format(sdk = sdk_version),
-    tools = ["//compiler/damlc"],
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "repl-test-two",
-    srcs = [
-        "ReplTest2.daml",
-    ],
-    outs = ["repl-test-two.dar"],
-    cmd = """
+    """.format(
+                sdk = sdk_version,
+                lf_version = lf_version,
+                major = major
+            ),
+            tools = ["//compiler/damlc"],
+            visibility = ["//visibility:public"],
+        ),
+        genrule(
+            name = "repl-test-two-v{}".format(major),
+            srcs = [
+                "ReplTest2.daml",
+            ],
+            outs = ["repl-test-two-v{}.dar".format(major)],
+            cmd = """
       set -eou pipefail
       TMP_DIR=$$(mktemp -d)
       mkdir -p $$TMP_DIR/daml
@@ -651,28 +659,31 @@ dependencies:
   - daml-prim
 build-options: ["--ghc-option", "-Werror"]
 EOF
-      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location repl-test-two.dar)
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR --target={lf_version} --ghc-option=-Werror -o $$PWD/$(location repl-test-two-v{major}.dar)
       rm -rf $$TMP_DIR
-    """.format(sdk = sdk_version),
-    tools = ["//compiler/damlc"],
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "repl-multi-test",
-    srcs = [
-        "ReplMulti.daml",
-        ":repl-test.dar",
-        ":repl-test-two.dar",
-    ],
-    outs = ["repl-multi-test.dar"],
-    cmd = """
+    """.format(
+                sdk = sdk_version,
+                lf_version = lf_version,
+                major = major
+            ),
+            tools = ["//compiler/damlc"],
+            visibility = ["//visibility:public"],
+        ),
+        genrule(
+            name = "repl-multi-test-v{}".format(major),
+            srcs = [
+                "ReplMulti.daml",
+                ":repl-test-v{}.dar".format(major),
+                ":repl-test-two-v{}.dar".format(major),
+            ],
+            outs = ["repl-multi-test-v{}.dar".format(major)],
+            cmd = """
       set -eou pipefail
       TMP_DIR=$$(mktemp -d)
       mkdir -p $$TMP_DIR/daml
       cp -L $(location ReplMulti.daml) $$TMP_DIR/daml
-      cp -L $(location repl-test-two.dar) $$TMP_DIR
-      cp -L $(location repl-test.dar) $$TMP_DIR
+      cp -L $(location repl-test-two-v{major}.dar) $$TMP_DIR
+      cp -L $(location repl-test-v{major}.dar) $$TMP_DIR
       cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: {sdk}
 name: repl-multi-test
@@ -682,26 +693,36 @@ dependencies:
   - daml-stdlib
   - daml-prim
 data-dependencies:
-  - repl-test.dar
-  - repl-test-two.dar
+  - repl-test-v{major}.dar
+  - repl-test-two-v{major}.dar
 build-options: ["--ghc-option", "-Werror"]
 EOF
-      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location repl-multi-test.dar)
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR --target={lf_version} --ghc-option=-Werror -o $$PWD/$(location repl-multi-test-v{major}.dar)
       rm -rf $$TMP_DIR
-  """.format(sdk = sdk_version),
-    tools = ["//compiler/damlc"],
-    visibility = ["//visibility:public"],
-)
+  """.format(
+                sdk = sdk_version,
+                lf_version = lf_version,
+                major = major
+            ),
+            tools = ["//compiler/damlc"],
+            visibility = ["//visibility:public"],
+        ),
+    ]
+    for major in LF_MAJOR_VERSIONS
+    for lf_version in [lf_version_latest.get(major)]
+]
 
 da_haskell_test(
     name = "repl",
     timeout = "long",
     srcs = ["src/DA/Test/Repl.hs"],
-    data = [
-        ":repl-multi-test.dar",
-        ":repl-test.dar",
+    data = [f for major in LF_MAJOR_VERSIONS for f in [
+        ":repl-multi-test-v{}.dar".format(major),
+        ":repl-test-v{}.dar".format(major),
+    ]] + [
         "//compiler/damlc",
         "//daml-script/daml:daml-script.dar",
+        "//daml-script/daml3:daml3-script.dar",
         "//test-common/test-certificates",
     ] + (["@sysctl_nix//:bin/sysctl"] if is_darwin else []),
     hackage_deps = [
@@ -729,6 +750,7 @@ da_haskell_test(
     deps = [
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
+        "//compiler/daml-lf-ast",
         "//libs-haskell/test-utils",
     ],
 )
@@ -736,15 +758,17 @@ da_haskell_test(
 da_haskell_test(
     name = "repl-functests",
     srcs = ["src/DA/Test/Repl/FuncTests.hs"],
-    data = [
-        ":repl-test.dar",
-        ":repl-test-two.dar",
-        ghc_pkg,
-        "//compiler/damlc/pkg-db",
-        "//compiler/damlc/stable-packages",
-        "//compiler/repl-service/server:repl_service_jar",
-        "//daml-script/daml:daml-script.dar",
-    ] + (["@sysctl_nix//:bin/sysctl"] if is_darwin else []),
+    data =
+        [f for major in LF_MAJOR_VERSIONS for f in [
+            ":repl-test-two-v{}.dar".format(major),
+            ":repl-test-v{}.dar".format(major),
+        ]] + [
+            ghc_pkg,
+            "//compiler/damlc/pkg-db",
+            "//compiler/damlc/stable-packages",
+            "//compiler/repl-service/server:repl_service_jar",
+            "//daml-script/daml:daml-script.dar",
+            ] + (["@sysctl_nix//:bin/sysctl"] if is_darwin else []),
     hackage_deps = [
         "async",
         "base",

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -768,7 +768,7 @@ da_haskell_test(
             "//compiler/damlc/stable-packages",
             "//compiler/repl-service/server:repl_service_jar",
             "//daml-script/daml:daml-script.dar",
-            ] + (["@sysctl_nix//:bin/sysctl"] if is_darwin else []),
+        ] + (["@sysctl_nix//:bin/sysctl"] if is_darwin else []),
     hackage_deps = [
         "async",
         "base",

--- a/compiler/damlc/tests/src/DA/Test/Repl.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl.hs
@@ -37,7 +37,7 @@ main = do
     setEnv "TASTY_NUM_THREADS" "1" True
     limitJvmMemory defaultJvmMemoryLimits{maxHeapSize = "1g"}
     damlc <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> exe "damlc")
-    certDir <- locateRunfiles (mainWorkspace </> "test-common" </> "test-certificates") -- TODO: loop over major versions
+    certDir <- locateRunfiles (mainWorkspace </> "test-common" </> "test-certificates")
     tests <- forM [minBound @LF.MajorVersion .. maxBound] $ \major -> do
         let prettyMajor = LF.renderMajorVersion major
         scriptDar <- locateRunfiles $ case major of

--- a/compiler/damlc/tests/src/DA/Test/Repl.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl.hs
@@ -54,7 +54,7 @@ main = do
             defaultSandboxConf
                 { dars = [testDar]
                 , timeMode = Static
-                , devVersionSupport = major == LF.V2
+                , devVersionSupport = LF.isDevVersion lfVersion
                 }
             $ \getSandboxPort ->
                 testGroup ("LF v" <> prettyMajor)
@@ -62,7 +62,7 @@ main = do
                         defaultSandboxConf
                             { mbSharedSecret = Just testSecret
                             , mbLedgerId = Just testLedgerId
-                            , devVersionSupport = major == LF.V2
+                            , devVersionSupport = LF.isDevVersion lfVersion
                             }
                         $ \getSandboxPort ->
                             withTokenFile $ \getTokenFile ->
@@ -71,7 +71,7 @@ main = do
                         defaultSandboxConf
                             { enableTls = True
                             , mbClientAuth = Just None
-                            , devVersionSupport = major == LF.V2
+                            , devVersionSupport = LF.isDevVersion lfVersion
                             }
                         $ \getSandboxPort ->
                             tlsTests lfVersion damlc scriptDar getSandboxPort certDir

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -66,7 +66,7 @@ main = do
     withTempDir $ \tmpDir ->
         withBinaryFile nullDevice WriteMode $ \devNull ->
         bracket (createCantonSandbox tmpDir devNull defaultSandboxConf { dars = testDars }) destroySandbox $ \SandboxResource{sandboxPort} ->
-        ReplClient.withReplClient (ReplClient.Options replJar (Just ("localhost", show sandboxPort)) Nothing Nothing Nothing Nothing ReplClient.ReplWallClock CreatePipe) $ \replHandle ->
+        ReplClient.withReplClient (ReplClient.Options replJar (Just ("localhost", show sandboxPort)) Nothing Nothing Nothing Nothing ReplClient.ReplWallClock LF.V1 CreatePipe) $ \replHandle ->
         -- TODO We could share some of this setup with the actual repl code in damlc.
         withTempDir $ \dir ->
         withCurrentDirectory dir $ do

--- a/compiler/repl-service/client/src/DA/Daml/LF/ReplClient.hs
+++ b/compiler/repl-service/client/src/DA/Daml/LF/ReplClient.hs
@@ -63,6 +63,7 @@ data Options = Options
   , optMbSslConfig :: Maybe ClientSSLConfig
   , optMaxInboundMessageSize :: Maybe MaxInboundMessageSize
   , optTimeMode :: ReplTimeMode
+  , optMajorLfVersion :: LF.MajorVersion
   , optStdout :: StdStream
   -- ^ This is intended for testing so we can redirect stdout there.
   }
@@ -119,6 +120,7 @@ withReplClient opts@Options{..} f = withTempFile $ \portFile -> do
                 ReplWallClock -> "--wall-clock-time"
           ]
         , concat [ ["--max-inbound-message-size", show (getMaxInboundMessageSize size)] | Just size <- [optMaxInboundMessageSize] ]
+        , [ "--major-lf-version", LF.renderMajorVersion optMajorLfVersion]
         ]
     withCreateProcess replServer { std_out = optStdout } $ \_ stdout _ ph -> do
       clientBarrier <- newBarrier

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/speedy/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/speedy/ReplServiceMain.scala
@@ -243,7 +243,6 @@ class ReplService(
 
   import ReplService._
 
-  // TODO(#17366): Support LF v2
   private val compilerConfig = Compiler.Config
     .Default(majorLanguageVersion)
     .copy(stacktracing = Compiler.FullStackTrace)

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/speedy/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/speedy/ReplServiceMain.scala
@@ -56,6 +56,7 @@ object ReplServiceMain extends App {
       tlsConfig: TlsConfiguration,
       // optional so we can detect if both --static-time and --wall-clock-time are passed.
       timeMode: Option[ScriptTimeMode],
+      majorLanguageVersion: LanguageMajorVersion,
   )
   object Config {
     private def setTimeMode(
@@ -118,6 +119,19 @@ object ReplServiceMain extends App {
         }
         .text("Use static time.")
 
+      implicit val majorLanguageVersionRead: scopt.Read[LanguageMajorVersion] =
+        scopt.Read.reads(s =>
+          LanguageMajorVersion.fromString(s) match {
+            case Some(v) => v
+            case None => throw new IllegalArgumentException(s"$s is not a valid major LF version")
+          }
+        )
+      opt[LanguageMajorVersion]('v', "major-lf-version")
+        .optional()
+        .valueName("version")
+        .text("the major version of LF to use")
+        .action((v, c) => c.copy(majorLanguageVersion = v))
+
       checkConfig(c =>
         (c.ledgerHost, c.ledgerPort) match {
           case (Some(_), None) =>
@@ -140,6 +154,7 @@ object ReplServiceMain extends App {
           maxInboundMessageSize = RunnerMainConfig.DefaultMaxInboundMessageSize,
           timeMode = None,
           applicationId = None,
+          majorLanguageVersion = LanguageMajorVersion.V1,
         ),
       )
   }
@@ -176,7 +191,9 @@ object ReplServiceMain extends App {
   val server =
     NettyServerBuilder
       .forAddress(new InetSocketAddress(InetAddress.getLoopbackAddress, 0))
-      .addService(new ReplService(clients, timeMode, ec, sequencer, materializer))
+      .addService(
+        new ReplService(clients, timeMode, ec, sequencer, materializer, config.majorLanguageVersion)
+      )
       .maxInboundMessageSize(maxMessageSize)
       .build
       .start
@@ -189,12 +206,6 @@ object ReplServiceMain extends App {
 }
 
 object ReplService {
-  // TODO(#17366): Support LF v2
-  private val compilerConfig = Compiler.Config
-    .Default(LanguageMajorVersion.V1)
-    .copy(
-      stacktracing = Compiler.FullStackTrace
-    )
   private val homePackageId: PackageId = PackageId.assertFromString("-homePackageId-")
 
   private def moduleRefs(v: SValue): Set[ModuleName] = {
@@ -219,6 +230,7 @@ class ReplService(
     ec: ExecutionContext,
     esf: ExecutionSequencerFactory,
     mat: Materializer,
+    val majorLanguageVersion: LanguageMajorVersion,
 ) extends ReplServiceGrpc.ReplServiceImplBase
     with StrictLogging {
   var signatures: Map[PackageId, PackageSignature] = Map.empty
@@ -231,12 +243,29 @@ class ReplService(
 
   import ReplService._
 
+  // TODO(#17366): Support LF v2
+  private val compilerConfig = Compiler.Config
+    .Default(majorLanguageVersion)
+    .copy(stacktracing = Compiler.FullStackTrace)
+
+  private[this] def validatePackagesLanguageVersion(pkgMap: Map[PackageId, Package]): Unit = {
+    val invalidPackages =
+      pkgMap.view.mapValues(_.languageVersion.major).filter(_._2 != majorLanguageVersion)
+    if (invalidPackages.nonEmpty) {
+      throw new IllegalArgumentException(
+        "the following packages don't have expected major LF version "
+          + s"${majorLanguageVersion}: ${invalidPackages}"
+      )
+    }
+  }
+
   override def loadPackages(
       req: LoadPackagesRequest,
       respObs: StreamObserver[LoadPackagesResponse],
   ): Unit = {
     val pkgMap =
       req.getPackagesList.asScala.view.map(archive.ArchiveDecoder.assertFromByteString).toMap
+    validatePackagesLanguageVersion(pkgMap)
     val newSignatures = signatures ++ AstUtil.toSignatures(pkgMap)
     val newCompiledDefinitions = compiledDefinitions ++
       assertRight(
@@ -252,7 +281,7 @@ class ReplService(
       req: RunScriptRequest,
       respObs: StreamObserver[RunScriptResponse],
   ): Unit = {
-    val lfVer = LanguageVersion(LanguageVersion.Major.V1, LanguageVersion.Minor(req.getMinor))
+    val lfVer = LanguageVersion(majorLanguageVersion, LanguageVersion.Minor(req.getMinor))
     val mod = archive.moduleDecoder(lfVer, homePackageId).assertFromByteString(req.getDamlLf1)
     val pkg = Package(mainModules.updated(mod.name, mod), Set.empty, lfVer, None)
     // TODO[AH] Provide daml-script package id from REPL client.

--- a/daml-script/daml3/BUILD.bazel
+++ b/daml-script/daml3/BUILD.bazel
@@ -4,7 +4,7 @@
 # TODO Once daml_compile uses build instead of package we should use
 # daml_compile instead of a genrule.
 load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
-load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF2_VERSIONS")
+load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF2_VERSIONS", "lf_version_latest")
 
 [
     genrule(
@@ -44,6 +44,17 @@ EOF
     )
     for lf_version in COMPILER_LF2_VERSIONS
 ]
+
+# For convenience, we define daml3-script.dar which is always compiled to the
+# default stable version of LF2.
+genrule(
+    name = "daml3-script",
+    # TODO(#17366): use lf_version_default or equivalent once available
+    srcs = [":daml3-script-{}.dar".format(lf_version_latest.get("2"))],
+    outs = ["daml3-script.dar"],
+    cmd = "cp -L $(location :daml3-script-{}.dar) $$PWD/$@".format(lf_version_latest.get("2")),
+    visibility = ["//visibility:public"],
+)
 
 filegroup(
     name = "daml3-script-dars",

--- a/daml-script/daml3/BUILD.bazel
+++ b/daml-script/daml3/BUILD.bazel
@@ -3,6 +3,7 @@
 
 # TODO Once daml_compile uses build instead of package we should use
 # daml_compile instead of a genrule.
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
 load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF2_VERSIONS", "lf_version_latest")
 
@@ -47,12 +48,12 @@ EOF
 
 # For convenience, we define daml3-script.dar which is always compiled to the
 # default stable version of LF2.
-genrule(
+copy_file(
     name = "daml3-script",
     # TODO(#17366): use lf_version_default or equivalent once available
-    srcs = [":daml3-script-{}.dar".format(lf_version_latest.get("2"))],
-    outs = ["daml3-script.dar"],
-    cmd = "cp -L $(location :daml3-script-{}.dar) $$PWD/$@".format(lf_version_latest.get("2")),
+    src = ":daml3-script-{}.dar".format(lf_version_latest.get("2")),
+    out = "daml3-script.dar",
+    allow_symlink = True,
     visibility = ["//visibility:public"],
 )
 

--- a/libs-haskell/test-utils/DA/Test/Sandbox.hs
+++ b/libs-haskell/test-utils/DA/Test/Sandbox.hs
@@ -170,6 +170,7 @@ getCantonConfig conf@SandboxConfig{..} portFile mCerts (ledgerPort, adminPort, d
                         [ "type" Aeson..= ("sim-clock" :: T.Text) ]
                   | Static <- [timeMode] ]
                 , [ "dev-version-support" Aeson..= devVersionSupport]
+                , [ "non-standard-config" Aeson..= True]
                 ] )
             , "participants" Aeson..= Aeson.object
                 [ (AesonKey.fromString $ getParticipantName conf) Aeson..= Aeson.object
@@ -188,6 +189,7 @@ getCantonConfig conf@SandboxConfig{..} portFile mCerts (ledgerPort, adminPort, d
                                 ] ]
                           | Just secret <- [mbSharedSecret] ]
                           )
+                     , "parameters" Aeson..= Aeson.object [ "dev-version-support" Aeson..= devVersionSupport ]
                      ] <>
                      [ "testing-time" Aeson..= Aeson.object [ "type" Aeson..= ("monotonic-time" :: T.Text) ]
                      | Static <- [timeMode]
@@ -196,10 +198,18 @@ getCantonConfig conf@SandboxConfig{..} portFile mCerts (ledgerPort, adminPort, d
                 ]
             , "domains" Aeson..= Aeson.object
                 [ "domain" Aeson..= Aeson.object
-                     [ storage
-                     , "public-api" Aeson..= port domainPublicPort
-                     , "admin-api" Aeson..= port domainAdminPort
-                     ]
+                    (
+                        [ storage
+                        , "public-api" Aeson..= port domainPublicPort
+                        , "admin-api" Aeson..= port domainAdminPort
+                        ] <>
+                        [ "init" Aeson..= Aeson.object
+                              [ "domain-parameters" Aeson..= Aeson.object
+                                  [ "protocol-version" Aeson..= ("dev" :: T.Text) ]
+                              ]
+                        | devVersionSupport
+                        ]
+                    )
                 ]
             ]
         ]

--- a/libs-haskell/test-utils/DA/Test/Sandbox.hs
+++ b/libs-haskell/test-utils/DA/Test/Sandbox.hs
@@ -170,7 +170,7 @@ getCantonConfig conf@SandboxConfig{..} portFile mCerts (ledgerPort, adminPort, d
                         [ "type" Aeson..= ("sim-clock" :: T.Text) ]
                   | Static <- [timeMode] ]
                 , [ "dev-version-support" Aeson..= devVersionSupport]
-                , [ "non-standard-config" Aeson..= True]
+                , [ "non-standard-config" Aeson..= devVersionSupport]
                 ] )
             , "participants" Aeson..= Aeson.object
                 [ (AesonKey.fromString $ getParticipantName conf) Aeson..= Aeson.object

--- a/libs-haskell/test-utils/DA/Test/Sandbox.hs
+++ b/libs-haskell/test-utils/DA/Test/Sandbox.hs
@@ -68,6 +68,7 @@ data SandboxConfig = SandboxConfig
     , mbClientAuth :: Maybe ClientAuth
     , mbSharedSecret :: Maybe String
     , mbLedgerId :: Maybe String
+    , devVersionSupport :: Bool
     }
 
 defaultSandboxConf :: SandboxConfig
@@ -78,6 +79,7 @@ defaultSandboxConf = SandboxConfig
     , mbClientAuth = Nothing
     , mbSharedSecret = Nothing
     , mbLedgerId = Just "MyLedger"
+    , devVersionSupport = False
     }
 
 getCerts :: IO Certs
@@ -167,6 +169,7 @@ getCantonConfig conf@SandboxConfig{..} portFile mCerts (ledgerPort, adminPort, d
                 , [ "clock" Aeson..= Aeson.object
                         [ "type" Aeson..= ("sim-clock" :: T.Text) ]
                   | Static <- [timeMode] ]
+                , [ "dev-version-support" Aeson..= devVersionSupport]
                 ] )
             , "participants" Aeson..= Aeson.object
                 [ (AesonKey.fromString $ getParticipantName conf) Aeson..= Aeson.object
@@ -179,7 +182,7 @@ getCantonConfig conf@SandboxConfig{..} portFile mCerts (ledgerPort, adminPort, d
                           [ tlsOpts certs
                           | Just certs <- [mCerts]
                           ] <>
-                          [ "auth-services" Aeson..= aesonArray [ Aeson.object 
+                          [ "auth-services" Aeson..= aesonArray [ Aeson.object
                                 [ "type" Aeson..= ("unsafe-jwt-hmac-256" :: T.Text)
                                 , "secret" Aeson..= secret
                                 ] ]


### PR DESCRIPTION
`ReplServiceMain.scala` now accepts a major LF version flag that defaults to 1. The service only accepts packages whose major version matches the flag.

The haskell client retrieves the major version from the value of the  `--target` flag passed to `daml repl`.

The repl tests now test both LF1 and LF2.