### PR TITLE
JSON API: perf test and possible fix for support ticket 6577

### DIFF
--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/MultiPartyQueryOnStaleCache.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/MultiPartyQueryOnStaleCache.scala
@@ -1,0 +1,63 @@
+// Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.daml.http.perf.scenario
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+import io.gatling.core.structure.PopulationBuilder
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+class MultiPartyQueryOnStaleCache extends Simulation with SimulationConfig with HasRandomAmount {
+
+  private val createRequest =
+    http("CreateCommand")
+      .post("/v1/create")
+      .body(StringBody(s"""{
+  "templateId": "Iou:Iou",
+  "payload": {
+    "issuer": "$aliceParty",
+    "owner": "$aliceParty",
+    "currency": "USD",
+    "amount": "1",
+    "observers": ["$bobParty", "$charlieParty"]
+  }
+}"""))
+
+  private def queryRequest(parties: Seq[String]) = {
+    val readAs = parties.map("\"" + _ + "\"").mkString("[", ",", "]")
+    val body = s"""{
+    "templateIds": ["Iou:Iou"],
+    "query": {"amount": "0"},
+    "readers": ${readAs}
+}"""
+    http("QueryRequest")
+      .post("/v1/query")
+      .body(StringBody(body))
+  }
+
+  private def createContracts(step: String) =
+    scenario(s"MultiPartyQueryOnStaleCache - CreateContracts - $step")
+      .exec(createRequest.silent)
+
+  private def queryBy(parties: String*) =
+    scenario(s"MultiPartyQueryOnStaleCache - Query By ${parties.mkString(",")}")
+      .exec(queryRequest(parties))
+
+  private def inOrder(steps: Seq[PopulationBuilder]): PopulationBuilder = steps match {
+    case head :: Nil => head
+    case head :: tail => head.andThen(inOrder(tail))
+  }
+
+  setUp(
+    inOrder(
+      Seq(
+        createContracts("initialize").inject(atOnceUsers(50)),
+        queryBy(aliceParty).inject(atOnceUsers(1)),
+        queryBy(bobParty).inject(atOnceUsers(1)),
+        queryBy(charlieParty).inject(atOnceUsers(1)),
+        createContracts("update").inject(atOnceUsers(1)),
+        queryBy(aliceParty, bobParty, charlieParty).inject(atOnceUsers(20)),
+      )
+    )
+  ).protocols(httpProtocolForBearer(aliceBobCharlieJwt))
+}

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SimulationConfig.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SimulationConfig.scala
@@ -13,14 +13,16 @@ private[scenario] trait SimulationConfig {
     Option(System.getProperty(name))
       .getOrElse(throw new RuntimeException("Missing system property " + name))
 
-  lazy val httpProtocol: HttpProtocolBuilder = http
+  lazy val httpProtocol: HttpProtocolBuilder = httpProtocolForBearer(aliceJwt)
+
+  def httpProtocolForBearer(jwt: String) = http
     .baseUrl(s"http://$hostAndPort")
     .wsBaseUrl(s"ws://$hostAndPort")
     .warmUp(s"http://$hostAndPort/v1/query")
     .inferHtmlResources()
     .acceptHeader("*/*")
     .acceptEncodingHeader("gzip, deflate")
-    .authorizationHeader(s"Bearer $aliceJwt")
+    .authorizationHeader(s"Bearer $jwt")
     .contentTypeHeader("application/json")
 
   protected[this] val defaultNumUsers = 10
@@ -34,6 +36,8 @@ private[scenario] trait SimulationConfig {
 
   protected[this] lazy val charlieParty: String = getPropertyOrFail(CharliePartyKey)
   protected[this] lazy val charlieJwt: String = getPropertyOrFail(CharlieJwtKey)
+
+  protected[this] lazy val aliceBobCharlieJwt: String = getPropertyOrFail(AliceBobCharlieJwtKey)
 }
 
 object SimulationConfig {
@@ -45,4 +49,6 @@ object SimulationConfig {
   val BobJwtKey = "com.daml.http.perf.bobJwt"
   val CharliePartyKey = "com.daml.http.perf.charlieParty"
   val CharlieJwtKey = "com.daml.http.perf.charlieJwt"
+
+  val AliceBobCharlieJwtKey = "com.daml.http.perf.aliceBobCharlieJwt"
 }


### PR DESCRIPTION
A part of https://digitalasset.atlassian.net/browse/ETX-461

Can be run against postgres with
```
bazel run //ledger-service/http-json-perf:http-json-perf-binary-ce -- --scenario=com.daml.http.perf.scenario.MultiPartyQueryOnStaleCache --dars="${PWD}/bazel-bin/docs/quickstart-model.dar" --query-store-index="postgres" --reports-dir=/tmp/daml/ --max-duration=10min
```
and against oracle with
```
bazel run --build_tag_filters=+canton-ee //ledger-service/http-json-perf:http-json-perf-binary-ee -- --scenario=com.daml.http.perf.scenario.MultiPartyQueryOnStaleCache --dars="${PWD}/bazel-bin/docs/quickstart-model.dar" --query-store-index="oracle" --reports-dir=/tmp/daml/ --max-duration=10min
```
after starting an oracle container.

Currently we're not seeing the postgres deadlock error reported in the ticket. However, in the absence of a proper reproduction, I've gone with the theory that the issue occurs when multiple concurrent queries attempt to update the same set of rows in the `ledger_offset` table, and the different updates acquire the row locks in different orders. The fix I've applied here is to first do a `SELECT ... ORDER BY ... FOR UPDATE`, so that we have ordered row lock acquisition, and the various threads should not deadlock each other.