### PR TITLE
Java Codegen: use Exercises.Archivable instead of Exercises.Archive

### DIFF
--- a/language-support/java/codegen/src/it/java/com/daml/TemplateMethodTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/TemplateMethodTest.java
@@ -88,7 +88,7 @@ public class TemplateMethodTest {
   @Test
   void templateHasArchive() {
     SimpleTemplate.ContractId cid = new SimpleTemplate.ContractId("id");
-    Exercises.Archive<?> wideCid = cid;
+    Exercises.Archivable<?> wideCid = cid;
     assertEquals(
         wideCid.exerciseArchive().commands(), cid.exerciseArchive(new Archive()).commands());
   }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
@@ -101,7 +101,7 @@ object ContractIdClass {
   ) = {
     val exercisesParent =
       if (hasStandardArchive(choices, typeDeclarations))
-        classOf[javaapi.data.codegen.Exercises.Archive[_]]
+        classOf[javaapi.data.codegen.Exercises.Archivable[_]]
       else classOf[javaapi.data.codegen.Exercises[_]]
     val exercisesClass = TypeSpec
       .interfaceBuilder(exercisesInterface(className))


### PR DESCRIPTION
Step 2 of the two-repo tango, described here

https://github.com/DACH-NY/canton/pull/17210