### PR TITLE
[release] fix daily-snapshot logic

### DIFF
--- a/ci/daily-snapshot.yml
+++ b/ci/daily-snapshot.yml
@@ -34,9 +34,9 @@ jobs:
         eval "$(./dev-env/bin/dade-assist)"
         source $(bash-lib)
 
-        prefix=$(cat NIGHTLY_PREFIX)
+        prefix=$(git show ${{ parameters.commit }}:sdk/NIGHTLY_PREFIX)
         if [ "${{ parameters.version }}" = "snapshot" ]; then
-            release=$(./release.sh snapshot HEAD $prefix | awk '{print $2}')
+            release=$(./release.sh snapshot ${{ parameters.commit }} $prefix | awk '{print $2}')
         else
             release=${{ parameters.version }}
         fi


### PR DESCRIPTION
When we manually run the daily-snapshot job to make a specific commit, the resulting release should be named based on the release commit, not the trigger commit.