### PR TITLE
docker: switch to jammy

### DIFF
--- a/ci/docker/daml-sdk/Dockerfile
+++ b/ci/docker/daml-sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:kinetic
+FROM ubuntu:jammy
 RUN apt-get update \
  && apt-get install -y curl openjdk-11-jre-headless \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
`kinetic`, aka 22.10, wasn't an LTS and is out of support now. Canonical is apparently pretty explicit about that as they seem to have simply removed all files for 22.10 in the repositories, making `apt-get update` fail.

`jammy`, aka 22.04, is the current LTS.