### PR TITLE
Fix upgrades tests following package name changes.

### DIFF
--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -410,10 +410,8 @@ da_scala_test_suite(
 
 da_scala_test_suite(
     name = "test-dev",
-    # TODO[#18195] Fix daml3-script and re-enable this test.
     srcs = glob(
         ["src/com/**/*Dev*.scala"],
-        exclude = ["**/UpgradesITDev.scala"],
     ),
     data = [dep for deps in [[
         ":coin-upgrade-v1-v2-{}.dar".format(lf),

--- a/daml-script/test/daml/upgrades/UpgradesTest.daml
+++ b/daml-script/test/daml/upgrades/UpgradesTest.daml
@@ -185,20 +185,17 @@ queryDowngradedSome = do
     Left (FailedCmd (CommandName "QueryContractId") _ _) -> pure ()
     _ -> assertFail $ "Expected QueryContractId to error, but got " <> show res
 
-exerciseV1Util : Choice V1Utils c r => Party -> c -> Script r
-exerciseV1Util p c = p `submit` createAndExerciseCmd (V1Utils with party = p) c
+exerciseV1Util : Choice V1.ValidUpgradeUtils c r => Party -> c -> Script r
+exerciseV1Util p c = p `submit` createAndExerciseExactCmd (V1.ValidUpgradeUtils with party = p) c
 
-exerciseV2Util : Choice V2Utils c r => Party -> c -> Script r
-exerciseV2Util p c = p `submit` createAndExerciseCmd (V2Utils with party = p) c
+exerciseV2Util : Choice V2.ValidUpgradeUtils c r => Party -> c -> Script r
+exerciseV2Util p c = p `submit` createAndExerciseExactCmd (V2.ValidUpgradeUtils with party = p) c
 
-tryExerciseV1Util : Choice V1Utils c r => Party -> c -> Script (Either SubmitError r)
-tryExerciseV1Util p c = p `trySubmit` createAndExerciseCmd (V1Utils with party = p) c
+tryExerciseV1Util : Choice V1.ValidUpgradeUtils c r => Party -> c -> Script (Either SubmitError r)
+tryExerciseV1Util p c = p `trySubmit` createAndExerciseExactCmd (V1.ValidUpgradeUtils with party = p) c
 
-tryExerciseV1UtilExact : Choice V1Utils c r => Party -> c -> Script (Either SubmitError r)
-tryExerciseV1UtilExact p c = p `trySubmit` createAndExerciseExactCmd (V1Utils with party = p) c
-
-tryExerciseV2Util : Choice V2Utils c r => Party -> c -> Script (Either SubmitError r)
-tryExerciseV2Util p c = p `trySubmit` createAndExerciseCmd (V2Utils with party = p) c
+tryExerciseV2Util : Choice V2.ValidUpgradeUtils c r => Party -> c -> Script (Either SubmitError r)
+tryExerciseV2Util p c = p `trySubmit` createAndExerciseExactCmd (V2.ValidUpgradeUtils with party = p) c
 
 fetchUpgraded : Script ()
 fetchUpgraded = do
@@ -206,7 +203,7 @@ fetchUpgraded = do
   cid <- a `submit` createExactCmd V1.ValidUpgrade with party = a
 
   let v2Cid = coerceContractId @V1.ValidUpgrade @V2.ValidUpgrade cid
-  v2Name <- a `exerciseV2Util` V2Fetch with cid = v2Cid
+  v2Name <- a `exerciseV2Util` V2.ValidUpgradeFetch with cid = v2Cid
   v2Name === V2.ValidUpgrade with party = a, newField = None
 
 fetchDowngradedNone : Script ()
@@ -214,7 +211,7 @@ fetchDowngradedNone = do
   a <- allocatePartyOn "alice" participant0
   cid <- a `submit` createCmd V2.ValidUpgrade with party = a, newField = None
   let v1Cid = coerceContractId @V2.ValidUpgrade @V1.ValidUpgrade cid
-  v1Name <- a `exerciseV1Util` V1Fetch with cid = v1Cid
+  v1Name <- a `exerciseV1Util` V1.ValidUpgradeFetch with cid = v1Cid
   v1Name === V1.ValidUpgrade with party = a
 
 fetchDowngradedSome : Script ()
@@ -222,7 +219,7 @@ fetchDowngradedSome = do
   a <- allocatePartyOn "alice" participant0
   cid <- a `submit` createCmd V2.ValidUpgrade with party = a, newField = Some "hi"
   let v1Cid = coerceContractId @V2.ValidUpgrade @V1.ValidUpgrade cid
-  eV1Name <- a `tryExerciseV1Util` V1Fetch with cid = v1Cid
+  eV1Name <- a `tryExerciseV1Util` V1.ValidUpgradeFetch with cid = v1Cid
   
   case eV1Name of
     Left (DevError Upgrade msg)
@@ -238,7 +235,7 @@ fetchUpgradedSourceUnvetted = do
   -- Unvet v1, so the engine cannot have type information about the real packageid of the contract
   unvetDarOnParticipant v1DarName participant0
   let v2Cid = coerceContractId @V1.ValidUpgrade @V2.ValidUpgrade cid
-  res <- a `tryExerciseV2Util` V2Fetch with cid = v2Cid
+  res <- a `tryExerciseV2Util` V2.ValidUpgradeFetch with cid = v2Cid
   case res of
     Right v2Name -> v2Name === V2.ValidUpgrade with party = a, newField = None
     Left err -> assertFail $ "Expected success but got " <> show err
@@ -254,7 +251,7 @@ fetchDowngradedNoneSourceUnvetted = do
   -- Unvet the upgraded type and ensure downgrade occurs
   unvetDarOnParticipant v2DarName participant0
   let v1Cid = coerceContractId @V2.ValidUpgrade @V1.ValidUpgrade cid
-  res <- a `tryExerciseV1UtilExact` V1Fetch with cid = v1Cid
+  res <- a `tryExerciseV1Util` V1.ValidUpgradeFetch with cid = v1Cid
 
   case res of
     Right v1Name -> v1Name === V1.ValidUpgrade with party = a
@@ -268,7 +265,7 @@ exerciseV1ChoiceV1ContractSameType = do
   a <- allocatePartyOn "alice" participant0
   cid <- a `submit` createExactCmd V1.ValidUpgrade with party = a
 
-  sameTypeResult <- a `exerciseV1Util` V1SameChoiceExercise with cid = cid
+  sameTypeResult <- a `exerciseV1Util` V1.SameChoiceExercise with cid = cid
   sameTypeResult === "V1"
 
 exerciseV1ChoiceV2ContractSameType : Script ()
@@ -277,7 +274,7 @@ exerciseV1ChoiceV2ContractSameType = do
   cid <- a `submit` createCmd V2.ValidUpgrade with party = a, newField = None
   let cidV1 = coerceContractId @V2.ValidUpgrade @V1.ValidUpgrade cid
 
-  sameTypeResult <- a `exerciseV1Util` V1SameChoiceExercise with cid = cidV1
+  sameTypeResult <- a `exerciseV1Util` V1.SameChoiceExercise with cid = cidV1
   sameTypeResult === "V1"
 
 exerciseV1ChoiceV2ContractSameTypeSome : Script ()
@@ -286,7 +283,7 @@ exerciseV1ChoiceV2ContractSameTypeSome = do
   cid <- a `submit` createCmd V2.ValidUpgrade with party = a, newField = Some "hi"
   let cidV1 = coerceContractId @V2.ValidUpgrade @V1.ValidUpgrade cid
 
-  sameTypeResult <- a `tryExerciseV1Util` V1SameChoiceExercise with cid = cidV1
+  sameTypeResult <- a `tryExerciseV1Util` V1.SameChoiceExercise with cid = cidV1
   case sameTypeResult of
     Left _ -> pure ()
     Right _ -> assertFail "Wrong"
@@ -297,7 +294,7 @@ exerciseV2ChoiceV1ContractSameType = do
   cid <- a `submit` createCmd V1.ValidUpgrade with party = a
   let cidV2 = coerceContractId @V1.ValidUpgrade @V2.ValidUpgrade cid
 
-  sameTypeResult <- a `exerciseV2Util` V2SameChoiceExercise with cid = cidV2
+  sameTypeResult <- a `exerciseV2Util` V2.SameChoiceExercise with cid = cidV2
   sameTypeResult === "V2"
 
 exerciseV2ChoiceV2ContractSameType : Script ()
@@ -305,7 +302,7 @@ exerciseV2ChoiceV2ContractSameType = do
   a <- allocatePartyOn "alice" participant0
   cid <- a `submit` createCmd V2.ValidUpgrade with party = a, newField = Some "hi"
 
-  sameTypeResult <- a `exerciseV2Util` V2SameChoiceExercise with cid = cid
+  sameTypeResult <- a `exerciseV2Util` V2.SameChoiceExercise with cid = cid
   sameTypeResult === "V2"
 
 genericUpgradeTest 

--- a/daml-script/test/daml/upgrades/v1/MyTemplates.daml
+++ b/daml-script/test/daml/upgrades/v1/MyTemplates.daml
@@ -205,17 +205,17 @@ template VariantAdditional
       controller party
       do pure "V1"
 
-template V1Utils
+template ValidUpgradeUtils
   with
     party : Party
   where
     signatory party
-    choice V1Fetch : ValidUpgrade with
+    choice ValidUpgradeFetch : ValidUpgrade with
         cid : ContractId ValidUpgrade
       controller party
       do fetch cid
 
-    choice V1SameChoiceExercise : Text with
+    choice SameChoiceExercise : Text with
         cid : ContractId ValidUpgrade
       controller party
       do exercise cid SameTypeChoice

--- a/daml-script/test/daml/upgrades/v2/MyTemplates.daml
+++ b/daml-script/test/daml/upgrades/v2/MyTemplates.daml
@@ -217,17 +217,17 @@ template VariantAdditional
       controller party
       do pure "V2"
 
-template V2Utils
+template ValidUpgradeUtils
   with
     party : Party
   where
     signatory party
-    choice V2Fetch : ValidUpgrade with
+    choice ValidUpgradeFetch : ValidUpgrade with
         cid : ContractId ValidUpgrade
       controller party
       do fetch cid
 
-    choice V2SameChoiceExercise : Text with
+    choice SameChoiceExercise : Text with
         cid : ContractId ValidUpgrade
       controller party
       do exercise cid SameTypeChoice


### PR DESCRIPTION
Fixes #18195

Blocks by the fact that canton3 doesn't seem to have the package name upgrades changes