### PR TITLE
Change default multi-package behaviour to search

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -935,9 +935,7 @@ execBuild projectOpts opts mbOutFile incrementalBuild initPkgDb enableMultiPacka
     relativize <- ContT $ withProjectRoot' (projectOpts {projectCheck = ProjectCheck "" False})
 
     let buildSingle :: PackageConfigFields -> IO ()
-        buildSingle pkgConfig = do
-          putStrLn $ "Running single package build of " <> T.unpack (LF.unPackageName $ pName pkgConfig) <> " as no multi-package.yaml was found."
-          void $ buildEffect relativize pkgConfig opts mbOutFile incrementalBuild initPkgDb
+        buildSingle pkgConfig = void $ buildEffect relativize pkgConfig opts mbOutFile incrementalBuild initPkgDb
         buildMulti :: Maybe PackageConfigFields -> ProjectPath -> IO ()
         buildMulti mPkgConfig multiPackageConfigPath = do
           putStrLn $ "Running multi-package build of "
@@ -968,7 +966,9 @@ execBuild projectOpts opts mbOutFile incrementalBuild initPkgDb enableMultiPacka
         (False, Just pkgConfig, Just multiPackagePath) -> buildMulti (Just pkgConfig) multiPackagePath
 
         -- We know the package we want but we do not have a multi-package. The user has provided no reason they would want a multi-package build.
-        (False, Just pkgConfig, Nothing) -> buildSingle pkgConfig
+        (False, Just pkgConfig, Nothing) -> do
+          putStrLn $ "Running single package build of " <> T.unpack (LF.unPackageName $ pName pkgConfig) <> " as no multi-package.yaml was found."
+          buildSingle pkgConfig
 
         -- We have no package context, but we have found a multi package at the current directory
         (False, Nothing, Just _) -> do

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -171,23 +171,16 @@ data MultiPackageLocation
   = MPLSearch
   -- | Expect the multi-package.yaml at the given path
   | MPLPath FilePath
-  -- | Expect the multi-package.yaml at the current directory
-  | MPLCurrent
   deriving (Show, Eq)
 
 multiPackageLocationOpt :: Parser MultiPackageLocation
 multiPackageLocationOpt =
-  flag' MPLSearch 
-      (  long "multi-package-search"
-      <> help "Allows daml build to search up the directory tree for a multi-package.yaml. Cannot be used with --multi-package-path"
-      <> internal
-      )
-    <|> optionOnce (MPLPath <$> str)
-      (  metavar "FILE"
-      <> help "Path to the multi-package.yaml file. Cannot be used with --multi-package-search"
-      <> long "multi-package-path"
-      <> value MPLCurrent
-      )
+  optionOnce (MPLPath <$> str)
+    (  metavar "FILE"
+    <> help "Path to the multi-package.yaml file"
+    <> long "multi-package-path"
+    <> value MPLSearch
+    )
 
 newtype MultiPackageCleanAll = MultiPackageCleanAll {getMultiPackageCleanAll :: Bool}
 multiPackageCleanAllOpt :: Parser MultiPackageCleanAll


### PR DESCRIPTION
Following some discussion with users, we've decided the cleanest interface to multi-package is to default to searching for the `multi-package.yaml`, and make it clear when build starts whether or not we found one.
