### PR TITLE
bump python to make dependabot less sad

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -120,10 +120,9 @@ in rec {
     chromedriver = pkgs.chromedriver;
 
     # Python development
-    pip3        = pkgs.python37Packages.pip;
-    python      = pkgs.python37Packages.python;
+    pip3        = pkgs.python38Packages.pip;
+    python      = pkgs.python38Packages.python;
     python3     = python;
-    python37 = python;
 
     yapf = pkgs.python38Packages.yapf;
 


### PR DESCRIPTION
Python 3.8 was published on Oct 14, **2019**.