### PR TITLE
fix canton 3 build

### DIFF
--- a/canton-3x/BUILD.bazel
+++ b/canton-3x/BUILD.bazel
@@ -1219,6 +1219,10 @@ da_scala_library(
     scala_deps = [
         "@maven//:org_scalacheck_scalacheck",
     ],
+    scalacopts = [
+        "-Xsource:3",
+        "-language:postfixOps",
+    ],
     visibility = [
         "//ledger-service/http-json:__subpackages__",
     ],
@@ -1242,6 +1246,10 @@ da_scala_test_suite(
         "@maven//:org_scalatest_scalatest_shouldmatchers",
         "@maven//:org_scalatest_scalatest_wordspec",
         "@maven//:org_scalatestplus_scalacheck_1_15",
+    ],
+    scalacopts = [
+        "-Xsource:3",
+        "-language:postfixOps",
     ],
     deps = [
         ":bindings-java",


### PR DESCRIPTION
This fixes the *hourly build* that runs against canton (3) head. The fact that the CI is green here doesn't prove that canton head will build. But I ran the following command:

```
ci/build-canton-3x.sh
```

and it succeeded.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
