### PR TITLE
Revert "[Backport 2.8.x] Bump grpc-java to 1.60.0"

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -278,9 +278,9 @@ def daml_deps():
     if "io_grpc_grpc_java" not in native.existing_rules():
         http_archive(
             name = "io_grpc_grpc_java",
-            strip_prefix = "grpc-java-1.60.0",
-            urls = ["https://github.com/grpc/grpc-java/archive/v1.60.0.tar.gz"],
-            sha256 = "02c9a7f9400d4e29c7e55667851083a9f695935081787079a834da312129bf97",
+            strip_prefix = "grpc-java-1.59.0",
+            urls = ["https://github.com/grpc/grpc-java/archive/v1.59.0.tar.gz"],
+            sha256 = "3bcf6be49fc7ab8187577a5211421258cb8e6d179f46023cc82e42e3a6188e51",
         )
 
     if "com_github_johnynek_bazel_jar_jar" not in native.existing_rules():


### PR DESCRIPTION
Reverts digital-asset/daml#18317

This is partial (missing https://github.com/digital-asset/daml/blob/3571bbd63b662eb14dac7b504e5bae150f6ef26f/bazel-java-deps.bzl#L50) and we are not able to do the bu,p in Canton because of the deadline for 2.8.1

Reverting for now and we will ship for 2.8.2