### PR TITLE
Java Codegen error improvements

### DIFF
--- a/language-support/java/codegen/src/it/daml/Tests/UpgradeTest.daml
+++ b/language-support/java/codegen/src/it/daml/Tests/UpgradeTest.daml
@@ -18,6 +18,9 @@ data OptionalAtEnd = OptionalAtEnd
     d : Optional Text
   deriving (Show, Eq)
 
+data MyVariant = MyVariant1 Text | MyVariant2 Int deriving (Show, Eq)
+data MyEnum = MyEnum1 | MyEnum2 deriving (Show, Eq)
+
 -- Not part of the test but the codegen filters out
 -- data definitions which are not used in a template
 template UpgradeTestTemplate
@@ -25,5 +28,7 @@ template UpgradeTestTemplate
         p : Party
         noOptional : NoOptional
         optionalAtEnd : OptionalAtEnd
+        myVariant : MyVariant
+        myEnum : MyEnum
     where
         signatory p

--- a/language-support/java/codegen/src/it/java/com/daml/UpgradeTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/UpgradeTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 import tests.upgradetest.*;
+import tests.upgradetest.myvariant.*;
 
 @RunWith(JUnitPlatform.class)
 public class UpgradeTest {
@@ -88,5 +89,53 @@ public class UpgradeTest {
   void upgradeNonOptionalFields() {
     DamlRecord record = new DamlRecord(new DamlRecord.Field(new Text("abc")));
     assertThrows(IllegalArgumentException.class, () -> NoOptional.fromValue(record));
+  }
+
+  @Test
+  void exactMatchVariant() {
+    Variant variant = new Variant("MyVariant1", new Text("abc"));
+    MyVariant actual = MyVariant.fromValue(variant);
+
+    MyVariant expected = new MyVariant1("abc");
+
+    assertEquals(actual, expected);
+  }
+
+  @Test
+  void newMatchVariant() {
+    Variant variant = new Variant("MyVariant3", new Text("abc"));
+    Exception exception =
+        assertThrows(IllegalArgumentException.class, () -> MyVariant.fromValue(variant));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "Found unknown constructor MyVariant3 for variant tests.upgradetest.MyVariant,"
+                    + " expected one of [MyVariant1, MyVariant2]. This could be a failed variant"
+                    + " downgrade."));
+  }
+
+  @Test
+  void exactMatchEnum() {
+    DamlEnum damlenum = new DamlEnum("MyEnum1");
+    MyEnum actual = MyEnum.fromValue(damlenum);
+
+    MyEnum expected = MyEnum.MYENUM1;
+
+    assertEquals(actual, expected);
+  }
+
+  @Test
+  void newMatchEnum() {
+    DamlEnum damlenum = new DamlEnum("MyEnum3");
+    Exception exception =
+        assertThrows(IllegalArgumentException.class, () -> MyEnum.fromValue(damlenum));
+    System.out.println(exception);
+    assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "Found unknown constructor MyEnum3 for enum tests.upgradetest.MyEnum, expected one"
+                    + " of [MyEnum1, MyEnum2]. This could be a failed enum downgrade."));
   }
 }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/EnumClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/EnumClass.scala
@@ -118,19 +118,20 @@ private[inner] object EnumClass extends StrictLogging {
       enumeration: typesig.Enum,
   ): MethodSpec = {
     logger.debug(s"Generating valueDecoder static method for $enumeration")
-
+    val constructorsAsString = enumeration.constructors.mkString("[", ", ", "]")
     val valueDecoderCode = CodeBlock
       .builder()
       .addStatement(
         "$T constructor$$ = value$$.asEnum().orElseThrow(() -> new $T($S)).getConstructor()",
         classOf[String],
         classOf[IllegalArgumentException],
-        s"Expected DamlEnum to build an instance of the Enum ${className.simpleName()}",
+        s"Expected DamlEnum to build an instance of the Enum $className",
       )
       .addStatement(
-        "if (!__enums$$.containsKey(constructor$$)) throw new $T($S + constructor$$)",
+        "if (!__enums$$.containsKey(constructor$$)) throw new $T($S + constructor$$ + $S)",
         classOf[IllegalArgumentException],
-        s"Expected a DamlEnum with ${className.simpleName()} constructor, found ",
+        "Found unknown constructor ",
+        s" for enum $className, expected one of $constructorsAsString. This could be a failed enum downgrade.",
       )
       .addStatement("return __enums$$.get(constructor$$)")
 

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantClass.scala
@@ -112,8 +112,9 @@ private[inner] object VariantClass extends StrictLogging {
     }
     builder
       .addStatement(
-        "throw new IllegalArgumentException($S)",
-        s"Found unknown constructor variant$$.getConstructor() for variant $variant, expected one of $constructorsAsString",
+        "throw new IllegalArgumentException($S + variant$$.getConstructor() + $S)",
+        "Found unknown constructor ",
+        s" for variant $variant, expected one of $constructorsAsString. This could be a failed variant downgrade.",
       )
   }
 


### PR DESCRIPTION
Improves the variant/enum missing constructor errors to suggest a failed downgrade, and provide all information needed.