### PR TITLE
Support split release artifactory, improve missing connection errors

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -93,7 +93,7 @@ import DA.Daml.Project.Types
       ProjectPath(..),
       ProjectConfig,
       unsafeResolveReleaseVersion)
-import DA.Daml.Assistant.Version (resolveReleaseVersion)
+import DA.Daml.Assistant.Version (resolveReleaseVersionUnsafe)
 import qualified DA.Daml.Compiler.Repl as Repl
 import DA.Daml.Compiler.DocTest (docTest)
 import DA.Daml.Desugar (desugar)
@@ -921,7 +921,7 @@ installDepsAndInitPackageDb opts (InitPkgDb shouldInit) =
                   then do
                     damlPath <- getDamlPath
                     damlEnv <- getDamlEnv damlPath (LookForProjectPath False)
-                    resolveReleaseVersion (envUseCache damlEnv) pSdkVersion
+                    resolveReleaseVersionUnsafe (Just "installing dependencies and initializing package database") (envUseCache damlEnv) pSdkVersion
                   else pure (unsafeResolveReleaseVersion pSdkVersion)
               installDependencies
                   (toNormalizedFilePath' projRoot)
@@ -1613,7 +1613,7 @@ execDocTest opts scriptDar (ImportSource importSource) files =
           then do
             damlPath <- getDamlPath
             damlEnv <- getDamlEnv damlPath (LookForProjectPath False)
-            resolveReleaseVersion (envUseCache damlEnv) SdkVersion.Class.unresolvedBuiltinSdkVersion
+            resolveReleaseVersionUnsafe (Just "running doc test") (envUseCache damlEnv) SdkVersion.Class.unresolvedBuiltinSdkVersion
           else pure (unsafeResolveReleaseVersion SdkVersion.Class.unresolvedBuiltinSdkVersion)
       installDependencies "." opts releaseVersion [scriptDar] []
       createProjectPackageDb "." opts mempty

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -94,6 +94,7 @@ import DA.Daml.Project.Types
       ProjectConfig,
       unsafeResolveReleaseVersion)
 import DA.Daml.Assistant.Version (resolveReleaseVersionUnsafe)
+import DA.Daml.Assistant.Util (wrapErr)
 import qualified DA.Daml.Compiler.Repl as Repl
 import DA.Daml.Compiler.DocTest (docTest)
 import DA.Daml.Desugar (desugar)
@@ -921,7 +922,8 @@ installDepsAndInitPackageDb opts (InitPkgDb shouldInit) =
                   then do
                     damlPath <- getDamlPath
                     damlEnv <- getDamlEnv damlPath (LookForProjectPath False)
-                    resolveReleaseVersionUnsafe (Just "installing dependencies and initializing package database") (envUseCache damlEnv) pSdkVersion
+                    wrapErr "installing dependencies and initializing package database" $
+                      resolveReleaseVersionUnsafe (envUseCache damlEnv) pSdkVersion
                   else pure (unsafeResolveReleaseVersion pSdkVersion)
               installDependencies
                   (toNormalizedFilePath' projRoot)
@@ -1613,7 +1615,8 @@ execDocTest opts scriptDar (ImportSource importSource) files =
           then do
             damlPath <- getDamlPath
             damlEnv <- getDamlEnv damlPath (LookForProjectPath False)
-            resolveReleaseVersionUnsafe (Just "running doc test") (envUseCache damlEnv) SdkVersion.Class.unresolvedBuiltinSdkVersion
+            wrapErr "running doc test" $
+              resolveReleaseVersionUnsafe (envUseCache damlEnv) SdkVersion.Class.unresolvedBuiltinSdkVersion
           else pure (unsafeResolveReleaseVersion SdkVersion.Class.unresolvedBuiltinSdkVersion)
       installDependencies "." opts releaseVersion [scriptDar] []
       createProjectPackageDb "." opts mempty

--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -67,6 +67,7 @@ da_haskell_library(
         "tls",
         "typed-process",
         "unix-compat",
+        "uri-encode",
         "utf8-string",
         "yaml",
     ] + (["Win32"] if is_windows else []),

--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -200,7 +200,7 @@ runCommand env@Env{..} = \case
         let useCache =
               UseCache
                 { cachePath = envCachePath
-                , damlPath = envDamlPath
+                , damlPathUnsafe = envDamlPath
                 , overrideTimeout = if vForceRefresh then Just (CacheTimeout 1) else Nothing
                 }
         installedVersionsE <- tryAssistant $ getInstalledSdkVersions envDamlPath

--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -279,8 +279,8 @@ runCommand env@Env{..} = \case
         install options envDamlPath (envUseCache env) envProjectPath envDamlAssistantSdkVersion
 
     Builtin (Uninstall unresolvedVersion) -> do
-        version <- resolveReleaseVersion (envUseCache env) unresolvedVersion
-        uninstallVersion env version
+        versionOrErr <- resolveReleaseVersion (envUseCache env) unresolvedVersion
+        uninstallVersion env versionOrErr
 
     Builtin (Exec cmd args) -> do
         wrapErr "Running executable in daml environment." $ do

--- a/daml-assistant/src/DA/Daml/Assistant/Cache.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Cache.hs
@@ -6,6 +6,7 @@ module DA.Daml.Assistant.Cache
     ( cacheAvailableSdkVersions
     , CacheAge (..)
     , UseCache (..)
+    , damlPath
     , cacheWith
     , loadFromCacheWith
     , saveToCacheWith
@@ -53,17 +54,21 @@ data UseCache
   = UseCache
       { overrideTimeout :: Maybe CacheTimeout
       , cachePath :: CachePath
-      , damlPath :: DamlPath
+      , damlPathUnsafe :: DamlPath
       }
   | DontUseCache
   deriving (Show, Eq)
+
+damlPath :: UseCache -> Maybe DamlPath
+damlPath DontUseCache = Nothing
+damlPath UseCache { damlPathUnsafe } = Just damlPathUnsafe
 
 cacheAvailableSdkVersions
     :: UseCache
     -> (Maybe [ReleaseVersion] -> IO [ReleaseVersion])
     -> IO ([ReleaseVersion], CacheAge)
 cacheAvailableSdkVersions DontUseCache getVersions = (, Fresh) <$> getVersions Nothing
-cacheAvailableSdkVersions UseCache { overrideTimeout, cachePath, damlPath } getVersions = do
+cacheAvailableSdkVersions UseCache { overrideTimeout, cachePath, damlPathUnsafe = damlPath } getVersions = do
     damlConfigE <- tryConfig $ readDamlConfig damlPath
     let configUpdateCheckM = join $ eitherToMaybe (queryDamlConfig ["update-check"] =<< damlConfigE)
         (neverRefresh, timeout)

--- a/daml-assistant/src/DA/Daml/Assistant/Env.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Env.hs
@@ -108,7 +108,7 @@ getFreshStableSdkVersionForCheck useCache = do
       parsed <- requiredE
         ("Invalid value for environment variable " <> pack sdkVersionLatestEnvVar <> ".")
         (parseVersion (pack value))
-      pure (Just <$> resolveReleaseVersionUnsafe (Just "getFreshStableSdkVersionForCheck") useCache parsed)
+      pure (Just <$> resolveReleaseVersionUnsafe useCache parsed)
 
 -- | Determine the viability of running sdk commands in the environment.
 -- Returns the first failing test's error message.
@@ -152,7 +152,7 @@ getDamlAssistantPathDefault (DamlPath damlPath) =
 getDamlAssistantSdkVersion :: UseCache -> IO (Maybe DamlAssistantSdkVersion)
 getDamlAssistantSdkVersion useCache =
     overrideWithEnvVarMaybeIO damlAssistantVersionEnvVar pure
-        (fmap (fmap DamlAssistantSdkVersion) . traverse (resolveReleaseVersionUnsafe (Just "getDamlAssistantSdkVersion") useCache) . parseVersion . pack)
+        (fmap (fmap DamlAssistantSdkVersion) . traverse (resolveReleaseVersionUnsafe useCache) . parseVersion . pack)
         (fmap DamlAssistantSdkVersion <$> tryAssistantM (getAssistantSdkVersion useCache))
 
 -- | Determine absolute path of daml home directory.
@@ -225,7 +225,7 @@ getSdk useCache damlPath projectPathM =
     wrapErr "Determining SDK version and path." $ do
         releaseVersion <-
             let parseAndResolve =
-                  traverse (resolveReleaseVersionUnsafe (Just "determining SDK version and path") useCache) .
+                  traverse (resolveReleaseVersionUnsafe useCache) .
                     parseVersion .
                       pack
             in

--- a/daml-assistant/src/DA/Daml/Assistant/Env.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Env.hs
@@ -50,7 +50,7 @@ envUseCache Env {..} =
 
 mkUseCache :: CachePath -> DamlPath -> UseCache
 mkUseCache cachePath damlPath =
-  UseCache { cachePath, damlPath, overrideTimeout = Nothing }
+  UseCache { cachePath, damlPathUnsafe = damlPath, overrideTimeout = Nothing }
 
 -- | (internal) Override function with environment variable
 -- if it is available.

--- a/daml-assistant/src/DA/Daml/Assistant/Util.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Util.hs
@@ -22,25 +22,39 @@ throwErr msg = throwIO (assistantError msg)
 
 -- | Handle synchronous exceptions by wrapping them in an AssistantError,
 -- add context to any assistant errors that are missing context.
-wrapErr :: Text -> IO a -> IO a
-wrapErr ctx m = m `catches`
+wrapErrG :: (Text -> SomeException -> AssistantError) -> Text -> IO a -> IO a
+wrapErrG wrapSomeException ctx m = m `catches`
     [ Handler $ throwIO @IO @ExitCode
     , Handler $ \ExitCodeException{eceExitCode} -> exitWith eceExitCode
     , Handler $ throwIO . addErrorContext
-    , Handler $ throwIO . wrapException
+    , Handler $ throwIO . wrapSomeException ctx
     ]
     where
-        wrapException :: SomeException -> AssistantError
-        wrapException err =
-            AssistantError
-                { errContext  = Just ctx
-                , errMessage  = Just (pack (displayException err))
-                , errInternal = Just (pack (show err))
-                }
-
         addErrorContext :: AssistantError -> AssistantError
         addErrorContext err =
             err { errContext = errContext err <|> Just ctx }
+
+wrapErr :: Text -> IO a -> IO a
+wrapErr = wrapErrG wrapSomeExceptionWithoutMsg
+
+wrapSomeExceptionWithoutMsg :: Text -> SomeException -> AssistantError
+wrapSomeExceptionWithoutMsg ctx err =
+    AssistantError
+        { errContext  = Just ctx
+        , errMessage  = Nothing
+        , errInternal = Just (pack (show err))
+        }
+
+wrapErrDisplay :: Text -> IO a -> IO a
+wrapErrDisplay = wrapErrG wrapSomeExceptionWithMsg
+
+wrapSomeExceptionWithMsg :: Text -> SomeException -> AssistantError
+wrapSomeExceptionWithMsg ctx err =
+    AssistantError
+        { errContext  = Just ctx
+        , errMessage  = Just (pack (displayException err))
+        , errInternal = Just (pack (show err))
+        }
 
 -- | Catch a config error.
 tryConfig :: IO t -> IO (Either ConfigError t)

--- a/daml-assistant/src/DA/Daml/Assistant/Util.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Util.hs
@@ -34,7 +34,7 @@ wrapErr ctx m = m `catches`
         wrapException err =
             AssistantError
                 { errContext  = Just ctx
-                , errMessage  = Nothing
+                , errMessage  = Just (pack (displayException err))
                 , errInternal = Just (pack (show err))
                 }
 

--- a/daml-assistant/src/DA/Daml/Assistant/Version.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Version.hs
@@ -612,19 +612,17 @@ artifactoryVersionLocation releaseVersion apiKey =
         NonEmpty.:|
         [ HttpInstallLocation
             { hilUrl = T.concat
-                [ "https://digitalasset.jfrog.io/artifactory/external-files/daml-enterprise/"
-                , textShow majorVersion <> "." <> textShow minorVersion
-                , "/"
-                , versionToText releaseVersion
+                [ "https://digitalasset.jfrog.io/artifactory/sdk-ee/"
+                , sdkVersionToText (sdkVersionFromReleaseVersion releaseVersion)
                 , "/daml-sdk-"
                 , sdkVersionToText (sdkVersionFromReleaseVersion releaseVersion)
                 , "-"
                 , osName
-                , "-ee.tar.gz"
+                , "-ee.tar.gz" 
                 ]
             , hilHeaders =
                 [("X-JFrog-Art-Api", T.encodeUtf8 (unwrapArtifactoryApiKey apiKey))]
-            , hilAlternativeName = "Artifactory `external-files` repo"
+            , hilAlternativeName = "Artifactory `sdk-ee` repo (legacy)"
             }
         ]
 
@@ -634,7 +632,7 @@ githubVersionLocation releaseVersion = HttpInstallLocations $ pure
     HttpInstallLocation
         { hilUrl = renderVersionLocation releaseVersion "https://github.com/digital-asset/daml/releases/download"
         , hilHeaders = []
-        , hilAlternativeName = "Github Daml repo"
+        , hilAlternativeName = "Github `daml` repo releases"
         }
 
 alternateVersionLocation :: ReleaseVersion -> Text -> IO (Either Text InstallLocation)

--- a/daml-assistant/src/DA/Daml/Assistant/Version.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Version.hs
@@ -63,6 +63,7 @@ import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.UTF8 as BSU
 import qualified Data.SemVer as V
 import Data.Function ((&))
+import Data.Foldable (fold)
 import Control.Lens (view)
 import System.Directory (listDirectory, doesFileExist)
 import System.FilePath ((</>))
@@ -544,8 +545,7 @@ resolveReleaseVersionFromArtifactory damlPath unresolvedVersion = do
   case queryArtifactoryApiKey <$> damlConfig of
     Right (Just apiKey) -> do
       let url = "https://digitalasset.jfrog.io/artifactory/api/search/pattern"
-          --searchParam = foldMap id [ "sdk-ee:", encodeTextToBS $ unresolvedReleaseVersionToText unresolvedVersion, "/*" ]
-          searchParam = foldMap id [ "external-files:daml-enterprise/*/", encodeTextToBS $ unresolvedReleaseVersionToText unresolvedVersion, "/*" ]
+          searchParam = fold [ "external-files:daml-enterprise/*/", encodeTextToBS $ unresolvedReleaseVersionToText unresolvedVersion, "/*" ]
       req <- parseRequest url
       resOrErr <- try $ httpJSONEither $
                 setRequestHeaders

--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -42,6 +42,7 @@ import DA.Daml.Project.Types
 import qualified DA.Daml.Project.Types as DATypes
 import qualified DA.Daml.Assistant.Version as DAVersion
 import qualified DA.Daml.Assistant.Env as DAEnv
+import qualified DA.Daml.Assistant.Util as DAUtil
 
 -- Version of the "@mojotech/json-type-validation" library we're using.
 jtvVersion :: T.Text
@@ -131,7 +132,7 @@ main = do
               Left _ -> fail "Invalid SDK version"
               Right v -> do
                 useCache <- DAEnv.mkUseCache <$> DAEnv.getCachePath <*> DAEnv.getDamlPath
-                DAVersion.resolveReleaseVersionUnsafe (Just "Getting version for codegen") useCache v
+                DAUtil.wrapErr "Getting SDK version for codegen" $ DAVersion.resolveReleaseVersionUnsafe useCache v
         pkgs <- readPackages optInputDars
         case mergePackageMap pkgs of
           Left err -> fail . T.unpack $ err

--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -131,7 +131,7 @@ main = do
               Left _ -> fail "Invalid SDK version"
               Right v -> do
                 useCache <- DAEnv.mkUseCache <$> DAEnv.getCachePath <*> DAEnv.getDamlPath
-                DAVersion.resolveReleaseVersion useCache v
+                DAVersion.resolveReleaseVersionUnsafe (Just "Getting version for codegen") useCache v
         pkgs <- readPackages optInputDars
         case mergePackageMap pkgs of
           Left err -> fail . T.unpack $ err

--- a/libs-haskell/da-version-types/src/DA/Daml/Version/Types.hs
+++ b/libs-haskell/da-version-types/src/DA/Daml/Version/Types.hs
@@ -87,6 +87,9 @@ sdkVersionToText = V.toText . unwrapSdkVersion
 unresolvedReleaseVersionToString :: UnresolvedReleaseVersion -> String
 unresolvedReleaseVersionToString = V.toString . unwrapUnresolvedReleaseVersion
 
+unresolvedReleaseVersionToText :: UnresolvedReleaseVersion -> Text
+unresolvedReleaseVersionToText = V.toText . unwrapUnresolvedReleaseVersion
+
 class IsVersion a where
     isHeadVersion :: a -> Bool
 


### PR DESCRIPTION
~~TODO: Make `damlPath` uses on UseCache not fallible.~~

- Improve errors for failed resolution or missing internet connection
  - Enables searching artifactory for a split release when an artifactory API key is present (storing split EE releases in artifactory is upcoming)
- Support resolving from artifactory's split release repository (upcoming)
  - Daml assistant copes more gracefully with situations where Github and/or Artifactory isn't available from the network. It used to be it spat out a giant mess of network problem errors when the network wasn't available.