### PR TITLE
Remove "lax" from call to IDE.

### DIFF
--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -74,7 +74,7 @@ commands:
   completion: true
 - name: ide
   path: damlc/damlc
-  args: ["lax", "ide"]
+  args: ["ide"]
 - name: json-api
   path: daml-helper/daml-helper
   desc: "Launch the HTTP JSON API"


### PR DESCRIPTION
IDE is fully broken as we're no longer expecting the "lax" argument on the command line