### PR TITLE
remove the shared keys flag for good

### DIFF
--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -58,9 +58,6 @@ object LanguageVersion {
     val bigNumeric = v2_1
     val exceptions = v2_1
     val packageUpgrades = v2_1
-    // TODO(https://github.com/digital-asset/daml/issues/18240): remove this feature once canton
-    //  stops using it.
-    val sharedKeys = v2_1
     val choiceFuncs = v2_dev
     val choiceAuthority = v2_dev
     val dynamicExercise = v2_dev

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -89,11 +89,7 @@ object Error {
 
   /** A fetch or lookup of a contract key without maintainers */
   final case class FetchEmptyContractKeyMaintainers(templateId: TypeConName, key: Value)
-      extends Error {
-    // TODO(https://github.com/digital-asset/daml/issues/18240): remove this field once Canton stops
-    //  reading it.
-    val shared = true
-  }
+      extends Error
 
   /** We tried to fetch / exercise a contract of the wrong type --
     * see <https://github.com/digital-asset/daml/issues/1005>.

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
@@ -9,8 +9,6 @@ import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.{Party, TypeConName}
 import com.daml.lf.value.Value
 
-import scala.annotation.nowarn
-
 /** Useful in various circumstances -- basically this is what a ledger implementation must use as
   * a key. The 'hash' is guaranteed to be stable over time.
   */
@@ -56,34 +54,16 @@ object GlobalKey {
       .hashContractKey(templateId, key)
       .map(new GlobalKey(templateId, key, _))
 
-  // TODO(https://github.com/digital-asset/daml/issues/18240) remove this method once canton stops
-  //  using this it.
-  @nowarn("cat=unused")
-  def build(
-      templateId: Ref.TypeConName,
-      key: Value,
-      shared: Boolean,
-  ): Either[crypto.Hash.HashingError, GlobalKey] =
-    build(templateId, key)
-
   // Like `build` but,  in case of error, throws an exception instead of returning a message.
   @throws[IllegalArgumentException]
   def assertBuild(templateId: TypeConName, key: Value): GlobalKey =
     data.assertRight(build(templateId, key).left.map(_.msg))
-
-  // TODO(https://github.com/digital-asset/daml/issues/18240) remove this method once canton stops
-  //  using this it.
-  @throws[IllegalArgumentException]
-  @nowarn("cat=unused")
-  def assertBuild(templateId: TypeConName, key: Value, shared: Boolean): GlobalKey =
-    assertBuild(templateId, key)
 
   private[lf] def unapply(globalKey: GlobalKey): Some[(TypeConName, Value)] =
     Some((globalKey.templateId, globalKey.key))
 
   def isShared(key: GlobalKey): Boolean =
     Hash.hashContractKey(key.templateId, key.key) == Right(key.hash)
-
 }
 
 final case class GlobalKeyWithMaintainers(
@@ -102,34 +82,12 @@ object GlobalKeyWithMaintainers {
   ): GlobalKeyWithMaintainers =
     data.assertRight(build(templateId, value, maintainers).left.map(_.msg))
 
-  // TODO(https://github.com/digital-asset/daml/issues/18240) remove this method once canton stops
-  //  using this it.
-  @nowarn("cat=unused")
-  def assertBuild(
-      templateId: Ref.TypeConName,
-      value: Value,
-      maintainers: Set[Ref.Party],
-      shared: Boolean,
-  ): GlobalKeyWithMaintainers =
-    assertBuild(templateId, value, maintainers)
-
   def build(
       templateId: TypeConName,
       value: Value,
       maintainers: Set[Party],
   ): Either[Hash.HashingError, GlobalKeyWithMaintainers] =
     GlobalKey.build(templateId, value).map(GlobalKeyWithMaintainers(_, maintainers))
-
-  // TODO(https://github.com/digital-asset/daml/issues/18240) remove this method once canton stops
-  //  using this it.
-  @nowarn("cat=unused")
-  def build(
-      templateId: Ref.TypeConName,
-      value: Value,
-      maintainers: Set[Ref.Party],
-      shared: Boolean,
-  ): Either[Hash.HashingError, GlobalKeyWithMaintainers] =
-    build(templateId, value, maintainers)
 }
 
 /** Controls whether the engine should error out when it encounters duplicate keys.

--- a/ledger/error/src/main/scala/com/daml/error/ErrorResource.scala
+++ b/ledger/error/src/main/scala/com/daml/error/ErrorResource.scala
@@ -21,7 +21,6 @@ object ErrorResource {
     ContractId,
     ContractIds,
     ContractKey,
-    SharedKey,
     ContractKeyHash,
     DalfPackage,
     DevErrorType,
@@ -48,12 +47,6 @@ object ErrorResource {
   }
   object ContractKey extends ErrorResource {
     def asString: String = "CONTRACT_KEY"
-  }
-
-  // TODO https://github.com/digital-asset/daml/issues/17661 - this match is only needed for
-  //  temporary backward compatibility with Canton so can soon be removed
-  object SharedKey extends ErrorResource {
-    def asString: String = "SHARED_KEY"
   }
 
   object ContractArg extends ErrorResource {

--- a/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/CommandExecution.scala
+++ b/ledger/ledger-api-errors/src/main/scala/com/daml/error/definitions/groups/CommandExecution.scala
@@ -122,7 +122,6 @@ object CommandExecution extends ErrorGroup()(LedgerApiErrors.errorClass) {
               Seq(
                 (ErrorResource.TemplateId, key.templateId.toString),
                 (ErrorResource.ContractKey, encodedKey),
-                (ErrorResource.SharedKey, GlobalKey.isShared(key).toString),
               )
             }
         }
@@ -173,7 +172,6 @@ object CommandExecution extends ErrorGroup()(LedgerApiErrors.errorClass) {
               (ErrorResource.TemplateId, err.key.templateId.toString),
               (ErrorResource.ContractId, err.coid.coid),
               (ErrorResource.ContractKey, encodedKey),
-              (ErrorResource.SharedKey, GlobalKey.isShared(err.key).toString),
               (ErrorResource.ContractKeyHash, err.declaredHash.toString),
             )
           }


### PR DESCRIPTION
Context: https://github.com/digital-asset/daml/issues/18240.

Now that the overloaded `build` methods introduced in https://github.com/digital-asset/daml/pull/18376 are not used anymore by canton (https://github.com/DACH-NY/canton/pull/16944), we can delete them. Same for the flag and the error resource.