### PR TITLE
Address LF2 TODOs in the daml repo

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -1124,9 +1124,6 @@ da_haskell_test(
 daml_compile(
     name = "pkg-manager-test",
     srcs = glob(["PkgManagerTest.daml"]),
-    # TODO(https://github.com/digital-asset/daml/issues/17366): delete the
-    #  explicit target once the default major version is 2.
-    target = "2.1",
 )
 
 sh_test(

--- a/compiler/damlc/tests/src/DA/Test/Repl.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl.hs
@@ -41,9 +41,7 @@ main = do
     tests <- forM [minBound @LF.MajorVersion .. maxBound] $ \major -> do
         let lfVersion = LF.defaultOrLatestStable major
         let prettyMajor = LF.renderMajorVersion major
-        -- TODO(#17366): replace with LF.isDevVersion lfVersion once the engine supports running
-        --  LF 2.x dars.
-        let runCantonInDevMode = major == LF.V2
+        let runCantonInDevMode = LF.isDevVersion lfVersion
         scriptDar <- locateRunfiles $ case major of
             LF.V2 -> mainWorkspace </> "daml-script" </> "daml3" </> "daml3-script.dar"
         testDar <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "tests" </> "repl-test-v" <> prettyMajor <.> "dar")

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -91,9 +91,7 @@ withInteractionTester major action = do
                 devNull
                 defaultSandboxConf
                     { dars = testDars
-                    -- TODO(#17366): replace with LF.isDevVersion lfVersion once
-                    --  the engine supports running
-                    , devVersionSupport = major == LF.V2
+                    , devVersionSupport = LF.isDevVersion lfVersion
                     }
             )
             destroySandbox

--- a/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Deployment.hs
+++ b/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Deployment.hs
@@ -173,8 +173,6 @@ writeMinimalProject = do
       , "name: proj1"
       , "version: 0.0.1"
       , "source: ."
-      -- TODO(#17366): Remove this the default LF version is 2
-      , "build-options: [--target=2.1]"
       , "dependencies:"
       , "  - daml-prim"
       , "  - daml-stdlib"

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -64,7 +64,7 @@ import com.daml.scalautil.Statement.discard
   *
   * This class is thread safe as long `nextRandomInt` is.
   */
-class Engine(val config: EngineConfig = Engine.StableConfig) {
+class Engine(val config: EngineConfig) {
 
   config.profileDir.foreach(Files.createDirectories(_))
 
@@ -628,13 +628,7 @@ object Engine {
     }
   }
 
-  private def StableConfig =
-    EngineConfig(allowedLanguageVersions = LanguageVersion.StableVersions)
-
-  def StableEngine(): Engine = new Engine(StableConfig)
-
   def DevEngine(majorLanguageVersion: LanguageMajorVersion): Engine = new Engine(
-    StableConfig.copy(allowedLanguageVersions = LanguageVersion.AllVersions(majorLanguageVersion))
+    EngineConfig(allowedLanguageVersions = LanguageVersion.AllVersions(majorLanguageVersion))
   )
-
 }

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineInfoTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineInfoTest.scala
@@ -19,8 +19,8 @@ class EngineInfoTest extends AnyWordSpec with Matchers {
     ) =
       List(
         LanguageVersion.LegacyVersions,
-        LanguageVersion.StableVersions,
-        LanguageVersion.EarlyAccessVersions,
+        LanguageVersion.StableVersions(LanguageMajorVersion.V2),
+        LanguageVersion.EarlyAccessVersions(LanguageMajorVersion.V2),
         LanguageVersion.AllVersions(LanguageMajorVersion.V2),
       ).map(versions => new EngineInfo(EngineConfig(allowedLanguageVersions = versions)))
 

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineValidatePackagesTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineValidatePackagesTest.scala
@@ -21,11 +21,7 @@ class EngineValidatePackagesTest(majorLanguageVersion: LanguageMajorVersion)
 
   val pkgId = Ref.PackageId.assertFromString("-pkg-")
 
-  // TODO(#17366): use something like LanguageVersion.default(major) once available
-  val langVersion = majorLanguageVersion match {
-    case LanguageMajorVersion.V1 => LanguageVersion.default
-    case LanguageMajorVersion.V2 => LanguageVersion.v2_1
-  }
+  val langVersion = LanguageVersion.defaultOrLatestStable(majorLanguageVersion)
 
   implicit val parserParameters: parser.ParserParameters[this.type] =
     parser.ParserParameters(pkgId, langVersion)

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/PreprocessorSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/PreprocessorSpec.scala
@@ -8,7 +8,7 @@ import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.{Bytes, FrontStack, ImmArray, Ref}
 import com.daml.lf.command.ApiCommand
-import com.daml.lf.language.{Ast, LanguageMajorVersion, LanguageMinorVersion, LanguageVersion}
+import com.daml.lf.language.{Ast, LanguageMajorVersion, LanguageVersion}
 import com.daml.lf.speedy.{ArrayList, Command, DisclosedContract, SValue}
 import com.daml.lf.value.Value.{ContractId, ValueInt64, ValueList, ValueParty, ValueRecord}
 import org.scalatest.{Assertion, Inside, Inspectors}
@@ -287,8 +287,7 @@ final class PreprocessorSpecHelpers(majorLanguageVersion: LanguageMajorVersion) 
   implicit val parserParameters: ParserParameters[this.type] =
     ParserParameters(
       defaultPackageId = Ref.PackageId.assertFromString("-pkgId-"),
-      // TODO(#17366): use something like LanguageVersion.default(major) once available
-      LanguageVersion(majorLanguageVersion, LanguageMinorVersion("dev")),
+      LanguageVersion.defaultOrLatestStable(majorLanguageVersion),
     )
 
   implicit val defaultPackageId: Ref.PackageId = parserParameters.defaultPackageId

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -79,20 +79,13 @@ private[lf] object Compiler {
   )
 
   object Config {
-    def Default(majorLanguageVersion: LanguageMajorVersion) = {
-      majorLanguageVersion match {
-        case LanguageMajorVersion.V1 =>
-          Config(
-            allowedLanguageVersions = LanguageVersion.StableVersions,
-            packageValidation = FullPackageValidation,
-            profiling = NoProfile,
-            stacktracing = NoStackTrace,
-          )
-        // TODO(#17366): once 2.0 is introduced, remove match on major language
-        //  version and use StableVersions(majorLanguageVersion) or similar.
-        case LanguageMajorVersion.V2 => Dev(LanguageMajorVersion.V2)
-      }
-    }
+    def Default(majorLanguageVersion: LanguageMajorVersion) =
+      Config(
+        allowedLanguageVersions = LanguageVersion.StableVersions(majorLanguageVersion),
+        packageValidation = FullPackageValidation,
+        profiling = NoProfile,
+        stacktracing = NoStackTrace,
+      )
 
     def Dev(majorLanguageVersion: LanguageMajorVersion) = Config(
       allowedLanguageVersions = LanguageVersion.AllVersions(majorLanguageVersion),

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TransactionVersionTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TransactionVersionTest.scala
@@ -137,8 +137,7 @@ private[lf] class TransactionVersionTestHelpers(majorLanguageVersion: LanguageMa
     case V1 => (LanguageVersion.default, LanguageVersion.v1_15, LanguageVersion.v1_dev)
     case V2 =>
       (
-        // TODO(#17366): Use something like languageVersion.default(V2) once available
-        LanguageVersion.v2_1,
+        LanguageVersion.defaultOrLatestStable(LanguageMajorVersion.V2),
         LanguageVersion.v2_1,
         LanguageVersion.v2_dev,
       )

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -27,8 +27,6 @@ object LanguageVersion {
 
   def assertFromString(s: String): LanguageVersion = data.assertRight(fromString(s))
 
-  // TODO(#17366): As soon as LF2 introduces breaking changes w.r.t. LF1, this order will no longer
-  //    be total and should be replaced by ad-hoc methods wherever it is used.
   implicit val Ordering: scala.Ordering[LanguageVersion] = {
     case (LanguageVersion(Major.V1, leftMinor), LanguageVersion(Major.V1, rightMinor)) =>
       Major.V1.minorVersionOrdering.compare(leftMinor, rightMinor)
@@ -84,29 +82,53 @@ object LanguageVersion {
 
   }
 
-  // All the stable versions.
-  val StableVersions: VersionRange[LanguageVersion] =
-    VersionRange(min = v2_1, max = v2_1)
+  /** All the stable versions for a given major language version.
+    * Version ranges don't make sense across major language versions because major language versions
+    * break backwards compatibility. Clients of [[VersionRange]] in the codebase assume that all LF
+    * versions in a range are backwards compatible with the older versions within that range. Hence
+    * the majorLanguageVersion parameter.
+    */
+  def StableVersions(majorLanguageVersion: LanguageMajorVersion): VersionRange[LanguageVersion] =
+    majorLanguageVersion match {
+      case Major.V1 => throw new IllegalArgumentException("LF V1 is no longer supported")
+      case Major.V2 => VersionRange(v2_1, v2_1)
+    }
 
-  // Versions of LF that are no longer supported.
+  /** Versions of LF that are no longer supported. */
   val LegacyVersions: VersionRange[LanguageVersion] =
     VersionRange(min = v1_6, max = v1_15)
 
-  // All the stable and preview versions
-  // Equals `Stable` if no preview version is available
-  val EarlyAccessVersions: VersionRange[LanguageVersion] =
-    StableVersions
+  /** All the stable and preview versions for a given major language version.
+    * Equals [[StableVersions(majorLanguageVersion)]] if no preview version is available.
+    */
+  def EarlyAccessVersions(
+      majorLanguageVersion: LanguageMajorVersion
+  ): VersionRange[LanguageVersion] =
+    StableVersions(majorLanguageVersion)
 
-  // All the versions
+  /** All the supported versions for a given major language version: stable, early access and dev.
+    */
   def AllVersions(majorLanguageVersion: LanguageMajorVersion): VersionRange[LanguageVersion] = {
     majorLanguageVersion match {
-      case Major.V1 => throw new IllegalArgumentException("V1 is not supported")
+      case Major.V1 => throw new IllegalArgumentException("LF V1 is no longer supported")
       case Major.V2 => VersionRange(v2_1, v2_dev)
     }
   }
 
+  /** The Daml-LF version used by default by the compiler if it matches the
+    * provided major version, the latest non-dev version with that major version
+    * otherwise. This function is meant to be used in tests who want to test the
+    * closest thing to the default user experience given a major version.
+    */
+  def defaultOrLatestStable(majorLanguageVersion: LanguageMajorVersion): LanguageVersion = {
+    majorLanguageVersion match {
+      case Major.V1 => throw new IllegalArgumentException("LF V1 is no longer supported")
+      case Major.V2 => v2_1
+    }
+  }
+
   // This refers to the default output LF version in the compiler
-  val default: LanguageVersion = v2_1
+  val default: LanguageVersion = defaultOrLatestStable(Major.V2)
 }
 
 /** Operations on [[VersionRange]] that only make sense for ranges of [[LanguageVersion]]. */

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/StablePackage.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/StablePackage.scala
@@ -7,6 +7,7 @@ package language
 
 import com.daml.lf.data.Ref
 import com.daml.lf.language.LanguageVersion._
+import com.daml.lf.language.LanguageVersionRangeOps._
 
 private[daml] sealed class StablePackage(
     moduleNameStr: String,
@@ -50,17 +51,9 @@ object StablePackages {
       case LanguageMajorVersion.V2 => StablePackagesV2
     }
 
-  // TODO(#17366): remove once ids uses StablePackages(allowedLanguageVersion.majorVersion).allPackages
-  private[this] val allStablePackagesAcrossMajorVersions: List[StablePackage] =
-    LanguageMajorVersion.All.flatMap(major => StablePackages(major).allPackages)
-
   def ids(allowedLanguageVersions: VersionRange[LanguageVersion]): Set[Ref.PackageId] = {
     import scala.Ordering.Implicits.infixOrderingOps
-    // TODO(#17366): use StablePackages(allowedLanguageVersion.majorVersion).allPackages instead to
-    //    restrict the packages to those matching the major version of allowedLanguageVersions once
-    //    Canton stops feeding LF v1 packages (AdminWorkflowsWithVacuuming and AdminWorkflows) to
-    //    the engine no matter what.
-    allStablePackagesAcrossMajorVersions.view
+    StablePackages(allowedLanguageVersions.majorVersion).allPackages.view
       .filter(_.languageVersion <= allowedLanguageVersions.max)
       .map(_.packageId)
       .toSet

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ParserParameters.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ParserParameters.scala
@@ -17,10 +17,6 @@ private[daml] object ParserParameters {
   def defaultFor[P](majorLanguageVersion: LanguageMajorVersion): ParserParameters[P] =
     ParserParameters(
       defaultPackageId = Ref.PackageId.assertFromString("-pkgId-"),
-      // TODO(#17366): use something like LanguageVersion.default(major) once available
-      majorLanguageVersion match {
-        case LanguageMajorVersion.V1 => LanguageVersion.default
-        case LanguageMajorVersion.V2 => LanguageVersion.v2_1
-      },
+      LanguageVersion.defaultOrLatestStable(majorLanguageVersion),
     )
 }

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -610,12 +610,7 @@ object Repl {
 
   def defaultCompilerConfig(majorLanguageVersion: LanguageMajorVersion): Compiler.Config =
     Compiler.Config(
-      // TODO(#17366): change for something like LV.StableVersions(majorLanguageVersion) after the
-      //   refactoring of LanguageVersion and the introduction of 2.0.
-      allowedLanguageVersions = majorLanguageVersion match {
-        case LanguageMajorVersion.V1 => LV.StableVersions
-        case LanguageMajorVersion.V2 => LV.AllVersions(LanguageMajorVersion.V2)
-      },
+      allowedLanguageVersions = LV.StableVersions(majorLanguageVersion),
       packageValidation = Compiler.FullPackageValidation,
       profiling = Compiler.NoProfile,
       stacktracing = Compiler.FullStackTrace,

--- a/daml-lf/tests/reinterpret-v2/daml.yaml
+++ b/daml-lf/tests/reinterpret-v2/daml.yaml
@@ -5,8 +5,7 @@ sdk-version: 0.0.0
 name: reinterpret-tests
 version: 1.0.0
 build-options:
-  # TODO(#17366): change for 2.0 once it is introduced
-  - --target=2.dev
+  - --target=2.1
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -85,10 +85,10 @@ object TransactionVersion {
     VersionedTransaction(txVersion(tx), tx.nodes, tx.roots)
 
   val StableVersions: VersionRange[TransactionVersion] =
-    LanguageVersion.StableVersions.map(assignNodeVersion)
+    LanguageVersion.StableVersions(LanguageVersion.default.major).map(assignNodeVersion)
 
   private[lf] val EarlyAccessVersions: VersionRange[TransactionVersion] =
-    LanguageVersion.EarlyAccessVersions.map(assignNodeVersion)
+    LanguageVersion.EarlyAccessVersions(LanguageVersion.default.major).map(assignNodeVersion)
 
   // TODO(#17366): parameterize by major language version once there's a transaction v2
   private[lf] val DevVersions: VersionRange[TransactionVersion] =

--- a/daml-script/export/integration-tests/reproduces-transactions/BUILD.bazel
+++ b/daml-script/export/integration-tests/reproduces-transactions/BUILD.bazel
@@ -13,8 +13,7 @@ da_scala_test(
     data = [
         "//compiler/damlc",
         "//daml-script/daml3:daml3-script.dar",
-        #TODO(#17366): change to dar-files once LF2 is the default
-        "//test-common:dar-files-2.1",
+        "//test-common:dar-files",
     ],
     resources = ["test/resources/logback-test.xml"],
     scala_deps = [
@@ -49,8 +48,7 @@ da_scala_test(
         "//libs-scala/resources",
         "//libs-scala/rs-grpc-bridge",
         "//libs-scala/testing-utils",
-        #TODO(#17366): change to dar-files-default-lib once LF2 is the default
-        "//test-common:dar-files-2.1-lib",
+        "//test-common:dar-files-default-lib",
         "//test-common/canton/it-lib",
         "@maven//:io_netty_netty_handler",
         "@maven//:org_scalatest_scalatest_compatible",

--- a/daml-script/export/src/main/scala/com/daml/script/export/Dependencies.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Dependencies.scala
@@ -9,7 +9,7 @@ import com.daml.daml_lf_dev.DamlLf
 import com.digitalasset.canton.ledger.api.refinements.ApiTypes
 import com.daml.ledger.api.v1.value
 import com.digitalasset.canton.ledger.client.LedgerClient
-import com.daml.lf.{VersionRange, archive}
+import com.daml.lf.archive
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.language.{Ast, LanguageVersion, StablePackages}
@@ -132,12 +132,8 @@ object Dependencies {
     Set("daml-stdlib", "daml-prim", "daml-script").map(Ref.PackageName.assertFromString(_))
 
   private def isProvidedLibrary(pkgId: PackageId, pkg: Ast.Package): Boolean = {
-    // We use the list of stable packages for the compiler not the engine so we really want to catch
-    // all of them ignoring the version.
-    // TODO(#17366): make this code more elegant once we refactor LanguageVersion
     val stablePackages =
-      (StablePackages.ids(VersionRange(LanguageVersion.v1_dev, LanguageVersion.v1_dev))
-        | StablePackages.ids(VersionRange(LanguageVersion.v2_1, LanguageVersion.v2_dev)))
+      StablePackages.ids(LanguageVersion.AllVersions(LanguageVersion.default.major))
     providedLibraries.contains(pkg.metadata.name) || stablePackages.contains(pkgId)
   }
 

--- a/daml-script/runner/BUILD.bazel
+++ b/daml-script/runner/BUILD.bazel
@@ -158,8 +158,6 @@ da_scala_binary(
         name = "test-script{n}".format(n = n),
         srcs = glob(["src/test/resources/TestScript.daml"]),
         dependencies = ["//daml-script/daml3:daml3-script.dar"],
-        # TODO(#17366): delete the explicit target once the default major version is 2.
-        target = "2.1",
     )
     for n in range(
         1,

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/AuthIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/AuthIT.scala
@@ -26,9 +26,6 @@ class AuthIT(override val majorLanguageVersion: LanguageMajorVersion)
   final override protected lazy val authSecret = Some("secret")
   final override protected lazy val timeMode = ScriptTimeMode.WallClock
 
-  // TODO(#17366): Delete once 2.0 is introduced and Canton supports LF v2 in non-dev mode.
-  final override protected lazy val devMode = (majorLanguageVersion == LanguageMajorVersion.V2)
-
   "Daml Script against authorized ledger" can {
     "auth" should {
       "create and accept Proposal" in {

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/MultiParticipantIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/MultiParticipantIT.scala
@@ -26,9 +26,6 @@ class MultiParticipantIT(override val majorLanguageVersion: LanguageMajorVersion
   final override protected lazy val nParticipants = 2
   final override protected lazy val timeMode = ScriptTimeMode.WallClock
 
-  // TODO(#17366): Delete once 2.0 is introduced and Canton supports LF v2 in non-dev mode.
-  final override protected lazy val devMode = (majorLanguageVersion == LanguageMajorVersion.V2)
-
   "Multi-participant Daml Script" can {
     "multiTest" should {
       "return 42" in {

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TlsIT.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TlsIT.scala
@@ -20,9 +20,6 @@ class TlsIT(override val majorLanguageVersion: LanguageMajorVersion)
   final override protected lazy val tlsEnable = true
   final override protected lazy val timeMode = ScriptTimeMode.WallClock
 
-  // TODO(#17366): Delete once 2.0 is introduced and Canton supports LF v2 in non-dev mode.
-  final override protected lazy val devMode = (majorLanguageVersion == LanguageMajorVersion.V2)
-
   "Daml Script against ledger with TLS" can {
     "test0" should {
       "create and accept Proposal" in {

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
@@ -10,7 +10,6 @@ import com.daml.lf.data.ImmArray
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{FrontStack, FrontStackCons, Numeric}
 import com.daml.lf.engine.script.Runner.InterpretationError
-import com.daml.lf.language.LanguageMajorVersion
 import com.daml.lf.speedy.SValue
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.value.Value
@@ -27,9 +26,6 @@ abstract class AbstractFuncIT
     with AbstractScriptTest
     with Matchers
     with Inside {
-
-  // TODO(#17366): Reset to false once 2.0 is introduced and Canton supports LF v2 in non-dev mode.
-  final override protected lazy val devMode = (majorLanguageVersion == LanguageMajorVersion.V2)
 
   def assertSTimestamp(v: SValue) =
     v match {

--- a/language-support/hs/bindings/BUILD.bazel
+++ b/language-support/hs/bindings/BUILD.bazel
@@ -40,15 +40,11 @@ da_haskell_library(
 daml_compile(
     name = "for-tests",
     srcs = glob(["test/daml/for-tests/*.daml"]),
-    # TODO(#17366): remove explicit target once LF2 is the default
-    target = "2.1",
 )
 
 daml_compile(
     name = "for-upload",
     srcs = ["test/daml/for-upload/ExtraModule.daml"],
-    # TODO(#17366): remove explicit target once LF2 is the default
-    target = "2.1",
 )
 
 da_haskell_test(

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -379,9 +379,6 @@ java_test(
 daml_compile(
     name = "ledger-tests-model",
     srcs = glob(["src/ledger-tests/daml/**/*.daml"]),
-    # TODO(https://github.com/digital-asset/daml/issues/17366)
-    # remove target, once interfaces are stable.
-    target = lf_version_default_or_latest("2"),
 )
 
 dar_to_java(


### PR DESCRIPTION
Remove/simplify code that had to be there because the default language version wasn't 2.1 yet.

The most notable change is in `LanguageVersion`: now `StableVersions` is parameterized by the major language version. Another way to simplify things would have been to stop parameterizing everything by major language version and assume Major.V2 everywhere, but that is a massive change that I'm not willing to invest in right now. 

This PR does not remove V1 as a major version yet. That has other implications that are better handled in a separate PR. For now, we throw in a bunch of places when V1 is provided.