### PR TITLE
Disallow keys in LF 2.1 in the compiler

### DIFF
--- a/sdk/compatibility/bazel_tools/data_dependencies/example/UpgradeFromCoinV1.daml
+++ b/sdk/compatibility/bazel_tools/data_dependencies/example/UpgradeFromCoinV1.daml
@@ -15,8 +15,6 @@ template UpgradeCoinProposal
   where
     signatory issuer
     observer owner
-    key (issuer, owner) : (Party, Party)
-    maintainer key._1
     choice Accept : ContractId UpgradeCoinAgreement
       controller owner
       do create UpgradeCoinAgreement with ..
@@ -29,8 +27,6 @@ template UpgradeCoinAgreement
     owner : Party
   where
     signatory issuer, owner
-    key (issuer, owner) : (Party, Party)
-    maintainer key._1
     nonconsuming choice Upgrade : ContractId CoinWithAmount
       with
         coinId : ContractId Coin

--- a/sdk/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/sdk/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1116,6 +1116,9 @@ convertTemplate env mc tplTypeCon tbinds@TemplateBinds{..}
 
 convertTemplateKey :: SdkVersioned => Env -> LF.TypeConName -> TemplateBinds -> ConvertM (Maybe TemplateKey)
 convertTemplateKey env tname TemplateBinds{..}
+    | Just fKey <- tbKey
+    , not (envLfVersion env `supports` featureContractKeys) =
+        unsupported "Contract keys." ()
     | Just keyTy <- tbKeyType
     , Just fKey <- tbKey
     , Just fMaintainer <- tbMaintainer

--- a/sdk/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/sdk/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1118,7 +1118,7 @@ convertTemplateKey :: SdkVersioned => Env -> LF.TypeConName -> TemplateBinds -> 
 convertTemplateKey env tname TemplateBinds{..}
     | Just fKey <- tbKey
     , not (envLfVersion env `supports` featureContractKeys) =
-        unsupported "Contract keys." ()
+        unsupported "Contract keys." (T.unpack $ T.intercalate "." $ unTypeConName tname)
     | Just keyTy <- tbKeyType
     , Just fKey <- tbKey
     , Just fMaintainer <- tbMaintainer

--- a/sdk/compiler/damlc/tests/BUILD.bazel
+++ b/sdk/compiler/damlc/tests/BUILD.bazel
@@ -459,6 +459,7 @@ da_haskell_test(
         "filepath",
         "process",
         "regex-tdfa",
+        "safe",
         "tasty",
         "tasty-hunit",
         "text",

--- a/sdk/compiler/damlc/tests/daml-test-files/ContractKeysNotSupported.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/ContractKeysNotSupported.daml
@@ -1,0 +1,12 @@
+-- @DOES-NOT-SUPPORT-LF-FEATURE DAML_CONTRACT_KEYS
+-- @ERROR Contract keys
+
+module ContractKeysNotSupported where
+
+template TemplateWithKey
+  with
+    p: Party
+  where
+    signatory p
+    key p: Party
+    maintainer key

--- a/sdk/compiler/damlc/tests/daml-test-files/UnusedMatchTestsWithKeys.EXPECTED.desugared-daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/UnusedMatchTestsWithKeys.EXPECTED.desugared-daml
@@ -1,4 +1,4 @@
-module UnusedMatchTests where
+module UnusedMatchTestsWithKeys where
 import (implicit) qualified DA.Internal.Record
 import (implicit) qualified GHC.Types
 import (implicit) qualified DA.Internal.Desugar
@@ -103,6 +103,33 @@ _choice$_T$Revoke
      \ self this@T {..} arg@Revoke
        -> let _ = self in
           let _ = this in let _ = arg in do pure (revokeRetVal this))
+instance DA.Internal.Desugar.HasExerciseByKey T (Party,
+                                                 Text) DA.Internal.Desugar.Archive (()) where
+  _exerciseByKey = GHC.Types.primitive @"UExerciseByKey"
+instance DA.Internal.Desugar.HasExerciseByKey T (Party,
+                                                 Text) Revoke (()) where
+  _exerciseByKey = GHC.Types.primitive @"UExerciseByKey"
+instance DA.Internal.Desugar.HasKey T (Party, Text) where
+  key this@T {..}
+    = userWrittenTuple (sig this, ident this)
+    where
+        _ = this
+instance DA.Internal.Desugar.HasMaintainer T (Party, Text) where
+  _maintainer _ key
+    = DA.Internal.Desugar.toParties
+        ((DA.Internal.Record.getField @"_1" key))
+    where
+        _ = key
+instance DA.Internal.Desugar.HasFetchByKey T (Party, Text) where
+  fetchByKey = GHC.Types.primitive @"UFetchByKey"
+instance DA.Internal.Desugar.HasLookupByKey T (Party, Text) where
+  lookupByKey = GHC.Types.primitive @"ULookupByKey"
+instance DA.Internal.Desugar.HasToAnyContractKey T (Party,
+                                                    Text) where
+  _toAnyContractKey = GHC.Types.primitive @"EToAnyContractKey"
+instance DA.Internal.Desugar.HasFromAnyContractKey T (Party,
+                                                      Text) where
+  _fromAnyContractKey = GHC.Types.primitive @"EFromAnyContractKey"
 revokeRetVal : T -> ()
 revokeRetVal _ = ()
 assertion : T -> Bool

--- a/sdk/compiler/damlc/tests/daml-test-files/UnusedMatchTestsWithKeys.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/UnusedMatchTestsWithKeys.daml
@@ -1,7 +1,8 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its
 -- affiliates. All rights reserved.
 
--- @WARN range=19:3-19:4; Defined but not used
+-- @SUPPORTS-LF-FEATURE DAML_CONTRACT_KEYS
+-- @WARN range=20:3-20:4; Defined but not used
 
 {-# OPTIONS_GHC -Wunused-matches #-}
 {-# OPTIONS_GHC -Wunused-foralls #-}
@@ -11,7 +12,7 @@
 {-# OPTIONS_GHC -Wunused-type-patterns #-}
 -- We know this will fail and why.
 --   {-# OPTIONS_GHC -Wunused-local-binds #-}
-module UnusedMatchTests where
+module UnusedMatchTestsWithKeys where
 
 -- It should be OK to enable -Wunused-* and not get warnings from
 -- template desugared code.
@@ -28,6 +29,8 @@ template T
     signatory sig this
     observer obs this
     ensure assertion this
+    key (sig this, ident this): (Party, Text)
+    maintainer key._1
     choice Revoke: () with
       controller p
       do

--- a/sdk/daml-lf/engine/BUILD.bazel
+++ b/sdk/daml-lf/engine/BUILD.bazel
@@ -96,10 +96,8 @@ da_scala_test_suite(
             major = major,
         )
         for name in [
-            "//daml-lf/tests:Exceptions",
             "//daml-lf/tests:Interfaces",
             "//daml-lf/tests:InterfaceViews",
-            "//daml-lf/tests:MultiKeys",
             "//daml-lf/tests:ReinterpretTests",
         ]
         for major in SUPPORTED_LF_MAJOR_VERSIONS

--- a/sdk/daml-lf/engine/BUILD.bazel
+++ b/sdk/daml-lf/engine/BUILD.bazel
@@ -96,6 +96,9 @@ da_scala_test_suite(
             major = major,
         )
         for name in [
+            # TODO(https://github.com/digital-asset/daml/issues/18457): split
+            #  //daml-lf/tests:Exceptions into templates that use keys and those
+            #  that don't. Split the corresponding test, and add it back here.
             "//daml-lf/tests:Interfaces",
             "//daml-lf/tests:InterfaceViews",
             "//daml-lf/tests:ReinterpretTests",

--- a/sdk/daml-lf/engine/src/test/daml/BasicTests.daml
+++ b/sdk/daml-lf/engine/src/test/daml/BasicTests.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-
+{-# LANGUAGE CPP #-}
 
 module BasicTests where
 
@@ -70,6 +70,7 @@ template CallablePayout
       controller receiver
       do create this with receiver = newReceiver
 
+#ifdef DAML_CONTRACT_KEYS
 template WithKey
   with p: Party
        k: Int
@@ -132,6 +133,7 @@ template ExerciseByKey
       controller p
       do
         exerciseByKey @WithKey (p, 42) SumToK with n = 0
+#endif
 
 -- Tests for the dynamic computation of fetch actors
 template Fetched
@@ -345,6 +347,7 @@ template TimeGetter with
       controller p
       do pure $ product [1, 2, 3]
 
+#ifdef DAML_CONTRACT_KEYS
 template ComputeContractKeyAfterEnsureClause with
     owner: Party
   where
@@ -376,3 +379,4 @@ template NoMaintainer
       controller sig
       do
         pure ()
+#endif

--- a/sdk/daml-lf/engine/src/test/daml/Demonstrator.daml
+++ b/sdk/daml-lf/engine/src/test/daml/Demonstrator.daml
@@ -1,6 +1,8 @@
 -- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE CPP #-}
+
 module Demonstrator where
 
 template RegistrarRole
@@ -48,5 +50,7 @@ template CancelledTransfer
     signatory operator
     observer investor
 
+#ifdef DAML_CONTRACT_KEYS
     key operator : Party
     maintainer key
+#endif

--- a/sdk/daml-lf/tests/BUILD.bazel
+++ b/sdk/daml-lf/tests/BUILD.bazel
@@ -17,16 +17,6 @@ load("@os_info//:os_info.bzl", "is_intel")
 
 [
     daml_compile(
-        name = "Exceptions-v{}".format(major),
-        srcs = ["Exceptions.daml"],
-        target = lf_version_default_or_latest(major),
-        visibility = ["//daml-lf:__subpackages__"],
-    )
-    for major in SUPPORTED_LF_MAJOR_VERSIONS
-]
-
-[
-    daml_compile(
         name = "Exceptions-{}".format(mangle_for_damlc(version)),
         srcs = ["Exceptions.daml"],
         target = version,
@@ -76,16 +66,6 @@ daml_compile(
     target = "1.14",
     visibility = ["//daml-lf:__subpackages__"],
 ) if is_intel else None
-
-[
-    daml_compile(
-        name = "MultiKeys-v{}".format(major),
-        srcs = ["MultiKeys.daml"],
-        target = lf_version_default_or_latest(major),
-        visibility = ["//daml-lf:__subpackages__"],
-    )
-    for major in SUPPORTED_LF_MAJOR_VERSIONS
-]
 
 [
     daml_compile(

--- a/sdk/daml-lf/tests/BUILD.bazel
+++ b/sdk/daml-lf/tests/BUILD.bazel
@@ -15,6 +15,19 @@ load(
 )
 load("@os_info//:os_info.bzl", "is_intel")
 
+# TODO(https://github.com/digital-asset/daml/issues/18457): split
+#  Exceptions.daml into templates that use keys and those that don't. Split the
+# corresponding test, and re-enable this target.
+# [
+#     daml_compile(
+#         name = "Exceptions-v{}".format(major),
+#         srcs = ["Exceptions.daml"],
+#         target = lf_version_default_or_latest(major),
+#         visibility = ["//daml-lf:__subpackages__"],
+#     )
+#     for major in LF_MAJOR_VERSIONS
+# ]
+
 [
     daml_compile(
         name = "Exceptions-{}".format(mangle_for_damlc(version)),

--- a/sdk/daml-lf/tests/Exceptions.daml
+++ b/sdk/daml-lf/tests/Exceptions.daml
@@ -1,6 +1,9 @@
 -- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+-- TODO(https://github.com/digital-asset/daml/issues/18457): split into non-key
+--   and key-related cases.
+
 module Exceptions where
 
 import DA.Assert

--- a/sdk/daml-lf/tests/Exceptions.daml
+++ b/sdk/daml-lf/tests/Exceptions.daml
@@ -1,8 +1,9 @@
 -- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- TODO(https://github.com/digital-asset/daml/issues/18457): split into non-key
---   and key-related cases.
+-- TODO(https://github.com/digital-asset/daml/issues/18457): split this daml
+-- file into tempates that use keys and those that don't. Split the
+-- corresponding test.
 
 module Exceptions where
 

--- a/sdk/daml-script/test/BUILD.bazel
+++ b/sdk/daml-script/test/BUILD.bazel
@@ -16,6 +16,7 @@ load(
     "//daml-lf/language:daml-lf.bzl",
     "SUPPORTED_LF_DEV_VERSIONS",
     "SUPPORTED_LF_MAJOR_VERSIONS",
+    "LF_DEFAULT_DEV_VERSION",
     "lf_version_default_or_latest",
     "mangle_for_damlc",
 )
@@ -84,10 +85,12 @@ EOF
         tools = ["//compiler/damlc"],
         visibility = ["//visibility:public"],
     )
-    for (target, name) in [(
-        lf_version_default_or_latest(major),
-        major,
-    ) for major in SUPPORTED_LF_MAJOR_VERSIONS] + [
+    for (target, name) in 
+    #[(
+    #    lf_version_default_or_latest(major),
+    #    major,
+    #) for major in SUPPORTED_LF_MAJOR_VERSIONS] + 
+    [
         (target, target)
         for target in SUPPORTED_LF_DEV_VERSIONS
     ]
@@ -141,7 +144,7 @@ genrule(
     name = "script-test-no-ledger",
     srcs =
         glob(["**/*.daml"]) + [
-            "//daml-script/daml3:daml3-script.dar",
+            "//daml-script/daml3:daml3-script-{}.dar".format(LF_DEFAULT_DEV_VERSION),
             "//docs:source/daml-script/template-root/src/ScriptExample.daml",
         ],
     outs = ["script-test-no-ledger.dar"],
@@ -150,7 +153,7 @@ genrule(
       TMP_DIR=$$(mktemp -d)
       mkdir -p $$TMP_DIR/daml
       cp -L $(location :daml/ScriptTest.daml) $$TMP_DIR/daml
-      cp -L $(location //daml-script/daml3:daml3-script.dar) $$TMP_DIR/
+      cp -L $(location //daml-script/daml3:daml3-script-{target}.dar) $$TMP_DIR/
       cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: {sdk}
 name: script-test-no-ledger
@@ -161,13 +164,13 @@ build-options:
 dependencies:
   - daml-stdlib
   - daml-prim
-  - daml3-script.dar
+  - daml3-script-{target}.dar
 EOF
       $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location script-test-no-ledger.dar)
       rm -rf $$TMP_DIR
     """.format(
         sdk = sdk_version,
-        target = lf_version_default_or_latest("2"),
+        target = LF_DEFAULT_DEV_VERSION
     ),
     tools = ["//compiler/damlc"],
     visibility = ["//visibility:public"],
@@ -369,16 +372,17 @@ da_scala_test_suite(
         ":script3-test-v2.dev.dar",
         "//compiler/damlc",
         "//daml-script/runner:daml-script-binary",
-    ] + [
-        ":script{scriptVersion}-test-v{major}.dar".format(
-            major = major,
-            scriptVersion = scriptVersion,
-        )
-        for major in SUPPORTED_LF_MAJOR_VERSIONS
-        for scriptVersion in [
-            "",
-            "3",
-        ]
+    #] 
+    #+ [
+    #     ":script{scriptVersion}-test-v{major}.dar".format(
+    #         major = major,
+    #         scriptVersion = scriptVersion,
+    #     )
+    #     for major in SUPPORTED_LF_MAJOR_VERSIONS
+    #     for scriptVersion in [
+    #         "",
+    #         "3",
+    #    ]
     ],
     resources = glob(["src/main/resources/**/*"]),
     scala_deps = [

--- a/sdk/daml-script/test/BUILD.bazel
+++ b/sdk/daml-script/test/BUILD.bazel
@@ -14,9 +14,9 @@ load("@os_info//:os_info.bzl", "is_windows")
 load("//rules_daml:daml.bzl", "daml_compile")
 load(
     "//daml-lf/language:daml-lf.bzl",
+    "LF_DEFAULT_DEV_VERSION",
     "SUPPORTED_LF_DEV_VERSIONS",
     "SUPPORTED_LF_MAJOR_VERSIONS",
-    "LF_DEFAULT_DEV_VERSION",
     "lf_version_default_or_latest",
     "mangle_for_damlc",
 )
@@ -85,11 +85,11 @@ EOF
         tools = ["//compiler/damlc"],
         visibility = ["//visibility:public"],
     )
-    for (target, name) in 
+    for (target, name) in
     #[(
     #    lf_version_default_or_latest(major),
     #    major,
-    #) for major in SUPPORTED_LF_MAJOR_VERSIONS] + 
+    #) for major in SUPPORTED_LF_MAJOR_VERSIONS] +
     [
         (target, target)
         for target in SUPPORTED_LF_DEV_VERSIONS
@@ -170,7 +170,7 @@ EOF
       rm -rf $$TMP_DIR
     """.format(
         sdk = sdk_version,
-        target = LF_DEFAULT_DEV_VERSION
+        target = LF_DEFAULT_DEV_VERSION,
     ),
     tools = ["//compiler/damlc"],
     visibility = ["//visibility:public"],
@@ -372,17 +372,17 @@ da_scala_test_suite(
         ":script3-test-v2.dev.dar",
         "//compiler/damlc",
         "//daml-script/runner:daml-script-binary",
-    #] 
-    #+ [
-    #     ":script{scriptVersion}-test-v{major}.dar".format(
-    #         major = major,
-    #         scriptVersion = scriptVersion,
-    #     )
-    #     for major in SUPPORTED_LF_MAJOR_VERSIONS
-    #     for scriptVersion in [
-    #         "",
-    #         "3",
-    #    ]
+        #]
+        #+ [
+        #     ":script{scriptVersion}-test-v{major}.dar".format(
+        #         major = major,
+        #         scriptVersion = scriptVersion,
+        #     )
+        #     for major in SUPPORTED_LF_MAJOR_VERSIONS
+        #     for scriptVersion in [
+        #         "",
+        #         "3",
+        #    ]
     ],
     resources = glob(["src/main/resources/**/*"]),
     scala_deps = [

--- a/sdk/daml-script/test/BUILD.bazel
+++ b/sdk/daml-script/test/BUILD.bazel
@@ -86,6 +86,9 @@ EOF
         visibility = ["//visibility:public"],
     )
     for (target, name) in
+    # TODO(https://github.com/digital-asset/daml/issues/18457): re-enable once
+    #  script tests have been split into those that use keys and those that
+    #  don't.
     #[(
     #    lf_version_default_or_latest(major),
     #    major,
@@ -372,18 +375,20 @@ da_scala_test_suite(
         ":script3-test-v2.dev.dar",
         "//compiler/damlc",
         "//daml-script/runner:daml-script-binary",
-        #]
-        #+ [
-        #     ":script{scriptVersion}-test-v{major}.dar".format(
-        #         major = major,
-        #         scriptVersion = scriptVersion,
-        #     )
-        #     for major in SUPPORTED_LF_MAJOR_VERSIONS
-        #     for scriptVersion in [
-        #         "",
-        #         "3",
-        #    ]
     ],
+    # TODO(https://github.com/digital-asset/daml/issues/18457): re-enable once
+    #  script tests have been split into those that use keys and those that
+    #  don't.
+    #+ [
+    #     ":script{scriptVersion}-test-v{major}.dar".format(
+    #         major = major,
+    #         scriptVersion = scriptVersion,
+    #     )
+    #     for major in SUPPORTED_LF_MAJOR_VERSIONS
+    #     for scriptVersion in [
+    #         "",
+    #         "3",
+    #    ]
     resources = glob(["src/main/resources/**/*"]),
     scala_deps = [
         "@maven//:org_apache_pekko_pekko_actor",

--- a/sdk/docs/BUILD.bazel
+++ b/sdk/docs/BUILD.bazel
@@ -577,7 +577,7 @@ daml_build_test(
 daml_build_test(
     name = "daml-upgrade-example-v1",
     dar_dict = {
-        "//daml-script/daml:daml-script.dar": "daml-script.dar",
+        "//daml-script/daml3:daml3-script-2.dev.dar": "daml3-script.dar",
     },
     project_dir = "source/upgrade/example/carbon-1.0.0",
 )
@@ -610,7 +610,7 @@ daml_build_test(
         ":daml-upgrade-example-v1": "path/to/carbon-1.0.0.dar",
         ":daml-upgrade-example-v2": "path/to/carbon-2.0.0.dar",
         ":daml-upgrade-example-upgrade": "path/to/carbon-upgrade-1.0.0.dar",
-        "//daml-script/daml:daml-script.dar": "daml-script.dar",
+        "//daml-script/daml3:daml3-script-2.dev.dar": "daml3-script.dar",
     },
     project_dir = "source/upgrade/example/carbon-initiate-upgrade",
 )

--- a/sdk/docs/BUILD.bazel
+++ b/sdk/docs/BUILD.bazel
@@ -400,8 +400,9 @@ java_binary(
 daml_test(
     name = "ledger-api-daml-test",
     srcs = glob(["source/app-dev/code-snippets/**/*.daml"]),
-    # TODO(https://github.com/digital-asset/daml/issues/18457): remove contract keys from the
-    #  docs, delete the explicit target, and revert the daml-script.dar to the non-dev version.
+    # TODO(https://github.com/digital-asset/daml/issues/18457): remove contract
+    #   keys from the docs, delete the explicit target, and revert the
+    #   daml-script.dar to the non-dev version.
     target = "2.dev",
     deps = ["//daml-script/daml3:daml3-script-2.dev.dar"],
 )
@@ -410,8 +411,8 @@ daml_test(
     name = "bindings-java-daml-test",
     srcs = glob(["source/app-dev/bindings-java/code-snippets/**/*.daml"]),
     enable_interfaces = True,
-    # TODO(https://github.com/digital-asset/daml/issues/18457): remove contract keys from the
-    #  docs and delete the explicit target.
+    # TODO(https://github.com/digital-asset/daml/issues/18457): remove contract
+    #   keys from the docs and delete the explicit target.
     target = "2.dev",
 )
 
@@ -577,6 +578,9 @@ daml_build_test(
 daml_build_test(
     name = "daml-upgrade-example-v1",
     dar_dict = {
+        # TODO(https://github.com/digital-asset/daml/issues/18457): remove
+        # contract keys from the docs and revert daml-script.dar to the non-dev
+        # version.
         "//daml-script/daml3:daml3-script-2.dev.dar": "daml3-script.dar",
     },
     project_dir = "source/upgrade/example/carbon-1.0.0",
@@ -610,6 +614,9 @@ daml_build_test(
         ":daml-upgrade-example-v1": "path/to/carbon-1.0.0.dar",
         ":daml-upgrade-example-v2": "path/to/carbon-2.0.0.dar",
         ":daml-upgrade-example-upgrade": "path/to/carbon-upgrade-1.0.0.dar",
+        # TODO(https://github.com/digital-asset/daml/issues/18457): remove
+        # contract keys from the docs and revert daml-script.dar to the non-dev
+        # version.
         "//daml-script/daml3:daml3-script-2.dev.dar": "daml3-script.dar",
     },
     project_dir = "source/upgrade/example/carbon-initiate-upgrade",

--- a/sdk/docs/BUILD.bazel
+++ b/sdk/docs/BUILD.bazel
@@ -410,9 +410,9 @@ daml_test(
     name = "bindings-java-daml-test",
     srcs = glob(["source/app-dev/bindings-java/code-snippets/**/*.daml"]),
     enable_interfaces = True,
-    # FIXME: https://github.com/digital-asset/daml/issues/12051
-    #  remove target, once interfaces are stable.
-    target = lf_version_configuration.get("latest"),
+    # TODO(https://github.com/digital-asset/daml/issues/18457): remove contract keys from the
+    #  docs and delete the explicit target.
+    target = "2.dev",
 )
 
 daml_test(

--- a/sdk/docs/source/upgrade/example/carbon-1.0.0/daml.yaml
+++ b/sdk/docs/source/upgrade/example/carbon-1.0.0/daml.yaml
@@ -4,10 +4,12 @@
 sdk-version: 0.0.0
 # BEGIN
 name: carbon
+build-options:
+ - --target=2.dev
 version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml3-script
 source: .
 # END

--- a/sdk/docs/source/upgrade/example/carbon-1.0.0/daml.yaml
+++ b/sdk/docs/source/upgrade/example/carbon-1.0.0/daml.yaml
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# TODO(https://github.com/digital-asset/daml/issues/18457): remove contract keys
+#   from the docs and delete the explicit target.
+
 sdk-version: 0.0.0
 # BEGIN
 name: carbon

--- a/sdk/docs/source/upgrade/example/carbon-2.0.0/daml.yaml
+++ b/sdk/docs/source/upgrade/example/carbon-2.0.0/daml.yaml
@@ -5,6 +5,8 @@ sdk-version: 0.0.0
 # BEGIN
 name: carbon
 version: 2.0.0
+build-options:
+ - --target=2.dev
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/sdk/docs/source/upgrade/example/carbon-2.0.0/daml.yaml
+++ b/sdk/docs/source/upgrade/example/carbon-2.0.0/daml.yaml
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# TODO(https://github.com/digital-asset/daml/issues/18457): remove contract keys
+#   from the docs and delete the explicit target.
+
 sdk-version: 0.0.0
 # BEGIN
 name: carbon

--- a/sdk/docs/source/upgrade/example/carbon-initiate-upgrade/daml.yaml
+++ b/sdk/docs/source/upgrade/example/carbon-initiate-upgrade/daml.yaml
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# TODO(https://github.com/digital-asset/daml/issues/18457): remove contract keys
+#   from the docs and delete the explicit target.
+
 sdk-version: 0.0.0
 # BEGIN
 name: carbon-initiate-upgrade

--- a/sdk/docs/source/upgrade/example/carbon-initiate-upgrade/daml.yaml
+++ b/sdk/docs/source/upgrade/example/carbon-initiate-upgrade/daml.yaml
@@ -5,10 +5,12 @@ sdk-version: 0.0.0
 # BEGIN
 name: carbon-initiate-upgrade
 version: 1.0.0
+build-options:
+ - --target=2.dev
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml3-script
 data-dependencies:
   - path/to/carbon-upgrade-1.0.0.dar
   - path/to/carbon-1.0.0.dar

--- a/sdk/docs/source/upgrade/example/carbon-label/daml.yaml
+++ b/sdk/docs/source/upgrade/example/carbon-label/daml.yaml
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# TODO(https://github.com/digital-asset/daml/issues/18457): remove contract keys
+#   from the docs and delete the explicit target.
+
 sdk-version: 0.0.0
 # DAML_YAML_BEGIN
 name: carbon-label

--- a/sdk/docs/source/upgrade/example/carbon-label/daml.yaml
+++ b/sdk/docs/source/upgrade/example/carbon-label/daml.yaml
@@ -5,6 +5,8 @@ sdk-version: 0.0.0
 # DAML_YAML_BEGIN
 name: carbon-label
 version: 1.0.0
+build-options:
+  - --target=2.dev
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/sdk/docs/source/upgrade/example/carbon-upgrade/daml.yaml
+++ b/sdk/docs/source/upgrade/example/carbon-upgrade/daml.yaml
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# TODO(https://github.com/digital-asset/daml/issues/18457): remove contract keys
+#   from the docs and delete the explicit target.
+
 sdk-version: 0.0.0
 # BEGIN
 name: carbon-upgrade

--- a/sdk/docs/source/upgrade/example/carbon-upgrade/daml.yaml
+++ b/sdk/docs/source/upgrade/example/carbon-upgrade/daml.yaml
@@ -5,6 +5,8 @@ sdk-version: 0.0.0
 # BEGIN
 name: carbon-upgrade
 version: 1.0.0
+build-options:
+ - --target=2.dev
 dependencies:
   - daml-prim
   - daml-stdlib


### PR DESCRIPTION
This change only rejects daml templates that use the `key` and `maintainer` keywords. It doesn't reject daml program that look up templates by key. This would be the subject of a follow-up PR.

Before that change, the engine was already rejecting any template using keys when running in LF2.1 mode, so the change should have in theory no impact. In practice, we were still compiling a bunch of daml files that feature keys to LF2.1 and then never running them. This PR fixes these cases.
