### PR TITLE
tweaks to help reproduce and explore https issue

### DIFF
--- a/canton.conf
+++ b/canton.conf
@@ -1,0 +1,9 @@
+canton {
+  participants {
+    participant_foo {
+      storage.type = memory
+      ledger-api.port = 5011
+      admin-api.port = 5012
+    }
+  }
+}

--- a/jsonapi.conf
+++ b/jsonapi.conf
@@ -1,0 +1,15 @@
+{
+  server {
+    address = "127.0.0.1"
+    port = 1235
+    https {
+        cert-chain-file = "/home/raphael/code/daml/bazel-bin/test-common/test-certificates/server.crt"
+        private-key-file = "/home/raphael/code/daml/bazel-bin/test-common/test-certificates/server.pem"
+        trust-collection-file = "/home/raphael/code/daml/bazel-bin/test-common/test-certificates/ca.crt"
+    }
+  }
+  ledger-api {
+    address = "127.0.0.1"
+    port = 5011
+  }
+}

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/Config.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/Config.scala
@@ -29,7 +29,7 @@ private[http] final case class Config(
     ledgerPort: Int,
     address: String = com.daml.cliopts.Http.defaultAddress,
     httpPort: Int,
-    https: Option[TlsConfiguration] = None,
+    https: Option[HttpsConfig] = None,
     portFile: Option[Path] = None,
     packageReloadInterval: FiniteDuration = StartSettings.DefaultPackageReloadInterval,
     packageMaxInboundMessageSize: Option[Int] = None,
@@ -52,6 +52,11 @@ private[http] final case class Config(
 private[http] object Config {
   val Empty = Config(ledgerHost = "", ledgerPort = -1, httpPort = -1)
 }
+
+final case class HttpsConfig(
+    keyStoreFile: File,
+    keyStorePassword: String,
+)
 
 // It is public for Daml Hub
 final case class WebsocketConfig(

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/FileBasedConfig.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/FileBasedConfig.scala
@@ -74,7 +74,7 @@ private[http] final case class FileBasedConfig(
       address = server.address,
       httpPort = server.port,
       portFile = server.portFile,
-      https = server.https.map(_.tlsConfiguration),
+      https = server.https.map(h => HttpsConfig(h.keyStore.file, h.keyStore.password)),
       packageReloadInterval = packageReloadInterval,
       packageMaxInboundMessageSize = packageMaxInboundMessageSize,
       maxInboundMessageSize = maxInboundMessageSize,

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/JsonApiCli.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/JsonApiCli.scala
@@ -22,7 +22,7 @@ private[http] final case class JsonApiCli(
     ledgerPort: Int,
     address: String = com.daml.cliopts.Http.defaultAddress,
     httpPort: Int,
-    https: Option[TlsConfiguration] = None,
+    https: Option[HttpsConfig] = None,
     portFile: Option[Path] = None,
     packageReloadInterval: FiniteDuration = StartSettings.DefaultPackageReloadInterval,
     packageMaxInboundMessageSize: Option[Int] = None,

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/StartSettings.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/StartSettings.scala
@@ -22,7 +22,7 @@ trait StartSettings {
   val address: String
   val httpPort: Int
   val portFile: Option[Path]
-  val https: Option[TlsConfiguration]
+  val https: Option[HttpsConfig]
   val tlsConfig: TlsConfiguration
   val wsConfig: Option[WebsocketConfig]
   val allowNonHttps: Boolean

--- a/ledger-service/http-json-testing/BUILD.bazel
+++ b/ledger-service/http-json-testing/BUILD.bazel
@@ -50,7 +50,6 @@ load("//ledger-service/utils:scalaopts.bzl", "hj_scalacopts")
             "//ledger-service/http-json-cli:{}".format(edition),
             "//ledger-service/cli-opts",
             "//ledger-service/metrics",
-            "//ledger-service/pureconfig-utils",
             "//ledger-service/utils",
             "//ledger/ledger-api-auth",
             "//ledger/ledger-api-common",

--- a/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
+++ b/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
@@ -40,7 +40,6 @@ import com.daml.ledger.resources.ResourceContext
 import com.daml.logging.LoggingContextOf
 import com.daml.platform.services.time.TimeProviderType
 import com.daml.ports.Port
-import com.daml.pureconfigutils.HttpsConfig
 import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.{Assertions, Inside}
 import org.scalatest.OptionValues._
@@ -266,13 +265,13 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
   }
   type UseHttps = UseHttps.T
 
-  private val List(serverCrt, serverPem, caCrt, clientCrt, clientPem) = {
-    List("server.crt", "server.pem", "ca.crt", "client.crt", "client.pem").map { src =>
+  private val List(serverKeyStore, caCrt, clientCrt, clientPem) = {
+    List("server.p12", "ca.crt", "client.crt", "client.pem").map { src =>
       new File(rlocation("test-common/test-certificates/" + src))
     }
   }
 
-  final val serverHttpsConfig = HttpsConfig(serverCrt, serverPem, Some(caCrt)).tlsConfiguration
+  final val serverHttpsConfig = HttpsConfig(serverKeyStore, "")
   final val clientTlsConfig =
     TlsConfiguration(enabled = true, Some(clientCrt), Some(clientPem), Some(caCrt))
   private val noTlsConfig = TlsConfiguration(enabled = false, None, None, None)

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -82,7 +82,6 @@ load("//ledger-service/utils:scalaopts.bzl", "hj_scalacopts")
             "//observability/metrics",
             "@maven//:com_google_guava_guava",
             "@maven//:io_dropwizard_metrics_metrics_core",
-            "@maven//:io_netty_netty_buffer",
             "@maven//:io_opentelemetry_opentelemetry_api",
         ],
     )

--- a/ledger-service/http-json/src/it/resources/logback.xml
+++ b/ledger-service/http-json/src/it/resources/logback.xml
@@ -13,7 +13,7 @@
     <logger name="io.grpc.netty" level="WARN">
         <appender-ref ref="STDOUT"/>
     </logger>
-    <root level="INFO">
+    <root level="TRACE">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
@@ -73,7 +73,7 @@ abstract class HttpServiceIntegrationTest
 
   override protected def beforeAll() = {
     super.beforeAll()
-    val _ = System.setProperty("javax.net.debug", "ssl:handshake")
+    val _ = System.setProperty("javax.net.debug", "all")
   }
 
   private def httpsContextForSelfSignedCert = {
@@ -102,7 +102,8 @@ abstract class HttpServiceIntegrationTest
   //  }
 
   // TODO(lt-37): This is also broken on linux after the netty_tcnative update.
-  "should serve HTTPS requests" ignore withHttpService(useHttps = UseHttps.Https) { fixture =>
+  "should serve HTTPS requests" in withHttpService(useHttps = UseHttps.Https) { fixture =>
+    val _ = logger.info("starting the actual fixture")
     Http()
       .singleRequest(
         HttpRequest(

--- a/ledger-service/http-json/src/main/resources/logback.xml
+++ b/ledger-service/http-json/src/main/resources/logback.xml
@@ -16,7 +16,8 @@
             </appender>
         </else>
     </if>
-    <logger name="io.netty" level="WARN" />
+    <logger name="io.netty" level="DEBUG" />
+    <logger name="akka.http.slf4j" level="DEBUG" />
     <logger name="io.grpc.netty" level="WARN" />
     <logger name="ch.qos.logback" level="WARN" />
 

--- a/ledger-service/http-json/src/main/resources/logback.xml
+++ b/ledger-service/http-json/src/main/resources/logback.xml
@@ -18,6 +18,7 @@
     </if>
     <logger name="io.netty" level="DEBUG" />
     <logger name="akka.http.slf4j" level="DEBUG" />
+    <logger name="sun.security.ssl" level="DEBUG"/>
     <logger name="io.grpc.netty" level="WARN" />
     <logger name="ch.qos.logback" level="WARN" />
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -248,6 +248,7 @@ object HttpService {
         https
           .fold(builder) { config =>
             logger.info(s"Enabling HTTPS with $config")
+            val _ = System.setProperty("javax.net.debug", "all")
             builder.enableHttps(httpsConnectionContext(config))
           }
           .bind(allEndpoints)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -47,7 +47,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import ch.qos.logback.classic.{Level => LogLevel}
 import com.daml.jwt.domain.Jwt
 import com.daml.ledger.api.{domain => LedgerApiDomain}
-import com.daml.ledger.api.tls.TlsConfiguration
 
 object HttpService {
 
@@ -261,22 +260,31 @@ object HttpService {
     bindingEt.run: Future[Error \/ (ServerBinding, Option[ContractDao])]
   }
 
-  private[http] def httpsConnectionContext(
-      config: TlsConfiguration
-  )(implicit lc: LoggingContextOf[InstanceUUID]): HttpsConnectionContext = {
-    import io.netty.buffer.ByteBufAllocator
-    val sslContext =
-      config.server
-        .getOrElse(
-          throw new IllegalArgumentException(s"$config could not be built as a server ssl context")
-        )
-    val theEngine = sslContext.newEngine(ByteBufAllocator.DEFAULT)
-    theEngine.setUseClientMode(false)
-    theEngine.setWantClientAuth(false)
-    ConnectionContext.httpsServer(() => {
-      logger.info(s"Wrapping an sslEngine of type ${theEngine.getClass.getName}")
-      new LoggingSSLEngine(theEngine)
-    })
+  private[http] def httpsConnectionContext(config: HttpsConfig): HttpsConnectionContext = {
+    import java.io.FileInputStream
+    import java.security.{KeyStore, SecureRandom}
+    import javax.net.ssl.{SSLContext, KeyManagerFactory, TrustManagerFactory}
+
+    val keyStoreFile = config.keyStoreFile
+    val password = config.keyStorePassword.toCharArray
+
+    val keyStore = KeyStore.getInstance("PKCS12")
+    keyStore.load(new FileInputStream(keyStoreFile), password)
+
+    val keyManagerFactory = KeyManagerFactory.getInstance("SunX509")
+    keyManagerFactory.init(keyStore, password)
+
+    val trustManagerFactory = TrustManagerFactory.getInstance("SunX509")
+    trustManagerFactory.init(keyStore)
+
+    val context = SSLContext.getInstance("TLS")
+    context.init(
+      keyManagerFactory.getKeyManagers,
+      trustManagerFactory.getTrustManagers,
+      new SecureRandom,
+    )
+
+    ConnectionContext.httpsServer(context)
   }
 
   private[http] def doLoad(

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -261,7 +261,9 @@ object HttpService {
     bindingEt.run: Future[Error \/ (ServerBinding, Option[ContractDao])]
   }
 
-  private[http] def httpsConnectionContext(config: TlsConfiguration)(implicit lc: LoggingContextOf[InstanceUUID]): HttpsConnectionContext = {
+  private[http] def httpsConnectionContext(
+      config: TlsConfiguration
+  )(implicit lc: LoggingContextOf[InstanceUUID]): HttpsConnectionContext = {
     import io.netty.buffer.ByteBufAllocator
     val sslContext =
       config.server

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -271,6 +271,8 @@ object HttpService {
           throw new IllegalArgumentException(s"$config could not be built as a server ssl context")
         )
     val theEngine = sslContext.newEngine(ByteBufAllocator.DEFAULT)
+    theEngine.setUseClientMode(false)
+    theEngine.setWantClientAuth(false)
     ConnectionContext.httpsServer(() => {
       logger.info(s"Wrapping an sslEngine of type ${theEngine.getClass.getName}")
       new LoggingSSLEngine(theEngine)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/LoggingSSLEngine.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/LoggingSSLEngine.scala
@@ -38,7 +38,10 @@ class LoggingSSLEngine(delegate: SSLEngine) extends SSLEngine {
   }
 
   override def getDelegatedTask: Runnable = {
-    delegate.getDelegatedTask
+    logger.info("getDelegatedTask start")
+    val res = delegate.getDelegatedTask()
+    logger.info(s"getDelegatedTask end $res")
+    res
   }
 
   override def closeInbound(): Unit = {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/LoggingSSLEngine.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/LoggingSSLEngine.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.daml.http
 
 import java.nio.ByteBuffer
@@ -10,14 +13,24 @@ class LoggingSSLEngine(delegate: SSLEngine) extends SSLEngine {
   private val logger = ContextualizedLogger.get(getClass)
   private implicit val emptyContext = LoggingContext.empty
 
-  override def wrap(byteBuffers: Array[ByteBuffer], i: Int, i1: Int, byteBuffer: ByteBuffer): SSLEngineResult = {
+  override def wrap(
+      byteBuffers: Array[ByteBuffer],
+      i: Int,
+      i1: Int,
+      byteBuffer: ByteBuffer,
+  ): SSLEngineResult = {
     logger.info("wrap start")
     val res = delegate.wrap(byteBuffers, i, i1, byteBuffer)
     logger.info(s"wrap end $res")
     res
   }
 
-  override def unwrap(byteBuffer: ByteBuffer, byteBuffers: Array[ByteBuffer], i: Int, i1: Int): SSLEngineResult = {
+  override def unwrap(
+      byteBuffer: ByteBuffer,
+      byteBuffers: Array[ByteBuffer],
+      i: Int,
+      i1: Int,
+  ): SSLEngineResult = {
     logger.info("unwrap start")
     val res = delegate.unwrap(byteBuffer, byteBuffers, i, i1)
     logger.info(s"unwrap end $res")

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/LoggingSSLEngine.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/LoggingSSLEngine.scala
@@ -1,0 +1,122 @@
+package com.daml.http
+
+import java.nio.ByteBuffer
+import javax.net.ssl.{SSLEngine, SSLEngineResult, SSLSession}
+
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
+
+class LoggingSSLEngine(delegate: SSLEngine) extends SSLEngine {
+
+  private val logger = ContextualizedLogger.get(getClass)
+  private implicit val emptyContext = LoggingContext.empty
+
+  override def wrap(byteBuffers: Array[ByteBuffer], i: Int, i1: Int, byteBuffer: ByteBuffer): SSLEngineResult = {
+    logger.info("wrap start")
+    val res = delegate.wrap(byteBuffers, i, i1, byteBuffer)
+    logger.info(s"wrap end $res")
+    res
+  }
+
+  override def unwrap(byteBuffer: ByteBuffer, byteBuffers: Array[ByteBuffer], i: Int, i1: Int): SSLEngineResult = {
+    logger.info("unwrap start")
+    val res = delegate.unwrap(byteBuffer, byteBuffers, i, i1)
+    logger.info(s"unwrap end $res")
+    res
+  }
+
+  override def getDelegatedTask: Runnable = {
+    delegate.getDelegatedTask
+  }
+
+  override def closeInbound(): Unit = {
+    logger.info("closeInbound start")
+    delegate.closeInbound()
+    logger.info("closeInbound end")
+  }
+
+  override def isInboundDone: Boolean = {
+    delegate.isInboundDone
+  }
+
+  override def closeOutbound(): Unit = {
+    logger.info("closeOutbound start")
+    delegate.closeOutbound()
+    logger.info("closeOutbound end")
+  }
+
+  override def isOutboundDone: Boolean = {
+    delegate.isOutboundDone
+  }
+
+  override def getSupportedCipherSuites: Array[String] = {
+    delegate.getSupportedCipherSuites
+  }
+
+  override def getEnabledCipherSuites: Array[String] = {
+    delegate.getEnabledCipherSuites
+  }
+
+  override def setEnabledCipherSuites(strings: Array[String]): Unit = {
+    delegate.setEnabledCipherSuites(strings)
+  }
+
+  override def getSupportedProtocols: Array[String] = {
+    delegate.getSupportedProtocols
+  }
+
+  override def getEnabledProtocols: Array[String] = {
+    delegate.getEnabledProtocols
+  }
+
+  override def setEnabledProtocols(strings: Array[String]): Unit = {
+    delegate.setEnabledProtocols(strings)
+  }
+
+  override def getSession: SSLSession = {
+    val res = delegate.getSession
+    logger.info("getSession end")
+    res
+  }
+
+  override def beginHandshake(): Unit = {
+    logger.info("beginHandshake start")
+    delegate.beginHandshake()
+    logger.info("beginHandshake end")
+  }
+
+  override def getHandshakeStatus: SSLEngineResult.HandshakeStatus = {
+    delegate.getHandshakeStatus
+  }
+
+  override def setUseClientMode(b: Boolean): Unit = {
+    delegate.setUseClientMode(b)
+  }
+
+  override def getUseClientMode: Boolean = {
+    delegate.getUseClientMode
+  }
+
+  override def setNeedClientAuth(b: Boolean): Unit = {
+    delegate.setNeedClientAuth(b)
+  }
+
+  override def getNeedClientAuth: Boolean = {
+    delegate.getNeedClientAuth
+  }
+
+  override def setWantClientAuth(b: Boolean): Unit = {
+    delegate.setWantClientAuth(b)
+  }
+
+  override def getWantClientAuth: Boolean = {
+    delegate.getWantClientAuth
+  }
+
+  override def setEnableSessionCreation(b: Boolean): Unit = {
+    delegate.setEnableSessionCreation(b)
+  }
+
+  override def getEnableSessionCreation: Boolean = {
+    delegate.getEnableSessionCreation
+  }
+}

--- a/ledger-service/pureconfig-utils/src/main/scala/com/daml/pureconfigutils/SharedConfigReaders.scala
+++ b/ledger-service/pureconfig-utils/src/main/scala/com/daml/pureconfigutils/SharedConfigReaders.scala
@@ -9,7 +9,6 @@ import com.daml.dbutils.JdbcConfig
 import com.daml.jwt.{ECDSAVerifier, HMAC256Verifier, JwksVerifier, JwtVerifierBase, RSA256Verifier}
 import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.platform.services.time.TimeProviderType
-import io.netty.handler.ssl.ClientAuth
 import pureconfig.error.{CannotConvert, ConvertFailure, FailureReason}
 import pureconfig.{ConfigObjectCursor, ConfigReader, ConvertHelpers}
 import pureconfig.generic.semiauto.deriveReader
@@ -28,19 +27,12 @@ final case class HttpServerConfig(
     https: Option[HttpsConfig] = None,
 )
 final case class HttpsConfig(
-    certChainFile: File,
-    privateKeyFile: File,
-    trustCollectionFile: Option[File] = None,
-) {
-  def tlsConfiguration: TlsConfiguration =
-    TlsConfiguration(
-      enabled = true,
-      certChainFile = Some(certChainFile),
-      privateKeyFile = Some(privateKeyFile),
-      trustCollectionFile = trustCollectionFile,
-      clientAuth = ClientAuth.NONE,
-    )
-}
+    keyStore: HttpsKeyStoreConfig
+)
+final case class HttpsKeyStoreConfig(
+    file: File,
+    password: String = "",
+)
 final case class LedgerTlsConfig(
     enabled: Boolean = false,
     certChainFile: Option[File] = None,
@@ -137,6 +129,8 @@ object SharedConfigReaders {
   implicit val jdbcCfgReader: ConfigReader[JdbcConfig] = deriveReader[JdbcConfig]
 
   implicit val httpsCfgReader: ConfigReader[HttpsConfig] = deriveReader[HttpsConfig]
+  implicit val httpsKeyStoreCfgReader: ConfigReader[HttpsKeyStoreConfig] =
+    deriveReader[HttpsKeyStoreConfig]
 
   implicit val httpServerCfgReader: ConfigReader[HttpServerConfig] =
     deriveReader[HttpServerConfig]

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
@@ -113,9 +113,13 @@ final case class TlsConfiguration(
       sslContext: SslContext,
       isServer: Boolean,
   ): Unit = {
-    val who = if (isServer) "Server" else "Client"
+    val (who, provider) =
+      if (isServer)
+        ("Server", SslContext.defaultServerProvider())
+      else
+        ("Client", SslContext.defaultClientProvider())
     val tlsInfo = TlsInfo.fromSslContext(sslContext)
-    logger.info(s"$who TLS - enabled.")
+    logger.info(s"$who TLS - enabled via $provider")
     logger.debug(
       s"$who TLS - supported protocols: ${filterSSLv2Hello(tlsInfo.supportedProtocols).mkString(", ")}."
     )

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
@@ -74,6 +74,8 @@ final case class TlsConfiguration(
         TlsInfo.fromSslContext(defaultSslContext)
       }
 
+      logger.info(s"and now the tlsInfo is ${tlsInfo}")
+
       scala.util.Using.resources(
         keyCertChainInputStreamOrFail,
         keyInputStreamOrFail,

--- a/simple-https/BUILD.bazel
+++ b/simple-https/BUILD.bazel
@@ -18,6 +18,10 @@ da_scala_binary(
     ],
     scalacopts = hj_scalacopts,
     visibility = ["//visibility:public"],
+    runtime_deps = [
+        "@maven//:org_bouncycastle_bcpkix_jdk15on",
+        "@maven//:org_bouncycastle_bcprov_jdk15on",
+    ],
     deps = [
         "//bazel_tools/runfiles:scala_runfiles",
         "//language-support/scala/bindings-akka",

--- a/simple-https/BUILD.bazel
+++ b/simple-https/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_binary",
+)
+load("//ledger-service/utils:scalaopts.bzl", "hj_scalacopts")
+
+da_scala_binary(
+    name = "simple",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    data = ["//test-common/test-certificates"],
+    main_class = "simple.Main",
+    scala_deps = [
+        "@maven//:com_typesafe_akka_akka_http",
+        "@maven//:com_typesafe_akka_akka_http_core",
+    ],
+    scalacopts = hj_scalacopts,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//bazel_tools/runfiles:scala_runfiles",
+        "//language-support/scala/bindings-akka",
+        "//ledger/ledger-api-common",
+        "@maven//:io_netty_netty_buffer",
+    ],
+)

--- a/simple-https/src/main/scala/simple/Main.scala
+++ b/simple-https/src/main/scala/simple/Main.scala
@@ -1,0 +1,60 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright (C) 2009-2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package simple
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.server.{Directives, Route}
+import akka.http.scaladsl.{ConnectionContext, Http, HttpsConnectionContext}
+import com.daml.bazeltools.BazelRunfiles
+import com.daml.ledger.api.tls.TlsConfiguration
+import io.netty.handler.ssl.ClientAuth
+import java.nio.file.Paths
+
+object Main extends Directives {
+
+  def main(args: Array[String]): Unit = {
+    val _ = System.setProperty("javax.net.debug", "all")
+
+    val tlsConfig = TlsConfiguration(
+      enabled = true,
+      certChainFile = Some(testCerts("server.crt")),
+      privateKeyFile = Some(testCerts("server.pem")),
+      trustCollectionFile = Some(testCerts("ca.crt")),
+      clientAuth = ClientAuth.NONE,
+      enableCertRevocationChecking = false,
+      minimumServerProtocolVersion = None,
+    )
+    val https: HttpsConnectionContext = httpsConnectionContext(tlsConfig)
+
+    val routes: Route = get { complete("Hello world!") }
+
+    implicit val system: ActorSystem = ActorSystem()
+    val _ = Http().newServerAt("127.0.0.1", 1235).enableHttps(https).bind(routes)
+  }
+
+  // copied from ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+  private def httpsConnectionContext(config: TlsConfiguration): HttpsConnectionContext = {
+    import io.netty.buffer.ByteBufAllocator
+    val sslContext =
+      config.server
+        .getOrElse(
+          throw new IllegalArgumentException(s"$config could not be built as a server ssl context")
+        )
+    ConnectionContext.httpsServer(() => {
+      println("now creating the engine")
+      val engine: javax.net.ssl.SSLEngine = sslContext.newEngine(ByteBufAllocator.DEFAULT)
+      engine.setUseClientMode(false)
+      engine.setWantClientAuth(false)
+      println(s"created the engine: $engine")
+      engine
+    })
+  }
+
+  private def testCerts(basename: String) =
+    BazelRunfiles.rlocation(Paths.get(s"test-common/test-certificates/${basename}")).toFile
+}

--- a/simple-https/src/main/scala/simple/Main.scala
+++ b/simple-https/src/main/scala/simple/Main.scala
@@ -20,7 +20,7 @@ object Main extends Directives {
   def main(args: Array[String]): Unit = {
     val _ = System.setProperty("javax.net.debug", "all")
 
-    val tlsConfig = TlsConfiguration(
+    val _ = TlsConfiguration(
       enabled = true,
       certChainFile = Some(testCerts("server.crt")),
       privateKeyFile = Some(testCerts("server.pem")),
@@ -29,22 +29,48 @@ object Main extends Directives {
       enableCertRevocationChecking = false,
       minimumServerProtocolVersion = None,
     )
-    val https: HttpsConnectionContext = httpsConnectionContext(tlsConfig)
+    val https: HttpsConnectionContext = doesWork // doesNotWorkHttpsConnectionContext(tlsConfig)
 
-    val routes: Route = get { complete("Hello world!") }
+    val routes: Route = get { complete("Hello world!\n") }
 
     implicit val system: ActorSystem = ActorSystem()
     val _ = Http().newServerAt("127.0.0.1", 1235).enableHttps(https).bind(routes)
   }
 
+  def doesWork = {
+    import java.io.FileInputStream
+    import java.security.{KeyStore, SecureRandom}
+    import javax.net.ssl.{SSLContext, KeyManagerFactory, TrustManagerFactory}
+
+    val keyStoreFile = testCerts("server.p12")
+    val password = "".toCharArray // The password used to create the keystore file above
+
+    val keyStore = KeyStore.getInstance("PKCS12")
+    keyStore.load(new FileInputStream(keyStoreFile), password)
+
+    val keyManagerFactory = KeyManagerFactory.getInstance("SunX509")
+    keyManagerFactory.init(keyStore, password)
+
+    val trustManagerFactory = TrustManagerFactory.getInstance("SunX509")
+    trustManagerFactory.init(keyStore)
+
+    val context = SSLContext.getInstance("TLS")
+    context.init(
+      keyManagerFactory.getKeyManagers,
+      trustManagerFactory.getTrustManagers,
+      new SecureRandom,
+    )
+
+    ConnectionContext.httpsServer(context)
+  }
+
   // copied from ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
-  private def httpsConnectionContext(config: TlsConfiguration): HttpsConnectionContext = {
+  def doesNotWorkHttpsConnectionContext(config: TlsConfiguration): HttpsConnectionContext = {
     import io.netty.buffer.ByteBufAllocator
-    val sslContext =
-      config.server
-        .getOrElse(
-          throw new IllegalArgumentException(s"$config could not be built as a server ssl context")
-        )
+    val sslContext = config.server
+      .getOrElse(
+        throw new IllegalArgumentException(s"$config could not be built as a server ssl context")
+      )
     ConnectionContext.httpsServer(() => {
       println("now creating the engine")
       val engine: javax.net.ssl.SSLEngine = sslContext.newEngine(ByteBufAllocator.DEFAULT)

--- a/test-common/test-certificates/BUILD.bazel
+++ b/test-common/test-certificates/BUILD.bazel
@@ -24,6 +24,7 @@ genrule(
         "server.pem.enc",
         "server.csr",
         "server.crt",
+        "server.p12",
         "ocsp.key.pem",
         "ocsp.csr",
         "ocsp.crt",
@@ -163,6 +164,9 @@ $(location @openssl_dev_env//:openssl) req -config $(location openssl-alternativ
 # Dump out cert details
 $(location @openssl_dev_env//:openssl) x509 -noout -text -in $(location ca_alternative.crt)
 
+
+# Create keystore for server, with password of empty string
+$(location @openssl_dev_env//:openssl) pkcs12 -export -out $(location server.p12) -in $(location server.crt) -inkey $(location server.pem) -name key -CAfile $(location ca.crt) -caname root -password pass:
     """,
     tools = [
         "@openssl_dev_env//:openssl",


### PR DESCRIPTION
Currently the target `//ledger-service/http-json:integration-tests-ce_test_suite_src_it_scala_http_HttpServiceIntegrationTest.scala` fails in the test `"should serve HTTPS requests"`

To run just this one test, avoiding the flake retries, you can
```
bazel run //ledger-service/http-json:integration-tests-ce_test_suite_src_it_scala_http_HttpServiceIntegrationTest.scala -- -z HTTPS
```
We see that it produces and writes the ClientHello 6 times, each 1 minute apart, and there’s never a ServerHello sent back. After 6 attempts it gives up and dies with
```
  akka.stream.scaladsl.TcpIdleTimeoutException: TCP idle-timeout encountered on connection to [localhost:36993], no bytes passed in the last 60 seconds
```
I imagine this is the exception getting thrown every time, and when establishing the connection the client just catches and retries 5 times before rethrowing.

Now to test it manually, we can also start canton locally with
```
bazel run canton:community_app -- -c $(pwd)/canton.conf
```
and then update the paths in `jsonapi.conf` and in another terminal
```
bazel run ledger-service/http-json:http-json-binary -- -c $(pwd)/jsonapi.conf 
```

Then you can try connecting using other tools, such as curl
```
curl -vikI https://127.0.0.1:1235/livez
```
or openssl
```
openssl s_client -connect localhost:1235 -prexit -showcerts -debug -tlsextdebug -state -msg -tls1_2 </dev/null
```
and you get the same behaviour, it just hangs after sending the clienthello.

We do see that the server sees the request and logs 
```
javax.net.ssl|DEBUG|1A|http-json-ledger-api-akka.actor.default-dispatcher-6|2023-11-13 15:46:20.493 AEDT|SunX509KeyManagerImpl.java:392|matching alias: key
```
but gets no further than that.