### PR TITLE
compat versions start at 3.0

### DIFF
--- a/compatibility/versions/UpdateVersions.hs
+++ b/compatibility/versions/UpdateVersions.hs
@@ -35,7 +35,7 @@ instance Semigroup Versions where
     Versions a <> Versions b = Versions (a <> b)
 
 minimumVersion :: Version
-minimumVersion =  fromRight (error "Invalid version") $ SemVer.fromText "2.0.0"
+minimumVersion =  fromRight (error "Invalid version") $ SemVer.fromText "3.0.0"
 
 headVersion :: Version
 headVersion = SemVer.initial


### PR DESCRIPTION
The goal is to avoid future PRs like [this one](https://github.com/digital-asset/daml/pull/18207).

This is invoked by the daily check through [ci/cron/dail-compat.yml](https://github.com/digital-asset/daml/blob/47c9baa28c6108ca5b106adb5f1932998238d2d7/ci/cron/daily-compat.yml#L318) -> [compatibility/update-versions.sh](https://github.com/digital-asset/daml/blob/47c9baa28c6108ca5b106adb5f1932998238d2d7/compatibility/update-versions.sh#L12) -> [compatibility/versions/BUILD](https://github.com/digital-asset/daml/blob/47c9baa28c6108ca5b106adb5f1932998238d2d7/compatibility/versions/BUILD#L4).