### PR TITLE
Disable v2 integration tests for now

### DIFF
--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/AuthIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/AuthIT.scala
@@ -17,7 +17,10 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 class AuthITV1 extends AuthIT(LanguageMajorVersion.V1)
-class AuthITV2 extends AuthIT(LanguageMajorVersion.V2)
+
+// TODO(https://github.com/digital-asset/daml/issues/17812): re-enable this test and control its run
+//  at the bazel target level.
+//class AuthITV2 extends AuthIT(LanguageMajorVersion.V2)
 
 class AuthIT(override val majorLanguageVersion: LanguageMajorVersion)
     extends AsyncWordSpec

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/DevIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/DevIT.scala
@@ -8,7 +8,7 @@ import com.daml.bazeltools.BazelRunfiles
 import com.daml.lf.data.Ref._
 import com.daml.lf.engine.script.ScriptTimeMode
 import com.daml.lf.language.LanguageMajorVersion
-import com.daml.lf.language.LanguageMajorVersion.{V1, V2}
+import com.daml.lf.language.LanguageMajorVersion.V1
 import com.daml.lf.speedy.SValue._
 
 import java.nio.file.Paths

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/DevIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/DevIT.scala
@@ -19,7 +19,10 @@ import org.scalatest.wordspec.AsyncWordSpec
 // TODO(#17366): Once daml3-script diverges from script, V1DevIT and V2DevIT may not be able to
 //     share the same code anymore.
 class DevITV1 extends DevIT(V1)
-class DevITV2 extends DevIT(V2)
+
+// TODO(https://github.com/digital-asset/daml/issues/17812): re-enable this test and control its run
+//  at the bazel target level.
+//class DevITV2 extends DevIT(V2)
 
 class DevIT(override val majorLanguageVersion: LanguageMajorVersion)
     extends AsyncWordSpec

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/FuncStaticTimeIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/FuncStaticTimeIT.scala
@@ -10,7 +10,10 @@ import com.daml.lf.language.LanguageMajorVersion
 import com.daml.lf.speedy.SValue.SRecord
 
 class FuncStaticTimeITV1 extends FuncStaticTimeIT(LanguageMajorVersion.V1)
-class FuncStaticTimeITV2 extends FuncStaticTimeIT(LanguageMajorVersion.V2)
+
+// TODO(https://github.com/digital-asset/daml/issues/17812): re-enable this test and control its run
+//  at the bazel target level.
+//class FuncStaticTimeITV2 extends FuncStaticTimeIT(LanguageMajorVersion.V2)
 
 class FuncStaticTimeIT(override val majorLanguageVersion: LanguageMajorVersion)
     extends AbstractFuncIT {

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/FuncWallClockIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/FuncWallClockIT.scala
@@ -10,7 +10,10 @@ import com.daml.lf.language.LanguageMajorVersion
 import com.daml.lf.speedy.SValue.SRecord
 
 class FuncWallClockITV1 extends FuncWallClockIT(LanguageMajorVersion.V1)
-class FuncWallClockITV2 extends FuncWallClockIT(LanguageMajorVersion.V2)
+
+// TODO(https://github.com/digital-asset/daml/issues/17812): re-enable this test and control its run
+//  at the bazel target level.
+//class FuncWallClockITV2 extends FuncWallClockIT(LanguageMajorVersion.V2)
 
 class FuncWallClockIT(override val majorLanguageVersion: LanguageMajorVersion)
     extends AbstractFuncIT {

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/MultiParticipantIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/MultiParticipantIT.scala
@@ -14,7 +14,10 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
 class MultiParticipantITV1 extends MultiParticipantIT(LanguageMajorVersion.V1)
-class MultiParticipantITV2 extends MultiParticipantIT(LanguageMajorVersion.V2)
+
+// TODO(https://github.com/digital-asset/daml/issues/17812): re-enable this test and control its run
+//  at the bazel target level.
+//class MultiParticipantITV2 extends MultiParticipantIT(LanguageMajorVersion.V2)
 
 class MultiParticipantIT(override val majorLanguageVersion: LanguageMajorVersion)
     extends AsyncWordSpec

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TlsIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TlsIT.scala
@@ -11,7 +11,10 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
 class TlsITV1 extends TlsIT(LanguageMajorVersion.V1)
-class TlsITV2 extends TlsIT(LanguageMajorVersion.V2)
+
+// TODO(https://github.com/digital-asset/daml/issues/17812): re-enable this test and control its run
+//  at the bazel target level.
+//class TlsITV2 extends TlsIT(LanguageMajorVersion.V2)
 
 class TlsIT(override val majorLanguageVersion: LanguageMajorVersion)
     extends AsyncWordSpec

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestAuthWithOracle.scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestAuthWithOracle.scala
@@ -7,8 +7,11 @@ import com.daml.lf.language.LanguageMajorVersion
 
 class TriggerServiceTestAuthWithOracleV1
     extends TriggerServiceTestAuthWithOracle(LanguageMajorVersion.V1)
-class TriggerServiceTestAuthWithOracleV2
-    extends TriggerServiceTestAuthWithOracle(LanguageMajorVersion.V2)
+
+// TODO(https://github.com/digital-asset/daml/issues/17812): re-enable this test and control its run
+//  at the bazel target level.
+//class TriggerServiceTestAuthWithOracleV2
+//    extends TriggerServiceTestAuthWithOracle(LanguageMajorVersion.V2)
 
 class TriggerServiceTestAuthWithOracle(override val majorLanguageVersion: LanguageMajorVersion)
     extends AbstractTriggerServiceTest
@@ -19,8 +22,11 @@ class TriggerServiceTestAuthWithOracle(override val majorLanguageVersion: Langua
 
 class TriggerServiceTestAuthWithOracleClaimsV1
     extends TriggerServiceTestAuthWithOracleClaims(LanguageMajorVersion.V1)
-class TriggerServiceTestAuthWithOracleClaimsV2
-    extends TriggerServiceTestAuthWithOracleClaims(LanguageMajorVersion.V2)
+
+// TODO(https://github.com/digital-asset/daml/issues/17812): re-enable this test and control its run
+//  at the bazel target level.
+//class TriggerServiceTestAuthWithOracleClaimsV2
+//    extends TriggerServiceTestAuthWithOracleClaims(LanguageMajorVersion.V2)
 
 class TriggerServiceTestAuthWithOracleClaims(
     override val majorLanguageVersion: LanguageMajorVersion

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestAuthWithPostgres.Scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestAuthWithPostgres.Scala
@@ -6,7 +6,10 @@ package com.daml.lf.engine.trigger
 import com.daml.lf.language.LanguageMajorVersion
 
 class TriggerServiceTestAuthWithPostgresV1 extends TriggerServiceTestAuthWithPostgres(LanguageMajorVersion.V1)
-class TriggerServiceTestAuthWithPostgresV2 extends TriggerServiceTestAuthWithPostgres(LanguageMajorVersion.V2)
+
+// TODO(https://github.com/digital-asset/daml/issues/17812): re-enable this test and control its run
+//  at the bazel target level.
+//class TriggerServiceTestAuthWithPostgresV2 extends TriggerServiceTestAuthWithPostgres(LanguageMajorVersion.V2)
 
 class TriggerServiceTestAuthWithPostgres(override val majorLanguageVersion: LanguageMajorVersion)
     extends AbstractTriggerServiceTest

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestWithOracle.scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestWithOracle.scala
@@ -6,7 +6,10 @@ package com.daml.lf.engine.trigger
 import com.daml.lf.language.LanguageMajorVersion
 
 class TriggerServiceTestWithOracleV1 extends TriggerServiceTestWithOracle(LanguageMajorVersion.V1)
-class TriggerServiceTestWithOracleV2 extends TriggerServiceTestWithOracle(LanguageMajorVersion.V2)
+
+// TODO(https://github.com/digital-asset/daml/issues/17812): re-enable this test and control its run
+//  at the bazel target level.
+//class TriggerServiceTestWithOracleV2 extends TriggerServiceTestWithOracle(LanguageMajorVersion.V2)
 
 class TriggerServiceTestWithOracle(override val majorLanguageVersion: LanguageMajorVersion)
     extends AbstractTriggerServiceTest

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestWithPostgres.scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestWithPostgres.scala
@@ -7,8 +7,11 @@ import com.daml.lf.language.LanguageMajorVersion
 
 class TriggerServiceTestWithPostgresV1
     extends TriggerServiceTestWithPostgres(LanguageMajorVersion.V1)
-class TriggerServiceTestWithPostgresV2
-    extends TriggerServiceTestWithPostgres(LanguageMajorVersion.V2)
+
+// TODO(https://github.com/digital-asset/daml/issues/17812): re-enable this test and control its run
+//  at the bazel target level.
+//class TriggerServiceTestWithPostgresV2
+//    extends TriggerServiceTestWithPostgres(LanguageMajorVersion.V2)
 
 class TriggerServiceTestWithPostgres(override val majorLanguageVersion: LanguageMajorVersion)
     extends AbstractTriggerServiceTest


### PR DESCRIPTION
Disable LF v2 integration tests for now. Context: https://github.com/digital-asset/daml/issues/17812.

The base is  pb/l2r-only-in-lf2 for now but will revert to main once https://github.com/digital-asset/daml/pull/17811 is merged. Would appreciate a review already.