### PR TITLE
remove chromedriver

### DIFF
--- a/dev-env/bin/chromedriver
+++ b/dev-env/bin/chromedriver
@@ -1,1 +1,0 @@
-../lib/dade-exec-nix-tool

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -117,8 +117,6 @@ in rec {
 
     node2nix  = pkgs.nodePackages.node2nix;
 
-    chromedriver = pkgs.chromedriver;
-
     # Python development
     pip3        = pkgs.python38Packages.pip;
     python      = pkgs.python38Packages.python;


### PR DESCRIPTION
* `git grep chromedriver` doesn't return anything, so presumably it's not used anymore.
* It's only ever been used for testing, so if tests turn up green then that's probably good enough.
* It's not available on Linux/arm and Nix complains about that.