### PR TITLE
fix handling of main-only tests on linux and darwin

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -84,19 +84,18 @@ if ($env:SKIP_TESTS -ceq "False") {
     ./ci/remap-scala-test-short-names.ps1 `
       | Out-File -Encoding UTF8 -NoNewline scala-test-suite-name-map.json
 
-    $ALL_TESTS_FILTER = "-pr-only"
     $FEWER_TESTS_FILTER = "-main-only"
 
     $tag_filter = "-dev-canton-test,-canton-ee"
     switch ($env:TEST_MODE) {
       'main' {
-        $tag_filter = "$tag_filter,$ALL_TESTS_FILTER"
+          Write-Output "Running all tests because TEST_MODE is 'main'"
       }
       'pr' {
         if (Has-Run-All-Tests-Trailer) {
           Write-Output "ignoring 'pr' test mode because the commit message features 'run-all-tests: true'"
-          $tag_filter = "$tag_filter,$ALL_TESTS_FILTER"
         } else {
+          Write-Output "Running fewer tests because TEST_MODE is 'pr'"
           $tag_filter = "$tag_filter,$FEWER_TESTS_FILTER"
         }
       }

--- a/build.sh
+++ b/build.sh
@@ -25,22 +25,19 @@ has_run_all_tests_trailer() {
   [[ $run_all_tests == "true" ]]
 }
 
-ALL_TESTS_FILTER="-pr-only"
-FEWER_TESTS_FILTER="-main-only"
-
+tag_filter=""
 case $test_mode in
-  # When running against main, exclude "pr-only" tests
   main)
-    tag_filter=$FEWER_TESTS_FILTER
+    echo "running all tests because test mode is 'main'"
     ;;
   # When running against a PR, exclude "main-only" tests, unless the commit message features a
   # 'run-all-tests: true' trailer
   pr)
     if has_run_all_tests_trailer; then
       echo "ignoring 'pr' test mode because the commit message features 'run-all-tests: true'"
-      tag_filter=$ALL_TESTS_FILTER
     else
-      tag_filter=$FEWER_TESTS_FILTER
+      echo "running fewer tests because test mode is 'pr'"
+      tag_filter="-main-only"
     fi
     ;;
   *)


### PR DESCRIPTION
We were accidentally **excluding** main-only tests when running against main.

Also remove `pr-only` which is no longer used.