### PR TITLE
Stop downloading the canton opensource jar

### DIFF
--- a/canton_dep.bzl
+++ b/canton_dep.bzl
@@ -2,7 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 canton = {
-    "sha": "ffb22922afe3eaf51f861e6d0ee1c4abb6f5759832e12d7631de7cf6c04b47ca",
-    "url": "https://storage.googleapis.com/daml-binaries/canton-stable/2.8.0-snapshot.20231117.11560.0.v57ba6d0f/ffb22922afe3eaf51f861e6d0ee1c4abb6f5759832e12d7631de7cf6c04b47ca/canton-open-source-2.8.0-snapshot.20231117.11560.0.v57ba6d0f.tar.gz",
     "local": False,
 }

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -206,17 +206,6 @@ jobs:
                          | sort -V \
                          | tail -1)
 
-        os_url="https://digitalasset.jfrog.io/artifactory/assembly/canton/$canton_version/canton-open-source-$canton_version.tar.gz"
-        os_tmp=$(mktemp)
-        curl -u $AUTH --fail --location --silent "$os_url" > $os_tmp
-        os_sha=$(sha256sum $os_tmp | awk '{print $1}')
-        os_url_path=canton-stable/$canton_version/$os_sha/canton-open-source-$canton_version.tar.gz
-        os_upload_url=gs://daml-binaries/$os_url_path
-        os_download_url=https://storage.googleapis.com/daml-binaries/$os_url_path
-        if ! gcs "$GCRED" ls $os_upload_url; then
-            gcs "$GCRED" cp $os_tmp $os_upload_url
-        fi
-
         ee_url="https://digitalasset.jfrog.io/artifactory/assembly/canton/$canton_version/canton-enterprise-$canton_version.tar.gz"
         ee_tmp=$(mktemp)
         curl -u $AUTH --fail --location --silent "$ee_url" > $ee_tmp
@@ -234,16 +223,6 @@ jobs:
         fi
 
         sed -i 's|SKIP_DEV_CANTON_TESTS=.*|SKIP_DEV_CANTON_TESTS=false|' build.sh
-        sed -e 's/^/# /' COPY > canton_dep.bzl
-        cat <<EOF >> canton_dep.bzl
-
-        canton = {
-            "sha": "$os_sha",
-            "url": "$os_download_url",
-            "local": False,
-        }
-        EOF
-
         sed -i "s|CANTON_ENTERPRISE_VERSION=.*|CANTON_ENTERPRISE_VERSION=$canton_version|" test-common/canton/BUILD.bazel
         sed -i "s|CANTON_ENTERPRISE_SHA=.*|CANTON_ENTERPRISE_SHA=$ee_sha|" test-common/canton/BUILD.bazel
         sed -i "s|CANTON_ENTERPRISE_URL=.*|CANTON_ENTERPRISE_URL=$ee_target_url|" test-common/canton/BUILD.bazel

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -260,11 +260,11 @@ jobs:
         canton_tag=$commit_date.$number_of_commits.0.v$commit_sha_8
         branch="canton-update-$canton_tag-$canton_version"
 
-        if git diff --exit-code origin/main -- canton canton_dep.bzl build.sh arbitrary_canton_sha test-common/canton/BUILD.bazel >/dev/null; then
+        if git diff --exit-code origin/main -- canton build.sh arbitrary_canton_sha test-common/canton/BUILD.bazel >/dev/null; then
             echo "Already up-to-date with latest Canton source & snapshot."
         else
             if [ "main" = "$(Build.SourceBranchName)" ]; then
-                git add canton_dep.bzl build.sh test-common/canton/BUILD.bazel
+                git add build.sh test-common/canton/BUILD.bazel
                 git ls-files | grep arbitrary_canton_sha >&2 && git rm -f arbitrary_canton_sha
                 open_pr "$branch" "update canton to $canton_tag/$canton_version"
                 az extension add --name azure-devops

--- a/deps.bzl
+++ b/deps.bzl
@@ -380,20 +380,6 @@ genrule(
             """,
         )
 
-    if "canton" not in native.existing_rules():
-        http_archive(
-            name = "canton",
-            build_file_content = """
-package(default_visibility = ["//visibility:public"])
-filegroup(
-  name = "jar",
-  srcs = glob(["*/lib/**/*.jar"]),
-)
-        """,
-            sha256 = canton["sha"],
-            urls = [canton["url"]],
-        )
-
     if "freefont" not in native.existing_rules():
         http_archive(
             name = "freefont",

--- a/test-common/canton/BUILD.bazel
+++ b/test-common/canton/BUILD.bazel
@@ -13,7 +13,7 @@ load("@os_info//:os_info.bzl", "is_windows")
 genrule(
     name = "canton-lib-ee",
     # We don't use the else branch but we need a resolvable value
-    srcs = [":lib/canton-ee.jar"] if canton["local"] else ["@canton//:jar"],
+    srcs = [":lib/canton-ee.jar"] if canton["local"] else ["//canton:community_app_deploy.jar"],
     outs = ["canton-lib-ee.jar"],
     cmd = """
 set -euo pipefail
@@ -54,7 +54,7 @@ tar xzf $$tmp
 
 cp canton-*/lib/*.jar $@
 """.format(
-        src = ":lib/canton-ee.jar" if canton["local"] else "@canton//:jar",  # not used in else case but still must resolve
+        src = ":lib/canton-ee.jar" if canton["local"] else "//canton:community_app_deploy.jar",  # not used in else case but still must resolve
         artif_pass = artif_pass,
         artif_user = artif_user,
         curl = "@curl_dev_env//:bin/curl" if not is_windows else "@curl_dev_env//:bin/curl.exe",

--- a/test-common/canton/README.md
+++ b/test-common/canton/README.md
@@ -1,60 +1,27 @@
 # Canton dependency
 
 This folder (along with the `canton` entry in `//deps.bzl`) contains the
-infrastructure to work with custom Canton versions.
+infrastructure to work with custom Canton Enterprise Edition versions.
 
-By default, we rely on the Canton artifact defined in `//canton_dep.bzl`.
+By default, we rely on the Canton-EE artifact defined in `BUILD.bazel`.
 However, we have the ability to, rather than depend on a published version,
 depend on an arbitrary Canton build.
 
 ## Local development
 
-For local development, you can set the `local` attribute to `True` in `canton_dep.bzl`, and, rather than looking at the downloaded Canton release, the Bazel build will then look for a local file under `canton/lib/canton.jar` for its Canton source.
+For local development, you can set the `local` attribute to `True` in
+`canton_dep.bzl`, and, rather than looking at the downloaded Canton-EE release,
+the Bazel build will then look for a local file under `canton/lib/canton-ee.jar`
+for its Canton source.
 
-How you get that canton jar there is entirely up to you; the assumption is that
-this would be the result of building a local checkout of Canton with your own
-local, uncommitted changes.
-
-Possibly something like:
-
-```
-mkdir -p $daml_checkout/canton/lib
-cd $canton_checkout
-nix-shell --max-jobs 2 --run "sbt community-app/assembly"
-cp community/app/target/scala-*/canton-open-source-*.jar $daml_checkout/canton/lib/canton.jar
-```
+How you get that canton-ee jar there is entirely up to you; the assumption is
+that this would be the result of building a local checkout of Canton with your
+own local, uncommitted changes.
 
 Once you have things working locally, you can push your Canton branch, and
 start building Daml against that even before the Canton branch gets merged.
 
-## CI
-
-If you want your pull request to use a custom Canton commit, rather than a
-released snapshot, you can do that as follows. First, you need a Canton commit
-to point to in the Canton repo (it doesn't need to be on main, any commit on
-the GitHub repo can be used). Then:
-
-- Make sure your branch sets the `local` key to `True` in `canton_dep.bzl`.
-- Add a file called `arbitrary_canton_sha` to the root of the daml repository,
-  that contains just the sha of the canton commit you want to build.
-
-If the `arbitrary_canton_sha` file exists, the daml CI will clone the Canton
-repo, check out the corresponding sha, build the jar, and make it available to
-all three platforms. If the `local` attribute is set to `True`, just like
-locally, the CI builds will use the local `canton.jar` file instead of
-downloading the snapshot.
-
-## Main branch
-
-Generally speaking, the main branch of the repo _should_ depend on a published
-snapshot rather than a specific commit. However, there may be situations where
-we need to temporarily depend on a specific commit. To cater to those
-situations, the daily canton bump job will reset the daml repo to depend on the
-snapshot (i.e. if the tip of the main branch has an `arbitrary_canton_sha`
-file, the daily job will delete it as part of the canton bump PR, and likely it
-will set the `local` attibute back to `False`).
-
-## Enterprise Edition
+## Running Enterprise Edition Tests
 
 Some situations may require running Canton Enterprise Edition, but this is an
 open-source repository so we cannot assume every contributor will have a Canton
@@ -70,7 +37,8 @@ and including the tests).
 
 Those tests are run on CI.
 
-If you're using a local build of canton (setting `local` to `True` per above)
-_and_ you are explicitly overwriting the `*_tag_filters` to run the Canton EE
-tests, they will be run using your provided `canton-ee.jar` (which therefore
-needs to be an EE jar at that point).
+## Running Tests with a Custom Open-Source Edition Canton
+
+The non-ee tests run against the code under the `canton` directory at the root
+of the repo. In order to run against a custom version of that code, simply
+modify it.


### PR DESCRIPTION
This is no longer necessary as we rely on the code drop only. This simplifies the `update_canton` CI job a bit.

Also update the README that explains how to run against a custom version of canton, and doesn't apply anymore to the open-source version, even before this PR.