### PR TITLE
introduce transaction version 3.1

### DIFF
--- a/canton/community/common/src/main/scala/com/digitalasset/canton/version/DamlLfVersionToProtocolVersions.scala
+++ b/canton/community/common/src/main/scala/com/digitalasset/canton/version/DamlLfVersionToProtocolVersions.scala
@@ -14,9 +14,7 @@ object DamlLfVersionToProtocolVersions {
   /** This Map links the Daml Lf-version to the minimum protocol version that supports it. */
   val damlLfVersionToMinimumProtocolVersions: SortedMap[TransactionVersion, ProtocolVersion] =
     SortedMap(
-      TransactionVersion.V14 -> ProtocolVersion.v30,
-      // Interfaces
-      TransactionVersion.V15 -> ProtocolVersion.v30,
+      TransactionVersion.V31 -> ProtocolVersion.v30,
       TransactionVersion.VDev -> ProtocolVersion.v30,
     )
 
@@ -24,8 +22,8 @@ object DamlLfVersionToProtocolVersions {
       transactionVersion: TransactionVersion
   ): ProtocolVersion = {
     assert(
-      transactionVersion >= TransactionVersion.V14,
-      s"Canton only supports transaction versions more recent or equal to ${TransactionVersion.V14}",
+      transactionVersion >= TransactionVersion.V31,
+      s"Canton only supports transaction versions more recent or equal to ${TransactionVersion.V31}",
     )
     damlLfVersionToMinimumProtocolVersions(transactionVersion)
   }

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -290,7 +290,7 @@ object ValueGenerators {
     * 2. key's maintainers may not be a subset of signatories
     */
   def malformedCreateNodeGen(
-      minVersion: TransactionVersion = TransactionVersion.V14
+      minVersion: TransactionVersion = TransactionVersion.V31
   ): Gen[Node.Create] = {
     for {
       version <- transactionVersionGen(minVersion)

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -238,7 +238,7 @@ object TransactionCoder {
         if (enclosingVersion < nodeVersion)
           Left(
             EncodeError(
-              s"A transaction of version $enclosingVersion cannot contain nodes of newer version ($nodeVersion)"
+              s"A transaction of version ${enclosingVersion.protoValue} cannot contain nodes of newer version ($nodeVersion)"
             )
           )
         else {
@@ -699,7 +699,7 @@ object TransactionCoder {
           case Right(nodeVersion) if (txVersion < nodeVersion) =>
             Left(
               DecodeError(
-                s"A transaction of version $txVersion cannot contain node of newer version (${protoNode.getVersion})"
+                s"A transaction of version ${txVersion.protoValue} cannot contain node of newer version (${protoNode.getVersion})"
               )
             )
           case otherwise => otherwise
@@ -945,11 +945,6 @@ object TransactionCoder {
     for {
       versionedBlob <- decodeVersioned(bytes)
       Versioned(version, unversioned) = versionedBlob
-      _ <- Either.cond(
-        version >= TransactionVersion.V14,
-        (),
-        DecodeError(s"version $version does not support FatContractInstance"),
-      )
       proto <- scala.util
         .Try(TransactionOuterClass.FatContractInstance.parseFrom(unversioned))
         .toEither

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -16,11 +16,15 @@ sealed abstract class TransactionVersion private (
   */
 object TransactionVersion {
 
+  // TODO(https://github.com/digital-asset/daml/issues/18240): delete V14 and V15 once canton stops
+  //  mentioning them.
   case object V14 extends TransactionVersion("14", 14)
   case object V15 extends TransactionVersion("15", 15)
-  case object VDev extends TransactionVersion("dev", Int.MaxValue)
 
-  val All = List(V14, V15, VDev)
+  case object V31 extends TransactionVersion("301", 301)
+  case object VDev extends TransactionVersion("3dev", Int.MaxValue)
+
+  val All = List(V14, V15, V31, VDev)
 
   implicit val Ordering: scala.Ordering[TransactionVersion] =
     scala.Ordering.by(_.index)
@@ -44,17 +48,23 @@ object TransactionVersion {
   val minVersion: TransactionVersion = All.min
   def maxVersion: TransactionVersion = VDev
 
+  // TODO(https://github.com/digital-asset/daml/issues/18240) remove these 3 feature flags and kill
+  //  the transitively dead code. Make sure canton doesn't mention them anymore.
   private[lf] val minExceptions = V14
   private[lf] val minByKey = V14
   private[lf] val minInterfaces = V15
+
+  private[lf] val minUpgrade = V31
+  private[lf] val minSharedKeys = V31
   private[lf] val minExplicitDisclosure = VDev
   private[lf] val minChoiceAuthorizers = VDev
-  private[lf] val minUpgrade = VDev
-  private[lf] val minSharedKeys = VDev
 
   private[lf] val assignNodeVersion: LanguageVersion => TransactionVersion = {
     import LanguageVersion._
     Map(
+      // TODO(https://github.com/digital-asset/daml/issues/18240): v1 versions are only mentioned
+      //  here to ensure the map is total, which is tested elsewhere. But these versions are never
+      //  used by the daml3 engine. Once we delete the V1 LanguageMajorVersion, they will go away.
       v1_6 -> V14,
       v1_7 -> V14,
       v1_8 -> V14,
@@ -64,9 +74,7 @@ object TransactionVersion {
       v1_14 -> V14,
       v1_15 -> V15,
       v1_dev -> VDev,
-      // TODO(#17366): Map to TransactionVersion 2.1 once it exists.
-      v2_1 -> VDev,
-      // TODO(#17366): Map to TransactionVersion 2.dev once it exists.
+      v2_1 -> V31,
       v2_dev -> VDev,
     )
   }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
@@ -16,12 +16,7 @@ class TransactionVersionSpec extends AnyWordSpec with Matchers with TableDrivenP
     "be stable" in {
       val testCases = Table(
         "language version" -> "transaction version",
-        LanguageVersion.v1_14 -> TransactionVersion.V14,
-        LanguageVersion.v1_15 -> TransactionVersion.V15,
-        LanguageVersion.v1_dev -> TransactionVersion.VDev,
-        // TODO(#17366): Map to TransactionVersion 2.1 once it exists.
-        LanguageVersion.v2_1 -> TransactionVersion.VDev,
-        // TODO(#17366): Map to TransactionVersion 2.dev once it exists.
+        LanguageVersion.v2_1 -> TransactionVersion.V31,
         LanguageVersion.v2_dev -> TransactionVersion.VDev,
       )
 


### PR DESCRIPTION
Context: https://github.com/digital-asset/daml/issues/18240

We use "301" as the proto representation to avoid any clash with a possible version 1.31. We go for "3" instead of "2" to align with the public-facing "daml 3" name and avoid internal confusion. We'll rename LF 2 into LF 3 at some point too.

Some tests error message were using the name of the scala case class instead of the proto version string, which is now breaking some tests because "301" is not a substring of "V31". I fixed it by changing the error messages to use the protocol version string.