### PR TITLE
Add Upgrade key support + tests (backport)

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1539,8 +1539,10 @@ private[lf] object SBuiltin {
     }
   }
 
-  private[speedy] sealed abstract class SBUKeyBuiltin(operation: KeyOperation)
-      extends UpdateBuiltin(1)
+  private[speedy] sealed abstract class SBUKeyBuiltin(
+      operation: KeyOperation,
+      optTargetTemplateId: Option[TypeConName],
+  ) extends UpdateBuiltin(1)
       with Product {
     override protected def executeUpdate(
         args: util.ArrayList[SValue],
@@ -1565,7 +1567,6 @@ private[lf] object SBuiltin {
       } else {
         val keyOpt = SOptional(Some(keyValue))
         val gkey = cachedKey.globalKey
-        val optTargetTemplateId: Option[TypeConName] = None // no upgrading
         machine.ptx.contractState.resolveKey(gkey) match {
           case Right((keyMapping, next)) =>
             machine.ptx = machine.ptx.copy(contractState = next)
@@ -1627,15 +1628,19 @@ private[lf] object SBuiltin {
     *   :: { key: key, maintainers: List Party }
     *   -> ContractId T
     */
-  final case class SBUFetchKey(templateId: TypeConName)
-      extends SBUKeyBuiltin(new KeyOperation.Fetch(templateId))
+  final case class SBUFetchKey(
+      templateId: TypeConName,
+      optTargetTemplateId: Option[TypeConName] = None,
+  ) extends SBUKeyBuiltin(new KeyOperation.Fetch(templateId), optTargetTemplateId)
 
   /** $lookupKey[T]
     *   :: { key: key, maintainers: List Party }
     *   -> Maybe (ContractId T)
     */
-  final case class SBULookupKey(templateId: TypeConName)
-      extends SBUKeyBuiltin(new KeyOperation.Lookup(templateId))
+  final case class SBULookupKey(
+      templateId: TypeConName,
+      optTargetTemplateId: Option[TypeConName] = None,
+  ) extends SBUKeyBuiltin(new KeyOperation.Lookup(templateId), optTargetTemplateId)
 
   /** $getTime :: Token -> Timestamp */
   final case object SBUGetTime extends UpdateBuiltin(1) {
@@ -2215,11 +2220,11 @@ private[lf] object SBuiltin {
             case None =>
               (false, srcTmplId) // upgrading not enabled; import at source type
           }
-          if (srcTmplId.qualifiedName != dstTmplId.qualifiedName)
+          if (srcTmplId.qualifiedName != dstTmplId.qualifiedName) {
             Control.Error(
               IE.WronglyTypedContract(coid, dstTmplId, srcTmplId)
             )
-          else
+          } else
             machine.ensurePackageIsLoaded(
               dstTmplId.packageId,
               language.Reference.Template(dstTmplId),

--- a/daml-script/daml3/Daml/Script/Questions/Packages.daml
+++ b/daml-script/daml3/Daml/Script/Questions/Packages.daml
@@ -56,19 +56,27 @@ data UnvetDar = UnvetDar with
   participant : Optional Text
 instance IsQuestion UnvetDar () where command = "UnvetDar"
 
--- Add a wait after performing the action, as unvetting takes a little bit of time
+-- Add a wait after performing the action, as vetting and unvetting takes a little bit of time
 -- https://github.com/digital-asset/daml/issues/17707
 thenWait : Script a -> Script a
 thenWait s = s <* sleep (seconds 1)
 
 vetDar : HasCallStack => Text -> Script ()
-vetDar darName = lift $ VetDar darName None
+vetDar darName = thenWait $ lift $ VetDar darName None
 
 vetDarOnParticipant : HasCallStack => Text -> ParticipantName -> Script ()
-vetDarOnParticipant darName (ParticipantName participant) = lift $ VetDar darName (Some participant)
+vetDarOnParticipant darName (ParticipantName participant) = thenWait $ lift $ VetDar darName (Some participant)
 
 unvetDar : HasCallStack => Text -> Script ()
 unvetDar darName = thenWait $ lift $ UnvetDar darName None
 
 unvetDarOnParticipant : HasCallStack => Text -> ParticipantName -> Script ()
 unvetDarOnParticipant darName (ParticipantName participant) = thenWait $ lift $ UnvetDar darName (Some participant)
+
+-- | This does not wait for the topology transaction to land, be sure to sleep for 1 second between calling this and using a template from the given package
+unsafeVetDarOnParticipant : HasCallStack => Text -> Optional ParticipantName -> Script ()
+unsafeVetDarOnParticipant darName mParticipantName = lift $ VetDar darName (participantName <$> mParticipantName)
+
+-- | This does not wait for the topology transaction to land, be sure to sleep for 1 second between calling this and using a template from the given package
+unsafeUnvetDarOnParticipant : HasCallStack => Text -> Optional ParticipantName -> Script ()
+unsafeUnvetDarOnParticipant darName mParticipantName = lift $ UnvetDar darName (participantName <$> mParticipantName)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/AdminLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/AdminLedgerClient.scala
@@ -22,6 +22,11 @@ final class AdminLedgerClient private (
 )(implicit ec: ExecutionContext)
     extends Closeable {
 
+  // Follow community/app-base/src/main/scala/com/digitalasset/canton/console/commands/TopologyAdministration.scala:1149
+  // Shows how to do a list request
+  // Try filtering for just Adds, assuming a Remove cancels an Add.
+  // If it doesn't, change the filter to all and fold them
+
   private val packageServiceStub =
     AdminLedgerClient.stub(admin_package_service.PackageServiceGrpc.stub(channel), token)
 

--- a/daml-script/test/daml/upgrades/UpgradesTest.daml
+++ b/daml-script/test/daml/upgrades/UpgradesTest.daml
@@ -9,8 +9,10 @@ import DA.Assert
 import DA.Exception
 import DA.Foldable
 import DA.Text
+import DA.Time
 import Daml.Script
 import Daml.Script.Questions.Exceptions (tryToEither)
+import Daml.Script.Questions.Packages (unsafeVetDarOnParticipant, unsafeUnvetDarOnParticipant)
 import Daml.Script.Questions.Testing.Internal
 import qualified V1.MyTemplates as V1
 import qualified V2.MyTemplates as V2
@@ -50,13 +52,19 @@ main = forA_ tests $ \(testName, test) -> do
 brokenScript : Script () -> Script ()
 brokenScript act = do
   tryToEither (\() -> liftFailedCommandToException act) >>= \case
-    Right _ -> assertFail "Expected failed and got success! Did you fix this logic? Remove the wrapping `failure` to mark this as working."
+    Right _ -> assertFail "Expected failed and got success! Did you fix this logic? Remove the wrapping `broken` to mark this as working."
     Left _ -> do
-      -- Cleanup so next test can run.
-      vetDarOnParticipant v1DarName participant0
-      vetDarOnParticipant v1DarName participant1
-      vetDarOnParticipant v2DarName participant0
-      vetDarOnParticipant v2DarName participant1
+      -- Unvet first so we don't end up vetting a package twice
+      unsafeUnvetDarOnParticipant v1DarName $ Some participant0
+      unsafeUnvetDarOnParticipant v1DarName $ Some participant1
+      unsafeUnvetDarOnParticipant v2DarName $ Some participant0
+      unsafeUnvetDarOnParticipant v2DarName $ Some participant1
+      sleep $ seconds 1
+      unsafeVetDarOnParticipant v1DarName $ Some participant0
+      unsafeVetDarOnParticipant v1DarName $ Some participant1
+      unsafeVetDarOnParticipant v2DarName $ Some participant0
+      unsafeVetDarOnParticipant v2DarName $ Some participant1
+      sleep $ seconds 1
 
 broken : (Text, Script ()) -> (Text, Script ())
 broken (name, act) = ("(BROKEN) " <> name, brokenScript act)
@@ -141,6 +149,12 @@ tests = mconcat
     , ("Fails if a nested variant is a removed case", templateVariantUpgradeToRemoved)
     , ("Fails if a nested variant is an additional case when downgrading", templateVariantDowngradeFromNew)
 
+    , -- Contract key upgrades
+      ("Query an unchanged old key for a new contract", queryKeyUnchanged)
+    , ("ExerciseByKey command an unchanged old key for a new contract", exerciseCmdKeyUnchanged)
+    , ("Fetching an unchanged old key for a new contract", fetchKeyUnchanged)
+    , ("ExerciseByKey in Update an unchanged old key for a new contract", exerciseUpdateKeyUnchanged)
+  
     , -- Edge behaviour
       -- https://github.com/DACH-NY/canton/issues/14718
       broken ("Chooses the v1 contract if v2 is unvetted and package id is omitted.", packageSelectionChoosesUnvettedPackages)
@@ -150,10 +164,8 @@ tests = mconcat
     ]
   , -- Multi participant tests
     [ ("Both participants have v2, upgraded create succeeds.", bothParticipantsV2)
-    , ("Submitting participant has v2, other has v1, failure.", submitV1OtherV2)
-    , ("Submitting participant has v1, other has v2, failure.", submitV2OtherV1)
-      -- TODO: Consider a final test where both participants have v2 disabled. Sadly this cannot work given the
-      -- packageSelectionChoosesUnvettedPackages shows that even an individual participant will pick v2 in this case.
+    , ("Submitting participant has v2, other has v1, expect v1 used.", submitV2OtherV1)
+    , ("Submitting participant has v1, other has v2, expect v1 used.", submitV1OtherV2)
     ]
   ]
 
@@ -603,6 +615,37 @@ templateVariantDowngradeFromNew = do
     Left (UnknownError msg) | "An error occurred." `isInfixOf` msg -> pure ()
     _ -> assertFail $ "Expected specific failure but got " <> show res
 
+queryKeyUnchanged : Script ()
+queryKeyUnchanged = do
+  a <- allocateParty "alice"
+  cid <- a `submit` createExactCmd (V1.UnchangedKey a 1)
+  keyRes <- queryContractKey a $ V2.UnchangedKeyKey a 1
+  case keyRes of
+    Some (foundCid, foundContract) | show foundCid == show cid && foundContract == V2.UnchangedKey a 1 None -> pure ()
+    _ -> assertFail $ "Didn't find correct contract, expected " <> show (cid, V2.UnchangedKey a 1 None) <> ", got " <> show keyRes
+
+exerciseCmdKeyUnchanged : Script ()
+exerciseCmdKeyUnchanged = do
+  a <- allocateParty "alice"
+  cid <- a `submit` createExactCmd (V1.UnchangedKey a 1)
+  res <- a `submit` exerciseByKeyExactCmd @V2.UnchangedKey (V2.UnchangedKeyKey a 1) V2.UnchangedKeyCall
+  res === "V2"
+
+fetchKeyUnchanged : Script ()
+fetchKeyUnchanged = do
+  a <- allocateParty "alice"
+  cid <- a `submit` createCmd (V1.UnchangedKey a 1)
+  (foundCid, foundContract) <- a `submit` createAndExerciseCmd (V2.UnchangedKeyHelper a) (V2.UnchangedKeyFetch $ V2.UnchangedKeyKey a 1)
+  foundContract === V2.UnchangedKey a 1 None
+  show foundCid === show cid
+
+exerciseUpdateKeyUnchanged : Script ()
+exerciseUpdateKeyUnchanged = do
+  a <- allocateParty "alice"
+  _ <- a `submit` createCmd (V1.UnchangedKey a 1)
+  res <- a `submit` createAndExerciseCmd (V2.UnchangedKeyHelper a) (V2.UnchangedKeyExercise $ V2.UnchangedKeyKey a 1)
+  res === "V2"
+
 packageSelectionChoosesUnvettedPackages : Script ()
 packageSelectionChoosesUnvettedPackages = do
   -- Unvet the v2 dar on all participants on the domain
@@ -635,7 +678,7 @@ submitV1OtherV2 = do
   a <- allocatePartyOn "alice" participant0
   b <- allocatePartyOn "bob" participant1
   unvetDarOnParticipant v2DarName participant0
-  liftAssertUnknownPackageError $ a `trySubmit` createCmd V1.SharedTemplate with party = a, ob = b
+  a `trySubmit` createCmd V1.SharedTemplate with party = a, ob = b
   vetDarOnParticipant v2DarName participant0
 
 submitV2OtherV1 : Script ()

--- a/daml-script/test/daml/upgrades/v1/MyTemplates.daml
+++ b/daml-script/test/daml/upgrades/v1/MyTemplates.daml
@@ -227,3 +227,36 @@ template SharedTemplate
   where
     signatory party
     observer ob
+
+data UnchangedKeyKey = UnchangedKeyKey with
+    p : Party
+    n : Int
+  deriving (Eq, Show)
+
+template UnchangedKey
+  with
+    party : Party
+    n : Int
+  where
+    signatory party
+    key (UnchangedKeyKey party n) : UnchangedKeyKey
+    maintainer key.p
+
+    choice UnchangedKeyCall : Text
+      controller party
+      do pure "V1"
+
+template UnchangedKeyHelper
+  with
+    party : Party
+  where
+    signatory party
+    choice UnchangedKeyFetch : (ContractId UnchangedKey, UnchangedKey) with
+        k : UnchangedKeyKey
+      controller party
+      do fetchByKey k
+    
+    choice UnchangedKeyExercise : Text with
+        k : UnchangedKeyKey
+      controller party
+      do exerciseByKey @UnchangedKey k UnchangedKeyCall

--- a/daml-script/test/daml/upgrades/v2/MyTemplates.daml
+++ b/daml-script/test/daml/upgrades/v2/MyTemplates.daml
@@ -240,3 +240,37 @@ template SharedTemplate
   where
     signatory party
     observer ob
+
+data UnchangedKeyKey = UnchangedKeyKey with
+    p : Party
+    n : Int
+  deriving (Eq, Show)
+
+template UnchangedKey
+  with
+    party : Party
+    n : Int
+    newField : Optional Text
+  where
+    signatory party
+    key (UnchangedKeyKey party n) : UnchangedKeyKey
+    maintainer key.p
+
+    choice UnchangedKeyCall : Text
+      controller party
+      do pure "V2"
+
+template UnchangedKeyHelper
+  with
+    party : Party
+  where
+    signatory party
+    choice UnchangedKeyFetch : (ContractId UnchangedKey, UnchangedKey) with
+        k : UnchangedKeyKey
+      controller party
+      do fetchByKey k
+    
+    choice UnchangedKeyExercise : Text with
+        k : UnchangedKeyKey
+      controller party
+      do exerciseByKey @UnchangedKey k UnchangedKeyCall


### PR DESCRIPTION
Adds upgrade coercion to contract keys in the speedy compiler, adds tests for this behaviour
Backport of #17867, however that PR cannot be merged as we're waiting on canton to forward port their work.