### PR TITLE
UpgradingIT conformance test

### DIFF
--- a/canton/BUILD.bazel
+++ b/canton/BUILD.bazel
@@ -238,6 +238,9 @@ scala_library(
         "-language:postfixOps",
     ],
     unused_dependency_checker_mode = "error",
+    visibility = [
+        "//visibility:public",
+    ],
     deps = [
         ":community_ledger_ledger-common_configuration_proto_java",
         ":daml-common-staging_daml-errors",

--- a/canton/BUILD.bazel
+++ b/canton/BUILD.bazel
@@ -238,9 +238,6 @@ scala_library(
         "-language:postfixOps",
     ],
     unused_dependency_checker_mode = "error",
-    visibility = [
-        "//visibility:public",
-    ],
     deps = [
         ":community_ledger_ledger-common_configuration_proto_java",
         ":daml-common-staging_daml-errors",

--- a/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/CreateAndExerciseCommand.java
+++ b/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/CreateAndExerciseCommand.java
@@ -46,7 +46,7 @@ public final class CreateAndExerciseCommand extends Command {
   }
 
   @Override
-  Identifier getTemplateId() {
+  public Identifier getTemplateId() {
     return templateId;
   }
 

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/Main.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/Main.scala
@@ -16,7 +16,7 @@ object StandaloneMain extends StrictLogging {
       Main.main(args)
     } catch {
       case NonFatal(t) =>
-        logger.error(s"Error generating code: {}", t.getMessage)
+        logger.error(s"Error generating code: {}", t)
         sys.exit(-1)
     }
 }

--- a/ledger-test-tool/runner/src/main/scala/com/daml/ledger/api/testtool/runner/Config.scala
+++ b/ledger-test-tool/runner/src/main/scala/com/daml/ledger/api/testtool/runner/Config.scala
@@ -8,6 +8,7 @@ import com.daml.ledger.api.testtool.runner
 import com.daml.ledger.api.tls.TlsConfiguration
 
 import scala.concurrent.duration.FiniteDuration
+import scala.util.matching.Regex
 
 final case class Config(
     participantsEndpoints: Vector[(String, Int)],
@@ -26,7 +27,7 @@ final case class Config(
     shuffleParticipants: Boolean,
     partyAllocation: PartyAllocationConfiguration,
     ledgerClockGranularity: FiniteDuration,
-    uploadDars: Boolean,
+    skipDarNamesPattern: Option[Regex],
 ) {
   def withTlsConfig(modify: TlsConfiguration => TlsConfiguration): Config = {
     val base = tlsConfig.getOrElse(TlsConfiguration.Empty)
@@ -35,6 +36,8 @@ final case class Config(
 }
 
 object Config {
+  val DefaultTestDarExclusions = new Regex(".*upgrade-tests.*")
+
   val default: Config = Config(
     participantsEndpoints = Vector.empty,
     maxConnectionAttempts = 10,
@@ -52,6 +55,6 @@ object Config {
     shuffleParticipants = false,
     partyAllocation = PartyAllocationConfiguration.ClosedWorldWaitingForAllParticipants,
     ledgerClockGranularity = runner.Defaults.LedgerClockGranularity,
-    uploadDars = true,
+    skipDarNamesPattern = Some(DefaultTestDarExclusions),
   )
 }

--- a/ledger-test-tool/runner/src/main/scala/com/daml/ledger/api/testtool/runner/TestRunner.scala
+++ b/ledger-test-tool/runner/src/main/scala/com/daml/ledger/api/testtool/runner/TestRunner.scala
@@ -180,12 +180,12 @@ final class TestRunner(availableTests: AvailableTests, config: Config) {
         new LedgerTestCasesRunner(
           testCases = cases,
           participantChannels = participantChannels,
+          skipDarNamesPattern = config.skipDarNamesPattern,
           maxConnectionAttempts = config.maxConnectionAttempts,
           partyAllocation = config.partyAllocation,
           shuffleParticipants = config.shuffleParticipants,
           timeoutScaleFactor = config.timeoutScaleFactor,
           concurrentTestRuns = concurrentTestRuns,
-          uploadDars = config.uploadDars,
           identifierSuffix = identifierSuffix,
         )
       )

--- a/ledger-test-tool/suites/deps.bzl
+++ b/ledger-test-tool/suites/deps.bzl
@@ -10,13 +10,26 @@ def _has_model_tests(lf_version):
         v2_minor_version_range = ("0", "dev"),
     )
 
+def _has_upgrading_tests(lf_version):
+    return version_in(
+        lf_version,
+        v1_minor_version_range = ("16", "dev"),
+        v2_minor_version_range = ("0", "dev"),
+    )
+
 def deps(lf_version):
     carbon_tests = [
         "//test-common:carbonv1-tests-%s.java-codegen" % lf_version,
         "//test-common:carbonv2-tests-%s.java-codegen" % lf_version,
         "//test-common:carbonv3-tests-%s.java-codegen" % lf_version,
     ]
-    additional_tests = carbon_tests if _has_model_tests(lf_version) else []
+    upgrading_tests = [
+        "//canton:community_ledger_ledger-common",
+        "//test-common:upgrade-tests-1.0.0-%s.java-codegen" % lf_version,
+        "//test-common:upgrade-tests-2.0.0-%s.java-codegen" % lf_version,
+        "//test-common:upgrade-tests-3.0.0-%s.java-codegen" % lf_version,
+    ]
+    additional_tests = (carbon_tests if _has_model_tests(lf_version) else []) + (upgrading_tests if _has_upgrading_tests(lf_version) else [])
     return [
         "//canton:bindings-java",
         "//daml-lf/data",

--- a/ledger-test-tool/suites/deps.bzl
+++ b/ledger-test-tool/suites/deps.bzl
@@ -24,7 +24,6 @@ def deps(lf_version):
         "//test-common:carbonv3-tests-%s.java-codegen" % lf_version,
     ]
     upgrading_tests = [
-        "//canton:community_ledger_ledger-common",
         "//test-common:upgrade-tests-1.0.0-%s.java-codegen" % lf_version,
         "//test-common:upgrade-tests-2.0.0-%s.java-codegen" % lf_version,
         "//test-common:upgrade-tests-3.0.0-%s.java-codegen" % lf_version,

--- a/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev.scala
+++ b/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev.scala
@@ -11,5 +11,8 @@ package object v1_dev {
     v1_15.default(timeoutScaleFactor)
 
   def optional(tlsConfig: Option[TlsConfiguration]): Vector[LedgerTestSuite] =
-    v1_15.optional(tlsConfig)
+    v1_15.optional(tlsConfig) ++ Vector(
+      // TODO(16362): Make non-optional once all failure-exclusions are removed
+      new UpgradingIT
+    )
 }

--- a/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/UpgradingIT.scala
+++ b/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/UpgradingIT.scala
@@ -1,0 +1,451 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.testtool.suites.v1_dev
+
+import com.daml.ledger.api.testtool.infrastructure.Allocation.{
+  Participant,
+  Participants,
+  SingleParty,
+  allocate,
+}
+import com.daml.ledger.api.testtool.infrastructure.Assertions._
+import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers.createdEvents
+import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
+import com.daml.ledger.api.testtool.infrastructure.{Dars, LedgerTestSuite}
+import com.daml.ledger.api.testtool.suites.v1_dev.UpgradingIT.EnrichedCommands
+import com.daml.ledger.api.v1.active_contracts_service.GetActiveContractsRequest
+import com.daml.ledger.api.v1.event.CreatedEvent
+import com.daml.ledger.api.v1.transaction_filter.{
+  Filters,
+  InclusiveFilters,
+  TemplateFilter,
+  TransactionFilter,
+}
+import com.daml.ledger.api.v1.transaction_service.GetTransactionsRequest
+import com.daml.ledger.api.v1.value.Identifier.toJavaProto
+import com.daml.ledger.api.v1.value.{Identifier => ScalaPbIdentifier}
+import com.daml.ledger.api.v1.{transaction, value}
+import com.daml.ledger.javaapi.data.codegen.{ContractCompanion, ValueDecoder}
+import com.daml.ledger.javaapi.data.{DamlRecord, Unit => _, _}
+import com.daml.ledger.test.java.upgrade.v1_0_0.upgrade.{UA => UA_V1}
+import com.daml.ledger.test.java.upgrade.v2_0_0.upgrade.{UA => UA_V2, UB => UB_V2}
+import com.daml.ledger.test.java.upgrade.v3_0_0.upgrade.{UB => UB_V3}
+import com.daml.ledger.test.{UpgradeTestDar1_0_0, UpgradeTestDar2_0_0, UpgradeTestDar3_0_0}
+import com.daml.lf.data.Ref
+import com.daml.lf.data.Ref.{PackageName, PackageRef}
+import com.digitalasset.canton.ledger.error.groups.RequestValidationErrors
+
+import java.util.Optional
+import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
+
+class UpgradingIT extends LedgerTestSuite {
+  implicit val upgradingUA_V1Companion
+      : ContractCompanion.WithoutKey[UA_V1.Contract, UA_V1.ContractId, UA_V1] =
+    UA_V1.COMPANION
+  implicit val upgradingUA_V2Companion
+      : ContractCompanion.WithoutKey[UA_V2.Contract, UA_V2.ContractId, UA_V2] =
+    UA_V2.COMPANION
+  implicit val upgradingUB_V2Companion
+      : ContractCompanion.WithoutKey[UB_V2.Contract, UB_V2.ContractId, UB_V2] =
+    UB_V2.COMPANION
+  implicit val upgradingUB_V3Companion
+      : ContractCompanion.WithoutKey[UB_V3.Contract, UB_V3.ContractId, UB_V3] =
+    UB_V3.COMPANION
+
+  private val PkgRef = PackageRef.Name(PackageName.assertFromString("upgrade-tests"))
+  private val UA_Identifier = ScalaPbIdentifier
+    .fromJavaProto(UA_V1.TEMPLATE_ID.toProto)
+    .withPackageId(PkgRef.toString)
+  private val UB_Identifier = ScalaPbIdentifier
+    .fromJavaProto(UB_V2.TEMPLATE_ID.toProto)
+    .withPackageId(PkgRef.toString)
+
+  private val UnknownPackageNameIdentifier = ScalaPbIdentifier.of(
+    Ref.PackageRef.Name(Ref.PackageName.assertFromString("unknown")).toString,
+    "module",
+    "entity",
+  )
+
+  private val PkgRefUA_V1 =
+    PackageRef.Id(Ref.PackageId.assertFromString(UA_V1.TEMPLATE_ID.getPackageId))
+
+  test(
+    "UDynamicTemplates",
+    "Template-id resolution is updated on package upload during ongoing subscriptions",
+    allocate(SingleParty),
+  )(implicit ec => { case Participants(Participant(ledger, party)) =>
+    for {
+      _ <- `assert subscriptions for unknown package-names fail`(ledger, party)
+
+      // Upload 1.0.0 package
+      _ <- upload(ledger, UpgradeTestDar1_0_0.path)
+
+      _ <- `assert subscriptions for unknown template names succeed if package-name present`(
+        ledger,
+        party,
+      )
+
+      // Start ongoing UA subscriptions
+      subscriptions_UA_no_blob = new Subscriptions(
+        "UA without created event blob filter",
+        ledger,
+        party,
+        UA_Identifier,
+        includeCreatedEventBlob = false,
+        expectedCreatesSize = 5,
+      )
+      subscriptions_UA_blob = new Subscriptions(
+        "UA with created event blob filter",
+        ledger,
+        party,
+        UA_Identifier,
+        includeCreatedEventBlob = true,
+        expectedCreatesSize = 5,
+      )
+
+      // Start ongoing UB subscriptions
+      subscriptions_UB_no_blob = new Subscriptions(
+        "UB without createdEventBlob filter",
+        ledger,
+        party,
+        UB_Identifier,
+        includeCreatedEventBlob = false,
+        expectedCreatesSize = 2,
+      )
+      subscriptions_UB_blob = new Subscriptions(
+        "UB with createdEventBlob filter",
+        ledger,
+        party,
+        UB_Identifier,
+        includeCreatedEventBlob = true,
+        expectedCreatesSize = 2,
+      )
+
+      // Create UA#1: UA 1.0.0 contract arguments and use package-name scoped type in command
+      payloadUA_1 = new UA_V1(party, party, 0L)
+      _ <- createContract(ledger, party, payloadUA_1, Some(PkgRef))
+
+      // Create UA#2: UA 2.0.0 contract arguments and use explicit downgrade type (Upgrading V1) in command
+      payloadUA_2 = new UA_V2(party, party, 0L, Optional.empty())
+      _ <- createContract(ledger, party, payloadUA_2, Some(PkgRefUA_V1))
+
+      // Upload 2.0.0 package
+      // 2.0.0 becomes the default package preference on the ledger
+      _ <- upload(ledger, UpgradeTestDar2_0_0.path)
+
+      // Create UA#3: UA 1.0.0 contract arguments and use package-name scoped type in command
+      //            expecting an upgrade to V2
+      payloadUA_3 = new UA_V1(party, party, 0L)
+      _ <- createContract(ledger, party, payloadUA_3, Some(PkgRef))
+
+      // Create UA#4: UA 2.0.0 contract arguments and use package-name scoped type in command
+      //            expecting a record on ledger of V2
+      payloadUA_4 = new UA_V2(party, party, 0L, Optional.of(Seq("more").asJava))
+      _ <- createContract(ledger, party, payloadUA_4, Some(PkgRef))
+
+      // Create UA#5: UA 1.0.0 contract arguments with its default type in command
+      payloadUA_5 = new UA_V1(party, party, 0L)
+      _ <- createContract(ledger, party, payloadUA_5)
+
+      // Create UB#1: UB 2.0.0 contract arguments with its default type in command
+      payloadUB_1 = new UB_V2(party, 0L)
+      _ <- createContract(ledger, party, payloadUB_1)
+
+      // Upload 3.0.0 package
+      // 3.0.0 becomes the default package preference on the ledger
+      _ <- upload(ledger, UpgradeTestDar3_0_0.path)
+
+      // Create UB#2: UB 3.0.0 contract arguments with its default type in command
+      payloadUB_2 = new UB_V3(party, 0L, Optional.of(Seq("extra").asJava))
+      _ <- createContract(ledger, party, payloadUB_2)
+
+      // Wait for all UA transactions to be visible in the transaction streams
+      creates_UA_noBlob <- subscriptions_UA_no_blob.createsF
+      creates_UA_blob <- subscriptions_UA_blob.createsF
+
+      // Wait for all UB transactions to be visible in the transaction streams
+      creates_UB_noBlob <- subscriptions_UB_no_blob.createsF
+      creates_UB_blob <- subscriptions_UB_blob.createsF
+    } yield {
+      def assertUACreates(expectedCreatedEventBlob: Boolean): Vector[CreatedEvent] => Unit = {
+        case Vector(create1, create2, create3, create4, create5) =>
+          assertPayloadEquals(
+            "UA create 1",
+            create1,
+            payloadUA_1,
+            UA_V1.valueDecoder(),
+            UA_V1.TEMPLATE_ID,
+            expectedCreatedEventBlob,
+          )
+          assertPayloadEquals(
+            "UA create 2",
+            create2,
+            new UA_V1(party, party, 0L),
+            UA_V1.valueDecoder(),
+            UA_V1.TEMPLATE_ID,
+            expectedCreatedEventBlob,
+          )
+          assertPayloadEquals(
+            "UA create 3",
+            create3,
+            new UA_V2(party, party, 0L, Optional.empty()),
+            UA_V2.valueDecoder(),
+            UA_V2.TEMPLATE_ID,
+            expectedCreatedEventBlob,
+          )
+          assertPayloadEquals(
+            "UA create 4",
+            create4,
+            payloadUA_4,
+            UA_V2.valueDecoder(),
+            UA_V2.TEMPLATE_ID,
+            expectedCreatedEventBlob,
+          )
+          assertPayloadEquals(
+            "UA create 5",
+            create5,
+            payloadUA_5,
+            UA_V1.valueDecoder(),
+            UA_V1.TEMPLATE_ID,
+            expectedCreatedEventBlob,
+          )
+        case other => fail(s"Expected five create events, got ${other.size}")
+      }
+
+      def assertUBCreates(expectedCreatedEventBlob: Boolean): Vector[CreatedEvent] => Unit = {
+        case Vector(create1, create2) =>
+          assertPayloadEquals(
+            "UB create 1",
+            create1,
+            payloadUB_1,
+            UB_V2.valueDecoder(),
+            UB_V2.TEMPLATE_ID,
+            expectedCreatedEventBlob,
+          )
+          assertPayloadEquals(
+            "UB create 2",
+            create2,
+            payloadUB_2,
+            UB_V3.valueDecoder(),
+            UB_V3.TEMPLATE_ID,
+            expectedCreatedEventBlob,
+          )
+        case other => fail(s"Expected two create events, got ${other.size}")
+      }
+
+      assertUACreates(expectedCreatedEventBlob = false)(creates_UA_noBlob)
+      assertUACreates(expectedCreatedEventBlob = true)(creates_UA_blob)
+
+      assertUBCreates(expectedCreatedEventBlob = false)(creates_UB_noBlob)
+      assertUBCreates(expectedCreatedEventBlob = true)(creates_UB_blob)
+
+      // TODO(#16547): Check for transaction trees as well in 3.x
+    }
+  })
+
+  private def `assert subscriptions for unknown package-names fail`(
+      ledger: ParticipantTestContext,
+      party: Party,
+  )(implicit ec: ExecutionContext): Future[Unit] = {
+    import ledger._
+
+    for {
+      failedFlatTransactionsPackageNameNotFound <- flatTransactions(
+        txRequest(ledger, UnknownPackageNameIdentifier, party, continuous = true)
+      ).mustFail("Package-name not found")
+      failedActiveContractsPackageNameNotFound <- activeContracts(
+        getActiveContractsRequest(ledger, UnknownPackageNameIdentifier, party)
+      ).mustFail("Package-name not found")
+    } yield {
+      assertGrpcError(
+        failedFlatTransactionsPackageNameNotFound,
+        RequestValidationErrors.NotFound.PackageNamesNotFound,
+        Some(
+          "The following package names do not match upgradable packages uploaded on this participant: [unknown]."
+        ),
+      )
+      assertGrpcError(
+        failedActiveContractsPackageNameNotFound,
+        RequestValidationErrors.NotFound.PackageNamesNotFound,
+        Some(
+          "The following package names do not match upgradable packages uploaded on this participant: [unknown]."
+        ),
+      )
+    }
+  }
+
+  private def `assert subscriptions for unknown template names succeed if package-name present`(
+      ledger: ParticipantTestContext,
+      party: Party,
+  )(implicit ec: ExecutionContext): Future[Unit] = {
+    import ledger._
+
+    for {
+      flatTransactions <- flatTransactions(
+        txRequest(ledger, UB_Identifier, party, continuous = false)
+      )
+      (_, acsCreates) <- activeContracts(getActiveContractsRequest(ledger, UB_Identifier, party))
+    } yield {
+      assertIsEmpty(flatTransactions)
+      assertIsEmpty(acsCreates)
+    }
+  }
+
+  private class Subscriptions(
+      context: String,
+      ledger: ParticipantTestContext,
+      party: Party,
+      filterIdentifier: ScalaPbIdentifier,
+      includeCreatedEventBlob: Boolean,
+      expectedCreatesSize: Int,
+  )(implicit ec: ExecutionContext) {
+    import ledger._
+
+    private val flatTxsF: Future[Vector[transaction.Transaction]] = flatTransactions(
+      take = expectedCreatesSize,
+      txRequest(
+        ledger,
+        filterIdentifier,
+        party,
+        continuous = true,
+        includeCreatedEventBlob = includeCreatedEventBlob,
+      ),
+    )
+
+    def createsF: Future[Vector[CreatedEvent]] = {
+      val acsAtQueryTime = activeContracts(
+        getActiveContractsRequest(ledger, filterIdentifier, party, includeCreatedEventBlob)
+      )
+
+      flatTxsF.map(_.flatMap(createdEvents)) zip acsAtQueryTime
+        .map(_._2) map { case (flatTxs, acsCreates) =>
+        val flatTxsCreates = flatTxs
+        assertLength(s"$context: Flat transactions creates", expectedCreatesSize, flatTxsCreates)
+        assertLength(s"$context: ACS creates", expectedCreatesSize, acsCreates)
+        assertSameElements(flatTxsCreates, acsCreates)
+        acsCreates
+      }
+    }
+  }
+
+  private def assertPayloadEquals[T](
+      context: String,
+      createdEvent: CreatedEvent,
+      payload: T,
+      valueDecoder: ValueDecoder[T],
+      templateId: Identifier,
+      expectedCreatedEventBlob: Boolean,
+  ): Unit = {
+    assertEquals(context, toJavaProto(createdEvent.templateId.get), templateId.toProto)
+
+    assertEquals(
+      context,
+      valueDecoder.decode(
+        DamlRecord.fromProto(value.Record.toJavaProto(createdEvent.getCreateArguments))
+      ),
+      payload,
+    )
+
+    if (expectedCreatedEventBlob)
+      assert(!createdEvent.createdEventBlob.isEmpty, s"$context: createdEventBlob was empty")
+    else assert(createdEvent.createdEventBlob.isEmpty, s"$context: createdEventBlob was non-empty")
+  }
+
+  private def upload(ledger: ParticipantTestContext, darPath: String)(implicit
+      ec: ExecutionContext
+  ): Future[Unit] =
+    ledger
+      .uploadDarFile(Dars.read(darPath))
+      // Wait for the package vetting topology transaction to finish
+      .map(_ => Thread.sleep(1000L))
+
+  private def createContract(
+      ledger: ParticipantTestContext,
+      party: Party,
+      template: Template,
+      overrideTypeO: Option[Ref.PackageRef] = None,
+  ): Future[Unit] = {
+    val commands = template.create().commands()
+
+    ledger.submitAndWait(
+      ledger.submitAndWaitRequest(
+        party,
+        overrideTypeO
+          .map(overrideType => commands.overridePackageId(overrideType.toString))
+          .getOrElse(commands),
+      )
+    )
+  }
+
+  private def getActiveContractsRequest(
+      ledger: ParticipantTestContext,
+      identifier: ScalaPbIdentifier,
+      party: Party,
+      includeCreatedEventBlobs: Boolean = false,
+  ) =
+    GetActiveContractsRequest(
+      ledgerId = ledger.ledgerId,
+      filter = Some(transactionFilter(identifier, party, includeCreatedEventBlobs)),
+      verbose = true,
+    )
+
+  private def txRequest(
+      ledger: ParticipantTestContext,
+      identifier: ScalaPbIdentifier,
+      party: Party,
+      continuous: Boolean,
+      includeCreatedEventBlob: Boolean = false,
+  ): GetTransactionsRequest =
+    new GetTransactionsRequest(
+      ledgerId = ledger.ledgerId,
+      begin = Some(ledger.begin),
+      end = if (continuous) None else Some(ledger.end),
+      filter = Some(transactionFilter(identifier, party, includeCreatedEventBlob)),
+      verbose = true,
+    )
+
+  private def transactionFilter(
+      identifier: ScalaPbIdentifier,
+      party: Party,
+      includeCreatedEventBlobs: Boolean,
+  ) =
+    TransactionFilter(
+      filtersByParty = Map(
+        party.getValue -> Filters(
+          Some(
+            InclusiveFilters(
+              templateFilters = Seq(
+                TemplateFilter(Some(identifier), includeCreatedEventBlob = includeCreatedEventBlobs)
+              )
+            )
+          )
+        )
+      )
+    )
+}
+
+object UpgradingIT {
+  implicit class EnrichedCommands(commands: java.util.List[Command]) {
+    def overridePackageId(packageIdOverride: String): java.util.List[Command] =
+      commands.asScala
+        .map {
+          case cmd: CreateCommand =>
+            new CreateCommand(
+              identifierWithPackageIdOverride(packageIdOverride, cmd.getTemplateId),
+              cmd.getCreateArguments,
+            ): Command
+          case other => fail(s"Unexpected command $other")
+        }
+        .toList
+        .asJava
+  }
+
+  private def identifierWithPackageIdOverride(packageIdOverride: String, templateId: Identifier) =
+    new Identifier(
+      packageIdOverride,
+      templateId.getModuleName,
+      templateId.getEntityName,
+    )
+}

--- a/ledger-test-tool/tool/BUILD.bazel
+++ b/ledger-test-tool/tool/BUILD.bazel
@@ -273,3 +273,54 @@ conformance_test(
     ]
     if not is_windows
 ]
+
+# Conformance tests with contract upgrading enabled
+# TODO(16362): Merge with the default LF dev test once the tests failing due to upgrading are fixed
+[
+    conformance_test(
+        name = "conformance-test-upgrading-dev",
+        dev_mod_flag = "",
+        extra_data =
+            conformance_test_extra_data_base + [
+                "//canton:community_app_deploy.jar",
+            ],
+        extra_runner_args = ["7000"],
+        lf_versions = lf_versions,
+        ports = conformance_test_ports,
+        preview_mod_flag = "",
+        runner = "@//bazel_tools/client_server/runner_with_health_check",
+        server = ":canton-test-runner-with-dependencies",
+        server_args = conformance_server_args_base + [
+            "-C",
+            ",".join([
+                "dev-mode=yes",
+                "canton.domains.test_domain.init.domain-parameters.protocol-version=dev",
+                "_shared.participant_parameters.enable-contract-upgrading=true",
+            ]),
+        ],
+        tags = ["dev-canton-test"] + extra_tags,
+        test_tool_args = conformance_test_tool_args_base + [
+            "--include=UpgradingIT " + "--exclude=" + ",".join(conformance_test_excluded_test + [
+                # we skip those tests for preview/dev
+                "TLSOnePointThreeIT",
+                "TLSAtLeastOnePointTwoIT",
+                # Tests failing due to upgrading
+                "CommandServiceIT:CSRefuseBadParameter",
+                "CommandServiceIT:CSBadCreateAndExercise",
+                "InterfaceIT:ExerciseInterfaceSuccess",
+                "InterfaceIT:ExerciseRetroactiveInterfaceInstanceSuccess",
+            ]),
+        ],
+    )
+    for (lf_versions, extra_tags) in [
+        (
+            [LF_DEFAULT_DEV_VERSION],
+            [],
+        ),
+        (
+            ["preview"] + [v for v in LF_DEV_VERSIONS if v != LF_DEFAULT_DEV_VERSION],
+            ["main-only"],
+        ),
+    ]
+    if not is_windows
+]

--- a/ledger-test-tool/tool/src/main/scala/com/daml/ledger/api/testtool/CliParser.scala
+++ b/ledger-test-tool/tool/src/main/scala/com/daml/ledger/api/testtool/CliParser.scala
@@ -5,7 +5,6 @@ package com.daml.ledger.api.testtool
 
 import java.io.File
 import java.nio.file.Paths
-
 import com.daml.buildinfo.BuildInfo
 import com.daml.ledger.api.testtool.infrastructure.PartyAllocationConfiguration
 import com.daml.ledger.api.testtool.runner.Config
@@ -13,6 +12,7 @@ import scopt.{OptionParser, Read}
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.Try
+import scala.util.matching.Regex
 
 object CliParser {
   private val Name = "ledger-api-test-tool"
@@ -202,10 +202,12 @@ object CliParser {
           |on the ledger under test. The default is \"1s\" (1 second).""".stripMargin
       )
 
-    opt[Unit]("skip-dar-upload")
+    opt[String]("skip-dar-names-upload")
       .optional()
-      .action((_, c) => c.copy(uploadDars = false))
-      .text("Skip DARs upload into ledger before running tests")
+      .action((skipPattern, c) =>
+        c.copy(skipDarNamesPattern = Option.when(skipPattern.nonEmpty)(new Regex(skipPattern)))
+      )
+      .text("Skip uploading DARs whose names match the provided pattern")
 
     checkConfig(c =>
       if (c.included.nonEmpty && c.additional.nonEmpty)

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -175,6 +175,12 @@
   type: jar-lib
 - target: //test-common:modelext-tests-1.dev.java-codegen
   type: jar-lib
+- target: //test-common:upgrade-tests-1.0.0-1.dev.java-codegen
+  type: jar-lib
+- target: //test-common:upgrade-tests-2.0.0-1.dev.java-codegen
+  type: jar-lib
+- target: //test-common:upgrade-tests-3.0.0-1.dev.java-codegen
+  type: jar-lib
 - target: //ledger-service/lf-value-json:lf-value-json
   type: jar-scala
 - target: //ledger-service/cli-opts:cli-opts

--- a/test-common/BUILD.bazel
+++ b/test-common/BUILD.bazel
@@ -16,6 +16,9 @@ load(
 )
 load("//ledger-test-tool:conformance.bzl", "testtool_lf_versions")
 load("//test-common:test-common.bzl", "da_scala_dar_resources_library")
+load("//test-common:test-common.bzl", "merge_test_dars_versioned")
+load("//rules_daml:daml.bzl", "daml_compile")
+load("//daml-lf/language:daml-lf.bzl", "mangle_for_java")
 
 alias(
     name = "dar-files",
@@ -46,35 +49,40 @@ alias(
 ]
 
 # Carbon tests helps to test upgrades when packages are dependent on each other
-carbon_test_names = [
-    "carbonv1",
-    "carbonv2",  #carbonv2 depends on carbon v1
-    "carbonv3",  #carbonv3 depends on carbon v2
-    "modelext",  #modelext depends on model
-]
-
-general_test_names = [
-    "benchtool",
-    "model",
-    "semantic",
-    "performance",
-    "package_management",
-]
-
-# Correspond to the directories under src/test/lib/daml
-test_names = {
-    lf_version: general_test_names +
-                (carbon_test_names if version_in(
-                    lf_version,
-                    v1_minor_version_range = ("15", "dev"),
-                    v2_minor_version_range = ("0", "dev"),
-                ) else [])
-    for lf_version in testtool_lf_versions
+carbon_test_dars = {
+    "carbonv1": [],
+    "carbonv2": [],  #carbonv2 depends on carbon v1
+    "carbonv3": [],  #carbonv3 depends on carbon v2
+    "modelext": [],  #modelext depends on model
 }
+
+general_test_dars = {
+    "benchtool": [],
+    "model": [],
+    "semantic": [],
+    "performance": [],
+    "package_management": [],
+}
+
+upgrading_test_dars = {"upgrade": [
+    "1.0.0",
+    "2.0.0",
+    "3.0.0",
+]}
+
+test_dars = merge_test_dars_versioned(
+    carbon_test_dars = carbon_test_dars,
+    carbon_test_dars_v1_minor_version_range = ("15", "dev"),
+    carbon_test_dars_v2_minor_version_range = ("0", "dev"),
+    general_test_dars = general_test_dars,
+    lf_versions = testtool_lf_versions,
+    upgrading_test_dars = upgrading_test_dars,
+    upgrading_test_dars_v1_minor_version_range = ("16", "dev"),
+    upgrading_test_dars_v2_minor_version_range = ("0", "dev"),
+)
 
 da_scala_dar_resources_library(
     add_maven_tag = True,
-    daml_dir_names = test_names,
     daml_root_dir = "src/main/daml",
     data_dependencies = {
         "carbonv2": ["//test-common:carbonv1-tests-%s.build"],
@@ -94,6 +102,7 @@ da_scala_dar_resources_library(
     },
     lf_versions = testtool_lf_versions,
     maven_name_prefix = "test",
+    test_dars = test_dars,
     visibility = ["//visibility:public"],
 )
 
@@ -111,7 +120,34 @@ da_scala_dar_resources_library(
                 visibility = ["//visibility:public"],
             ),
         ]
-        for test_name in test_names.get(target, [])
+        for test_name in test_dars.get(target, []).keys()
+        if not test_dars[target][test_name]
+    ]
+    for target in testtool_lf_versions
+]
+
+[
+    [
+        [
+            [
+                dar_to_java(
+                    name = "%s-tests-%s-%s.java-codegen" % (test_name, package_version, target),
+                    src = ":%s-tests-%s-%s.dar" % (test_name, package_version, target),
+                    package_prefix = "com.daml.ledger.test.java.%s.v%s" % (
+                        test_name,
+                        mangle_for_java(package_version),
+                    ),
+                    tags = ["maven_coordinates=com.daml:test-common-%s-tests-java-%s-%s:__VERSION__" % (
+                        test_name.replace("_", "-"),
+                        package_version,
+                        target,
+                    )],
+                    visibility = ["//visibility:public"],
+                ),
+            ]
+            for package_version in test_dars[target][test_name]
+        ]
+        for test_name in test_dars.get(target, []).keys()
     ]
     for target in testtool_lf_versions
 ]

--- a/test-common/src/main/daml/upgrade/1.0.0/Upgrade.daml
+++ b/test-common/src/main/daml/upgrade/1.0.0/Upgrade.daml
@@ -1,0 +1,12 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Upgrade where
+
+template UA with
+  issuer : Party
+  owner : Party
+  field : Int
+ where
+  signatory issuer
+  observer owner

--- a/test-common/src/main/daml/upgrade/2.0.0/Upgrade.daml
+++ b/test-common/src/main/daml/upgrade/2.0.0/Upgrade.daml
@@ -1,0 +1,22 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Upgrade where
+
+-- Upgraded template with new optional field
+template UA with
+  issuer : Party
+  owner : Party
+  field : Int
+  more : Optional[Text]
+ where
+  signatory issuer
+  observer owner
+
+-- New template
+template UB with
+  owner : Party
+  field : Int
+ where
+  signatory owner
+  observer owner

--- a/test-common/src/main/daml/upgrade/3.0.0/Upgrade.daml
+++ b/test-common/src/main/daml/upgrade/3.0.0/Upgrade.daml
@@ -1,0 +1,23 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Upgrade where
+
+-- Template with the same definition as the one defined in 2.0.0
+template UA with
+  issuer : Party
+  owner : Party
+  field : Int
+  more : Optional[Text]
+ where
+  signatory issuer
+  observer owner
+
+-- Updated with extra field compared to 2.0.0
+template UB with
+  owner : Party
+  field : Int
+  extra: Optional[Text]
+ where
+  signatory owner
+  observer owner

--- a/test-common/test-common.bzl
+++ b/test-common/test-common.bzl
@@ -4,13 +4,18 @@
 load("//bazel_tools:scala.bzl", "da_scala_library")
 load("//rules_daml:daml.bzl", "daml_compile")
 load("//daml-lf/language:daml-lf.bzl", "mangle_for_java")
+load(
+    "//daml-lf/language:daml-lf.bzl",
+    "lf_version_configuration",
+    "version_in",
+)
 
 def to_camel_case(name):
     return "".join([part.capitalize() for part in name.split("_")])
 
 def da_scala_dar_resources_library(
         daml_root_dir,
-        daml_dir_names,
+        test_dars,
         lf_versions,
         add_maven_tag = False,
         maven_name_prefix = "",
@@ -21,24 +26,40 @@ def da_scala_dar_resources_library(
     Define a Scala library with dar files as resources.
     """
     for lf_version in lf_versions:
-        for daml_dir_name in daml_dir_names.get(lf_version, []):
-            # 1. Compile daml files
-            daml_compile_name = "%s-tests-%s" % (daml_dir_name, lf_version)
-            daml_compile_kwargs = {
-                "project_name": "%s-tests" % daml_dir_name.replace("_", "-"),
-                "srcs": native.glob(["%s/%s/*.daml" % (daml_root_dir, daml_dir_name)], exclude = exclusions.get(lf_version, [])),
-                "target": lf_version,
-            }
-            daml_compile_kwargs.update(kwargs)
-            daml_compile(
-                name = daml_compile_name,
-                data_dependencies = [dep % (lf_version) for dep in data_dependencies.get(daml_dir_name, [])],
-                **daml_compile_kwargs
-            )
+        for test_dar in test_dars.get(lf_version, {}).keys():
+            package_versions = test_dars[lf_version][test_dar]
+            if package_versions:
+                for package_version in package_versions:
+                    daml_compile_name = "%s-tests-%s-%s" % (test_dar, package_version, lf_version)
+                    daml_compile_kwargs = {
+                        "project_name": "%s-tests" % test_dar.replace("_", "-"),
+                        "srcs": native.glob(["%s/%s/%s/*.daml" % (daml_root_dir, test_dar, package_version)], exclude = exclusions.get(lf_version, [])),
+                        "target": lf_version,
+                        "version": package_version,
+                    }
+                    daml_compile_kwargs.update(kwargs)
+                    daml_compile(
+                        name = daml_compile_name,
+                        data_dependencies = [dep % (lf_version) for dep in data_dependencies.get(test_dar, [])],
+                        **daml_compile_kwargs
+                    )
+            else:
+                daml_compile_name = "%s-tests-%s" % (test_dar, lf_version)
+                daml_compile_kwargs = {
+                    "project_name": "%s-tests" % test_dar.replace("_", "-"),
+                    "srcs": native.glob(["%s/%s/*.daml" % (daml_root_dir, test_dar)], exclude = exclusions.get(lf_version, [])),
+                    "target": lf_version,
+                }
+                daml_compile_kwargs.update(kwargs)
+                daml_compile(
+                    name = daml_compile_name,
+                    data_dependencies = [dep % (lf_version) for dep in data_dependencies.get(test_dar, [])],
+                    **daml_compile_kwargs
+                )
 
         # 2. Generate lookup objects
         genrule_name = "test-dar-lookup-%s" % lf_version
-        genrule_command = """
+        header = """
 cat > $@ <<EOF
 package com.daml.ledger.test
 
@@ -50,26 +71,58 @@ object TestDar {{
   val lfVersion: LanguageVersion = LanguageVersion.v{lf_version}
   val paths: List[String] = List(
 EOF
-""".format(lf_version = mangle_for_java(lf_version)) + "\n".join(["""
+""".format(lf_version = mangle_for_java(lf_version))
+
+        dar_list = []
+        for test_dar in test_dars.get(lf_version, {}).keys():
+            package_versions = test_dars[lf_version][test_dar]
+            if package_versions:
+                for package_version in package_versions:
+                    dar_list += ["""
+echo "    \\"%s/%s-tests-%s-%s.dar\\"," >> $@
+""" % (native.package_name(), test_dar, package_version, lf_version)]
+            else:
+                dar_list += ["""
 echo "    \\"%s/%s-tests-%s.dar\\"," >> $@
-""" % (native.package_name(), test_name, lf_version) for test_name in daml_dir_names.get(lf_version, [])]) + """
-echo "  )\n}\n" >> $@
-""" + "\n".join(["""
+""" % (native.package_name(), test_dar, lf_version)]
+
+        dar_def_list = []
+        for test_dar in test_dars.get(lf_version, {}).keys():
+            package_versions = test_dars[lf_version][test_dar]
+            if package_versions:
+                for package_version in package_versions:
+                    dar_def_list += ["""
+echo "case object %sTestDar%s extends TestDar { val path = \\"%s/%s-tests-%s-%s.dar\\" }" >> $@
+""" % (to_camel_case(test_dar), mangle_for_java(package_version), native.package_name(), test_dar, package_version, lf_version)]
+            else:
+                dar_def_list += ["""
 echo "case object %sTestDar extends TestDar { val path = \\"%s/%s-tests-%s.dar\\" }" >> $@
-""" % (to_camel_case(test_name), native.package_name(), test_name, lf_version) for test_name in daml_dir_names.get(lf_version, [])])
+""" % (to_camel_case(test_dar), native.package_name(), test_dar, lf_version)]
+
+        delimiter = """
+echo "  )\n}\n" >> $@
+"""
 
         genrule_kwargs = {
             "outs": ["TestDar-%s.scala" % mangle_for_java(lf_version)],
-            "cmd": genrule_command,
+            "cmd": header + "\n".join(dar_list) + delimiter + "\n".join(dar_def_list),
         }
         genrule_kwargs.update(kwargs)
         native.genrule(name = genrule_name, **genrule_kwargs)
 
         # 3. Build a Scala library with the above
-        filegroup_name = "dar-files-%s" % lf_version
+        srcs = []
+        for test_name in test_dars.get(lf_version, {}).keys():
+            package_versions = test_dars[lf_version][test_name]
+            if package_versions:
+                for package_version in package_versions:
+                    srcs += ["%s-tests-%s-%s.dar" % (test_name, package_version, lf_version)]
+            else:
+                srcs += ["%s-tests-%s.dar" % (test_name, lf_version)]
         filegroup_kwargs = {
-            "srcs": ["%s-tests-%s.dar" % (dar_name, lf_version) for dar_name in daml_dir_names.get(lf_version, [])],
+            "srcs": srcs,
         }
+        filegroup_name = "dar-files-%s" % lf_version
         filegroup_kwargs.update(kwargs)
         native.filegroup(name = filegroup_name, **filegroup_kwargs)
 
@@ -84,3 +137,15 @@ echo "case object %sTestDar extends TestDar { val path = \\"%s/%s-tests-%s.dar\\
             da_scala_library_kwargs.update({"tags": ["maven_coordinates=com.daml:%s-dar-files-%s-lib:__VERSION__" % (maven_name_prefix, lf_version)]})
         da_scala_library_kwargs.update(kwargs)
         da_scala_library(name = da_scala_library_name, **da_scala_library_kwargs)
+
+def merge_test_dars_versioned(lf_versions, general_test_dars, carbon_test_dars, carbon_test_dars_v1_minor_version_range, carbon_test_dars_v2_minor_version_range, upgrading_test_dars, upgrading_test_dars_v1_minor_version_range, upgrading_test_dars_v2_minor_version_range):
+    merged_tests = {}
+    for lf_version in lf_versions:
+        tests_for_lf_version = {}
+        tests_for_lf_version.update(general_test_dars)
+        if version_in(lf_version, v1_minor_version_range = carbon_test_dars_v1_minor_version_range, v2_minor_version_range = carbon_test_dars_v2_minor_version_range):
+            tests_for_lf_version.update(carbon_test_dars)
+        if version_in(lf_version, v1_minor_version_range = upgrading_test_dars_v1_minor_version_range, v2_minor_version_range = upgrading_test_dars_v2_minor_version_range):
+            tests_for_lf_version.update(upgrading_test_dars)
+        merged_tests[lf_version] = tests_for_lf_version
+    return merged_tests


### PR DESCRIPTION
Contributes to https://github.com/DACH-NY/canton/issues/16651

The purpose of this PR is to implement the `UpgradingIT` conformance test. This required multiple changes:
* The actual implementation of `UpgradingIT`. It's relevant for this test that packages are uploaded dynamically and not at the ledger test tool runner suite start-up. 
* Bazel support in `test-common` for allowing several package versions defined for the same package-name. 
* Change of the test-runner setup to support excluding specific DARs from upload at start-up.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
