### PR TITLE
fix dade-check-main-only-files instructions

### DIFF
--- a/dev-env/bin/dade-check-main-only-files
+++ b/dev-env/bin/dade-check-main-only-files
@@ -24,7 +24,7 @@ if [[ -n "$SUSPECT_FILES" ]]; then
 The following modified files sit under a directory with 'main-only' targets:
 $SUSPECT_FILES
 
-Consider putting a line with 'run-all-tests: true' in your PR description, or \`export DADE_SKIP_MAIN_ONLY_CHECK=1\` and try again.
+Consider putting a 'run-all-tests: true' line at the end of your commit message, or \`export DADE_SKIP_MAIN_ONLY_CHECK=1\` and try again.
     " >&2
   exit 1
 fi


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
