### PR TITLE
Fixed ParticipantPruningIT test.

### DIFF
--- a/ledger-test-tool/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger-test-tool/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -352,11 +352,11 @@ trait ParticipantTestContext extends UserManagementTestContext {
       party: Party,
       exercise: Update[T],
   ): Future[Transaction]
-  def exerciseAndGetContract[TCid <: ContractId[T], T]( // TODO: Check if T is not needed
+  def exerciseAndGetContract[TCid <: ContractId[T], T](
       party: Party,
       exercise: Update[Exercised[TCid]],
   )(implicit companion: ContractCompanion[?, TCid, T]): Future[TCid]
-  def exerciseAndGetContractNoDisclose[TCid <: ContractId[?]]( // TODO: rename??
+  def exerciseAndGetContractNoDisclose[TCid <: ContractId[?]](
       party: Party,
       exercise: Update[Exercised[UnitData]],
   )(implicit companion: ContractCompanion[?, TCid, ?]): Future[TCid]


### PR DESCRIPTION
Porting the conformance tests to java bindings left a bug which was not tested in ci since it is excluded (as community canton does not support pruning).

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
