### PR TITLE
fix blackduck script update

### DIFF
--- a/ci/blackduck.yml
+++ b/ci/blackduck.yml
@@ -180,7 +180,7 @@ jobs:
       latest=$(git ls-remote https://github.com/DACH-NY/security-blackduck.git master | awk '{print $1}')
       current=$(cat ci/blackduck.yml | grep blackduck_script_sha: | head -1 | cut -f2 -d: | cut -c2- )
 
-      branch="bump-blackduck-script-${latest:0:8}"
+      branch="bump-blackduck-script-${latest:0:8}-$(Build.SourceBranchName)"
 
       if git ls-remote --exit-code --heads https://github.com/digital-asset/daml.git refs/heads/$branch >/dev/null; then
         echo "$branch already exists, nothing to do."


### PR DESCRIPTION
This job runs on both `main` and `main-2.x`, and generates the same branch name. This results in only the first of the two that runs generating a PR.

With this change the branch name will be different so when an update is needed we'll update both on the same day.