### PR TITLE
[release] make sure //release is built before running it

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -144,6 +144,7 @@ steps:
       set -euo pipefail
       cd sdk
       eval "$(./dev-env/bin/dade-assist)"
+      bazel build //release:release
       ./bazel-bin/release/release --release-dir "$(mktemp -d)" --upload
     env:
       DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}


### PR DESCRIPTION
As `main` currently stands, this addition is redundant - we always run the release step after building everything. However, I am trying to reduce the time it takes to make a release (see https://github.com/digital-asset/daml/pull/18812 and https://github.com/digital-asset/daml/pull/18831 for context), so this may not hold moving forward, and it is quite important that we make sure the `release` executable we run is the one from the version being published, and not a leftover from a previous build.