### PR TITLE
[LF] make Ids en/decoder optional in TransactionCoder

### DIFF
--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/UtilSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/UtilSpec.scala
@@ -18,9 +18,9 @@ class UtilSpec extends AnyWordSpec with Matchers with ScalaCheckPropertyChecks {
       forAll(valueGen(), transactionVersionGen()) { (v, version) =>
         val reference = for {
           encoded <-
-            ValueCoder.encodeValue(ValueCoder.CidEncoder, version, v).left.map(_ => ())
+            ValueCoder.encodeValue(valueVersion = version, v0 = v).left.map(_ => ())
           decoded <-
-            ValueCoder.decodeValue(ValueCoder.CidDecoder, version, encoded).left.map(_ => ())
+            ValueCoder.decodeValue(version = version, bytes = encoded).left.map(_ => ())
         } yield decoded
 
         Util.normalizeValue(v, version).left.map(_ => ()) shouldBe reference

--- a/daml-script/runner/BUILD.bazel
+++ b/daml-script/runner/BUILD.bazel
@@ -75,6 +75,7 @@ da_scala_library(
         "//daml-lf/language",
         "//daml-lf/scenario-interpreter",
         "//daml-lf/transaction",
+        "//daml-lf/transaction:value_proto_java",
         "//daml-script/converter",
         "//ledger-service/lf-value-json",
         "//libs-scala/auth-utils",


### PR DESCRIPTION
First step to remove completly them without breaking canton

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
