### PR TITLE
restrict code drop and canton jars to 2.x

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -202,7 +202,7 @@ jobs:
                               https://digitalasset.jfrog.io/artifactory/api/storage/assembly/canton \
                          | jq -r '.children[].uri' \
                          | sed -e 's/^\///' \
-                         | grep -P '^\d+\.\d+\.\d+' \
+                         | grep -P '^2\.\d+\.\d+' \
                          | sort -V \
                          | tail -1)
 


### PR DESCRIPTION
As canton is forking, we want the `canton` directory and the `canton-ee` jar to reflect its 2.x branch. We will later introduce a code drop for the 3.x branch.

As a sanity check, on my machine:

```
$ curl -u $ARTIFACTORY_USERNAME:$ARTIFACTORY_PASSWORD --fail  --location --silent https://digitalasset.jfrog.io/artifactory/api/storage/assembly/canton |  jq -r '.children[].uri' | sed -e 's/^\///' | grep -P '^2\.\d+\.\d+'  | sort -V  | tail -1
2.8.0-snapshot.20231120.11569.0.v2461ac9b
```