### PR TITLE
#15209 Remove agreementText from Java codegen and bindings

### DIFF
--- a/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/CreatedEvent.java
+++ b/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/CreatedEvent.java
@@ -30,8 +30,6 @@ public final class CreatedEvent implements Event, TreeEvent {
 
   private final @NonNull Map<@NonNull Identifier, @NonNull Status> failedInterfaceViews;
 
-  private final Optional<String> agreementText;
-
   private final Optional<Value> contractKey;
 
   private final @NonNull Set<@NonNull String> signatories;
@@ -54,7 +52,6 @@ public final class CreatedEvent implements Event, TreeEvent {
       @NonNull ByteString createdEventBlob,
       @NonNull Map<@NonNull Identifier, @NonNull DamlRecord> interfaceViews,
       @NonNull Map<@NonNull Identifier, com.google.rpc.@NonNull Status> failedInterfaceViews,
-      @NonNull Optional<String> agreementText,
       @NonNull Optional<Value> contractKey,
       @NonNull Collection<@NonNull String> signatories,
       @NonNull Collection<@NonNull String> observers,
@@ -67,7 +64,6 @@ public final class CreatedEvent implements Event, TreeEvent {
     this.createdEventBlob = createdEventBlob;
     this.interfaceViews = Map.copyOf(interfaceViews);
     this.failedInterfaceViews = Map.copyOf(failedInterfaceViews);
-    this.agreementText = agreementText;
     this.contractKey = contractKey;
     this.signatories = Set.copyOf(signatories);
     this.observers = Set.copyOf(observers);
@@ -118,11 +114,6 @@ public final class CreatedEvent implements Event, TreeEvent {
   }
 
   @NonNull
-  public Optional<String> getAgreementText() {
-    return agreementText;
-  }
-
-  @NonNull
   public Optional<Value> getContractKey() {
     return contractKey;
   }
@@ -161,7 +152,6 @@ public final class CreatedEvent implements Event, TreeEvent {
         && Objects.equals(createdEventBlob, that.createdEventBlob)
         && Objects.equals(interfaceViews, that.interfaceViews)
         && Objects.equals(failedInterfaceViews, that.failedInterfaceViews)
-        && Objects.equals(agreementText, that.agreementText)
         && Objects.equals(contractKey, that.contractKey)
         && Objects.equals(signatories, that.signatories)
         && Objects.equals(observers, that.observers)
@@ -179,7 +169,6 @@ public final class CreatedEvent implements Event, TreeEvent {
         createdEventBlob,
         interfaceViews,
         failedInterfaceViews,
-        agreementText,
         contractKey,
         signatories,
         observers,
@@ -207,8 +196,6 @@ public final class CreatedEvent implements Event, TreeEvent {
         + interfaceViews
         + ", failedInterfaceViews="
         + failedInterfaceViews
-        + ", agreementText='"
-        + agreementText
         + "', contractKey="
         + contractKey
         + ", signatories="
@@ -244,7 +231,6 @@ public final class CreatedEvent implements Event, TreeEvent {
                     .setSeconds(this.createdAt.getEpochSecond())
                     .setNanos(this.createdAt.getNano())
                     .build());
-    agreementText.ifPresent(a -> builder.setAgreementText(StringValue.of(a)));
     contractKey.ifPresent(a -> builder.setContractKey(a.toProto()));
     return builder.build();
   }
@@ -285,9 +271,6 @@ public final class CreatedEvent implements Event, TreeEvent {
                 Collectors.toUnmodifiableMap(
                     iv -> Identifier.fromProto(iv.getInterfaceId()),
                     EventOuterClass.InterfaceView::getViewStatus)),
-        createdEvent.hasAgreementText()
-            ? Optional.of(createdEvent.getAgreementText().getValue())
-            : Optional.empty(),
         createdEvent.hasContractKey()
             ? Optional.of(Value.fromProto(createdEvent.getContractKey()))
             : Optional.empty(),

--- a/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/codegen/Contract.java
+++ b/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/codegen/Contract.java
@@ -5,7 +5,6 @@ package com.daml.ledger.javaapi.data.codegen;
 
 import com.daml.ledger.javaapi.data.Identifier;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -20,9 +19,6 @@ public abstract class Contract<Id, Data> implements com.daml.ledger.javaapi.data
 
   /** The contract payload, as declared after {@code template X with}. */
   public final Data data;
-
-  /** If defined, the contract's agreement text. */
-  public final Optional<String> agreementText;
 
   /** The party IDs of this contract's signatories. */
   public final Set<String> signatories;
@@ -41,12 +37,10 @@ public abstract class Contract<Id, Data> implements com.daml.ledger.javaapi.data
   protected Contract(
       Id id,
       Data data,
-      Optional<String> agreementText,
       Set<String> signatories,
       Set<String> observers) {
     this.id = id;
     this.data = data;
-    this.agreementText = agreementText;
     this.signatories = signatories;
     this.observers = observers;
   }
@@ -82,24 +76,22 @@ public abstract class Contract<Id, Data> implements com.daml.ledger.javaapi.data
     // already compares the associated record types' classes
     return this.id.equals(other.id)
         && this.data.equals(other.data)
-        && this.agreementText.equals(other.agreementText)
         && this.signatories.equals(other.signatories)
         && this.observers.equals(other.observers);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.id, this.data, this.agreementText, this.signatories, this.observers);
+    return Objects.hash(this.id, this.data, this.signatories, this.observers);
   }
 
   @Override
   public String toString() {
     return String.format(
-        "%s.Contract(%s, %s, %s, %s, %s)",
+        "%s.Contract(%s, %s, %s, %s)",
         getCompanion().TEMPLATE_CLASS_NAME,
         this.id,
         this.data,
-        this.agreementText,
         this.signatories,
         this.observers);
   }

--- a/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractCompanion.java
+++ b/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractCompanion.java
@@ -120,12 +120,11 @@ public abstract class ContractCompanion<Ct, Id, Data>
     public Ct fromIdAndRecord(
         String contractId,
         DamlRecord record$,
-        Optional<String> agreementText,
         Set<String> signatories,
         Set<String> observers) {
       Id id = newContractId.apply(contractId);
       Data data = fromValue.apply(record$);
-      return newContract.newContract(id, data, agreementText, signatories, observers);
+      return newContract.newContract(id, data, signatories, observers);
     }
 
     @Override
@@ -133,7 +132,6 @@ public abstract class ContractCompanion<Ct, Id, Data>
       return fromIdAndRecord(
           event.getContractId(),
           event.getArguments(),
-          event.getAgreementText(),
           event.getSignatories(),
           event.getObservers());
     }
@@ -143,7 +141,6 @@ public abstract class ContractCompanion<Ct, Id, Data>
       Ct newContract(
           Id id,
           Data data,
-          Optional<String> agreementText,
           Set<String> signatories,
           Set<String> observers);
     }
@@ -180,13 +177,12 @@ public abstract class ContractCompanion<Ct, Id, Data>
     public Ct fromIdAndRecord(
         String contractId,
         DamlRecord record$,
-        Optional<String> agreementText,
         Optional<Key> key,
         Set<String> signatories,
         Set<String> observers) {
       Id id = newContractId.apply(contractId);
       Data data = fromValue.apply(record$);
-      return newContract.newContract(id, data, agreementText, key, signatories, observers);
+      return newContract.newContract(id, data, key, signatories, observers);
     }
 
     @Override
@@ -194,7 +190,6 @@ public abstract class ContractCompanion<Ct, Id, Data>
       return fromIdAndRecord(
           event.getContractId(),
           event.getArguments(),
-          event.getAgreementText(),
           event.getContractKey().map(keyFromValue),
           event.getSignatories(),
           event.getObservers());
@@ -205,7 +200,6 @@ public abstract class ContractCompanion<Ct, Id, Data>
       Ct newContract(
           Id id,
           Data data,
-          Optional<String> agreementText,
           Optional<Key> key,
           Set<String> signatories,
           Set<String> observers);

--- a/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractWithInterfaceView.java
+++ b/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractWithInterfaceView.java
@@ -14,10 +14,9 @@ final class ContractWithInterfaceView<Id, View> extends Contract<Id, View> {
       InterfaceCompanion<?, Id, View> contractTypeCompanion,
       Id id,
       View interfaceView,
-      Optional<String> agreementText,
       Set<String> signatories,
       Set<String> observers) {
-    super(id, interfaceView, agreementText, signatories, observers);
+    super(id, interfaceView, signatories, observers);
     this.contractTypeCompanion = contractTypeCompanion;
   }
 

--- a/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractWithKey.java
+++ b/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractWithKey.java
@@ -29,11 +29,10 @@ public abstract class ContractWithKey<Id, Data, Key> extends Contract<Id, Data> 
   protected ContractWithKey(
       Id id,
       Data data,
-      Optional<String> agreementText,
       Optional<Key> key,
       Set<String> signatories,
       Set<String> observers) {
-    super(id, data, agreementText, signatories, observers);
+    super(id, data, signatories, observers);
     this.key = key;
   }
 
@@ -47,17 +46,16 @@ public abstract class ContractWithKey<Id, Data, Key> extends Contract<Id, Data> 
   @Override
   public final int hashCode() {
     return Objects.hash(
-        this.id, this.data, this.agreementText, this.key, this.signatories, this.observers);
+        this.id, this.data, this.key, this.signatories, this.observers);
   }
 
   @Override
   public final String toString() {
     return String.format(
-        "%s.Contract(%s, %s, %s, %s, %s, %s)",
+        "%s.Contract(%s, %s, %s, %s, %s)",
         getCompanion().TEMPLATE_CLASS_NAME,
         this.id,
         this.data,
-        this.agreementText,
         this.key,
         this.signatories,
         this.observers);

--- a/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/codegen/InterfaceCompanion.java
+++ b/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/codegen/InterfaceCompanion.java
@@ -60,7 +60,6 @@ public abstract class InterfaceCompanion<I, Id, View>
   private Contract<Id, View> fromIdAndRecord(
       String contractId,
       Map<Identifier, DamlRecord> interfaceViews,
-      Optional<String> agreementText,
       Set<String> signatories,
       Set<String> observers)
       throws IllegalArgumentException {
@@ -73,7 +72,7 @@ public abstract class InterfaceCompanion<I, Id, View>
             record -> {
               View view = valueDecoder.decode(record);
               return new ContractWithInterfaceView<>(
-                  this, id, view, agreementText, signatories, observers);
+                  this, id, view, signatories, observers);
             })
         .orElseThrow(
             () ->
@@ -94,7 +93,6 @@ public abstract class InterfaceCompanion<I, Id, View>
     return fromIdAndRecord(
         event.getContractId(),
         event.getInterfaceViews(),
-        event.getAgreementText(),
         event.getSignatories(),
         event.getObservers());
   }

--- a/canton/community/bindings-java/src/test/scala/com/daml/ledger/javaapi/data/EventSpec.scala
+++ b/canton/community/bindings-java/src/test/scala/com/daml/ledger/javaapi/data/EventSpec.scala
@@ -52,7 +52,6 @@ class EventSpec extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyC
       base.getCreatedEventBlob,
       mutatingIVs,
       mutatingFIVs,
-      base.getAgreementText,
       base.getContractKey,
       mutatingSignatories,
       mutatingObservers,

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
@@ -240,7 +240,6 @@ object TransactionGenerator {
       createdEventBlob,
       interfaceViews.view.collect { case (_, (id, Right(rec))) => (id, rec) }.toMap.asJava,
       interfaceViews.view.collect { case (_, (id, Left(stat))) => (id, stat) }.toMap.asJava,
-      None.toJava, // agreementText, to be removed
       contractKey.map(_._2).toJava,
       signatories.toSet.asJava,
       observers.toSet.asJava,

--- a/language-support/java/codegen/src/it/java/com/daml/ContractKeysTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/ContractKeysTest.java
@@ -26,14 +26,12 @@ public class ContractKeysTest {
       new NoKey.Contract(
           new NoKey.ContractId("no-key"),
           new NoKey("Alice"),
-          Optional.empty(),
           Collections.emptySet(),
           Collections.emptySet());
   PartyKey.Contract partyKey =
       new PartyKey.Contract(
           new PartyKey.ContractId("party-key"),
           new PartyKey("Alice"),
-          Optional.empty(),
           Optional.of("Alice"),
           Collections.emptySet(),
           Collections.emptySet());
@@ -41,7 +39,6 @@ public class ContractKeysTest {
       new RecordKey.Contract(
           new RecordKey.ContractId("record-key"),
           new RecordKey("Alice", 42L),
-          Optional.empty(),
           Optional.of(new PartyAndInt("Alice", 42L)),
           Collections.emptySet(),
           Collections.emptySet());
@@ -49,7 +46,6 @@ public class ContractKeysTest {
       new TupleKey.Contract(
           new TupleKey.ContractId("tuple-key"),
           new TupleKey("Alice", 42L),
-          Optional.empty(),
           Optional.of(new Tuple2<>("Alice", 42L)),
           Collections.emptySet(),
           Collections.emptySet());
@@ -57,7 +53,6 @@ public class ContractKeysTest {
       new NestedTupleKey.Contract(
           new NestedTupleKey.ContractId("nested-tuple-key"),
           new NestedTupleKey("Alice", 42L, "blah", 47L, true, "foobar", 0L),
-          Optional.empty(),
           Optional.of(
               new Tuple2<>(
                   new Tuple3<>("Alice", 42L, "blah"), new Tuple4<>(47L, true, "foobar", 0L))),

--- a/language-support/java/codegen/src/it/java/com/daml/TemplateMethodTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/TemplateMethodTest.java
@@ -108,7 +108,6 @@ public class TemplateMethodTest {
           ByteString.EMPTY,
           Collections.emptyMap(),
           Collections.emptyMap(),
-          Optional.of(""), // to be removed
           Optional.empty(),
           Collections.emptySet(),
           Collections.emptySet(),
@@ -132,7 +131,7 @@ public class TemplateMethodTest {
   void contractHasToString() {
     assertEquals(
         "tests.template1.SimpleTemplate.Contract(ContractId(cid), "
-            + "tests.template1.SimpleTemplate(Bob), Optional[], [], [])",
+            + "tests.template1.SimpleTemplate(Bob), [], [])",
         SimpleTemplate.Contract.fromCreatedEvent(createdEvent).toString());
   }
 }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClass.scala
@@ -4,7 +4,7 @@
 package com.daml.lf.codegen.backend.java.inner
 
 import com.daml.ledger.javaapi
-import ClassGenUtils.{companionFieldName, optional, optionalString, setOfStrings}
+import ClassGenUtils.{companionFieldName, optional, setOfStrings}
 import com.daml.lf.typesig.Type
 import com.squareup.javapoet._
 import scalaz.syntax.std.option._
@@ -46,7 +46,6 @@ object ContractClass {
   object Builder {
     private val idFieldName = "id"
     private val dataFieldName = "data"
-    private val agreementFieldName = "agreementText"
     private val contractKeyFieldName = "key"
     private val signatoriesFieldName = "signatories"
     private val observersFieldName = "observers"
@@ -68,7 +67,6 @@ object ContractClass {
       val methodParameters = Seq(
         (ClassName get classOf[String], "contractId"),
         (ClassName get classOf[javaapi.data.DamlRecord], "record$"),
-        (optionalString, agreementFieldName),
       ) ++ maybeContractKeyClassName
         .map(name => (optional(name), contractKeyFieldName))
         .toList ++ Iterable(
@@ -144,7 +142,6 @@ object ContractClass {
         .addModifiers(Modifier.PUBLIC)
         .addParameter(contractIdClassName(templateClassName), idFieldName)
         .addParameter(templateClassName, dataFieldName)
-        .addParameter(optionalString, agreementFieldName)
 
       contractKeyClassName.foreach { name =>
         constructorBuilder.addParameter(optional(name), contractKeyFieldName)
@@ -158,7 +155,7 @@ object ContractClass {
       constructorBuilder.addStatement(
         "super($L)",
         CodeBlock.join(
-          (Seq(idFieldName, dataFieldName, agreementFieldName)
+          (Seq(idFieldName, dataFieldName)
             ++ superCtorKeyArgs
             ++ Seq(signatoriesFieldName, observersFieldName)).map(CodeBlock.of("$L", _)).asJava,
           ",$W",

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/InterfaceSpec.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/InterfaceSpec.scala
@@ -50,7 +50,6 @@ final class InterfaceSpec extends AnyWordSpec with Matchers {
             Map(ic.TEMPLATE_ID -> data.toValue).asJava,
             emptyMap,
             Optional.empty,
-            Optional.empty,
             emptyList,
             emptyList,
             Instant.EPOCH,

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClassBuilderSpec.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClassBuilderSpec.scala
@@ -35,7 +35,6 @@ final class ContractClassBuilderSpec
     parameters should contain theSameElementsInOrderAs Seq(
       "contractId" -> string,
       "record$" -> record,
-      "agreementText" -> optionalString, // will be removed
       "key" -> optionalContractKey,
       "signatories" -> setOfStrings,
       "observers" -> setOfStrings,
@@ -48,7 +47,6 @@ final class ContractClassBuilderSpec
     parameters should contain theSameElementsInOrderAs Seq(
       "contractId" -> string,
       "record$" -> record,
-      "agreementText" -> optionalString, // will be removed
       "signatories" -> setOfStrings,
       "observers" -> setOfStrings,
     )
@@ -65,8 +63,6 @@ final class ContractClassBuilderSpec
     ContractClass.Builder.generateFromIdAndRecord(className, None)
   private[this] val string = TypeName.get(classOf[String])
   private[this] val record = TypeName.get(classOf[javaapi.data.DamlRecord])
-  private[this] val optionalString =
-    ParameterizedTypeName.get(classOf[Optional[_]], classOf[String])
   private[this] val optionalContractKey =
     ParameterizedTypeName.get(ClassName.get(classOf[Optional[_]]), ckClassName)
   private[this] val setOfStrings =


### PR DESCRIPTION
It would probably be easier to make this change in the canton repo first, as there are a bit more changes on the Java bindings side, but that's impossible as Canton depends on `daml-codegen-java` (and this PR is a breaking change for Canton).

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
