### PR TITLE
bump semver in ts tests

### DIFF
--- a/language-support/ts/packages/package.json
+++ b/language-support/ts/packages/package.json
@@ -24,6 +24,7 @@
     "jest": "^27.0.5",
     "jest-cli": "^27.0.5",
     "jest-mock-console": "^1.0.0",
+    "semver": "5.7.2",
     "ts-jest": "^27.0.3",
     "typedoc": "^0.22.11"
   },

--- a/language-support/ts/packages/yarn.lock
+++ b/language-support/ts/packages/yarn.lock
@@ -3104,6 +3104,11 @@ semver@5.6.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
+semver@5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
+
 semver@7.x, semver@^7.3.2, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"


### PR DESCRIPTION
~also, remove seemingly unused yarn.lock~ Turns out it is used.