### PR TITLE
remove the nat synonyms feature from the compiler

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -169,14 +169,6 @@ featureExceptions = Feature
     , featureCppFlag = Just "DAML_EXCEPTIONS"
     }
 
-featureNatSynonyms :: Feature
-featureNatSynonyms = Feature
-    { featureName = "Nat type synonyms"
-    , featureVersionReq = VersionReq \case
-          V2 -> allMinorVersions
-    , featureCppFlag = Just "DAML_NAT_SYN"
-    }
-
 featureSimpleInterfaces :: Feature
 featureSimpleInterfaces = Feature
     { featureName = "Daml Interfaces"
@@ -264,7 +256,6 @@ allFeatures =
     , featureTypeInterning
     , featureBigNumeric
     , featureExceptions
-    , featureNatSynonyms
     , featureSimpleInterfaces
     , featureExtendedInterfaces
     , featureChoiceFuncs

--- a/compiler/damlc/daml-prim-src/DA/Internal/NatSyn.daml
+++ b/compiler/damlc/daml-prim-src/DA/Internal/NatSyn.daml
@@ -4,8 +4,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
-#ifdef DAML_NAT_SYN
-
 -- | HIDE
 module DA.Internal.NatSyn (
   NatSyn
@@ -15,11 +13,3 @@ import GHC.Types (Nat)
 
 -- | NatSyn type used for encoding type-level Nats with kind *.
 data NatSyn (n : Nat)
-
-#else
-
--- | HIDE
-module DA.Internal.NatSyn () where
-import GHC.Types ()
-
-#endif


### PR DESCRIPTION
Context: https://github.com/digital-asset/daml/issues/18240

Remove any usage of the feature, in code and in the integration tests.