### PR TITLE
fix main-only tests on linux and darwin on main-2.x

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ FEWER_TESTS_FILTER="-main-only"
 case $test_mode in
   # When running against main, exclude "pr-only" tests
   main)
-    tag_filter=$FEWER_TESTS_FILTER
+    tag_filter=$ALL_TESTS_FILTER
     ;;
   # When running against a PR, exclude "main-only" tests, unless the commit message features a
   # 'run-all-tests: true' trailer


### PR DESCRIPTION
We were accidentally excluding main-only tests when running against main.