### PR TITLE
[daml-2.x Backport] Update new-working-on-ghc-lib.md to mention `da-master-8.8.1-daml-2.x` [#18259]

### DIFF
--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "9a5018eaf92752176929728524173bbbc38b641d"
+GHC_REV = "fa2837afabeccd99f4c78e7fd7346ea91068da7d"
 GHC_PATCHES = [
 ]
 

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "6cea01bd8eec50722bffa9b3b1b9067653ee6123"
+GHC_REV = "9a5018eaf92752176929728524173bbbc38b641d"
 GHC_PATCHES = [
 ]
 

--- a/ghc-lib/new-working-on-ghc-lib.md
+++ b/ghc-lib/new-working-on-ghc-lib.md
@@ -21,7 +21,10 @@ git remote add da-fork git@github.com:digital-asset/ghc.git
 git fetch da-fork
 ```
 
-3. Checkout the version of interest (usually `da-master-8.8.1`, which should match `GHC_REV` from [`$DAML_REPO/bazel_tools/ghc-lib/version.bzl`](https://github.com/digital-asset/daml/blob/main/bazel_tools/ghc-lib/version.bzl)) and update the submodules:
+3. Checkout the version of interest (usually `da-master-8.8.1`, or
+`da-master-8.8.1-daml-2.x` if you're targetting (daml) `main-2.x`) which should
+match `GHC_REV` from [`$DAML_REPO/bazel_tools/ghc-lib/version.bzl`](https://github.com/digital-asset/daml/blob/main/bazel_tools/ghc-lib/version.bzl))
+and update the submodules:
 ```
 git checkout da-master-8.8.1
 git submodule update --init --recursive

--- a/ghc-lib/new-working-on-ghc-lib.md
+++ b/ghc-lib/new-working-on-ghc-lib.md
@@ -25,7 +25,12 @@ git fetch da-fork
 ```
 git checkout da-master-8.8.1
 git submodule update --init --recursive
+git clean -xfdf
 ```
+
+The last `git clean` is needed to remove the submodules from upstream master
+that aren't used in our fork. `-xfdf` with two `f`s is needed because
+submodules contain their own `.git` directories.
 
 ### Iterating on parser/desugaring in `ghc`
 


### PR DESCRIPTION
Also backports #18237

Daml PR: https://github.com/digital-asset/daml/pull/18260
DA-GHC PR: https://github.com/digital-asset/ghc/pull/174