### PR TITLE
Warn on import of internal daml-script module

### DIFF
--- a/compiler/damlc/daml-preprocessor/BUILD.bazel
+++ b/compiler/damlc/daml-preprocessor/BUILD.bazel
@@ -23,6 +23,7 @@ da_haskell_library(
         "mtl",
         "recursion-schemes",
         "safe",
+        "split",
         "text",
         "uniplate",
     ],

--- a/compiler/damlc/tests/daml-test-files/Daml3ScriptTrySubmitConcurrently.daml
+++ b/compiler/damlc/tests/daml-test-files/Daml3ScriptTrySubmitConcurrently.daml
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @ SCRIPT-V2
+-- @ WARN range=18:1-18:69; Import of internal module Daml.Script.Questions.Submit.Internal of package daml3-script is discouraged, as this module will change without warning.
 
 {-# LANGUAGE ApplicativeDo #-}
 

--- a/compiler/damlc/tests/daml-test-files/DamlScriptInternalWarning.daml
+++ b/compiler/damlc/tests/daml-test-files/DamlScriptInternalWarning.daml
@@ -1,0 +1,11 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @WARN range=10:1-10:31; Import of internal module Daml.Script.Internal of package daml3-script is discouraged, as this module will change without warning.
+-- @WARN range=11:1-11:49; Import of internal module Daml.Script.Questions.Testing.Internal of package daml3-script is discouraged, as this module will change without warning.
+
+module DamlScriptInternalWarning where
+
+import Daml.Script ()
+import Daml.Script.Internal ()
+import Daml.Script.Questions.Testing.Internal ()

--- a/compiler/damlc/tests/daml-test-files/DamlScriptInternalWarning.daml
+++ b/compiler/damlc/tests/daml-test-files/DamlScriptInternalWarning.daml
@@ -1,8 +1,10 @@
 -- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @WARN range=10:1-10:31; Import of internal module Daml.Script.Internal of package daml3-script is discouraged, as this module will change without warning.
--- @WARN range=11:1-11:49; Import of internal module Daml.Script.Questions.Testing.Internal of package daml3-script is discouraged, as this module will change without warning.
+-- @ SCRIPT-V2
+
+-- @ WARN range=12:1-12:31; Import of internal module Daml.Script.Internal of package daml3-script is discouraged, as this module will change without warning.
+-- @ WARN range=13:1-13:49; Import of internal module Daml.Script.Questions.Testing.Internal of package daml3-script is discouraged, as this module will change without warning.
 
 module DamlScriptInternalWarning where
 

--- a/compiler/damlc/tests/daml-test-files/TryCommands.daml
+++ b/compiler/damlc/tests/daml-test-files/TryCommands.daml
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @ SCRIPT-V2
+-- @ WARN range=12:1-12:46; Import of internal module Daml.Script.Questions.Testing.Internal of package daml3-script is discouraged, as this module will change without warning.
 
 {-# LANGUAGE ApplicativeDo #-}
 


### PR DESCRIPTION
Resolves #[17645](https://github.com/digital-asset/daml/issues/17645)
Allows for easily adding more packages with this warning. We may want to add Triggers, for example