### PR TITLE
Revert "Revert "Support both LF v1 and v2 in triggers""

### DIFF
--- a/daml-lf/language/daml-lf.bzl
+++ b/daml-lf/language/daml-lf.bzl
@@ -76,6 +76,13 @@ lf_version_configuration = {
 
 # TODO(#17366): rework lf_version_configuration to be indexed by major version
 #  and delete this dictionary
+lf_version_default = {
+    "1": lf_version_configuration.get("default"),
+    "2": "2.dev",
+}
+
+# TODO(#17366): rework lf_version_configuration to be indexed by major version
+#  and delete this dictionary
 lf_version_latest = {
     "1": lf_version_configuration.get("latest"),
     "2": "2.dev",

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
@@ -28,7 +28,8 @@ import com.daml.ledger.api.v1.event.{ArchivedEvent, CreatedEvent, Event, Interfa
 import com.daml.ledger.api.v1.transaction.Transaction
 import com.daml.ledger.api.v1.value
 import com.daml.ledger.api.validation.NoLoggingValueValidator
-import com.daml.lf.language.StablePackagesV1
+import com.daml.lf.language.LanguageVersionRangeOps.LanguageVersionRange
+import com.daml.lf.language.StablePackages
 import com.daml.lf.speedy.Command
 import com.daml.lf.value.Value
 import com.daml.platform.participant.util.LfEngineToApi.{
@@ -67,10 +68,12 @@ final class Converter(
 
   private[this] val triggerIds: TriggerIds = triggerDef.triggerIds
 
-  // TODO(#17366): support both LF v1 and v2 in triggers
-  private[this] val templateTypeRepTyCon = StablePackagesV1.TemplateTypeRep
-  private[this] val anyTemplateTyCon = StablePackagesV1.AnyTemplate
-  private[this] val anyViewTyCon = StablePackagesV1.AnyView
+  private[this] val stablePackages = StablePackages(
+    compiledPackages.compilerConfig.allowedLanguageVersions.majorVersion
+  )
+  private[this] val templateTypeRepTyCon = stablePackages.TemplateTypeRep
+  private[this] val anyTemplateTyCon = stablePackages.AnyTemplate
+  private[this] val anyViewTyCon = stablePackages.AnyView
   private[this] val activeContractsTy = triggerIds.damlTriggerLowLevel("ActiveContracts")
   private[this] val triggerConfigTy = triggerIds.damlTriggerLowLevel("TriggerConfig")
   private[this] val triggerSetupArgumentsTy =

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
@@ -118,7 +118,7 @@ object RunnerMain {
             config.timeProviderType.getOrElse(RunnerConfig.DefaultTimeProviderType),
             config.applicationId,
             parties,
-            config.compilerConfig,
+            config.compilerConfigBuilder.build(config.majorLanguageVersion),
             config.triggerConfig,
           )
         } yield ()

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -226,6 +226,7 @@ da_scala_library(
 
 da_scala_test_suite(
     name = "test",
+    timeout = "long",
     srcs = glob(
         ["src/test-suite/scala/**/*.scala"],
         exclude = ["**/*Oracle*"],

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -3,7 +3,7 @@
 
 load("@oracle//:index.bzl", "oracle_tags")
 load("@build_environment//:configuration.bzl", "sdk_version")
-load("//daml-lf/language:daml-lf.bzl", "LF_DEV_VERSIONS", "lf_version_configuration", "lf_versions_aggregate")
+load("//daml-lf/language:daml-lf.bzl", "LF_DEV_VERSIONS", "LF_MAJOR_VERSIONS", "lf_version_configuration", "lf_version_default", "lf_versions_aggregate")
 load("@os_info//:os_info.bzl", "is_windows")
 load(
     "//bazel_tools:scala.bzl",
@@ -16,7 +16,10 @@ load(
 
 triggerMain = "src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala"
 
-target_lf_versions = lf_versions_aggregate(["default"] + LF_DEV_VERSIONS)
+target_lf_versions = lf_versions_aggregate(
+    [lf_version_default.get(major) for major in LF_MAJOR_VERSIONS] +
+    LF_DEV_VERSIONS,
+)
 
 da_scala_library(
     name = "trigger-service",
@@ -157,7 +160,10 @@ da_scala_library(
     data = [
         ":test-model-{}.dar".format(lf_version)
         for lf_version in target_lf_versions
-    ] + [":test-model.dar"] + (
+    ] + [
+        ":test-model-v{}.dar".format(major)
+        for major in LF_MAJOR_VERSIONS
+    ] + (
         [
             "@toxiproxy_dev_env//:bin/toxiproxy-server",
         ] if not is_windows else [
@@ -300,6 +306,7 @@ da_scala_test_suite(
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/archive:daml_lf_dev_archive_proto_java",
         "//daml-lf/data",
+        "//daml-lf/language",
         "//language-support/scala/bindings-akka",
         "//ledger-api/rs-grpc-bridge",
         "//ledger-api/testing-utils",
@@ -371,12 +378,15 @@ EOF
     for lf_version in target_lf_versions
 ]
 
-genrule(
-    name = "test-model",
-    srcs = [":test-model-{}".format(lf_version_configuration.get("default"))],
-    outs = ["test-model.dar"],
-    cmd = "cp -L $(location :test-model-{}) $$PWD/$@".format(lf_version_configuration.get("default")),
-    visibility = ["//visibility:public"],
-)
+[
+    genrule(
+        name = "test-model-{}".format(major),
+        srcs = [":test-model-{}".format(lf_version_default.get(major))],
+        outs = ["test-model-v{}.dar".format(major)],
+        cmd = "cp -L $(location :test-model-{}) $$PWD/$@".format(lf_version_default.get(major)),
+        visibility = ["//visibility:public"],
+    )
+    for major in LF_MAJOR_VERSIONS
+]
 
 exports_files(["release/trigger-service-logback.xml"])

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -286,6 +286,7 @@ da_scala_test_suite(
 
 da_scala_test_suite(
     name = "test-oracle",
+    timeout = "long",
     srcs = glob(["src/test-suite/scala/**/*Oracle*.scala"]),
     scala_deps = [
         "@maven//:io_spray_spray_json",

--- a/triggers/service/src/test-suite/resources/trigger-service.conf
+++ b/triggers/service/src/test-suite/resources/trigger-service.conf
@@ -30,6 +30,8 @@
   time-provider-type = "static"
   //Compiler config type to use , default or dev mode
   compiler-config = "dev"
+  //Major LF version to use: 1 or 2
+  lf-major-version = 2
   //TTL in seconds used for commands emitted by the trigger. Defaults to 30s.
   ttl = 60s
 

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/CliSpec.scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/CliSpec.scala
@@ -7,14 +7,15 @@ import akka.http.scaladsl.model.Uri
 import com.daml.auth.middleware.api.{Client => AuthClient}
 import com.daml.bazeltools.BazelRunfiles.requiredResource
 import com.daml.dbutils.JdbcConfig
+import com.daml.lf.engine.trigger.TriggerServiceAppConf.CompilerConfigBuilder
 import com.daml.lf.language.LanguageMajorVersion
-import com.daml.lf.speedy.Compiler
 import com.daml.platform.services.time.TimeProviderType
 import org.scalatest.Inside.inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 import pureconfig.error.{CannotReadFile, ConfigReaderFailures}
 import com.daml.pureconfigutils.LedgerApiConfig
+import com.daml.lf.speedy.Compiler
 
 import java.nio.file.Paths
 import scala.concurrent.duration._
@@ -62,8 +63,8 @@ class CliSpec extends AsyncWordSpec with Matchers {
         authorization = expectedAuthCfg,
         triggerStore = Some(expectedJdbcConfig),
         timeProviderType = TimeProviderType.Static,
-        // TODO(#17366): support both LF v1 and v2 in triggers
-        compilerConfig = Compiler.Config.Dev(LanguageMajorVersion.V1),
+        compilerConfig = CompilerConfigBuilder.Dev,
+        lfMajorVersion = LanguageMajorVersion.V2,
         initDb = true,
         ttl = 60.seconds,
         allowExistingSchema = true,
@@ -103,10 +104,19 @@ class CliSpec extends AsyncWordSpec with Matchers {
   "should load config from cli args when no conf file is specified" in {
     Cli
       .parseConfig(
-        Array("--ledger-host", "localhost", "--ledger-port", "9999"),
+        Array(
+          "--ledger-host",
+          "localhost",
+          "--ledger-port",
+          "9999",
+          "--lf-major-version",
+          "2",
+          "--dev-mode-unsafe",
+        ),
         Set(),
       ) shouldBe Some(Cli.Default.copy(ledgerHost = "localhost", ledgerPort = 9999))
       .map(_.loadFromCliArgs)
+      .map(_.copy(compilerConfig = Compiler.Config.Dev(LanguageMajorVersion.V2)))
   }
 
   "should fail to load config from cli args on missing required params" in {

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestAuth.scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestAuth.scala
@@ -3,7 +3,12 @@
 
 package com.daml.lf.engine.trigger
 
-class TriggerServiceTestAuth
+import com.daml.lf.language.LanguageMajorVersion
+
+class TriggerServiceTestAuthV1 extends TriggerServiceTestAuth(LanguageMajorVersion.V1)
+class TriggerServiceTestAuthV2 extends TriggerServiceTestAuth(LanguageMajorVersion.V2)
+
+class TriggerServiceTestAuth(override val majorLanguageVersion: LanguageMajorVersion)
     extends AbstractTriggerServiceTestInMem
     with AbstractTriggerServiceTestAuthMiddleware
     with DisableOauthClaimsTests

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestAuthClaims.scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestAuthClaims.scala
@@ -3,7 +3,12 @@
 
 package com.daml.lf.engine.trigger
 
-class TriggerServiceTestAuthClaims
+import com.daml.lf.language.LanguageMajorVersion
+
+class TriggerServiceTestAuthClaimsV1 extends TriggerServiceTestAuthClaims(LanguageMajorVersion.V1)
+class TriggerServiceTestAuthClaimsV2 extends TriggerServiceTestAuthClaims(LanguageMajorVersion.V2)
+
+class TriggerServiceTestAuthClaims(override val majorLanguageVersion: LanguageMajorVersion)
     extends AbstractTriggerServiceTestInMem
     with AbstractTriggerServiceTestAuthMiddleware {
   override protected[this] def oauth2YieldsUserTokens = false

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestAuthWithOracle.scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestAuthWithOracle.scala
@@ -3,15 +3,28 @@
 
 package com.daml.lf.engine.trigger
 
-class TriggerServiceTestAuthWithOracle
+import com.daml.lf.language.LanguageMajorVersion
+
+class TriggerServiceTestAuthWithOracleV1
+    extends TriggerServiceTestAuthWithOracle(LanguageMajorVersion.V1)
+class TriggerServiceTestAuthWithOracleV2
+    extends TriggerServiceTestAuthWithOracle(LanguageMajorVersion.V2)
+
+class TriggerServiceTestAuthWithOracle(override val majorLanguageVersion: LanguageMajorVersion)
     extends AbstractTriggerServiceTest
     with AbstractTriggerServiceTestWithDatabase
     with TriggerDaoOracleFixture
     with AbstractTriggerServiceTestAuthMiddleware
     with DisableOauthClaimsTests
 
-class TriggerServiceTestAuthWithOracleClaims
-    extends AbstractTriggerServiceTest
+class TriggerServiceTestAuthWithOracleClaimsV1
+    extends TriggerServiceTestAuthWithOracleClaims(LanguageMajorVersion.V1)
+class TriggerServiceTestAuthWithOracleClaimsV2
+    extends TriggerServiceTestAuthWithOracleClaims(LanguageMajorVersion.V2)
+
+class TriggerServiceTestAuthWithOracleClaims(
+    override val majorLanguageVersion: LanguageMajorVersion
+) extends AbstractTriggerServiceTest
     with AbstractTriggerServiceTestWithDatabase
     with TriggerDaoOracleFixture
     with AbstractTriggerServiceTestAuthMiddleware {

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestAuthWithPostgres.Scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestAuthWithPostgres.Scala
@@ -3,7 +3,12 @@
 
 package com.daml.lf.engine.trigger
 
-class TriggerServiceTestAuthWithPostgres
+import com.daml.lf.language.LanguageMajorVersion
+
+class TriggerServiceTestAuthWithPostgresV1 extends TriggerServiceTestAuthWithPostgres(LanguageMajorVersion.V1)
+class TriggerServiceTestAuthWithPostgresV2 extends TriggerServiceTestAuthWithPostgres(LanguageMajorVersion.V2)
+
+class TriggerServiceTestAuthWithPostgres(override val majorLanguageVersion: LanguageMajorVersion)
     extends AbstractTriggerServiceTest
     with AbstractTriggerServiceTestWithDatabase
     with TriggerDaoPostgresFixture

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestInMem.scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestInMem.scala
@@ -3,6 +3,11 @@
 
 package com.daml.lf.engine.trigger
 
-class TriggerServiceTestInMem
+import com.daml.lf.language.LanguageMajorVersion
+
+class TriggerServiceTestInMemV1 extends TriggerServiceTestInMem(LanguageMajorVersion.V1)
+class TriggerServiceTestInMemV2 extends TriggerServiceTestInMem(LanguageMajorVersion.V2)
+
+class TriggerServiceTestInMem(override val majorLanguageVersion: LanguageMajorVersion)
     extends AbstractTriggerServiceTestInMem
     with AbstractTriggerServiceTestNoAuth {}

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestTls.scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestTls.scala
@@ -5,12 +5,16 @@ package com.daml.lf.engine.trigger
 
 import akka.http.scaladsl.model.Uri
 import com.daml.ledger.api.v1.value.Identifier
+import com.daml.lf.language.LanguageMajorVersion
 import com.daml.timer.RetryStrategy
 import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
-class TriggerServiceTestTls
+class TriggerServiceTestTlsV1 extends TriggerServiceTestTls(LanguageMajorVersion.V1)
+class TriggerServiceTestTlsV2 extends TriggerServiceTestTls(LanguageMajorVersion.V2)
+
+class TriggerServiceTestTls(override val majorLanguageVersion: LanguageMajorVersion)
     extends AbstractTriggerServiceTest
     with NoAuthFixture
     with TriggerDaoInMemFixture

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestWithOracle.scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestWithOracle.scala
@@ -3,7 +3,12 @@
 
 package com.daml.lf.engine.trigger
 
-class TriggerServiceTestWithOracle
+import com.daml.lf.language.LanguageMajorVersion
+
+class TriggerServiceTestWithOracleV1 extends TriggerServiceTestWithOracle(LanguageMajorVersion.V1)
+class TriggerServiceTestWithOracleV2 extends TriggerServiceTestWithOracle(LanguageMajorVersion.V2)
+
+class TriggerServiceTestWithOracle(override val majorLanguageVersion: LanguageMajorVersion)
     extends AbstractTriggerServiceTest
     with AbstractTriggerServiceTestWithDatabase
     with TriggerDaoOracleFixture

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestWithPostgres.scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestWithPostgres.scala
@@ -3,7 +3,14 @@
 
 package com.daml.lf.engine.trigger
 
-class TriggerServiceTestWithPostgres
+import com.daml.lf.language.LanguageMajorVersion
+
+class TriggerServiceTestWithPostgresV1
+    extends TriggerServiceTestWithPostgres(LanguageMajorVersion.V1)
+class TriggerServiceTestWithPostgresV2
+    extends TriggerServiceTestWithPostgres(LanguageMajorVersion.V2)
+
+class TriggerServiceTestWithPostgres(override val majorLanguageVersion: LanguageMajorVersion)
     extends AbstractTriggerServiceTest
     with AbstractTriggerServiceTestWithDatabase
     with TriggerDaoPostgresFixture

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -457,6 +457,11 @@ trait TriggerServiceFixture
     with AbstractAuthFixture {
   self: Suite =>
 
+  protected val majorLanguageVersion: LanguageMajorVersion
+
+  // TODO(#17366): remove once 2.0 is introduced
+  override protected lazy val devMode: Boolean = (majorLanguageVersion == LanguageMajorVersion.V2)
+
   private val triggerLog: ConcurrentMap[UUID, Vector[(LocalDateTime, String)]] =
     new ConcurrentHashMap
 
@@ -508,8 +513,7 @@ trait TriggerServiceFixture
                 jdbcConfig,
                 false,
                 config.tlsClientConfig,
-                // TODO(#17366) support both LF v1 and v2 in triggers
-                Compiler.Config.Dev(LanguageMajorVersion.V1),
+                Compiler.Config.Dev(majorLanguageVersion),
                 triggerRunnerConfig.getOrElse(DefaultTriggerRunnerConfig),
                 logTriggerStatus,
               )

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -80,7 +80,9 @@ trait AbstractTriggerServiceTestHelper
   val confidentialitySecurity: SecurityTest =
     SecurityTest(property = Privacy, asset = "Trigger Service")
 
-  lazy protected val darPath: File = requiredResource("triggers/service/test-model.dar")
+  lazy protected val darPath: File = requiredResource(
+    s"triggers/service/test-model-v${majorLanguageVersion.pretty}.dar"
+  )
 
   // Encoded dar used in service initialization
   protected lazy val dar: Dar[(PackageId, DamlLf.ArchivePayload)] =

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -9,13 +9,11 @@ load(
     "lf_scalacopts_stricter",
 )
 load("@build_environment//:configuration.bzl", "sdk_version")
-
-DAML_LF_VERSIONS = (
-    [
-        "",  # SDK default
-    ]
-    # disable dev tests as trigger currently does not use any dev features.
-    # + LF_DEV_VERSIONS
+load(
+    "//daml-lf/language:daml-lf.bzl",
+    "LF_DEV_VERSIONS",
+    "LF_MAJOR_VERSIONS",
+    "lf_version_latest",
 )
 
 da_scala_library(
@@ -57,18 +55,17 @@ da_scala_library(
 )
 
 [
-    [
-        genrule(
-            name = "acs" + suffix,
-            srcs =
-                glob(["**/*.daml"]) + [
-                    "//triggers/daml:daml-trigger%s.dar" % suffix,
-                    "//daml-script/daml:daml-script%s.dar" % suffix,
-                ] + [
-                    "//templates:copy-trigger/src/CopyTrigger.daml",
-                ],
-            outs = ["acs%s.dar" % suffix],
-            cmd = """
+    genrule(
+        name = "acs-%s" % major,
+        srcs =
+            glob(["**/*.daml"]) + [
+                "//triggers/daml:daml-trigger-%s.dar" % lf_version_latest.get(major),
+                "//daml-script/daml:daml-script-%s.dar" % lf_version_latest.get(major),
+            ] + [
+                "//templates:copy-trigger/src/CopyTrigger.daml",
+            ],
+        outs = ["acs-%s.dar" % major],
+        cmd = """
       set -eou pipefail
       TMP_DIR=$$(mktemp -d)
       mkdir -p $$TMP_DIR/daml
@@ -89,8 +86,8 @@ da_scala_library(
       cp -L $(location :daml/Cats.daml) $$TMP_DIR/daml
       cp -L $(location :daml/BatchTrigger.daml) $$TMP_DIR/daml
       cp -L $(location //templates:copy-trigger/src/CopyTrigger.daml) $$TMP_DIR/daml
-      cp -L $(location //triggers/daml:daml-trigger{suffix}.dar) $$TMP_DIR/daml-trigger.dar
-      cp -L $(location //daml-script/daml:daml-script{suffix}.dar) $$TMP_DIR/daml-script.dar
+      cp -L $(location //triggers/daml:daml-trigger-{lf_version}.dar) $$TMP_DIR/daml-trigger.dar
+      cp -L $(location //daml-script/daml:daml-script-{lf_version}.dar) $$TMP_DIR/daml-script.dar
       cp -L $(location :daml/Interface.daml) $$TMP_DIR/daml
       cp -L $(location :daml/InterfaceTriggers.daml) $$TMP_DIR/daml
       cat << EOF > $$TMP_DIR/daml.yaml
@@ -103,119 +100,121 @@ dependencies:
   - daml-prim
   - daml-trigger.dar
   - daml-script.dar
+build-options: [--target={lf_version}]
 EOF
-      test -z "{lf_version}" || echo "build-options: [--target={lf_version}]" >> $$TMP_DIR/daml.yaml
-      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location acs{suffix}.dar)
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location acs-{major}.dar)
       rm -rf $$TMP_DIR
     """.format(
-                lf_version = lf_version,
-                sdk = sdk_version,
-                suffix = suffix,
-            ),
-            tools = ["//compiler/damlc"],
-            visibility = ["//visibility:public"],
+            lf_version = lf_version_latest.get(major),
+            major = major,
+            sdk = sdk_version,
         ),
-        da_scala_test_suite(
-            name = "trigger-integration-tests" + suffix,
-            srcs = [
-                "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/%s.scala" % f
-                for f in [
-                    "FuncTestsStaticTime",
-                    "FuncTestsWallClock",
-                    "Jwt",
-                    "Tls",
-                    "RunnerSpec",
-                    "UnfoldStateSpec",
-                    "ConfigSpec",
-                    "InterfaceSpec",
-                ]
-            ],
-            data = [
-                ":acs%s.dar" % suffix,
-            ],
-            resources = ["//triggers/runner:src/main/resources/logback.xml"],
-            scala_deps = [
-                "@maven//:com_typesafe_akka_akka_stream",
-                "@maven//:org_scalacheck_scalacheck",
-                "@maven//:org_scalatestplus_scalacheck_1_15",
-                "@maven//:org_scalaz_scalaz_core",
-            ],
-            tags = ["cpu:4"] + (["dev-canton-test"] if lf_version else []),
-            deps = [
-                ":test-utils",
-                "//bazel_tools/runfiles:scala_runfiles",
-                "//daml-lf/archive:daml_lf_archive_reader",
-                "//daml-lf/data",
-                "//daml-lf/engine",
-                "//daml-lf/interpreter",
-                "//daml-lf/language",
-                "//language-support/scala/bindings",
-                "//language-support/scala/bindings-akka",
-                "//ledger-api/rs-grpc-bridge",
-                "//ledger-api/testing-utils",
-                "//ledger/ledger-api-auth",
-                "//ledger/ledger-api-common",
-                "//libs-scala/caching",
-                "//libs-scala/contextualized-logging",
-                "//libs-scala/ledger-resources",
-                "//libs-scala/logging-entries",
-                "//libs-scala/ports",
-                "//libs-scala/resources",
-                "//libs-scala/scalatest-utils",
-                "//observability/tracing",
-                "//test-common",
-                "//test-common/canton/it-lib",
-                "//triggers/runner:trigger-runner-lib",
-            ],
-        ),
-        da_scala_test_suite(
-            name = "trigger-failure-integration-tests" + suffix,
-            timeout = "long",
-            srcs = [
-                "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/LoadTesting.scala",
-            ],
-            data = [
-                ":acs%s.dar" % suffix,
-            ],
-            resources = ["//triggers/runner:src/main/resources/logback.xml"],
-            scala_deps = [
-                "@maven//:com_typesafe_akka_akka_stream",
-                "@maven//:org_scalacheck_scalacheck",
-                "@maven//:org_scalatestplus_scalacheck_1_15",
-                "@maven//:org_scalaz_scalaz_core",
-            ],
-            tags = ["exclusive"],
-            deps = [
-                ":test-utils",
-                "//bazel_tools/runfiles:scala_runfiles",
-                "//daml-lf/archive:daml_lf_archive_reader",
-                "//daml-lf/data",
-                "//daml-lf/engine",
-                "//daml-lf/interpreter",
-                "//daml-lf/language",
-                "//language-support/scala/bindings",
-                "//language-support/scala/bindings-akka",
-                "//ledger-api/rs-grpc-bridge",
-                "//ledger-api/testing-utils",
-                "//ledger/ledger-api-auth",
-                "//ledger/ledger-api-common",
-                "//libs-scala/caching",
-                "//libs-scala/contextualized-logging",
-                "//libs-scala/ledger-resources",
-                "//libs-scala/logging-entries",
-                "//libs-scala/ports",
-                "//libs-scala/resources",
-                "//libs-scala/scalatest-utils",
-                "//observability/tracing",
-                "//test-common",
-                "//test-common/canton/it-lib",
-                "//triggers/runner:trigger-runner-lib",
-            ],
-        ),
-    ]
-    for lf_version in DAML_LF_VERSIONS
-    for suffix in [("-" + lf_version) if lf_version else ""]
+        tools = ["//compiler/damlc"],
+        visibility = ["//visibility:public"],
+    )
+    for major in LF_MAJOR_VERSIONS
 ]
+
+da_scala_test_suite(
+    name = "trigger-integration-tests",
+    srcs = [
+        "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/%s.scala" % f
+        for f in [
+            "FuncTestsStaticTime",
+            "FuncTestsWallClock",
+            "Jwt",
+            "Tls",
+            "RunnerSpec",
+            "UnfoldStateSpec",
+            "ConfigSpec",
+            "InterfaceSpec",
+        ]
+    ],
+    data = [
+        ":acs-%s.dar" % major
+        for major in LF_MAJOR_VERSIONS
+    ],
+    resources = ["//triggers/runner:src/main/resources/logback.xml"],
+    scala_deps = [
+        "@maven//:com_typesafe_akka_akka_stream",
+        "@maven//:org_scalacheck_scalacheck",
+        "@maven//:org_scalatestplus_scalacheck_1_15",
+        "@maven//:org_scalaz_scalaz_core",
+    ],
+    tags = ["cpu:4"],
+    deps = [
+        ":test-utils",
+        "//bazel_tools/runfiles:scala_runfiles",
+        "//daml-lf/archive:daml_lf_archive_reader",
+        "//daml-lf/data",
+        "//daml-lf/engine",
+        "//daml-lf/interpreter",
+        "//daml-lf/language",
+        "//language-support/scala/bindings",
+        "//language-support/scala/bindings-akka",
+        "//ledger-api/rs-grpc-bridge",
+        "//ledger-api/testing-utils",
+        "//ledger/ledger-api-auth",
+        "//ledger/ledger-api-common",
+        "//libs-scala/caching",
+        "//libs-scala/contextualized-logging",
+        "//libs-scala/ledger-resources",
+        "//libs-scala/logging-entries",
+        "//libs-scala/ports",
+        "//libs-scala/resources",
+        "//libs-scala/scalatest-utils",
+        "//observability/tracing",
+        "//test-common",
+        "//test-common/canton/it-lib",
+        "//triggers/runner:trigger-runner-lib",
+    ],
+)
+
+da_scala_test_suite(
+    name = "trigger-failure-integration-tests",
+    timeout = "long",
+    srcs = [
+        "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/LoadTesting.scala",
+    ],
+    data = [
+        ":acs-%s.dar" % major
+        for major in LF_MAJOR_VERSIONS
+    ],
+    resources = ["//triggers/runner:src/main/resources/logback.xml"],
+    scala_deps = [
+        "@maven//:com_typesafe_akka_akka_stream",
+        "@maven//:org_scalacheck_scalacheck",
+        "@maven//:org_scalatestplus_scalacheck_1_15",
+        "@maven//:org_scalaz_scalaz_core",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        ":test-utils",
+        "//bazel_tools/runfiles:scala_runfiles",
+        "//daml-lf/archive:daml_lf_archive_reader",
+        "//daml-lf/data",
+        "//daml-lf/engine",
+        "//daml-lf/interpreter",
+        "//daml-lf/language",
+        "//language-support/scala/bindings",
+        "//language-support/scala/bindings-akka",
+        "//ledger-api/rs-grpc-bridge",
+        "//ledger-api/testing-utils",
+        "//ledger/ledger-api-auth",
+        "//ledger/ledger-api-common",
+        "//libs-scala/caching",
+        "//libs-scala/contextualized-logging",
+        "//libs-scala/ledger-resources",
+        "//libs-scala/logging-entries",
+        "//libs-scala/ports",
+        "//libs-scala/resources",
+        "//libs-scala/scalatest-utils",
+        "//observability/tracing",
+        "//test-common",
+        "//test-common/canton/it-lib",
+        "//triggers/runner:trigger-runner-lib",
+    ],
+)
 
 da_scala_library(
     name = "trigger-simulation-lib",
@@ -265,7 +264,8 @@ da_scala_test_suite(
     timeout = "long",
     srcs = glob(["src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/*Test.scala"]),
     data = [
-        ":acs.dar",
+        ":acs-%s.dar" % major
+        for major in LF_MAJOR_VERSIONS
     ],
     resources = ["//triggers/runner:src/main/resources/logback.xml"],
     scala_deps = [
@@ -312,7 +312,8 @@ da_scala_test_suite(
     timeout = "eternal",
     srcs = ["src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/CatAndFoodTriggerSimulation.scala"],
     data = [
-        ":acs.dar",
+        ":acs-%s.dar" % major
+        for major in LF_MAJOR_VERSIONS
     ],
     resources = ["//triggers/runner:src/main/resources/logback.xml"],
     scala_deps = [

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/CatAndFoodTriggerSimulation.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/CatAndFoodTriggerSimulation.scala
@@ -12,6 +12,7 @@ import com.daml.lf.engine.trigger.simulation.TriggerMultiProcessSimulation.Trigg
 import com.daml.lf.engine.trigger.simulation.process.ledger.{LedgerExternalAction, LedgerProcess}
 import com.daml.lf.engine.trigger.simulation.process.TriggerProcessFactory
 import com.daml.lf.engine.trigger.test.AbstractTriggerTest
+import com.daml.lf.language.LanguageMajorVersion
 import com.daml.lf.speedy.SValue
 import org.scalacheck.Gen
 import scalaz.syntax.tag._
@@ -19,7 +20,10 @@ import scalaz.syntax.tag._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class CatAndFoodTriggerSimulation
+class CatAndFoodTriggerSimulationV1 extends CatAndFoodTriggerSimulation(LanguageMajorVersion.V1)
+class CatAndFoodTriggerSimulationV2 extends CatAndFoodTriggerSimulation(LanguageMajorVersion.V2)
+
+class CatAndFoodTriggerSimulation(override val majorLanguageVersion: LanguageMajorVersion)
     extends TriggerMultiProcessSimulation
     with CatTriggerResourceUsageTestGenerators {
 

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/CatTriggerResourceUsageTest.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/CatTriggerResourceUsageTest.scala
@@ -9,6 +9,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import com.daml.lf.data.Ref.QualifiedName
 import com.daml.lf.engine.trigger.test.AbstractTriggerTest
+import com.daml.lf.language.LanguageMajorVersion
 import com.daml.lf.speedy.SValue
 import org.scalatest.{Inside, TryValues}
 import org.scalatest.matchers.should.Matchers
@@ -17,7 +18,10 @@ import scalaz.syntax.tag._
 
 import scala.concurrent.ExecutionContext
 
-class CatTriggerResourceUsageTest
+class CatTriggerResourceUsageTestV1 extends CatTriggerResourceUsageTest(LanguageMajorVersion.V1)
+class CatTriggerResourceUsageTestV2 extends CatTriggerResourceUsageTest(LanguageMajorVersion.V2)
+
+class CatTriggerResourceUsageTest(override val majorLanguageVersion: LanguageMajorVersion)
     extends AsyncWordSpec
     with AbstractTriggerTest
     with Matchers

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/TriggerMultiProcessSimulation.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/TriggerMultiProcessSimulation.scala
@@ -12,7 +12,6 @@ import com.daml.lf.engine.trigger.simulation.process.TriggerProcessFactory
 import com.daml.lf.engine.trigger.simulation.process.ledger.LedgerProcess
 import com.daml.lf.engine.trigger.test.AbstractTriggerTest
 import com.daml.lf.engine.trigger.test.AbstractTriggerTest.allocateParty
-import com.daml.lf.language.LanguageMajorVersion
 import com.daml.lf.speedy.{SValue, Speedy}
 import com.daml.lf.testing.parser
 import com.daml.lf.testing.parser.parseExpr
@@ -138,9 +137,8 @@ abstract class TriggerMultiProcessSimulation extends AsyncWordSpec with Abstract
   }
 
   protected def safeSValueFromLf(lfValue: String): Either[String, SValue] = {
-    // TODO(#17366): support both LF v1 and v2 in triggers
     val parserParameters: parser.ParserParameters[this.type] =
-      parser.ParserParameters.defaultFor(LanguageMajorVersion.V1).copy(defaultPackageId = packageId)
+      parser.ParserParameters.defaultFor(majorLanguageVersion).copy(defaultPackageId = packageId)
 
     parseExpr(lfValue)(parserParameters).flatMap(expr =>
       Speedy.Machine

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/TriggerRuleSimulationLibTest.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/simulation/TriggerRuleSimulationLibTest.scala
@@ -13,6 +13,7 @@ import com.daml.lf.engine.trigger.Runner.{
   numberOfPendingContracts,
 }
 import com.daml.lf.engine.trigger.test.AbstractTriggerTest
+import com.daml.lf.language.LanguageMajorVersion
 import com.daml.lf.speedy.SValue
 import org.scalacheck.Gen
 import org.scalatest.{Inside, TryValues}
@@ -22,7 +23,10 @@ import scalaz.syntax.tag._
 
 import java.util.UUID
 
-class TriggerRuleSimulationLibTest
+class TriggerRuleSimulationLibTestV1 extends TriggerRuleSimulationLibTest(LanguageMajorVersion.V1)
+class TriggerRuleSimulationLibTestV2 extends TriggerRuleSimulationLibTest(LanguageMajorVersion.V2)
+
+class TriggerRuleSimulationLibTest(override val majorLanguageVersion: LanguageMajorVersion)
     extends AsyncWordSpec
     with AbstractTriggerTest
     with Matchers

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
@@ -36,19 +36,18 @@ import scalaz.syntax.tag._
 import java.nio.file.Path
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
 
 trait AbstractTriggerTest extends CantonFixture {
   self: Suite =>
 
-  protected lazy val darFile: Either[Path, Path] =
-    Try(BazelRunfiles.requiredResource("triggers/tests/acs.dar").toPath) match {
-      case Success(value) => Right(value)
-      case Failure(_) => Left(BazelRunfiles.requiredResource("triggers/tests/acs-1.dev.dar").toPath)
-    }
+  protected val majorLanguageVersion: LanguageMajorVersion
 
-  override protected lazy val darFiles: List[Path] = List(darFile.merge)
-  override protected lazy val devMode: Boolean = darFile.isLeft
+  protected lazy val darFile: Path =
+    BazelRunfiles.requiredResource(s"triggers/tests/acs-${majorLanguageVersion.pretty}.dar").toPath
+
+  override protected lazy val darFiles: List[Path] = List(darFile)
+  // TODO(#17366): remove once 2.0 is introduced
+  override protected lazy val devMode: Boolean = (majorLanguageVersion == LanguageMajorVersion.V2)
 
   implicit override protected lazy val applicationId: ApplicationId =
     RunnerConfig.DefaultApplicationId
@@ -80,8 +79,7 @@ trait AbstractTriggerTest extends CantonFixture {
   protected def triggerRunnerConfiguration: TriggerRunnerConfig = DefaultTriggerRunnerConfig
 
   protected val CompiledDar(packageId, compiledPackages) = {
-    // TODO(#17366): support both LF v1 and v2 in triggers
-    CompiledDar.read(darFile.merge, speedy.Compiler.Config.Dev(LanguageMajorVersion.V1))
+    CompiledDar.read(darFile, speedy.Compiler.Config.Dev(majorLanguageVersion))
   }
 
   protected def getRunner(

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/CompiledDar.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/CompiledDar.scala
@@ -7,7 +7,6 @@ package trigger
 package test
 
 import com.daml.lf.data.Ref
-import com.daml.lf.language.LanguageMajorVersion
 
 import java.nio.file.Path
 
@@ -19,8 +18,7 @@ final case class CompiledDar(
 object CompiledDar {
   def read(
       path: Path,
-      // TODO(#17366): support both LF v1 and v2 in triggers
-      compilerConfig: speedy.Compiler.Config = speedy.Compiler.Config.Dev(LanguageMajorVersion.V1),
+      compilerConfig: speedy.Compiler.Config,
   ): CompiledDar = {
     val dar = archive.DarDecoder.assertReadArchiveFromFile(path.toFile)
     val pkgs = PureCompiledPackages.assertBuild(dar.all.toMap, compilerConfig)

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsStaticTime.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsStaticTime.scala
@@ -3,9 +3,14 @@
 
 package com.daml.lf.engine.trigger.test
 
+import com.daml.lf.language.LanguageMajorVersion
 import com.daml.platform.services.time.TimeProviderType
 
-final class FuncTestsStaticTime extends AbstractFuncTests {
+class FuncTestsStaticTimeV1 extends FuncTestsStaticTime(LanguageMajorVersion.V1)
+class FuncTestsStaticTimeV2 extends FuncTestsStaticTime(LanguageMajorVersion.V2)
+
+class FuncTestsStaticTime(override val majorLanguageVersion: LanguageMajorVersion)
+    extends AbstractFuncTests {
 
   final override protected lazy val timeProviderType: TimeProviderType = TimeProviderType.Static
 

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsWallClock.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsWallClock.scala
@@ -3,9 +3,14 @@
 
 package com.daml.lf.engine.trigger.test
 
+import com.daml.lf.language.LanguageMajorVersion
 import com.daml.platform.services.time.TimeProviderType
 
-final class FuncTestsWallClock extends AbstractFuncTests {
+class FuncTestsWallClockV1 extends FuncTestsWallClock(LanguageMajorVersion.V1)
+class FuncTestsWallClockV2 extends FuncTestsWallClock(LanguageMajorVersion.V2)
+
+class FuncTestsWallClock(override val majorLanguageVersion: LanguageMajorVersion)
+    extends AbstractFuncTests {
 
   final override protected lazy val timeProviderType: TimeProviderType = TimeProviderType.WallClock
 

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/InterfaceSpec.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/InterfaceSpec.scala
@@ -15,12 +15,16 @@ import org.scalatest._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 import com.daml.lf.engine.trigger.TriggerMsg
+import com.daml.lf.language.LanguageMajorVersion
 import com.daml.util.Ctx
 import scalaz.syntax.tag._
 
 import scala.collection.concurrent.TrieMap
 
-class InterfaceSpec
+class InterfaceSpecV1 extends InterfaceSpec(LanguageMajorVersion.V1)
+class InterfaceSpecV2 extends InterfaceSpec(LanguageMajorVersion.V2)
+
+class InterfaceSpec(override val majorLanguageVersion: LanguageMajorVersion)
     extends AsyncWordSpec
     with AbstractTriggerTest
     with Matchers

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Jwt.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Jwt.scala
@@ -12,12 +12,20 @@ import com.daml.ledger.api.v1.{value => LedgerApi}
 import com.daml.lf.data.Ref._
 import com.daml.lf.engine.trigger.Runner.TriggerContext
 import com.daml.lf.engine.trigger.TriggerMsg
+import com.daml.lf.language.LanguageMajorVersion
 import org.scalatest._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 import scalaz.syntax.tag._
 
-class Jwt extends AsyncWordSpec with AbstractTriggerTest with Matchers with TryValues {
+class JwtV1 extends Jwt(LanguageMajorVersion.V1)
+class JwtV2 extends Jwt(LanguageMajorVersion.V2)
+
+class Jwt(override val majorLanguageVersion: LanguageMajorVersion)
+    extends AsyncWordSpec
+    with AbstractTriggerTest
+    with Matchers
+    with TryValues {
 
   import AbstractTriggerTest._
 

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/LoadTesting.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/LoadTesting.scala
@@ -19,6 +19,7 @@ import com.daml.lf.engine.trigger.{
   TriggerRuleEvaluationTimeout,
   TriggerRunnerConfig,
 }
+import com.daml.lf.language.LanguageMajorVersion
 import com.daml.util.Ctx
 import org.scalatest.{Inside, TryValues}
 import org.scalatest.matchers.should.Matchers
@@ -78,7 +79,10 @@ abstract class LoadTesting
   }
 }
 
-final class BaseLoadTesting extends LoadTesting {
+class BaseLoadTestingV1 extends BaseLoadTesting(LanguageMajorVersion.V1)
+class BaseLoadTestingV2 extends BaseLoadTesting(LanguageMajorVersion.V2)
+
+class BaseLoadTesting(override val majorLanguageVersion: LanguageMajorVersion) extends LoadTesting {
 
   import AbstractTriggerTest._
 
@@ -143,7 +147,11 @@ final class BaseLoadTesting extends LoadTesting {
   }
 }
 
-final class InFlightLoadTesting extends LoadTesting {
+class InFlightLoadTestingV1 extends InFlightLoadTesting(LanguageMajorVersion.V1)
+class InFlightLoadTestingV2 extends InFlightLoadTesting(LanguageMajorVersion.V2)
+
+class InFlightLoadTesting(override val majorLanguageVersion: LanguageMajorVersion)
+    extends LoadTesting {
 
   import AbstractTriggerTest._
 
@@ -191,7 +199,10 @@ final class InFlightLoadTesting extends LoadTesting {
   }
 }
 
-final class ACSLoadTesting extends LoadTesting {
+class ACSLoadTestingV1 extends ACSLoadTesting(LanguageMajorVersion.V1)
+class ACSLoadTestingV2 extends ACSLoadTesting(LanguageMajorVersion.V2)
+
+class ACSLoadTesting(override val majorLanguageVersion: LanguageMajorVersion) extends LoadTesting {
 
   import AbstractTriggerTest._
 
@@ -253,7 +264,13 @@ final class ACSLoadTesting extends LoadTesting {
   }
 }
 
-final class TriggerRuleEvaluationTimeoutTesting extends LoadTesting {
+class TriggerRuleEvaluationTimeoutTestingV1
+    extends TriggerRuleEvaluationTimeoutTesting(LanguageMajorVersion.V1)
+class TriggerRuleEvaluationTimeoutTestingV2
+    extends TriggerRuleEvaluationTimeoutTesting(LanguageMajorVersion.V2)
+
+class TriggerRuleEvaluationTimeoutTesting(override val majorLanguageVersion: LanguageMajorVersion)
+    extends LoadTesting {
 
   import AbstractTriggerTest._
 

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala
@@ -10,12 +10,20 @@ import com.daml.ledger.api.v1.{value => LedgerApi}
 import com.daml.lf.data.Ref._
 import com.daml.lf.engine.trigger.Runner.TriggerContext
 import com.daml.lf.engine.trigger.TriggerMsg
+import com.daml.lf.language.LanguageMajorVersion
 import org.scalatest._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 import scalaz.syntax.tag._
 
-class Tls extends AsyncWordSpec with AbstractTriggerTest with Matchers with TryValues {
+class TlsV1 extends Tls(LanguageMajorVersion.V1)
+class TlsV2 extends Tls(LanguageMajorVersion.V2)
+
+class Tls(override val majorLanguageVersion: LanguageMajorVersion)
+    extends AsyncWordSpec
+    with AbstractTriggerTest
+    with Matchers
+    with TryValues {
 
   import AbstractTriggerTest._
 


### PR DESCRIPTION
Context: https://github.com/digital-asset/daml/issues/17366

Reverts digital-asset/daml#17802 and fixes the failing oracle test that caused the initial revert by increasing the timeout of the trigger tests.

Note that the newly introduced V2 test will be temporarily disabled in https://github.com/digital-asset/daml/pull/17813, but I want to keep it enabled in this PR as a proof that it passes.