### PR TITLE
Make CI steps `publish_npm_mvn`, `publish` and `PublishPipelineArtifact@0` only run on `main{,-2.x}`

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -107,7 +107,8 @@ steps:
     name: publish_npm_mvn
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
-                   eq(${{parameters.name_exp}}, 'linux-intel'))
+                   eq(${{parameters.name_exp}}, 'linux-intel'),
+                   in(variables['Build.SourceBranchName'], 'main', 'main-2.x'))
   - template: bash-lib.yml
     parameters:
       var_name: bash-lib
@@ -124,11 +125,13 @@ steps:
     name: publish
     condition: and(succeeded(),
                    ne(${{parameters.name_exp}}, 'm1'),
-                   eq(${{parameters.is_release}}, 'true'))
+                   eq(${{parameters.is_release}}, 'true'),
+                   in(variables['Build.SourceBranchName'], 'main', 'main-2.x'))
   - task: PublishPipelineArtifact@0
     inputs:
       targetPath: $(Build.StagingDirectory)/release
       artifactName: ${{parameters.name_str}}-release
     condition: and(succeeded(),
                    ne(${{parameters.name_exp}}, 'm1'),
-                   eq(${{parameters.is_release}}, 'true'))
+                   eq(${{parameters.is_release}}, 'true'),
+                   in(variables['Build.SourceBranchName'], 'main', 'main-2.x'))


### PR DESCRIPTION
This is a partial revert of https://github.com/digital-asset/daml/pull/18597, which removed the condition `in(variables['Build.SourceBranchName'], 'main', 'main-2.x')` from those steps
