### PR TITLE
Multi-package CLI changes

### DIFF
--- a/compiler/damlc/daml-package-config/BUILD.bazel
+++ b/compiler/damlc/daml-package-config/BUILD.bazel
@@ -21,6 +21,7 @@ da_haskell_library(
         "regex-tdfa",
         "safe-exceptions",
         "text",
+        "transformers",
         "yaml",
     ],
     src_strip_prefix = "src",

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -421,6 +421,7 @@ cmdTest numProcessors =
       <*> fmap TransactionsOutputPath transactionsOutputPathOpt
       <*> coveragePathsOpt
       <*> many coverageFilterSkipOpt
+      <* strOptionOnce @String (internal <> short 'o' <> long "output" <> value "") -- We use build-options in daml test, but we need to ignore --output.
     filesOpt = optional (flag' () (long "files" <> help filesDoc) *> many inputFileOpt)
     filesDoc = "Only run test declarations in the specified files."
     junitOutput = optional $ strOptionOnce $ long "junit" <> metavar "FILENAME" <> help "Filename of JUnit output file"

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -9,21 +9,26 @@ load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
 load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS", "LF_DEV_VERSIONS", "LF_MAJOR_VERSIONS", "lf_version_configuration", "lf_version_latest")
 load("//compiler/damlc:util.bzl", "ghc_pkg")
 
-# Tests for the lax CLI parser
+# Tests for the lax CLI parser + damlc CLI parser
 da_haskell_test(
     name = "damlc-cliparser",
     srcs = ["src/CliParser.hs"],
     hackage_deps = [
-        "tasty",
         "base",
+        "directory",
+        "extra",
         "optparse-applicative",
+        "silently",
         "tasty-hunit",
+        "tasty",
+        "text",
     ],
     main_function = "Cli.main",
     src_strip_prefix = "tests",
     visibility = ["//visibility:private"],
     deps = [
         "//compiler/damlc:damlc-lib",
+        "//libs-haskell/da-hs-base",
     ],
 )
 

--- a/compiler/damlc/tests/src/CliParser.hs
+++ b/compiler/damlc/tests/src/CliParser.hs
@@ -5,12 +5,20 @@ module Cli
     ( main
     ) where
 
+import Control.Exception (SomeException, try)
+import qualified DA.Cli.Args as ParseArgs
+import DA.Cli.Damlc (Command (..), fullParseArgs)
+import Data.Either (isRight)
+import Data.List (isInfixOf)
+import qualified Data.Text as T
+import qualified Data.Text.Extended as T
 import Options.Applicative
+import System.Directory (getCurrentDirectory, withCurrentDirectory)
 import System.Environment.Blank
+import System.IO.Extra (stderr, stdout, withTempDir)
+import System.IO.Silently (hCapture)
 import Test.Tasty
 import Test.Tasty.HUnit
-
-import qualified DA.Cli.Args as ParseArgs
 
 main :: IO ()
 main = do
@@ -24,6 +32,10 @@ tests = testGroup
     , testCase "Bad flags in strict mode" $ parseFails ["ide", "--badFlag"]
     , testCase "Good flags in lax mode" $ parseSucceeds ["lax", "ide"]
     , testCase "Bad flags in lax mode" $ parseSucceeds ["lax", "ide", "--badFlag"]
+    , testCase "Damlc correctly ignores build flags in build-options when running daml test" $ assertDamlcParser ["test"] ["--output", "./myDar.dar"] Nothing
+    , testCase "Damlc correctly errors on build flags in daml test cli flags" $ assertDamlcParser ["test", "--output", "./myDar.dar"] [] (Just "Invalid option `--output'")
+    , testCase "Damlc correctly errors on test flags in build-options when running daml build" $ assertDamlcParser ["build"] ["--save-coverage", "./here"] (Just "Invalid option `--save-coverage'")
+    , testCase "Damlc correctly uses build-options flags in daml test if it can" $ assertDamlcParserRunIO ["test"] ["--debug"] "DEBUG"
     ]
 
 parse :: [String] -> Maybe ()
@@ -38,3 +50,54 @@ parseFails args = parse args @?= Nothing
 parserInfo :: ParserInfo ()
 parserInfo = info (subparser cmdIde) idm
    where cmdIde = command "ide" $ info (pure ()) idm
+
+withCurrentTempDir :: IO a -> IO a
+withCurrentTempDir = withTempDir . flip withCurrentDirectory
+
+-- Runs the damlc parser with a set of command line flags/options, and a set of daml.yaml flags/options
+-- Takes a maybe expected error infix
+assertDamlcParser :: [String] -> [String] -> Maybe String -> Assertion
+assertDamlcParser cliArgs damlYamlArgs mExpectedError = withCurrentTempDir $ do
+  (err, res) <- runDamlcParser cliArgs damlYamlArgs
+  case (isRight res, mExpectedError) of
+    (True, Nothing) -> pure ()
+    (False, Just expectedErr) | expectedErr `isInfixOf` err -> pure ()
+    (False, Just expectedErr) -> assertFailure $ "Computation failed correctly but was missing the expected error \"" <> expectedErr <> "\". Stderr was:\n" <> err
+    (True, Just _) -> assertFailure "Expected failure but got success"
+    (False, Nothing) -> assertFailure $ "Expected success but got failure:\n" <> err
+
+withDamlProject :: IO a -> IO a
+withDamlProject f = do
+  cwd <- getCurrentDirectory
+  setEnv "DAML_PROJECT" cwd True
+  res <- f
+  unsetEnv "DAML_PROJECT"
+  pure res
+
+-- Run the damlc parser with a set of command line flags/options, and a set of daml.yaml flags/options
+-- Run the resulting computation and assert a given string is part of stdout+stderr
+assertDamlcParserRunIO :: [String] -> [String] -> String -> Assertion
+assertDamlcParserRunIO cliArgs damlYamlArgs expectedOutput = withCurrentTempDir $ do
+  (err, res) <- runDamlcParser cliArgs damlYamlArgs
+  case res of
+    Right (Command _ _ io) -> do
+      -- We don't care if the computation succeeds or fails here (it will fail, because we havent installed the sdk fully.)
+      -- We're only testing flag behaviour that is discoverable before compilation happens
+      (out, _) <- hCapture [stdout, stderr] $ try @SomeException $ withDamlProject io
+      assertBool ("Expected " <> expectedOutput <> " in stdout/stderr, but didn't find") $ expectedOutput `isInfixOf` out
+    Left _ -> assertFailure $ "Expected parse to succeed but got " <> err
+
+runDamlcParser :: [String] -> [String] -> IO (String, Either SomeException Command)
+runDamlcParser cliArgs damlYamlArgs = do
+  T.writeFileUtf8 "./daml.yaml" $ T.unlines $
+    [ "sdk-version: 0.0.0" -- Fixed version as the parser doesn't care for its value.
+    , "name: test"
+    , "source: daml"
+    , "version: 0.0.1"
+    , "dependencies:"
+    , "  - daml-prim"
+    , "  - daml-stdlib"
+    , "build-options:"
+    ] <> fmap (("  - " <>) . T.pack) damlYamlArgs
+
+  hCapture [stderr] $ try @SomeException $ fullParseArgs 1 cliArgs


### PR DESCRIPTION
Allows for cycles in multi-package.yaml `project` definitions
Fixes `daml test` when `build-options:` contains `--output`. Achieved by using the build cmd parser as a backup to any command that uses the daml.yaml build options. This further enforces that `build-options:` defines additional options for `daml build` first and foremost, and other commands are free to use any subset of those options themselves.
`build-options` cannot contain an option that is unrecognised to `daml build`.