### PR TITLE
Restore Has{Ensure=>Agreement} constraint in template-only daml-script functions

### DIFF
--- a/compiler/damlc/tests/daml-test-files/DivulgeFetchNodeActors.daml
+++ b/compiler/damlc/tests/daml-test-files/DivulgeFetchNodeActors.daml
@@ -25,7 +25,7 @@ data TestCase t c = TestCase
   , divulgeChoice : c
   }
 
-buildScript : (Choice t c r, HasEnsure t) => (TestData -> TestCase t c) -> Script ()
+buildScript : (Choice t c r, HasAgreement t) => (TestData -> TestCase t c) -> Script ()
 buildScript mkTestCase = do
   alice <- allocateParty "alice"
   bank <- allocateParty "bank"

--- a/compiler/damlc/tests/daml-test-files/ScriptAssertHelpers.daml
+++ b/compiler/damlc/tests/daml-test-files/ScriptAssertHelpers.daml
@@ -8,12 +8,12 @@ import Daml.Script
 import DA.Assert
 import DA.Functor (void)
 
-cantSee : forall t p. (Show t, Eq t, Template t, HasEnsure t, IsParties p) => p -> ContractId t -> Script ()
+cantSee : forall t p. (Show t, Eq t, Template t, HasAgreement t, IsParties p) => p -> ContractId t -> Script ()
 cantSee p cid = do
   cArchived <- queryContractId p cid
   cArchived === None
 
-canSee : forall t p. (Show t, Eq t, Template t, HasEnsure t, IsParties p) => p -> ContractId t -> Script ()
+canSee : forall t p. (Show t, Eq t, Template t, HasAgreement t, IsParties p) => p -> ContractId t -> Script ()
 canSee p = void . queryAssertContractId p
 
 -- Note that, because of the requirement of specifying `t`, this cannot be used with infix notation, consider renaming
@@ -25,7 +25,7 @@ cantSeeKey p k = do
 canSeeKey : forall t k p. (Show k, TemplateKey t k, IsParties p) => p -> k -> Script ()
 canSeeKey p = void . queryAssertContractKey @t p
 
-queryAssertContractId : forall t p. (Template t, HasEnsure t, IsParties p) => p -> ContractId t -> Script t
+queryAssertContractId : forall t p. (Template t, HasAgreement t, IsParties p) => p -> ContractId t -> Script t
 queryAssertContractId p cid =
   queryContractId @t p cid >>= \case
     Some c -> pure c

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -210,8 +210,8 @@ data QueryACS a = QueryACS
 
 -- | Query the set of active contracts of the template
 -- that are visible to the given party.
-query : forall t p. (Template t, HasEnsure t, IsParties p) => p -> Script [(ContractId t, t)]
--- The 'HasEnsure t' constraint prevents this function from being used on interface types.
+query : forall t p. (Template t, HasAgreement t, IsParties p) => p -> Script [(ContractId t, t)]
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 query p = lift $ Free $ Query QueryACS with
   parties = toParties p
   tplId = templateTypeRep @t
@@ -220,8 +220,8 @@ query p = lift $ Free $ Query QueryACS with
 
 -- | Query the set of active contracts of the template
 -- that are visible to the given party and match the given predicate.
-queryFilter : (Template c, HasEnsure c, IsParties p) => p -> (c -> Bool) -> Script [(ContractId c, c)]
--- The 'HasEnsure c' constraint prevents this function from being used on interface types.
+queryFilter : (Template c, HasAgreement c, IsParties p) => p -> (c -> Bool) -> Script [(ContractId c, c)]
+-- The 'HasAgreement c' constraint prevents this function from being used on interface types.
 queryFilter p f = filter (\(_, c) -> f c) <$> query p
 
 data QueryContractIdPayload a = QueryContractIdPayload
@@ -242,8 +242,8 @@ data QueryContractIdPayload a = QueryContractIdPayload
 --
 -- This is semantically equivalent to calling `query`
 -- and filtering on the client side.
-queryContractId : forall t p. (Template t, HasEnsure t, IsParties p) => HasCallStack => p -> ContractId t -> Script (Optional t)
--- The 'HasEnsure t' constraint prevents this function from being used on interface types.
+queryContractId : forall t p. (Template t, HasAgreement t, IsParties p) => HasCallStack => p -> ContractId t -> Script (Optional t)
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 queryContractId p c = lift $ Free $ QueryContractId QueryContractIdPayload with
   parties = toParties p
   tplId = templateTypeRep @t
@@ -311,8 +311,8 @@ data QueryDisclosurePayload a = QueryDisclosurePayload
 -- WARNING: Over the gRPC this performs a linear search so only use this if the number of
 -- active contracts is small.
 -- Not supported by JSON API
-queryDisclosure : forall t p. (Template t, HasEnsure t, IsParties p) => HasCallStack => p -> ContractId t -> Script (Optional Disclosure)
--- The 'HasEnsure t' constraint prevents this function from being used on interface types.
+queryDisclosure : forall t p. (Template t, HasAgreement t, IsParties p) => HasCallStack => p -> ContractId t -> Script (Optional Disclosure)
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 queryDisclosure p c = lift $ Free $ QueryDisclosure QueryDisclosurePayload with
     parties = toParties p
     tplId = templateTypeRep @t
@@ -728,8 +728,8 @@ internalCreateAndExerciseCmd : forall r. AnyTemplate -> AnyChoice -> Commands r
 internalCreateAndExerciseCmd tplArg choiceArg = Commands $ Ap (\f -> f (CreateAndExercise tplArg choiceArg identity) (pure (fromLedgerValue @r)))
 
 -- | Create a contract of the given template.
-createCmd : (Template t, HasEnsure t) => t -> Commands (ContractId t)
--- The 'HasEnsure t' constraint prevents this function from being used on interface types.
+createCmd : (Template t, HasAgreement t) => t -> Commands (ContractId t)
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 createCmd arg = internalCreateCmd (toAnyTemplate arg)
 
 -- | Exercise a choice on the given contract.
@@ -741,8 +741,8 @@ exerciseByKeyCmd : forall t k c r. (TemplateKey t k, Choice t c r) => k -> c -> 
 exerciseByKeyCmd key arg = internalExerciseByKeyCmd (templateTypeRep @t) (toAnyContractKey @t key) (toAnyChoice @t arg)
 
 -- | Create a contract and exercise a choice on it in the same transaction.
-createAndExerciseCmd : forall t c r. (Template t, Choice t c r, HasEnsure t) => t -> c -> Commands r
--- The 'HasEnsure t' constraint prevents this function from being used on interface types.
+createAndExerciseCmd : forall t c r. (Template t, Choice t c r, HasAgreement t) => t -> c -> Commands r
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 createAndExerciseCmd tplArg choiceArg = internalCreateAndExerciseCmd (toAnyTemplate tplArg) (toAnyChoice @t choiceArg)
 
 -- | Archive the given contract.

--- a/daml-script/daml3/Daml/Script/Questions/Commands.daml
+++ b/daml-script/daml3/Daml/Script/Questions/Commands.daml
@@ -105,8 +105,8 @@ internalCreateAndExerciseCmd tplArg choiceArg explicitPackageId = Commands [Comm
 
 -- Typed commands but still internal as explicitPackageId not determined
 -- | HIDE
-internalTypedCreateCmd : (Template t, HasEnsure t) => t -> Bool -> Commands (ContractId t)
--- The 'HasEnsure t' constraint prevents this function from being used on interface types.
+internalTypedCreateCmd : (Template t, HasAgreement t) => t -> Bool -> Commands (ContractId t)
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 internalTypedCreateCmd arg explicitPackageId =
   coerceContractId <$> internalCreateCmd (toAnyTemplate arg) explicitPackageId
 
@@ -121,15 +121,15 @@ internalTypedExerciseByKeyCmd key arg explicitPackageId =
   fromLedgerValue @r <$> internalExerciseByKeyCmd (templateTypeRep @t) (toAnyContractKey @t key) (toAnyChoice @t arg) explicitPackageId
 
 -- | HIDE
-internalTypedCreateAndExerciseCmdWithCid : forall t c r. (Template t, Choice t c r, HasEnsure t) => t -> c -> Bool -> Commands (ContractId t, r)
--- The 'HasEnsure t' constraint prevents this function from being used on interface types.
+internalTypedCreateAndExerciseCmdWithCid : forall t c r. (Template t, Choice t c r, HasAgreement t) => t -> c -> Bool -> Commands (ContractId t, r)
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 internalTypedCreateAndExerciseCmdWithCid tplArg choiceArg explicitPackageId =
   bimap coerceContractId (fromLedgerValue @r) <$> internalCreateAndExerciseCmd (toAnyTemplate tplArg) (toAnyChoice @t choiceArg) explicitPackageId
 
 -- Main command API, without explicit package ids
 -- | Create a contract of the given template.
-createCmd : (Template t, HasEnsure t) => t -> Commands (ContractId t)
--- The 'HasEnsure t' constraint prevents this function from being used on interface types.
+createCmd : (Template t, HasAgreement t) => t -> Commands (ContractId t)
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 createCmd arg = internalTypedCreateCmd arg False
 
 -- | Exercise a choice on the given contract.
@@ -141,19 +141,19 @@ exerciseByKeyCmd : forall t k c r. (TemplateKey t k, Choice t c r) => k -> c -> 
 exerciseByKeyCmd key arg = internalTypedExerciseByKeyCmd @t key arg False
 
 -- | Create a contract and exercise a choice on it in the same transaction, returns the created ContractId, and the choice result.
-createAndExerciseWithCidCmd : forall t c r. (Template t, Choice t c r, HasEnsure t) => t -> c -> Commands (ContractId t, r)
--- The 'HasEnsure t' constraint prevents this function from being used on interface types.
+createAndExerciseWithCidCmd : forall t c r. (Template t, Choice t c r, HasAgreement t) => t -> c -> Commands (ContractId t, r)
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 createAndExerciseWithCidCmd tplArg choiceArg = internalTypedCreateAndExerciseCmdWithCid tplArg choiceArg False
 
 -- | Create a contract and exercise a choice on it in the same transaction, returns only the choice result.
-createAndExerciseCmd : forall t c r. (Template t, Choice t c r, HasEnsure t) => t -> c -> Commands r
--- The 'HasEnsure t' constraint prevents this function from being used on interface types.
+createAndExerciseCmd : forall t c r. (Template t, Choice t c r, HasAgreement t) => t -> c -> Commands r
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 createAndExerciseCmd tplArg choiceArg = snd <$> createAndExerciseWithCidCmd tplArg choiceArg
 
 -- Main command API, WITH explicit package ids
 -- | Create a contract of the given template, using the exact package ID of the template given - upgrades are disabled.
-createExactCmd : (Template t, HasEnsure t) => t -> Commands (ContractId t)
--- The 'HasEnsure t' constraint prevents this function from being used on interface types.
+createExactCmd : (Template t, HasAgreement t) => t -> Commands (ContractId t)
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 createExactCmd arg = internalTypedCreateCmd arg True
 
 -- | Exercise a choice on the given contract, using the exact package ID of the template given - upgrades are disabled.
@@ -166,13 +166,13 @@ exerciseByKeyExactCmd key arg = internalTypedExerciseByKeyCmd @t key arg True
 
 -- | Create a contract and exercise a choice on it in the same transaction, returns the created ContractId, and the choice result.
 -- Uses the exact package ID of the template given - upgrades are disabled.
-createAndExerciseWithCidExactCmd : forall t c r. (Template t, Choice t c r, HasEnsure t) => t -> c -> Commands (ContractId t, r)
--- The 'HasEnsure t' constraint prevents this function from being used on interface types.
+createAndExerciseWithCidExactCmd : forall t c r. (Template t, Choice t c r, HasAgreement t) => t -> c -> Commands (ContractId t, r)
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 createAndExerciseWithCidExactCmd tplArg choiceArg = internalTypedCreateAndExerciseCmdWithCid tplArg choiceArg True
 
 -- | Create a contract and exercise a choice on it in the same transaction, returns only the choice result.
-createAndExerciseExactCmd : forall t c r. (Template t, Choice t c r, HasEnsure t) => t -> c -> Commands r
--- The 'HasEnsure t' constraint prevents this function from being used on interface types.
+createAndExerciseExactCmd : forall t c r. (Template t, Choice t c r, HasAgreement t) => t -> c -> Commands r
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 createAndExerciseExactCmd tplArg choiceArg = snd <$> createAndExerciseWithCidExactCmd tplArg choiceArg
 
 -- | Archive the given contract.

--- a/daml-script/daml3/Daml/Script/Questions/Query.daml
+++ b/daml-script/daml3/Daml/Script/Questions/Query.daml
@@ -17,8 +17,8 @@ instance IsQuestion QueryACS [(ContractId (), AnyTemplate)] where command = "Que
 
 -- | Query the set of active contracts of the template
 -- that are visible to the given party.
-query : forall t p. (Template t, HasEnsure t, IsParties p) => p -> Script [(ContractId t, t)]
--- The 'HasEnsure t' constraint prevents this function from being used on interface types.
+query : forall t p. (Template t, HasAgreement t, IsParties p) => p -> Script [(ContractId t, t)]
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 query p = fmap convert $ lift $ QueryACS with
     parties = toParties p
     tplId = templateTypeRep @t
@@ -28,8 +28,8 @@ query p = fmap convert $ lift $ QueryACS with
 
 -- | Query the set of active contracts of the template
 -- that are visible to the given party and match the given predicate.
-queryFilter : (Template c, HasEnsure c, IsParties p) => p -> (c -> Bool) -> Script [(ContractId c, c)]
--- The 'HasEnsure c' constraint prevents this function from being used on interface types.
+queryFilter : (Template c, HasAgreement c, IsParties p) => p -> (c -> Bool) -> Script [(ContractId c, c)]
+-- The 'HasAgreement c' constraint prevents this function from being used on interface types.
 queryFilter p f = filter (\(_, c) -> f c) <$> query p
 
 data QueryContractId = QueryContractId with
@@ -49,7 +49,7 @@ instance IsQuestion QueryContractId (Optional (AnyTemplate, Text)) where command
 -- This is semantically equivalent to calling `query`
 -- and filtering on the client side.
 queryContractId_ : forall t p. (Template t, IsParties p) => HasCallStack => p -> ContractId t -> Script (Optional (AnyTemplate, Text))
--- The 'HasEnsure t' constraint prevents this function from being used on interface types.
+-- The 'HasAgreement t' constraint prevents this function from being used on interface types.
 queryContractId_ p c = lift $ QueryContractId with
     parties = toParties p
     tplId = templateTypeRep @t
@@ -58,15 +58,15 @@ queryContractId_ p c = lift $ QueryContractId with
 --    convert : Optional AnyTemplate -> Optional t
 --    convert = fmap $ fromSome . fromAnyTemplate
 
-queryContractId: forall t p. (Template t, HasEnsure t, IsParties p) => HasCallStack => p -> ContractId t -> Script (Optional t)
+queryContractId: forall t p. (Template t, HasAgreement t, IsParties p) => HasCallStack => p -> ContractId t -> Script (Optional t)
 queryContractId p c = fmap (fmap $ fromSome . fromAnyTemplate . fst) $ queryContractId_ p c
 
 -- TODO https://github.com/digital-asset/daml/issues/17755
 --  clean the API for different query function
 queryDisclosure: forall t p. (Template t, IsParties p) => HasCallStack => p -> ContractId t -> Script (Optional Disclosure)
 queryDisclosure p c = fmap (fmap  $ \(_, blob) -> Disclosure tplId cid blob) $ queryContractId_ p c
- where 
-    tplId = templateTypeRep @t 
+ where
+    tplId = templateTypeRep @t
     cid = coerceContractId c
 
 data QueryInterface = QueryInterface with

--- a/daml-script/test/daml/MultiTest.daml
+++ b/daml-script/test/daml/MultiTest.daml
@@ -71,7 +71,7 @@ tries : Int
 tries = 60
 
 
-waitForCid : (Template t, HasEnsure t) => Int -> Party -> ContractId t -> Script ()
+waitForCid : (Template t, HasAgreement t) => Int -> Party -> ContractId t -> Script ()
 waitForCid tries p cid
   | tries <= 0 = abort $ "Cid " <> show cid <> " did not appear"
   | otherwise = do

--- a/daml-script/test/daml/upgrades/UpgradesTest.daml
+++ b/daml-script/test/daml/upgrades/UpgradesTest.daml
@@ -319,7 +319,7 @@ exerciseV2ChoiceV2ContractSameType = do
 
 genericUpgradeTest 
   : forall t2 t1 c2 r
-  . (Template t1, HasEnsure t1, Choice t2 c2 r)
+  . (Template t1, HasAgreement t1, Choice t2 c2 r)
   => (Party -> t1)
   -> c2
   -> Bool
@@ -332,7 +332,7 @@ genericUpgradeTest makeV1Contract v2Choice explicitPackageIds handleRes = do
   res <- a `trySubmit` (if explicitPackageIds then exerciseExactCmd else exerciseCmd) cidV2 v2Choice
   handleRes res
 
-choiceTest : forall t2 t1 c2 r. (Template t1, HasEnsure t1, Choice t2 c2 r, Eq r, Show r) => (Party -> t1) -> c2 -> Bool -> r -> Script ()
+choiceTest : forall t2 t1 c2 r. (Template t1, HasAgreement t1, Choice t2 c2 r, Eq r, Show r) => (Party -> t1) -> c2 -> Bool -> r -> Script ()
 choiceTest makeV1Contract v2Choice explicitPackageIds expectedResult = genericUpgradeTest @t2 makeV1Contract v2Choice explicitPackageIds $ \res ->
   case res of
     Right returnValue -> returnValue === expectedResult
@@ -534,7 +534,7 @@ ensureClauseDowngradeToNoLongerValid =
     Left (UnhandledException (Some (fromAnyException -> Some (PreconditionFailed _)))) -> pure ()
     res -> assertFail $ "Expected PreconditionFailed, got " <> show res
 
-templateInvalidChange : forall t2 t1 c2. (Template t1, HasEnsure t1, Choice t2 c2 Text) => Bool -> (Party -> t1) -> c2 -> Script ()
+templateInvalidChange : forall t2 t1 c2. (Template t1, HasAgreement t1, Choice t2 c2 Text) => Bool -> (Party -> t1) -> c2 -> Script ()
 templateInvalidChange shouldSucceed makeV1Contract v2Choice =
   genericUpgradeTest @t2 makeV1Contract v2Choice False $ \res ->
     case (res, shouldSucceed) of

--- a/docs/source/daml-script/template-root/src/ScriptExample.daml
+++ b/docs/source/daml-script/template-root/src/ScriptExample.daml
@@ -131,7 +131,7 @@ initializeUser = do
 tries : Int
 tries = 60
 
-waitForCid : (Template t, HasEnsure t) => Int -> Party -> ContractId t -> Script ()
+waitForCid : (Template t, HasAgreement t) => Int -> Party -> ContractId t -> Script ()
 waitForCid tries p cid
   | tries <= 0 = abort $ "Cid " <> show cid <> " did not appear"
   | otherwise = do

--- a/docs/source/daml/intro/daml/daml-intro-13/daml/Main.daml
+++ b/docs/source/daml/intro/daml/daml-intro-13/daml/Main.daml
@@ -245,7 +245,7 @@ mkArchiveNftTransferProposalTest Parties {..} = do
 
 -- MK_ASSET_TEST_BEGIN
 mkAssetTest : forall t.
-  (Template t, Implements t IAsset, HasEnsure t) =>
+  (Template t, Implements t IAsset, HasAgreement t) =>
   Text -> Parties -> (Party -> Party -> t) -> Script (ContractId IAsset)
 mkAssetTest assetTxt Parties {..} mkAsset = do
   aliceAsset <-
@@ -314,7 +314,7 @@ mkAssetTest assetTxt Parties {..} mkAsset = do
 -- MK_ASSET_TEST_END
 
 mkArchiveAssetTest : forall t.
-  (Template t, Implements t IAsset, HasEnsure t) =>
+  (Template t, Implements t IAsset, HasAgreement t) =>
   Parties -> (Party -> Party -> t) -> Script ()
 mkArchiveAssetTest Parties {..} mkAsset = do
   aliceAsset <-
@@ -326,7 +326,7 @@ mkArchiveAssetTest Parties {..} mkAsset = do
     archiveCmd aliceAsset
 
 mkArchiveAssetTransferProposalTest : forall t.
-  (Template t, Implements t IAsset, HasEnsure t) =>
+  (Template t, Implements t IAsset, HasAgreement t) =>
   Parties -> (Party -> Party -> t) -> Script ()
 mkArchiveAssetTransferProposalTest Parties {..} mkAsset = do
   aliceAsset <-

--- a/triggers/daml/Daml/Trigger/Assert.daml
+++ b/triggers/daml/Daml/Trigger/Assert.daml
@@ -44,7 +44,7 @@ buildACS party (ACSBuilder fetches) = do
 
 -- | Include the given contract in the 'ACS'. Note that the `ContractId`
 -- must point to an active contract.
-toACS : (Template t, HasEnsure t) => ContractId t -> ACSBuilder
+toACS : (Template t, HasAgreement t) => ContractId t -> ACSBuilder
 toACS cid = ACSBuilder $ \p ->
   [ do t <-
          queryContractId p cid >>= \case
@@ -104,7 +104,7 @@ expectCommand commands fromCommand assertion = foldl step (Left []) commands
 
 -- | Check that at least one command is a create command whose payload fulfills the given assertions.
 assertCreateCmd
-  : (Template t, HasEnsure t, CanAbort m)
+  : (Template t, HasAgreement t, CanAbort m)
   => [Command]  -- ^ Check these commands.
   -> (t -> Either Text ())  -- ^ Perform these assertions.
   -> m ()
@@ -116,7 +116,7 @@ assertCreateCmd commands assertion =
 
 -- | Check that at least one command is an exercise command whose contract id and choice argument fulfill the given assertions.
 assertExerciseCmd
-  : (Template t, HasEnsure t, Choice t c r, CanAbort m)
+  : (Template t, HasAgreement t, Choice t c r, CanAbort m)
   => [Command]  -- ^ Check these commands.
   -> ((ContractId t, c) -> Either Text ())  -- ^ Perform these assertions.
   -> m ()


### PR DESCRIPTION
This is to avoid breaking backwards compatibility for users who define polymorphic functions based on daml-script functions with this constraint. 

In other words, this is a partial revert of https://github.com/digital-asset/daml/pull/18468

This change only affects `daml-script` and downstream uses (some integration tests, some daml files used for docs and `triggers`), but importantly it has no impact for packages that don't use `daml-script`