### PR TITLE
cron: fix canton3 checkout

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -221,7 +221,8 @@ jobs:
       - checkout: self
       - bash: |
           set -euo pipefail
-          git pull
+          git fetch
+          git checkout origin/main
           ci/build-canton-3x.sh
         env:
           GITHUB_TOKEN: $(CANTON_READONLY_TOKEN)


### PR DESCRIPTION
Turns out CI doesn't have `pull.default = current`.