### PR TITLE
Fixed multi-package build in presence of daml.yaml with only version and build options

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -1032,7 +1032,7 @@ withMaybeConfig withConfig handler = do
     handle (\case
       ConfigFileInvalid _ (Y.InvalidYaml (Just (Y.YamlException exc))) | "Yaml file not found: " `isPrefixOf` exc ->
         pure Nothing
-      ConfigFileInvalid _ (Y.InvalidYaml (Just (Y.YamlException exc))) | "contains only sdk-version" `isInfixOf` exc -> do
+      ConfigFileInvalid _ (Y.InvalidYaml (Just (Y.YamlException exc))) | "packageless daml.yaml" `isInfixOf` exc -> do
         putStrLn "Found daml.yaml with only sdk-version, ignoring this file."
         pure Nothing
       e -> throwIO e


### PR DESCRIPTION
Fixes first issue listed [here](https://github.com/DACH-NY/canton-network-node/issues/8780)

Needs to be backported to 2.8.x and main-2.x