### PR TITLE
Fix //language-support/hs/bindings:test

### DIFF
--- a/language-support/hs/bindings/BUILD.bazel
+++ b/language-support/hs/bindings/BUILD.bazel
@@ -40,6 +40,10 @@ da_haskell_library(
 daml_compile(
     name = "for-tests",
     srcs = glob(["test/daml/for-tests/*.daml"]),
+    # TODO(https://github.com/digital-asset/daml/issues/18457): split the lib
+    # into modules that use contract keys and those that don't. Revert to the
+    # default target for those that don't.
+    target = "2.dev",
 )
 
 daml_compile(
@@ -91,7 +95,6 @@ da_haskell_test(
     # try not to overload the machine.
     tags = [
         "cpu:4",
-        "main-only",
     ] + (["manual"] if is_darwin else []),
     visibility = ["//visibility:public"],
     deps = [

--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -99,8 +99,15 @@ tListPackages :: SandboxTest
 tListPackages withSandbox = testCase "listPackages" $ run withSandbox $ \DarMetadata{mainPackageId,manifest} _testId -> do
     pids <- listPackages
     liftIO $ do
-        -- Canton loads the `AdminWorkflows` package at boot, hence the + 1
-        assertEqual "#packages" (length (dalfPaths manifest) + 1) (length pids)
+        putStrLn ("PIDS" <> show pids)
+        putStrLn ("dalfPaths manifest" <> show (dalfPaths manifest))
+        -- Canton loads the `AdminWorkflows` package at boot, hence the + 1.
+        -- The `AdminWorkflows` package transitively pulls the 2.1 prim and
+        -- stdlib packages, while our test dar pulls the 2.dev ones, hence the 
+        -- temporary + 2.
+        -- TODO(https://github.com/digital-asset/daml/issues/18457): revert to
+        --  just +1 once the test dar targets 2.1 again.
+        assertEqual "#packages" (length (dalfPaths manifest) + 1 + 2) (length pids)
         assertBool "The pid is listed" (mainPackageId `elem` pids)
 
 tGetPackage :: SandboxTest


### PR DESCRIPTION
Also remove the `main-only` label from that test. This was the last test using it, so now the CI run all tests against PRs again.