### PR TITLE
no more bazel clean in build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -59,8 +59,6 @@ bazel shutdown
 # It isn’t clear where exactly those errors are coming from.
 bazel fetch @nodejs_dev_env//...
 
-bazel clean --expunge
-
 bazel build //... `
   `-`-profile build-profile.json `
   `-`-experimental_profile_include_target_label `


### PR DESCRIPTION
Now that me managed to build the repo once on windows with the new global cache key, we can stop running `bazel clean --expunge` at each invocation of the build script.