### PR TITLE
add contract key feature to the compiler

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -180,6 +180,13 @@ featureScenarios = Feature
     , featureCppFlag = Just "DAML_SCENARIOS"
     }
 
+featureContractKeys :: Feature
+featureContractKeys = Feature
+    { featureName = "Contract Keys"
+    , featureVersionReq = devOnly
+    , featureCppFlag = Just "DAML_CONTRACT_KEYS"
+    }
+
 featureExperimental :: Feature
 featureExperimental = Feature
     { featureName = "Daml Experimental"
@@ -207,6 +214,7 @@ allFeatures =
     , featureChoiceFuncs
     , featureTemplateTypeRepToText
     , featureScenarios
+    , featureContractKeys
     , featureUnstable
     , featureExperimental
     , featureDynamicExercise


### PR DESCRIPTION
This will allow us to hide key-related code behind and `#ifdef`.