### PR TITLE
Adapt UpgradingIT disallowing unknown qualified names for pkg name

### DIFF
--- a/ledger-test-tool/tool/BUILD.bazel
+++ b/ledger-test-tool/tool/BUILD.bazel
@@ -324,6 +324,5 @@ conformance_test(
             ["main-only"],
         ),
     ]
-    # TODO reenable the test
-    if False and not is_windows and is_intel
+    if not is_windows and is_intel
 ]


### PR DESCRIPTION
This is a port and adaptation of the changes in the `UpgradingIT` conformance tests from https://github.com/DACH-NY/canton/pull/17537. Note that the Canton-side changes have been done in https://github.com/DACH-NY/canton/commit/97240cb97961533e47cc730b14df8e26d1cc8e9b

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
