### PR TITLE
[2.3] fix create-daml-app template for NodeJS 18

### DIFF
--- a/compatibility/bazel_tools/create-daml-app/Main.hs
+++ b/compatibility/bazel_tools/create-daml-app/Main.hs
@@ -287,9 +287,13 @@ patchTsDependencies uiDir packageJsonFile = do
                    , depName `elem` depNames
                    ]) `KM.union`
                 dependencies
-          let newPackageJson =
-                Aeson.Object $
-                KM.insert "dependencies" (Aeson.Object patchedDeps) packageJson
+          let t1 = KM.insert "dependencies" (Aeson.Object patchedDeps) packageJson
+          let newPackageJson = case KM.lookup "scripts" packageJson of
+                Just (Aeson.Object oldScripts) -> do
+                  let t2 = KM.insert "start" "react-scripts start" oldScripts
+                  let t3 = KM.insert "build" "react-scripts build" t2
+                  Aeson.Object $ KM.insert "scripts" (Aeson.Object t3) t1
+                _ -> Aeson.Object t1
           -- Make sure we have write permissions before writing
           p <- getPermissions packageJsonFile
           setPermissions packageJsonFile (setOwnerWritable True p)

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/CreateDamlAppTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/CreateDamlAppTests.hs
@@ -188,9 +188,13 @@ patchTsDependencies uiDir packageJsonFile = do
                   , depName `elem` depNames
                   ] `KM.union`
                 dependencies
-          let newPackageJson =
-                Object $
-                KM.insert "dependencies" (Object patchedDeps) packageJson
+          let t1 = KM.insert "dependencies" (Object patchedDeps) packageJson
+          let newPackageJson = case KM.lookup "scripts" packageJson of
+                Just (Object oldScripts) -> do
+                  let t2 = KM.insert "start" "react-scripts start" oldScripts
+                  let t3 = KM.insert "build" "react-scripts build" t2
+                  Object $ KM.insert "scripts" (Object t3) t1
+                _ -> Object t1
           p <- getPermissions packageJsonFile
           setPermissions packageJsonFile (setOwnerWritable True p)
           BSL.writeFile packageJsonFile (encode newPackageJson)

--- a/templates/create-daml-app/ui/package.json.template
+++ b/templates/create-daml-app/ui/package.json.template
@@ -16,8 +16,8 @@
     "semantic-ui-react": "^2.0.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "react-scripts --openssl-legacy-provider start",
+    "build": "react-scripts --openssl-legacy-provider build",
     "test": "react-scripts test --testURL='http://localhost:7575'",
     "eject": "react-scripts eject",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src/"


### PR DESCRIPTION
I grow tired of making these changes manually on every release.