### PR TITLE
LT-45 - Java Codegen: add JSON-LF codec methods for contract keys

### DIFF
--- a/language-support/java/codegen/src/it/java/com/daml/ContractKeysTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/ContractKeysTest.java
@@ -113,4 +113,12 @@ public class ContractKeysTest {
     JsonLfDecoder<Tuple2<Tuple3<String, Long, String>, Tuple4<Long, Boolean, String, Long>>> ntk =
         NestedTupleKey.Contract.keyJsonDecoder();
   }
+
+  @Test
+  void keyJsonEncoder() {
+    partyKey.keyJsonEncoder();
+    recordKey.keyJsonEncoder();
+    tupleKey.keyJsonEncoder();
+    nestedTupleKey.keyJsonEncoder();
+  }
 }

--- a/language-support/java/codegen/src/it/java/com/daml/ContractKeysTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/ContractKeysTest.java
@@ -5,6 +5,7 @@ package com.daml;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.daml.ledger.javaapi.data.codegen.json.JsonLfDecoder;
 import da.types.Tuple2;
 import da.types.Tuple3;
 import da.types.Tuple4;
@@ -102,5 +103,14 @@ public class ContractKeysTest {
     assertEquals(nestedTupleKey.key.get()._2._2.booleanValue(), true);
     assertEquals(nestedTupleKey.key.get()._2._3, "foobar");
     assertEquals(nestedTupleKey.key.get()._2._4.longValue(), 0L);
+  }
+
+  @Test
+  void keyJsonDecoder() {
+    JsonLfDecoder<String> pk = PartyKey.Contract.keyJsonDecoder();
+    JsonLfDecoder<PartyAndInt> rk = RecordKey.Contract.keyJsonDecoder();
+    JsonLfDecoder<Tuple2<String, Long>> tk = TupleKey.Contract.keyJsonDecoder();
+    JsonLfDecoder<Tuple2<Tuple3<String, Long, String>, Tuple4<Long, Boolean, String, Long>>> ntk =
+        NestedTupleKey.Contract.keyJsonDecoder();
   }
 }

--- a/language-support/java/codegen/src/it/java/com/daml/ContractKeysTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/ContractKeysTest.java
@@ -106,19 +106,11 @@ public class ContractKeysTest {
   }
 
   @Test
-  void keyJsonDecoder() {
-    JsonLfDecoder<String> pk = PartyKey.Contract.keyJsonDecoder();
-    JsonLfDecoder<PartyAndInt> rk = RecordKey.Contract.keyJsonDecoder();
-    JsonLfDecoder<Tuple2<String, Long>> tk = TupleKey.Contract.keyJsonDecoder();
-    JsonLfDecoder<Tuple2<Tuple3<String, Long, String>, Tuple4<Long, Boolean, String, Long>>> ntk =
-        NestedTupleKey.Contract.keyJsonDecoder();
-  }
-
-  @Test
-  void keyJsonEncoder() {
-    partyKey.keyJsonEncoder();
-    recordKey.keyJsonEncoder();
-    tupleKey.keyJsonEncoder();
-    nestedTupleKey.keyJsonEncoder();
+  void roundTripKeyThroughJson() throws JsonLfDecoder.Error {
+    assertEquals(partyKey.key.get(), PartyKey.Contract.keyFromJson(partyKey.keyToJson()));
+    assertEquals(recordKey.key.get(), RecordKey.Contract.keyFromJson(recordKey.keyToJson()));
+    assertEquals(tupleKey.key.get(), TupleKey.Contract.keyFromJson(tupleKey.keyToJson()));
+    assertEquals(
+        nestedTupleKey.key.get(), NestedTupleKey.Contract.keyFromJson(nestedTupleKey.keyToJson()));
   }
 }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClass.scala
@@ -169,7 +169,10 @@ object ContractClass {
 
       classBuilder.addMethod(constructor)
 
-      key.foreach(keyDamlType => classBuilder.addMethod(FromJsonGenerator.forKey(keyDamlType)))
+      key.foreach { keyDamlType =>
+        classBuilder.addMethod(FromJsonGenerator.forKey(keyDamlType))
+        classBuilder.addMethod(ToJsonGenerator.forKey(keyDamlType))
+      }
 
       classBuilder
         .addMethod(generateGetCompanion(templateClassName))

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClass.scala
@@ -169,6 +169,8 @@ object ContractClass {
 
       classBuilder.addMethod(constructor)
 
+      key.foreach(keyDamlType => classBuilder.addMethod(FromJsonGenerator.forKey(keyDamlType)))
+
       classBuilder
         .addMethod(generateGetCompanion(templateClassName))
       new Builder(

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClass.scala
@@ -170,8 +170,8 @@ object ContractClass {
       classBuilder.addMethod(constructor)
 
       key.foreach { keyDamlType =>
-        classBuilder.addMethod(FromJsonGenerator.forKey(keyDamlType))
-        classBuilder.addMethod(ToJsonGenerator.forKey(keyDamlType))
+        classBuilder.addMethods(FromJsonGenerator.forKey(keyDamlType).asJava)
+        classBuilder.addMethods(ToJsonGenerator.forKey(keyDamlType).asJava)
       }
 
       classBuilder

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromJsonGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromJsonGenerator.scala
@@ -3,6 +3,7 @@
 
 package com.daml.lf.codegen.backend.java.inner
 
+import com.daml.lf.typesig.Type
 import com.daml.lf.codegen.backend.java.JavaEscaper.escapeString
 import com.daml.ledger.javaapi.data.codegen.json.{JsonLfReader, JsonLfDecoder, JsonLfDecoders}
 import com.typesafe.scalalogging.StrictLogging
@@ -208,6 +209,14 @@ private[inner] object FromJsonGenerator extends StrictLogging {
       )
       .build()
 
+    def forKey(damlType: Type)(implicit packagePrefixes: PackagePrefixes) =
+      MethodSpec
+        .methodBuilder("keyJsonDecoder")
+        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+        .returns(decoderTypeName(toJavaTypeName(damlType)))
+        .addStatement("return $L", jsonDecoderForType(damlType))
+        .build()
+
   def forEnum(className: ClassName, damlNameToEnumMap: String): Seq[MethodSpec] = {
     val jsonDecoder = MethodSpec
       .methodBuilder("jsonDecoder")
@@ -219,7 +228,6 @@ private[inner] object FromJsonGenerator extends StrictLogging {
     Seq(jsonDecoder, fromJsonString(className, IndexedSeq.empty[String]))
   }
 
-  import com.daml.lf.typesig.Type
   private def jsonDecoderForType(
       damlType: Type
   )(implicit packagePrefixes: PackagePrefixes): CodeBlock = {

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromJsonGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromJsonGenerator.scala
@@ -209,13 +209,13 @@ private[inner] object FromJsonGenerator extends StrictLogging {
       )
       .build()
 
-    def forKey(damlType: Type)(implicit packagePrefixes: PackagePrefixes) =
-      MethodSpec
-        .methodBuilder("keyJsonDecoder")
-        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-        .returns(decoderTypeName(toJavaTypeName(damlType)))
-        .addStatement("return $L", jsonDecoderForType(damlType))
-        .build()
+  def forKey(damlType: Type)(implicit packagePrefixes: PackagePrefixes) =
+    MethodSpec
+      .methodBuilder("keyJsonDecoder")
+      .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+      .returns(decoderTypeName(toJavaTypeName(damlType)))
+      .addStatement("return $L", jsonDecoderForType(damlType))
+      .build()
 
   def forEnum(className: ClassName, damlNameToEnumMap: String): Seq[MethodSpec] = {
     val jsonDecoder = MethodSpec

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToJsonGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToJsonGenerator.scala
@@ -127,6 +127,14 @@ private[inner] object ToJsonGenerator {
     (methods, staticImports)
   }
 
+  def forKey(keyDamlType: Type)(implicit packagePrefixes: PackagePrefixes) =
+    MethodSpec
+      .methodBuilder("keyJsonEncoder")
+      .addModifiers(Modifier.PUBLIC)
+      .returns(classOf[JsonLfEncoder])
+      .addStatement("return this.key.map($L).orElse(null)", encoderOf(keyDamlType))
+      .build()
+
   // When a type has type parameters (generic classes), we need to tell
   // the encoder how to encode that type argument,
   // e.g. if encoding a List<T>, we need to tell it how to encode a T.

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToJsonGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToJsonGenerator.scala
@@ -127,13 +127,32 @@ private[inner] object ToJsonGenerator {
     (methods, staticImports)
   }
 
-  def forKey(keyDamlType: Type)(implicit packagePrefixes: PackagePrefixes) =
-    MethodSpec
+  def forKey(keyDamlType: Type)(implicit packagePrefixes: PackagePrefixes) = {
+    val encoder = MethodSpec
       .methodBuilder("keyJsonEncoder")
       .addModifiers(Modifier.PUBLIC)
       .returns(classOf[JsonLfEncoder])
       .addStatement("return this.key.map($L).orElse(null)", encoderOf(keyDamlType))
       .build()
+
+    val toString = MethodSpec
+      .methodBuilder("keyToJson")
+      .addModifiers(Modifier.PUBLIC)
+      .addStatement("var enc = keyJsonEncoder()")
+      .addStatement("if (enc == null) return null")
+      .addStatement("var w = new $T()", classOf[StringWriter])
+      .beginControlFlow("try")
+      .addStatement("enc.encode(new $T(w))", classOf[JsonLfWriter])
+      .nextControlFlow("catch ($T e)", classOf[IOException])
+      .addComment("Not expected with StringWriter")
+      .addStatement("throw new $T(e)", classOf[UncheckedIOException])
+      .endControlFlow()
+      .addStatement("return w.toString()")
+      .returns(classOf[String])
+      .build()
+
+    Seq(encoder, toString)
+  }
 
   // When a type has type parameters (generic classes), we need to tell
   // the encoder how to encode that type argument,
@@ -207,7 +226,7 @@ private[inner] object ToJsonGenerator {
       CodeBlock.of(
         "$T.of($S, $L)",
         fieldClass,
-        f.javaName,
+        f.damlName,
         encoder,
       )
     }


### PR DESCRIPTION
The current code-gen supports encoding and decoding of contract **payload** data from and to JSON-LF format. However, it is currently missing facilities for encoding and decoding contract **keys**. This would be required by a user wishing to use codegen types to represent the content of the `contract_key` column returned by PQS.

This adds extra methods to the classes generated for templates with keys:
* static methods `keyJsonDecoder` and `keyFromJson`
* instance methods `keyJsonEncoder` and `keyToJson`