### PR TITLE
Add error message to assistant error

### DIFF
--- a/daml-assistant/src/DA/Daml/Assistant/Util.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Util.hs
@@ -34,7 +34,7 @@ wrapErr ctx m = m `catches`
         wrapException err =
             AssistantError
                 { errContext  = Just ctx
-                , errMessage  = Nothing
+                , errMessage  = Just (pack (displayException err))
                 , errInternal = Just (pack (show err))
                 }
 


### PR DESCRIPTION
Our wrapErr  primitive handles any exception just by running Show  on it - how do people feel about adding the result of displayException  to the error message?

So currently we handle SomeException to turn into an AssistantError like this:
```hs
wrapSomeExceptionWithoutMsg :: Text -> SomeException -> AssistantError
wrapSomeExceptionWithoutMsg ctx err =
    AssistantError
        { errContext  = Just ctx
        , errMessage  = Nothing
        , errInternal = Just (pack (show err))
        }
```

And I'm proposing we add displayException  to the message like this:
```hs
wrapSomeExceptionWithMsg :: Text -> SomeException -> AssistantError
wrapSomeExceptionWithMsg ctx err =
    AssistantError
        { errContext  = Just ctx
        , errMessage  = Just (pack (displayException err))
        , errInternal = Just (pack (show err))
        }
```