### PR TITLE
Fix `//daml-script/test:upgrade-test` for releases

### DIFF
--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -189,6 +189,7 @@ da_scala_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//:sdk-version-scala-lib",
         "//bazel_tools/runfiles:scala_runfiles",
         "//canton:community_base",
         "//canton:community_ledger_ledger-common",

--- a/daml-script/test/src/test-utils/com/daml/lf/DarUtil.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/DarUtil.scala
@@ -8,6 +8,7 @@ import com.daml.bazeltools.BazelRunfiles.requiredResource
 import com.daml.lf.archive.DarParser
 import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.language.LanguageVersion
+import com.daml.SdkVersion
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
 import scala.sys.process._
@@ -46,7 +47,7 @@ object DarUtil {
 
     def writeDamlYaml(pkgRoot: Path) = {
       val fileContent =
-        s"""sdk-version: 0.0.0
+        s"""sdk-version: ${SdkVersion.sdkVersion}
           |build-options: [--target=${lfVersion.pretty}]
           |name: $name
           |source: .


### PR DESCRIPTION
The problem was that these tests always used sdk version `0.0.0`, which works for PR builds but not for release builds.

I tested this locally with `DAML_SDK_RELEASE_VERSION=9.9.9 bazel test //daml-script/test:upgrade-test`