### PR TITLE
Accept a run-all-tests commit trailer

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -68,24 +68,49 @@ bazel build //... `
 
 bazel shutdown
 
+function Has-Run-All-Tests-Trailer {
+  if ($env:BUILD_REASON -eq "PullRequest") {
+    $ref = "HEAD^2"
+  } else {
+    $ref = "HEAD"
+  }
+  $commit = git rev-parse $ref
+  $run_all_tests = git log -n1 --format="%(trailers:key=run-all-tests,valueonly)" $commit
+  $run_all_tests -eq "true"
+}
+
 if ($env:SKIP_TESTS -ceq "False") {
     # Generate mapping from shortened scala-test names on Windows to long names on Linux and MacOS.
     ./ci/remap-scala-test-short-names.ps1 `
       | Out-File -Encoding UTF8 -NoNewline scala-test-suite-name-map.json
 
-    $tag_filter = "-dev-canton-test"
+    $ALL_TESTS_FILTER = "-pr-only"
+    $LESS_TESTS_FILTER = "-main-only"
+
+    $tag_filter = "-dev-canton-test,-canton-ee"
     switch ($env:TEST_MODE) {
-      'main' { $tag_filter = "$tag_filter,-pr-only" }
-      'pr'   { $tag_filter = "$tag_filter,-main-only" }
+      'main' {
+        $tag_filter = "$tag_filter,$ALL_TESTS_FILTER"
+      }
+      'pr' {
+        if (Has-Run-All-Tests-Trailer) {
+          Write-Output "ignoring 'pr' test mode because the commit message features 'run-all-tests: true'"
+          $tag_filter = "$tag_filter,$ALL_TESTS_FILTER"
+        } else {
+          $tag_filter = "$tag_filter,$LESS_TESTS_FILTER"
+        }
+      }
       Default {
         Write-Output "<< unknown test mode: $env:TEST_MODE)"
         throw ("Was given an unknown test mode: $env:TEST_MODE")
       }
     }
 
+    Write-Output "Running bazel test with the following tag filters: $tag_filter"
+
     bazel test //... `
-      `-`-build_tag_filters "$tag_filter,-canton-ee" `
-      `-`-test_tag_filters "$tag_filter,-canton-ee" `
+      `-`-build_tag_filters "$tag_filter" `
+      `-`-test_tag_filters "$tag_filter" `
       `-`-profile test-profile.json `
       `-`-experimental_profile_include_target_label `
       `-`-build_event_json_file test-events.json `

--- a/build.ps1
+++ b/build.ps1
@@ -85,7 +85,7 @@ if ($env:SKIP_TESTS -ceq "False") {
       | Out-File -Encoding UTF8 -NoNewline scala-test-suite-name-map.json
 
     $ALL_TESTS_FILTER = "-pr-only"
-    $LESS_TESTS_FILTER = "-main-only"
+    $FEWER_TESTS_FILTER = "-main-only"
 
     $tag_filter = "-dev-canton-test,-canton-ee"
     switch ($env:TEST_MODE) {
@@ -97,7 +97,7 @@ if ($env:SKIP_TESTS -ceq "False") {
           Write-Output "ignoring 'pr' test mode because the commit message features 'run-all-tests: true'"
           $tag_filter = "$tag_filter,$ALL_TESTS_FILTER"
         } else {
-          $tag_filter = "$tag_filter,$LESS_TESTS_FILTER"
+          $tag_filter = "$tag_filter,$FEWER_TESTS_FILTER"
         }
       }
       Default {

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 eval "$("$(dirname "$0")/dev-env/bin/dade-assist")"
 
 execution_log_postfix=${1:-}${2:-}
+test_mode=${3:-main}
 
 export LC_ALL=en_US.UTF-8
 
@@ -25,12 +26,12 @@ has_run_all_tests_trailer() {
 }
 
 ALL_TESTS_FILTER="-pr-only"
-LESS_TESTS_FILTER="-main-only"
+FEWER_TESTS_FILTER="-main-only"
 
-case ${3:-} in
+case $test_mode in
   # When running against main, exclude "pr-only" tests
-  main|'')
-    tag_filter=$ALL_TESTS_FILTER
+  main)
+    tag_filter=$FEWER_TESTS_FILTER
     ;;
   # When running against a PR, exclude "main-only" tests, unless the commit message features a
   # 'run-all-tests: true' trailer
@@ -39,11 +40,11 @@ case ${3:-} in
       echo "ignoring 'pr' test mode because the commit message features 'run-all-tests: true'"
       tag_filter=$ALL_TESTS_FILTER
     else
-      tag_filter=$LESS_TESTS_FILTER
+      tag_filter=$FEWER_TESTS_FILTER
     fi
     ;;
   *)
-    echo "unknown test mode: $3"
+    echo "unknown test mode: $test_mode"
     exit 1
     ;;
 esac


### PR DESCRIPTION
After https://github.com/digital-asset/daml/pull/17956, the CI only run a subset of tests against PRs, and all tests against main after merging. This PR introduces a way to force all tests to run against a PR, by adding a `run-all-tests: true` trailer to the commit message.

I tested it on the 3 platforms with and without the trailer.