### PR TITLE
[release] fix split-release step name

### DIFF
--- a/ci/split-release-job.yml
+++ b/ci/split-release-job.yml
@@ -40,7 +40,6 @@ jobs:
         else
           setvar skip false
         fi
-      name: check-arm-needed
     - task: DownloadPipelineArtifact@0
       inputs:
         artifactName: linux-intel-release


### PR DESCRIPTION
Turns out dashes are not valid in step names.