### PR TITLE
[release] faster releases - infra for experiment

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -63,6 +63,7 @@ steps:
     displayName: 'Platform-agnostic lints and checks'
     condition: and(succeeded(),
                    eq(variables.skip, 'false'),
+                   eq(${{parameters.is_release}}, 'false'),
                    eq(${{parameters.name_exp}}, 'linux-intel'))
 
   - bash: |
@@ -88,8 +89,30 @@ steps:
       IS_FORK: $(System.PullRequest.IsFork)
     condition: and(succeeded(),
                    eq(variables.skip, 'false'),
-                   or(eq(${{parameters.is_release}}, 'false'),
-                      ne(${{parameters.name_exp}}, 'm1')))
+                   eq(${{parameters.is_release}}, 'false'))
+
+  - bash: |
+      set -euo pipefail
+      p="_${{parameters.name_str}}"
+      a="_$(Build.BuildNumber)_$(System.JobAttempt)"
+      t="${{parameters.test_mode}}"
+      # Other branches may not have this optimization
+      if [ -f ci/build-release.sh ]; then
+        eval "$(dev-env/bin/dade-assist)"
+        ci/build-release.sh $p $a $t
+      else
+        ./build.sh $p $a $t
+      fi
+    displayName: 'Build Release'
+    env:
+      DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
+      DAML_SCALA_VERSION: ${{parameters.scala_version}}
+      ARTIFACTORY_USERNAME: $(ARTIFACTORY_USERNAME)
+      ARTIFACTORY_PASSWORD: $(ARTIFACTORY_PASSWORD)
+      IS_FORK: $(System.PullRequest.IsFork)
+    condition: and(succeeded(),
+                   eq(variables.skip, 'false'),
+                   eq(${{parameters.is_release}}, 'true'))
 
   # Do not publish dar from m1
   - ${{ if ne(parameters.name_exp, 'm1') }}:


### PR DESCRIPTION
When we build a release, it is always a "past" commit - typically, one that has already been tested twice: once when the corresponding PR was run, and then again as a "main"-branch commit.

Release branches don't run, but their protection rules enforce linear merges.

Either way, we know we're building a _good_ commit, and, assuming our builds and tests are hermetic, testing that commit again when we make a release is a pure waste of time and CPU resources.

The other case, where we make an ad-hoc release from a branch that has not been merged, has a similar issue: we do not necessarily want to run the full test suite, because part of the reason we need that commit may be that it doesn't succeed as is.

Based on that observation, I wondered what might be the minimal set of things we actually need to build when making a release. This PR is an experiment in trying to find that out.

--

This PR sets up the infrastructure needed for the experiment - as the YML files always come from main, this needs to be merged into main before any experiment can be done.

See #18812 for the first experiment.