### PR TITLE
Revert "Run the CI on PRs targetting main-3.x"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,6 @@ trigger:
   branches:
     include:
       - main
-      - main-3.x
       - release/*
 
 # Enable PR triggers that target the main branch


### PR DESCRIPTION
This didn't work as intended and we're getting rid of the main-3.x branch.