### PR TITLE
Refactor LF decoding in the compiler

### DIFF
--- a/compiler/daml-lf-proto-decode/BUILD.bazel
+++ b/compiler/daml-lf-proto-decode/BUILD.bazel
@@ -9,6 +9,7 @@ da_haskell_library(
         "src/DA/Daml/LF/Proto3/Archive/Decode.hs",
         "src/DA/Daml/LF/Proto3/Decode.hs",
         "src/DA/Daml/LF/Proto3/DecodeV1.hs",
+        "src/DA/Daml/LF/Proto3/DecodeV2.hs",
     ],
     hackage_deps = [
         "base",

--- a/compiler/daml-lf-proto-decode/daml-lf-proto-decode.cabal
+++ b/compiler/daml-lf-proto-decode/daml-lf-proto-decode.cabal
@@ -55,6 +55,7 @@ library
       DA.Daml.LF.Proto3.Archive.Decode
       DA.Daml.LF.Proto3.Decode
       DA.Daml.LF.Proto3.DecodeV1
+      DA.Daml.LF.Proto3.DecodeV2
     default-extensions:
       BangPatterns
       DeriveDataTypeable

--- a/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/Decode.hs
+++ b/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/Decode.hs
@@ -1,36 +1,62 @@
 -- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE MultiWayIf #-}
+
 module DA.Daml.LF.Proto3.Decode
   ( Error(..)
   , decodePayload
   ) where
 
 import Com.Daml.DamlLfDev.DamlLf (ArchivePayload(..), ArchivePayloadSum(..))
-import DA.Daml.LF.Ast (Package, PackageId, PackageRef, packageLfVersion, Version (..), versionMinor, MajorVersion(V2))
+import DA.Daml.LF.Ast.Base ( Package, PackageId, PackageRef )
 import DA.Daml.LF.Proto3.Error
 import qualified DA.Daml.LF.Proto3.DecodeV1 as DecodeV1
-import qualified Com.Daml.DamlLfDev.DamlLf1 as LF1
-import qualified Com.Daml.DamlLfDev.DamlLf2 as LF2
-import Proto3.Suite (toLazyByteString, fromByteString)
-import qualified Data.ByteString.Lazy as BL
-import Proto3.Wire.Decode (ParseError)
-import Data.Bifunctor (first)
+import qualified DA.Daml.LF.Proto3.DecodeV2 as DecodeV2
+import qualified DA.Daml.LF.Ast as LF
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text as T
+import Control.Monad.Except (throwError)
+import DA.Daml.StablePackagesList (stablePackages)
 
-decodePayload :: PackageId -> PackageRef -> ArchivePayload -> Either Error Package
+decodeLf1Version :: LF.PackageId -> T.Text -> Either Error LF.Version
+decodeLf1Version pkgId minorText = do
+  let unsupported :: Either Error a
+      unsupported = throwError (UnsupportedMinorVersion minorText)
+  -- we translate "no version" to minor version 0, since we introduced
+  -- minor versions once Daml-LF v1 was already out, and we want to be
+  -- able to parse packages that were compiled before minor versions
+  -- were a thing. DO NOT replicate this code bejond major version 1!
+  minor <- if
+    | T.null minorText -> pure $ LF.PointStable 0
+    | Just minor <- LF.parseMinorVersion (T.unpack minorText) -> pure minor
+    | otherwise -> unsupported
+  let version = LF.Version LF.V1 minor
+  if pkgId `elem` stablePackages || version `elem` LF.supportedInputVersions
+      then pure version
+      else unsupported
+
+decodeLf2Version :: LF.PackageId -> T.Text -> Either Error LF.Version
+decodeLf2Version pkgId minorText = do
+  let unsupported :: Either Error a
+      unsupported = unsupported
+  minor <- if
+    | Just minor <- LF.parseMinorVersion (T.unpack minorText) -> pure minor
+    | otherwise -> unsupported
+  let version = LF.Version LF.V2 minor
+  if pkgId `elem` stablePackages || version `elem` LF.supportedInputVersions
+      then pure version
+      else unsupported
+
+decodePayload ::
+    PackageId -> PackageRef -> ArchivePayload -> Either Error Package
 decodePayload pkgId selfPackageRef payload = case archivePayloadSum payload of
-    Just (ArchivePayloadSumDamlLf1 package) -> 
-      DecodeV1.decodePackage (Just pkgId) minor selfPackageRef package
+    Just (ArchivePayloadSumDamlLf1 package) -> do
+        version <- decodeLf1Version pkgId minorText
+        DecodeV1.decodePackage version selfPackageRef package
     Just (ArchivePayloadSumDamlLf2 package) -> do
-      -- The DamlLf2 proto is currently a copy of DamlLf1 so we can coerce one to the other.
-      -- TODO(#17366): Introduce a new DamlLf2 decoder once we introduce changes to DamlLf2.
-      lf1Package <- first (ParseError . show) (coerceLF2toLF1 package)
-      package <- DecodeV1.decodePackage (Just pkgId) minor selfPackageRef lf1Package
-      return (package { packageLfVersion = Version V2 (versionMinor $ packageLfVersion package) })
+        version <- decodeLf2Version pkgId minorText
+        DecodeV2.decodePackage version selfPackageRef package
     Nothing -> Left $ ParseError "Empty payload"
-    where
-        minor = archivePayloadMinor payload
-
--- TODO(#17366): Delete as soon as the DamlLf2 proto diverges from the DamlLF1 one.
-coerceLF2toLF1 :: LF2.Package -> Either ParseError LF1.Package
-coerceLF2toLF1 package = fromByteString (BL.toStrict $ toLazyByteString package)
+  where
+    minorText = TL.toStrict (archivePayloadMinor payload)

--- a/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -174,7 +174,6 @@ decodeInternedDottedName (LF1.InternedDottedName ids) = do
     (mangled, unmangledOrErr) <- mapAndUnzipM lookupString (V.toList ids)
     pure (mangled, sequence unmangledOrErr)
 
--- The package id is optional since we also call this function from decodeScenarioModule
 decodePackage :: LF.Version -> LF.PackageRef -> LF1.Package -> Either Error Package
 decodePackage version selfPackageRef (LF1.Package mods internedStringsV internedDottedNamesV metadata internedTypesV) = do
   let internedStrings = V.map decodeMangledString internedStringsV

--- a/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -20,7 +20,6 @@ import Control.Monad.Reader
 import Data.Int
 import Text.Read
 import           Data.List
-import    DA.Daml.StablePackagesList
 import           DA.Daml.LF.Mangling
 import qualified Com.Daml.DamlLfDev.DamlLf1 as LF1
 import qualified Data.NameMap as NM
@@ -170,32 +169,14 @@ decodePackageRef (LF1.PackageRef pref) =
 -- Decodings of everything else
 ------------------------------------------------------------------------
 
-decodeVersion :: Maybe LF.PackageId -> T.Text -> Either Error Version
-decodeVersion mbPkgId minorText = do
-  let unsupported :: Either Error a
-      unsupported = throwError (UnsupportedMinorVersion minorText)
-  -- we translate "no version" to minor version 0, since we introduced
-  -- minor versions once Daml-LF v1 was already out, and we want to be
-  -- able to parse packages that were compiled before minor versions
-  -- were a thing. DO NOT replicate this code bejond major version 1!
-  minor <- if
-    | T.null minorText -> pure $ LF.PointStable 0
-    | Just minor <- LF.parseMinorVersion (T.unpack minorText) -> pure minor
-    | otherwise -> unsupported
-  let version = Version V1 minor
-  if  isStablePackage || version `elem` LF.supportedInputVersions then pure version else unsupported
-  where
-    isStablePackage = maybe False (`elem` stablePackages) mbPkgId
-
 decodeInternedDottedName :: LF1.InternedDottedName -> Decode ([T.Text], Either String [UnmangledIdentifier])
 decodeInternedDottedName (LF1.InternedDottedName ids) = do
     (mangled, unmangledOrErr) <- mapAndUnzipM lookupString (V.toList ids)
     pure (mangled, sequence unmangledOrErr)
 
 -- The package id is optional since we also call this function from decodeScenarioModule
-decodePackage :: Maybe LF.PackageId -> TL.Text -> LF.PackageRef -> LF1.Package -> Either Error Package
-decodePackage mbPkgId minorText selfPackageRef (LF1.Package mods internedStringsV internedDottedNamesV metadata internedTypesV) = do
-  version <- decodeVersion mbPkgId (decodeString minorText)
+decodePackage :: LF.Version -> LF.PackageRef -> LF1.Package -> Either Error Package
+decodePackage version selfPackageRef (LF1.Package mods internedStringsV internedDottedNamesV metadata internedTypesV) = do
   let internedStrings = V.map decodeMangledString internedStringsV
   let internedDottedNames = V.empty
   let internedTypes = V.empty
@@ -219,9 +200,9 @@ decodePackageMetadata LF1.PackageMetadata{..} = do
     upgradedPackageId <- traverse decodeUpgradedPackageId packageMetadataUpgradedPackageId
     pure (PackageMetadata pkgName pkgVersion upgradedPackageId)
 
-decodeScenarioModule :: TL.Text -> LF1.Package -> Either Error Module
-decodeScenarioModule minorText protoPkg = do
-    Package { packageModules = modules } <- decodePackage Nothing minorText PRSelf protoPkg
+decodeScenarioModule :: LF.Version -> LF1.Package -> Either Error Module
+decodeScenarioModule version protoPkg = do
+    Package { packageModules = modules } <- decodePackage version PRSelf protoPkg
     pure $ head $ NM.toList modules
 
 decodeModule :: LF1.Module -> Decode Module

--- a/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/DecodeV2.hs
+++ b/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/DecodeV2.hs
@@ -1,0 +1,37 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module DA.Daml.LF.Proto3.DecodeV2
+    ( decodePackage
+    , decodeScenarioModule
+    , Error(..)
+    ) where
+
+import qualified Com.Daml.DamlLfDev.DamlLf1 as LF1
+import qualified Com.Daml.DamlLfDev.DamlLf2 as LF2
+import DA.Daml.LF.Ast as LF
+import DA.Daml.LF.Proto3.Error
+import Data.Bifunctor (first)
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.NameMap as NM
+import Proto3.Suite (fromByteString, toLazyByteString)
+import Proto3.Wire.Decode (ParseError)
+
+import qualified DA.Daml.LF.Proto3.DecodeV1 as DecodeV1
+
+coerceLF2toLF1 :: LF2.Package -> Either ParseError LF1.Package
+coerceLF2toLF1 package = fromByteString (BL.toStrict $ toLazyByteString package)
+
+-- The package id is optional since we also call this function from decodeScenarioModule
+decodePackage :: LF.Version -> LF.PackageRef -> LF2.Package -> Either Error Package
+decodePackage version selfPackageRef package = do
+  lf1Package <- first (ParseError . show) (coerceLF2toLF1 package)
+  DecodeV1.decodePackage version selfPackageRef lf1Package
+
+decodeScenarioModule :: LF.Version -> LF2.Package -> Either Error Module
+decodeScenarioModule version protoPkg = do
+    Package { packageModules = modules } <- decodePackage version PRSelf protoPkg
+    pure $ head $ NM.toList modules
+

--- a/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/DecodeV2.hs
+++ b/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/DecodeV2.hs
@@ -24,7 +24,6 @@ import qualified DA.Daml.LF.Proto3.DecodeV1 as DecodeV1
 coerceLF2toLF1 :: LF2.Package -> Either ParseError LF1.Package
 coerceLF2toLF1 package = fromByteString (BL.toStrict $ toLazyByteString package)
 
--- The package id is optional since we also call this function from decodeScenarioModule
 decodePackage :: LF.Version -> LF.PackageRef -> LF2.Package -> Either Error Package
 decodePackage version selfPackageRef package = do
   lf1Package <- first (ParseError . show) (coerceLF2toLF1 package)

--- a/compiler/daml-lf-proto-encode/BUILD.bazel
+++ b/compiler/daml-lf-proto-encode/BUILD.bazel
@@ -9,6 +9,7 @@ da_haskell_library(
         "src/DA/Daml/LF/Proto3/Archive/Encode.hs",
         "src/DA/Daml/LF/Proto3/Encode.hs",
         "src/DA/Daml/LF/Proto3/EncodeV1.hs",
+        "src/DA/Daml/LF/Proto3/EncodeV2.hs",
     ],
     hackage_deps = [
         "base",

--- a/compiler/daml-lf-proto-encode/daml-lf-proto-encode.cabal
+++ b/compiler/daml-lf-proto-encode/daml-lf-proto-encode.cabal
@@ -53,6 +53,7 @@ library
       DA.Daml.LF.Proto3.Archive.Encode
       DA.Daml.LF.Proto3.Encode
       DA.Daml.LF.Proto3.EncodeV1
+      DA.Daml.LF.Proto3.EncodeV2
     default-extensions:
       BangPatterns
       DeriveDataTypeable

--- a/compiler/daml-lf-proto-encode/src/DA/Daml/LF/Proto3/EncodeV2.hs
+++ b/compiler/daml-lf-proto-encode/src/DA/Daml/LF/Proto3/EncodeV2.hs
@@ -1,0 +1,29 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+
+-- | Encoding of the LF package into LF version 1 format.
+module DA.Daml.LF.Proto3.EncodeV2
+  ( encodeScenarioModule
+  , encodePackage
+  ) where
+
+import qualified Com.Daml.DamlLfDev.DamlLf1 as LF1
+import qualified Com.Daml.DamlLfDev.DamlLf2 as LF2
+import DA.Daml.LF.Ast ( Version, Module, Package )
+import qualified DA.Daml.LF.Proto3.EncodeV1 as EncodeV1
+import Proto3.Suite (toLazyByteString, fromByteString)
+import qualified Data.ByteString.Lazy as BL
+import Data.Either (fromRight)
+
+encodePackage :: Package -> LF2.Package
+encodePackage = coerceLF1toLF2 . EncodeV1.encodePackage
+
+encodeScenarioModule :: Version -> Module -> LF2.Package
+encodeScenarioModule version mod = coerceLF1toLF2 (EncodeV1.encodeScenarioModule version mod)
+
+coerceLF1toLF2 :: LF1.Package -> LF2.Package
+coerceLF1toLF2 package =
+  fromRight
+    (error "cannot coerce LF1 proto to LF2 proto")
+    (fromByteString (BL.toStrict $ toLazyByteString package))

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -53,7 +53,6 @@ import qualified Data.NameMap as NM
 import qualified Data.Set as Set
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Extended as T
-import qualified Data.Text.Lazy as TL
 import Data.Tuple.Extra
 import Data.Typeable (Typeable())
 import qualified Data.Vector as V
@@ -720,7 +719,7 @@ readDalfFromFile dalfFile = do
             protoPkg <- case Proto.fromByteString bytes of
                 Left err -> fail (show err)
                 Right a -> pure a
-            case decodeScenarioModule (TL.pack $ LF.renderMinorVersion $ LF.versionMinor lfVersion) protoPkg of
+            case decodeScenarioModule lfVersion protoPkg of
                 Left err -> fail (show err)
                 Right mod -> pure mod
 

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -19,7 +19,8 @@ import Data.IORef
 import qualified Proto3.Suite             as Proto
 import qualified DA.Daml.LF.Proto3.DecodeV1 as DecodeV1
 import qualified DA.Daml.LF.Proto3.DecodeV2 as DecodeV2
-import DA.Daml.LF.Proto3.EncodeV1
+import qualified DA.Daml.LF.Proto3.EncodeV1 as EncodeV1
+import qualified DA.Daml.LF.Proto3.EncodeV2 as EncodeV2
 import HscTypes
 import MkIface
 import Maybes (MaybeErr(..))
@@ -31,6 +32,7 @@ import Control.Exception
 import Control.Monad.Except
 import Control.Monad.Extra
 import Control.Monad.Trans.Maybe
+import DA.Daml.LF.Ast (renderMajorVersion, Version (versionMajor))
 import DA.Daml.Options
 import DA.Daml.Options.Packaging.Metadata
 import DA.Daml.Options.Types
@@ -107,7 +109,6 @@ import SdkVersion (damlStdlib)
 import Language.Haskell.HLint4
 
 import Development.IDE.Core.Rules.Daml.SpanInfo
-import DA.Daml.LF.Ast (renderMajorVersion, Version (versionMajor))
 
 -- | Get thr URI that corresponds to a virtual resource. The VS Code has a
 -- document provider that will handle our special documents.
@@ -737,8 +738,20 @@ readDalfFromFile dalfFile = do
 writeDalfFile :: NormalizedFilePath -> LF.Module -> Action ()
 writeDalfFile dalfFile mod = do
     lfVersion <- getDamlLfVersion
-    liftIO $ createDirectoryIfMissing True (takeDirectory $ fromNormalizedFilePath dalfFile)
-    liftIO $ BSL.writeFile (fromNormalizedFilePath dalfFile) $ Proto.toLazyByteString $ encodeScenarioModule lfVersion mod
+    liftIO $
+        case LF.versionMajor lfVersion of
+            LF.V1 -> encode EncodeV1.encodeScenarioModule lfVersion
+            LF.V2 -> encode EncodeV2.encodeScenarioModule lfVersion
+  where
+    encode encodeScenarioModule lfVersion = do
+        liftIO $
+            createDirectoryIfMissing
+                True
+                (takeDirectory $ fromNormalizedFilePath dalfFile)
+        liftIO $
+            BSL.writeFile (fromNormalizedFilePath dalfFile) $
+                Proto.toLazyByteString $
+                    encodeScenarioModule lfVersion mod
 
 -- Generates a Daml-LF archive without adding serializability information
 -- or type checking it. This must only be used for debugging/testing.

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -721,11 +721,6 @@ readDalfFromFile dalfFile = do
             LF.V1 -> decode DecodeV1.decodeScenarioModule lfVersion
             LF.V2 -> decode DecodeV2.decodeScenarioModule lfVersion
   where
-    decode ::
-        (Proto.Message a, Show e) =>
-        (LF.Version -> a -> Either e LF.Module) ->
-        LF.Version ->
-        IO LF.Module
     decode decodeScenarioModule lfVersion = do
         bytes <- BS.readFile $ fromNormalizedFilePath dalfFile
         protoPkg <- case Proto.fromByteString bytes of

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -380,6 +380,7 @@ da_haskell_test(
     data = [
         "//compiler/damlc",
         "//daml-script/daml:daml-script.dar",
+        "//daml-script/daml3:daml3-script.dar",
         "//daml-script/runner:daml-script-binary",
     ],
     hackage_deps = [
@@ -399,6 +400,7 @@ da_haskell_test(
         "//:sdk-version-hs-lib",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/test-utils",
+        "//compiler/daml-lf-ast",
     ],
 )
 

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -398,9 +398,9 @@ da_haskell_test(
     visibility = ["//visibility:public"],
     deps = [
         "//:sdk-version-hs-lib",
+        "//compiler/daml-lf-ast",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/test-utils",
-        "//compiler/daml-lf-ast",
     ],
 )
 

--- a/compiler/damlc/tests/src/DA/Test/IncrementalBuilds.hs
+++ b/compiler/damlc/tests/src/DA/Test/IncrementalBuilds.hs
@@ -7,6 +7,7 @@ module DA.Test.IncrementalBuilds (main) where
 
 import Control.Monad.Extra
 import DA.Bazel.Runfiles
+import qualified DA.Daml.LF.Ast.Version as LF
 import Data.Foldable
 import qualified Data.Set as Set
 import Data.Traversable
@@ -22,11 +23,27 @@ main :: IO ()
 main = do
     damlc <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> exe "damlc")
     damlScript <- locateRunfiles (mainWorkspace </> "daml-script" </> "runner" </> exe "daml-script-binary")
-    scriptDar <- locateRunfiles (mainWorkspace </> "daml-script" </> "daml" </> "daml-script.dar")
-    defaultMain $ tests damlc damlScript scriptDar
+    v1TestArgs <- do
+      scriptDar <- locateRunfiles (mainWorkspace </> "daml-script" </> "daml" </> "daml-script.dar")
+      let lfVersion = LF.versionDefault
+      pure TestArgs{..}
+    v2TestArgs <- do
+      scriptDar <- locateRunfiles (mainWorkspace </> "daml-script" </> "daml3" </> "daml3-script.dar")
+      -- TODO(#17366): replace with the latest stable version of 2.x once it exists
+      let lfVersion = LF.version2_dev
+      pure TestArgs{..}
+    let testTrees = map tests [v1TestArgs, v2TestArgs]
+    defaultMain (testGroup "Incremental builds" testTrees)
 
-tests :: FilePath -> FilePath -> FilePath -> TestTree
-tests damlc damlScript scriptDar = testGroup "Incremental builds"
+data TestArgs = TestArgs
+  { damlc :: FilePath
+  , damlScript :: FilePath
+  , scriptDar :: FilePath
+  , lfVersion :: LF.Version
+  }
+
+tests :: TestArgs -> TestTree
+tests TestArgs{..} = testGroup ("LF " <> LF.renderVersion lfVersion)
     [ test "No changes"
         [ ("daml/A.daml", unlines
            [ "module A where"
@@ -165,11 +182,13 @@ tests damlc damlScript scriptDar = testGroup "Incremental builds"
             , dir
             , "-o"
             , dar
+            , "--target=" <> LF.renderVersion lfVersion
             , "--incremental=yes" ]
-          callProcessSilent damlc 
+          callProcessSilent damlc
             [ "test"
             , "--project-root"
             , dir
+            , "--target=" <> LF.renderVersion lfVersion
             ]
           dalfFiles <- getDalfFiles $ dir </> ".daml/build"
           dalfModTimes <- for dalfFiles $ \f -> do
@@ -184,6 +203,7 @@ tests damlc damlScript scriptDar = testGroup "Incremental builds"
             , dir
             , "-o"
             , dar
+            , "--target=" <> LF.renderVersion lfVersion
             , "--incremental=yes" ]
           rebuilds <- forMaybeM dalfModTimes $ \(f, oldModTime) -> do
               newModTime <- getModificationTime f


### PR DESCRIPTION
Context: https://github.com/digital-asset/daml/issues/17366

This PR moves LF v2 decoding to its own `DecodeV2` module, which for now delegates the decoding to `DecodeV1`. Decoding in `DecodeV1` is now parameterized by the language version instead of the minor version's text representation. The parsing of the minor version is done by `Decode`, before dispatching to `DecodeV1` or `DecodeV2`. 

Without this change, `DecodeV1` would interpret "1" as version 1.1, even when the intended major version is 2, and reject it because 1.1 is not a supported input LF version.