### PR TITLE
check-releases: record verified releases

### DIFF
--- a/ci/cron/check-releases.sh
+++ b/ci/cron/check-releases.sh
@@ -137,7 +137,6 @@ verify_backup() (
 check_release() (
     release=$1
     tag=$(echo $release | jq -r .tag)
-    echo "[$(date --date=@$SECONDS -u +%H:%M:%S)] $tag"
     tmp_dir=$(mktemp -d)
     trap "cd; rm -rf $tmp_dir" EXIT
     cd $tmp_dir
@@ -146,13 +145,83 @@ check_release() (
     verify_backup $tag
 )
 
-setup_gpg
-releases=$(get_releases)
+create_record() (
+  listing=$1
+  release=$2
+  gcloud_resp=$(mktemp)
+  gcloud storage ls "gs://daml-data/releases/$release/**/*" --json \
+    > $gcloud_resp
+  github_resp=$(mktemp)
+  curl --fail \
+       --silent \
+       --location \
+       -H "$AUTH" \
+       -H "$USER_AGENT" \
+       -H "X-GitHub-Api-Version: 2022-11-28" \
+       "https://api.github.com/repos/digital-asset/daml/releases/tags/v$release" \
+    | jq '[.assets[] | {name, created_at, updated_at, uploader: .uploader.login}]' \
+    > $github_resp
+  jq -n '{gcloud: input, github: input}' $gcloud_resp $github_resp > $listing
+)
 
-if [ "" != "$MAX_RELEASES" ]; then
+remote_record_location() (
+  release=$1
+  echo "gs://daml-data/checked-releases/$release"
+)
+
+has_record() (
+  release=$1
+  gcloud storage ls $(remote_record_location $release) &>/dev/null
+)
+
+matches_record() (
+  listing=$1
+  release=$2
+  remote=$(mktemp)
+  gcloud storage cat $(remote_record_location $release) > $remote
+  diff $remote $listing
+)
+
+record_success() (
+  record_before=$1
+  release=$2
+  record_after=$3
+  create_record $record_after $release
+  if diff $record_before $record_after; then
+    echo "[$(date --date=@$SECONDS -u +%H:%M:%S)] $tag: saving record."
+    gsutil -q cp $record_before $(remote_record_location $release)
+  else
+    echo "[$(date --date=@$SECONDS -u +%H:%M:%S)] $tag: artifacts have changed while verifying."
+    exit 1
+  fi
+)
+
+main() (
+  setup_gpg
+  releases=$(get_releases)
+
+  if [ "" != "$MAX_RELEASES" ]; then
     releases=$( (echo "$releases" | head -n $MAX_RELEASES) || test $? -eq 141)
-fi
+  fi
 
-for r in $releases; do
-    check_release $r
-done
+  for r in $releases; do
+    listing=$(mktemp)
+    tag=$(echo $r | jq -r .tag)
+    create_record $listing $tag
+    if has_record $tag; then
+      if matches_record $listing $tag; then
+        echo "[$(date --date=@$SECONDS -u +%H:%M:%S)] $tag: matches record, skipping."
+      else
+        echo "[$(date --date=@$SECONDS -u +%H:%M:%S)] $tag: does not match records, see above for differences."
+      fi
+    else
+      echo "[$(date --date=@$SECONDS -u +%H:%M:%S)] $tag: verifying."
+      check_release $r
+      record_success $listing $tag
+    fi
+  done
+)
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
With the current setup, every single day we download every single artifact of evry single release we've ever made on GitHub, twice (once from GitHub, once from GCS). Then we check signatures and compare the two.

With this change, we save a representation of the state of both GCS and GitHub, and if that representation hasn't changed, we assume the artifacts haven't changed either. The assumption seems reasonable to me as the representation includes platform timestamps, which no user can tamper with as far as I'm aware.

Note: we do not save the entire GitHub release representation, and instead just save relevant metadata for the associated artifacts. The goal of this job is to verify that the artifacts haven't changed; it is acceptable (and even expected in routine circumstances) that the release description will change, as well as its "prerelease" and "latest release" flags.