### PR TITLE
[Triggers] prevent attempt of creating of interface

### DIFF
--- a/sdk/triggers/daml/Daml/Trigger.daml
+++ b/sdk/triggers/daml/Daml/Trigger.daml
@@ -234,7 +234,7 @@ emitCommandsV2 cmds pending = do
 -- Note that this will send the create as a single-command transaction.
 -- If you need to send multiple commands in one transaction, use
 -- `emitCommands` with `createCmd` and handle filtering yourself.
-dedupCreate : (Eq t, Template t) => t -> TriggerA s ()
+dedupCreate : (Eq t, Template t, HasAgreement t) => t -> TriggerA s ()
 dedupCreate t = do
   aState <- liftTriggerRule get
   -- This is a very naive approach that is linear in the number of commands in flight.

--- a/sdk/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/sdk/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -245,7 +245,7 @@ data Command
       }
 
 -- | Create a contract of the given template.
-createCmd : Template t => t -> Command
+createCmd : (Template t, HasAgreement t) => t -> Command
 createCmd templateArg =
   CreateCommand (toAnyTemplate templateArg)
 


### PR DESCRIPTION
as creating interface result in a crash.

This bug was discover as discussing on the forum:
https://discuss.daml.com/t/creating-contracts-via-their-interface-in-daml-script/7197

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
