### PR TITLE
fix build.sh when PostgreSQL is still running

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -91,10 +91,6 @@ $bazel build //... \
 
 # Set up a shared PostgreSQL instance.
 export POSTGRESQL_ROOT_DIR="${POSTGRESQL_TMP_ROOT_DIR:-$DIR/.tmp-pg}/daml/postgresql"
-if [ -e "$POSTGRESQL_ROOT_DIR" ]; then
-  echo "'$POSTGRESQL_ROOT_DIR' exists, please choose another one by setting $POSTGRESQL_TMP_ROOT_DIR."
-  exit 1
-fi
 export POSTGRESQL_DATA_DIR="${POSTGRESQL_ROOT_DIR}/data"
 export POSTGRESQL_LOG_FILE="${POSTGRESQL_ROOT_DIR}/postgresql.log"
 export POSTGRESQL_HOST='localhost'


### PR DESCRIPTION
I've seen this crash on #18398 and, while in an ideal world we shouldn't have dangling PG's running, crashing the build is annoying.

Note: The specific failure was
```
./build.sh: line 95: POSTGRESQL_TMP_ROOT_DIR: unbound variable
```
because there's an extra `$` in
```
echo "'$POSTGRESQL_ROOT_DIR' exists, please choose another one by setting $POSTGRESQL_TMP_ROOT_DIR."
                                                                          ^
```
but the intent was to crash if we enter that if regardless.