### PR TITLE
infra/azure.tf: heredoc for /root/get-targets.sh is now correctly quoted

### DIFF
--- a/infra/azure.tf
+++ b/infra/azure.tf
@@ -145,7 +145,7 @@ CRON
 
 chmod +x /root/daily-reset.sh
 
-cat <<GET_TARGETS > /root/get-targets.sh
+cat <<'GET_TARGETS' > /root/get-targets.sh
 #!/usr/bin/env bash
 set -euo pipefail
 


### PR DESCRIPTION
This is necessary so that variables are only evaluated when the script runs, not when it's written to disk
