### PR TITLE
Set 'optDetailLevel = PrettyLevel (-1)' in integration tests

### DIFF
--- a/compiler/damlc/tests/daml-test-files/ExceptionSemantics.daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionSemantics.daml
@@ -3,7 +3,7 @@
 
 -- @SUPPORTS-LF-FEATURE DAML_EXCEPTIONS
 -- @ERROR range=132:1-132:23; Unhandled exception: ExceptionSemantics:E
--- @ERROR range=147:1-147:25; Unhandled exception: DA.Exception.ArithmeticError:ArithmeticError@XXXXXX with message = "ArithmeticError while evaluating (DIV_INT64 1 0)."
+-- @ERROR range=147:1-147:25; Unhandled exception: DA.Exception.ArithmeticError:ArithmeticError with message = "ArithmeticError while evaluating (DIV_INT64 1 0)."
 -- @WARN range=181:3-181:12; Use of divulged contracts is deprecated
 -- @ERROR range=184:1-184:11; Attempt to exercise a consumed contract
 module ExceptionSemantics where

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -19,7 +19,7 @@ module DA.Test.DamlcIntegration
 import           DA.Bazel.Runfiles
 import           DA.Daml.Options
 import           DA.Daml.Options.Types
-import           DA.Test.Util (redactStablePackageIds, standardizeQuotes)
+import           DA.Test.Util (standardizeQuotes)
 
 import           DA.Daml.LF.Ast as LF hiding (IsTest)
 import           "ghc-lib-parser" UniqSupply
@@ -328,6 +328,7 @@ getIntegrationTests registerTODO scenarioService (packageDbPath, packageFlags) =
                     , dlintHintFiles = NoDlintHintFiles
                     }
                 , optPackageImports = packageFlags
+                , optDetailLevel = PrettyLevel (-1)
                 }
 
               mkIde options = do
@@ -522,7 +523,7 @@ checkDiagnostics log expected got
             DMessage m ->
               standardizeQuotes (T.pack m)
                   `T.isInfixOf`
-                      standardizeQuotes (redactStablePackageIds (T.unwords (T.words _message)))
+                      standardizeQuotes (T.unwords (T.words _message))
           logDiags = log $ T.unpack $ showDiagnostics got
           bad = filter
             (\expFields -> not $ any (\diag -> all (checkField diag) expFields) got)

--- a/libs-haskell/test-utils/BUILD.bazel
+++ b/libs-haskell/test-utils/BUILD.bazel
@@ -39,8 +39,6 @@ da_haskell_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//compiler/daml-lf-ast",
-        "//compiler/damlc/stable-packages:stable-packages-lib",
         "//daml-assistant/daml-helper:daml-helper-lib",
         "//language-support/hs/bindings:hs-ledger",
         "//libs-haskell/bazel-runfiles",

--- a/libs-haskell/test-utils/DA/Test/Util.hs
+++ b/libs-haskell/test-utils/DA/Test/Util.hs
@@ -3,7 +3,6 @@
 
 -- | Test utils
 module DA.Test.Util (
-    redactStablePackageIds,
     standardizeQuotes,
     standardizeEoL,
     assertInfixOf,
@@ -26,7 +25,6 @@ import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Data.List.Extra (isInfixOf)
-import qualified Data.Map.Strict as MS
 import qualified Data.Text as T
 import System.Directory
 import System.IO.Extra
@@ -35,16 +33,6 @@ import System.Environment.Blank
 import Test.Tasty
 import Test.Tasty.HUnit
 import qualified UnliftIO.Exception as Unlift
-
-import DA.Daml.StablePackages (allStablePackages)
-import DA.Daml.LF.Ast.Base (unPackageId)
-
--- | Replaces known stable package IDs by 'XXXXXX' in a string.
-redactStablePackageIds :: T.Text -> T.Text
-redactStablePackageIds msg = foldr redact msg knownPackageIds
-  where
-    knownPackageIds = map unPackageId (MS.keys allStablePackages)
-    redact pkgId text = T.replace pkgId "XXXXXX" text
 
 standardizeQuotes :: T.Text -> T.Text
 standardizeQuotes msg = let


### PR DESCRIPTION
This means we don't need to postprocess the damlc output to remove package ids

This was originally part of PR #17558, which was reverted by #17696 due to a regression unrelated to this change.