### PR TITLE
Revert "remove support of retroactie interface instance in api-type-s…

### DIFF
--- a/sdk/canton/community/ledger/ledger-json-api/src/main/scala/com/digitalasset/canton/http/PackageService.scala
+++ b/sdk/canton/community/ledger/ledger-json-api/src/main/scala/com/digitalasset/canton/http/PackageService.scala
@@ -49,7 +49,7 @@ class PackageService(
   ) {
 
     def append(diff: PackageStore): State = {
-      val newPackageStore = this.packageStore ++ resolveChoicesIn(diff)
+      val newPackageStore = appendAndResolveRetroactiveInterfaces(resolveChoicesIn(diff))
       val (tpIdMap, ifaceIdMap) = getTemplateIdInterfaceMaps(newPackageStore)
       State(
         packageIds = newPackageStore.keySet,

--- a/sdk/canton/community/ledger/ledger-json-api/src/main/scala/com/digitalasset/canton/http/PackageService.scala
+++ b/sdk/canton/community/ledger/ledger-json-api/src/main/scala/com/digitalasset/canton/http/PackageService.scala
@@ -49,7 +49,7 @@ class PackageService(
   ) {
 
     def append(diff: PackageStore): State = {
-      val newPackageStore = appendAndResolveRetroactiveInterfaces(resolveChoicesIn(diff))
+      val newPackageStore = this.packageStore ++ resolveChoicesIn(diff)
       val (tpIdMap, ifaceIdMap) = getTemplateIdInterfaceMaps(newPackageStore)
       State(
         packageIds = newPackageStore.keySet,

--- a/sdk/daml-lf/api-type-signature/src/main/scala/lf/typesig/DefDataType.scala
+++ b/sdk/daml-lf/api-type-signature/src/main/scala/lf/typesig/DefDataType.scala
@@ -12,7 +12,17 @@ import scalaz.syntax.semigroup._
 import scalaz.syntax.traverse._
 import scalaz.syntax.std.map._
 import scalaz.syntax.std.option._
-import scalaz.{Applicative, Bifunctor, Bitraverse, Bifoldable, Foldable, Functor, Monoid, Traverse}
+import scalaz.{
+  Applicative,
+  Bifunctor,
+  Bitraverse,
+  Bifoldable,
+  Foldable,
+  Functor,
+  Monoid,
+  Semigroup,
+  Traverse,
+}
 import scalaz.Tags.FirstVal
 import java.{util => j}
 
@@ -203,6 +213,29 @@ final case class DefTemplate[+Ty](
   }
 
   def getKey: j.Optional[_ <: Ty] = key.toJava
+
+  private[typesig] def extendWithInterface[OTy >: Ty](
+      ifaceName: Ref.TypeConName,
+      ifc: DefInterface[OTy],
+  ): DefTemplate[OTy] = {
+    import TemplateChoices.{Resolved, Unresolved}
+    copy(
+      implementedInterfaces = implementedInterfaces :+ ifaceName,
+      tChoices = tChoices match {
+        case unr @ Unresolved(_, sources) =>
+          unr.copy(unresolvedChoiceSources = sources incl ifaceName)
+        // If unresolved, we need only add ifc as a future interface to resolve;
+        // otherwise, we must self-resolve and add to preexisting resolutions
+        case r @ Resolved(rc) =>
+          type K[C] = Semigroup[Resolved.Choices[C]]
+          r.copy(resolvedChoices =
+            FirstVal
+              .unsubst[K, TemplateChoice[OTy]](Semigroup.apply)
+              .append(rc, ifc choicesAsResolved ifaceName)
+          )
+      },
+    )
+  }
 }
 
 object DefTemplate {
@@ -282,16 +315,14 @@ sealed abstract class TemplateChoices[+Ty] extends Product with Serializable {
   ): Either[ResolveError[Resolved[O]], Resolved[O]] = this match {
     case Unresolved(direct, unresolved) =>
       val getAstInterface = astInterfaces.lift
-      type ResolutionResult[C] =
-        (Set[Ref.TypeConName], Map[Ref.ChoiceName, NonEmpty[Map[Option[Ref.TypeConName], C]]])
+      type ResolutionResult[C] = (Set[Ref.TypeConName], Resolved.Choices[C])
       val (missing, resolved): ResolutionResult[TemplateChoice[O]] =
         FirstVal.unsubst[ResolutionResult, TemplateChoice[O]](
           unresolved.forgetNE
             .foldMap { tcn =>
               getAstInterface(tcn).cata(
                 { astIf =>
-                  val tcnResolved =
-                    astIf.choices.transform((_, tc) => NonEmpty(Map, some(tcn) -> tc))
+                  val tcnResolved = astIf choicesAsResolved tcn
                   FirstVal.subst[ResolutionResult, TemplateChoice[O]](
                     Set.empty[Ref.TypeConName],
                     tcnResolved,
@@ -350,6 +381,11 @@ object TemplateChoices {
   object Resolved {
     private[daml] def fromDirect[Ty](directChoices: Map[Ref.ChoiceName, TemplateChoice[Ty]]) =
       Resolved(directAsResolved(directChoices))
+
+    // choice type abstracted over the TemplateChoice, for specifying
+    // aggregation of choices (typically with tags, foldMap, semigroup)
+    private[typesig] type Choices[C] =
+      Map[Ref.ChoiceName, NonEmpty[Map[Option[Ref.TypeConName], C]]]
   }
 
   implicit val `TemplateChoices traverse`: Traverse[TemplateChoices] = new Traverse[TemplateChoices]
@@ -388,13 +424,38 @@ object TemplateChoice {
 }
 
 /** @param choices Choices of this interface, indexed by name
+  * @param retroImplements IDs of templates that implement this interface, upon
+  *                        introduction of this interface into the environment
   */
 final case class DefInterface[+Ty](
     choices: Map[Ref.ChoiceName, TemplateChoice[Ty]],
     viewType: Option[Ref.TypeConName],
+    // retroImplements are used only by LF 1.x
+    retroImplements: Set[Ref.TypeConName] = Set.empty,
 ) {
   def getChoices: j.Map[Ref.ChoiceName, _ <: TemplateChoice[Ty]] =
     choices.asJava
+
+  // Restructure `choices` in the resolved-choices data structure format,
+  // for aggregation with [[TemplateChoices.Resolved]].
+  private[typesig] def choicesAsResolved[Name](
+      selfName: Name
+  ): Map[Ref.ChoiceName, NonEmpty[Map[Option[Name], TemplateChoice[Ty]]]] =
+    choices transform ((_, tc) => NonEmpty(Map, some(selfName) -> tc))
+
+  private[typesig] def resolveRetroImplements[S, OTy >: Ty](selfName: Ref.TypeConName, s: S)(
+      setTemplate: SetterAt[Ref.TypeConName, S, DefTemplate[OTy]]
+  ): (S, DefInterface[OTy]) = {
+    def addMySelf(dt: DefTemplate[OTy]) =
+      dt.extendWithInterface(selfName, this)
+
+    retroImplements
+      .foldLeft((s, retroImplements)) { (sr, tplName) =>
+        val (s, remaining) = sr
+        setTemplate(s, tplName).cata(setter => (setter(addMySelf), remaining - tplName), sr)
+      }
+      .map(remaining => copy(retroImplements = remaining))
+  }
 }
 
 object DefInterface extends FWTLike[DefInterface] {

--- a/sdk/daml-lf/api-type-signature/src/test/scala/lf/typesig/reader/SignatureReaderSpec.scala
+++ b/sdk/daml-lf/api-type-signature/src/test/scala/lf/typesig/reader/SignatureReaderSpec.scala
@@ -201,6 +201,14 @@ class SignatureReaderSpec extends AnyWordSpec with Matchers with Inside {
     }
     lazy val itpES = EnvironmentSignature.fromPackageSignatures(itp).resolveChoices
 
+    lazy val itpWithoutRetroImplements = itp.copy(
+      main = itp.main.copy(
+        interfaces = itp.main.interfaces - qn("RetroInterface:RetroIf")
+      )
+    )
+    lazy val itpESWithoutRetroImplements =
+      EnvironmentSignature.fromPackageSignatures(itpWithoutRetroImplements).resolveChoices
+
     "load without errors" in {
       itp shouldBe itp
     }
@@ -320,6 +328,13 @@ class SignatureReaderSpec extends AnyWordSpec with Matchers with Inside {
         Useless -> Set(Some(Ref.Identifier(itpPid, TIf)), Some(Ref.Identifier(itpPid, LibTIf))),
         Bar -> Set(None),
       )
+    }
+
+    "resolve retro implements harmlessly when there are none" in {
+      PackageSignature.resolveRetroImplements((), itpWithoutRetroImplements.all)((_, _) =>
+        None
+      ) should ===((), itpWithoutRetroImplements.all)
+      itpESWithoutRetroImplements.resolveRetroImplements should ===(itpESWithoutRetroImplements)
     }
   }
 


### PR DESCRIPTION
…ignature (#18382)"

This reverts commit 0b1ceafe6c39ebc11ed6c8580a92944b75ef4629.

part of resolving #18821

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
