### PR TITLE
reneable oracle EE tests after updating canton

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -175,8 +175,6 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
     - bash: |
         set -euo pipefail
-        # Temporarily disable Oracle EE test due to breaking HttpJson change
-        exit 0  
         eval "$(./dev-env/bin/dade-assist)"
         docker login --username "$DOCKER_LOGIN" --password "$DOCKER_PASSWORD"
         IMAGE=$(cat ci/oracle_image)


### PR DESCRIPTION
those were disable in #18239

run-all-tests: true

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
