### PR TITLE
cron/canton3: build with current main

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -219,7 +219,10 @@ jobs:
       demands: assignment -equals default
     steps:
       - checkout: self
-      - bash: ci/build-canton-3x.sh
+      - bash: |
+          set -euo pipefail
+          git pull
+          ci/build-canton-3x.sh
         env:
           GITHUB_TOKEN: $(CANTON_READONLY_TOKEN)
       - template: ci/tell-slack-failed.yml


### PR DESCRIPTION
We want to know if it works "now", at the time of running the test. There is no real point in tying the run to the commit it was triggered on.