### PR TITLE
Revert "ci holiday: even CI nodes deserve a break (#18045)"

### DIFF
--- a/infra/azure.tf
+++ b/infra/azure.tf
@@ -146,13 +146,9 @@ CRON
 chmod +x /root/daily-reset.sh
 
 cat <<CRONTAB >> /etc/crontab
-30 5 * 1-11 1-5 root /root/daily-reset.sh '{"du1":10,"du2":0,"dw1":5,"dw2":0}' >> /root/log 2>&1
-30 18 * 1-11 1-5 root /root/daily-reset.sh '{"du1":2,"du2":0,"dw1":1,"dw2":0}' >> /root/log 2>&1
-30 5 * 1-11 6,7 root /root/daily-reset.sh '{"du1":2,"du2":0,"dw1":1,"dw2":0}' >> /root/log 2>&1
-30 5 1-22 12 1-5 root /root/daily-reset.sh '{"du1":10,"du2":0,"dw1":5,"dw2":0}' >> /root/log 2>&1
-30 18 1-22 12 1-5 root /root/daily-reset.sh '{"du1":2,"du2":0,"dw1":1,"dw2":0}' >> /root/log 2>&1
-30 5 1-22 12 6,7 root /root/daily-reset.sh '{"du1":2,"du2":0,"dw1":1,"dw2":0}' >> /root/log 2>&1
-30 5 23-31 12 * root /root/daily-reset.sh '{"du1":2,"du2":0,"dw1":1,"dw2":0}' >> /root/log 2>&1
+30 5 * * 1-5 root /root/daily-reset.sh '{"du1":10,"du2":0,"dw1":5,"dw2":0}' >> /root/log 2>&1
+30 18 * * 1-5 root /root/daily-reset.sh '{"du1":2,"du2":0,"dw1":1,"dw2":0}' >> /root/log 2>&1
+30 5 * * 6,7 root /root/daily-reset.sh '{"du1":2,"du2":0,"dw1":1,"dw2":0}' >> /root/log 2>&1
 CRONTAB
 
 tail -f /root/log


### PR DESCRIPTION
> Note: The day of a command's execution can be specified in the
> following two fields — 'day of month', and 'day of week'.  If
> both fields are restricted (i.e., do not contain the "*"
> character), the command will be run when either field matches the
> current time.  For example,
> "30 4 1,15 * 5" would cause a command to be run at 4:30 am on the
> 1st and 15th of each month, plus every Friday.
> -- [man crontab](https://www.man7.org/linux/man-pages/man5/crontab.5.html)

"the command will be run when either field matches the current time", iiuc this means that line 152 _and_ 154 both ran this morning, and line 154 (setting `'{"du1": 2,"du2":0,"dw1":1,"dw2":0}`) won, giving us a weekend amount of machines

https://github.com/digital-asset/daml/blob/6a88119637a04c75a7c2f7915e1b1932f8b2e9f8/infra/azure.tf#L152-L154