### PR TITLE
Make ci/build-canton-3x.sh work on MacOS by managing dir exclusions

### DIFF
--- a/ci/build-canton-3x.sh
+++ b/ci/build-canton-3x.sh
@@ -44,7 +44,5 @@ rsync -a \
 
 rsync -a $daml_common_staging_src canton-3x
 
-git add $daml_common_staging_dst $community_dst
-
 sed -i 's/canton-3x\///' .bazelignore
 bazel build //canton-3x/...

--- a/ci/build-canton-3x.sh
+++ b/ci/build-canton-3x.sh
@@ -19,14 +19,32 @@ git clone --depth 1 --branch main $repo_url $tmp
 head=$(git -C $tmp rev-parse HEAD)
 echo "cloned at revision $head"
 
-for path in community daml-common-staging; do
-  src=$tmp/$path
-  dst=canton-3x/$path
-  rm -rf $dst
-  mkdir -p $(dirname $dst)
-  cp -rf $src $dst
-  git add $dst
-done
+daml_common_staging_src="$tmp/daml-common-staging"
+community_src="$tmp/community"
+
+daml_common_staging_dst="canton-3x/daml-common-staging"
+community_dst="canton-3x/community"
+
+# Clean-up existing dirs
+rm -rf $daml_common_staging_dst $community_dst
+
+# Copy files from the cloned Canton repo /community and exclude symlinks to Daml sources
+rsync -a \
+  --exclude="$community_src/participant/src/main/resources/ledger-api/VERSION" \
+  --exclude="$community_src/lib/daml-copy-testing/sample-service-test-symlink/scala/com" \
+  --exclude="$community_src/lib/daml-copy-testing/rs-grpc-pekko-test-symlink/scala/com" \
+  --exclude="$community_src/lib/daml-copy-protobuf-java/protobuf-daml-symlinks/transaction/com" \
+  --exclude="$community_src/lib/daml-copy-protobuf-java/protobuf-daml-symlinks/archive/com" \
+  --exclude="$community_src/lib/daml-copy-testing-0/rs-grpc-bridge-test-symlink/java/com" \
+  --exclude="$community_src/lib/daml-copy-testing-0/ledger-resources-test-symlink/scala/com" \
+  --exclude="$community_src/lib/daml-copy-testing-0/protobuf-daml-symlinks/ledger-api-sample-service/hello.proto" \
+  --exclude="$community_src/lib/daml-copy-testing-0/observability-metrics-test-symlink/scala/com" \
+  --exclude="$community_src/lib/daml-copy-testing-0/observability-tracing-test-symlink/scala/com" \
+  $community_src canton-3x
+
+rsync -a $daml_common_staging_src canton-3x
+
+git add $daml_common_staging_dst $community_dst
 
 sed -i 's/canton-3x\///' .bazelignore
 bazel build //canton-3x/...


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
