### PR TITLE
fix tag_filter in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -55,7 +55,7 @@ fi
 
 # Bazel test only builds targets that are dependencies of a test suite so do a full build first.
 $bazel build //... \
-  --build_tag_filters "${tag_filter:1}" \
+  --build_tag_filters "${tag_filter}" \
   --profile build-profile.json \
   --experimental_profile_include_target_label \
   --build_event_json_file build-events.json \
@@ -94,8 +94,8 @@ start_postgresql
 
 # Run the tests.
 $bazel test //... \
-  --build_tag_filters "${tag_filter:1}" \
-  --test_tag_filters "${tag_filter:1}" \
+  --build_tag_filters "${tag_filter}" \
+  --test_tag_filters "${tag_filter}" \
   --test_env "POSTGRESQL_HOST=${POSTGRESQL_HOST}" \
   --test_env "POSTGRESQL_PORT=${POSTGRESQL_PORT}" \
   --test_env "POSTGRESQL_USERNAME=${POSTGRESQL_USERNAME}" \


### PR DESCRIPTION
Context: https://github.com/digital-asset/daml/issues/17812

Yet another bug in the handling of tag filters in `build.sh`. This time I realized I can check the [summary](https://dev.azure.com/digitalasset/adadc18a-d7df-446a-aacb-86042c1619c6/_apis/build/builds/155381/logs/185) printed by `bazel test` at the end of the log, and we see that only the 1.dev conformance test is executed. So it seems to be finally working as intended.

The `:1` used to drop a leading comma, which doesn't exist anymore.