### PR TITLE
Run upgrades participant api tests on Admin API

### DIFF
--- a/canton/BUILD.bazel
+++ b/canton/BUILD.bazel
@@ -942,7 +942,6 @@ scala_library(
         "//daml-lf/engine",
         "//daml-lf/language",
         "//daml-lf/transaction",
-        "//daml-lf/transaction:transaction_proto_java",
         "//daml-lf/validation",
         "//libs-scala/contextualized-logging",
         "//libs-scala/executors",

--- a/canton/BUILD.bazel
+++ b/canton/BUILD.bazel
@@ -330,7 +330,10 @@ proto_gen(
         "flat_package",
         "grpc",
     ],
-    visibility = ["//daml-script:__subpackages__", "//daml-lf/validation:__subpackages__"],
+    visibility = [
+        "//daml-lf/validation:__subpackages__",
+        "//daml-script:__subpackages__",
+    ],
 )
 
 filegroup(

--- a/canton/BUILD.bazel
+++ b/canton/BUILD.bazel
@@ -330,7 +330,7 @@ proto_gen(
         "flat_package",
         "grpc",
     ],
-    visibility = ["//daml-script:__subpackages__"],
+    visibility = ["//daml-script:__subpackages__", "//daml-lf/validation:__subpackages__"],
 )
 
 filegroup(
@@ -346,6 +346,7 @@ scala_library(
         "-Xsource:3",
         "-language:postfixOps",
     ],
+    visibility = ["//daml-lf/validation:__subpackages__"],
 )
 
 ### community/base ###
@@ -938,6 +939,8 @@ scala_library(
         "//daml-lf/engine",
         "//daml-lf/language",
         "//daml-lf/transaction",
+        "//daml-lf/transaction:transaction_proto_java",
+        "//daml-lf/validation",
         "//libs-scala/contextualized-logging",
         "//libs-scala/executors",
         "//libs-scala/jwt",

--- a/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/admin/PackageService.scala
+++ b/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/admin/PackageService.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.canton.participant.admin
 
 import cats.data.EitherT
-import cats.implicits.toBifunctorOps
+import cats.implicits.{toBifunctorOps, toTraverseOps}
 import cats.syntax.either.*
 import cats.syntax.functorFilter.*
 import cats.syntax.parallel.*
@@ -15,13 +15,14 @@ import com.daml.lf.archive.{DarParser, Decode, Error as LfArchiveError}
 import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.engine.Engine
 import com.daml.lf.language.Ast.Package
-import com.digitalasset.canton.LedgerSubmissionId
+import com.daml.lf.validation.{TypecheckUpgrades, UpgradeError}
 import com.digitalasset.canton.config.CantonRequireTypes.LengthLimitedString.DarName
 import com.digitalasset.canton.config.CantonRequireTypes.{String255, String256M}
 import com.digitalasset.canton.config.ProcessingTimeout
 import com.digitalasset.canton.crypto.{Hash, HashOps, HashPurpose}
 import com.digitalasset.canton.error.CantonError
 import com.digitalasset.canton.ledger.error.PackageServiceErrors
+import com.digitalasset.canton.ledger.error.PackageServiceErrors.Validation
 import com.digitalasset.canton.lifecycle.{FlagCloseable, FutureUnlessShutdown, Lifecycle}
 import com.digitalasset.canton.logging.{ErrorLoggingContext, NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.participant.admin.CantonPackageServiceError.PackageRemovalErrorCode
@@ -41,6 +42,7 @@ import com.digitalasset.canton.protocol.{PackageDescription, PackageInfoService}
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.FutureInstances.*
 import com.digitalasset.canton.util.{EitherTUtil, PathUtils}
+import com.digitalasset.canton.{LedgerSubmissionId, LfPackageId}
 import com.google.protobuf.ByteString
 import slick.jdbc.GetResult
 
@@ -334,14 +336,13 @@ class PackageService(
     val ret: EitherT[FutureUnlessShutdown, DamlError, Hash] = for {
       lengthValidatedName <- EitherT
         .fromEither[FutureUnlessShutdown](
-          String255
-            .create(darName, Some("DAR file name"))
+          String255.create(darName, Some("DAR file name"))
         )
         .leftMap(PackageServiceErrors.Reading.InvalidDarFileName.Error(_))
       dar <- catchUpstreamErrors(DarParser.readArchive(darName, stream))
         .mapK(FutureUnlessShutdown.outcomeK)
       // Validate the packages before storing them in the DAR store or the package store
-      _ <- validateArchives(dar.all).mapK(FutureUnlessShutdown.outcomeK)
+      _ <- validateArchives(dar).mapK(FutureUnlessShutdown.outcomeK)
       _ <- storeValidatedPackagesAndSyncEvent(
         dar.all,
         lengthValidatedName.asString1GB,
@@ -379,21 +380,70 @@ class PackageService(
         .map(_.toRight(s"No such dar ${darId}").flatMap(PackageService.darToLf))
     )
 
-  private def validateArchives(archives: List[DamlLf.Archive])(implicit
+  private def validateArchives(archives: archive.Dar[DamlLf.Archive])(implicit
       traceContext: TraceContext
   ): EitherT[Future, DamlError, Unit] =
     for {
-      packages <- archives
+      mainPackage <- catchUpstreamErrors(Decode.decodeArchive(archives.main))
+      dependencies <- archives.dependencies
         .parTraverse(archive => catchUpstreamErrors(Decode.decodeArchive(archive)))
-        .map(_.toMap)
       _ <- EitherT.fromEither[Future](
         engine
-          .validatePackages(packages)
+          .validatePackages((mainPackage :: dependencies).toMap)
           .leftMap(
             PackageServiceErrors.Validation.handleLfEnginePackageError(_): DamlError
           )
       )
+      _ <- validateUpgrade(mainPackage._1, mainPackage._2)
     } yield ()
+
+  private def validateUpgrade(upgradingPackageId: LfPackageId, upgradingPackage: Package)(implicit
+      traceContext: TraceContext
+  ): EitherT[Future, DamlError, Unit] =
+    upgradingPackage.metadata.upgradedPackageId match {
+      case Some(upgradedPackageId) =>
+        logger.info(s"Package $upgradingPackageId claims to upgrade package id $upgradedPackageId")
+        for {
+          upgradedArchiveMb <- EitherT.right(getLfArchive(upgradedPackageId))
+          upgradedPackageMb <-
+            upgradedArchiveMb
+              .traverse(Decode.decodeArchive(_))
+              .leftMap(Validation.handleLfArchiveError)
+              .toEitherT[Future]
+          upgradeCheckResult = TypecheckUpgrades.typecheckUpgrades(
+            upgradingPackageId -> upgradingPackage,
+            upgradedPackageId,
+            upgradedPackageMb.map(_._2),
+          )
+          _ <- upgradeCheckResult match {
+            case Success(()) =>
+              logger.info(s"Typechecking upgrades for $upgradingPackageId succeeded.")
+              EitherT.rightT[Future, DamlError](())
+            case Failure(err: UpgradeError) =>
+              EitherT
+                .leftT[Future, Unit](
+                  Validation.Upgradeability.Error(upgradingPackageId, upgradedPackageId, err)
+                )
+                .leftWiden[DamlError]
+
+            case Failure(err: Throwable) =>
+              EitherT
+                .leftT[Future, Unit](
+                  PackageServiceErrors.InternalError
+                    .Unhandled(
+                      err,
+                      Some(
+                        s"Typechecking upgrades for $upgradingPackageId failed with unknown error."
+                      ),
+                    )
+                )
+                .leftWiden[DamlError]
+          }
+        } yield ()
+      case None =>
+        logger.info(s"Package $upgradingPackageId does not upgrade anything.")
+        EitherT.rightT[Future, DamlError](())
+    }
 
   def vetPackages(packages: Seq[PackageId], syncVetting: Boolean)(implicit
       traceContext: TraceContext

--- a/daml-lf/validation/BUILD.bazel
+++ b/daml-lf/validation/BUILD.bazel
@@ -62,15 +62,15 @@ da_scala_library(
         [
             "//canton:community_admin-api_proto_scala",
         ],
+    scaladoc = False,
     visibility = ["//visibility:public"],
     deps = [
+        "//canton:community_admin-api",
         "//canton:community_ledger_ledger-common",
         "//canton:ledger_api_proto_scala",
-        "//canton:community_admin-api",
         "@maven//:io_grpc_grpc_netty",
         "@maven//:io_netty_netty_handler",
     ],
-    scaladoc = False,
 )
 
 upgrade_test_file = "src/test/scala/com/digitalasset/daml/lf/validation/UpgradesSpec.scala"
@@ -157,6 +157,9 @@ da_scala_test(
     ],
     scalacopts = lf_scalacopts,
     deps = [
+        ":validation",
+        ":validation-test-lib",
+        ":validation-upgrades-test-lib",
         "//bazel_tools/runfiles:scala_runfiles",
         "//canton:community_ledger_ledger-common",
         "//canton:ledger_api_proto_scala",
@@ -171,7 +174,6 @@ da_scala_test(
         "@maven//:com_google_guava_guava",
         "@maven//:io_grpc_grpc_netty",
         "@maven//:io_netty_netty_handler",
-        ":validation-upgrades-test-lib",
     ],
 )
 

--- a/daml-lf/validation/BUILD.bazel
+++ b/daml-lf/validation/BUILD.bazel
@@ -69,7 +69,8 @@ da_scala_library(
         "//canton:community_ledger_ledger-common",
         "//canton:ledger_api_proto_scala",
         "@maven//:io_grpc_grpc_netty",
-        "@maven//:io_netty_netty_handler",
+        "//libs-scala/ports",
+        "//test-common/canton/it-lib",
     ],
 )
 
@@ -157,8 +158,6 @@ da_scala_test(
     ],
     scalacopts = lf_scalacopts,
     deps = [
-        ":validation",
-        ":validation-test-lib",
         ":validation-upgrades-test-lib",
         "//bazel_tools/runfiles:scala_runfiles",
         "//canton:community_ledger_ledger-common",
@@ -171,9 +170,6 @@ da_scala_test(
         "//libs-scala/rs-grpc-bridge",
         "//libs-scala/testing-utils",
         "//test-common/canton/it-lib",
-        "@maven//:com_google_guava_guava",
-        "@maven//:io_grpc_grpc_netty",
-        "@maven//:io_netty_netty_handler",
     ],
 )
 

--- a/daml-lf/validation/BUILD.bazel
+++ b/daml-lf/validation/BUILD.bazel
@@ -68,9 +68,9 @@ da_scala_library(
         "//canton:community_admin-api",
         "//canton:community_ledger_ledger-common",
         "//canton:ledger_api_proto_scala",
-        "@maven//:io_grpc_grpc_netty",
         "//libs-scala/ports",
         "//test-common/canton/it-lib",
+        "@maven//:io_grpc_grpc_netty",
     ],
 )
 

--- a/daml-lf/validation/BUILD.bazel
+++ b/daml-lf/validation/BUILD.bazel
@@ -158,6 +158,7 @@ da_scala_test(
     ],
     scalacopts = lf_scalacopts,
     deps = [
+        ":validation",
         ":validation-upgrades-test-lib",
         "//bazel_tools/runfiles:scala_runfiles",
         "//canton:community_ledger_ledger-common",

--- a/daml-lf/validation/BUILD.bazel
+++ b/daml-lf/validation/BUILD.bazel
@@ -7,6 +7,7 @@ load(
     "da_scala_library",
     "da_scala_test",
     "da_scala_test_suite",
+    "default_scalacopts",
     "lf_scalacopts",
     "lf_scalacopts_stricter",
 )
@@ -49,6 +50,27 @@ da_scala_library(
         "//daml-lf/language",
         "//daml-lf/parser",
     ],
+)
+
+da_scala_library(
+    name = "validation-upgrades-test-lib",
+    srcs =
+        glob(
+            ["src/test/**/UpgradesSpecUtil.scala"],
+        ) +
+        #  we depend on sources to avoid pushing a canton artifact to maven
+        [
+            "//canton:community_admin-api_proto_scala",
+        ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//canton:community_ledger_ledger-common",
+        "//canton:ledger_api_proto_scala",
+        "//canton:community_admin-api",
+        "@maven//:io_grpc_grpc_netty",
+        "@maven//:io_netty_netty_handler",
+    ],
+    scaladoc = False,
 )
 
 upgrade_test_file = "src/test/scala/com/digitalasset/daml/lf/validation/UpgradesSpec.scala"
@@ -146,6 +168,10 @@ da_scala_test(
         "//libs-scala/rs-grpc-bridge",
         "//libs-scala/testing-utils",
         "//test-common/canton/it-lib",
+        "@maven//:com_google_guava_guava",
+        "@maven//:io_grpc_grpc_netty",
+        "@maven//:io_netty_netty_handler",
+        ":validation-upgrades-test-lib",
     ],
 )
 

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/UpgradesSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/UpgradesSpec.scala
@@ -24,7 +24,7 @@ import com.daml.lf.validation.Upgrading
 
 class UpgradesSpecAdminAPI extends UpgradesSpec {
   override def uploadPackagePair(
-      path: Upgrading[String],
+      path: Upgrading[String]
   ): Future[Upgrading[(PackageId, Option[Throwable])]] = {
     val client = AdminLedgerClient.singleHost(
       ledgerPorts(0).adminPort,
@@ -47,14 +47,14 @@ class UpgradesSpecAdminAPI extends UpgradesSpec {
         })
     } yield Upgrading(
       (testPackageV1Id, uploadV1Result),
-      (testPackageV2Id, uploadV2Result)
+      (testPackageV2Id, uploadV2Result),
     )
   }
 }
 
 class UpgradesSpecLedgerAPI extends UpgradesSpec {
   override def uploadPackagePair(
-      path: Upgrading[String],
+      path: Upgrading[String]
   ): Future[Upgrading[(PackageId, Option[Throwable])]] = {
     for {
       client <- defaultLedgerClient()
@@ -74,7 +74,7 @@ class UpgradesSpecLedgerAPI extends UpgradesSpec {
         })
     } yield Upgrading(
       (testPackageV1Id, uploadV1Result),
-      (testPackageV2Id, uploadV2Result)
+      (testPackageV2Id, uploadV2Result),
     )
   }
 }
@@ -98,7 +98,7 @@ abstract class UpgradesSpec extends AsyncWordSpec with Matchers with Inside with
   }
 
   def uploadPackagePair(
-      path: Upgrading[String],
+      path: Upgrading[String]
   ): Future[Upgrading[(PackageId, Option[Throwable])]]
 
   def testPackagePair(
@@ -115,7 +115,7 @@ abstract class UpgradesSpec extends AsyncWordSpec with Matchers with Inside with
       for {
         Upgrading(
           (testPackageV1Id, uploadV1Result),
-          (testPackageV2Id, uploadV2Result)
+          (testPackageV2Id, uploadV2Result),
         ) <- uploadPackagePair(Upgrading(upgraded, upgrading))
       } yield {
         val cantonLog = Source.fromFile(s"$cantonTmpDir/canton.log")
@@ -166,7 +166,6 @@ abstract class UpgradesSpec extends AsyncWordSpec with Matchers with Inside with
         }
       }
     }
-
 
   "Upload-time Upgradeability Checks" should {
     "report no upgrade errors for valid upgrade" in {

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/UpgradesSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/UpgradesSpec.scala
@@ -66,10 +66,8 @@ class UpgradesSpec extends AsyncWordSpec with Matchers with Inside with CantonFi
       for {
         _ <- Future(())
         client = AdminLedgerClient.singleHost(
-          "localhost",
-          ledgerPorts(0).adminPort.value,
-          config.adminToken,
-          config.tlsClientConfig.client(),
+          ledgerPorts(0).adminPort,
+          config,
         )
         (testPackageV1Id, testPackageV1BS) <- loadPackageIdAndBS(upgraded)
         (testPackageV2Id, testPackageV2BS) <- loadPackageIdAndBS(upgrading)

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/UpgradesSpecUtil.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/UpgradesSpecUtil.scala
@@ -1,0 +1,64 @@
+// Temporary stand-in for the real admin api clients defined in canton. Needed only for upgrades testing
+// We should intend to replace this as soon as possible
+
+package com.daml.lf.validation
+
+import com.digitalasset.canton.ledger.client.LedgerCallCredentials.authenticatingStub
+import com.digitalasset.canton.ledger.client.configuration.LedgerClientChannelConfiguration
+import com.digitalasset.canton.ledger.client.GrpcChannel
+import com.digitalasset.canton.admin.participant.{v30 => admin_package_service}
+import io.grpc.Channel
+import io.grpc.netty.NettyChannelBuilder
+import io.grpc.stub.AbstractStub
+import java.io.Closeable
+import scala.concurrent.{ExecutionContext, Future}
+import com.google.protobuf.ByteString
+import io.netty.handler.ssl.SslContext
+
+private[validation] final class AdminLedgerClient (
+    val channel: Channel,
+    token: Option[String],
+)(implicit ec: ExecutionContext)
+    extends Closeable {
+
+  private val packageServiceStub =
+    AdminLedgerClient.stub(admin_package_service.PackageServiceGrpc.stub(channel), token)
+
+  def uploadDar(bytes: ByteString, filename: String): Future[Unit] = {
+    packageServiceStub.uploadDar(
+      admin_package_service.UploadDarRequest(
+        bytes, filename, false, false
+      ))
+      .map(_ => ())
+  }
+
+  override def close(): Unit = GrpcChannel.close(channel)
+}
+
+object AdminLedgerClient {
+  def stub[A <: AbstractStub[A]](stub: A, token: Option[String]): A =
+    token.fold(stub)(authenticatingStub(stub, _))
+
+  def singleHost(
+      hostIp: String,
+      port: Int,
+      token: Option[String] = None,
+      sslContext: Option[SslContext] = None,
+      maxInboundMessageSize: Int = 64 * 1024 * 1024,
+  )(implicit
+      ec: ExecutionContext
+  ): AdminLedgerClient =
+    fromBuilder(
+      LedgerClientChannelConfiguration(sslContext, maxInboundMessageSize).builderFor(hostIp, port),
+      token
+    )
+
+  def fromBuilder(
+      builder: NettyChannelBuilder,
+      token: Option[String] = None,
+  )(implicit ec: ExecutionContext): AdminLedgerClient =
+    new AdminLedgerClient(
+      GrpcChannel.withShutdownHook(builder),
+      token,
+    )
+}

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/UpgradesSpecUtil.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/UpgradesSpecUtil.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Temporary stand-in for the real admin api clients defined in canton. Needed only for upgrades testing
 // We should intend to replace this as soon as possible
 
@@ -15,7 +18,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import com.google.protobuf.ByteString
 import io.netty.handler.ssl.SslContext
 
-private[validation] final class AdminLedgerClient (
+private[validation] final class AdminLedgerClient(
     val channel: Channel,
     token: Option[String],
 )(implicit ec: ExecutionContext)
@@ -25,10 +28,15 @@ private[validation] final class AdminLedgerClient (
     AdminLedgerClient.stub(admin_package_service.PackageServiceGrpc.stub(channel), token)
 
   def uploadDar(bytes: ByteString, filename: String): Future[Unit] = {
-    packageServiceStub.uploadDar(
-      admin_package_service.UploadDarRequest(
-        bytes, filename, false, false
-      ))
+    packageServiceStub
+      .uploadDar(
+        admin_package_service.UploadDarRequest(
+          bytes,
+          filename,
+          false,
+          false,
+        )
+      )
       .map(_ => ())
   }
 
@@ -50,7 +58,7 @@ object AdminLedgerClient {
   ): AdminLedgerClient =
     fromBuilder(
       LedgerClientChannelConfiguration(sslContext, maxInboundMessageSize).builderFor(hostIp, port),
-      token
+      token,
     )
 
   def fromBuilder(

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -229,7 +229,7 @@ da_scala_library(
         srcs = [":upgrades/coin-v2/Coin.daml"],
         project_name = "coin",
         target = lf_version,
-        upgrades = "//daml-script/test:coin-v1-{}.dar".format(lf_version),
+        # upgrades = "//daml-script/test:coin-v1-{}.dar".format(lf_version),
         version = "2.0.0",
     )
     for lf_version in LF_DEV_VERSIONS
@@ -241,7 +241,7 @@ da_scala_library(
         srcs = [":upgrades/coin-v2-new-field/Coin.daml"],
         project_name = "coin",
         target = lf_version,
-        upgrades = "//daml-script/test:coin-v1-{}.dar".format(lf_version),
+        # upgrades = "//daml-script/test:coin-v1-{}.dar".format(lf_version),
         version = "2.0.0",
     )
     for lf_version in LF_DEV_VERSIONS
@@ -253,7 +253,7 @@ da_scala_library(
         srcs = [":upgrades/coin-v3/Coin.daml"],
         project_name = "coin",
         target = lf_version,
-        upgrades = "//daml-script/test:coin-v2-{}.dar".format(lf_version),
+        # upgrades = "//daml-script/test:coin-v2-{}.dar".format(lf_version),
         version = "3.0.0",
     )
     for lf_version in LF_DEV_VERSIONS


### PR DESCRIPTION
On top of Tudor's changes here: https://github.com/DACH-NY/canton/pull/17194
Basically ports tests on Ledger API (from here https://github.com/digital-asset/daml/pull/18431) to also run against Admin API