### PR TITLE
store the home package's metadata in the context of scenario service

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/IdeState/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/IdeState/Daml.hs
@@ -52,7 +52,7 @@ withDamlIdeState
     -> IO a
 withDamlIdeState opts@Options{..} loggerH eventHandler f = do
     scenarioServiceConfig <- Scenario.readScenarioServiceConfig
-    Scenario.withScenarioService' optScenarioService optEnableScenarios optDamlLfVersion loggerH scenarioServiceConfig $ \mbScenarioService -> do
+    Scenario.withScenarioService' optScenarioService optEnableScenarios optDamlLfVersion (optPackageMetadata opts) loggerH scenarioServiceConfig $ \mbScenarioService -> do
         vfs <- makeVFSHandle
         bracket
             (getDamlIdeState opts (StudioAutorunAllScenarios True) mbScenarioService loggerH noopDebouncer (DummyLspEnv eventHandler) vfs)

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -783,8 +783,7 @@ contextForFile file = do
         NM.toList $ LF.packageModules pkg
     DamlEnv{..} <- getDamlServiceEnv
     pure SS.Context
-        { ctxPackageMetadata = LF.packageMetadata pkg
-        , ctxModules = Map.fromList encodedModules
+        { ctxModules = Map.fromList encodedModules
         , ctxPackages = [(LF.dalfPackageId pkg, LF.dalfPackageBytes pkg) | pkg <- Map.elems pkgMap ++ Map.elems stablePackages]
         , ctxSkipValidation = SS.SkipValidation (getSkipScenarioValidation envSkipScenarioValidation)
         }
@@ -799,8 +798,7 @@ contextForPackage file pkg = do
     stablePackages <- useNoFile_ GenerateStablePackages
     pure
         SS.Context
-            { ctxPackageMetadata = LF.packageMetadata pkg
-            , ctxModules = Map.fromList encodedModules
+            { ctxModules = Map.fromList encodedModules
             , ctxPackages =
                   [ (LF.dalfPackageId pkg, LF.dalfPackageBytes pkg)
                   | pkg <- Map.elems pkgMap ++ Map.elems stablePackages

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -783,7 +783,8 @@ contextForFile file = do
         NM.toList $ LF.packageModules pkg
     DamlEnv{..} <- getDamlServiceEnv
     pure SS.Context
-        { ctxModules = Map.fromList encodedModules
+        { ctxPackageMetadata = LF.packageMetadata pkg
+        , ctxModules = Map.fromList encodedModules
         , ctxPackages = [(LF.dalfPackageId pkg, LF.dalfPackageBytes pkg) | pkg <- Map.elems pkgMap ++ Map.elems stablePackages]
         , ctxSkipValidation = SS.SkipValidation (getSkipScenarioValidation envSkipScenarioValidation)
         }
@@ -798,7 +799,8 @@ contextForPackage file pkg = do
     stablePackages <- useNoFile_ GenerateStablePackages
     pure
         SS.Context
-            { ctxModules = Map.fromList encodedModules
+            { ctxPackageMetadata = LF.packageMetadata pkg
+            , ctxModules = Map.fromList encodedModules
             , ctxPackages =
                   [ (LF.dalfPackageId pkg, LF.dalfPackageBytes pkg)
                   | pkg <- Map.elems pkgMap ++ Map.elems stablePackages

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -33,6 +33,7 @@ module DA.Daml.Options.Types
     , pkgNameVersion
     , fullPkgName
     , optUnitId
+    , optPackageMetadata
     , getLogger
     ) where
 
@@ -283,3 +284,12 @@ optUnitId Options{..} = fmap (\name -> pkgNameVersion name optMbPackageVersion) 
 
 getLogger :: Options -> T.Text -> IO (Logger.Handle IO)
 getLogger Options {optLogLevel} name = Logger.IO.newStderrLogger optLogLevel name
+
+optPackageMetadata :: Options -> Maybe LF.PackageMetadata
+optPackageMetadata Options{..}
+   | getIgnorePackageMetadata optIgnorePackageMetadata = Nothing
+   | otherwise =
+       LF.PackageMetadata
+           <$> optMbPackageName
+           <*> optMbPackageVersion
+           <*> pure Nothing

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -115,7 +115,7 @@ import DA.Daml.Options (toCompileOpts)
 import DA.Daml.Options.Types (EnableScenarioService(..),
                               Haddock(..),
                               IncrementalBuild (..),
-                              Options,
+                              Options (optMbPackageName),
                               SkipScenarioValidation(..),
                               StudioAutorunAllScenarios,
                               damlArtifactDir,
@@ -133,6 +133,7 @@ import DA.Daml.Options.Types (EnableScenarioService(..),
                               optMbPackageVersion,
                               optPackageDbs,
                               optPackageImports,
+                              optPackageMetadata,
                               optScenarioService,
                               optSkipScenarioValidation,
                               optThreads,
@@ -509,7 +510,7 @@ cmdBuild numProcessors =
     command "build" $
     info (helper <*> cmdBuildParser numProcessors) $
     progDesc "Initialize, build and package the Daml project" <> fullDesc
-    
+
 cmdBuildParser :: Int -> Parser Command
 cmdBuildParser numProcessors =
     execBuild
@@ -786,7 +787,7 @@ execIde telemetry (Debug debug) enableScenarioService autorunAllScenarios option
           installDepsAndInitPackageDb options (InitPkgDb True)
           scenarioServiceConfig <- readScenarioServiceConfig
           withLogger $ \loggerH ->
-              withScenarioService' enableScenarioService (optEnableScenarios options) (optDamlLfVersion options) loggerH scenarioServiceConfig $ \mbScenarioService -> do
+              withScenarioService' enableScenarioService (optEnableScenarios options) (optDamlLfVersion options) (optPackageMetadata options) loggerH scenarioServiceConfig $ \mbScenarioService -> do
                   sdkVersion <- getSdkVersion `catchIO` const (pure "Unknown (not started via the assistant)")
                   Logger.logInfo loggerH (T.pack $ "SDK version: " <> sdkVersion)
                   debouncer <- newAsyncDebouncer

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -206,9 +206,14 @@ main = do
                        { SS.cnfJvmOptions = ["-Xmx200M"]
                        , SS.cnfEvaluationTimeout = Just 3
                        }
+  let metadata =
+        LF.PackageMetadata
+          (LF.PackageName "-dummy-package-name-")
+          (LF.PackageVersion "0.0.0")
+          Nothing
 
   withDep $ \scriptPackageData ->
-    SS.withScenarioService lfVer scenarioLogger scenarioConf $ \scenarioService -> do
+    SS.withScenarioService lfVer (Just metadata) scenarioLogger scenarioConf $ \scenarioService -> do
       hSetEncoding stdout utf8
       setEnv "TASTY_NUM_THREADS" "1" True
       todoRef <- newIORef DList.empty

--- a/compiler/damlc/tests/src/DA/Test/ScriptService_1_15.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService_1_15.hs
@@ -10,7 +10,7 @@ import Control.Monad
 import DA.Bazel.Runfiles
 import DA.Cli.Damlc.Packaging
 import DA.Cli.Damlc.DependencyDb
-import qualified DA.Daml.LF.Ast.Version as LF
+import qualified DA.Daml.LF.Ast as LF
 import DA.Daml.LF.PrettyScenario (prettyScenarioError, prettyScenarioResult)
 import qualified DA.Daml.LF.ScenarioServiceClient as SS
 import DA.Daml.Options.Types
@@ -65,7 +65,7 @@ main =
             "- daml-stdlib",
             "- " <> show scriptDar
           ]
-      withPackageConfig (ProjectPath ".") $ \PackageConfigFields {..} -> do
+      metadata <- withPackageConfig (ProjectPath ".") $ \PackageConfigFields {..} -> do
         let projDir = toNormalizedFilePath' dir
         installDependencies
             projDir
@@ -77,11 +77,12 @@ main =
           projDir
           options
           pModulePrefixes
+        pure (LF.PackageMetadata pName <$> pVersion <*> pure Nothing)
 
       logger <- Logger.newStderrLogger Logger.Debug "script-service"
 
       -- Spinning up the scenario service is expensive so we do it once at the beginning.
-      SS.withScenarioService lfVersion logger scenarioConfig $ \scriptService ->
+      SS.withScenarioService lfVersion metadata logger scenarioConfig $ \scriptService ->
         defaultMain $
           testGroup
             "Script Service 1.15"

--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -52,7 +52,7 @@ test lfVersion scenarioLogger = do
     -- The startup of each scenario service is fairly expensive so instead of launching a separate
     -- service for each test, we launch a single service that is shared across all tests on the same LF version.
     withResourceCps
-        (SS.withScenarioService lfVersion scenarioLogger scenarioConfig)
+        (SS.withScenarioService lfVersion Nothing scenarioLogger scenarioConfig)
         $ \getScenarioService ->
             withResourceCps (withDamlScript (Just lfVersion)) $ \getScriptPackageData ->
                 ideTests lfVersion (Just getScenarioService) getScriptPackageData

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -1020,7 +1020,8 @@ prettyGlobalKey lvl world gk = vcat [
   ]
 
 prettyPackageMetadata :: PackageMetadata -> Doc SyntaxClass
-prettyPackageMetadata (PackageMetadata name version) = text $ TL.toStrict $ name <> "-" <> version
+prettyPackageMetadata (PackageMetadata name version _upgradedPackageId) =
+  text $ TL.toStrict $ name <> "-" <> version
 
 prettyChoiceId
   :: LF.World -> Maybe Identifier -> TL.Text

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
@@ -196,7 +196,8 @@ parseScenarioServiceConfig conf = do
                 Just a -> pure (Just a)
 
 data Context = Context
-  { ctxModules :: MS.Map Hash (LF.ModuleName, BS.ByteString)
+  { ctxPackageMetadata :: Maybe LF.PackageMetadata
+  , ctxModules :: MS.Map Hash (LF.ModuleName, BS.ByteString)
   , ctxPackages :: [(LF.PackageId, BS.ByteString)]
   , ctxSkipValidation :: LowLevel.SkipValidation
   }
@@ -216,6 +217,7 @@ getNewCtx Handle{..} Context{..} = withLock hContextLock $ withSem hConcurrencyS
       S.fromList (map fst $ MS.elems ctxModules)
 
     ctxUpdate = LowLevel.ContextUpdate
+      ctxPackageMetadata
       (MS.elems loadModules)
       (S.toList unloadModules)
       loadPackages

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -48,6 +48,7 @@ service ScenarioService {
 message NewContextRequest {
   string lf_major = 3;
   string lf_minor = 1;
+  PackageMetadata home_package_metadata = 4;
   int64 evaluation_timeout = 2;
 }
 
@@ -108,10 +109,9 @@ message UpdateContextRequest {
   }
 
   int64 context_id = 1;
-  PackageMetadata home_package_metadata = 2;
-  UpdateModules update_modules = 3;
-  UpdatePackages update_packages = 4;
-  bool noValidation = 5; // if true, does not run the package validations
+  UpdateModules update_modules = 2;
+  UpdatePackages update_packages = 3;
+  bool noValidation = 4; // if true, does not run the package validations
 }
 
 message UpdateContextResponse {
@@ -290,7 +290,7 @@ message ScenarioError {
       string instance = 1;
       string context = 2;
     }
-    
+
     oneof error {
       NotFound not_found = 1;
       AmbiguousInterfaceInstance ambiguous_interface_instance = 2;

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -108,9 +108,10 @@ message UpdateContextRequest {
   }
 
   int64 context_id = 1;
-  UpdateModules update_modules = 2;
-  UpdatePackages update_packages = 3;
-  bool noValidation = 4; // if true, does not run the package validations
+  PackageMetadata home_package_metadata = 2;
+  UpdateModules update_modules = 3;
+  UpdatePackages update_packages = 4;
+  bool noValidation = 5; // if true, does not run the package validations
 }
 
 message UpdateContextResponse {
@@ -174,6 +175,7 @@ message ContractRef {
 message PackageMetadata {
   string package_name = 1;
   string package_version = 2;
+  string upgraded_package_id = 3; // Optional
 }
 
 message GlobalKey {

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -100,11 +100,10 @@ class Context(
       omitValidation: Boolean,
   ): Unit = synchronized {
 
-    (this.homePackageMetadata, homePackageMetadata) match {
-      case (Some(oldMetadata), Some(newMetadata)) if oldMetadata != newMetadata =>
-        throw new IllegalArgumentException("home package metadata can only be modified once")
-      case _ => this.homePackageMetadata = homePackageMetadata
-    }
+    // We trust the clients of the service (which we all control) to never
+    // ovewrite an already set homePackageMetadata unless the context was just
+    // freshly cloned.
+    this.homePackageMetadata = homePackageMetadata
 
     val newModules = loadModules.map(module =>
       archive.moduleDecoder(languageVersion, homePackageId).assertFromByteString(module.getDamlLf1)

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -517,11 +517,13 @@ final class Conversions(
       .setTemplateId(convertIdentifier(templateId))
       .build
 
-  def mkPackageMetadata(packageMetadata: PackageMetadata): proto.PackageMetadata =
-    proto.PackageMetadata.newBuilder
-      .setPackageName(packageMetadata.name.toString)
-      .setPackageVersion(packageMetadata.version.toString)
-      .build
+  def mkPackageMetadata(packageMetadata: PackageMetadata): proto.PackageMetadata = {
+    val builder = proto.PackageMetadata.newBuilder
+      .setPackageName(packageMetadata.name)
+      .setPackageVersion(packageMetadata.version)
+    packageMetadata.upgradedPackageId.foreach(builder.setUpgradedPackageId(_))
+    builder.build
+  }
 
   def convertScenarioStep(
       stepId: Int,


### PR DESCRIPTION
Ideally `NewContextRequest` would specify the metadata of the home package once and for all, but unfortunately it is called very early in many places in daml/damlc before we even have that information.

Instead we let `UpdateContextRequest` set the home package's metadata, and crash if it subsequently tries to change it to a different value or to unset it.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
