### PR TITLE
precommit: add check for modified files under packages with `main-only` targets.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,10 @@ repos:
       language: system
       pass_filenames: false
       entry: "pre-commit/platform-independence-check.sh"
+    - id: mainonly
+      name: main only
+      description: Check for changes under packages with targets tagged with main-only
+      language: system
+      pass_filenames: true
+      entry: "dade-check-main-only-files"
+      types: [text]

--- a/dev-env/bin/dade-check-main-only-files
+++ b/dev-env/bin/dade-check-main-only-files
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Checks whether any of the modified files sit under packages with targets marked as 'main-only'.
+#
+# This is as intended a simple heuristic to avoid accidentally omitting 'run-all-tests: true'
+# on a PR branch which touches those files.
+#
+
+DADE_SKIP_MAIN_ONLY_CHECK="${DADE_SKIP_MAIN_ONLY_CHECK:-$(git log -1 | grep 'run-all-tests')}"
+if [[ -n "$DADE_SKIP_MAIN_ONLY_CHECK" ]]; then
+  # The user has been explicit about whether they want all tests run,
+  # either by setting the env var, or adding a line to their last commit.
+  exit 0; 
+fi
+
+MODIFIED_FILES=$(echo "$@" | xargs -n1 | sort)
+MAIN_ONLY_DIRS=$(bazel query "attr(tags, 'main-only', //...)" 2>/dev/null | awk -F: '{print $1}' | sort -u | sed -e 's|^//||')
+
+# Does a cartesian product of the main-only dirs and modified files, and filters to files that are within dir.
+SUSPECT_FILES=$(join -j99 <(echo "$MAIN_ONLY_DIRS") <(echo "$MODIFIED_FILES") | awk '$1 == substr($2, 1, length($1)) {print $2}')
+
+if [[ -n "$SUSPECT_FILES" ]]; then
+  echo """
+The following modified files sit under a directory with 'main-only' targets:
+$SUSPECT_FILES
+
+Consider putting a line with 'run-all-tests: true' in your PR description, or \`export DADE_SKIP_MAIN_ONLY_CHECK=1\` and try again.
+    """ >&2
+  exit 1
+fi

--- a/dev-env/bin/dade-check-main-only-files
+++ b/dev-env/bin/dade-check-main-only-files
@@ -6,7 +6,7 @@
 # on a PR branch which touches those files.
 #
 
-DADE_SKIP_MAIN_ONLY_CHECK="${DADE_SKIP_MAIN_ONLY_CHECK:-$(git log -1 | grep 'run-all-tests')}"
+DADE_SKIP_MAIN_ONLY_CHECK="${DADE_SKIP_MAIN_ONLY_CHECK:-$(git log -1 --format=%b | tr -d ' ' | grep '^run-all-tests:true$')}"
 if [[ -n "$DADE_SKIP_MAIN_ONLY_CHECK" ]]; then
   # The user has been explicit about whether they want all tests run,
   # either by setting the env var, or adding a line to their last commit.
@@ -20,11 +20,11 @@ MAIN_ONLY_DIRS=$(bazel query "attr(tags, 'main-only', //...)" 2>/dev/null | awk 
 SUSPECT_FILES=$(join -j99 <(echo "$MAIN_ONLY_DIRS") <(echo "$MODIFIED_FILES") | awk '$1 == substr($2, 1, length($1)) {print $2}')
 
 if [[ -n "$SUSPECT_FILES" ]]; then
-  echo """
+  echo "
 The following modified files sit under a directory with 'main-only' targets:
 $SUSPECT_FILES
 
 Consider putting a line with 'run-all-tests: true' in your PR description, or \`export DADE_SKIP_MAIN_ONLY_CHECK=1\` and try again.
-    """ >&2
+    " >&2
   exit 1
 fi


### PR DESCRIPTION
Since https://github.com/digital-asset/daml/pull/17989

A simple heuristic to remind you to consider adding `run-all-tests: true` to your commit message if making changes in corners of the codebase most likely affected.