### PR TITLE
Reenabled Canton JVM metrics and prometheus filtering

### DIFF
--- a/canton/BUILD.bazel
+++ b/canton/BUILD.bazel
@@ -1149,6 +1149,7 @@ scala_library(
         "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_services",
         "@maven//:io_grpc_grpc_stub",
+        "@maven//:io_opentelemetry_instrumentation_opentelemetry_runtime_telemetry_java8",
         "@maven//:io_opentelemetry_opentelemetry_api",
         "@maven//:io_opentelemetry_opentelemetry_exporter_common",
         "@maven//:io_opentelemetry_opentelemetry_exporter_otlp_common",

--- a/canton/community/app-base/src/main/scala/com/digitalasset/canton/config/CantonConfig.scala
+++ b/canton/community/app-base/src/main/scala/com/digitalasset/canton/config/CantonConfig.scala
@@ -886,6 +886,10 @@ object CantonConfig {
       deriveReader[MetricsReporterConfig.Prometheus]
     lazy implicit val metricsConfigCsvReader: ConfigReader[MetricsReporterConfig.Csv] =
       deriveReader[MetricsReporterConfig.Csv]
+    lazy implicit val metricsConfigLoggingReader: ConfigReader[MetricsReporterConfig.Logging] =
+      deriveReader[MetricsReporterConfig.Logging]
+    lazy implicit val metricsConfigJvmConfigReader: ConfigReader[MetricsConfig.JvmMetrics] =
+      deriveReader[MetricsConfig.JvmMetrics]
     lazy implicit val metricsReporterConfigReader: ConfigReader[MetricsReporterConfig] =
       deriveReader[MetricsReporterConfig]
     lazy implicit val histogramDefinitionConfigReader: ConfigReader[HistogramDefinition] =
@@ -1270,7 +1274,10 @@ object CantonConfig {
       deriveWriter[MetricsReporterConfig.Prometheus]
     lazy implicit val metricsConfigCsvWriter: ConfigWriter[MetricsReporterConfig.Csv] =
       deriveWriter[MetricsReporterConfig.Csv]
-
+    lazy implicit val metricsConfigLoggingWriter: ConfigWriter[MetricsReporterConfig.Logging] =
+      deriveWriter[MetricsReporterConfig.Logging]
+    lazy implicit val metricsConfigJvmMetricsWriter: ConfigWriter[MetricsConfig.JvmMetrics] =
+      deriveWriter[MetricsConfig.JvmMetrics]
     lazy implicit val metricsReporterConfigWriter: ConfigWriter[MetricsReporterConfig] =
       deriveWriter[MetricsReporterConfig]
     lazy implicit val histogramDefinitionConfigWriter: ConfigWriter[HistogramDefinition] =

--- a/canton/community/app-base/src/main/scala/com/digitalasset/canton/environment/Environment.scala
+++ b/canton/community/app-base/src/main/scala/com/digitalasset/canton/environment/Environment.scala
@@ -9,14 +9,7 @@ import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.digitalasset.canton.DiscardOps
 import com.digitalasset.canton.concurrent.*
 import com.digitalasset.canton.config.*
-import com.digitalasset.canton.console.{
-  ConsoleEnvironment,
-  ConsoleGrpcAdminCommandRunner,
-  ConsoleOutput,
-  GrpcAdminCommandRunner,
-  HealthDumpGenerator,
-  StandardConsoleOutput,
-}
+import com.digitalasset.canton.console.{ConsoleEnvironment, ConsoleGrpcAdminCommandRunner, ConsoleOutput, GrpcAdminCommandRunner, HealthDumpGenerator, StandardConsoleOutput}
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.domain.mediator.{MediatorNodeBootstrapX, MediatorNodeParameters}
 import com.digitalasset.canton.domain.metrics.MediatorMetrics
@@ -26,6 +19,7 @@ import com.digitalasset.canton.environment.Environment.*
 import com.digitalasset.canton.environment.ParticipantNodes.ParticipantNodesX
 import com.digitalasset.canton.lifecycle.Lifecycle
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
+import com.digitalasset.canton.metrics.MetricsConfig.JvmMetrics
 import com.digitalasset.canton.metrics.MetricsRegistry
 import com.digitalasset.canton.participant.*
 import com.digitalasset.canton.resource.DbMigrationsFactory
@@ -70,10 +64,11 @@ trait Environment extends NamedLogging with AutoCloseable with NoTracing {
     )
   }
 
+  config.monitoring.metrics.jvmMetrics.foreach(JvmMetrics.setup(_, configuredOpenTelemetry.openTelemetry))
+
   // public for buildDocs task to be able to construct a fake participant and domain to document available metrics via reflection
 
   lazy val metricsRegistry: MetricsRegistry = new MetricsRegistry(
-    config.monitoring.metrics.reportJvmMetrics,
     configuredOpenTelemetry.openTelemetry.meterBuilder("canton").build(),
     testingConfig.metricsFactoryType,
   )

--- a/canton/community/app-base/src/main/scala/com/digitalasset/canton/metrics/CsvReporter.scala
+++ b/canton/community/app-base/src/main/scala/com/digitalasset/canton/metrics/CsvReporter.scala
@@ -21,14 +21,9 @@ import scala.concurrent.blocking
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
-class CsvReporter(config: MetricsReporterConfig.Csv, val loggerFactory: NamedLoggerFactory)(implicit
-    scheduledExecutorService: ScheduledExecutorService
-) extends MetricExporter
+class CsvReporter(config: MetricsReporterConfig.Csv, val loggerFactory: NamedLoggerFactory) extends MetricExporter
     with NamedLogging
     with NoTracing {
-
-  val reader: MetricReader =
-    PeriodicMetricReader.builder(this).setExecutor(scheduledExecutorService).setInterval(config.interval.asJava).build()
 
   private val running = new AtomicBoolean(true)
   private val files = new TrieMap[String, (FileWriter, BufferedWriter)]
@@ -36,11 +31,7 @@ class CsvReporter(config: MetricsReporterConfig.Csv, val loggerFactory: NamedLog
 
   def getAggregationTemporality(instrumentType: InstrumentType): AggregationTemporality = AggregationTemporality.CUMULATIVE
 
-  private def includeMetric(data: MetricData): Boolean = {
-    data.getName.nonEmpty && (config.filters.isEmpty || config.filters.exists(
-      _.matches(data.getName)
-    ))
-  }
+
 
   override def flush(): CompletableResultCode = {
     (new CompletableResultCode()).whenComplete(() => {
@@ -69,10 +60,10 @@ class CsvReporter(config: MetricsReporterConfig.Csv, val loggerFactory: NamedLog
     lock.synchronized {
       if (running.get()) {
         val ts = CantonTimestamp.now()
-        val filtered = metrics.asScala.filter(includeMetric).flatMap { data =>
+        val converted = metrics.asScala.flatMap { data =>
           MetricValue.fromMetricData(data).map { value => (value, data) }
         }
-        filtered.foreach { case (value, metadata) => writeRow(ts, value, metadata) }
+        converted.foreach { case (value, metadata) => writeRow(ts, value, metadata) }
       }
     }
   })

--- a/canton/community/app-base/src/main/scala/com/digitalasset/canton/metrics/FilteringMetricsReader.scala
+++ b/canton/community/app-base/src/main/scala/com/digitalasset/canton/metrics/FilteringMetricsReader.scala
@@ -1,0 +1,42 @@
+package com.digitalasset.canton.metrics
+
+import com.digitalasset.canton.metrics.MetricsConfig.MetricsFilterConfig
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.metrics.InstrumentType
+import io.opentelemetry.sdk.metrics.`export`.{CollectionRegistration, MetricReader}
+import io.opentelemetry.sdk.metrics.data.{AggregationTemporality, MetricData}
+
+import java.util
+import java.util.Collections
+import java.util.stream.Collectors
+import scala.jdk.CollectionConverters.*
+import scala.collection.concurrent.TrieMap
+
+class FilteringMetricsReader private (filters: Seq[MetricsFilterConfig], parent: MetricReader) extends MetricReader {
+
+  // cache the result of the filter for each metric name so we don't have to traverse lists all the time
+  private val computedFilters = TrieMap[String, Boolean]()
+
+  private def includeMetric(data: MetricData): Boolean = {
+    if(data.getName.isEmpty) false
+    else if(filters.isEmpty) true
+    else computedFilters.getOrElseUpdate(data.getName, filters.exists(_.matches(data.getName)))
+  }
+
+  override def register(registration: CollectionRegistration): Unit = parent.register(new CollectionRegistration {
+    override def collectAllMetrics(): util.Collection[MetricData] = {
+      registration.collectAllMetrics().stream().filter(includeMetric(_)).collect(Collectors.toList())
+    }
+  })
+
+  override def forceFlush(): CompletableResultCode = parent.forceFlush()
+
+  override def shutdown(): CompletableResultCode = parent.shutdown()
+
+  override def getAggregationTemporality(instrumentType: InstrumentType): AggregationTemporality = parent.getAggregationTemporality(instrumentType)
+}
+
+object FilteringMetricsReader {
+  def create(filters: Seq[MetricsFilterConfig], parent: MetricReader): MetricReader =
+    if(filters.isEmpty) parent else new FilteringMetricsReader(filters, parent)
+}

--- a/canton/community/util-logging/src/main/scala/com/digitalasset/canton/telemetry/OpenTelemetryFactory.scala
+++ b/canton/community/util-logging/src/main/scala/com/digitalasset/canton/telemetry/OpenTelemetryFactory.scala
@@ -7,7 +7,7 @@ import com.daml.metrics.HistogramDefinition
 import com.daml.telemetry.OpenTelemetryOwner.addViewsToProvider
 import com.digitalasset.canton.logging.{NamedLoggerFactory, TracedLogger}
 import com.digitalasset.canton.metrics.OnDemandMetricsReader.NoOpOnDemandMetricsReader$
-import com.digitalasset.canton.metrics.OpenTelemetryOnDemandMetricsReader
+import com.digitalasset.canton.metrics.{OpenTelemetryOnDemandMetricsReader}
 import com.digitalasset.canton.tracing.{NoopSpanExporter, TraceContext, TracingConfig}
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.propagation.ContextPropagators
@@ -15,11 +15,7 @@ import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.metrics.{SdkMeterProvider, SdkMeterProviderBuilder}
-import io.opentelemetry.sdk.trace.`export`.{
-  BatchSpanProcessor,
-  BatchSpanProcessorBuilder,
-  SpanExporter,
-}
+import io.opentelemetry.sdk.trace.`export`.{BatchSpanProcessor, BatchSpanProcessorBuilder, SpanExporter}
 import io.opentelemetry.sdk.trace.samplers.Sampler
 import io.opentelemetry.sdk.trace.{SdkTracerProvider, SdkTracerProviderBuilder}
 

--- a/observability/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/Slf4jMetricExporter.scala
+++ b/observability/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/Slf4jMetricExporter.scala
@@ -13,15 +13,19 @@ import org.slf4j.{Logger, LoggerFactory}
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 class Slf4jMetricExporter(
-    logger: Logger = LoggerFactory.getLogger("logging-metrics-exporter")
+    logAsInfo: Boolean,
+    logger: Logger = LoggerFactory.getLogger("logging-metrics-exporter"),
 ) extends MetricExporter {
 
   override def `export`(
       metrics: util.Collection[MetricData]
   ): CompletableResultCode = {
-    logger.debug(s"Logging ${metrics.size()} metrics")
-    metrics.asScala.foreach(metricData => logger.debug(s"metric: $metricData"))
-    CompletableResultCode.ofSuccess()
+    (new CompletableResultCode()).whenComplete(() => {
+      metrics.asScala.foreach(metricData =>
+        if (logAsInfo) logger.info(s"$metricData")
+        else logger.debug(s"$metricData")
+      )
+    })
   }
 
   override def flush(): CompletableResultCode = CompletableResultCode.ofSuccess()


### PR DESCRIPTION
Before this change, we didn't have JVM metrics and we didn't have prometheus filtering. Now, we do.

Addresses https://github.com/DACH-NY/canton/issues/16647
and https://github.com/DACH-NY/canton/issues/17860
and https://github.com/DACH-NY/canton-network-node/issues/10440

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
