### PR TITLE
Clean up version handling in the bazel rules

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -4,9 +4,9 @@
 load("//bazel_tools:haskell.bzl", "da_haskell_binary", "da_haskell_library", "da_haskell_test")
 load("@os_info//:os_info.bzl", "is_darwin", "is_windows")
 load(":util.bzl", "damlc_compile_test")
-load("//rules_daml:daml.bzl", "daml_build_test", "daml_compile", "daml_compile_with_dalf", "daml_test")
+load("//rules_daml:daml.bzl", "daml_compile", "daml_compile_with_dalf")
 load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
-load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS", "LF_DEV_VERSIONS", "LF_MAJOR_VERSIONS", "lf_version_configuration", "lf_version_latest", "mangle_for_damlc")
+load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS", "LF_MAJOR_VERSIONS", "lf_version_default_or_latest", "mangle_for_damlc")
 load("//compiler/damlc:util.bzl", "ghc_pkg")
 
 # Tests for the lax CLI parser + damlc CLI parser
@@ -692,7 +692,7 @@ EOF
         ),
     ]
     for major in LF_MAJOR_VERSIONS
-    for lf_version in [lf_version_latest.get(major)]
+    for lf_version in [lf_version_default_or_latest(major)]
 ]
 
 da_haskell_test(

--- a/daml-lf/engine/BUILD.bazel
+++ b/daml-lf/engine/BUILD.bazel
@@ -17,7 +17,7 @@ load(
     "//daml-lf/language:daml-lf.bzl",
     "LF_DEV_VERSIONS",
     "LF_MAJOR_VERSIONS",
-    "lf_version_latest",
+    "lf_version_default_or_latest",
     "mangle_for_damlc",
 )
 
@@ -58,7 +58,7 @@ ENGINE_TEST_FILES = \
             major = major,
         ),
         srcs = ["src/test/daml/%s.daml" % name],
-        target = lf_version_latest.get(major),
+        target = lf_version_default_or_latest(major),
     )
     for name in ENGINE_TEST_FILES
     for major in LF_MAJOR_VERSIONS
@@ -144,7 +144,7 @@ da_scala_test_suite(
     daml_compile(
         name = "LargeTransaction-v{}".format(major),
         srcs = ["src/test/daml/LargeTransaction.daml"],
-        target = lf_version_latest.get(major),
+        target = lf_version_default_or_latest(major),
     )
     for major in LF_MAJOR_VERSIONS
 ]

--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -14,7 +14,7 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repl")
 load(
     "//daml-lf/language:daml-lf.bzl",
     "LF_MAJOR_VERSIONS",
-    "lf_version_latest",
+    "lf_version_default_or_latest",
 )
 
 da_scala_library(
@@ -144,7 +144,7 @@ scala_repl(
         name = "speedy-compilation-benchmark-v{}".format(major),
         srcs = glob(["src/bench/**/SpeedyCompilationBench.scala"]),
         data = [
-            "//test-common:model-tests-{}.dar".format(lf_version_latest.get(major)),
+            "//test-common:model-tests-{}.dar".format(lf_version_default_or_latest(major)),
         ],
         scala_deps = [
             "@maven//:org_scalaz_scalaz_core",
@@ -161,7 +161,7 @@ scala_repl(
             "//daml-lf/scenario-interpreter",
             "//daml-lf/transaction",
             "//daml-lf/validation",
-            "//test-common:dar-files-{}-lib".format(lf_version_latest.get(major)),
+            "//test-common:dar-files-{}-lib".format(lf_version_default_or_latest(major)),
             "@maven//:com_google_protobuf_protobuf_java",
         ],
     )

--- a/daml-lf/language/daml-lf.bzl
+++ b/daml-lf/language/daml-lf.bzl
@@ -52,43 +52,37 @@ def version_in(
     else:
         return False
 
-# The following dictionary alias LF versions to keywords:
-# - "legacy" is the keyword for last LF version that supports legacy
-#    contract ID scheme,
+# The lastest stable version for each major LF version.
+lf_version_latest = {
+    "1": "1.15",
+    "2": "2.1",
+}
+
+# The following dictionary aliases LF versions to keywords:
 # - "default" is the keyword for the default compiler output,
 # - "latest" is the keyword for the latest stable LF version,
 # - "preview" is the keyword fort he next LF version, *not stable*,
 #    usable for beta testing,
-# The following dictionary is always defined for "legacy", "stable",
-# and "latest". It contains "preview" iff a preview version is
-# available.  If it exists, "preview"'s value is guaranteed to be different
-# from all other values. If we make a new LF release, we bump latest
-# and once we make it the compiler default we bump stable.
-
+# The following dictionary is always defined for "default" and "latest". It
+# contains "preview" iff a preview version is available. If it exists,
+# "preview"'s value is guaranteed to be different from all other values. If we
+# make a new LF release, we bump latest and once we make it the compiler default
+# we bump default.
 lf_version_configuration = {
-    "legacy": "1.8",
     "default": "1.15",
-    "latest": "1.15",
-    #    "preview": "",
-
-    # "dev" is now ambiguous, use either 1.dev or 2.dev explicitly
+    "latest": lf_version_latest.get("1"),
+    # "preview": "",
+    # "dev" is ambiguous, use either 1.dev or 2.dev explicitly
 }
 
-# TODO(#17366): rework lf_version_configuration to be indexed by major version
-#  and delete this dictionary
-lf_version_default = {
-    "1": lf_version_configuration.get("default"),
-    "2": "2.dev",
-}
-
-# TODO(#17366): rework lf_version_configuration to be indexed by major version
-#  and delete this dictionary
-lf_version_latest = {
-    "1": lf_version_configuration.get("latest"),
-    "2": "2.1",
-}
-
-lf_version_configuration_versions = depset(lf_version_configuration.values()).to_list()
+# The Daml-LF version used by default by the compiler if it matches the
+# provided major version, the latest non-dev version with that major version
+# otherwise. Can be used as a future-proof approximation of "default" version
+# across major versions.
+def lf_version_default_or_latest(major):
+    default_version = lf_version_configuration.get("default")
+    (default_major, _) = _to_major_minor_str(default_version)
+    return default_version if default_major == major else lf_version_latest.get(major)
 
 # aggregates a list of version keywords and versions:
 # 1. converts keyword in version

--- a/daml-lf/tests/BUILD.bazel
+++ b/daml-lf/tests/BUILD.bazel
@@ -9,14 +9,14 @@ load(
 load(
     "//daml-lf/language:daml-lf.bzl",
     "LF_MAJOR_VERSIONS",
-    "lf_version_latest",
+    "lf_version_default_or_latest",
 )
 
 [
     daml_compile(
         name = "Exceptions-v{}".format(major),
         srcs = ["Exceptions.daml"],
-        target = lf_version_latest.get(major),
+        target = lf_version_default_or_latest(major),
         visibility = ["//daml-lf:__subpackages__"],
     )
     for major in LF_MAJOR_VERSIONS
@@ -26,7 +26,7 @@ load(
     daml_compile(
         name = "Interfaces-v{}".format(major),
         srcs = ["Interfaces.daml"],
-        target = lf_version_latest.get(major),
+        target = lf_version_default_or_latest(major),
         visibility = ["//daml-lf:__subpackages__"],
     )
     for major in LF_MAJOR_VERSIONS
@@ -48,7 +48,7 @@ load(
     daml_compile(
         name = "InterfaceViews-v{}".format(major),
         srcs = ["InterfaceViews.daml"],
-        target = lf_version_latest.get(major),
+        target = lf_version_default_or_latest(major),
         visibility = ["//daml-lf:__subpackages__"],
     )
     for major in LF_MAJOR_VERSIONS
@@ -88,7 +88,7 @@ daml_compile(
     daml_compile(
         name = "MultiKeys-v{}".format(major),
         srcs = ["MultiKeys.daml"],
-        target = lf_version_latest.get(major),
+        target = lf_version_default_or_latest(major),
         visibility = ["//daml-lf:__subpackages__"],
     )
     for major in LF_MAJOR_VERSIONS

--- a/daml-script/daml3/BUILD.bazel
+++ b/daml-script/daml3/BUILD.bazel
@@ -5,7 +5,7 @@
 # daml_compile instead of a genrule.
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
-load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF2_VERSIONS", "lf_version_latest")
+load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF2_VERSIONS", "lf_version_default_or_latest")
 
 [
     genrule(
@@ -50,8 +50,7 @@ EOF
 # default stable version of LF2.
 copy_file(
     name = "daml3-script",
-    # TODO(#17366): use lf_version_default or equivalent once available
-    src = ":daml3-script-{}.dar".format(lf_version_latest.get("2")),
+    src = ":daml3-script-{}.dar".format(lf_version_default_or_latest("2")),
     out = "daml3-script.dar",
     allow_symlink = True,
     visibility = ["//visibility:public"],

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -12,7 +12,13 @@ load("//bazel_tools:haskell.bzl", "da_haskell_test")
 load("@build_environment//:configuration.bzl", "sdk_version")
 load("@os_info//:os_info.bzl", "is_windows")
 load("//rules_daml:daml.bzl", "daml_compile")
-load("//daml-lf/language:daml-lf.bzl", "LF_DEV_VERSIONS", "LF_MAJOR_VERSIONS", "lf_version_latest", "mangle_for_damlc")
+load(
+    "//daml-lf/language:daml-lf.bzl",
+    "LF_DEV_VERSIONS",
+    "LF_MAJOR_VERSIONS",
+    "lf_version_default_or_latest",
+    "mangle_for_damlc",
+)
 
 [
     genrule(
@@ -66,7 +72,7 @@ EOF
         visibility = ["//visibility:public"],
     )
     for major in LF_MAJOR_VERSIONS
-    for target in [lf_version_latest.get(major)]
+    for target in [lf_version_default_or_latest(major)]
 ]
 
 [

--- a/ledger-test-tool/infrastructure/BUILD.bazel
+++ b/ledger-test-tool/infrastructure/BUILD.bazel
@@ -5,7 +5,6 @@ load("//bazel_tools:scala.bzl", "da_scala_library")
 load(
     "//daml-lf/language:daml-lf.bzl",
     "lf_version_configuration",
-    "lf_version_configuration_versions",
 )
 load("//ledger-test-tool:conformance.bzl", "testtool_lf_versions")
 

--- a/ledger-test-tool/runner/BUILD.bazel
+++ b/ledger-test-tool/runner/BUILD.bazel
@@ -3,13 +3,7 @@
 
 load(
     "//bazel_tools:scala.bzl",
-    "da_scala_binary",
     "da_scala_library",
-)
-load(
-    "//daml-lf/language:daml-lf.bzl",
-    "lf_version_configuration",
-    "lf_version_configuration_versions",
 )
 load("@os_info//:os_info.bzl", "is_windows")
 load("//ledger-test-tool:conformance.bzl", "testtool_lf_versions")

--- a/ledger-test-tool/tool/BUILD.bazel
+++ b/ledger-test-tool/tool/BUILD.bazel
@@ -4,15 +4,11 @@
 load(
     "//bazel_tools:scala.bzl",
     "da_scala_binary",
-    "da_scala_library",
-    "da_scala_library_suite",
-    "da_scala_test_suite",
 )
 load(
     "//daml-lf/language:daml-lf.bzl",
     "LF_DEV_VERSIONS",
     "lf_version_configuration",
-    "lf_version_configuration_versions",
 )
 load("//ledger-test-tool:conformance.bzl", "conformance_test", "testtool_lf_versions")
 load("@os_info//:os_info.bzl", "is_windows")

--- a/test-common/BUILD.bazel
+++ b/test-common/BUILD.bazel
@@ -9,12 +9,9 @@ load(
     "//language-support/scala/codegen:codegen.bzl",
     "dar_to_scala",
 )
-load("@scala_version//:index.bzl", "scala_major_version")
-load("@scala_version//:index.bzl", "scala_major_version")
 load(
     "//daml-lf/language:daml-lf.bzl",
     "lf_version_configuration",
-    "lf_version_configuration_versions",
     "version_in",
 )
 load("//ledger-test-tool:conformance.bzl", "testtool_lf_versions")

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -3,21 +3,26 @@
 
 load("@oracle//:index.bzl", "oracle_tags")
 load("@build_environment//:configuration.bzl", "sdk_version")
-load("//daml-lf/language:daml-lf.bzl", "LF_DEV_VERSIONS", "LF_MAJOR_VERSIONS", "lf_version_configuration", "lf_version_default", "lf_versions_aggregate")
+load(
+    "//daml-lf/language:daml-lf.bzl",
+    "LF_DEV_VERSIONS",
+    "LF_MAJOR_VERSIONS",
+    "lf_version_default_or_latest",
+    "lf_versions_aggregate",
+)
 load("@os_info//:os_info.bzl", "is_windows")
 load(
     "//bazel_tools:scala.bzl",
     "da_scala_binary",
     "da_scala_library",
-    "da_scala_test",
     "da_scala_test_suite",
     "lf_scalacopts_stricter",
 )
 
-triggerMain = "src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala"
+TRIGGER_MAIN = "src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala"
 
 target_lf_versions = lf_versions_aggregate(
-    [lf_version_default.get(major) for major in LF_MAJOR_VERSIONS] +
+    [lf_version_default_or_latest(major) for major in LF_MAJOR_VERSIONS] +
     LF_DEV_VERSIONS,
 )
 
@@ -25,7 +30,7 @@ da_scala_library(
     name = "trigger-service",
     srcs = glob(
         ["src/main/scala/**/*.scala"],
-        exclude = [triggerMain],
+        exclude = [TRIGGER_MAIN],
     ),
     resources = glob(["src/main/resources/**/*"]),
     scala_deps = [
@@ -135,7 +140,7 @@ trigger_service_runtime_deps = {
 [
     da_scala_binary(
         name = "trigger-service-binary-{}".format(edition),
-        srcs = [triggerMain],
+        srcs = [TRIGGER_MAIN],
         main_class = "com.daml.lf.engine.trigger.ServiceMain",
         resource_strip_prefix = "triggers/service/release/trigger-service-",
         resources = ["release/trigger-service-logback.xml"],
@@ -383,9 +388,9 @@ EOF
 [
     genrule(
         name = "test-model-{}".format(major),
-        srcs = [":test-model-{}".format(lf_version_default.get(major))],
+        srcs = [":test-model-{}".format(lf_version_default_or_latest(major))],
         outs = ["test-model-v{}.dar".format(major)],
-        cmd = "cp -L $(location :test-model-{}) $$PWD/$@".format(lf_version_default.get(major)),
+        cmd = "cp -L $(location :test-model-{}) $$PWD/$@".format(lf_version_default_or_latest(major)),
         visibility = ["//visibility:public"],
     )
     for major in LF_MAJOR_VERSIONS

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -3,17 +3,14 @@
 
 load(
     "//bazel_tools:scala.bzl",
-    "da_scala_binary",
     "da_scala_library",
     "da_scala_test_suite",
-    "lf_scalacopts_stricter",
 )
 load("@build_environment//:configuration.bzl", "sdk_version")
 load(
     "//daml-lf/language:daml-lf.bzl",
-    "LF_DEV_VERSIONS",
     "LF_MAJOR_VERSIONS",
-    "lf_version_latest",
+    "lf_version_default_or_latest",
 )
 
 da_scala_library(
@@ -59,8 +56,8 @@ da_scala_library(
         name = "acs-%s" % major,
         srcs =
             glob(["**/*.daml"]) + [
-                "//triggers/daml:daml-trigger-%s.dar" % lf_version_latest.get(major),
-                "//daml-script/daml:daml-script-%s.dar" % lf_version_latest.get(major),
+                "//triggers/daml:daml-trigger-%s.dar" % lf_version_default_or_latest(major),
+                "//daml-script/daml:daml-script-%s.dar" % lf_version_default_or_latest(major),
             ] + [
                 "//templates:copy-trigger/src/CopyTrigger.daml",
             ],
@@ -105,7 +102,7 @@ EOF
       $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location acs-{major}.dar)
       rm -rf $$TMP_DIR
     """.format(
-            lf_version = lf_version_latest.get(major),
+            lf_version = lf_version_default_or_latest(major),
             major = major,
             sdk = sdk_version,
         ),


### PR DESCRIPTION
Context: https://github.com/digital-asset/daml/issues/17366

This PR cleans up the way LF version can be addressed by name in bazel rules.

I reorganized the aliases as follows:
- The "legacy" alias is used nowhere, so I remove it.
- The latest versions for each major version are now defined in their own dictionary. We could compute them from LF_VERSIONS, but I don't know if we necessarily want "latest" to be the version with the greatest minor version, so for now they are hardcoded.
- The "latest" alias now points to the latest version for LF 1. Later we'll point it to the latest version for LF 2.
- The "default" alias is harcoded: it makes no sense to have one default version per major version: the compiler has one single default version.

I also introduced a `lf_version_default_or_latest(major)` function which takes a major version ("1" or "2") and returns either the default version of the compiler if it matches the provided major version, the latest stable version otherwise. For instance currently:
```
lf_version_default_or_latest("1") = "1.15"  # because 1.15 is the default version 
lf_version_default_or_latest("2") = "2.1"   # because 2.1 is the latest version for LF 2
```
This function may sound a bit ad-hoc, but its intent is that you often want to run your tests with the default version of the compiler (because that's what the users see by default), or with the closest thing to a default version for a given major version as a fallback: the latest stable version. Users of this functions won't have to touch a line once we make `2.1` the default version.

(There's already a [similar function](https://github.com/digital-asset/daml/blob/9d0ac21c86a7e51bf43cd030c5ab1a8a20e7ae4e/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs#L106) in the compiler.)

Finally, there are a bunch of places that were implicitly using the default version of LF before I introduced LF2. I had changed these places to use `latest` which was conceptually wrong, but a no-op since currently latest = default. I now fixed them to use `lf_version_default_or_latest`.
