### PR TITLE
Improve ResourceOwner teardown for Timers and ExecutorServices

### DIFF
--- a/libs-scala/resources/src/main/scala/com/digitalasset/resources/ResourceOwnerFactories.scala
+++ b/libs-scala/resources/src/main/scala/com/digitalasset/resources/ResourceOwnerFactories.scala
@@ -54,11 +54,24 @@ trait ResourceOwnerFactories[Context] {
     new ReleasableResourceOwner(acquire)(release)
 
   def forExecutorService[T <: ExecutorService](
-      acquire: () => T
+      acquire: () => T,
+      gracefulAwaitTerminationMillis: Long = Long.MaxValue,
+      forcefulAwaitTerminationMillis: Long = Long.MaxValue,
   ): AbstractResourceOwner[Context, T] =
-    new ExecutorServiceResourceOwner(acquire)
+    new ExecutorServiceResourceOwner(
+      acquire,
+      gracefulAwaitTerminationMillis,
+      forcefulAwaitTerminationMillis,
+    )
 
-  def forTimer(acquire: () => Timer): AbstractResourceOwner[Context, Timer] =
-    new TimerResourceOwner(acquire)
+  /** @param waitForRunningTasks If this flag is false, there could be long running scheduled tasks blocking
+    *                            termination of the Timer instance. In this case it is recommended to instantiate
+    *                            Timer with isDaemon = true, to not let it block JVM termination.
+    */
+  def forTimer(
+      acquire: () => Timer,
+      waitForRunningTasks: Boolean = true,
+  ): AbstractResourceOwner[Context, Timer] =
+    new TimerResourceOwner(acquire, waitForRunningTasks)
 
 }


### PR DESCRIPTION
* Introduce additional parameters to factory functions with new functionality
* Set default parameters as such, so previous behavior does not change
* Add possibility to Timer Resources to not wait for all running tasks to finish
* Add configurable graceful and forceful shutdown to ExecutorServiceResourceOwner

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
