### PR TITLE
Fix typo in Timestamp LF conversion error message

### DIFF
--- a/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
+++ b/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
@@ -182,7 +182,7 @@ object Time {
         s: String,
         rounding: RoundingMode = DefaultRounding,
     ): Either[String, Timestamp] =
-      safely(assertFromString(s, rounding), s"cannot convert sting $s into Timestamp")
+      safely(assertFromString(s, rounding), s"cannot convert string $s into Timestamp")
 
     def now(): Timestamp = assertFromInstant(Instant.now(), DefaultRounding)
 


### PR DESCRIPTION
Fixes a tiny typo in one of the error messages.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
