### PR TITLE
Remove dead code in speedy now that evaluation is right-to-left only

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -23,8 +23,6 @@ import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SBuiltin._
 
-import scala.annotation.nowarn
-
 //
 // Pretty-printer for the interpreter errors and the scenario ledger
 //
@@ -580,7 +578,6 @@ private[lf] object Pretty {
       case SELocF(i) => char('F') + str(i)
     }
 
-    @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppOnlyFunIsAtomic")
     def prettySExpr(index: Int)(e: SExpr): Doc =
       e match {
         case SEVal(defId) =>
@@ -625,10 +622,6 @@ private[lf] object Pretty {
             case SBUGetTime | SBSGetTime => text("$getTime")
             case _ => str(x)
           }
-        case SEAppOnlyFunIsAtomic(fun, args) =>
-          val prefix = prettySExpr(index)(fun) + text("@N(")
-          intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
-            .tightBracketBy(prefix, char(')'))
         case SEAppAtomicGeneral(fun, args) =>
           val prefix = prettySExpr(index)(fun) + text("@A(")
           intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -10,8 +10,6 @@ import com.daml.lf.speedy.Speedy._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
 
-import scala.annotation.nowarn
-
 private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK machine states
 
   def ppMachine(m: Machine[_]): String = {
@@ -53,11 +51,9 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
     s"${x.ref.qualifiedName.name}"
   }
 
-  @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppOnlyFunIsAtomic")
   def pp(e: SExpr): String = e match {
     case SEValue(v) => s"(VALUE)${pp(v)}"
     case loc: SELoc => pp(loc)
-    case SEAppOnlyFunIsAtomic(func, args) => s"@N(${pp(func)},${commas(args.map(pp))})"
     case SEAppAtomicGeneral(func, args) => s"@A(${pp(func)},${commas(args.map(pp))})"
     case SEAppAtomicSaturatedBuiltin(b, args) => s"@B(${pp(SEBuiltin(b))},${commas(args.map(pp))})"
     case SEMakeClo(fvs, arity, body) => s"[${commas(fvs.map(pp))}]\\$arity.${pp(body)}"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -105,22 +105,6 @@ private[lf] object SExpr {
 
   object SEValue extends SValueContainer[SEValue] // used by Compiler
 
-  /** Function application with general arguments (deprecated)
-    * Although 'fun' is atomic, 'args' are still any kind of expression.
-    * This case would not exist if we performed a full/standard ANF pass.
-    * Because this case exists we must retain the complicated/slow path in the
-    * speedy-machine: executeApplication
-    */
-  @deprecated("Prefer SEAppAtomic or SEApp helper instead.", since = "2.4.0")
-  final case class SEAppOnlyFunIsAtomic(fun: SExprAtomic, args: Array[SExpr])
-      extends SExpr
-      with SomeArrayEquals {
-    override def execute[Q](machine: Machine[Q]): Control[Nothing] = {
-      val vfun = fun.lookupValue(machine)
-      machine.executeApplication(vfun, args)
-    }
-  }
-
   object SEApp {
     // Helper: build an application of an unrestricted expression, to value-arguments.
     def apply(fun: SExpr, args: Array[SValue]): SExpr = {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
@@ -38,7 +38,7 @@ package speedy
   * - In SExpr{1,}: SELocA, SELocF, SELocS, SEMakeClo, SELet1General,
   *
   * - In SExpr: SEAppAtomicGeneral, SEAppAtomicSaturatedBuiltin, SECaseAtomic,
-  *   SELet1Builtin, SELet1BuiltinArithmetic, SEAppOnlyFunIsAtomic
+  *   SELet1Builtin, SELet1BuiltinArithmetic
   *
   * - In SExpr (runtime only, i.e. rejected by validate): SEDamlException, SEImportValue
   */

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -1225,70 +1225,6 @@ private[lf] object Speedy {
       }
     }
 
-    /** The function has been evaluated to a value, now start evaluating the arguments. */
-    private[speedy] final def executeApplication(
-        vfun: SValue,
-        newArgs: Array[SExpr],
-    ): Control[Nothing] = {
-      vfun match {
-        case SValue.SPAP(prim, actualsSoFar, arity) =>
-          val missing = arity - actualsSoFar.size
-          val newArgsLimit = Math.min(missing, newArgs.length)
-
-          val actuals = new util.ArrayList[SValue](actualsSoFar.size + newArgsLimit)
-          discard[Boolean](actuals.addAll(actualsSoFar))
-
-          val othersLength = newArgs.length - missing
-
-          // Not enough arguments. Push a continuation to construct the PAP.
-          if (othersLength < 0) {
-            this.pushKont(KPap(prim, actuals, arity))
-          } else {
-            // Too many arguments: Push a continuation to re-apply the over-applied args.
-            if (othersLength > 0) {
-              val others = new Array[SExpr](othersLength)
-              System.arraycopy(newArgs, missing, others, 0, othersLength)
-              this.pushKont(KArg(this, others))
-            }
-            // Now the correct number of arguments is ensured. What kind of prim do we have?
-            prim match {
-              case closure: SValue.PClosure =>
-                // Push a continuation to execute the function body when the arguments have been evaluated
-                this.pushKont(KFun(this, closure, actuals))
-
-              case SValue.PBuiltin(builtin) =>
-                // Push a continuation to execute the builtin when the arguments have been evaluated
-                this.pushKont(KBuiltin(this, builtin, actuals))
-            }
-          }
-          this.evaluateArguments(actuals, newArgs, newArgsLimit)
-
-        case _ =>
-          throw SErrorCrash(NameOf.qualifiedNameOfCurrentFunc, s"Applying non-PAP: $vfun")
-      }
-    }
-
-    /** Evaluate the first 'n' arguments in 'args'.
-      *      'args' will contain at least 'n' expressions, but it may contain more(!)
-      *
-      *      This is because, in the call from 'executeApplication' below, although over-applied
-      *      arguments are pushed into a continuation, they are not removed from the original array
-      *      which is passed here as 'args'.
-      */
-    private[speedy] final def evaluateArguments(
-        actuals: util.ArrayList[SValue],
-        args: Array[SExpr],
-        n: Int,
-    ): Control[Nothing] = {
-      var i = 1
-      while (i < n) {
-        val arg = args(n - i)
-        this.pushKont(KPushTo(this, actuals, arg))
-        i = i + 1
-      }
-      Control.Expression(args(0))
-    }
-
     // This translates a well-typed LF value (typically coming from the ledger)
     // to speedy value and set the control of with the result.
     // Note the method does not check the value is well-typed as opposed as
@@ -1709,28 +1645,6 @@ private[lf] object Speedy {
   object KOverApp {
     def apply[Q](machine: Machine[Q], newArgs: Array[SExprAtomic]): KOverApp[Q] =
       KOverApp(machine, machine.markBase(), machine.currentFrame, machine.currentActuals, newArgs)
-  }
-
-  /** The function has been evaluated to a value. Now restore the environment and execute the application */
-  private[speedy] final case class KArg[Q] private (
-      machine: Machine[Q],
-      savedBase: Int,
-      frame: Frame,
-      actuals: Actuals,
-      newArgs: Array[SExpr],
-  ) extends Kont[Q]
-      with SomeArrayEquals
-      with NoCopy {
-    override def execute(vfun: SValue): Control[Nothing] = {
-      machine.restoreBase(savedBase);
-      machine.restoreFrameAndActuals(frame, actuals)
-      machine.executeApplication(vfun, newArgs)
-    }
-  }
-
-  object KArg {
-    def apply[Q](machine: Machine[Q], newArgs: Array[SExpr]): KArg[Q] =
-      KArg(machine, machine.markBase(), machine.currentFrame, machine.currentActuals, newArgs)
   }
 
   /** The function-closure and arguments have been evaluated. Now execute the body. */

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
@@ -5,17 +5,14 @@ package com.daml.lf.speedy.iterable
 
 import com.daml.lf.speedy.{SExpr, SValue}
 import com.daml.lf.speedy.SExpr.SExpr
-import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
 // Iterates only over immediate children similar to Haskell’s
 // uniplate.
-@nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppOnlyFunIsAtomic")
 private[speedy] object SExprIterable {
   that =>
   private[iterable] def iterator(e: SExpr): Iterator[SExpr] = e match {
     case SExpr.SEVal(_) => Iterator.empty
-    case SExpr.SEAppOnlyFunIsAtomic(fun, args) => Iterator(fun) ++ args.iterator
     case SExpr.SEAppAtomicGeneral(fun, args) => Iterator(fun) ++ args.iterator
     case SExpr.SEAppAtomicSaturatedBuiltin(_, args) => args.iterator
     case SExpr.SEMakeClo(_, _, body) => Iterator(body)


### PR DESCRIPTION
Context: https://github.com/digital-asset/daml/issues/18240

Now that right-to-left evaluation is the default we always perform full ANF. Thus we don't need the `KArg` continuation in the machine, neither do we need the code to handle it.
