### PR TITLE
Sematically ordered typesafe PackageVersion (#18145)

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
@@ -74,7 +74,6 @@ sealed abstract class IdString {
 
   // Human-readable package names and versions.
   type PackageName <: String
-  type PackageVersion <: String
 
   /** Party identifiers are non-empty US-ASCII strings built from letters, digits, space, colon, minus and,
     *      underscore. We use them to represent [Party] literals. In this way, we avoid
@@ -110,7 +109,6 @@ sealed abstract class IdString {
   val HexString: HexStringModule[HexString]
   val Name: StringModule[Name]
   val PackageName: ConcatenableStringModule[PackageName, HexString]
-  val PackageVersion: StringModule[PackageVersion]
   val Party: ConcatenableStringModule[Party, HexString]
   val PackageId: ConcatenableStringModule[PackageId, HexString]
   val ParticipantId: StringModule[ParticipantId]
@@ -304,13 +302,6 @@ private[data] final class IdStringImpl extends IdString {
   override type PackageName = String
   override val PackageName: ConcatenableStringModule[PackageName, HexString] =
     new ConcatenableMatchingStringModule("Daml-LF Package Name", "-_", 255)
-
-  /** Package versions are non-empty strings consisting of segments of digits (without leading zeros)
-    *      separated by dots.
-    */
-  override type PackageVersion = String
-  override val PackageVersion: StringModule[PackageVersion] =
-    new MatchingStringModule("Daml-LF Package Version", """(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*""")
 
   /** Party identifiers are non-empty US-ASCII strings built from letters, digits, space, colon, minus and,
     * underscore limited to 255 chars. We use them to represent [Party] literals. In this way, we avoid

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
@@ -6,6 +6,9 @@ package data
 
 import com.daml.lf
 import com.daml.scalautil.Statement.discard
+import scalaz.Scalaz.eitherMonad
+import scalaz.syntax.traverse._
+import scalaz.std.list._
 
 object Ref {
 
@@ -20,9 +23,6 @@ object Ref {
 
   type PackageName = IdString.PackageName
   val PackageName: IdString.PackageName.type = IdString.PackageName
-
-  type PackageVersion = IdString.PackageVersion
-  val PackageVersion: IdString.PackageVersion.type = IdString.PackageVersion
 
   /** Party identifiers are non-empty US-ASCII strings built from letters, digits, space, colon, minus and,
     * underscore. We use them to represent [Party] literals. In this way, we avoid
@@ -209,6 +209,7 @@ object Ref {
         this.name compare that.name
     }
   }
+
   object QualifiedName {
     def fromString(s: String): Either[String, QualifiedName] = {
       val segments = split(s, ':')
@@ -364,4 +365,40 @@ object Ref {
       assertRight(fromString(s))
   }
 
+  /** Package versions are non-empty strings consisting of segments of digits (without leading zeros)
+    *      separated by dots: "(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*"
+    */
+  final case class PackageVersion private[data] (segments: ImmArray[Int])
+      extends Ordered[PackageVersion] {
+    override def toString: String = segments.toSeq.mkString(".")
+
+    override def compare(that: PackageVersion): Int = {
+      import scala.math.Ordering.Implicits._
+
+      implicitly[Ordering[Seq[Int]]].compare(segments.toSeq, that.segments.toSeq)
+    }
+  }
+
+  object PackageVersion {
+    private val MaxPackageVersionLength = 255
+    final def fromString(s: String): Either[String, PackageVersion] = for {
+      _ <- Either.cond(
+        s.length <= MaxPackageVersionLength,
+        (),
+        s"Package version string length (${s.length}) exceeds the maximum supported length ($MaxPackageVersionLength)",
+      )
+      _ <- Either.cond(
+        s.matches("(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))*"),
+        (),
+        s"Invalid package version string: `$s`. Package versions are non-empty strings consisting of segments of digits (without leading zeros) separated by dots.",
+      )
+      rawSegments = s.split("\\.").toList
+      segments <- rawSegments.traverse(rawSegmentStr =>
+        rawSegmentStr.toIntOption.toRight(s"Failed parsing $rawSegmentStr as an integer")
+      )
+    } yield PackageVersion(ImmArray.from(segments))
+
+    @throws[IllegalArgumentException]
+    final def assertFromString(s: String): PackageVersion = assertRight(fromString(s))
+  }
 }

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RefTest.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RefTest.scala
@@ -183,6 +183,82 @@ class RefTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks w
     }
   }
 
+  "PackageVersion.fromString" - {
+    "parse valid package version strings" in {
+      val testCases = Table(
+        "Raw version string" -> "Parsed package version",
+        "0" -> ImmArray(0),
+        "1" -> ImmArray(1),
+        "1.10" -> ImmArray(1, 10),
+        Int.MaxValue.toString -> ImmArray(Int.MaxValue),
+        "1.0.2" -> ImmArray(1, 0, 2),
+        // Max size (255)
+        "0" + ".123" * 63 + ".1" -> ImmArray.from(Seq(0) ++ Seq.fill(63)(123) ++ Seq(1)),
+        // Max size - 1 (254)
+        "0" + ".123" * 62 + ".1234" -> ImmArray.from(Seq(0) ++ Seq.fill(62)(123) ++ Seq(1234)),
+      )
+
+      testCases.forEvery { (input, expected) =>
+        PackageVersion.fromString(input) shouldBe Right(PackageVersion(expected))
+      }
+    }
+
+    "reject invalid package version strings" in {
+      val testCases = Table(
+        "(Invalid) Raw version string",
+        "",
+        ".",
+        "1.",
+        ".0",
+        "00",
+        "1.002",
+        "0.-1",
+        "+1.0",
+        "beef.0",
+        "0.1.beef",
+      )
+
+      testCases.forEvery(input =>
+        PackageVersion.fromString(input) shouldBe Left(
+          s"Invalid package version string: `$input`. Package versions are non-empty strings consisting of segments of digits (without leading zeros) separated by dots."
+        )
+      )
+
+      val tooBigForInt = s"${Int.MaxValue.toLong + 1}"
+      val versionWithNumberBiggerThanInt = s"1.$tooBigForInt"
+      PackageVersion.fromString(versionWithNumberBiggerThanInt) shouldBe Left(
+        s"Failed parsing $tooBigForInt as an integer"
+      )
+
+      // Correct format, but length over limit
+      PackageVersion.fromString("0" + ".123" * 63 + ".12") shouldBe Left(
+        "Package version string length (256) exceeds the maximum supported length (255)"
+      )
+
+      // Invalid format, but length over limit
+      // This checks that first the length is checked, and then the regex conformance
+      PackageVersion.fromString("abcd" * 64) shouldBe Left(
+        "Package version string length (256) exceeds the maximum supported length (255)"
+      )
+    }
+  }
+
+  private[this] val packageVersionsInOrder = List(
+    // Lowest possible package version
+    PackageVersion.assertFromString("0"),
+    PackageVersion.assertFromString("0.1"),
+    PackageVersion.assertFromString("0.11"),
+    PackageVersion.assertFromString("1.0"),
+    PackageVersion.assertFromString("2"),
+    PackageVersion.assertFromString("10"),
+    PackageVersion.assertFromString(s"${Int.MaxValue}"),
+    PackageVersion.assertFromString(s"${Int.MaxValue}.3"),
+    // Highest possible package version
+    PackageVersion.assertFromString(s"${Int.MaxValue}." * 23 + "99"),
+  )
+
+  testOrdered("PackageVersion", packageVersionsInOrder)
+
   private[this] val qualifiedNamesInOrder =
     for {
       modNane <- dottedNamesInOrder
@@ -399,20 +475,20 @@ class RefTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks w
         } ((x compare y) == 0) shouldBe (x == y)
       }
 
-      "is reflexive" - {
+      "is reflexive" in {
         for {
           x <- elems
         } (x compare x) shouldBe 0
       }
 
-      "is symmetric" - {
+      "is symmetric" in {
         for {
           x <- elems
           y <- elems
         } (x compare y) shouldBe -(y compare x)
       }
 
-      "is transitive on comparable values" - {
+      "is transitive on comparable values" in {
         for {
           x <- elems
           y <- elems

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeCommon.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeCommon.scala
@@ -56,7 +56,7 @@ private[daml] class EncodeCommon(languageVersion: LV) {
         pkg.metadata.foreach { metadata =>
           val metadataBuilder = PLF.PackageMetadata.newBuilder
           metadataBuilder.setNameInternedStr(stringsTable.insert(metadata.name))
-          metadataBuilder.setVersionInternedStr(stringsTable.insert(metadata.version))
+          metadataBuilder.setVersionInternedStr(stringsTable.insert(metadata.version.toString))
           metadata.upgradedPackageId match {
             case None =>
             case Some(pid) =>


### PR DESCRIPTION
This is a port of https://github.com/digital-asset/daml/pull/18145 from 2.x

* Made PackageVersion typed and orderable semantically
* PackageVersion size limit is 255 and enforce comparisons
* Fix bug that led to some tests not running

run-all-tests: true

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
