### PR TITLE
remove support of retroactie interface instance in api-type-signature

### DIFF
--- a/canton/community/ledger/ledger-json-api/src/main/scala/com/digitalasset/canton/http/PackageService.scala
+++ b/canton/community/ledger/ledger-json-api/src/main/scala/com/digitalasset/canton/http/PackageService.scala
@@ -49,7 +49,7 @@ class PackageService(
   ) {
 
     def append(diff: PackageStore): State = {
-      val newPackageStore = appendAndResolveRetroactiveInterfaces(resolveChoicesIn(diff))
+      val newPackageStore = this.packageStore ++ resolveChoicesIn(diff)
       val (tpIdMap, ifaceIdMap) = getTemplateIdInterfaceMaps(newPackageStore)
       State(
         packageIds = newPackageStore.keySet,
@@ -66,17 +66,6 @@ class PackageService(
       def lookupIf(pkgId: Ref.PackageId) = (packageStore get pkgId) orElse (diff get pkgId)
       val findIface = typesig.PackageSignature.findInterface(Function unlift lookupIf)
       diff.transform((_, iface) => iface resolveChoicesAndIgnoreUnresolvedChoices findIface)
-    }
-
-    private[this] def appendAndResolveRetroactiveInterfaces(diff: PackageStore): PackageStore = {
-      def lookupIf(packageStore: PackageStore, pkId: Ref.PackageId) =
-        packageStore
-          .get(pkId)
-          .map((_, { (newSig: typesig.PackageSignature) => packageStore.updated(pkId, newSig) }))
-
-      val (packageStore2, diffElems) =
-        typesig.PackageSignature.resolveRetroImplements(packageStore, diff.values.toSeq)(lookupIf)
-      packageStore2 ++ diffElems.view.map(p => (p.packageId, p))
     }
   }
 

--- a/daml-lf/api-type-signature/src/main/scala/lf/typesig/EnvironmentSignature.scala
+++ b/daml-lf/api-type-signature/src/main/scala/lf/typesig/EnvironmentSignature.scala
@@ -8,8 +8,6 @@ import com.daml.lf.archive.Dar
 import data.Ref, Ref.{Identifier, PackageId}
 
 import scala.collection.immutable.Map
-import scalaz.std.tuple._
-import scalaz.syntax.functor._
 import scalaz.syntax.std.map._
 import scalaz.Semigroup
 
@@ -46,21 +44,6 @@ final case class EnvironmentSignature(
         case z: TypeDecl.Normal => z
       }
     })
-
-  def resolveRetroImplements: EnvironmentSignature = {
-    import PackageSignature.findTemplate
-    val (newTypeDecls, newInterfaces) = interfaces.foldLeft((typeDecls, interfaces)) {
-      case ((typeDecls, interfaces), (ifTc, defIf)) =>
-        defIf
-          .resolveRetroImplements(ifTc, typeDecls) { case (typeDecls, tplName) =>
-            findTemplate(typeDecls, tplName) map { itt => f =>
-              typeDecls.updated(tplName, itt.copy(template = f(itt.template)))
-            }
-          }
-          .map(defIf => interfaces.updated(ifTc, defIf))
-    }
-    copy(typeDecls = newTypeDecls, interfaces = newInterfaces)
-  }
 
   def resolveInterfaceViewType(tcn: Ref.TypeConName): Option[DefInterface.ViewTypeFWT] =
     typeDecls get tcn flatMap (_.asInterfaceViewType)

--- a/daml-lf/api-type-signature/src/main/scala/lf/typesig/PackageSignature.scala
+++ b/daml-lf/api-type-signature/src/main/scala/lf/typesig/PackageSignature.scala
@@ -11,11 +11,9 @@ import reader.Errors
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.lf.archive.ArchivePayload
 import scalaz.std.either._
-import scalaz.std.tuple._
 import scalaz.syntax.bifunctor._
-import scalaz.syntax.std.boolean._
 
-import scala.collection.immutable.{Map, SeqOps}
+import scala.collection.immutable.Map
 import scala.jdk.CollectionConverters._
 
 // Duplicate of the one in com.daml.lf.language to separate Ast and Iface
@@ -100,40 +98,6 @@ final case class PackageSignature(
       findInterface: PartialFunction[Ref.TypeConName, DefInterface.FWT]
   ): PackageSignature = resolveChoices(findInterface, failIfUnresolvedChoicesLeft = false)
 
-  /** Update internal templates, as well as external templates via `setTemplates`,
-    * with retroactive interface implementations.
-    *
-    * @param setTemplate Used to look up templates that can't be found in this
-    *                    interface
-    */
-  private def resolveRetroImplements[S](
-      s: S
-  )(setTemplate: SetterAt[Ref.TypeConName, S, DefTemplate.FWT]): (S, PackageSignature) = {
-    type SandTpls = (S, Map[QualifiedName, TypeDecl.Template])
-    def setTpl(
-        sm: SandTpls,
-        tcn: Ref.TypeConName,
-    ): Option[(DefTemplate.FWT => DefTemplate.FWT) => SandTpls] = {
-      import PackageSignature.findTemplate
-      val (s, tplsM) = sm
-      if (tcn.packageId == packageId)
-        findTemplate(tplsM orElse typeDecls, tcn.qualifiedName).map {
-          case itt @ TypeDecl.Template(_, dt) =>
-            f => (s, tplsM.updated(tcn.qualifiedName, itt.copy(template = f(dt))))
-        }
-      else setTemplate(s, tcn) map (_ andThen ((_, tplsM)))
-    }
-
-    val ((sEnd, newTpls), newIfcs) = interfaces.foldLeft(
-      ((s, Map.empty): SandTpls, Map.empty[QualifiedName, DefInterface.FWT])
-    ) { case ((s, astIfs), (ifcName, astIf)) =>
-      astIf
-        .resolveRetroImplements(Ref.TypeConName(packageId, ifcName), s)(setTpl)
-        .rightMap(newIf => astIfs.updated(ifcName, newIf))
-    }
-    (sEnd, copy(typeDecls = typeDecls ++ newTpls, interfaces = newIfcs))
-  }
-
   private def resolveInterfaceViewType(n: Ref.QualifiedName): Option[Record.FWT] =
     typeDecls get n flatMap (_.asInterfaceViewType)
 }
@@ -191,55 +155,6 @@ object PackageSignature {
       k: K,
   ): Option[TypeDecl.Template] =
     m.lift(k) collect { case itt: TypeDecl.Template => itt }
-
-  // Given a lookup function for package state setters, produce a lookup function
-  // for setters on specific templates in that set of packages.
-  private[this] def setPackageTemplates[S](
-      findPackage: GetterSetterAt[PackageId, S, PackageSignature]
-  ): SetterAt[Ref.TypeConName, S, DefTemplate.FWT] = {
-    def go(s: S, tcn: Ref.TypeConName): Option[(DefTemplate.FWT => DefTemplate.FWT) => S] = for {
-      foundPkg <- findPackage(s, tcn.packageId)
-      (ifc, sIfc) = foundPkg
-      itt <- findTemplate(ifc.typeDecls, tcn.qualifiedName)
-    } yield f =>
-      sIfc(
-        ifc.copy(typeDecls =
-          ifc.typeDecls.updated(tcn.qualifiedName, itt.copy(template = f(itt.template)))
-        )
-      )
-    go
-  }
-
-  /** Extend the set of interfaces represented by `s` and `findPackage` with
-    * `newSignatures`.  Produce the resulting `S` and a replacement copy of
-    * `newSignatures` with templates and interfaces therein resolved.
-    *
-    * Does not search members of `s` for fresh interfaces.
-    */
-  def resolveRetroImplements[S, CC[B] <: Seq[B] with SeqOps[B, CC, CC[B]]](
-      s: S,
-      newSignatures: CC[PackageSignature],
-  )(
-      findPackage: GetterSetterAt[PackageId, S, PackageSignature]
-  ): (S, CC[PackageSignature]) = {
-    type St = (S, CC[PackageSignature])
-    val findTpl = setPackageTemplates[St] { case ((s, newSignatures), pkgId) =>
-      findPackage(s, pkgId).map(_.rightMap(_ andThen ((_, newSignatures)))).orElse {
-        val ix = newSignatures indexWhere (_.packageId == pkgId)
-        (ix >= 0) option ((newSignatures(ix), newSig => (s, newSignatures.updated(ix, newSig))))
-      }
-    }
-
-    (0 until newSignatures.size).foldLeft((s, newSignatures)) {
-      case (st @ (_, newSignatures), ifcK) =>
-        val ((s2, newSignatures2), newAtIfcK) =
-          newSignatures(ifcK).resolveRetroImplements(st)(findTpl)
-        // the tricky part here: newSignatures2 is guaranteed not to have altered
-        // the value at ifcK, and to have made all "self" changes in newAtIfcK.
-        // So there is no conflict, we can discard the value in the seq
-        (s2, newSignatures2.updated(ifcK, newAtIfcK))
-    }
-  }
 
   /** An argument for [[PackageSignature#resolveChoices]] given a package database,
     * such as json-api's `LedgerReader.PackageStore`.

--- a/daml-lf/api-type-signature/src/main/scala/lf/typesig/reader/SignatureReader.scala
+++ b/daml-lf/api-type-signature/src/main/scala/lf/typesig/reader/SignatureReader.scala
@@ -260,7 +260,7 @@ object SignatureReader {
           s"interface view type ${astIf.view.pretty} must be either a no-argument type reference or unit",
         )
     }
-  } yield name -> typesig.DefInterface(choices, Set.empty, viewType)
+  } yield name -> typesig.DefInterface(choices, viewType)
 
   private[lf] def toIfaceType(
       ctx: QualifiedName,

--- a/daml-lf/api-type-signature/src/test/scala/lf/typesig/reader/SignatureReaderSpec.scala
+++ b/daml-lf/api-type-signature/src/test/scala/lf/typesig/reader/SignatureReaderSpec.scala
@@ -201,14 +201,6 @@ class SignatureReaderSpec extends AnyWordSpec with Matchers with Inside {
     }
     lazy val itpES = EnvironmentSignature.fromPackageSignatures(itp).resolveChoices
 
-    lazy val itpWithoutRetroImplements = itp.copy(
-      main = itp.main.copy(
-        interfaces = itp.main.interfaces - qn("RetroInterface:RetroIf")
-      )
-    )
-    lazy val itpESWithoutRetroImplements =
-      EnvironmentSignature.fromPackageSignatures(itpWithoutRetroImplements).resolveChoices
-
     "load without errors" in {
       itp shouldBe itp
     }
@@ -328,13 +320,6 @@ class SignatureReaderSpec extends AnyWordSpec with Matchers with Inside {
         Useless -> Set(Some(Ref.Identifier(itpPid, TIf)), Some(Ref.Identifier(itpPid, LibTIf))),
         Bar -> Set(None),
       )
-    }
-
-    "resolve retro implements harmlessly when there are none" in {
-      PackageSignature.resolveRetroImplements((), itpWithoutRetroImplements.all)((_, _) =>
-        None
-      ) should ===((), itpWithoutRetroImplements.all)
-      itpESWithoutRetroImplements.resolveRetroImplements should ===(itpESWithoutRetroImplements)
     }
   }
 

--- a/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/dependencygraph/DependencyGraphSpec.scala
+++ b/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/dependencygraph/DependencyGraphSpec.scala
@@ -52,7 +52,6 @@ final class DependencyGraphSpec extends AnyWordSpec with Matchers {
                   returnType = TypeCon(TypeConName(baz), ImmArraySeq.empty),
                 )
               ),
-              retroImplements = Set.empty,
               viewType = Some(vt),
             )
           ),

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
@@ -167,20 +167,18 @@ object CodeGenRunner extends StrictLogging {
       Reference.Module(id.packageId, id.qualifiedName.module)
     }
 
-    val resolvedSignatures = resolveRetroInterfaces(signatures)
-
     implicit val resolvedPrefixes: PackagePrefixes =
       PackagePrefixes(
         resolvePackagePrefixes(
           packagePrefixes,
           modulePrefixes,
-          resolvedSignatures,
+          signatures,
           generatedModuleIds,
         )
       )
 
     new CodeGenRunner.Scope(
-      resolvedSignatures,
+      signatures,
       transitiveClosure.serializableTypes,
     )
   }
@@ -270,11 +268,6 @@ object CodeGenRunner extends StrictLogging {
       logger.trace(s"Daml-LF Archive decoded, packageId '${interface.packageId}'")
       interface
     }
-
-  private[this] def resolveRetroInterfaces(
-      signatures: Seq[PackageSignature]
-  ): Seq[PackageSignature] =
-    PackageSignature.resolveRetroImplements((), signatures)((_, _) => None)._2
 
   /** Given the package prefixes specified per DAR and the module-prefixes specified in
     * daml.yaml, produce the combined prefixes per package id.


### PR DESCRIPTION
mostly a revert of #14192  
This target only daml-3, retroactive instance will stay in Daml 2.x

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
