### PR TITLE
[3.1] trigger all snapshots from main

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -310,3 +310,26 @@ jobs:
         else
           tell_slack "Daily tests failed ($(Build.SourceBranchName)): $COMMIT_LINK." "$(Slack.ci-failures-daml)"
         fi
+
+  - job: snapshots
+    timeoutInMinutes: 60
+    #condition: eq(variables['Build.SourceBranchName'], 'main')
+    pool:
+      name: 'ubuntu_20_04'
+      demands: assignment -equals default
+    steps:
+      - bash: |
+          cd sdk
+          eval "$(./dev-env/bin/dade-assist)"
+
+          for branch in main main-2.x; do
+            sha=$(git rev-parse origin/$branch)
+            az extension add --name azure-devops
+            trap "az devops logout" EXIT
+            echo "$(System.AccessToken)" | az devops login --org "https://dev.azure.com/digitalasset"
+            az pipelines run --org "https://dev.azure.com/digitalasset" \
+                             --project daml \
+                             --name "snapshot" \
+                             --commit-id main \
+                             --parameters "commit=$sha"
+          done

--- a/ci/daily-snapshot.yml
+++ b/ci/daily-snapshot.yml
@@ -3,13 +3,6 @@
 
 pr: none
 trigger: none
-schedules:
-- cron: "0 1 * * *"
-  displayName: Daily split snapshot
-  branches:
-    include:
-    - main
-    - main-2.x
 
 parameters:
 - name: version


### PR DESCRIPTION
Rationale: real releases are triggered from main, and therefore only ever use the main branch yaml files. Having daily snapshots triggered from another branch (currently main-2.x) means we have to keep all those yaml files in sync. Which I've apparently failed to do last week, so now 2.9 daily snapshots are broken.

Companion PRs:
- https://github.com/digital-asset/daml/pull/18915 (2.3)
- https://github.com/digital-asset/daml/pull/18916 (2.7)
- https://github.com/digital-asset/daml/pull/18918 (2.8)
- https://github.com/digital-asset/daml/pull/18919 (2.9)
- https://github.com/digital-asset/daml/pull/18917 (3.0)