### PR TITLE
remove type interning feature flag from the compiler

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -120,15 +120,6 @@ featureMinVersion :: Feature -> MajorVersion -> Maybe Version
 featureMinVersion Feature{featureVersionReq = VersionReq rangeForMajor} major =
   Version major <$> R.minBound (rangeForMajor major)
 
--- | Kept for serialization of stable packages.
-featureTypeInterning :: Feature
-featureTypeInterning = Feature
-    { featureName = "Type interning"
-    , featureVersionReq = VersionReq \case
-          V2 -> allMinorVersions
-    , featureCppFlag = Nothing
-    }
-
 -- Unstable, experimental features. This should stay in x.dev forever.
 -- Features implemented with this flag should be moved to a separate
 -- feature flag once the decision to add them permanently has been made.
@@ -246,8 +237,7 @@ featureExperimental = Feature
 
 allFeatures :: [Feature]
 allFeatures =
-    [ featureTypeInterning
-    , featureBigNumeric
+    [ featureBigNumeric
     , featureExceptions
     , featureNatSynonyms
     , featureSimpleInterfaces

--- a/compiler/daml-lf-proto-encode/src/DA/Daml/LF/Proto3/EncodeV2.hs
+++ b/compiler/daml-lf-proto-encode/src/DA/Daml/LF/Proto3/EncodeV2.hs
@@ -345,20 +345,17 @@ encodeType t = Just <$> encodeType' t
 
 allocType :: P.TypeSum -> Encode P.Type
 allocType ptyp = fmap (P.Type . Just) $ do
-    env@EncodeEnv{version, internedTypes, nextInternedTypeId = n} <- get
-    if version `supports` featureTypeInterning then
-        case ptyp `Map.lookup` internedTypes of
-            Just n -> pure (P.TypeSumInterned n)
-            Nothing -> do
-                when (n == maxBound) $
-                    error "Type interning table grew too large"
-                put $! env
-                    { internedTypes = Map.insert ptyp n internedTypes
-                    , nextInternedTypeId = n + 1
-                    }
-                pure (P.TypeSumInterned n)
-    else
-        pure ptyp
+    env@EncodeEnv{internedTypes, nextInternedTypeId = n} <- get
+    case ptyp `Map.lookup` internedTypes of
+        Just n -> pure (P.TypeSumInterned n)
+        Nothing -> do
+            when (n == maxBound) $
+                error "Type interning table grew too large"
+            put $! env
+                { internedTypes = Map.insert ptyp n internedTypes
+                , nextInternedTypeId = n + 1
+                }
+            pure (P.TypeSumInterned n)
 
 ------------------------------------------------------------------------
 -- Encoding of expressions


### PR DESCRIPTION
Context: https://github.com/digital-asset/daml/issues/18240

And delete the resulting dead code paths from the encoder.

Currently targeting pb/remove-interned-names-feature because it is stacked on top of it, but ready for review already.