### PR TITLE
[LF] prevent use of non-comparable values in Map

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
@@ -149,7 +149,7 @@ private[lf] final class ValueTranslator(
                     } else {
                       SValue.SMap(
                         isTextMap = true,
-                        entries = entries.iterator.map { case (k, v) =>
+                        entries = entries.toImmArray.toSeq.view.map { case (k, v) =>
                           SValue.SText(k) -> go(typeArg0, v, newNesting)
                         },
                       )
@@ -165,7 +165,7 @@ private[lf] final class ValueTranslator(
                     } else {
                       SValue.SMap(
                         isTextMap = false,
-                        entries = entries.iterator.map { case (k, v) =>
+                        entries = entries.toSeq.view.map { case (k, v) =>
                           go(typeArg0, k, newNesting) -> go(typeArg1, v, newNesting)
                         },
                       )

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValueTranslatorSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValueTranslatorSpec.scala
@@ -115,12 +115,12 @@ class ValueTranslatorSpec(majorLanguageVersion: LanguageMajorVersion)
       (
         TTextMap(TBool),
         ValueTextMap(SortedLookupList(Map("0" -> ValueTrue, "1" -> ValueFalse))),
-        SMap(true, Iterator(SText("0") -> SValue.True, SText("1") -> SValue.False)),
+        SMap(true, SText("0") -> SValue.True, SText("1") -> SValue.False),
       ),
       (
         TGenMap(TInt64, TText),
         ValueGenMap(ImmArray(ValueInt64(1) -> ValueText("1"), ValueInt64(42) -> ValueText("42"))),
-        SMap(false, Iterator(SInt64(1) -> SText("1"), SInt64(42) -> SText("42"))),
+        SMap(false, SInt64(1) -> SText("1"), SInt64(42) -> SText("42")),
       ),
       (TOptional(TText), ValueOptional(Some(ValueText("text"))), SOptional(Some(SText("text")))),
       (

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -674,7 +674,7 @@ private[lf] object SBuiltinFun {
 
   final case object SBMapLookup extends SBuiltinPure(2) {
     override private[speedy] def executePure(args: util.ArrayList[SValue]): SOptional =
-      SOptional(getSMap(args, 1).entries.get(getSMapKey(args, 0)))
+      SOptional(getSMap(args, 1).get(getSMapKey(args, 0)))
   }
 
   final case object SBMapDelete extends SBuiltinPure(2) {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -231,15 +231,25 @@ object SValue {
   final case class SList(list: FrontStack[SValue]) extends SValue
 
   // We make the constructor private to ensure entries are sorted using `SMap Ordering`
+  // and all value are comparable.
   final case class SMap private (isTextMap: Boolean, entries: TreeMap[SValue, SValue])
       extends SValue
       with NoCopy {
 
-    def insert(key: SValue, value: SValue): SMap =
+    def insert(key: SValue, value: SValue): SMap = {
+      SMap.comparable(key)
       SMap(isTextMap, entries.updated(key, value))
+    }
 
-    def delete(key: SValue): SMap =
+    def delete(key: SValue): SMap = {
+      SMap.comparable(key)
       SMap(isTextMap, entries - key)
+    }
+
+    def get(key: SValue): Option[SValue] = {
+      SMap.comparable(key)
+      entries.get(key)
+    }
 
   }
 
@@ -260,25 +270,30 @@ object SValue {
     def fromOrderedEntries(
         isTextMap: Boolean,
         entries: Iterable[(SValue, SValue)],
-    ): SMap = SMap(isTextMap, data.TreeMap.fromOrderedEntries(entries))
+    ): SMap = {
+      entries.foreach { case (k, _) => comparable(k) }
+      SMap(isTextMap, data.TreeMap.fromOrderedEntries(entries))
+    }
 
     /** Build an SMap from an iterator over SValue key/value pairs.
       *
       * SValue keys are not assumed to be ordered - hence the SMap will be built in time O(n log(n)).
       * If keys are duplicate, the last overrides the firsts
       */
-    def apply(isTextMap: Boolean, entries: Iterator[(SValue, SValue)]): SMap =
+    def apply(isTextMap: Boolean, entries: Iterable[(SValue, SValue)]): SMap = {
+      entries.foreach { case (k, _) => comparable(k) }
       SMap(
         isTextMap,
-        entries.map { case p @ (k, _) => comparable(k); p }.to(TreeMap),
+        entries.to(TreeMap),
       )
+    }
 
     /** Build an SMap from a vararg sequence of SValue key/value pairs.
       *
       * SValue keys are not assumed to be ordered - hence the SMap will be built in time O(n log(n)).
       */
     def apply(isTextMap: Boolean, entries: (SValue, SValue)*): SMap =
-      SMap(isTextMap: Boolean, entries.iterator)
+      SMap(isTextMap: Boolean, entries)
   }
 
   // represents Any And AnyException

--- a/daml-lf/spec/daml-lf-2.rst
+++ b/daml-lf/spec/daml-lf-2.rst
@@ -4545,18 +4545,14 @@ ordered by keys according to the comparison function ``LESS``.
 
   Returns an empty generic map.
 
-  [*Available in versions >= 1.11*]
-
 * ``GENMAP_INSERT : ∀ α. ∀ β.  α → β → 'GenMap' α β → 'GenMap' α β``
 
   Inserts a new key and value in the map. If the key is already
   present according the builtin function ``EQUAL``, the associated
   value is replaced with the supplied value, otherwise the key/value
-  is inserted in order according to the builtin function ``LESS`` applied
-  on keys. This raises a runtime error if it tries to compare
-  incomparable values.
-
-  [*Available in versions >= 1.11*]
+  is inserted in order according to the builtin function ``LESS``
+  applied on keys. This raises a runtime error if it the first
+  argument is not a comparable value.
 
   Formally the builtin function ``GENMAP_INSERT`` semantics is defined
   by the following rules. ::
@@ -4595,9 +4591,7 @@ ordered by keys according to the comparison function ``LESS``.
 
   Looks up the value at a key in the map using the builtin function
   ``EQUAL`` to test key equality. This raises a runtime error if it
-  try to compare incomparable values.
-
-  [*Available in versions >= 1.11*]
+  the first argument is not a comparable value.
 
   Formally the builtin function ``GENMAP_LOOKUP`` semantics is defined
   by the following rules. ::
@@ -4623,10 +4617,8 @@ ordered by keys according to the comparison function ``LESS``.
 
   Deletes a key and its value from the map, using the builtin function
   ``EQUAL`` to test key equality. When the key is not a member of the
-  map, the original map is returned.  This raises a runtime error if it
-  try to compare incomparable values.
-
-  [*Available in versions >= 1.11*]
+  map, the original map is returned. This raises a runtime error if it
+  the first argument is not a comparable value.
 
   Formally the builtin function ``GENMAP_DELETE`` semantics is defined
   by the following rules. ::
@@ -4650,8 +4642,6 @@ ordered by keys according to the comparison function ``LESS``.
   Get the list of keys in the map. The keys are returned in the order
   they appear in the map.
 
-  [*Available in versions >= 1.11*]
-
   Formally the builtin function ``GENMAP_KEYS`` semantics is defined
   by the following rules. ::
 
@@ -4668,8 +4658,6 @@ ordered by keys according to the comparison function ``LESS``.
   Get the list of values in the map. The values are returned in the
   order they appear in the map (i.e. sorted by key).
 
-  [*Available in versions >= 1.11*]
-
   Formally the builtin function ``GENMAP_VALUES`` semantics is defined
   by the following rules. ::
 
@@ -4684,8 +4672,6 @@ ordered by keys according to the comparison function ``LESS``.
 * ``GENMAP_SIZE : ∀ α. ∀ β.  'GenMap' α β → 'Int64'``
 
   Return the number of elements in the map.
-
-  [*Available in versions >= 1.11*]
 
 Type Representation function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This fixes the behavior of Map, from LF point of view.  We do not backport this to 2.x, as compiler prevents the use of non comparable value.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
