### PR TITLE
fix //language-support/hs/bindings:test

### DIFF
--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -138,9 +138,8 @@ tListPackages withSandbox = testCase "listPackages" $ run withSandbox $ \DarMeta
     lid <- getLedgerIdentity
     pids <- listPackages lid
     liftIO $ do
-        -- Canton loads the `AdminWorkflowsWithVacuuming` package at boot, which adds a bunch of deps
-        -- In this case, `AdminWorkflowsWithVacuuming` has 3 deps that we don't already pull in, thus the + 3
-        assertEqual "#packages" (length (dalfPaths manifest) + 3) (length pids)
+        -- Canton loads the `AdminWorkflows` package at boot, hence the + 1
+        assertEqual "#packages" (length (dalfPaths manifest) + 1) (length pids)
         assertBool "The pid is listed" (mainPackageId `elem` pids)
 
 tGetPackage :: SandboxTest


### PR DESCRIPTION
The test was failing because the WorkflowAdmin package no longer pulls additional packages.

run-all-tests: true

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
