### PR TITLE
disable macOS over the weekend

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -170,7 +170,7 @@ jobs:
   dependsOn:
     - Windows
     - Linux
-    - macOS
+    #- macOS
   pool:
     name: 'ubuntu_20_04'
     demands: assignment -equals default
@@ -190,10 +190,10 @@ jobs:
       inputs:
         artifactName: platform-independence-dar-windows
         targetPath: $(Build.StagingDirectory)/platform-independence/windows/
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: platform-independence-dar-macos
-        targetPath: $(Build.StagingDirectory)/platform-independence/macos/
+    #- task: DownloadPipelineArtifact@2
+    #  inputs:
+    #    artifactName: platform-independence-dar-macos
+    #    targetPath: $(Build.StagingDirectory)/platform-independence/macos/
     - bash: |
         set -euo pipefail
         eval "$(./dev-env/bin/dade-assist)"
@@ -206,12 +206,12 @@ jobs:
 
         unzip -d $DIR1 $(Build.StagingDirectory)/platform-independence/linux-intel/platform-independence.dar
         unzip -d $DIR2 $(Build.StagingDirectory)/platform-independence/windows/platform-independence.dar
-        unzip -d $DIR3 $(Build.StagingDirectory)/platform-independence/macos/platform-independence.dar
+        #unzip -d $DIR3 $(Build.StagingDirectory)/platform-independence/macos/platform-independence.dar
         unzip -d $DIR4 $(Build.StagingDirectory)/platform-independence/linux-arm/platform-independence.dar
 
         # hie/hi files may differ.
         diff -r --strip-trailing-cr -x '*.hie' -x '*.hi' $DIR1 $DIR2
-        diff -r --strip-trailing-cr -x '*.hie' -x '*.hi' $DIR1 $DIR3
+        #diff -r --strip-trailing-cr -x '*.hie' -x '*.hi' $DIR1 $DIR3
         diff -r --strip-trailing-cr -x '*.hie' -x '*.hi' $DIR1 $DIR4
       displayName: 'Compare platform-independence dars of different platforms.'
 

--- a/ci/daily-snapshot.yml
+++ b/ci/daily-snapshot.yml
@@ -3,13 +3,13 @@
 
 pr: none
 trigger: none
-schedules:
-- cron: "0 1 * * *"
-  displayName: Daily split snapshot
-  branches:
-    include:
-    - main
-    - main-2.x
+schedules: none
+#- cron: "0 1 * * *"
+#  displayName: Daily split snapshot
+#  branches:
+#    include:
+#    - main
+#    - main-2.x
 
 parameters:
 - name: version

--- a/ci/macOS.yml
+++ b/ci/macOS.yml
@@ -15,7 +15,7 @@ jobs:
   pool:
     name: macOS-pool
     demands: assignment -equals ${{parameters.assignment}}
-  condition: and(succeeded(),
+  condition: and(false,succeeded(),
                  or(eq('${{parameters.name}}', 'macos'),
                     or(eq(variables['Build.SourceBranchName'], 'main'),
                        eq(variables['Build.SourceBranchName'], 'main-2.x'))))


### PR DESCRIPTION
Our macOS nodes will be shut down over the weekend. This is an attempt to make the minimal amount of change to still have a working CI over that period; this is meant to be merged late on Friday and reverted whenever the macOS nodes are back on Monday.