### PR TITLE
Fix daml3-script 1.dev error

### DIFF
--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -62,7 +62,7 @@ import Development.IDE.GHC.Util
 import qualified DA.Service.Logger as Logger
 import qualified Development.IDE.Types.Options as Ghcide
 import SdkVersion (damlStdlib)
-import DA.Daml.LF.Ast.Version (isDevVersion, Version (versionMajor))
+import DA.Daml.LF.Ast.Version (version2_dev, Version (versionMajor))
 
 -- | Convert to ghcide’s IdeOptions type.
 toCompileOpts :: Options -> Ghcide.IdeOptions
@@ -552,7 +552,7 @@ expandSdkPackages logger lfVersion dars = do
   where
     isSdkPackage fp = takeExtension fp `notElem` [".dar", ".dalf"]
     isInvalidDaml3Script = \case
-      "daml3-script" | not (isDevVersion lfVersion) -> True
+      "daml3-script" | lfVersion /= version2_dev -> True
       _ -> False
     sdkSuffix = "-" <> LF.renderVersion lfVersion
     expand mbSdkPath fp


### PR DESCRIPTION
Daml3-script is only pushed for 2.dev, but it allows using any dev version. Therefore, using 1.dev give a "no such dar, daml3-script-1.dev.dar" error.
This fixes the version check to disallow 1.dev
