### PR TITLE
Pass project name and version from `daml.yaml` to `daml test` when not using `--files`

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -487,9 +487,7 @@ runTestsInProjectOrFiles
   where
     effect
       | getLoadCoverageOnly loadCoverageOnly = loadTestCoverageEffect
-      | otherwise = case mbInFiles of
-          Nothing -> runTestsInProjectEffect
-          Just inFiles -> runTestsInFilesEffect inFiles
+      | otherwise = maybe runTestsInProjectEffect runTestsInFilesEffect mbInFiles
 
     loadTestCoverageEffect = do
       when (getRunAllTests allTests) $ do

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -482,12 +482,12 @@ runTestsInProjectOrFiles projectOpts Nothing allTests _ coverage color mbJUnitOu
   where effect = withExpectProjectRoot (projectRoot projectOpts) "daml test" $ \pPath relativize -> do
         installDepsAndInitPackageDb cliOptions initPkgDb
         mbJUnitOutput <- traverse relativize mbJUnitOutput
-        withPackageConfig (ProjectPath pPath) $ \PackageConfigFields{..} -> do
+        withPackageConfig (ProjectPath pPath) $ \pkgConfigFields -> do
             -- TODO: We set up one scenario service context per file that
             -- we pass to execTest and scenario contexts are quite expensive.
             -- Therefore we keep the behavior of only passing the root file
             -- if source points to a specific file.
-            files <- getDamlRootFiles pSrc
+            files <- getDamlRootFiles (pSrc pkgConfigFields)
             execTest files allTests coverage color mbJUnitOutput cliOptions tableOutputPath transactionsOutputPath coveragePaths coverageFilters
 runTestsInProjectOrFiles projectOpts (Just inFiles) allTests _ coverage color mbJUnitOutput cliOptions initPkgDb tableOutputPath transactionsOutputPath coveragePaths coverageFilters = Command Test (Just projectOpts) effect
   where effect = withProjectRoot' projectOpts $ \relativize -> do

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -509,6 +509,9 @@ runTestsInProjectOrFiles
             -- if source points to a specific file.
             files <- getDamlRootFiles (pSrc pkgConfigFields)
             execTestsFrom files relativize cliOptions
+              { optMbPackageName = Just (pName pkgConfigFields)
+              , optMbPackageVersion = pVersion pkgConfigFields
+              }
 
     runTestsInFilesEffect inFiles =
       withProjectRoot' projectOpts $ \relativize -> do

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -502,22 +502,23 @@ runTestsInProjectOrFiles
 
     runTestsInProjectEffect =
       withExpectProjectRoot (projectRoot projectOpts) "daml test" $ \pPath relativize -> do
-        installDepsAndInitPackageDb cliOptions initPkgDb
-        mbJUnitOutput <- traverse relativize mbJUnitOutput
         withPackageConfig (ProjectPath pPath) $ \pkgConfigFields -> do
             -- TODO: We set up one scenario service context per file that
             -- we pass to execTest and scenario contexts are quite expensive.
             -- Therefore we keep the behavior of only passing the root file
             -- if source points to a specific file.
             files <- getDamlRootFiles (pSrc pkgConfigFields)
-            execTest files allTests coverage color mbJUnitOutput cliOptions tableOutputPath transactionsOutputPath coveragePaths coverageFilters
+            execTestsFrom files relativize cliOptions
 
     runTestsInFilesEffect inFiles =
       withProjectRoot' projectOpts $ \relativize -> do
-        installDepsAndInitPackageDb cliOptions initPkgDb
-        mbJUnitOutput <- traverse relativize mbJUnitOutput
         inFiles' <- mapM (fmap toNormalizedFilePath' . relativize) inFiles
-        execTest inFiles' allTests coverage color mbJUnitOutput cliOptions tableOutputPath transactionsOutputPath coveragePaths coverageFilters
+        execTestsFrom inFiles' relativize cliOptions
+
+    execTestsFrom normPaths relativize options = do
+      installDepsAndInitPackageDb options initPkgDb
+      mbJUnitOutput <- traverse relativize mbJUnitOutput
+      execTest normPaths allTests coverage color mbJUnitOutput options tableOutputPath transactionsOutputPath coveragePaths coverageFilters
 
 cmdInspect :: Mod CommandFields Command
 cmdInspect =

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -181,7 +181,7 @@ import Data.List (isPrefixOf, isInfixOf)
 import Data.List.Extra (elemIndices, nubOrd, nubSort, nubSortOn)
 import qualified Data.List.Split as Split
 import qualified Data.Map.Strict as Map
-import Data.Maybe (catMaybes, fromMaybe, listToMaybe, mapMaybe)
+import Data.Maybe (catMaybes, fromMaybe, isJust, listToMaybe, mapMaybe)
 import qualified Data.Text.Extended as T
 import Data.Text.Encoding (encodeUtf8)
 import qualified Data.Text.Lazy.IO as TL
@@ -474,12 +474,10 @@ runTestsInProjectOrFiles projectOpts mbInFiles allTests (LoadCoverageOnly True) 
           when (getRunAllTests allTests) $ do
             hPutStrLn stderr "Cannot specify --all and --load-coverage-only at the same time."
             exitFailure
-          case mbInFiles of
-            Just _ -> do
-              hPutStrLn stderr "Cannot specify --files and --load-coverage-only at the same time."
-              exitFailure
-            Nothing -> do
-              loadAggregatePrintResults coveragePaths coverageFilters coverage Nothing
+          when (isJust mbInFiles) $ do
+            hPutStrLn stderr "Cannot specify --files and --load-coverage-only at the same time."
+            exitFailure
+          loadAggregatePrintResults coveragePaths coverageFilters coverage Nothing
 runTestsInProjectOrFiles projectOpts Nothing allTests _ coverage color mbJUnitOutput cliOptions initPkgDb tableOutputPath transactionsOutputPath coveragePaths coverageFilters = Command Test (Just projectOpts) effect
   where effect = withExpectProjectRoot (projectRoot projectOpts) "daml test" $ \pPath relativize -> do
         installDepsAndInitPackageDb cliOptions initPkgDb

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -476,7 +476,7 @@ runTestsInProjectOrFiles projectOpts mbInFiles allTests (LoadCoverageOnly True) 
             exitFailure
           case mbInFiles of
             Just _ -> do
-              hPutStrLn stderr "Cannot specify --all and --load-coverage-only at the same time."
+              hPutStrLn stderr "Cannot specify --files and --load-coverage-only at the same time."
               exitFailure
             Nothing -> do
               loadAggregatePrintResults coveragePaths coverageFilters coverage Nothing


### PR DESCRIPTION
The core of the change here is that we set `optMbPackage{Name,Version}` in the `cliOptions` passed to `execTest` to the values from `daml.yaml`, but only when running `daml test` in "project" mode (i.e. when not using `--files`). I also took the freedom to refactor this a bit, since I had a hard time following the logic as it was.

Status: a bunch of tests are failing with errors like the one below, which points to the scenario service not expecting the package name to be present. I'm making this a draft PR until I have time to fix that.

```
Script execution failed:
  CRASH: Unexpected conversion exception: Unknown package <package-name>-0.0.1
```