### PR TITLE
JSON API: add new PrunedOffset error for websocket queries that attempt to use an offset that has been pruned

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
@@ -9,6 +9,7 @@ import org.apache.pekko.stream.{ClosedShape, FanOutShape2, Materializer}
 import com.daml.http.dbbackend.{ContractDao, SupportedJdbcDriver}
 import com.daml.http.dbbackend.Queries.{DBContract, SurrogateTpId}
 import com.daml.http.domain.ContractTypeId
+import com.daml.http.EndpointsCompanion.PrunedOffset
 import com.daml.http.LedgerClientJwt.Terminates
 import com.daml.http.util.ApiValueToLfValueConverter.apiValueToLfValue
 import com.daml.http.json.JsonProtocol.LfValueDatabaseCodec.{
@@ -207,11 +208,6 @@ private class ContractsFetch(
 
     import doobie.implicits._, cats.syntax.apply._
     import java.sql.SQLException
-    import io.grpc.StatusRuntimeException
-
-    def failedDueToPrune(s: io.grpc.Status) =
-      s.getCode == io.grpc.Status.Code.FAILED_PRECONDITION &&
-        s.getDescription.contains("PARTICIPANT_PRUNED_DATA_ACCESSED")
 
     def loop(maxAttempts: Int): ConnectionIO[BeginBookmark[domain.Offset]] = {
       logger.debug(s"contractsIo, maxAttempts: $maxAttempts")
@@ -221,7 +217,7 @@ private class ContractsFetch(
           case e: SQLException if maxAttempts > 0 && retrySqlStates(e.getSQLState) =>
             logger.error(s"contractsIo, exception: ${e.description}, state: ${e.getSQLState}")
             fconn.rollback flatMap (_ => loop(maxAttempts - 1))
-          case e: StatusRuntimeException if maxAttempts > 0 && failedDueToPrune(e.getStatus) =>
+          case e if maxAttempts > 0 && PrunedOffset.wasCause(e) =>
             logger.error(
               "contractsIo, exception: Failed as the ledger has been pruned since the last cached offset. " +
                 s"Clearing local cache for template $templateId and re-attempting. $e"

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -865,6 +865,7 @@ class WebSocketService(
         }.valueOr(e => Source.single(-\/(e))): Source[Error \/ Message, NotUsed],
       )
       .takeWhile(_.isRight, inclusive = true) // stop after emitting 1st error
+      .recover { case e if PrunedOffset.wasCause(e) => -\/(PrunedOffset) }
       .map(
         _.fold(e => extendWithRequestIdLogCtx(implicit lc => wsErrorMessage(e)), identity): Message
       )


### PR DESCRIPTION
This means that if a websocket query is initiated with an explicit offset, and the ledger returns an error reporting that the offset has been pruned, the websocket query will be terminated with an error containing a status of `410` (Gone) and a message indicating that the offset has been pruned.

The client will need to react to this by clearing any state that had been incrementally built based on updates, and refresh with current version of ledger state.

This is related to https://github.com/digital-asset/daml/issues/13788 and https://github.com/digital-asset/daml/issues/13680

As discussed there, the existing akka APIs do not support setting the websocket close code and reason. The approach taken here is to return a single message with a custom error and close the websocket.