### PR TITLE
Java codegen: better naming hygiene

### DIFF
--- a/language-support/java/codegen/src/it/daml/Tests/Escape.daml
+++ b/language-support/java/codegen/src/it/daml/Tests/Escape.daml
@@ -29,7 +29,13 @@ data EscapeVariants abstract new = New new
                                  | VarRecord with abstract : abstract; new : new
   deriving (Eq, Show)
 
-data FieldVsPackage = FieldVsPackage with tests: ()
+
+data FieldVsPackage = FieldVsPackage
+    with
+        -- The field name is the same as the (lowercased) package name of the field type.
+        -- Ensure that generated Java does not get confused by "obscuring".
+        -- https://docs.oracle.com/javase/specs/jls/se7/html/jls-6.html#jls-6.4.2
+        tests: EscapeRecords () () ()
   deriving (Eq, Show)
 
 --------------------

--- a/language-support/java/codegen/src/it/daml/Tests/Escape.daml
+++ b/language-support/java/codegen/src/it/daml/Tests/Escape.daml
@@ -16,6 +16,7 @@ data EscapeRecords int void synchronized = EscapeRecords
         int : int
         void : void
         synchronized : synchronized
+  deriving (Eq, Show)
 
 --------------------
 -- Variants
@@ -26,6 +27,10 @@ data EscapeRecords int void synchronized = EscapeRecords
 data EscapeVariants abstract new = New new
                                  | Abstract abstract
                                  | VarRecord with abstract : abstract; new : new
+  deriving (Eq, Show)
+
+data FieldVsPackage = FieldVsPackage with tests: ()
+  deriving (Eq, Show)
 
 --------------------
 -- Templates
@@ -36,6 +41,9 @@ template EscapeTemplates
     with
         int : Int
         owner : Party
+        r : EscapeRecords () () ()
+        v : EscapeVariants () ()
+        p : FieldVsPackage
     where
         signatory owner
 

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromJsonGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromJsonGenerator.scala
@@ -232,7 +232,7 @@ private[inner] object FromJsonGenerator extends StrictLogging {
 
     damlType match {
       case TypeCon(TypeConName(ident), typeParams) =>
-        CodeBlock.of("$T.jsonDecoder($L)", guessClass(ident), typeReaders(typeParams))
+        CodeBlock.of("$L.jsonDecoder($L)", guessClass(ident).simpleName, typeReaders(typeParams))
       case TypePrim(PrimTypeBool, _) => CodeBlock.of("$T.bool", decodeClass)
       case TypePrim(PrimTypeInt64, _) => CodeBlock.of("$T.int64", decodeClass)
       case TypeNumeric(scale) => CodeBlock.of("$T.numeric($L)", decodeClass, scale)

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToJsonGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToJsonGenerator.scala
@@ -3,6 +3,7 @@
 
 package com.daml.lf.codegen.backend.java.inner
 
+import com.daml.lf.codegen.backend.java.JavaEscaper.escapeString
 import com.daml.ledger.javaapi.data.codegen.json.{JsonLfEncoder, JsonLfEncoders, JsonLfWriter}
 import com.daml.lf.typesig.Type
 import com.squareup.javapoet.{
@@ -136,7 +137,7 @@ private[inner] object ToJsonGenerator {
 
   // Argument names, used when calling method.
   private def jsonEncoderArgsForTypeParams(typeParams: IndexedSeq[String]) =
-    CodeBlock.join(typeParams.map(t => CodeBlock.of(makeEncoderParamName(t))).asJava, ",$W")
+    CodeBlock.join(typeParams.map(t => CodeBlock.of("$L", makeEncoderParamName(t))).asJava, ",$W")
 
   // ParameterSpec's, used when defining method.
   private def jsonEncoderParamsForTypeParams(
@@ -275,7 +276,7 @@ private[inner] object ToJsonGenerator {
           encoderOf(keyType, nesting + 1),
           encoderOf(valType, nesting + 1),
         )
-      case TypeVar(t) => CodeBlock.of(makeEncoderParamName(t))
+      case TypeVar(t) => CodeBlock.of("$L", makeEncoderParamName(escapeString(t)))
       case _ => throw new IllegalArgumentException(s"Invalid Daml datatype: $damlType")
     }
   }


### PR DESCRIPTION
* ensure we java-sanitise the names of type variables when building identifiers for JSON decoding and encoding these types
* avoid name clashes (obscuring) when the package-qualified name of a type begins with the same identifier as a field name