### PR TITLE
only reject keys when both DAML_REJECT_KEYS is set and the version is <2.dev

### DIFF
--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV2.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV2.scala
@@ -1869,7 +1869,8 @@ private[archive] class DecodeV2(minor: LV.Minor) {
   // TODO(https://github.com/digital-asset/daml/issues/18457): this is a temporary hack. Replace
   //  with a feature flag.
   private[this] def assertSinceKeys(): Unit =
-    if (rejectKeys) throw Error.Parsing("Keys are not supported")
+    if (versionIsOlderThan(LV.Features.contractKeys) && rejectKeys)
+      throw Error.Parsing("Keys are not supported")
 }
 
 private[lf] object DecodeV2 {

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -55,6 +55,7 @@ object LanguageVersion {
     val bigNumeric = v2_dev
 
     val scenarios = v2_dev
+    val contractKeys = v2_dev
 
     /** Unstable, experimental features. This should stay in x.dev forever.
       * Features implemented with this flag should be moved to a separate


### PR DESCRIPTION
Context: https://github.com/digital-asset/daml/issues/18457

Without this change, DAML_REJECT_KEYS=1 prevents the canton CI from even passing the build step because codegen decodes dars.
