### PR TITLE
JSON API HTTPS: use a library to be more flexible in the private keys we support

### DIFF
--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -83,6 +83,8 @@ load("//ledger-service/utils:scalaopts.bzl", "hj_scalacopts")
             "@maven//:com_google_guava_guava",
             "@maven//:io_dropwizard_metrics_metrics_core",
             "@maven//:io_opentelemetry_opentelemetry_api",
+            "@maven//:org_bouncycastle_bcpkix_jdk15on",
+            "@maven//:org_bouncycastle_bcprov_jdk15on",
         ],
     )
     for edition in [


### PR DESCRIPTION
The original implementation parsed the private key file manually to avoid adding any library deps in the middle of the CVE-quake, where libraries were already being changed. To avoid inscrutable errors, I added an assertion to ensure the input was exactly what was expected.
Now that dependency flux settled down, we can switch BouncyCastle, which is more flexible in its formats and remove the extra assertion.