### PR TITLE
Clean up UNRELEASED.md

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,16 +1,4 @@
 # Release of Daml DAML_VERSION
-
-## Bugfixes
-
-## What’s New
-
-# Release of Daml 2.7.0
-
-## Bugfixes
-- Fixed the daml-script binary not using TLS and access token settings correctly when using the `--all` flag.
-
-## What’s New
-
 Use one of the following topics to capture your release notes. Duplicate this file if necessary.
 Add [links to the documentation too](https://docs.daml.com/DAML_VERSION/about.html).
 
@@ -19,6 +7,17 @@ Of course, perfect write-ups are very welcome.
 
 You need to update this file whenever you commit something of significance. Reviewers need to check your PR
 and ensure that the release notes and documentation has been included as part of the PR.
+
+## Bugfixes
+
+## What’s New
+
+# Release of Daml 2.8.0
+
+## Bugfixes
+- Fixed the daml-script binary not using TLS and access token settings correctly when using the `--all` flag.
+
+## What’s New
 
 ### Minor Script warning
 As part of the ongoing efforts to improve Scripts and the testing story around them, we've added a small warning for a test case that non-obviously doesn't run.
@@ -37,13 +36,18 @@ We now throw an error (or warning) early in those cases on the field name itself
 
 *Note: Exception as well as templates without any choices did not previously throw errors for both `self` and `arg`. While using these names is discouraged, we only throw a warning here to avoid a breaking change. We may promote this to an error in future.*
 
-### Dynamic Exercise
-As part of extending the language to support evolving template definitions, we've added a new function `dynamicExercise : HasDynamicExercise t c r => ContractId t -> c -> Update r`, only available when targetting Daml LF version `1.dev`. Currently, it operates just like `exercise`, but at a later stage it will instead use the most recent definition of template `t` choice `c` vetter by all stakeholders.
-
 ### `daml script --ide-ledger`
 In an effort to unify some of our internal and external tools, we now support the `--ide-ledger` option in `daml script`, allowing a user to directly invoke scripts within a `dar` file on their local machine, without a separate ledger running. Note the difference here with `daml test` being that `daml script` will not attempt to recompile or read the source code directly. This option cannot be used with `--ledger-host`, `--participant-config` or `--json-api`.
 
-# Release of Daml 2.8.0
+### Daml-script json support for --all
+The daml-script binary runner has been refactored to be more consistent across using `--script-name` and `--all`.  
+As such, now `--all` will work when using `--json-api`.  
+
+### Daml-script --upload-dar flag
+The daml-script binary now allows you to specify if you want the Dar containing your scripts to be uploaded to the ledger before execution.  
+**NOTE - DEPRECATION:** The previously implicit uploading behaviour of automatically uploading when using `--all` is now deprecated with a warning.  
+If you need to upload, you should explicitly write `--upload-dar=yes`. If you don't, you can either ignore the warning until it is dropped in daml3
+(at which point the default behaviour will change to never upload), or you can explicitly write `--upload-dar=no`, which will continue to work after daml3.
 
 ## Deprecation of template-local definitions
 
@@ -72,17 +76,6 @@ Note that, as a consequence, the warning flags `-Wcontroller-can` and
 
 See [Deprecation of `controller`-first syntax: Migrating](https://docs.daml.com/2.7.0/daml/reference/choices.html#migrating)
 for more information on how to adapt existing projects.
-
-## What’s New
-### Daml-script json support for --all
-The daml-script binary runner has been refactored to be more consistent across using `--script-name` and `--all`.  
-As such, now `--all` will work when using `--json-api`.  
-
-### Daml-script --upload-dar flag
-The daml-script binary now allows you to specify if you want the Dar containing your scripts to be uploaded to the ledger before execution.  
-**NOTE - DEPRECATION:** The previously implicit uploading behaviour of automatically uploading when using `--all` is now deprecated with a warning.  
-If you need to upload, you should explicitly write `--upload-dar=yes`. If you don't, you can either ignore the warning until it is dropped in daml3
-(at which point the default behaviour will change to never upload), or you can explicitly write `--upload-dar=no`, which will continue to work after daml3.
 
 # Release of Daml 2.9.0
 


### PR DESCRIPTION
Quick clean up of the release notes to make it easier to use for the Daml release planning. I've consolidated the relevant notes from 2.7 into 2.8 as we did not put the 2.7 notes in the last changelog. 