### PR TITLE
Make more tests main-only

### DIFF
--- a/daml-lf/language/daml-lf.bzl
+++ b/daml-lf/language/daml-lf.bzl
@@ -11,6 +11,9 @@ def _to_major_minor_str(v):
     (major_str, _, minor_str) = v.partition(".")
     return (major_str, minor_str)
 
+def _major_str(v):
+    return _to_major_minor_str(v)[0]
+
 def _cmp_int(a, b):
     if a == b:
         return 0
@@ -121,7 +124,7 @@ def lf_version_is_dev(versionStr):
     return versionStr in LF_DEV_VERSIONS
 
 # The stable versions for which we have an LF proto definition under daml-lf/archive/src/stable
-# TODO(#17366): add 2.0 once created
+# TODO(#17366): add 2.1 once it is released
 SUPPORTED_PROTO_STABLE_LF_VERSIONS = ["1.14", "1.15"]
 
 # The subset of LF versions accepted by the compiler's --target option.
@@ -135,4 +138,15 @@ COMPILER_LF2_VERSIONS = [
     if version_in(v, v2_minor_version_range = ("0", "dev"))
 ]
 
-LF_MAJOR_VERSIONS = ["1", "2"]
+# All LF major versions
+LF_MAJOR_VERSIONS = depset([_major_str(v) for v in LF_VERSIONS]).to_list()
+
+# The major version of the default LF version
+LF_DEFAULT_MAJOR_VERSION = _major_str(lf_version_configuration.get("default"))
+
+# The dev LF version with the same major version number as the default LF version.
+LF_DEFAULT_DEV_VERSION = [
+    v
+    for v in LF_DEV_VERSIONS
+    if _major_str(v) == LF_DEFAULT_MAJOR_VERSION
+][0]

--- a/language-support/hs/bindings/BUILD.bazel
+++ b/language-support/hs/bindings/BUILD.bazel
@@ -89,7 +89,10 @@ da_haskell_test(
     src_strip_prefix = "test",
     # We spin up Sandbox as a separate process, so
     # try not to overload the machine.
-    tags = ["cpu:4"] + (["manual"] if is_darwin else []),
+    tags = [
+        "cpu:4",
+        "main-only",
+    ] + (["manual"] if is_darwin else []),
     visibility = ["//visibility:public"],
     deps = [
         "//compiler/daml-lf-ast",

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -491,7 +491,10 @@ alias(
             "@maven//:org_typelevel_cats_kernel",
         ],
         scalacopts = hj_scalacopts,
-        tags = ["cpu:6"] + (["canton-ee"] if edition == "ee" else []),
+        tags = [
+            "cpu:6",
+            "main-only",
+        ] + (["canton-ee"] if edition == "ee" else []),
         visibility = ["//test-evidence:__pkg__"] if edition == "ce" else None,
         deps = [
             ":http-json-{}".format(edition),
@@ -636,7 +639,10 @@ test_suite(
             "@maven//:org_scalaz_scalaz_core",
         ],
         scalacopts = hj_scalacopts,
-        tags = ["cpu:6"] + (["canton-ee"] if edition == "ee" else []),
+        tags = [
+            "cpu:6",
+            "main-only",
+        ] + (["canton-ee"] if edition == "ee" else []),
         visibility = ["//test-evidence:__pkg__"] if edition == "ce" else None,
         deps = [
             ":http-json-{}".format(edition),

--- a/ledger-test-tool/tool/BUILD.bazel
+++ b/ledger-test-tool/tool/BUILD.bazel
@@ -7,6 +7,7 @@ load(
 )
 load(
     "//daml-lf/language:daml-lf.bzl",
+    "LF_DEFAULT_DEV_VERSION",
     "LF_DEV_VERSIONS",
     "lf_version_configuration",
 )
@@ -230,32 +231,45 @@ conformance_test(
 
 # conformance tests for preview and dev
 #  those test the conformance test it-self for preview/dev features
-conformance_test(
-    name = "conformance-test-dev",
-    dev_mod_flag = "",
-    extra_data =
-        conformance_test_extra_data_base + [
-            "//canton:community_app_deploy.jar",
+[
+    conformance_test(
+        name = "conformance-test-dev",
+        dev_mod_flag = "",
+        extra_data =
+            conformance_test_extra_data_base + [
+                "//canton:community_app_deploy.jar",
+            ],
+        extra_runner_args = ["7000"],
+        lf_versions = lf_versions,
+        ports = conformance_test_ports,
+        preview_mod_flag = "",
+        runner = "@//bazel_tools/client_server/runner_with_health_check",
+        server = ":canton-test-runner-with-dependencies",
+        server_args = conformance_server_args_base + [
+            "-C",
+            ",".join([
+                "dev-mode=yes",
+                "canton.domains.test_domain.init.domain-parameters.protocol-version=dev",
+            ]),
         ],
-    extra_runner_args = ["7000"],
-    lf_versions = ["preview"] + LF_DEV_VERSIONS,
-    ports = conformance_test_ports,
-    preview_mod_flag = "",
-    runner = "@//bazel_tools/client_server/runner_with_health_check",
-    server = ":canton-test-runner-with-dependencies",
-    server_args = conformance_server_args_base + [
-        "-C",
-        ",".join([
-            "dev-mode=yes",
-            "canton.domains.test_domain.init.domain-parameters.protocol-version=dev",
-        ]),
-    ],
-    tags = ["dev-canton-test"],
-    test_tool_args = conformance_test_tool_args_base + [
-        "--exclude=" + ",".join(conformance_test_excluded_test + [
-            # we skip those tests for preview/dev
-            "TLSOnePointThreeIT",
-            "TLSAtLeastOnePointTwoIT",
-        ]),
-    ],
-) if not is_windows else None
+        tags = ["dev-canton-test"] + extra_tags,
+        test_tool_args = conformance_test_tool_args_base + [
+            "--exclude=" + ",".join(conformance_test_excluded_test + [
+                # we skip those tests for preview/dev
+                "TLSOnePointThreeIT",
+                "TLSAtLeastOnePointTwoIT",
+            ]),
+        ],
+    )
+    for (lf_versions, extra_tags) in [
+        (
+            [LF_DEFAULT_DEV_VERSION],
+            [],
+        ),
+        (
+            ["preview"] + [v for v in LF_DEV_VERSIONS if v != LF_DEFAULT_DEV_VERSION],
+            ["main-only"],
+        ),
+    ]
+    if not is_windows
+]


### PR DESCRIPTION
Context: https://github.com/digital-asset/daml/issues/17812

Stop running some tests against PRs and run them against main after merging only:

- flaky hs biding tests: flaky but unlikely to break
- flaky json tests: same
- //ledger-test-tool/tool:conformance-test-dev-2.dev: were meant to be removed in https://github.com/digital-asset/daml/pull/17956 but were postponed to this PR to keep the diff to a minimum