### PR TITLE
Removed ExecutorServiceMetrics from InstrumentedExecutors.

### DIFF
--- a/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/index/InMemoryStateUpdater.scala
+++ b/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/index/InMemoryStateUpdater.scala
@@ -101,14 +101,12 @@ private[platform] object InMemoryStateUpdater {
       InstrumentedExecutors.newWorkStealingExecutor(
         metrics.daml.lapi.threadpool.indexBypass.prepareUpdates,
         prepareUpdatesParallelism,
-        metrics.executorServiceMetrics,
       )
     )
     updateCachesExecutor <- ResourceOwner.forExecutorService(() =>
       InstrumentedExecutors.newFixedThreadPool(
         metrics.daml.lapi.threadpool.indexBypass.updateInMemoryState,
         1,
-        metrics.executorServiceMetrics,
       )
     )
     logger = loggerFactory.getTracedLogger(getClass)

--- a/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/index/IndexServiceOwner.scala
+++ b/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/index/IndexServiceOwner.scala
@@ -218,7 +218,6 @@ final class IndexServiceOwner(
         InstrumentedExecutors.newWorkStealingExecutor(
           metrics.daml.lapi.threadpool.inMemoryFanOut.toString,
           threadPoolSize,
-          metrics.executorServiceMetrics,
         )
       )
 

--- a/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/indexer/parallel/AsyncSupport.scala
+++ b/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/indexer/parallel/AsyncSupport.scala
@@ -36,14 +36,13 @@ object AsyncSupport {
     val logger = loggerFactory.getTracedLogger(getClass)
     ResourceOwner
       .forExecutorService { () =>
-        val (executorName, executorServiceMetrics) = withMetric
+        val (executorName, _executorServiceMetrics) = withMetric
         InstrumentedExecutors.newFixedThreadPoolWithFactory(
           executorName,
           size,
           new ThreadFactoryBuilder()
             .setNameFormat(s"$namePrefix-%d")
             .build,
-          executorServiceMetrics,
           throwable =>
             logger
               .error(s"ExecutionContext $namePrefix has failed with an exception", throwable),

--- a/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/indexer/parallel/ParallelIndexerFactory.scala
+++ b/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/indexer/parallel/ParallelIndexerFactory.scala
@@ -82,7 +82,6 @@ object ParallelIndexerFactory {
                     "ha-coordinator",
                     1,
                     new ThreadFactoryBuilder().setNameFormat("ha-coordinator-%d").build,
-                    metrics.executorServiceMetrics,
                     throwable =>
                       logger
                         .error(

--- a/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/DbDispatcher.scala
+++ b/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/DbDispatcher.scala
@@ -169,7 +169,6 @@ object DbDispatcher {
                     .error("Uncaught exception in the SQL executor.", e)(TraceContext.empty)
                 )
                 .build(),
-              metrics.executorServiceMetrics,
             ),
           gracefulAwaitTerminationMillis =
             5000, // waiting 5s for ongoing SQL operations to finish and then forcing them with Thread.interrupt...

--- a/libs-scala/executors/BUILD.bazel
+++ b/libs-scala/executors/BUILD.bazel
@@ -13,6 +13,5 @@ da_scala_library(
     visibility = ["//visibility:public"],
     deps = [
         "//libs-scala/scala-utils",
-        "//observability/metrics",
     ],
 )

--- a/libs-scala/executors/src/main/scala/com/daml/executors/InstrumentedExecutors.scala
+++ b/libs-scala/executors/src/main/scala/com/daml/executors/InstrumentedExecutors.scala
@@ -6,7 +6,6 @@ package com.daml.executors
 import java.util.concurrent.{ThreadFactory, Executors => JavaExecutors}
 
 import com.daml.executors.executors.QueueAwareExecutionContextExecutorService
-import com.daml.metrics.ExecutorServiceMetrics
 
 import scala.concurrent.ExecutionContext
 
@@ -15,14 +14,11 @@ object InstrumentedExecutors {
   def newWorkStealingExecutor(
       name: String,
       parallelism: Int,
-      executorServiceMetrics: ExecutorServiceMetrics,
       errorReporter: Throwable => Unit = ExecutionContext.defaultReporter,
   ): QueueAwareExecutionContextExecutorService = {
     val executorService = JavaExecutors.newWorkStealingPool(parallelism)
-    val executorServiceWithMetrics = executorServiceMetrics
-      .monitorExecutorService(name, executorService)
     new QueueAwareExecutionContextExecutorService(
-      executorServiceWithMetrics,
+      executorService,
       name,
       errorReporter,
     )
@@ -31,14 +27,11 @@ object InstrumentedExecutors {
   def newFixedThreadPool(
       name: String,
       nThreads: Int,
-      executorServiceMetrics: ExecutorServiceMetrics,
       errorReporter: Throwable => Unit = ExecutionContext.defaultReporter,
   ): QueueAwareExecutionContextExecutorService = {
     val executorService = JavaExecutors.newFixedThreadPool(nThreads)
-    val executorServiceWithMetrics = executorServiceMetrics
-      .monitorExecutorService(name, executorService)
     new QueueAwareExecutionContextExecutorService(
-      executorServiceWithMetrics,
+      executorService,
       name,
       errorReporter,
     )
@@ -48,14 +41,11 @@ object InstrumentedExecutors {
       name: String,
       nThreads: Int,
       threadFactory: ThreadFactory,
-      executorServiceMetrics: ExecutorServiceMetrics,
       errorReporter: Throwable => Unit = ExecutionContext.defaultReporter,
   ): QueueAwareExecutionContextExecutorService = {
     val executorService = JavaExecutors.newFixedThreadPool(nThreads, threadFactory)
-    val executorServiceWithMetrics = executorServiceMetrics
-      .monitorExecutorService(name, executorService)
     new QueueAwareExecutionContextExecutorService(
-      executorServiceWithMetrics,
+      executorService,
       name,
       errorReporter,
     )
@@ -64,14 +54,11 @@ object InstrumentedExecutors {
   def newCachedThreadPoolWithFactory(
       name: String,
       threadFactory: ThreadFactory,
-      executorServiceMetrics: ExecutorServiceMetrics,
       errorReporter: Throwable => Unit = ExecutionContext.defaultReporter,
   ): QueueAwareExecutionContextExecutorService = {
     val executorService = JavaExecutors.newCachedThreadPool(threadFactory)
-    val executorServiceWithMetrics = executorServiceMetrics
-      .monitorExecutorService(name, executorService)
     new QueueAwareExecutionContextExecutorService(
-      executorServiceWithMetrics,
+      executorService,
       name,
       errorReporter,
     )


### PR DESCRIPTION
ExecutorService metrics are removed from InstrumentedExecutors since they are not used anymore. 
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
