### PR TITLE
Make package metadata mandatory in the compiler

### DIFF
--- a/compiler/daml-dar-reader/src/DA/Daml/Dar/Reader.hs
+++ b/compiler/daml-dar-reader/src/DA/Daml/Dar/Reader.hs
@@ -50,8 +50,8 @@ instance ToJSON InspectInfo where
 
 data DalfInfo = DalfInfo
   { dalfFilePath :: FilePath
-  , dalfPackageName :: Maybe LF.PackageName
-  , dalfPackageVersion :: Maybe LF.PackageVersion
+  , dalfPackageName :: LF.PackageName
+  , dalfPackageVersion :: LF.PackageVersion
   , dalfPackage :: LF.Package
   }
 
@@ -78,8 +78,8 @@ collectInfo archive = do
         ( pkgId
         , DalfInfo
               path
-              (LF.packageName <$> LF.packageMetadata pkg)
-              (LF.packageVersion <$> LF.packageMetadata pkg)
+              (LF.packageName (LF.packageMetadata pkg))
+              (LF.packageVersion (LF.packageMetadata pkg))
               pkg
         )
     decodeEntry :: FilePath -> Either String (LF.PackageId, LF.Package)

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -1121,7 +1121,7 @@ data PackageMetadata = PackageMetadata
 data Package = Package
     { packageLfVersion :: Version
     , packageModules :: NM.NameMap Module
-    , packageMetadata :: Maybe PackageMetadata
+    , packageMetadata :: PackageMetadata
     }
   deriving (Eq, Data, Generic, NFData, Show)
 

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -773,5 +773,5 @@ instance Pretty Package where
   pPrintPrec lvl _prec (Package version modules metadata) =
     vcat $
       "daml-lf" <-> pPrintPrec lvl 0 version
-      : maybe empty (\m -> "metadata" <-> pPrintPrec lvl 0 m) metadata
+      : "metadata" <-> pPrintPrec lvl 0 metadata
       : map (\m -> "" $-$ pPrintPrec lvl 0 m) (NM.toList modules)

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -294,15 +294,11 @@ removeLocations = cata $ \case
 
 -- | Given the name of a DALF and the decoded package return package metadata.
 --
--- For newer Daml-LF versions this is taken directly from the
--- package metadata in Daml-LF. For older versions, we instead infer
--- metadata from the filename.
-packageMetadataFromFile :: FilePath -> Package -> PackageId -> (PackageName, Maybe PackageVersion)
-packageMetadataFromFile file pkg pkgId
-    | Just (PackageMetadata name version _) <- packageMetadata pkg =
-          -- GHC insists on daml-prim not having a version so we filter it out.
-          (name, version <$ guard (name /= PackageName "daml-prim"))
-    | otherwise = splitUnitId (unitIdFromFile file pkgId)
+-- Extract the package metadata from the provided package, but returns no
+-- package version for daml-print, which GHC insists on not having a version.
+safePackageMetadata :: Package -> (PackageName, Maybe PackageVersion)
+safePackageMetadata (packageMetadata -> PackageMetadata name version _) =
+    (name, version <$ guard (name /= PackageName "daml-prim"))
 
 -- Get the name of a file and an expeted package id of the package, get the unit id
 -- by stripping away the package name at the end.

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -80,11 +80,6 @@ isDevVersion :: Version -> Bool
 isDevVersion (Version _ PointDev) = True
 isDevVersion _ = False
 
--- | True iff package metata is required for this LF version.
-requiresPackageMetadata :: Version -> Bool
-requiresPackageMetadata = \case
-  Version V2 _ -> True
-
 -- | A datatype describing a set of language versions. Used in the definition of
 -- 'Feature' below.
 newtype VersionReq = VersionReq (MajorVersion -> R.Range MinorVersion)

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
@@ -50,6 +50,8 @@ import qualified DA.Daml.LF.TemplateOrInterface as TemplateOrInterface
 -- module dependencies but we don't enforce this here.
 data World = World
   { _worldImported :: HMS.HashMap PackageId Package
+  -- _worldSelfLfVersion
+  -- _worldSelfModules
   , _worldSelf :: Package
   }
 
@@ -85,7 +87,7 @@ initWorld :: [ExternalPackage] -> Version -> World
 initWorld importedPkgs version =
   World
     (foldl' insertPkg HMS.empty importedPkgs)
-    (Package version NM.empty Nothing)
+    (Package version NM.empty undefined)
   where
     insertPkg hms (ExternalPackage pkgId pkg) = HMS.insert pkgId pkg hms
 

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
@@ -6,7 +6,8 @@
 module DA.Daml.LF.Ast.World(
     World,
     DalfPackage(..),
-    getWorldSelf,
+    getWorldSelfPkgLfVersion,
+    getWorldSelfPkgModules,
     getWorldImported,
     initWorld,
     initWorldSelf,
@@ -50,14 +51,16 @@ import qualified DA.Daml.LF.TemplateOrInterface as TemplateOrInterface
 -- module dependencies but we don't enforce this here.
 data World = World
   { _worldImported :: HMS.HashMap PackageId Package
-  -- _worldSelfLfVersion
-  -- _worldSelfModules
-  , _worldSelf :: Package
+  , _worldSelfPkgLfVersion :: Version
+  , _worldSelfPkgModules :: NM.NameMap Module
   }
 
 
-getWorldSelf :: World -> Package
-getWorldSelf = _worldSelf
+getWorldSelfPkgLfVersion :: World -> Version
+getWorldSelfPkgLfVersion = _worldSelfPkgLfVersion
+
+getWorldSelfPkgModules :: World -> NM.NameMap Module
+getWorldSelfPkgModules = _worldSelfPkgModules
 
 getWorldImported :: World -> [ExternalPackage]
 getWorldImported world = map (uncurry ExternalPackage) $ HMS.toList (_worldImported world)
@@ -71,7 +74,7 @@ data ExternalPackage = ExternalPackage
 
 instance NFData ExternalPackage
 
-makeLensesFor [("_worldSelf","worldSelf")] ''World
+makeLensesFor [("_worldSelfPkgModules","worldSelfPkgModules")] ''World
 
 data DalfPackage = DalfPackage
     { dalfPackageId :: PackageId
@@ -87,17 +90,22 @@ initWorld :: [ExternalPackage] -> Version -> World
 initWorld importedPkgs version =
   World
     (foldl' insertPkg HMS.empty importedPkgs)
-    (Package version NM.empty undefined)
+    version
+    NM.empty
   where
     insertPkg hms (ExternalPackage pkgId pkg) = HMS.insert pkgId pkg hms
 
 -- | Create a World with an initial self package
 initWorldSelf :: [ExternalPackage] -> Package -> World
-initWorldSelf importedPkgs pkg = (initWorld importedPkgs $ packageLfVersion pkg){_worldSelf = pkg}
+initWorldSelf importedPkgs pkg =
+    (initWorld importedPkgs $ packageLfVersion pkg)
+        { _worldSelfPkgLfVersion = packageLfVersion pkg
+        , _worldSelfPkgModules = packageModules pkg
+        }
 
 -- | Extend the 'World' by a module in the current package.
 extendWorldSelf :: Module -> World -> World
-extendWorldSelf = over (worldSelf . _packageModules) . NM.insert
+extendWorldSelf = over worldSelfPkgModules . NM.insert
 
 data LookupError
   = LEPackage !PackageId
@@ -116,13 +124,13 @@ data LookupError
   deriving (Eq, Ord, Show)
 
 lookupModule :: Qualified a -> World -> Either LookupError Module
-lookupModule (Qualified pkgRef modName _) (World importedPkgs selfPkg) = do
-  Package { packageModules = mods } <- case pkgRef of
-    PRSelf -> pure selfPkg
+lookupModule (Qualified pkgRef modName _) (World importedPkgs _ selfPkgMods) = do
+  mods <- case pkgRef of
+    PRSelf -> pure selfPkgMods
     PRImport pkgId ->
       case HMS.lookup pkgId importedPkgs of
         Nothing -> Left (LEPackage pkgId)
-        Just mods -> pure mods
+        Just pkg -> pure (packageModules pkg)
   case NM.lookup modName mods of
     Nothing -> Left (LEModule pkgRef modName)
     Just mod0 -> Right mod0

--- a/compiler/daml-lf-proto-encode/src/DA/Daml/LF/Proto3/EncodeV2.hs
+++ b/compiler/daml-lf-proto-encode/src/DA/Daml/LF/Proto3/EncodeV2.hs
@@ -1040,7 +1040,7 @@ encodeScenarioModule :: Version -> Module -> P.Package
 encodeScenarioModule version mod =
     encodePackage (Package version (NM.insert mod NM.empty) metadata)
   where
-    metadata = Just PackageMetadata
+    metadata = PackageMetadata
       { packageName = PackageName "scenario"
       , packageVersion = PackageVersion "0.0.0"
       , upgradedPackageId = Nothing
@@ -1101,7 +1101,7 @@ encodePackage :: Package -> P.Package
 encodePackage (Package version mods metadata) =
     let env = initEncodeEnv version (WithInterning True)
         ((packageModules, packageMetadata), EncodeEnv{internedStrings, internedDottedNames, internedTypes}) =
-            runState ((,) <$> encodeNameMap encodeModule mods <*> traverse encodePackageMetadata metadata) env
+            runState ((,) <$> encodeNameMap encodeModule mods <*> fmap Just (encodePackageMetadata metadata)) env
         packageInternedStrings =
             V.fromList $ map (encodeString . fst) $ L.sortOn snd $ HMS.toList internedStrings
         packageInternedDottedNames =

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker.hs
@@ -35,8 +35,7 @@ checkPackage ::
   -> [Diagnostic]
 checkPackage world version = concatMap (checkModuleInWorld world version) modules
     where
-      package = getWorldSelf world
-      modules = NM.toList (packageModules package)
+      modules = NM.toList (getWorldSelfPkgModules world)
 
 checkModuleInWorld :: World -> Version -> Module -> [Diagnostic]
 checkModuleInWorld world version m =

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
@@ -256,8 +256,7 @@ isAscendant (ModuleName xs) (ModuleName ys) =
 -- name collision condition.
 checkModuleDeps :: World -> Module -> NCMonad ()
 checkModuleDeps world mod0 = do
-    let package = getWorldSelf world
-        modules = NM.toList (packageModules package)
+    let modules = NM.toList (getWorldSelfPkgModules world)
         name0 = moduleName mod0
         ascendants = filter (flip isAscendant name0 . moduleName) modules
         descendants = filter (isAscendant name0 . moduleName) modules

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -17,7 +17,6 @@ module DA.Daml.Compiler.Dar
     ) where
 
 import qualified "zip" Codec.Archive.Zip as Zip
-import Control.Applicative
 import Control.Exception (assert)
 import Control.Monad.Extra
 import Control.Monad.IO.Class
@@ -282,9 +281,9 @@ mergePkgs meta ver pkgs =
              LF.Package
                  { LF.packageLfVersion = ver
                  , LF.packageModules = LF.packageModules pkg1 `NM.union` LF.packageModules pkg2
-                 , LF.packageMetadata = LF.packageMetadata pkg1 <|> LF.packageMetadata pkg2
+                 , LF.packageMetadata = LF.packageMetadata pkg1
                  })
-        LF.Package { LF.packageLfVersion = ver, LF.packageModules = NM.empty, LF.packageMetadata = Just meta }
+        LF.Package { LF.packageLfVersion = ver, LF.packageModules = NM.empty, LF.packageMetadata = meta }
         pkgs
 
 -- | Find all Daml files below a given source root. If the source root is a file we interpret it as

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -120,11 +120,8 @@ buildWorld Config{..} =
         self <- MS.lookup configSelfPkgId configPackages
         Just (LF.initWorldSelf extPackages self)
 
-worldLfVersion :: LF.World -> LF.Version
-worldLfVersion = LF.packageLfVersion . LF.getWorldSelf
-
 envLfVersion :: Env -> LF.Version
-envLfVersion = worldLfVersion . envWorld
+envLfVersion = LF.getWorldSelfPkgLfVersion . envWorld
 
 data DependencyInfo = DependencyInfo
   { depClassMap :: !DepClassMap
@@ -178,7 +175,7 @@ envLookupDepClass synName env =
 expandSynonyms :: LF.World -> LF.Type -> Either LF.Error ExpandedType
 expandSynonyms world ty =
     fmap (ExpandedType . fst) $ -- Ignore warnings from runGamma
-    LF.runGamma world (worldLfVersion world) $
+    LF.runGamma world (LF.getWorldSelfPkgLfVersion world) $
     LF.expandTypeSynonyms ty
 
 -- | Determine whether two type synonym definitions are similar enough to
@@ -1219,7 +1216,7 @@ buildHiddenRefMap config world =
     visitRef !refGraph ref
         | HMS.member ref refGraph
             = refGraph -- already in the map
-        | ref == RTypeCon (erasedTCon (LF.versionMajor (worldLfVersion world)))
+        | ref == RTypeCon (erasedTCon (LF.versionMajor (LF.getWorldSelfPkgLfVersion world)))
             = HMS.insert ref (True, []) refGraph -- Erased is always erased
 
         | RTypeCon tcon <- ref
@@ -1238,7 +1235,7 @@ buildHiddenRefMap config world =
         | RValue val <- ref
         , Right dval <- LF.lookupValue val world
         , -- we only care about typeclass instances
-          refs <- if hasDFunSig (LF.versionMajor (worldLfVersion world)) dval
+          refs <- if hasDFunSig (LF.versionMajor (LF.getWorldSelfPkgLfVersion world)) dval
             then DL.toList (refsFromDFun dval)
             else mempty
         , refGraph' <- HMS.insert ref (False, refs) refGraph
@@ -1279,10 +1276,10 @@ rootRefs :: Config -> LF.World -> DL.DList Ref
 rootRefs config world =
     fold
         [ modRootRefs
-            (LF.versionMajor (worldLfVersion world))
+            (LF.versionMajor (LF.getWorldSelfPkgLfVersion world))
             (configSelfPkgId config)
             mod
-        | mod <- NM.toList (LF.packageModules (LF.getWorldSelf world))
+        | mod <- NM.toList (LF.getWorldSelfPkgModules world)
         ]
 
 modRootRefs :: LF.MajorVersion -> LF.PackageId -> LF.Module -> DL.DList Ref

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -523,10 +523,7 @@ generatePackageMap version mbProjRoot userPkgDbs = do
       | "daml-stdlib" `T.isPrefixOf` name = stringToUnitId (takeBaseName dalf)
       | otherwise = pkgNameVersion (LF.PackageName name) mbVersion
       where (LF.PackageName name, mbVersion)
-               = LF.packageMetadataFromFile
-                     dalf
-                     (LF.extPackagePkg $ LF.dalfPackagePkg pkg)
-                     (LF.dalfPackageId pkg)
+               = LF.safePackageMetadata (LF.extPackagePkg $ LF.dalfPackagePkg pkg)
 
 
 readDalfPackage :: FilePath -> IO (Either FileDiagnostic LF.DalfPackage)
@@ -980,11 +977,10 @@ runScenariosScriptsPkg projRoot extPkg pkgs = do
     pure (concat diags, Just results)
   where
     pkg = LF.extPackagePkg extPkg
-    pkgId = LF.extPackageId extPkg
     pkgName' =
         toNormalizedFilePath' $
         T.unpack $
-        maybe (LF.unPackageId pkgId) (LF.unPackageName . LF.packageName) $ LF.packageMetadata pkg
+        LF.unPackageName (LF.packageName (LF.packageMetadata pkg))
     world = LF.initWorldSelf pkgs pkg
     scenarios =
         map fst $

--- a/compiler/damlc/daml-lf-util/src/DA/Daml/UtilLF.hs
+++ b/compiler/damlc/daml-lf-util/src/DA/Daml/UtilLF.hs
@@ -82,7 +82,7 @@ synthesizeVariantRecord (VariantConName dcon) (TypeConName tcon) = TypeConName (
 -- | Fails if there are any duplicate module names
 buildPackage :: HasCallStack => PackageMetadata -> Version -> [Module] -> Package
 buildPackage meta version mods =
-    Package version (NM.fromList mods) (Just meta)
+    Package version (NM.fromList mods) meta
 
 instance Outputable Expr where
     ppr = text . renderPretty

--- a/compiler/damlc/lib/DA/Cli/Damlc/DependencyDb.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/DependencyDb.hs
@@ -31,7 +31,6 @@ import qualified Data.ByteString.Lazy as BSL
 import Data.Char
 import Data.List.Extra
 import qualified Data.Map.Strict as M
-import Data.Maybe
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Yaml as Yaml
@@ -161,7 +160,7 @@ installDependencies projRoot opts releaseVersion pDeps pDataDeps = do
             installDataDepDalf
                 remoteDalfIsMain
                 depsDir
-                (packageNameToFp $ packageNameOrId remoteDalfPkgId remoteDalfName)
+                (packageNameToFp remoteDalfName)
                 remoteDalfBs
         -- Mark received packages as well as their transitive dependencies as data dependencies.
         Logger.logDebug logger "Mark data-dependencies"
@@ -398,18 +397,16 @@ resolvePkgsWithLedger depsDir tokFpM pkgs = do
         installDalf
             []
             depsDir
-            (packageNameToFp $ packageNameOrId remoteDalfPkgId remoteDalfName)
+            (packageNameToFp remoteDalfName)
             remoteDalfBs
     let m =
             M.fromList
                 [ ( FullPkgName
-                        { pkgName = pkgName
-                        , pkgVersion = version
+                        { pkgName = remoteDalfName
+                        , pkgVersion = remoteDalfVersion
                         }
                   , remoteDalfPkgId)
                 | RemoteDalf {..} <- rdalfs
-                , Just pkgName <- [remoteDalfName]
-                , Just version <- [remoteDalfVersion]
                 ]
     let m0 = M.restrictKeys m $ Set.fromList pkgs
     pure $
@@ -503,6 +500,3 @@ guardDefM def pM m = ifM pM m (pure def)
 
 packageNameToFp :: LF.PackageName -> FilePath
 packageNameToFp n = (T.unpack $ LF.unPackageName n) <.> "dalf"
-
-packageNameOrId :: LF.PackageId -> Maybe LF.PackageName -> LF.PackageName
-packageNameOrId pkgId pkgNameM = fromMaybe (LF.PackageName $ LF.unPackageId pkgId) pkgNameM

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -101,7 +101,7 @@ createProjectPackageDb projectRoot (disableScenarioService -> opts) modulePrefix
 
       let decodeDalf_ dalf = do
             bs <- BS.readFile dalf
-            (dalf,) <$> either fail pure (decodeDalf builtinDependenciesIds dalf bs)
+            (dalf,) <$> either fail pure (decodeDalf builtinDependenciesIds bs)
 
       -- This is only used for unit-id collision checks and dependencies on newer LF versions.
       dalfsFromDependencyFps <- queryDalfs (Just [depMarker]) depsDir

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test/TestResults.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test/TestResults.hs
@@ -395,7 +395,7 @@ scenarioResultsToTestResults allPackages results =
     pkgIdToPkgName targetPid =
         case mapMaybe isTargetPackage allPackages of
           [] -> targetPid
-          [matchingPkg] -> maybe targetPid (LF.unPackageName . LF.packageName) $ LF.packageMetadata $ LF.extPackagePkg matchingPkg
+          [matchingPkg] -> LF.unPackageName $ LF.packageName $ LF.packageMetadata $ LF.extPackagePkg matchingPkg
           _ -> error ("pkgIdToPkgName: more than one package matching name " <> T.unpack targetPid)
         where
             isTargetPackage loe

--- a/compiler/damlc/stable-packages/lib/DA/Daml/StablePackages.hs
+++ b/compiler/damlc/stable-packages/lib/DA/Daml/StablePackages.hs
@@ -74,21 +74,13 @@ stablePackageByModuleName = MS.fromListWithKey
     , m <- NM.toList (packageModules p)
     ]
 
--- | Helper function for optionally adding metadata to stable packages depending
--- on the LF version of the package.
-ifMetadataRequired :: Version -> PackageMetadata -> Maybe PackageMetadata
-ifMetadataRequired v metadata =
-  if requiresPackageMetadata v
-    then Just metadata
-    else Nothing
-
 ghcTypes :: Version -> Package
 ghcTypes version = Package
   { packageLfVersion = version
   , packageModules = NM.singleton (emptyModule modName)
     { moduleDataTypes = NM.fromList [dataOrdering]
     }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-prim-GHC-Types"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -112,7 +104,7 @@ ghcPrim version = Package
     { moduleDataTypes = NM.fromList [dataVoid]
     , moduleValues = NM.fromList [valVoid]
     }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-prim-GHC-Prim"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -143,7 +135,7 @@ daTypes version = Package
     { moduleDataTypes = types
     , moduleValues = values
     }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-prim-DA-Types"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -191,7 +183,7 @@ ghcTuple version = Package
     { moduleDataTypes = types
     , moduleValues = values
     }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-prim-GHC-Tuple"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -216,7 +208,7 @@ daInternalTemplate version = Package
   , packageModules = NM.singleton (emptyModule modName)
      { moduleDataTypes = types
      }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "ghc-stdlib-DA-Internal-Template"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -235,7 +227,7 @@ daInternalAny version = Package
   , packageModules = NM.singleton (emptyModule modName)
     { moduleDataTypes = types
     }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "ghc-stdlib-DA-Internal-Any"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -261,7 +253,7 @@ daInternalInterfaceAnyViewTypes version = Package
       { moduleDataTypes = datatypes
       , moduleValues = values
       }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-stdlib-DA-Internal-Interface-AnyView-Types"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -302,7 +294,7 @@ daActionStateType version daTypesPackageId = Package
       { moduleDataTypes = types
       , moduleValues = values
       }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-stdlib-DA-Action-State-Type"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -347,7 +339,7 @@ daRandomTypes version = Package
       { moduleDataTypes = types
       , moduleValues = values
       }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-stdlib-DA-Random-Types"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -377,7 +369,7 @@ daStackTypes version = Package
       { moduleDataTypes = types
       , moduleValues = values
       }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-stdlib-DA-Stack-Types"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -415,7 +407,7 @@ daTimeTypes version = Package
     { moduleDataTypes = types
     , moduleValues = values
     }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-stdlib-DA-Time-Types"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -441,7 +433,7 @@ daNonEmptyTypes version = Package
     { moduleDataTypes = types
     , moduleValues = values
     }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-stdlib-DA-NonEmpty-Types"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -470,7 +462,7 @@ daDateTypes version = Package
   , packageModules = NM.singleton (emptyModule modName)
     { moduleDataTypes = types
     }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-stdlib-DA-Date-Types"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -513,7 +505,7 @@ daSemigroupTypes version = Package
     { moduleDataTypes = types
     , moduleValues = values
     }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-stdlib-DA-Semigroup-Types"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -542,7 +534,7 @@ daMonoidTypes version = Package
     { moduleDataTypes = types
     , moduleValues = values
     }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-stdlib-DA-Monoid-Types"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -586,7 +578,7 @@ daValidationTypes version nonEmptyPkgId = Package
     { moduleDataTypes = types
     , moduleValues = values
     }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-stdlib-DA-Validation-Types"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -620,7 +612,7 @@ daLogicTypes version = Package
     { moduleDataTypes = types
     , moduleValues = values
     }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-stdlib-DA-Logic-Types"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -658,7 +650,7 @@ daInternalDown version = Package
     { moduleDataTypes = types
     , moduleValues = values
     }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-stdlib-DA-Internal-Down"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -684,7 +676,7 @@ daSetTypes version = Package
         { moduleDataTypes = types
         , moduleValues = values
         }
-    , packageMetadata = ifMetadataRequired version $ PackageMetadata
+    , packageMetadata = PackageMetadata
         { packageName = PackageName "daml-stdlib-DA-Set-Types"
         , packageVersion = PackageVersion "1.0.0"
         , upgradedPackageId = Nothing
@@ -710,7 +702,7 @@ daInternalErased version = Package
   , packageModules = NM.singleton (emptyModule modName)
     { moduleDataTypes = types
     }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-prim-DA-Internal-Erased"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -730,7 +722,7 @@ daInternalNatSyn version = Package
       { moduleDataTypes = types
       , moduleValues = NM.empty
       }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-prim-DA-Internal-NatSyn"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -749,7 +741,7 @@ daInternalPromotedText version = Package
   , packageModules = NM.singleton (emptyModule modName)
     { moduleDataTypes = types
     }
-  , packageMetadata = ifMetadataRequired version $ PackageMetadata
+  , packageMetadata = PackageMetadata
       { packageName = PackageName "daml-prim-DA-Internal-PromotedText"
       , packageVersion = PackageVersion "1.0.0"
       , upgradedPackageId = Nothing
@@ -782,7 +774,7 @@ builtinExceptionPackage version name = Package
         , moduleValues = values
         , moduleExceptions = exceptions
         }
-    , packageMetadata = ifMetadataRequired version $ PackageMetadata
+    , packageMetadata = PackageMetadata
         { packageName = PackageName ("daml-prim-DA-Exception-" <> name)
         , packageVersion = PackageVersion "1.0.0"
         , upgradedPackageId = Nothing

--- a/compiler/damlc/tests/src/DA/Test/GenerateSimpleDalf.hs
+++ b/compiler/damlc/tests/src/DA/Test/GenerateSimpleDalf.hs
@@ -140,7 +140,7 @@ main = do
     let pkg = Package
             { packageLfVersion = optLfVersion
             , packageModules = NM.fromList [mod]
-            , packageMetadata = Just $ PackageMetadata (PackageName "simple-dalf") (PackageVersion "1.0.0") Nothing
+            , packageMetadata = PackageMetadata (PackageName "simple-dalf") (PackageVersion "1.0.0") Nothing
             }
     let (bytes, PackageId hash) = encodeArchiveAndHash pkg
     BSL.writeFile optFile bytes

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -402,7 +402,7 @@ tests Tools{damlc} = testGroup "Packaging" $
           withCurrentDirectory projDir $ callProcessSilent damlc ["build", "-o", "foobar.dar", "--target=2.dev"]
           Right Dalfs{..} <- readDalfs . Zip.toArchive <$> BSL.readFile (projDir </> "foobar.dar")
           (_pkgId, pkg) <- either (fail . show) pure (LFArchive.decodeArchive LFArchive.DecodeAsMain (BSL.toStrict mainDalf))
-          LF.packageMetadata pkg @?= Just (LF.PackageMetadata (LF.PackageName "foobar") (LF.PackageVersion "1.2.3") Nothing)
+          LF.packageMetadata pkg @?= LF.PackageMetadata (LF.PackageName "foobar") (LF.PackageVersion "1.2.3") Nothing
 
     , testCase "Package metadata - single file" $ withTempDir $ \projDir -> do
           createDirectoryIfMissing True projDir
@@ -419,7 +419,7 @@ tests Tools{damlc} = testGroup "Packaging" $
           withCurrentDirectory projDir $ callProcessSilent damlc ["build", "-o", "foobar.dar", "--target=2.dev"]
           Right Dalfs{..} <- readDalfs . Zip.toArchive <$> BSL.readFile (projDir </> "foobar.dar")
           (_pkgId, pkg) <- either (fail . show) pure (LFArchive.decodeArchive LFArchive.DecodeAsMain (BSL.toStrict mainDalf))
-          LF.packageMetadata pkg @?= Just (LF.PackageMetadata (LF.PackageName "foobar") (LF.PackageVersion "1.2.3") Nothing)
+          LF.packageMetadata pkg @?= LF.PackageMetadata (LF.PackageName "foobar") (LF.PackageVersion "1.2.3") Nothing
 
     , testCase "Transitive package deps" $ withTempDir $ \projDir -> do
           -- Check that the depends field in the package config files does not depend on the name of the DAR.

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -277,29 +277,25 @@ fetchDar args rootPid saveAs = do
   let (dalf,pkgId) = LFArchive.encodeArchiveAndHash rootPkg
   let dalfDependencies :: [(T.Text,BS.ByteString,LF.PackageId)] =
         [ (txt,bs,pkgId)
-        | (pid,Just pkg) <- Map.toList (Map.delete rootPid pkgs)
-        , let txt = recoverPackageName pkg pid
+        | Just pkg <- Map.elems (Map.delete rootPid pkgs)
+        , let txt = recoverPackageName pkg
         , let (bsl,pkgId) = LFArchive.encodeArchiveAndHash pkg
         , let bs = BSL.toStrict bsl
         ]
   let (pName,pVersion) = do
         let LF.Package {packageMetadata} = rootPkg
         case packageMetadata of
-          Nothing -> (LF.PackageName $ T.pack "reconstructed",Nothing)
-          Just LF.PackageMetadata{packageName,packageVersion} -> (packageName,Just packageVersion)
+          LF.PackageMetadata{packageName,packageVersion} -> (packageName,Just packageVersion)
   let pSdkVersion = unresolvedBuiltinSdkVersion
   let srcRoot = error "unexpected use of srcRoot when there are no sources"
   let za = createArchive pName pVersion pSdkVersion pkgId dalf dalfDependencies srcRoot [] [] []
   createDarFile loggerH saveAs za
   return $ Map.size pkgs
 
-recoverPackageName :: LF.Package -> LF.PackageId -> T.Text
-recoverPackageName pkg pid= do
-  let LF.Package {packageMetadata} = pkg
-  case packageMetadata of
-    Just LF.PackageMetadata{packageName} -> LF.unPackageName packageName
-    -- fallback, manufacture a name from the pid
-    Nothing -> LF.unPackageId pid
+recoverPackageName :: LF.Package -> T.Text
+recoverPackageName pkg = do
+  let LF.Package{packageMetadata = LF.PackageMetadata{packageName}} = pkg
+  LF.unPackageName packageName
 
 -- | Download all Packages reachable from a PackageId; fail if any don't exist or can't be decoded.
 downloadAllReachablePackages ::
@@ -358,8 +354,8 @@ downloadPackage args pid = do
     convPid (LF.PackageId text) = L.PackageId $ TL.fromStrict text
 
 data RemoteDalf = RemoteDalf
-    { remoteDalfName :: Maybe LF.PackageName
-    , remoteDalfVersion :: Maybe LF.PackageVersion
+    { remoteDalfName :: LF.PackageName
+    , remoteDalfVersion :: LF.PackageVersion
     , remoteDalfBs :: BS.ByteString
     , remoteDalfIsMain :: Bool
     , remoteDalfPkgId :: LF.PackageId
@@ -384,10 +380,10 @@ runLedgerGetDalfs lflags pkgIds exclPkgIds
             , let (bsl, pid) = LFArchive.encodeArchiveAndHash pkg
             , let LF.Package {packageMetadata} = pkg
             , let remoteDalfPkgId = pid
-            , let remoteDalfName = LF.packageName <$> packageMetadata
+            , let remoteDalfName = LF.packageName packageMetadata
             , let remoteDalfBs = BSL.toStrict bsl
             , let remoteDalfIsMain = pid `Set.member` Set.fromList pkgIds
-            , let remoteDalfVersion = LF.packageVersion <$> packageMetadata
+            , let remoteDalfVersion = LF.packageVersion packageMetadata
             ]
 
 runLedgerListPackages :: LedgerFlags -> IO [LF.PackageId]
@@ -413,11 +409,8 @@ runLedgerListPackages0 flags = do
         , versionM <- [remoteDalfVersion]
         ]
   where
-    suffix (Just name) (Just version) =
+    suffix name version =
         "(" <> LF.unPackageName name <> "-" <> LF.unPackageVersion version <> ")"
-    suffix (Just name) Nothing = "(" <> LF.unPackageName name <> ")"
-    suffix Nothing (Just _version) = ""
-    suffix Nothing Nothing = ""
 
 listParties :: LedgerArgs -> IO [L.PartyDetails]
 listParties args =


### PR DESCRIPTION
Context: https://github.com/digital-asset/daml/issues/17366, https://github.com/digital-asset/daml/issues/18240

We don't need to support pre 1.8 packages so we can assume it is always present.