### PR TITLE
Use different branch names for the two code drops

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -270,7 +270,7 @@ jobs:
           number_of_commits=$(git -C $tmp rev-list --count HEAD)
           commit_sha_8=$(git -C $tmp log -n1 --format=%h --abbrev=8 HEAD)
           canton_tag=$commit_date.$number_of_commits.0.v$commit_sha_8
-          branch="canton-update-$canton_tag-$canton2_version-$canton3_version"
+          branch="canton-update-$canton_tag-$canton2_version-$canton3_version-main2x"
           
           if git diff --exit-code origin/main -- canton build.sh arbitrary_canton_sha test-common/canton/BUILD.bazel >/dev/null; then
               echo "Already up-to-date with latest Canton source & snapshot."


### PR DESCRIPTION
Context: https://github.com/digital-asset/daml/issues/18071

The code drop task targeting main-2.x uses the same feature branch name for its PR as the task targeting main. First one wins. This PR fixes that.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
