### PR TITLE
add copy canton script

### DIFF
--- a/ci/copy-canton.sh
+++ b/ci/copy-canton.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <canton_directory>"
+  exit 1
+else
+  canton_dir=$1
+fi
+
+#tmp=$(mktemp -d)
+#trap "rm -rf ${tmp}" EXIT
+#git -C $canton_dir worktree add -d $tmp
+#trap "git -C $canton_dir worktree remove -f $tmp" EXIT
+
+
+for path in community daml-common-staging README.md; do
+  rm -rf canton/$path
+  for f in  $(git -C "$canton_dir" ls-files $path); do
+    # we're only interested in copying files, not directories, as git-ls has
+    # explicitly expanded all directories
+    if [[ -f $canton_dir/$f ]]; then
+      # we create the parent directories of f under canton/ if they don't exist
+      mkdir -p canton/$(dirname $f)
+      cp $canton_dir/$f canton/$f
+    fi
+  done
+  #cp -rf $src $dst
+  git add canton/$path
+done

--- a/ci/copy-canton.sh
+++ b/ci/copy-canton.sh
@@ -10,22 +10,16 @@ else
   canton_dir=$1
 fi
 
-#tmp=$(mktemp -d)
-#trap "rm -rf ${tmp}" EXIT
-#git -C $canton_dir worktree add -d $tmp
-#trap "git -C $canton_dir worktree remove -f $tmp" EXIT
-
-
 for path in community daml-common-staging README.md; do
-  rm -rf canton/$path
+  rm -rf $DIR/canton/$path
   for f in  $(git -C "$canton_dir" ls-files $path); do
     # we're only interested in copying files, not directories, as git-ls has
     # explicitly expanded all directories
     if [[ -f $canton_dir/$f ]]; then
       # we create the parent directories of f under canton/ if they don't exist
-      mkdir -p canton/$(dirname $f)
-      cp $canton_dir/$f canton/$f
+      mkdir -p $DIR/canton/$(dirname $f)
+      cp $canton_dir/$f $DIR/canton/$f
     fi
   done
-  git add canton/$path
+  git add $DIR/canton/$path
 done

--- a/ci/copy-canton.sh
+++ b/ci/copy-canton.sh
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
+DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 <canton_directory>"
   exit 1
@@ -10,16 +12,17 @@ else
   canton_dir=$1
 fi
 
+code_drop_dir=$DIR/../canton
 for path in community daml-common-staging README.md; do
-  rm -rf $DIR/canton/$path
+  rm -rf $code_drop_dir/$path
   for f in  $(git -C "$canton_dir" ls-files $path); do
     # we're only interested in copying files, not directories, as git-ls has
     # explicitly expanded all directories
     if [[ -f $canton_dir/$f ]]; then
       # we create the parent directories of f under canton/ if they don't exist
-      mkdir -p $DIR/canton/$(dirname $f)
-      cp $canton_dir/$f $DIR/canton/$f
+      mkdir -p $code_drop_dir/$(dirname $f)
+      cp $canton_dir/$f $code_drop_dir/$f
     fi
   done
-  git add $DIR/canton/$path
+  git add $code_drop_dir/$path
 done

--- a/ci/copy-canton.sh
+++ b/ci/copy-canton.sh
@@ -27,6 +27,5 @@ for path in community daml-common-staging README.md; do
       cp $canton_dir/$f canton/$f
     fi
   done
-  #cp -rf $src $dst
   git add canton/$path
 done

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -238,24 +238,13 @@ jobs:
 
           ### code drop ###
 
-          copy_canton_code() {
-            canton_version=$1
-            canton_dir=$2
-
-            commitish=$(canton_version_to_commitish $canton_version)
             tmp=$(mktemp -d)
             trap "rm -rf ${tmp}" EXIT
-
+            
             git clone https://$GITHUB_TOKEN@github.com/DACH-NY/canton $tmp
-            git -C $tmp checkout $commitish
-            for path in community daml-common-staging README.md; do
-              src=$tmp/$path
-              dst=$canton_dir/$path
-              rm -rf $dst
-              mkdir -p $(dirname $dst)
-              cp -rf $src $dst
-              git add $dst
-            done
+            git -C $tmp checkout $(canton_version_to_commitish $canton3_version)
+
+            ci/copy-canton.sh $tmp
           }
 
           copy_canton_code $canton3_version canton


### PR DESCRIPTION
Add a script that lets developers pull the contents of the `canton/` directory in the daml repo from a local canton repo:

```
cd daml
ci/copy-canton.sh ../canton
bazel build //canton/...
```

The script uses `git ls-file` to ensure we only copy files tracked by git.