### PR TITLE
Fix split release for deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ dist
 *.log
 target
 *.tgz
+*.hi
+*.o
 
 # Daml
 .daml/

--- a/bazel_tools/haskell.bzl
+++ b/bazel_tools/haskell.bzl
@@ -258,6 +258,7 @@ def da_haskell_repl(**kwargs):
             "//nix/...",
         ],
         repl_ghci_args = [
+            "-fobject-code",
             "-fexternal-interpreter",
             "-j",
             "+RTS",

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -251,32 +251,6 @@ jobs:
         trigger_sha: '$(trigger_sha)'
     - template: report-end.yml
 
-- job: build_canton_3x_with_bazel
-  dependsOn:
-    - check_for_release
-    - build_canton
-  variables:
-    - name: release_sha
-      value: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
-    - template: job-variables.yml
-  timeoutInMinutes: 60
-  pool:
-    name: 'ubuntu_20_04'
-    demands: assignment -equals default
-  steps:
-    - template: report-start.yml
-    - checkout: self
-    - bash: |
-        set -euo pipefail
-        git checkout $(release_sha)
-        if [ -x ci/build-canton-3x.sh ]; then
-          ci/build-canton-3x.sh
-        fi
-      env:
-        GITHUB_TOKEN: $(CANTON_READONLY_TOKEN)
-      name: build_canton_3x
-    - template: report-end.yml
-
 
 - job: platform_independence_test
   condition: and(succeeded(),

--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -174,6 +174,9 @@ command_targets = {
         "2.7.1",
         "0.0.0",
     ],
+    "install_with_custom_version_and_build": [
+        "0.0.0",
+    ],
     "install_and_build_from_tarball": [
         "v2.8.0-snapshot.20231109.2/daml-sdk-2.8.0-snapshot.20231107.12319.0.v03a51e65-{}.tar.gz".format(os_name),
         "v2.7.5/daml-sdk-2.7.5-{}.tar.gz".format(os_name),
@@ -186,6 +189,9 @@ command_post_failure_behaviours = {
         "do_nothing",
     ],
     "build_from_version": [
+        "do_nothing",
+    ],
+    "install_with_custom_version_and_build": [
         "do_nothing",
     ],
     "install_and_build_from_tarball": [

--- a/compatibility/test-all-installs.sh
+++ b/compatibility/test-all-installs.sh
@@ -267,7 +267,7 @@ else
   export head_sdk_exe=daml
 fi
 "$(rlocation "head_sdk/$head_sdk_exe")" install --install-assistant yes "$(rlocation head_sdk/sdk-release-tarball-ce.tar.gz)"
-if [[ "$daml_exe" == "daml.exe" ]]; then
+if [[ "$os" == windows ]]; then
   # on windows, fully qualify daml command
   export daml_exe="$DAML_HOME/bin/daml.cmd"
 else

--- a/compatibility/test-all-installs.sh
+++ b/compatibility/test-all-installs.sh
@@ -140,6 +140,26 @@ parties:
 dependencies:
 - daml-prim
 - daml-stdlib
+""" > daml.yaml
+
+echo """
+module Main where
+""" > Main.daml
+}
+
+init_daml_package_with_script () {
+echo """
+sdk-version: $1
+name: test-daml-yaml-install
+version: 1.0.0
+source: Main.daml
+scenario: Main:main
+parties:
+- Alice
+- Bob
+dependencies:
+- daml-prim
+- daml-stdlib
 - daml-script
 """ > daml.yaml
 
@@ -304,6 +324,12 @@ case "$command_to_run" in
         error_echo "ERROR! Exit code for \`daml build\` on version $build_version is nonzero"
       fi
     fi
+    ;;
+  install_with_custom_version_and_build)
+    custom_version=2.99.0
+    "$(rlocation "head_sdk/$daml_exe")" install --install-assistant yes --install-with-custom-version $custom_version "$(rlocation head_sdk/sdk-release-tarball-ce.tar.gz)"
+    init_daml_package_with_script $custom_version
+    daml build
     ;;
   install_and_build_from_tarball)
     [[ "$#" -gt 0 ]] || error_echo "No tarball_path supplied via args"

--- a/compatibility/test-all-installs.sh
+++ b/compatibility/test-all-installs.sh
@@ -140,10 +140,16 @@ parties:
 dependencies:
 - daml-prim
 - daml-stdlib
+- daml-script
 """ > daml.yaml
 
 echo """
 module Main where
+
+import Daml.Script
+
+main : Script ()
+main = pure ()
 """ > Main.daml
 }
 

--- a/compatibility/test-all-installs.sh
+++ b/compatibility/test-all-installs.sh
@@ -262,11 +262,11 @@ fi
 export DAML_CACHE="$(mktemp -d -p "$PWD" "cache.XXXXXXXX")"
 export DAML_HOME="$(mktemp -d -p "$PWD" "daml_home.XXXXXXXX")"
 if [[ "$os" == windows ]]; then
-  export daml_exe=daml.exe
+  export head_sdk_exe=daml.exe
 else
-  export daml_exe=daml
+  export head_sdk_exe=daml
 fi
-"$(rlocation "head_sdk/$daml_exe")" install --install-assistant yes "$(rlocation head_sdk/sdk-release-tarball-ce.tar.gz)"
+"$(rlocation "head_sdk/$head_sdk_exe")" install --install-assistant yes "$(rlocation head_sdk/sdk-release-tarball-ce.tar.gz)"
 if [[ "$daml_exe" == "daml.exe" ]]; then
   # on windows, fully qualify daml command
   export daml_exe="$DAML_HOME/bin/daml.cmd"
@@ -327,9 +327,9 @@ case "$command_to_run" in
     ;;
   install_with_custom_version_and_build)
     custom_version=2.99.0
-    "$(rlocation "head_sdk/$daml_exe")" install --install-assistant yes --install-with-custom-version $custom_version "$(rlocation head_sdk/sdk-release-tarball-ce.tar.gz)"
+    "$(rlocation "head_sdk/$head_sdk_exe")" install --install-assistant yes --install-with-custom-version $custom_version "$(rlocation head_sdk/sdk-release-tarball-ce.tar.gz)"
     init_daml_package_with_script $custom_version
-    daml build
+    $daml_exe build
     ;;
   install_and_build_from_tarball)
     [[ "$#" -gt 0 ]] || error_echo "No tarball_path supplied via args"

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -245,12 +245,12 @@ da_haskell_library(
         "//compiler/scenario-service/client",
         "//compiler/scenario-service/protos:scenario_service_haskell_proto",
         "//compiler/scenario-service/protos:test_results_haskell_proto",
+        "//daml-assistant:daml-lib",
         "//daml-assistant:daml-project-config",
         "//daml-assistant/daml-helper:daml-helper-lib",
         "//daml-lf/archive:daml_lf_dev_archive_haskell_proto",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
-        "//daml-assistant:daml-lib",
     ],
 )
 

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -250,6 +250,7 @@ da_haskell_library(
         "//daml-lf/archive:daml_lf_dev_archive_haskell_proto",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
+        "//daml-assistant:daml-lib",
     ],
 )
 

--- a/compiler/damlc/daml-compiler/BUILD.bazel
+++ b/compiler/damlc/daml-compiler/BUILD.bazel
@@ -33,6 +33,7 @@ da_haskell_library(
         "safe",
         "safe-exceptions",
         "semigroupoids",
+        "semver",
         "shake",
         "text",
         "time",

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -66,6 +66,8 @@ import MkIface
 import Module
 import qualified Module as Ghc
 import HscTypes
+import qualified Data.SemVer as V
+import DA.Daml.Project.Types (UnresolvedReleaseVersion(..))
 
 import qualified "zip-archive" Codec.Archive.Zip as ZipArchive
 
@@ -363,7 +365,7 @@ sinkEntryDeterministic compression sink sel = do
 createArchive
     :: LF.PackageName
     -> Maybe LF.PackageVersion
-    -> PackageSdkVersion
+    -> UnresolvedReleaseVersion
     -> LF.PackageId
     -> BSL.ByteString -- ^ DALF
     -> [(T.Text, BS.ByteString, LF.PackageId)] -- ^ DALF dependencies
@@ -413,7 +415,7 @@ createArchive pName pVersion pSdkVersion pkgId dalf dalfDependencies srcRoot fil
             [ "Manifest-Version: 1.0"
             , "Created-By: damlc"
             , "Name: " <> unitIdString (pkgNameVersion pName pVersion)
-            , "Sdk-Version: " <> unPackageSdkVersion pSdkVersion
+            , "Sdk-Version: " <> V.toString (unwrapUnresolvedReleaseVersion pSdkVersion)
             , "Main-Dalf: " <> toPosixFilePath location
             , "Dalfs: " <> intercalate ", " (map toPosixFilePath dalfs)
             , "Format: daml-lf"

--- a/compiler/damlc/daml-package-config/BUILD.bazel
+++ b/compiler/damlc/daml-package-config/BUILD.bazel
@@ -49,6 +49,7 @@ da_haskell_test(
     deps = [
         ":daml-package-config",
         "//compiler/daml-lf-ast",
+        "//daml-assistant:daml-project-config",
         "//libs-haskell/test-utils",
     ],
 )

--- a/compiler/damlc/daml-package-config/BUILD.bazel
+++ b/compiler/damlc/daml-package-config/BUILD.bazel
@@ -20,6 +20,7 @@ da_haskell_library(
         "ghc-lib-parser",
         "regex-tdfa",
         "safe-exceptions",
+        "semver",
         "text",
         "transformers",
         "yaml",

--- a/compiler/damlc/daml-package-config/test/DA/Daml/Package/ConfigTest.hs
+++ b/compiler/damlc/daml-package-config/test/DA/Daml/Package/ConfigTest.hs
@@ -11,6 +11,7 @@ import qualified Data.Text as T
 import Test.Tasty
 import Test.Tasty.HUnit
 import Control.Exception (throw)
+import DA.Daml.Project.Types (parseUnresolvedVersion)
 
 main :: IO ()
 main = defaultMain $

--- a/compiler/damlc/daml-package-config/test/DA/Daml/Package/ConfigTest.hs
+++ b/compiler/damlc/daml-package-config/test/DA/Daml/Package/ConfigTest.hs
@@ -10,6 +10,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import Test.Tasty
 import Test.Tasty.HUnit
+import Control.Exception (throw)
 
 main :: IO ()
 main = defaultMain $
@@ -36,7 +37,7 @@ checkPkgConfigTests = testGroup "checkPkgConfig"
       , pDependencies = []
       , pDataDependencies = []
       , pModulePrefixes = Map.empty
-      , pSdkVersion = PackageSdkVersion "0.0.0"
+      , pSdkVersion = either throw id (parseUnresolvedVersion "0.0.0")
       , pUpgradedPackagePath = Nothing
       , pTypecheckUpgrades = False
       }

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -84,7 +84,13 @@ import DA.Daml.Compiler.Dar (FromDalf(..),
                              getDamlRootFiles,
                              writeIfacesAndHie)
 import DA.Daml.Compiler.Output (diagnosticsLogger, writeOutput, writeOutputBSL)
-import DA.Daml.Project.Types (UnresolvedReleaseVersion(..), unresolvedBuiltinSdkVersion, isHeadVersion)
+import DA.Daml.Project.Types
+    ( UnresolvedReleaseVersion(..),
+      unresolvedBuiltinSdkVersion,
+      isHeadVersion,
+      ConfigError(..),
+      ProjectPath(..),
+      ProjectConfig )
 import DA.Daml.Assistant.Version (resolveReleaseVersion)
 import qualified DA.Daml.Compiler.Repl as Repl
 import DA.Daml.Compiler.DocTest (docTest)
@@ -149,7 +155,6 @@ import DA.Daml.Project.Consts (ProjectCheck(..),
                                withProjectRoot)
 import DA.Daml.Assistant.Env (getDamlEnv, getDamlPath, envUseCache)
 import DA.Daml.Assistant.Types (LookForProjectPath(..))
-import DA.Daml.Project.Types (ConfigError(..), ProjectPath(..), ProjectConfig)
 import qualified DA.Pretty
 import qualified DA.Service.Logger as Logger
 import qualified DA.Service.Logger.Impl.GCP as Logger.GCP

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -84,6 +84,8 @@ import DA.Daml.Compiler.Dar (FromDalf(..),
                              getDamlRootFiles,
                              writeIfacesAndHie)
 import DA.Daml.Compiler.Output (diagnosticsLogger, writeOutput, writeOutputBSL)
+import DA.Daml.Project.Types (UnresolvedReleaseVersion(..), unresolvedBuiltinSdkVersion, isHeadVersion)
+import DA.Daml.Assistant.Version (resolveReleaseVersion)
 import qualified DA.Daml.Compiler.Repl as Repl
 import DA.Daml.Compiler.DocTest (docTest)
 import DA.Daml.Desugar (desugar)
@@ -130,7 +132,6 @@ import DA.Daml.Options.Types (EnableScenarioService(..),
                               projectPackageDatabase)
 import DA.Daml.Package.Config (MultiPackageConfigFields(..),
                                PackageConfigFields(..),
-                               PackageSdkVersion(..),
                                checkPkgConfig,
                                findMultiPackageConfig,
                                withPackageConfig,
@@ -146,6 +147,8 @@ import DA.Daml.Project.Consts (ProjectCheck(..),
                                sdkVersionEnvVar,
                                withExpectProjectRoot,
                                withProjectRoot)
+import DA.Daml.Assistant.Env (getDamlEnv, getDamlPath, envUseCache)
+import DA.Daml.Assistant.Types (LookForProjectPath(..))
 import DA.Daml.Project.Types (ConfigError(..), ProjectPath(..), ProjectConfig)
 import qualified DA.Pretty
 import qualified DA.Service.Logger as Logger
@@ -902,10 +905,13 @@ installDepsAndInitPackageDb opts (InitPkgDb shouldInit) =
         when isProject $ do
             projRoot <- getCurrentDirectory
             withPackageConfig defaultProjectPath $ \PackageConfigFields {..} -> do
+              damlPath <- getDamlPath
+              damlEnv <- getDamlEnv damlPath (LookForProjectPath False)
+              releaseVersion <- resolveReleaseVersion (envUseCache damlEnv) pSdkVersion
               installDependencies
                   (toNormalizedFilePath' projRoot)
                   opts
-                  pSdkVersion
+                  releaseVersion
                   pDependencies
                   pDataDependencies
               createProjectPackageDb (toNormalizedFilePath' projRoot) opts pModulePrefixes
@@ -1141,7 +1147,7 @@ type instance RuleResult BuildMulti = (LF.PackageName, LF.PackageVersion, LF.Pac
 
 -- Subset of PackageConfig needed for multi-package build deferring.
 data BuildMultiPackageConfig = BuildMultiPackageConfig
-  { bmSdkVersion :: PackageSdkVersion
+  { bmSdkVersion :: UnresolvedReleaseVersion
   , bmName :: LF.PackageName
   , bmVersion :: LF.PackageVersion
   , bmDataDeps :: [FilePath]
@@ -1289,7 +1295,7 @@ buildMultiRule assistantRunner buildableDataDeps (MultiPackageNoCache noCache) m
             -- Call build via daml assistant so it selects the correct SDK version.
             -- TODO[SW]: Update this check to compare version to most recent snapshot, once a snapshot is released that won't error with --enable-multi-package.
             runAssistant assistantRunner filePath $
-              ["build"] <> (["--enable-multi-package=no" | unPackageSdkVersion bmSdkVersion == "0.0.0"])
+              ["build"] <> (["--enable-multi-package=no" | isHeadVersion bmSdkVersion])
 
             darPath <- deriveDarPath filePath bmName bmVersion bmOutput
             -- Extract the new package ID from the dar we just built, by reading the DAR and looking for the dalf that matches our package name/version
@@ -1440,7 +1446,7 @@ execPackage projectOpts filePath opts mbOutFile dalfInput =
                               , pVersion = optMbPackageVersion opts
                               , pDependencies = []
                               , pDataDependencies = []
-                              , pSdkVersion = PackageSdkVersion SdkVersion.sdkVersion
+                              , pSdkVersion = unresolvedBuiltinSdkVersion
                               , pModulePrefixes = Map.empty
                               , pUpgradedPackagePath = Nothing
                               , pTypecheckUpgrades = False
@@ -1571,7 +1577,10 @@ execDocTest opts scriptDar (ImportSource importSource) files =
       -- An approach of copying out the deps into a temporary location to build/run the tests has been considered
       -- but the effort to build this, combined with the low number of users of this feature, as well as most projects
       -- already using daml-script has led us to leave this as is. We'll fix this if someone is affected and notifies us.
-      installDependencies "." opts (PackageSdkVersion SdkVersion.sdkVersion) [scriptDar] []
+      damlPath <- getDamlPath
+      damlEnv <- getDamlEnv damlPath (LookForProjectPath False)
+      releaseVersion <- resolveReleaseVersion (envUseCache damlEnv) unresolvedBuiltinSdkVersion
+      installDependencies "." opts releaseVersion [scriptDar] []
       createProjectPackageDb "." opts mempty
 
       opts <- pure opts

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -28,7 +28,6 @@ import           "ghc-lib-parser" Unique
 import           Control.Concurrent.Extra
 import           Control.DeepSeq
 import           Control.Exception.Extra
-import           Control.Exception (throw)
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           DA.Daml.LF.PrettyScenario (prettyScenarioError, prettyScenarioResult)
@@ -82,6 +81,7 @@ import qualified GHC
 import Options.Applicative (execParser, forwardOptions, info, many, strArgument)
 import Outputable (ppr, showSDoc)
 import qualified Proto3.Suite.JSONPB as JSONPB
+import DA.Daml.Project.Types (unsafeResolveReleaseVersion, parseUnresolvedVersion)
 
 import Test.Tasty
 import Test.Tasty.Golden (goldenVsStringDiff)
@@ -173,7 +173,7 @@ withVersionedDamlScriptDep packageFlagName darPath mLfVer extraPackages cont = d
       installDependencies
         projDir
         (defaultOptions mLfVer)
-        (either throw id (parseUnresolvedVersion sdkVersion))
+        (unsafeResolveReleaseVersion (either throw id (parseUnresolvedVersion (T.pack sdkVersion))))
         ["daml-prim", "daml-stdlib", scriptDar]
         extraDars
       createProjectPackageDb

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -28,6 +28,7 @@ import           "ghc-lib-parser" Unique
 import           Control.Concurrent.Extra
 import           Control.DeepSeq
 import           Control.Exception.Extra
+import           Control.Exception (throw)
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           DA.Daml.LF.PrettyScenario (prettyScenarioError, prettyScenarioResult)
@@ -90,7 +91,6 @@ import Test.Tasty.Options
 import Test.Tasty.Providers
 import Test.Tasty.Runners (Result(..))
 
-import DA.Daml.Package.Config (PackageSdkVersion (..))
 import DA.Cli.Damlc.DependencyDb (installDependencies)
 import DA.Cli.Damlc.Packaging (createProjectPackageDb)
 import Module (stringToUnitId)
@@ -173,7 +173,7 @@ withVersionedDamlScriptDep packageFlagName darPath mLfVer extraPackages cont = d
       installDependencies
         projDir
         (defaultOptions mLfVer)
-        (PackageSdkVersion sdkVersion)
+        (either throw id (parseUnresolvedVersion sdkVersion))
         ["daml-prim", "daml-stdlib", scriptDar]
         extraDars
       createProjectPackageDb

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -183,7 +183,7 @@ tests Tools{damlc} = testGroup "Packaging" $
           , "a = ()"
           ]
         writeFileUTF8 (projDir </> "daml.yaml") $ unlines
-          [ "sdk-version: a-bad-sdk-version"
+          [ "sdk-version: 0.0.0-a-bad-sdk-version"
           , "name: proj"
           , "version: \"1.0\""
           , "source: ."

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -144,7 +144,7 @@ initPackageConfig options scriptDar dars = do
         installDependencies
             (toNormalizedFilePath' dir)
             options
-            pSdkVersion
+            (unsafeResolveReleaseVersion pSdkVersion)
             pDependencies
             pDataDependencies
         createProjectPackageDb (toNormalizedFilePath' dir) options pModulePrefixes

--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -79,7 +79,7 @@ withScriptService lfVersion action =
         installDependencies
             projDir
             (options lfVersion)
-            pSdkVersion
+            (unsafeResolveReleaseVersion pSdkVersion)
             pDependencies
             pDataDependencies
         createProjectPackageDb

--- a/compiler/damlc/tests/src/DA/Test/ScriptService_1_15.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService_1_15.hs
@@ -70,7 +70,7 @@ main =
         installDependencies
             projDir
             options
-            pSdkVersion
+            (unsafeResolveReleaseVersion pSdkVersion)
             pDependencies
             pDataDependencies
         createProjectPackageDb

--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -24,7 +24,7 @@ da_haskell_library(
     ],
     src_strip_prefix = "daml-project-config",
     visibility = ["//visibility:public"],
-    deps = [],
+    deps = ["//:sdk-version-hs-lib"],
 )
 
 da_haskell_library(

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -71,17 +71,16 @@ import DA.Daml.Helper.Util
 import qualified DA.Daml.LF.Ast as LF
 import qualified DA.Daml.LF.Ast.Optics as LF (packageRefs)
 import qualified DA.Daml.LF.Proto3.Archive as LFArchive
-import DA.Daml.Package.Config (PackageSdkVersion(..))
 import DA.Daml.Project.Util (fromMaybeM)
 import qualified DA.Ledger as L
 import qualified DA.Service.Logger as Logger
 import qualified DA.Service.Logger.Impl.IO as Logger
-import qualified SdkVersion
 import DA.Ledger.Types (ApplicationId(..))
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Time.Calendar (Day(..))
 import DA.Ledger.Services.MeteringReportService(MeteringRequestByDay(..))
 import qualified Data.Aeson as Aeson
+import DA.Daml.Project.Types (unresolvedBuiltinSdkVersion)
 
 data LedgerApi
   = Grpc
@@ -311,7 +310,7 @@ fetchDar args rootPid saveAs = do
         case packageMetadata of
           Nothing -> (LF.PackageName $ T.pack "reconstructed",Nothing)
           Just LF.PackageMetadata{packageName,packageVersion} -> (packageName,Just packageVersion)
-  let pSdkVersion = PackageSdkVersion SdkVersion.sdkVersion
+  let pSdkVersion = unresolvedBuiltinSdkVersion
   let srcRoot = error "unexpected use of srcRoot when there are no sources"
   let za = createArchive pName pVersion pSdkVersion pkgId dalf dalfDependencies srcRoot [] [] []
   createDarFile loggerH saveAs za

--- a/daml-assistant/daml-project-config/DA/Daml/Project/Consts.hs
+++ b/daml-assistant/daml-project-config/DA/Daml/Project/Consts.hs
@@ -32,6 +32,7 @@ import System.Environment
 import System.Exit
 import System.FilePath
 import System.IO
+import qualified Data.Text as T
 
 import DA.Daml.Project.Types
 
@@ -146,8 +147,8 @@ getSdkVersion :: IO String
 getSdkVersion = getEnv sdkVersionEnvVar
 
 -- | Returns the current SDK version if set, or Nothing.
-getSdkVersionMaybe :: IO (Maybe String)
-getSdkVersionMaybe = lookupEnv sdkVersionEnvVar
+getSdkVersionMaybe :: IO (Maybe (Either InvalidVersion UnresolvedReleaseVersion))
+getSdkVersionMaybe = (fmap . fmap) (parseVersion . T.pack) $ lookupEnv sdkVersionEnvVar
 
 -- | Returns the absolute path to the assistant.
 --

--- a/daml-assistant/daml-project-config/DA/Daml/Project/Types.hs
+++ b/daml-assistant/daml-project-config/DA/Daml/Project/Types.hs
@@ -17,6 +17,8 @@ import Control.Monad
 import Control.Exception.Safe
 import Data.Either.Extra (eitherToMaybe)
 import Data.Function (on)
+import qualified SdkVersion
+import qualified Control.Exception as Unsafe
 
 data ConfigError
     = ConfigFileInvalid Text Y.ParseException
@@ -183,6 +185,9 @@ releaseVersionFromCacheString src =
       [both] -> OldReleaseVersion <$> parseVersionM both
       [release, sdk] -> SplitReleaseVersion <$> parseVersionM release <*> parseVersionM sdk
       _ -> Nothing
+
+unresolvedBuiltinSdkVersion :: UnresolvedReleaseVersion
+unresolvedBuiltinSdkVersion = either Unsafe.throw id $ parseUnresolvedVersion (T.pack SdkVersion.sdkVersion)
 
 -- | File path of daml installation root (by default ~/.daml on unix, %APPDATA%/daml on windows).
 newtype DamlPath = DamlPath

--- a/daml-assistant/daml-project-config/DA/Daml/Project/Types.hs
+++ b/daml-assistant/daml-project-config/DA/Daml/Project/Types.hs
@@ -189,6 +189,9 @@ releaseVersionFromCacheString src =
 unresolvedBuiltinSdkVersion :: UnresolvedReleaseVersion
 unresolvedBuiltinSdkVersion = either Unsafe.throw id $ parseUnresolvedVersion (T.pack SdkVersion.sdkVersion)
 
+unsafeResolveReleaseVersion :: UnresolvedReleaseVersion -> ReleaseVersion
+unsafeResolveReleaseVersion (UnresolvedReleaseVersion v) = OldReleaseVersion v
+
 -- | File path of daml installation root (by default ~/.daml on unix, %APPDATA%/daml on windows).
 newtype DamlPath = DamlPath
     { unwrapDamlPath :: FilePath

--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -126,7 +126,7 @@ main = do
     setRunfilesEnv
     withProgName "daml codegen js" $ do
         opts@Options{..} <- customExecParser (prefs showHelpOnError) optionsParserInfo
-        unresolvedVersionOrErr <- DATypes.parseVersion . T.pack . fromMaybe "0.0.0" <$> getSdkVersionMaybe
+        unresolvedVersionOrErr <- fromMaybe (DATypes.parseVersion (T.pack "0.0.0")) <$> getSdkVersionMaybe
         releaseVersion <- case unresolvedVersionOrErr of
               Left _ -> fail "Invalid SDK version"
               Right v -> do


### PR DESCRIPTION
Deps like `daml-script` are broken, because linking of dependencies is on the internal version. We now fix this and test in `test-all-installs.sh`