### PR TITLE
Move fromString utils to TypeConRef object (#18231)

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
@@ -320,7 +320,9 @@ object Ref {
       case PackageRef.Id(id) =>
         TypeConName(id, qName)
     }
+  }
 
+  object TypeConRef {
     def fromString(s: String): Either[String, TypeConRef] =
       splitInTwo(s, ':') match {
         case Some((packageRefString, qualifiedNameString)) =>
@@ -332,9 +334,10 @@ object Ref {
           Left(s"Separator ':' between package identifier and qualified name not found in $s")
       }
 
-    def assertFromString(s: String): TypeConRef =
-      assertRight(fromString(s))
+    def assertFromString(s: String): TypeConRef = assertRight(fromString(s))
 
+    def fromIdentifier(identifier: Identifier): TypeConRef =
+      TypeConRef(PackageRef.Id(identifier.packageId), identifier.qualifiedName)
   }
 
   /*

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/logging/package.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/logging/package.scala
@@ -3,7 +3,7 @@
 
 package com.daml.lf.data
 
-import com.daml.lf.data.Ref.{Identifier, LedgerString, Party}
+import com.daml.lf.data.Ref.{Identifier, LedgerString, Party, TypeConRef}
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.entries.{LoggingKey, LoggingValue, ToLoggingKey, ToLoggingValue}
 
@@ -14,6 +14,9 @@ package object logging {
 
   implicit val `Identifier to LoggingValue`: ToLoggingValue[Identifier] =
     ToLoggingValue.ToStringToLoggingValue
+
+  implicit val `TypeConRef to LoggingValue`: ToLoggingValue[TypeConRef] =
+    typeConRef => LoggingValue.OfString(typeConRef.toString)
 
   // The party name can grow quite long, so we offer ledger implementors the opportunity to truncate
   // it in structured log output.


### PR DESCRIPTION
This is a port of https://github.com/digital-asset/daml/pull/18231 to 3.x

* Move (assert)fromString to TypeConRef object

* Add fromIdentifier

* Add TypeConRef to LoggingValue

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
