### PR TITLE
bump goyaml again

### DIFF
--- a/nix/tools/nix-store-gcs-proxy/deps.nix
+++ b/nix/tools/nix-store-gcs-proxy/deps.nix
@@ -779,8 +779,8 @@
     fetch = {
       type = "git";
       url = "https://gopkg.in/yaml.v2";
-      rev = "v2.2.4";
-      sha256 = "sha256-4mnIZoZTmJhCe8pX+ChsXTSxN1rYPWpZbhNFfsqRfIU=";
+      rev = "v2.2.8";
+      sha256 = "sha256-/KoaoUbFCm3r8nZyPaWZshMVTM2iSebS5kz/5rc+zsY=";
     };
   }
   {

--- a/nix/tools/nix-store-gcs-proxy/go.mod
+++ b/nix/tools/nix-store-gcs-proxy/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/urfave/cli v1.20.0
 	github.com/urfave/negroni v1.0.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/yaml.v2 v2.2.4 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 )


### PR DESCRIPTION
When working on #18026 I missed that there was a separate, lower-severity vulnerability that wants 2.2.8 instead of 2.2.4.