### PR TITLE
Reduce artifacts and dependencies on ledger-api-core

### DIFF
--- a/canton/BUILD.bazel
+++ b/canton/BUILD.bazel
@@ -17,7 +17,7 @@ load("//language-support/java:javaopts.bzl", "da_java_bindings_javacopts")
 load("//language-support/java/codegen:codegen.bzl", "dar_to_java")
 load("//rules_daml:daml.bzl", "daml_compile")
 load("@build_environment//:configuration.bzl", "sdk_version")
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library", "scala_test_suite")
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library", "scala_macro_library")
 load("@scala_version//:index.bzl", "scala_major_version", "scala_version")
 load(
     "@com_github_johnynek_bazel_jar_jar//:jar_jar.bzl",
@@ -31,7 +31,7 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 # TODO(https://github.com/DACH-NY/canton/issues/15106): read 'version' from the canton repository
 #  once it is exposed in some file.
 genrule(
-    name = "community_buildinfo_source",
+    name = "community_buildinfo_src",
     outs = ["BuildInfo.scala"],
     cmd = """
 cat << EOF > $@
@@ -56,10 +56,9 @@ EOF
     ),
 )
 
-da_scala_library(
+scala_library(
     name = "community_buildinfo",
-    srcs = [":community_buildinfo_source"],
-    tags = ["maven_coordinates=com.daml:canton-community-buildinfo:__VERSION__"],
+    srcs = [":community_buildinfo_src"],
 )
 
 ### daml-common-staging/daml-errors ###
@@ -87,14 +86,13 @@ da_scala_library(
 
 ### community/lib/pekko ###
 
-da_scala_library(
+scala_library(
     name = "pekko-stream-patch",
     srcs = glob(["community/lib/pekko/src/main/**/*.scala"]),
-    override_scalacopts = [
+    scalacopts = [
         "-Xsource:3",
         "-language:postfixOps",
     ],
-    tags = ["maven_coordinates=com.daml:pekko-stream-patch:__VERSION__"],
     unused_dependency_checker_mode = "error",
     deps = [
         "@maven//:org_apache_pekko_pekko_actor_2_13",
@@ -110,13 +108,9 @@ jar_jar(
 
 ### community/lib/Blake2b ###
 
-da_java_library(
+java_library(
     name = "community_lib_Blake2b",
     srcs = glob(["community/lib/Blake2b/src/main/**/*.java"]),
-    tags = [
-        "javadoc_root_packages=org.bouncycastle.crypto.digests.canton",
-        "maven_coordinates=com.daml:canton-community-lib-blake2b:__VERSION__",
-    ],
     deps = [
         "@maven//:org_bouncycastle_bcprov_jdk15on",
     ],
@@ -124,11 +118,10 @@ da_java_library(
 
 ### community/lib/slick ###
 
-da_scala_macro_library(
+scala_macro_library(
     name = "community_lib_slick_slick-fork",
     srcs = glob(["community/lib/slick/src/main/**/*.scala"]),
-    override_scalacopts = ["-Wconf:cat=unused-imports:s"],
-    tags = ["maven_coordinates=com.daml:canton-community-lib-slick-slick-fork:__VERSION__"],
+    scalacopts = ["-Wconf:cat=unused-imports:s"],
     deps = [
         "@maven//:com_typesafe_slick_slick_2_13",
         "@maven//:org_reactivestreams_reactive_streams",
@@ -138,14 +131,13 @@ da_scala_macro_library(
 
 ### community/lib/wartremover ###
 
-da_scala_macro_library(
+scala_macro_library(
     name = "community_lib_wartremover",
     srcs = glob(["community/lib/wartremover/src/main/**/*.scala"]),
-    override_scalacopts = [
+    scalacopts = [
         "-Wconf:cat=unused-pat-vars:s",
         "-Xsource:3",
     ],
-    tags = ["maven_coordinates=com.daml:canton-community-lib-wartremover:__VERSION__"],
     unused_dependency_checker_mode = "error",
     deps = [
         "@maven//:com_typesafe_slick_slick_2_13",
@@ -207,14 +199,13 @@ da_scala_library(
 
 ### community/util-external ###
 
-da_scala_library(
+scala_library(
     name = "community_util-external",
     srcs = glob(["community/util-external/src/main/scala/**/*.scala"]),
-    override_scalacopts = [
+    scalacopts = [
         "-Xsource:3",
         "-language:postfixOps",
     ],
-    tags = ["maven_coordinates=com.daml:canton-community-util-external:__VERSION__"],
     unused_dependency_checker_mode = "error",
     deps = [
         ":community_util-logging",
@@ -349,14 +340,13 @@ filegroup(
     visibility = ["//daml-script:__subpackages__"],
 )
 
-da_scala_library(
+scala_library(
     name = "community_admin-api",
     srcs = [":community_admin-api-src"],
-    override_scalacopts = [
+    scalacopts = [
         "-Xsource:3",
         "-language:postfixOps",
     ],
-    tags = ["maven_coordinates=com.daml:canton-community-admin-api:__VERSION__"],
 )
 
 ### community/base ###
@@ -386,18 +376,16 @@ proto_gen(
     ],
 )
 
-da_scala_library(
+scala_library(
     name = "community_base",
     srcs = glob(["community/base/src/main/scala/**/*.scala"]) + [":community_base_proto_scala"] + [":community_admin-api_proto_scala"],
-    override_scalacopts = [
-        "-Xsource:3",
-        "-language:postfixOps",
-    ],
     plugins = [kind_projector_plugin],
     resource_strip_prefix = "canton/community/base/src/main/resources",
     resources = glob(["community/base/src/main/resources/**"]),
-    scaladoc = False,
-    tags = ["maven_coordinates=com.daml:canton-community-base:__VERSION__"],
+    scalacopts = [
+        "-Xsource:3",
+        "-language:postfixOps",
+    ],
     unused_dependency_checker_mode = "error",
     runtime_deps = [
         #  not used at compile time, but required by com.digitalasset.canton.util.PekkoUtil.createActorSystem
@@ -479,28 +467,18 @@ da_scala_library(
     ],
 )
 
-# Create empty Scaladoc JAR for uploading to Maven Central
-# Needed as scaladoc for base fails to compile
-scaladoc_jar(
-    name = "community_base_scaladoc",
-    srcs = [],
-    tags = ["scaladoc"],
-    deps = [],
-) if is_windows == False else None
-
 ### community/common ###
 
-da_scala_library(
+scala_library(
     name = "community_common",
     srcs = glob(["community/common/src/main/scala/**/*.scala"]),
-    override_scalacopts = [
-        "-Xsource:3",
-        "-language:postfixOps",
-    ],
     plugins = [kind_projector_plugin],
     resource_strip_prefix = "canton/community/common/src/main/resources",
     resources = glob(["community/common/src/main/resources/**"]),
-    tags = ["maven_coordinates=com.daml:canton-community-common:__VERSION__"],
+    scalacopts = [
+        "-Xsource:3",
+        "-language:postfixOps",
+    ],
     unused_dependency_checker_mode = "error",
     runtime_deps = [
         #  not used at compile time, but required by com.digitalasset.canton.util.PekkoUtil.createActorSystem
@@ -598,25 +576,21 @@ proto_gen(
     ],
 )
 
-da_scala_library(
+scala_library(
     name = "community_ledger_ledger-api-core",
     srcs = glob([
         "community/ledger/ledger-api-core/src/main/scala/**/*.scala",
         "community/ledger/ledger-api-core/src/main/scala/**/*.java",
     ]) + [":community_ledger_ledger-api-core_proto_scala"],
-    override_scalacopts = [
+    resource_strip_prefix = "canton/community/ledger/ledger-api-core/src/main/resources",
+    resources = glob(["community/ledger/ledger-api-core/src/main/resources/**"]),
+    scalacopts = [
         "-Xsource:3",
         "-language:postfixOps",
     ],
-    resource_strip_prefix = "canton/community/ledger/ledger-api-core/src/main/resources",
-    resources = glob(["community/ledger/ledger-api-core/src/main/resources/**"]),
-    scaladoc = False,
-    tags = ["maven_coordinates=com.daml:canton-community-ledger-ledger-api-core:__VERSION__"],
     unused_dependency_checker_mode = "error",
     visibility = [
-        "//daml-script:__subpackages__",
         "//language-support/java:__subpackages__",
-        "//test-common/canton:__subpackages__",
     ],
     deps = [
         ":bindings-java",
@@ -701,15 +675,6 @@ da_scala_library(
         "@maven//:org_typelevel_cats_kernel_2_13",
     ],
 )
-
-# Create empty Scaladoc JAR for uploading to Maven Central
-# Needed as scaladoc for ledger-api-core fails to compile
-scaladoc_jar(
-    name = "community_ledger_ledger-api-core_scaladoc",
-    srcs = [],
-    tags = ["scaladoc"],
-    deps = [],
-) if is_windows == False else None
 
 ### community/ledger/ledger-json-api ###
 

--- a/daml-script/export/integration-tests/reproduces-transactions/BUILD.bazel
+++ b/daml-script/export/integration-tests/reproduces-transactions/BUILD.bazel
@@ -34,7 +34,6 @@ da_scala_test(
     deps = [
         "//:sdk-version-scala-lib",
         "//bazel_tools/runfiles:scala_runfiles",
-        "//canton:community_ledger_ledger-api-core",
         "//canton:community_ledger_ledger-common",
         "//canton:ledger_api_proto_scala",
         "//daml-lf/archive:daml_lf_archive_reader",

--- a/daml-script/export/integration-tests/reproduces-transactions/test/scala/com/daml/script/export/ReproducesTransactions.scala
+++ b/daml-script/export/integration-tests/reproduces-transactions/test/scala/com/daml/script/export/ReproducesTransactions.scala
@@ -8,6 +8,7 @@ import java.util.UUID
 import org.apache.pekko.stream.scaladsl.Sink
 import com.daml.SdkVersion
 import com.daml.bazeltools.BazelRunfiles
+import com.daml.integrationtest.CantonConfig.TimeProviderType
 import com.daml.integrationtest.CantonFixture
 import com.digitalasset.canton.ledger.api.refinements.ApiTypes
 import com.digitalasset.canton.ledger.api.tls.TlsConfiguration
@@ -27,7 +28,6 @@ import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.engine.script.ledgerinteraction.GrpcLedgerClient
 import com.daml.lf.engine.script.{Participants, Runner, ScriptTimeMode}
 import com.daml.lf.language.Ast.Package
-import com.digitalasset.canton.platform.apiserver.services.TimeProviderType
 import org.scalatest._
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.matchers.should.Matchers

--- a/daml-script/runner/BUILD.bazel
+++ b/daml-script/runner/BUILD.bazel
@@ -119,7 +119,6 @@ da_scala_test(
     ],
     deps = [
         "//bazel_tools/runfiles:scala_runfiles",
-        "//canton:community_ledger_ledger-api-core",
         "//canton:community_ledger_ledger-common",
         "//canton:ledger_api_proto_scala",
         "//daml-lf/archive:daml_lf_archive_reader",

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -174,7 +174,6 @@ da_scala_library(
     visibility = ["//visibility:public"],
     deps = [
         "//bazel_tools/runfiles:scala_runfiles",
-        "//canton:community_ledger_ledger-api-core",
         "//canton:community_ledger_ledger-common",
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/data",
@@ -375,7 +374,6 @@ da_scala_test_suite(
     deps = [
         ":test-utils",
         "//bazel_tools/runfiles:scala_runfiles",
-        "//canton:community_ledger_ledger-api-core",
         "//canton:community_ledger_ledger-common",
         "//daml-lf/api-type-signature",
         "//daml-lf/archive:daml_lf_archive_reader",
@@ -449,7 +447,6 @@ da_scala_test_suite(
     deps = [
         ":test-utils",
         "//bazel_tools/runfiles:scala_runfiles",
-        "//canton:community_ledger_ledger-api-core",
         "//canton:community_ledger_ledger-common",
         "//daml-lf/api-type-signature",
         "//daml-lf/archive:daml_lf_archive_reader",

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractScriptTest.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractScriptTest.scala
@@ -7,6 +7,7 @@ package test
 
 import java.nio.file.{Path, Paths}
 import com.daml.bazeltools.BazelRunfiles.rlocation
+import com.daml.integrationtest.CantonConfig.TimeProviderType
 import com.daml.integrationtest.CantonFixture
 import com.daml.ledger.api.testing.utils.PekkoBeforeAndAfterAll
 import com.daml.lf.data.{ImmArray, Ref}
@@ -14,7 +15,6 @@ import com.daml.lf.engine.script.ledgerinteraction.{GrpcLedgerClient, ScriptLedg
 import com.daml.lf.language.{Ast, LanguageMajorVersion, StablePackages}
 import com.daml.lf.speedy.{ArrayList, SValue}
 import com.daml.lf.value.Value
-import com.digitalasset.canton.platform.apiserver.services.TimeProviderType
 import org.scalatest.Suite
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/DamlScriptTestRunner.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/DamlScriptTestRunner.scala
@@ -4,8 +4,8 @@
 package com.daml.lf.engine.script
 
 import com.daml.bazeltools.BazelRunfiles
+import com.daml.integrationtest.CantonConfig.TimeProviderType
 import com.daml.integrationtest.CantonFixture
-import com.digitalasset.canton.platform.apiserver.services.TimeProviderType
 import com.daml.scalautil.Statement.discard
 import org.scalatest.{Assertion, Suite}
 import org.scalatest.matchers.should.Matchers

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -410,7 +410,6 @@ da_scala_test(
         ":ledger-tests-model",
         "//bazel_tools/runfiles:scala_runfiles",
         "//canton:bindings-java",
-        "//canton:community_ledger_ledger-api-core",
         "//canton:community_ledger_ledger-common",
         "//daml-lf/data",
         "//libs-scala/ledger-resources",

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -197,36 +197,13 @@
   type: jar-scala
 - target: //observability/pekko-http-metrics:pekko-http-metrics
   type: jar-scala
-
-# Some temporary until slimmed canton LedgerClient created.
-
-- target: //canton:community_admin-api
-  type: jar-scala
-- target: //canton:community_base
-  type: jar-scala
-- target: //canton:community_buildinfo
-  type: jar-scala
-- target: //canton:community_common
-  type: jar-scala
-- target: //canton:community_ledger_ledger-api-core
-  type: jar-scala
 - target: //canton:community_ledger_ledger-common
   type: jar-scala
 - target: //canton:community_ledger_ledger-common_configuration_proto_java
   type: jar-proto
-- target: //canton:community_lib_Blake2b
-  type: jar-lib
-- target: //canton:community_lib_slick_slick-fork
-  type: jar-scala
-- target: //canton:community_lib_wartremover
-  type: jar-scala
-- target: //canton:community_util-external
-  type: jar-scala
 - target: //canton:community_util-logging
   type: jar-scala
 - target: //canton:daml-common-staging_daml-errors
-  type: jar-scala
-- target: //canton:pekko-stream-patch
   type: jar-scala
 
 

--- a/test-common/canton/it-lib/BUILD.bazel
+++ b/test-common/canton/it-lib/BUILD.bazel
@@ -26,7 +26,6 @@ da_scala_library(
     visibility = ["//visibility:public"],
     deps = [
         "//bazel_tools/runfiles:scala_runfiles",
-        "//canton:community_ledger_ledger-api-core",
         "//canton:community_ledger_ledger-common",
         "//canton:community_util-logging",
         "//canton:ledger_api_proto_scala",

--- a/test-common/canton/it-lib/src/main/com/daml/CantonConfig.scala
+++ b/test-common/canton/it-lib/src/main/com/daml/CantonConfig.scala
@@ -10,7 +10,6 @@ import com.digitalasset.canton.ledger.api.tls.TlsConfiguration
 import com.digitalasset.canton.ledger.client.{GrpcChannel, LedgerClient}
 import com.daml.ledger.resources.ResourceOwner
 import com.daml.lf.data.Ref
-import com.digitalasset.canton.platform.apiserver.services.TimeProviderType
 import com.daml.ports.Port
 import io.grpc.ManagedChannel
 import io.grpc.netty.NettyChannelBuilder
@@ -40,6 +39,11 @@ object CantonConfig {
 
   def noTlsConfig = TlsConfiguration(false)
 
+  sealed abstract class TimeProviderType extends Product with Serializable
+  object TimeProviderType {
+    case object Static extends TimeProviderType
+    case object WallClock extends TimeProviderType
+  }
 }
 
 final case class CantonConfig(
@@ -47,7 +51,7 @@ final case class CantonConfig(
     authSecret: Option[String] = None,
     devMode: Boolean = false,
     nParticipants: Int = 1,
-    timeProviderType: TimeProviderType = TimeProviderType.WallClock,
+    timeProviderType: CantonConfig.TimeProviderType = CantonConfig.TimeProviderType.WallClock,
     tlsEnable: Boolean = false,
     debug: Boolean = false,
     bootstrapScript: Option[String] = None,

--- a/test-common/canton/it-lib/src/main/com/daml/CantonFixture.scala
+++ b/test-common/canton/it-lib/src/main/com/daml/CantonFixture.scala
@@ -14,7 +14,6 @@ import com.daml.ledger.api.testing.utils.{
 import com.digitalasset.canton.ledger.client.LedgerClient
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.lf.data.Ref
-import com.digitalasset.canton.platform.apiserver.services.TimeProviderType
 import com.daml.ports.Port
 import org.scalatest.Suite
 
@@ -49,6 +48,7 @@ trait CantonFixtureWithResource[A]
     with PekkoBeforeAndAfterAll
     with SuiteResourceManagementAroundAll {
   self: Suite =>
+  import CantonConfig.TimeProviderType
 
   protected lazy val authSecret: Option[String] = Option.empty
   protected lazy val darFiles: List[Path] = List.empty

--- a/test-common/canton/it-lib/src/main/com/daml/CantonRunner.scala
+++ b/test-common/canton/it-lib/src/main/com/daml/CantonRunner.scala
@@ -10,7 +10,6 @@ import com.daml.jwt.domain.DecodedJwt
 import com.daml.lf.data.Ref
 import com.digitalasset.canton.ledger.api.auth
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
-import com.digitalasset.canton.platform.apiserver.services.TimeProviderType
 import com.daml.ports.{LockedFreePort, PortLock}
 import com.daml.scalautil.Statement.discard
 import com.daml.timer.RetryStrategy
@@ -25,6 +24,7 @@ import java.nio.file.{Files, Path, Paths}
 import scala.concurrent.ExecutionContext
 
 object CantonRunner {
+  import CantonConfig.TimeProviderType
 
   private[integrationtest] def toJson(s: String): String = JsString(s).toString()
   private[integrationtest] def toJson(path: Path): String = toJson(path.toString)


### PR DESCRIPTION
Following Marcin's work on refactoring ledger-common, we can now remove the dependency on ledger-api-core for many of our components. This also allows us to reduce the artifacts we push to maven.
