### PR TITLE
Inject language version lookup into gRPC error parsing

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/JsonLedgerClient.scala
@@ -28,7 +28,7 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.data.{Bytes, Ref, Time}
 import com.daml.lf.engine.script.LfValueCodec
 import com.daml.lf.engine.script.v2.Converter
-import com.daml.lf.language.Ast
+import com.daml.lf.language.{Ast, LanguageVersion}
 import com.daml.lf.speedy.SValue
 import com.daml.lf.typesig.EnvironmentSignature
 import com.daml.lf.typesig.PackageSignature.TypeDecl
@@ -687,6 +687,7 @@ class JsonLedgerClient(
       disclosures: List[Bytes],
       commands: List[command.ApiCommand],
       optLocation: Option[Location],
+      languageVersionLookup: PackageId => Either[String, LanguageVersion],
   )(implicit
       ec: ExecutionContext,
       mat: Materializer,
@@ -697,6 +698,7 @@ class JsonLedgerClient(
       readAs: Set[Ref.Party],
       commandss: List[List[command.ApiCommand]],
       optLocation: Option[Location],
+      languageVersionLookup: PackageId => Either[String, LanguageVersion],
   )(implicit
       ec: ExecutionContext,
       mat: Materializer,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.api.domain.{PartyDetails, User, UserRight}
 import com.daml.lf.command
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{Bytes, Ref, Time}
-import com.daml.lf.language.Ast
+import com.daml.lf.language.{Ast, LanguageVersion}
 import com.daml.lf.speedy.SValue
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
@@ -235,6 +235,7 @@ trait ScriptLedgerClient {
       disclosures: List[Bytes],
       commands: List[command.ApiCommand],
       optLocation: Option[Location],
+      languageVersionLookup: PackageId => Either[String, LanguageVersion],
   )(implicit
       ec: ExecutionContext,
       mat: Materializer,
@@ -245,6 +246,7 @@ trait ScriptLedgerClient {
       readAs: Set[Ref.Party],
       commandss: List[List[command.ApiCommand]],
       optLocation: Option[Location],
+      languageVersionLookup: PackageId => Either[String, LanguageVersion],
   )(implicit
       ec: ExecutionContext,
       mat: Materializer,

--- a/ledger/error/src/main/scala/com/daml/error/ErrorResource.scala
+++ b/ledger/error/src/main/scala/com/daml/error/ErrorResource.scala
@@ -49,9 +49,13 @@ object ErrorResource {
   object ContractKey extends ErrorResource {
     def asString: String = "CONTRACT_KEY"
   }
+
+  // TODO https://github.com/digital-asset/daml/issues/17661 - this match is only needed for
+  //  temporary backward compatibility with Canton so can soon be removed
   object SharedKey extends ErrorResource {
     def asString: String = "SHARED_KEY"
   }
+
   object ContractArg extends ErrorResource {
     def asString: String = "CONTRACT_ARG"
   }


### PR DESCRIPTION
Inject language version lookup into gRPC error parsing to allow the shared flag needed for the constuction of `GlobalKey` to be derived from the template `packageId` (as opposed to needing to pass this in the exception).