### PR TITLE
Remove `unvalidated` damlc integration tests

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -169,17 +169,12 @@ da_haskell_library(
     da_haskell_test(
         # NOTE(MH): For some reason, ghc-pkg gets very unhappy if we separate
         # the components of the version number by dot, dash or underscore.
-        name = "integration{skip}-v{version}".format(
-            skip = "-unvalidated" if skip_validation else "",
-            version = version.replace(".", ""),
-        ),
+        name = "integration-v{}".format(version.replace(".", "")),
         size = "large",
         srcs = ["src/DA/Test/DamlcIntegrationMain.hs"],
         args = [
             "--daml-lf-version",
             version,
-            "--skip-validation",
-            "true" if skip_validation else "false",
             "--daml-script-v2",
             "false",
         ],
@@ -207,10 +202,7 @@ da_haskell_library(
     )
     # Test stable versions with validation
     # Test dev and default versions without validation
-    for version, skip_validation in (
-        [(version, False) for version in COMPILER_LF_VERSIONS] +
-        [(version, True) for version in [lf_version_configuration.get("default")] + LF_DEV_VERSIONS]
-    )
+    for version in COMPILER_LF_VERSIONS
 ]
 
 da_haskell_test(
@@ -220,8 +212,6 @@ da_haskell_test(
     args = [
         "--daml-lf-version",
         "2.dev",  # script2 only supports 2.x
-        "--skip-validation",
-        "false",
         "--daml-script-v2",
         "true",
     ],

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -6,7 +6,7 @@ load("@os_info//:os_info.bzl", "is_darwin", "is_windows")
 load(":util.bzl", "damlc_compile_test")
 load("//rules_daml:daml.bzl", "daml_build_test", "daml_compile", "daml_compile_with_dalf", "daml_test")
 load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
-load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS", "LF_DEV_VERSIONS", "LF_MAJOR_VERSIONS", "lf_version_configuration", "lf_version_latest")
+load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS", "LF_DEV_VERSIONS", "LF_MAJOR_VERSIONS", "lf_version_configuration", "lf_version_latest", "mangle_for_damlc")
 load("//compiler/damlc:util.bzl", "ghc_pkg")
 
 # Tests for the lax CLI parser
@@ -169,7 +169,7 @@ da_haskell_library(
     da_haskell_test(
         # NOTE(MH): For some reason, ghc-pkg gets very unhappy if we separate
         # the components of the version number by dot, dash or underscore.
-        name = "integration-v{}".format(version.replace(".", "")),
+        name = "integration-{}".format(mangle_for_damlc(version)),
         size = "large",
         srcs = ["src/DA/Test/DamlcIntegrationMain.hs"],
         args = [

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -200,8 +200,6 @@ da_haskell_library(
             ":integration-lib",
         ],
     )
-    # Test stable versions with validation
-    # Test dev and default versions without validation
     for version in COMPILER_LF_VERSIONS
 ]
 


### PR DESCRIPTION
This PR removes the tests `//compiler/damlc/tests:integration-unvalidated-v{115,1dev,2dev}` since they no longer provide any value. 

For context, these tests (modulo LF versions) were introduced as part of #7778. That PR was fixing a regression caused by #7740. #7740 was trying to improve the speed of struct projection (`EStructProj` in the AST) by adding a `fieldIndex: Option[Int]` property to `EStructProj` ***during LF type checking***. Then, the LF compiler would construct an `SBStructProj` using the `fieldIndex` value and crashing if it was `None`. The regression was that, since the scenario-service by default doesn't run the LF type checker for modules in the "current" (open in the IDE) package, any use of `EStructProj` (e.g. any use of type class instances) would crash the IDE. According to #7778, This was only found during release testing, and so to prevent similar bugs, the `-unvalidated-` integration tests were added, and the regression was fixed by reinstating the older projection builtin with a new name `SBStructProjByName` to be used when `fieldIndex == None`. 

However, with the perspective of time, I would argue that the deeper issue was not lack of testing of the non-typechecked codepath but rather the use of mutation in the typechecker to achieve the goal of #7740. If the validation step doesn't mutate the module being validated, the only difference we could possibly see between `unvalidated` and `validated` codepaths would be that some daml code might work if unvalidated but fail validation, while any daml code that passes validation should behave the same regardless of validation actually being performed or not. 

AFAICT, the LF typechecker does not currently perform any mutation on the package/module/expressions it checks, and thus **I argue for removing the `unvalidated` tests**. 

I could not think of any other difference that we might find with the `unvalidated` but not the `validated` tests. Of course, if you, dear reviewer, can think of one, I'd be happy to consider it.