### PR TITLE
re-start publishing daml-sdk image

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -57,6 +57,62 @@ jobs:
           GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
       - template: ci/tell-slack-failed.yml
 
+  - job: docker_image
+    timeoutInMinutes: 60
+    pool:
+      name: 'ubuntu_20_04'
+      demands: assignment -equals default
+    steps:
+      - checkout: self
+      - bash: |
+          set -euo pipefail
+
+          eval "$(dev-env/bin/dade-assist)"
+          HEAD=$(git rev-parse HEAD)
+          while ! nix-build --no-out-link -A tools.sed -A tools.jq -A tools.curl -A tools.base64 nix; do :; done
+
+          trap 'rm -rf ~/.docker' EXIT
+          echo $DOCKER_PASSWORD | docker login --username $DOCKER_LOGIN --password-stdin
+          echo $DOCKER_CONTENT_TRUST_KEY | base64 -d > ~/.docker/da_automation.key
+          chmod 600 ~/.docker/da_automation.key
+          docker trust key load ~/.docker/da_automation.key --name $DOCKER_CONTENT_TRUST_USERNAME
+
+          RELEASES=$(curl https://api.github.com/repos/digital-asset/daml/releases -sSfL | jq -r '.[] | .tag_name')
+          DIR=$(pwd)
+          VERSIONS=$(curl 'https://hub.docker.com/v2/repositories/digitalasset/daml-sdk/tags/?page_size=10000' -sSfL)
+          # Our docker tags should be stable. Therefore, we only build the image if it has not already
+          # been built before and we checkout the Dockerfile for the release tag.
+          # We do not update docker images for older releases so only docker images for SDK releases
+          # >= 0.13.43 are built this way.
+          for version in $(echo $RELEASES | sed -e 's/ /\n/g'); do
+            LAST_UPDATE=$(echo $VERSIONS | jq -r '.results[] | select(.name == "'${version#v}'") | .last_updated')
+            if [[ -n "$LAST_UPDATE" ]]; then
+              echo "${version#v} already exists, skipping."
+            else
+              echo "Building version ${version#v}..."
+              #git checkout "$version"
+              cd ci/docker/daml-sdk
+              docker build -t digitalasset/daml-sdk:${version#v} --build-arg VERSION=${version#v} .
+              #git checkout Dockerfile
+              # Despite the name not suggesting it at all, this actually signs
+              # _and pushes_ the image; see
+              # https://docs.docker.com/engine/security/trust/#signing-images-with-docker-content-trust
+              docker trust sign digitalasset/daml-sdk:${version#v}
+              cd "$DIR"
+              git checkout $HEAD
+              echo "Done."
+            fi
+          done
+        env:
+          DOCKER_LOGIN: $(DOCKER_LOGIN)
+          DOCKER_PASSWORD: $(DOCKER_PASSWORD)
+          DOCKER_CONTENT_TRUST_KEY: $(DOCKER_CONTENT_TRUST_KEY)
+          DOCKER_CONTENT_TRUST_USERNAME: $(DOCKER_CONTENT_TRUST_USERNAME)
+          # Does not appear explicitly in the script, but is used by
+          # docker trust key load
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: $(DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE)
+      - template: ci/tell-slack-failed.yml
+
   - job: vscode_marketplace
     timeoutInMinutes: 10
     pool:

--- a/ci/docker/README.md
+++ b/ci/docker/README.md
@@ -1,0 +1,68 @@
+<!--
+
+This file is meant to be displayed as the description of the
+digitalasset/daml-sdk image on Docker Hub. Unfortunately, updating that is a
+manual process at the moment. This README is the source of truth and should
+overwrite the one on Docker Hub should they differ.
+
+-->
+
+# Dockerized Daml SDK
+
+> This image is not supported for production use-cases. Please contact Digital
+> Asset to obtain supported production-ready artifacts.
+
+Digital Asset's [Daml SDK](https://docs.daml.com/) in a can.
+
+## Tags
+
+* `${SDK_VERSION}`
+
+> Starting with tag 1.7.0, these images are signed.
+
+## Verifying signatures
+
+You can configure your Docker client to only pull & run signed Docker images by
+setting the `DOCKER_CONTENT_TRUST` environment variable to 1.
+
+This, however, only checks that the image is signed. If you want to further
+check the provenance of the signature, you can use `docker trust inspect
+--pretty digitalasset/daml-sdk:$TAG`; you should see a signer called
+`automation` with the key
+`533a6e09faa512f974f217668580da1ceb6aa5b00aad34ea1240afc7d249703f` and a
+repository key of
+`f5dc2aee6aed2d05d7eda75db7aa2b3fac7fc67afbb880d03535d5a5295a0d3b`.
+
+## Quick start
+
+* Ensure Docker is [installed](https://www.docker.com/get-started)
+* Check out existing demo Daml project (or use your own):
+  ```
+  git clone https://github.com/digital-asset/ex-bond-trading.git
+  cd ex-bond-trading
+  ```
+* Run Daml scenarios:
+  ```
+  DOCKER_CONTENT_TRUST=1 docker run --rm -it -v $PWD:/data digitalasset/daml-sdk:$SDK_VERSION bash -c "cd \$(mktemp -d) && cp -r /data/* ./ && DAML_SDK_VERSION=$SDK_VERSION daml test"
+  ```
+
+> Note: This image is primarily intended for CI workflows, where the benefits
+> of caching Docker images can outweigh the awkwardness of the above command.
+> For local development, we strongly recommend installing the Daml SDK on the
+> host development machine instead, by running `curl https://get.daml.com |
+> bash`. For production use-cases, we strongly recommend using a supported
+> production binary, which can be obtained by contacting Digital Asset.
+
+## License
+
+View [license information](https://www.apache.org/licenses/LICENSE-2.0) for the
+software contained in this image.
+
+As with all Docker images, these likely also contain other software which may
+be under other licenses (such as Bash, etc from the base distribution, along
+with any direct or indirect dependencies of the primary software being
+contained).
+
+As for any pre-built image usage, it is the image user's responsibility to
+ensure that any use of this image complies with any relevant licenses for all
+software contained within.

--- a/ci/docker/daml-sdk/Dockerfile
+++ b/ci/docker/daml-sdk/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:kinetic
+RUN apt-get update \
+ && apt-get install -y curl openjdk-11-jre-headless \
+ && rm -rf /var/lib/apt/lists/*
+ARG VERSION
+# This is needed to get the DNS requests
+# from Haskell binaries to succeed.
+# Otherwise they fail to even resolve localhost.
+RUN echo 'hosts: files dns' > /etc/nsswitch.conf
+RUN addgroup --system daml && adduser --system --ingroup daml daml
+USER daml
+RUN curl https://get.daml.com | sh -s $VERSION \
+    && printf "auto-install: false\nupdate-check: never\n" >> /home/daml/.daml/daml-config.yaml
+
+ENV PATH="/home/daml/.daml/bin:${PATH}"
+WORKDIR /home/daml


### PR DESCRIPTION
Turns out some people depend on it. I still think they shouldn't, and we should work with them to help them move away, but short-term the right thing to do is to not block their upgrade.