### PR TITLE
Enrich assert decode info package

### DIFF
--- a/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/packagemeta/PackageMetadata.scala
+++ b/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/packagemeta/PackageMetadata.scala
@@ -43,7 +43,7 @@ object PackageMetadata {
   }
 
   def from(archive: DamlLf.Archive, priority: Priority): PackageMetadata = {
-    val packageInfo = Decode.assertDecodeInfoPackage(archive)
+    val packageInfo = Decode.assertDecodeInfoPackage(archive)._2
     PackageMetadata(
       templates = createVersionedTemplatesMap(packageInfo.definedTemplates, priority),
       interfaces = packageInfo.definedInterfaces,

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Decode.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Decode.scala
@@ -58,11 +58,13 @@ object Decode {
   ): (PackageId, Ast.Package) =
     assertRight(decodeArchive(archive, onlySerializableDataDefs))
 
-  def decodeInfoPackage(archive: DamlLf.Archive): Either[Error, PackageInfo] =
+  def decodeInfoPackage(
+      archive: DamlLf.Archive
+  ): Either[Error, ((PackageId, Ast.Package), PackageInfo)] =
     decodeArchive(archive, onlySerializableDataDefs = true)
-      .map(entry => new PackageInfo(Map(entry)))
+      .map(entry => entry -> new PackageInfo(Map(entry)))
 
-  def assertDecodeInfoPackage(archive: DamlLf.Archive): PackageInfo =
+  def assertDecodeInfoPackage(archive: DamlLf.Archive): ((PackageId, Ast.Package), PackageInfo) =
     assertRight(decodeInfoPackage(archive: DamlLf.Archive))
 
 }


### PR DESCRIPTION
This PR enriches the method used in `PackageMetadata` to also return the original packageId and Ast.Package. This is needed in order to avoid double-decoding of the archive when all values are needed.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
