### PR TITLE
[LF] resurect lf.data.Decimal

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Decimal.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Decimal.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package data
+
+import java.math.BigDecimal
+
+import scala.math.{BigDecimal => BigDec}
+
+// Our legacy Numerics are fix scale 10, aka Decimals
+// This object provides some legacy utility functions for Decimal
+@deprecated("Use Numeric instead", since = "3.0.0")
+object Decimal {
+
+  @deprecated("Use Numeric.Scale.assertFromInt(10)", since = "3.0.0")
+  val scale: Numeric.Scale = Numeric.Scale.assertFromInt(10)
+
+  @deprecated("Use Numeric.Scale.assertFromInt(10).MaxValue", since = "3.0.0")
+  def MaxValue: Numeric = Numeric.maxValue(scale)
+  @deprecated("Use Numeric.Scale.assertFromInt(10).MinValue", since = "3.0.0")
+  def MinValue: Numeric = Numeric.minValue(scale)
+
+  @deprecated("Use Numeric.fromBigDecimal(Scale.assertFromInt(10), _)", since = "3.0.0")
+  def fromBigDecimal(x: BigDec): Either[String, data.Numeric.Numeric] =
+    Numeric.fromBigDecimal(scale, x)
+
+  private val hasExpectedFormat =
+    """[+-]?\d{1,28}(\.\d{1,10})?""".r.pattern
+
+  @deprecated(
+    """Use Numeric.fromString(Scale.assertFromInt(10), _). Note this alternative is stricter as it requires the string to match "`-?[1-9]\d{1,28}.([1-9]{10})`"""",
+    since = "3.0.0",
+  )
+  final def fromString(s: String): Either[String, Numeric] =
+    if (hasExpectedFormat.matcher(s).matches())
+      Numeric.fromBigDecimal(scale, new BigDecimal(s))
+    else
+      Left(s"""Could not read Decimal string "$s"""")
+
+  @deprecated("Use Numeric.fromString(Scale.assertFromInt(10), _)", since = "3.0.0")
+  final def assertFromString(s: String): Numeric =
+    assertRight(fromString(s))
+
+}

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/NumericModule.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/NumericModule.scala
@@ -225,6 +225,21 @@ abstract class NumericModule {
   def assertFromString(s: String): Numeric =
     assertRight(fromString(s))
 
+  /** Given a string representation of a decimal and a scale s returns the corresponding `Numeric s`.
+    * If the input does not match (where i = 38-s)
+    *   `-?([1-9]\d{1,i}|0).([1-9]{s})`
+    * or if the result of the conversion cannot be mapped into a numeric without loss of precision
+    * returns an error message instead.
+    */
+  def fromString(s: Scale, str: String): Either[String, Numeric] = for {
+    n <- fromString(str)
+    _ <- Either.cond(n.scale() == s, (), s"""Could not read Numeric $s string "$str"""")
+  } yield n
+
+  @throws[IllegalArgumentException]
+  def assertFromString(scale: Scale, s: String) =
+    assertRight(fromString(scale, s))
+
   /** Convert a BigDecimal to the Numeric with the smallest possible scale able to represent the
     * former without loss of precision. Returns an error if such Numeric does not exists.
     *

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/NumericModule.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/NumericModule.scala
@@ -228,7 +228,7 @@ abstract class NumericModule {
   /** Given a string representation of a decimal and a scale s returns the corresponding `Numeric s`.
     * If the input does not match (where i = 38-s)
     *   `-?([1-9]\d{1,i}|0).([1-9]{s})`
-    * or if the result of the conversion cannot be mapped into a numeric without loss of precision
+    * or if the result of the conversion cannot be mapped into a numeric of scale `s` without loss of precision
     * returns an error message instead.
     */
   def fromString(s: Scale, str: String): Either[String, Numeric] = for {

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/DecimalSpec.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/DecimalSpec.scala
@@ -1,0 +1,145 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.data
+
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+@scala.annotation.nowarn("cat=deprecation")
+class DecimalSpec extends AnyWordSpec with Matchers with TableDrivenPropertyChecks {
+
+  private def d(s: String) = BigDecimal(s).setScale(Decimal.scale).bigDecimal
+
+  "Decimal.fromString" should {
+
+    "accept properly formed string" in {
+
+      val testCases = Table(
+        "decimal without sign",
+        "0",
+        "1",
+        "123",
+        "123.4",
+        "0.123",
+        "1.234",
+        "12.34",
+        "00000",
+        "01",
+      )
+
+      val signs = Table("sign", "", "+", "-")
+
+      forEvery(signs) { sign =>
+        forEvery(testCases) { testCase =>
+          val decimal = sign + testCase
+          Decimal.fromString(decimal) shouldBe Right(d(decimal))
+        }
+      }
+    }
+
+    "reject strings that contain non expected characters" in {
+
+      val testCases = Table("strings", "a", "decimal", "0x00", "1E10", "2-1", "2+2", "2*3", "55/11")
+
+      forEvery(testCases) { testCase =>
+        Decimal.fromString(testCase) shouldBe a[Left[_, _]]
+      }
+
+    }
+
+    "reject improperly formatted decimal with one dot" in {
+
+      val testCases = Table(
+        "string",
+        ".",
+        ".0",
+        "0.",
+        "1.",
+        ".1",
+        "123.",
+        ".0",
+        ".0123",
+        ".123",
+      )
+
+      val signs = Table("sign", "", "+", "-")
+
+      forEvery(signs) { sign =>
+        forEvery(testCases) { testCase =>
+          val decimal = sign + testCase
+          Decimal.fromString(decimal) shouldBe a[Left[_, _]]
+        }
+      }
+    }
+
+    "reject strings containing more than one dot" in {
+
+      val testCases = Table(
+        "string",
+        "..",
+        "0..",
+        "..1",
+        "112..123",
+        "0.0.",
+        ".1.",
+      )
+
+      forEvery(testCases)(testCase => Decimal.fromString(testCase) shouldBe a[Left[_, _]])
+
+    }
+
+    "reject string with too many signs" in {
+
+      val testCases = Table(
+        "decimal without sign",
+        "1",
+        "123",
+        "12.34",
+      )
+
+      val signs = Table("sign", "++", "-+", "+-", "--", "+++", "-+-")
+
+      forEvery(signs) { sign =>
+        forEvery(testCases) { testCase =>
+          val decimal = sign + testCase
+          Decimal.fromString(decimal) shouldBe a[Left[_, _]]
+        }
+      }
+
+    }
+
+    "reject string with too many digit" in {
+
+      val negativeTestCases = Table(
+        "string",
+        "0" * 1 + "." + "0" * 1,
+        "0" * 28 + "." + "0" * 1,
+        "0" * 1 + "." + "0" * 10,
+        "0" * 28 + "." + "0" * 10,
+      )
+
+      val positiveTestCases = Table(
+        "string",
+        "0" * 29 + "." + "0" * 1,
+        "0" * 1 + "." + "0" * 11,
+        "0" * 29 + "." + "0" * 11,
+        "1" * 29 + "." + "1" * 1,
+        "1" * 50 + "." + "1" * 1,
+        "1" * 1 + "." + "1" * 11,
+        "1" * 1 + "." + "1" * 30,
+        "1" * 29 + "." + "1" * 11,
+        "1" * 55 + "." + "1" * 33,
+      )
+
+      forEvery(negativeTestCases)(testCase =>
+        Decimal.fromString(testCase) shouldBe Right(d(testCase))
+      )
+
+      forEvery(positiveTestCases)(testCase => Decimal.fromString(testCase) shouldBe a[Left[_, _]])
+    }
+
+  }
+
+}

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/NumericSpec.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/NumericSpec.scala
@@ -554,7 +554,7 @@ class NumericSpec
     }
   }
 
-  "Numeric.fromString" should {
+  "Numeric.fromString/1" should {
 
     import Numeric.fromString
 
@@ -602,6 +602,59 @@ class NumericSpec
       }
     }
 
+  }
+
+  "Numeric.fromString/2" should {
+
+    import Numeric.fromString
+
+    "reject improperly formatted string" in {
+
+      val testCases = Table[String](
+        "string",
+        "999999999999999999999999999999999999999.",
+        "82845904523536028.7471352662497757247012",
+        "0.31415926535897932384626433832795028842",
+        "1E10",
+        "00.0",
+        "+0.1",
+        "1..0",
+        ".4",
+        "--1.1",
+        "2.1.0",
+      )
+
+      fromString(Numeric.Scale.values(1), "1.0") shouldBe a[Right[_, _]]
+      forEvery(testCases) { x =>
+        Numeric.Scale.values.foreach(s => fromString(s, x) shouldBe a[Left[_, _]])
+      }
+    }
+
+    "parse proper strings accoring the scale" in {
+
+      val testCases = Table[Numeric.Scale, String](
+        "scale" -> "string",
+        Numeric.Scale.values(0) -> "99999999999999999999999999999999999999.",
+        Numeric.Scale.values(21) -> "82845904523536028.747135266249775724701",
+        Numeric.Scale.values(37) -> "0.3141592653589793238462643383279502884",
+        Numeric.Scale.values(1) -> "0.0",
+        Numeric.Scale.values(1) -> "-0.1",
+        Numeric.Scale.values(10) -> "9876543210.0123456789",
+        Numeric.Scale.values(37) -> "-9.9999999999999999999999999999999999999",
+        Numeric.Scale.values(37) -> "-0.0000000000000000000000000000000000001",
+      )
+
+      forAll(testCases) { (s, x) =>
+        Numeric.Scale.values.foreach {
+          case `s` =>
+            val n = assertRight(fromString(s, x))
+            n shouldBe new BigDecimal(x)
+            n.scale shouldBe s
+          case s =>
+            fromString(s, x) shouldBe a[Left[_, _]]
+        }
+      }
+    }
   }
 
 }


### PR DESCRIPTION
but make it deprecated

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
