### PR TITLE
publish versions 2.1 and 2.dev of ledger-test-tool on maven

### DIFF
--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -123,6 +123,10 @@
   type: jar-distribute
 - target: //ledger-test-tool/tool:tool-1.dev
   type: jar-distribute
+- target: //ledger-test-tool/tool:tool-2.1
+  type: jar-distribute
+- target: //ledger-test-tool/tool:tool-2.dev
+  type: jar-distribute
 - target: //ledger/participant-local-store:participant-local-store
   type: jar-scala
 - target: //test-common:dar-files-1.14-lib


### PR DESCRIPTION
Some canton tests download the ledger-test-tools jars from maven and I'm trying to upgrade canton to LF 2.x.