### PR TITLE
Java Codegen: better disambiguation between fields and packages

### DIFF
--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/EnumClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/EnumClass.scala
@@ -37,6 +37,7 @@ private[inner] object EnumClass extends StrictLogging {
         .addMethod(generateToValue)
         .addMethods(FromJsonGenerator.forEnum(className, "__enums$").asJava)
         .addMethods(ToJsonGenerator.forEnum(className).asJava)
+        .addType(FromJsonGenerator.decoderAccessorClass(className, Vector()))
       logger.debug("End")
       enumType.build()
     }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordClass.scala
@@ -41,6 +41,7 @@ private[inner] object RecordClass extends StrictLogging {
         .addFields(RecordFields(fields).asJava)
         .addField(createPackageIdField(packageId))
         .addMethods(recordMethods.asJava)
+        .addType(FromJsonGenerator.decoderAccessorClass(className, typeParameters))
         .build()
       logger.debug("End")
 

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -99,6 +99,7 @@ private[inner] object TemplateClass extends StrictLogging {
         .addMethod(companion.generateGetter())
         .addFields(RecordFields(fields).asJava)
         .addMethods(templateMethods.asJava)
+        .addType(FromJsonGenerator.decoderAccessorClass(className, Vector()))
       generateByKeyMethod(className, template.key) foreach { byKeyMethod =>
         templateType
           .addMethod(byKeyMethod)

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantClass.scala
@@ -63,6 +63,7 @@ private[inner] object VariantClass extends StrictLogging {
           ).asJava
         )
         .addField(createPackageIdField(typeWithContext.interface.packageId))
+        .addType(FromJsonGenerator.decoderAccessorClass(variantClassName, typeArguments))
         .build()
       val (constructors, constructorStaticImports) = generateConstructorClasses(
         typeArguments,


### PR DESCRIPTION
We can currently have a problem where we can generate code that the java compiler chokes on.

This occurs when we have a generated class with a field, say `public final Integer foo;`, and it needs to call the `jsonDecoder` static method of a class under a package which begins with "foo", e.g. `foo.bar.Baz.jsonDecoder()`

Java sees the `foo.bar` and interprets that as an attempt to access the `bar` field on the local `foo` variable, and fails with `symbol not found`, not understanding that `foo.bar` is simply the package qualifier of the `Bar` class. When hand-writing code, we can avoid this by importing `foo.bar.Baz`, and then calling the method with `Baz.jsonDecoder()`, but when generating code, the JavaPoet library seems to opt for using fully qualified references to these static methods, which is when we can hit the problematic expressions.

This workaround generates a class nested within `Baz` a la

    public static class JsonDecoder$ { public JsonLfDecoder<Baz> get() { return jsonDecoder(); } }

which simply forwards the call on. However it means that we can avoid the ambiguious parsing context at the call side by invoking the method via `new foo.bar.Baz.JsonDecoder$().get()`. Using the `new` keyword clarifies that the next thing is a type, and javac correctly resolves `foo.bar` as a package name.

I benchmarked the changes with `bazel run language-support/java/codegen:from-json-bench` and there was no appreciable impact on performance.

We had previously avoided this issue by using `.simpleName` on the class used for `jsonDecoder()` to explicitly drop the package name, but that won't work once we start supporting decoding of choice arguments and results, as the relevant types typically won't have already been imported.

This workaround would be unnecessary if JavaPoet would reliably import all referenced types, and then refer to the class name unqualified. It would also be unnecessary if javac were a bit smarter about its parsing. However as of this PR, that does not seem to be the behaviour.

run-all-tests: true