### PR TITLE
[release] small fix to split-release job

### DIFF
--- a/ci/split-release-job.yml
+++ b/ci/split-release-job.yml
@@ -85,7 +85,7 @@ jobs:
     - bash: |
         set -eou pipefail
         # Note: this gets dev-env from the release commit, not the trigger commit
-        eval "$(sdk/dev-env/bin/dade-assist)"
+        eval "$(cd sdk; ./dev-env/bin/dade-assist)"
         mkdir -p $(Build.StagingDirectory)/split-release
         ./ci/assembly-split-release-artifacts.sh $(release_tag) $(Build.StagingDirectory)/release-artifacts $(Build.StagingDirectory)/split-release
         jq -n \


### PR DESCRIPTION
It's not preventing that step from succeeding, because it only relies on curl and machines have curl installed (and Bash does not fail on nested job failures), but, still, it's cleaner for this line to succeed.