### PR TITLE
remove pex (#18641)

### DIFF
--- a/dev-env/bin/pex
+++ b/dev-env/bin/pex
@@ -1,1 +1,0 @@
-../lib/dade-exec-nix-tool

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -119,7 +119,6 @@ in rec {
 
     yapf = pkgs.python38Packages.yapf;
 
-    pex = pkgs.python38Packages.pex;
     pipenv = pkgs.pipenv;
 
     pre-commit = pkgs.pre-commit;


### PR DESCRIPTION
I can't find any usage site for it and it's failing to build on some platforms.