### PR TITLE
Make `TransactionFilter.toProto` public

### DIFF
--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/FiltersByParty.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/FiltersByParty.java
@@ -24,7 +24,7 @@ public final class FiltersByParty extends TransactionFilter {
   }
 
   @Override
-  TransactionFilterOuterClass.TransactionFilter toProto() {
+  public TransactionFilterOuterClass.TransactionFilter toProto() {
     HashMap<String, TransactionFilterOuterClass.Filters> partyToFilters =
         new HashMap<>(this.partyToFilters.size());
     for (Map.Entry<String, Filter> entry : this.partyToFilters.entrySet()) {

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/TransactionFilter.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/TransactionFilter.java
@@ -20,7 +20,7 @@ public abstract class TransactionFilter {
     return FiltersByParty.fromProto(transactionFilter);
   }
 
-  abstract TransactionFilterOuterClass.TransactionFilter toProto();
+  public abstract TransactionFilterOuterClass.TransactionFilter toProto();
 
   public abstract Set<String> getParties();
 


### PR DESCRIPTION
We are in the process of enabling the usage of the Java bindings from the Canton Console. In order to do so in a backward-compatible fashion, we often rely on existing Scala code and use the Protobuf representation as a bridge between the two. Unfortunately the fact that the `toProto` method on `TransactionFilter`s is package-private forced us to temporarily add a conversion method located within the package that re-exported it publicly for usage as part of the Canton Console. This change should enable us to remove this workaround. I would be happy to hear other possible approaches to consider.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
