### PR TITLE
Fixed the behaviour of the noop metrics gauge

### DIFF
--- a/observability/metrics/src/main/scala/com/daml/metrics/api/noop/Metrics.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/noop/Metrics.scala
@@ -5,6 +5,7 @@ package com.daml.metrics.api.noop
 
 import java.time.Duration
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 import com.daml.metrics.api.MetricHandle.Timer.TimerHandle
 import com.daml.metrics.api.MetricHandle.{Counter, Gauge, Histogram, Meter, Timer}
@@ -31,11 +32,15 @@ case object NoOpTimerHandle extends TimerHandle {
 
 case class NoOpGauge[T](name: String, value: T) extends Gauge[T] {
 
-  override def updateValue(newValue: T): Unit = ()
+  private val ref = new AtomicReference[T](value)
 
-  override def getValue: T = value
+  override def updateValue(newValue: T): Unit = ref.set(newValue)
 
-  override def updateValue(f: T => T): Unit = ()
+  override def getValue: T = ref.get()
+
+  override def updateValue(f: T => T): Unit = {
+    val _ = ref.updateAndGet(f(_))
+  }
 
   override def close(): Unit = ()
 }


### PR DESCRIPTION
Before this change, the noop metrics gauge just ignored any value update. Now, it's backed by an atomic ref.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
