### PR TITLE
Add `InterpretationTimeExceeded` error (for Canton #15108)

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -142,6 +142,8 @@ private[lf] object Pretty {
           prettyContractId(key.cids.head)
       case ValueNesting(limit) =>
         text(s"Value exceeds maximum nesting value of $limit")
+      case InterpretationTimeExceeded(let, tolerance) =>
+        text(s"Interpretation time exceeds limit of LET ($let) + tolerance ($tolerance)")
       case Dev(_, error) =>
         error match {
           case Dev.Limit(error) =>

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -5,11 +5,13 @@ package com.daml.lf
 package interpretation
 
 import com.daml.lf.data.Ref.{ChoiceName, Location, Party, TypeConName}
-import com.daml.lf.transaction.{NodeId, GlobalKey}
+import com.daml.lf.transaction.{GlobalKey, NodeId}
 import com.daml.lf.language.Ast
 import com.daml.lf.transaction.GlobalKeyWithMaintainers
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
+
+import java.time.{Duration, Instant}
 
 /** Daml exceptions that should be reported to the user
   */
@@ -153,6 +155,13 @@ object Error {
     * @param limit nesting limit that was exceeded
     */
   final case class ValueNesting(limit: Int) extends Error
+
+  /** The interpretation time exceeded the limit, given by the Ledger Effective Time plus the tolerance
+    *
+    * @param let the Ledger Effective Time of the transaction
+    * @param tolerance the time tolerance after the LET
+    */
+  final case class InterpretationTimeExceeded(let: Instant, tolerance: Duration) extends Error
 
   // Error that can be thrown by dev or PoC feature only
   final case class Dev(location: String, error: Dev.Error) extends Error


### PR DESCRIPTION
This PR adds an `InterpretationTimeExceeded` engine error, to be used in conjunction with [this Canton PR](https://github.com/DACH-NY/canton/pull/15267) for [this Canton issue](https://github.com/DACH-NY/canton/issues/15108).

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
