### PR TITLE
[dev-env removal] standardize nix-shell (init)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,10 +1,15 @@
+use nix
+
+PATH_add bin
+
+[[ -f .envrc.private ]] && source_env .envrc.private
+
+## LEGACY
+
 echo "[dev-env] Setting up DA Development Environment"
 eval "$(dev-env/bin/dade assist)"
 
 DADE_PRE_COMMIT_HOOK_TYPE=pre-push
-
-# Load private overrides
-[[ -f .envrc.private ]] && source_env .envrc.private
 
 if [ -n "${ARTIFACTORY_USERNAME:-}" ] && [ -n "${ARTIFACTORY_PASSWORD:-}" ]; then
     export ARTIFACTORY_AUTH=$(echo -n "$ARTIFACTORY_USERNAME:$ARTIFACTORY_PASSWORD" | base64 -w0)

--- a/bin/update-nixpkgs
+++ b/bin/update-nixpkgs
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+branch=$(jq -r '.branch' $DIR/../nix/src.json)
+repo=$(jq -r '.repo' $DIR/../nix/src.json)
+owner=$(jq -r '.owner' $DIR/../nix/src.json)
+
+commit=$(curl --silent \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/$owner/$repo/branches/$branch \
+         | jq -r .commit.sha)
+
+archive_sha=$(nix-prefetch-url \
+                 https://github.com/$owner/$repo/archive/$commit.tar.gz \
+                 --unpack \
+              2>/dev/null)
+
+jq -n \
+   --arg branch $branch \
+   --arg repo $repo \
+   --arg owner $owner \
+   --arg rev $commit \
+   --arg sha256 $archive_sha \
+   '{$owner, $repo, $branch, $rev, $sha256}' \
+   > $DIR/../nix/src.json

--- a/nix/new-nixpkgs.nix
+++ b/nix/new-nixpkgs.nix
@@ -1,0 +1,7 @@
+let
+  spec = builtins.fromJSON (builtins.readFile ./src.json);
+in
+  import (builtins.fetchTarball {
+    url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
+    sha256 = spec.sha256;
+  }) {}

--- a/nix/src.json
+++ b/nix/src.json
@@ -1,0 +1,7 @@
+{
+  "owner": "NixOS",
+  "repo": "nixpkgs",
+  "branch": "nixpkgs-unstable",
+  "rev": "9a82a9b5248919805a2400266ebd881d5783df2a",
+  "sha256": "142x1zq3cjadgmvfv0paydlq268pfinllqpq2vl0vxwdiq2nr9iz"
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,11 +1,10 @@
-{ pkgs ? import ./nix/nixpkgs.nix { }
-, default ? import ./nix/default.nix { inherit pkgs; }
-}:
+let
+  pkgs = import ./nix/new-nixpkgs.nix;
+in
 pkgs.mkShell {
-  buildInputs = pkgs.lib.attrsets.mapAttrsToList (name: value: value) default.toolAttrs;
-
-  shellHook = ''
-    # install pre-commit hook (opt-out by setting `DADE_NO_PRE_COMMIT`)
-    test "x$DADE_NO_PRE_COMMIT" = x && pre-commit install
-  '';
+  buildInputs = with pkgs; [
+    bash
+    curl
+    jq
+  ];
 }


### PR DESCRIPTION
I'd like to remove `dev-env`. It's served us well, but its original ambitions were to go way beyond a simple `nix-shell` equivalent, and now that it's all we're using it for it doesn't really add much anymore.

Using a standard nix-shell setup would reduce the complexity of this repo and make it easier for other developers to jump in. It would also somewhat reduce the dev-env verbosity, which is a minor annoyance.

This is, however, a big change, and I don't think trying to do it in one go is a great idea. So instead I'm setting a foundation in this PR and plan to move step by step over several follow-up PRs. In this one I just add a small default nix-shell configuration and add it to `.envrc`. In follow-up PRs, I'll be moving paclages over from the dev-env configuration to the nix shell, up to the point where dev-env is just an empty shell that we can easily remove.

This PR also serves as a not-so-implicit way of gathering support for this plan.