### PR TITLE
Allow for record re-ordering with upgrades

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
@@ -389,11 +389,7 @@ object ValueTranslator {
       allowFieldReordering: Boolean,
       ignorePackageId: Boolean,
       enableUpgrade: Boolean,
-  ) {
-    if (enableUpgrade) {
-      assert(!allowFieldReordering, "record fields reordering is possible only if upgrade is off")
-    }
-  }
+  )
   object Config {
     val Strict =
       Config(allowFieldReordering = false, ignorePackageId = false, enableUpgrade = false)
@@ -403,7 +399,7 @@ object ValueTranslator {
       Config(allowFieldReordering = true, ignorePackageId = false, enableUpgrade = false)
 
     val Upgradeable =
-      Config(allowFieldReordering = false, ignorePackageId = true, enableUpgrade = true)
+      Config(allowFieldReordering = true, ignorePackageId = true, enableUpgrade = true)
   }
 
 }


### PR DESCRIPTION
Allows `ValueTranslator.Config.allowFieldReordering` to be `true` when upgrades enabled.
Take note of the first 2 commits, which explore 2 ways of implementing this

First method:
- Additional fields are dropped if they are None
- Missing fields are only permitted if they are Optional, and appear consecutively at the end of the record.
  - So in a record `R` with field 1-5, where 4 and 5 are optional, the only valid missing fields would be 5, or 4 + 5. If 4 is missing and 5 is not, the record is invalid.
- If there are both missing and additional fields, the record is invalid, implies an upgrade + downgrade at same time.


Second method:
- Additional fields are dropped if they are None
- Missing fields are always filled in with `None` if they are `Optional`.
  - This makes the scenario with record `R` valid when 4 is missing and 5 is not.
  - Note that this applies to _any_ optional argument. e.g. for a record `R'` with fields 1-5, where only 3 is `Optional`, it can be omitted from the input record and still translated correctly (filling with None)
    - We may consider changing this behaviour such that missing fields can only appear in the final group of Optional fields in a record (with no non-optional fields after it)
- If there are both missing and additional fields, the missing ones are replaced with None, and the additional are removed if `None`
  - We may consider changing this.


This work is simply a proof of concept, we may not merge this.