### PR TITLE
[2.x] fix compat update PR

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -309,7 +309,7 @@ jobs:
 
         ## get latest version, in case it's already up to date
         git fetch origin
-        git merge origin/main
+        git merge --ff-only origin/$(Build.SourceBranchName)
 
         source $(bash_lib)
 


### PR DESCRIPTION
This currently fails on CI because the `git merge origin/main` step is not a fast-forward (which it has always been on the main branch). I can't remember why we don't just `git checkout origin/main` here, but either way this needs to be branch-dependent now.

The specific failure we get is that, in order to create a merge commit, git needs to know the `user.name` and `user.email` values, and those are not defined by default (they are set in `open_pr` when we create the commit for the PR, but we don't currently get that far).