### PR TITLE
Remove package name defaulting

### DIFF
--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TestNodeBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TestNodeBuilder.scala
@@ -33,9 +33,7 @@ trait TestNodeBuilder {
       signatories: Set[Party],
       observers: Set[Party] = Set.empty,
       key: CreateKey = CreateKey.NoKey,
-      // TODO: https://github.com/digital-asset/daml/issues/17995
-      //  review if we should really provide a defaul package name.
-      packageName: PackageName = Ref.PackageName.assertFromString("package-name"),
+      packageName: Option[PackageName] = None,
       version: CreateTransactionVersion = CreateTransactionVersion.StableMax,
       agreementText: String = "",
   ): Node.Create = {
@@ -73,8 +71,7 @@ trait TestNodeBuilder {
 
     Node.Create(
       coid = id,
-      packageName =
-        if (transactionVersion < TransactionVersion.minUpgrade) None else Some(packageName),
+      packageName = packageName.filter(_ => transactionVersion < TransactionVersion.minUpgrade),
       templateId = templateId,
       arg = argument,
       agreementText = agreementText,

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -36,8 +36,6 @@ object Node {
 
     private[lf] def updateVersion(version: TransactionVersion): Node
 
-    // TODO: https://github.com/digital-asset/daml/issues/17965
-    //  make it mandatory in daml 3
     def packageName: Option[PackageName]
 
     def templateId: TypeConName
@@ -85,9 +83,7 @@ object Node {
   /** Denotes the creation of a contract instance. */
   final case class Create(
       coid: ContractId,
-      // TODO: https://github.com/digital-asset/daml/issues/17995
-      //  remove default value once canton handle it.
-      override val packageName: Option[PackageName] = None,
+      override val packageName: Option[PackageName],
       override val templateId: TypeConName,
       arg: Value,
       agreementText: String,
@@ -127,9 +123,7 @@ object Node {
   /** Denotes that the contract identifier `coid` needs to be active for the transaction to be valid. */
   final case class Fetch(
       coid: ContractId,
-      // TODO: https://github.com/digital-asset/daml/issues/17995
-      //  remove default value once canton handle it.
-      override val packageName: Option[PackageName] = None,
+      override val packageName: Option[PackageName],
       override val templateId: TypeConName,
       actingParties: Set[Party],
       signatories: Set[Party],
@@ -161,9 +155,7 @@ object Node {
     */
   final case class Exercise(
       targetCoid: ContractId,
-      // TODO: https://github.com/digital-asset/daml/issues/17995
-      //  remove default value once canton handle it.
-      override val packageName: Option[PackageName] = None,
+      override val packageName: Option[PackageName],
       override val templateId: TypeConName,
       interfaceId: Option[TypeConName],
       choiceId: ChoiceName,
@@ -217,9 +209,7 @@ object Node {
   }
 
   final case class LookupByKey(
-      // TODO: https://github.com/digital-asset/daml/issues/17995
-      //  remove default value once canton handle it.
-      override val packageName: Option[PackageName] = None,
+      override val packageName: Option[PackageName],
       override val templateId: TypeConName,
       key: GlobalKeyWithMaintainers,
       result: Option[ContractId],

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -166,9 +166,7 @@ object Value {
   /** A contract instance is a value plus the template that originated it. */
   // Prefer to use transaction.FatContractInstance
   final case class ContractInstance(
-      // TODO: https://github.com/digital-asset/daml/issues/17995
-      //  remove default value once canton handle it.
-      packageName: Option[Ref.PackageName] = None,
+      packageName: Option[Ref.PackageName],
       template: Identifier,
       arg: Value,
   ) extends CidContainer[ContractInstance] {
@@ -200,9 +198,7 @@ object Value {
 
   object VersionedContractInstance {
     def apply(
-        // TODO: https://github.com/digital-asset/daml/issues/17
-        //  remove default value once canton handle it.
-        packageName: Option[Ref.PackageName] = None,
+        packageName: Option[Ref.PackageName],
         template: Identifier,
         arg: VersionedValue,
     ): VersionedContractInstance =

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionNodeStatisticsSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionNodeStatisticsSpec.scala
@@ -60,7 +60,7 @@ class TransactionNodeStatisticsSpec
       val parties = Set(b.newParty)
       b.create(
         id = b.newCid,
-        packageName = b.newPackageName,
+        packageName = Some(b.newPackageName),
         templateId = b.newIdentifier,
         argument = Value.ValueUnit,
         signatories = parties,


### PR DESCRIPTION
Following on from https://github.com/DACH-NY/canton/pull/16712 package name defaulting can now be removed from daml.