### PR TITLE
Fix daml3-script disclosure issue with canton

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
@@ -16,7 +16,7 @@ import com.daml.ledger.api.v1.event.InterfaceView
 import com.daml.ledger.api.v2.testing.time_service.TimeServiceGrpc.TimeServiceStub
 import com.daml.ledger.api.v2.testing.time_service.{GetTimeRequest, SetTimeRequest, TimeServiceGrpc}
 import com.daml.ledger.api.v2.transaction_filter.TransactionFilter
-import com.daml.ledger.api.v1.transaction_filter.{Filters, InclusiveFilters, InterfaceFilter}
+import com.daml.ledger.api.v1.transaction_filter.{Filters, InclusiveFilters, InterfaceFilter, TemplateFilter}
 import com.daml.ledger.api.v1.{value => api}
 import com.daml.lf.CompiledPackages
 import com.digitalasset.canton.ledger.api.validation.NoLoggingValueValidator
@@ -86,7 +86,13 @@ class GrpcLedgerClient(
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,
   ): TransactionFilter = {
-    val filters = Filters(Some(InclusiveFilters(Seq(toApiIdentifierUpgrades(templateId, false)))))
+    val filters = Filters(
+      Some(
+        InclusiveFilters(templateFilters =
+          Seq(TemplateFilter(Some(toApiIdentifierUpgrades(templateId, false)), includeCreatedEventBlob = true))
+        )
+      )
+    )
     TransactionFilter(parties.toList.map(p => (p, filters)).toMap)
   }
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
@@ -16,7 +16,12 @@ import com.daml.ledger.api.v1.event.InterfaceView
 import com.daml.ledger.api.v2.testing.time_service.TimeServiceGrpc.TimeServiceStub
 import com.daml.ledger.api.v2.testing.time_service.{GetTimeRequest, SetTimeRequest, TimeServiceGrpc}
 import com.daml.ledger.api.v2.transaction_filter.TransactionFilter
-import com.daml.ledger.api.v1.transaction_filter.{Filters, InclusiveFilters, InterfaceFilter, TemplateFilter}
+import com.daml.ledger.api.v1.transaction_filter.{
+  Filters,
+  InclusiveFilters,
+  InterfaceFilter,
+  TemplateFilter,
+}
 import com.daml.ledger.api.v1.{value => api}
 import com.daml.lf.CompiledPackages
 import com.digitalasset.canton.ledger.api.validation.NoLoggingValueValidator
@@ -89,7 +94,12 @@ class GrpcLedgerClient(
     val filters = Filters(
       Some(
         InclusiveFilters(templateFilters =
-          Seq(TemplateFilter(Some(toApiIdentifierUpgrades(templateId, false)), includeCreatedEventBlob = true))
+          Seq(
+            TemplateFilter(
+              Some(toApiIdentifierUpgrades(templateId, false)),
+              includeCreatedEventBlob = true,
+            )
+          )
         )
       )
     )

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -22,14 +22,14 @@ load(
 
 [
     genrule(
-        name = "script-test-v{}".format(major),
+        name = "script{scriptVersion}-test-v{major}".format(scriptVersion = scriptVersion, major = major),
         srcs =
             glob(["**/*.daml"]) + [
-                "//daml-script/daml:daml-script-{}.dar".format(target),
+                "//daml-script/daml{scriptVersion}:daml{scriptVersion}-script-{target}.dar".format(scriptVersion = scriptVersion, target = target),
                 "//docs:source/daml-script/template-root/src/ScriptExample.daml",
                 "//compiler/damlc/tests:divulgence-daml-test-files",
             ],
-        outs = ["script-test-v{}.dar".format(major)],
+        outs = ["script{scriptVersion}-test-v{major}.dar".format(scriptVersion = scriptVersion, major = major)],
         cmd = """
       set -eou pipefail
       TMP_DIR=$$(mktemp -d)
@@ -50,31 +50,33 @@ initializeFixed = do
   let parties = LedgerParties{{..}}
   initialize parties
 EOF
-      cp -L $(location //daml-script/daml:daml-script-{target}.dar) $$TMP_DIR/
+      cp -L $(location //daml-script/daml{scriptVersion}:daml{scriptVersion}-script-{target}.dar) $$TMP_DIR/
       cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: {sdk}
-name: script-test
+name: script{scriptVersion}-test
 source: daml
 version: 0.0.1
 dependencies:
   - daml-stdlib
   - daml-prim
-  - daml-script-{target}.dar
+  - daml{scriptVersion}-script-{target}.dar
 build-options:
   - --target={target}
 EOF
-      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location script-test-v{major}.dar)
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location script{scriptVersion}-test-v{major}.dar)
       rm -rf $$TMP_DIR
     """.format(
             major = major,
             sdk = sdk_version,
             target = target,
+            scriptVersion = scriptVersion,
         ),
         tools = ["//compiler/damlc"],
         visibility = ["//visibility:public"],
     )
     for major in LF_MAJOR_VERSIONS
     for target in [lf_version_default_or_latest(major)]
+    for scriptVersion in ["", "3"]
 ]
 
 [
@@ -357,8 +359,9 @@ da_scala_test_suite(
         ":script-test-no-ledger.dar",
         "//daml-script/runner:daml-script-binary",
     ] + [
-        ":script-test-v{}.dar".format(major)
+        ":script{scriptVersion}-test-v{major}.dar".format(scriptVersion = scriptVersion, major = major)
         for major in LF_MAJOR_VERSIONS
+        for scriptVersion in ["", "3"]
     ],
     resources = glob(["src/main/resources/**/*"]),
     scala_deps = [

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -22,14 +22,23 @@ load(
 
 [
     genrule(
-        name = "script{scriptVersion}-test-v{major}".format(scriptVersion = scriptVersion, major = major),
+        name = "script{scriptVersion}-test-v{major}".format(
+            major = major,
+            scriptVersion = scriptVersion,
+        ),
         srcs =
             glob(["**/*.daml"]) + [
-                "//daml-script/daml{scriptVersion}:daml{scriptVersion}-script-{target}.dar".format(scriptVersion = scriptVersion, target = target),
+                "//daml-script/daml{scriptVersion}:daml{scriptVersion}-script-{target}.dar".format(
+                    scriptVersion = scriptVersion,
+                    target = target,
+                ),
                 "//docs:source/daml-script/template-root/src/ScriptExample.daml",
                 "//compiler/damlc/tests:divulgence-daml-test-files",
             ],
-        outs = ["script{scriptVersion}-test-v{major}.dar".format(scriptVersion = scriptVersion, major = major)],
+        outs = ["script{scriptVersion}-test-v{major}.dar".format(
+            major = major,
+            scriptVersion = scriptVersion,
+        )],
         cmd = """
       set -eou pipefail
       TMP_DIR=$$(mktemp -d)
@@ -67,16 +76,19 @@ EOF
       rm -rf $$TMP_DIR
     """.format(
             major = major,
+            scriptVersion = scriptVersion,
             sdk = sdk_version,
             target = target,
-            scriptVersion = scriptVersion,
         ),
         tools = ["//compiler/damlc"],
         visibility = ["//visibility:public"],
     )
     for major in LF_MAJOR_VERSIONS
     for target in [lf_version_default_or_latest(major)]
-    for scriptVersion in ["", "3"]
+    for scriptVersion in [
+        "",
+        "3",
+    ]
 ]
 
 [
@@ -359,9 +371,15 @@ da_scala_test_suite(
         ":script-test-no-ledger.dar",
         "//daml-script/runner:daml-script-binary",
     ] + [
-        ":script{scriptVersion}-test-v{major}.dar".format(scriptVersion = scriptVersion, major = major)
+        ":script{scriptVersion}-test-v{major}.dar".format(
+            major = major,
+            scriptVersion = scriptVersion,
+        )
         for major in LF_MAJOR_VERSIONS
-        for scriptVersion in ["", "3"]
+        for scriptVersion in [
+            "",
+            "3",
+        ]
     ],
     resources = glob(["src/main/resources/**/*"]),
     scala_deps = [

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/Daml3ScriptTestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/Daml3ScriptTestRunner.scala
@@ -1,0 +1,90 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.engine.script
+
+import com.daml.bazeltools.BazelRunfiles
+import org.scalatest.Suite
+
+import java.nio.file.Paths
+
+class Daml3ScriptTestRunner extends DamlScriptTestRunner {
+  self: Suite =>
+
+  val darPath = Paths.get(BazelRunfiles.rlocation("daml-script/test/script3-test-v2.dar"))
+
+  "daml-script command line" should {
+    "pick up all scripts and returns somewhat sensible outputs" in
+      assertDamlScriptRunnerResult(
+        darPath,
+        """AuthFailure:t1_CreateMissingAuthorization FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: INVALID_ARGUMENT: DAML_AUTHORIZATION_ERROR(8,XXXXXXXX): Interpretation error: Error: node NodeId(0) (XXXXXXXX:AuthFailure:TheContract1) requires authorizers party, but only party were given
+          |AuthFailure:t2_MaintainersNotSubsetOfSignatories FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: INVALID_ARGUMENT: DAML_AUTHORIZATION_ERROR(8,XXXXXXXX): Interpretation error: Error: node NodeId(0) (XXXXXXXX:AuthFailure:TheContract2) has maintainers TreeSet(party) which are not a subset of the signatories TreeSet(party)
+          |AuthFailure:t3_FetchMissingAuthorization FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: INVALID_ARGUMENT: DAML_AUTHORIZATION_ERROR(8,XXXXXXXX): Interpretation error: Error: node NodeId(2) requires one of the stakeholders TreeSet(party) of the fetched contract to be an authorizer, but authorizers were TreeSet(party)
+          |AuthFailure:t4_LookupByKeyMissingAuthorization FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: INVALID_ARGUMENT: DAML_AUTHORIZATION_ERROR(8,XXXXXXXX): Interpretation error: Error: node NodeId(2) (XXXXXXXX:AuthFailure:TheContract4) requires authorizers TreeSet(party) for lookup by key, but it only has TreeSet(party)
+          |AuthFailure:t5_ExerciseMissingAuthorization FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: INVALID_ARGUMENT: DAML_AUTHORIZATION_ERROR(8,XXXXXXXX): Interpretation error: Error: node NodeId(0) (XXXXXXXX:AuthFailure:TheContract5) requires authorizers party, but only party were given
+          |AuthorizedDivulgence:test_authorizedFetch SUCCESS
+          |AuthorizedDivulgence:test_divulgeChoiceTargetContractId SUCCESS
+          |AuthorizedDivulgence:test_noDivulgenceForFetch FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: NOT_FOUND: CONTRACT_NOT_FOUND(11,XXXXXXXX): Contract could not be found with id XXXXXXXX
+          |AuthorizedDivulgence:test_noDivulgenceOfCreateArguments SUCCESS
+          |DiscloseViaChoiceObserver:test FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: NOT_FOUND: CONTRACT_NOT_FOUND(11,XXXXXXXX): Contract could not be found with id XXXXXXXX
+          |Divulgence:main FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: NOT_FOUND: CONTRACT_NOT_FOUND(11,XXXXXXXX): Contract could not be found with id XXXXXXXX
+          |ExceptionSemantics:divulgence FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: NOT_FOUND: CONTRACT_NOT_FOUND(11,XXXXXXXX): Contract could not be found with id XXXXXXXX
+          |ExceptionSemantics:duplicateKey FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: null
+          |ExceptionSemantics:handledArithmeticError SUCCESS
+          |ExceptionSemantics:handledUserException SUCCESS
+          |ExceptionSemantics:rollbackArchive SUCCESS
+          |ExceptionSemantics:tryContext FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: NOT_FOUND: CONTRACT_NOT_FOUND(11,XXXXXXXX): Contract could not be found with id XXXXXXXX
+          |ExceptionSemantics:uncaughtArithmeticError SUCCESS
+          |ExceptionSemantics:uncaughtUserException SUCCESS
+          |ExceptionSemantics:unhandledArithmeticError FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.ArithmeticError:ArithmeticError@XXXXXXXX{ message = "ArithmeticError while evaluating (DIV_INT64 1 0)." }. Details: Last location: [DA.Internal.Template.Functions:242], partial transaction: ...
+          |ExceptionSemantics:unhandledUserException FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: ExceptionSemantics:E@XXXXXXXX{  }. Details: Last location: [DA.Internal.Exception:176], partial transaction: ...
+          |LFContractKeys:lookupTest FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: null
+          |MoreChoiceObserverDivulgence:test FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: NOT_FOUND: CONTRACT_NOT_FOUND(11,XXXXXXXX): Contract could not be found with id XXXXXXXX
+          |MultiTest:disclosuresByKeyTest SUCCESS
+          |MultiTest:disclosuresTest SUCCESS
+          |MultiTest:inactiveDisclosureDoesNotFailDuringSubmission FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.GeneralError:GeneralError@XXXXXXXX{ message = "Here" }. Details: Last location: [GHC.Err:25], partial transaction: ...
+          |MultiTest:listKnownPartiesTest SUCCESS
+          |MultiTest:multiTest SUCCESS
+          |MultiTest:partyIdHintTest SUCCESS
+          |ScriptExample:allocateParties SUCCESS
+          |ScriptExample:initializeFixed SUCCESS
+          |ScriptExample:initializeUser SUCCESS
+          |ScriptExample:test SUCCESS
+          |ScriptTest:clearUsers SUCCESS
+          |ScriptTest:failingTest FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.AssertionFailed:AssertionFailed@XXXXXXXX{ message = "Assertion failed" }. Details: Last location: [DA.Internal.Exception:176], partial transaction: ...
+          |ScriptTest:listKnownPartiesTest SUCCESS
+          |ScriptTest:multiPartySubmission SUCCESS
+          |ScriptTest:partyIdHintTest SUCCESS
+          |ScriptTest:sleepTest SUCCESS
+          |ScriptTest:stackTrace FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.AssertionFailed:AssertionFailed@XXXXXXXX{ message = "Assertion failed" }. Details: Last location: [DA.Internal.Exception:176], partial transaction: ...
+          |ScriptTest:test0 SUCCESS
+          |ScriptTest:test1 SUCCESS
+          |ScriptTest:test3 SUCCESS
+          |ScriptTest:test4 SUCCESS
+          |ScriptTest:testCreateAndExercise SUCCESS
+          |ScriptTest:testGetTime SUCCESS
+          |ScriptTest:testKey SUCCESS
+          |ScriptTest:testMaxInboundMessageSize SUCCESS
+          |ScriptTest:testMultiPartyQueries SUCCESS
+          |ScriptTest:testQueryContractId SUCCESS
+          |ScriptTest:testQueryContractKey SUCCESS
+          |ScriptTest:testSetTime SUCCESS
+          |ScriptTest:testStack SUCCESS
+          |ScriptTest:testUserListPagination SUCCESS
+          |ScriptTest:testUserManagement SUCCESS
+          |ScriptTest:testUserRightManagement SUCCESS
+          |ScriptTest:traceOrder SUCCESS
+          |ScriptTest:tree SUCCESS
+          |ScriptTest:tupleKey SUCCESS
+          |TestContractId:testContractId SUCCESS
+          |TestExceptions:test SUCCESS
+          |TestExceptions:try_catch_recover SUCCESS
+          |TestExceptions:try_catch_then_abort FAILURE (com.daml.lf.engine.free.InterpretationError: Error: Unhandled Daml exception: DA.Exception.GeneralError:GeneralError@XXXXXXXX{ message = "expected exception" })
+          |TestExceptions:try_catch_then_error FAILURE (com.daml.lf.engine.free.InterpretationError: Error: Unhandled Daml exception: DA.Exception.GeneralError:GeneralError@XXXXXXXX{ message = "expected exception" })
+          |TestExceptions:try_catch_then_fail FAILURE (com.daml.lf.engine.free.InterpretationError: Error: Unhandled Daml exception: DA.Exception.GeneralError:GeneralError@XXXXXXXX{ message = "expected exception" })
+          |TestInterfaces:test SUCCESS
+          |TestInterfaces:test_queryInterface SUCCESS
+          |""".stripMargin,
+      )
+  }
+}


### PR DESCRIPTION
This fixes an issue where queryDisclosure in daml3-script was giving an empty blob. This PR fixes this issue, and copies the daml2-script test suite that would have caught this over to daml3-script, so we don't miss mistakes like this in future.