### PR TITLE
restore package name default None value

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -127,6 +127,8 @@ object Node {
   /** Denotes that the contract identifier `coid` needs to be active for the transaction to be valid. */
   final case class Fetch(
       coid: ContractId,
+      // TODO: https://github.com/digital-asset/daml/issues/17995
+      //  remove default value once canton handle it.
       override val packageName: Option[PackageName] = None,
       override val templateId: TypeConName,
       actingParties: Set[Party],
@@ -215,6 +217,8 @@ object Node {
   }
 
   final case class LookupByKey(
+      // TODO: https://github.com/digital-asset/daml/issues/17995
+      //  remove default value once canton handle it.
       override val packageName: Option[PackageName] = None,
       override val templateId: TypeConName,
       key: GlobalKeyWithMaintainers,

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -127,7 +127,7 @@ object Node {
   /** Denotes that the contract identifier `coid` needs to be active for the transaction to be valid. */
   final case class Fetch(
       coid: ContractId,
-      override val packageName: Option[PackageName],
+      override val packageName: Option[PackageName] = None,
       override val templateId: TypeConName,
       actingParties: Set[Party],
       signatories: Set[Party],
@@ -215,7 +215,7 @@ object Node {
   }
 
   final case class LookupByKey(
-      override val packageName: Option[PackageName],
+      override val packageName: Option[PackageName] = None,
       override val templateId: TypeConName,
       key: GlobalKeyWithMaintainers,
       result: Option[ContractId],


### PR DESCRIPTION
Removing these default values currently breaks some canton tests.
