### PR TITLE
Fix v1 2 3 upgrade tests

### DIFF
--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/UpgradesSpec.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/UpgradesSpec.scala
@@ -376,10 +376,12 @@ trait LongTests { this: UpgradesSpec =>
         val cantonLog = Source.fromFile(s"$cantonTmpDir/canton.log")
         try {
           val rawCantonLog = cantonLog.mkString
-          forEvery(List(
-            assertPackageUpgradeCheck(None)(v1Upload, v2Upload)(rawCantonLog),
-            assertPackageUpgradeCheck(None)(v2Upload, v3Upload)(rawCantonLog),
-          )) { a => a }
+          forEvery(
+            List(
+              assertPackageUpgradeCheck(None)(v1Upload, v2Upload)(rawCantonLog),
+              assertPackageUpgradeCheck(None)(v2Upload, v3Upload)(rawCantonLog),
+            )
+          ) { a => a }
         } finally {
           cantonLog.close()
         }
@@ -395,10 +397,12 @@ trait LongTests { this: UpgradesSpec =>
         val cantonLog = Source.fromFile(s"$cantonTmpDir/canton.log")
         try {
           val rawCantonLog = cantonLog.mkString
-          forEvery(List(
-            assertPackageUpgradeCheck(None)(v1Upload, v3Upload)(rawCantonLog),
-            assertPackageUpgradeCheck(None)(v1Upload, v2Upload)(rawCantonLog),
-          )) { a => a }
+          forEvery(
+            List(
+              assertPackageUpgradeCheck(None)(v1Upload, v3Upload)(rawCantonLog),
+              assertPackageUpgradeCheck(None)(v1Upload, v2Upload)(rawCantonLog),
+            )
+          ) { a => a }
         } finally {
           cantonLog.close()
         }
@@ -414,12 +418,14 @@ trait LongTests { this: UpgradesSpec =>
         val cantonLog = Source.fromFile(s"$cantonTmpDir/canton.log")
         try {
           val rawCantonLog = cantonLog.mkString
-          forEvery(List(
-            assertPackageUpgradeCheck(None)(v1Upload, v2Upload)(rawCantonLog),
-            assertPackageUpgradeCheck(
-              Some("The upgraded template T is missing some of its original fields.")
-            )(v2Upload, v3Upload)(rawCantonLog),
-          )) { a => a }
+          forEvery(
+            List(
+              assertPackageUpgradeCheck(None)(v1Upload, v2Upload)(rawCantonLog),
+              assertPackageUpgradeCheck(
+                Some("The upgraded template T is missing some of its original fields.")
+              )(v2Upload, v3Upload)(rawCantonLog),
+            )
+          ) { a => a }
         } finally {
           cantonLog.close()
         }
@@ -435,12 +441,14 @@ trait LongTests { this: UpgradesSpec =>
         val cantonLog = Source.fromFile(s"$cantonTmpDir/canton.log")
         try {
           val rawCantonLog = cantonLog.mkString
-          forEvery(List(
-            assertPackageUpgradeCheck(None)(v1Upload, v3Upload)(rawCantonLog),
-            assertPackageUpgradeCheck(
-              Some("The upgraded template T is missing some of its original fields.")
-            )(v1Upload, v2Upload)(rawCantonLog),
-          )) { a => a }
+          forEvery(
+            List(
+              assertPackageUpgradeCheck(None)(v1Upload, v3Upload)(rawCantonLog),
+              assertPackageUpgradeCheck(
+                Some("The upgraded template T is missing some of its original fields.")
+              )(v1Upload, v2Upload)(rawCantonLog),
+            )
+          ) { a => a }
         } finally {
           cantonLog.close()
         }
@@ -773,11 +781,13 @@ abstract class UpgradesSpec(val suffix: String)
       val cantonLog = Source.fromFile(s"$cantonTmpDir/canton.log")
       try {
         val rawCantonLog = cantonLog.mkString
-        forEvery(List(
-          assertFirstToSecond(firstUpload, secondUpload)(rawCantonLog),
-          assertSecondToThird(secondUpload, thirdUpload)(rawCantonLog),
-          assertFirstToThird(firstUpload, thirdUpload)(rawCantonLog),
-        )) { a => a }
+        forEvery(
+          List(
+            assertFirstToSecond(firstUpload, secondUpload)(rawCantonLog),
+            assertSecondToThird(secondUpload, thirdUpload)(rawCantonLog),
+            assertFirstToThird(firstUpload, thirdUpload)(rawCantonLog),
+          )
+        ) { a => a }
       } finally {
         cantonLog.close()
       }

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/UpgradesSpec.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/UpgradesSpec.scala
@@ -22,6 +22,7 @@ import com.daml.lf.archive.DarReader
 
 import scala.util.{Success, Failure}
 import com.daml.lf.validation.Upgrading
+import org.scalatest.Inspectors.{forEvery}
 
 class UpgradesSpecAdminAPIWithoutValidation
     extends UpgradesSpecAdminAPI("Admin API without validation")
@@ -44,6 +45,24 @@ class UpgradesSpecLedgerAPIWithValidation
     with LongTests
 
 abstract class UpgradesSpecAdminAPI(override val suffix: String) extends UpgradesSpec(suffix) {
+  override def uploadPackage(
+      path: String
+  ): Future[(PackageId, Option[Throwable])] = {
+    val client = AdminLedgerClient.singleHost(
+      ledgerPorts(0).adminPort,
+      config,
+    )
+    for {
+      (testPackageId, testPackageBS) <- loadPackageIdAndBS(path)
+      uploadResult <- client
+        .uploadDar(testPackageBS, path)
+        .transform({
+          case Failure(err) => Success(Some(err));
+          case Success(_) => Success(None);
+        })
+    } yield (testPackageId, uploadResult)
+  }
+
   override def uploadPackagePair(
       path: Upgrading[String]
   ): Future[Upgrading[(PackageId, Option[Throwable])]] = {
@@ -75,6 +94,21 @@ abstract class UpgradesSpecAdminAPI(override val suffix: String) extends Upgrade
 
 class UpgradesSpecLedgerAPI(override val suffix: String = "Ledger API")
     extends UpgradesSpec(suffix) {
+  override def uploadPackage(
+      path: String
+  ): Future[(PackageId, Option[Throwable])] = {
+    for {
+      client <- defaultLedgerClient()
+      (testPackageId, testPackageBS) <- loadPackageIdAndBS(path)
+      uploadResult <- client.packageManagementClient
+        .uploadDarFile(testPackageBS)
+        .transform({
+          case Failure(err) => Success(Some(err));
+          case Success(_) => Success(None);
+        })
+    } yield (testPackageId, uploadResult)
+  }
+
   override def uploadPackagePair(
       path: Upgrading[String]
   ): Future[Upgrading[(PackageId, Option[Throwable])]] = {
@@ -82,12 +116,14 @@ class UpgradesSpecLedgerAPI(override val suffix: String = "Ledger API")
       client <- defaultLedgerClient()
       (testPackageV1Id, testPackageV1BS) <- loadPackageIdAndBS(path.past)
       (testPackageV2Id, testPackageV2BS) <- loadPackageIdAndBS(path.present)
+      _ = logger.info(s"Uploading package ${path.past} $testPackageV1Id")
       uploadV1Result <- client.packageManagementClient
         .uploadDarFile(testPackageV1BS)
         .transform({
           case Failure(err) => Success(Some(err));
           case Success(_) => Success(None);
         })
+      _ = logger.info(s"Uploading package ${path.present} $testPackageV2Id")
       uploadV2Result <- client.packageManagementClient
         .uploadDarFile(testPackageV2BS)
         .transform({
@@ -332,59 +368,83 @@ trait LongTests { this: UpgradesSpec =>
     }
 
     s"Succeeds when v1 upgrades to v2 and then v3 ($suffix)" in {
-      testPackagePair(
-        "test-common/upgrades-SuccessUpgradingV2ThenV3-v1.dar",
-        "test-common/upgrades-SuccessUpgradingV2ThenV3-v2.dar",
-        assertPackageUpgradeCheck(None),
-      )
-      testPackagePair(
-        "test-common/upgrades-SuccessUpgradingV2ThenV3-v1.dar",
-        "test-common/upgrades-SuccessUpgradingV2ThenV3-v3.dar",
-        assertPackageUpgradeCheck(None),
-      )
+      for {
+        v1Upload <- uploadPackage("test-common/upgrades-SuccessUpgradingV2ThenV3-v1.dar")
+        v2Upload <- uploadPackage("test-common/upgrades-SuccessUpgradingV2ThenV3-v2.dar")
+        v3Upload <- uploadPackage("test-common/upgrades-SuccessUpgradingV2ThenV3-v3.dar")
+      } yield {
+        val cantonLog = Source.fromFile(s"$cantonTmpDir/canton.log")
+        try {
+          val rawCantonLog = cantonLog.mkString
+          forEvery(List(
+            assertPackageUpgradeCheck(None)(v1Upload, v2Upload)(rawCantonLog),
+            assertPackageUpgradeCheck(None)(v2Upload, v3Upload)(rawCantonLog),
+          )) { a => a }
+        } finally {
+          cantonLog.close()
+        }
+      }
     }
 
     s"Succeeds when v1 upgrades to v3 and then v2 ($suffix)" in {
-      testPackagePair(
-        "test-common/upgrades-SuccessUpgradingV3ThenV2-v1.dar",
-        "test-common/upgrades-SuccessUpgradingV3ThenV2-v3.dar",
-        assertPackageUpgradeCheck(None),
-      )
-      testPackagePair(
-        "test-common/upgrades-SuccessUpgradingV3ThenV2-v1.dar",
-        "test-common/upgrades-SuccessUpgradingV3ThenV2-v2.dar",
-        assertPackageUpgradeCheck(None),
-      )
+      for {
+        v1Upload <- uploadPackage("test-common/upgrades-SuccessUpgradingV3ThenV2-v1.dar")
+        v3Upload <- uploadPackage("test-common/upgrades-SuccessUpgradingV3ThenV2-v3.dar")
+        v2Upload <- uploadPackage("test-common/upgrades-SuccessUpgradingV3ThenV2-v2.dar")
+      } yield {
+        val cantonLog = Source.fromFile(s"$cantonTmpDir/canton.log")
+        try {
+          val rawCantonLog = cantonLog.mkString
+          forEvery(List(
+            assertPackageUpgradeCheck(None)(v1Upload, v3Upload)(rawCantonLog),
+            assertPackageUpgradeCheck(None)(v1Upload, v2Upload)(rawCantonLog),
+          )) { a => a }
+        } finally {
+          cantonLog.close()
+        }
+      }
     }
 
     s"Fails when v1 upgrades to v2, but v3 does not upgrade v2 ($suffix)" in {
-      testPackagePair(
-        "test-common/upgrades-FailsWhenUpgradingV2ThenV3-v1.dar",
-        "test-common/upgrades-FailsWhenUpgradingV2ThenV3-v2.dar",
-        assertPackageUpgradeCheck(None),
-      )
-      testPackagePair(
-        "test-common/upgrades-FailsWhenUpgradingV2ThenV3-v1.dar",
-        "test-common/upgrades-FailsWhenUpgradingV2ThenV3-v3.dar",
-        assertPackageUpgradeCheck(
-          Some("The upgraded template T has added new fields, but those fields are not Optional.")
-        ),
-      )
+      for {
+        v1Upload <- uploadPackage("test-common/upgrades-FailsWhenUpgradingV2ThenV3-v1.dar")
+        v2Upload <- uploadPackage("test-common/upgrades-FailsWhenUpgradingV2ThenV3-v2.dar")
+        v3Upload <- uploadPackage("test-common/upgrades-FailsWhenUpgradingV2ThenV3-v3.dar")
+      } yield {
+        val cantonLog = Source.fromFile(s"$cantonTmpDir/canton.log")
+        try {
+          val rawCantonLog = cantonLog.mkString
+          forEvery(List(
+            assertPackageUpgradeCheck(None)(v1Upload, v2Upload)(rawCantonLog),
+            assertPackageUpgradeCheck(
+              Some("The upgraded template T is missing some of its original fields.")
+            )(v2Upload, v3Upload)(rawCantonLog),
+          )) { a => a }
+        } finally {
+          cantonLog.close()
+        }
+      }
     }
 
     s"Fails when v1 upgrades to v3, but v3 does not upgrade v2 ($suffix)" in {
-      testPackagePair(
-        "test-common/upgrades-FailsWhenUpgradingV3ThenV2-v1.dar",
-        "test-common/upgrades-FailsWhenUpgradingV3ThenV2-v2.dar",
-        assertPackageUpgradeCheck(None),
-      )
-      testPackagePair(
-        "test-common/upgrades-FailsWhenUpgradingV3ThenV2-v1.dar",
-        "test-common/upgrades-FailsWhenUpgradingV3ThenV2-v3.dar",
-        assertPackageUpgradeCheck(
-          Some("The upgraded template T has added new fields, but those fields are not Optional.")
-        ),
-      )
+      for {
+        v1Upload <- uploadPackage("test-common/upgrades-FailsWhenUpgradingV3ThenV2-v1.dar")
+        v3Upload <- uploadPackage("test-common/upgrades-FailsWhenUpgradingV3ThenV2-v3.dar")
+        v2Upload <- uploadPackage("test-common/upgrades-FailsWhenUpgradingV3ThenV2-v2.dar")
+      } yield {
+        val cantonLog = Source.fromFile(s"$cantonTmpDir/canton.log")
+        try {
+          val rawCantonLog = cantonLog.mkString
+          forEvery(List(
+            assertPackageUpgradeCheck(None)(v1Upload, v3Upload)(rawCantonLog),
+            assertPackageUpgradeCheck(
+              Some("The upgraded template T is missing some of its original fields.")
+            )(v1Upload, v2Upload)(rawCantonLog),
+          )) { a => a }
+        } finally {
+          cantonLog.close()
+        }
+      }
     }
 
     "Fails when a top-level record adds a non-optional field" in {
@@ -547,25 +607,44 @@ abstract class UpgradesSpec(val suffix: String)
       path: Upgrading[String]
   ): Future[Upgrading[(PackageId, Option[Throwable])]]
 
+  def uploadPackage(
+      path: String
+  ): Future[(PackageId, Option[Throwable])]
+
+  def assertPackageUpgradeCheckSecondOnly(failureMessage: Option[String])(
+      v1: (PackageId, Option[Throwable]),
+      v2: (PackageId, Option[Throwable]),
+  )(cantonLogSrc: String): Assertion =
+    assertPackageUpgradeCheckGeneral(failureMessage)(v1, v2, false)(cantonLogSrc)
+
   def assertPackageUpgradeCheck(failureMessage: Option[String])(
-      testPackageV1Id: PackageId,
-      uploadV1Result: Option[Throwable],
-      testPackageV2Id: PackageId,
-      uploadV2Result: Option[Throwable],
+      v1: (PackageId, Option[Throwable]),
+      v2: (PackageId, Option[Throwable]),
+  )(cantonLogSrc: String): Assertion =
+    assertPackageUpgradeCheckGeneral(failureMessage)(v1, v2, true)(cantonLogSrc)
+
+  def assertPackageUpgradeCheckGeneral(failureMessage: Option[String])(
+      v1: (PackageId, Option[Throwable]),
+      v2: (PackageId, Option[Throwable]),
+      validateV1Checked: Boolean = true,
   )(cantonLogSrc: String): Assertion = {
+    val (testPackageV1Id, uploadV1Result) = v1
+    val (testPackageV2Id, uploadV2Result) = v2
     if (disableUpgradeValidation) {
       cantonLogSrc should include(s"Skipping upgrade validation for package $testPackageV1Id")
       cantonLogSrc should include(s"Skipping upgrade validation for package $testPackageV2Id")
     } else {
       uploadV1Result match {
-        case Some(err) =>
+        case Some(err) if validateV1Checked =>
           fail(s"Uploading first package $testPackageV1Id failed with message: $err");
         case _ => {}
       }
 
-      cantonLogSrc should include(
-        s"Package $testPackageV2Id claims to upgrade package id $testPackageV1Id"
-      )
+      if (validateV1Checked) {
+        cantonLogSrc should include(
+          s"Package $testPackageV2Id claims to upgrade package id $testPackageV1Id"
+        )
+      }
 
       failureMessage match {
         // If a failure message is expected, look for it in the canton logs
@@ -604,11 +683,11 @@ abstract class UpgradesSpec(val suffix: String)
 
   @scala.annotation.nowarn("cat=unused")
   def assertDuplicatePackageUpload()(
-      testPackageV1Id: PackageId,
-      uploadV1Result: Option[Throwable],
-      testPackageV2Id: PackageId,
-      uploadV2Result: Option[Throwable],
+      v1: (PackageId, Option[Throwable]),
+      v2: (PackageId, Option[Throwable]),
   )(cantonLogSrc: String): Assertion = {
+    val (testPackageV1Id, uploadV1Result) = v1
+    val (testPackageV2Id, uploadV2Result) = v2
     uploadV1Result should be(empty)
     cantonLogSrc should include(
       s"Ignoring upload of package $testPackageV2Id as it has been previously uploaded"
@@ -616,12 +695,17 @@ abstract class UpgradesSpec(val suffix: String)
     uploadV2Result should be(empty)
   }
 
+  def assertDontCheckUpload(
+      @annotation.unused v1: (PackageId, Option[Throwable]),
+      @annotation.unused v2: (PackageId, Option[Throwable]),
+  )(@annotation.unused cantonLogSrc: String): Assertion = succeed
+
   def assertPackageUploadVersionFailure(failureMessage: String, packageVersion: String)(
-      testPackageV1Id: PackageId,
-      uploadV1Result: Option[Throwable],
-      testPackageV2Id: PackageId,
-      uploadV2Result: Option[Throwable],
+      v1: (PackageId, Option[Throwable]),
+      v2: (PackageId, Option[Throwable]),
   )(cantonLogSrc: String): Assertion = {
+    val (testPackageV1Id, uploadV1Result) = v1
+    val (testPackageV2Id, uploadV2Result) = v2
     uploadV1Result match {
       case Some(err) =>
         fail(s"Uploading first package $testPackageV1Id failed with message: $err");
@@ -645,23 +729,55 @@ abstract class UpgradesSpec(val suffix: String)
       upgraded: String,
       upgrading: String,
       uploadAssertion: (
-          PackageId,
-          Option[Throwable],
-          PackageId,
-          Option[Throwable],
+          (PackageId, Option[Throwable]),
+          (PackageId, Option[Throwable]),
       ) => String => Assertion,
   ): Future[Assertion] = {
     for {
-      Upgrading(
-        (testPackageV1Id, uploadV1Result),
-        (testPackageV2Id, uploadV2Result),
-      ) <- uploadPackagePair(Upgrading(upgraded, upgrading))
+      v1Upload <- uploadPackage(upgraded)
+      v2Upload <- uploadPackage(upgrading)
     } yield {
       val cantonLog = Source.fromFile(s"$cantonTmpDir/canton.log")
       try {
-        uploadAssertion(testPackageV1Id, uploadV1Result, testPackageV2Id, uploadV2Result)(
+        uploadAssertion(v1Upload, v2Upload)(
           cantonLog.mkString
         )
+      } finally {
+        cantonLog.close()
+      }
+    }
+  }
+
+  def testPackageTriple(
+      first: String,
+      second: String,
+      third: String,
+      assertFirstToSecond: (
+          (PackageId, Option[Throwable]),
+          (PackageId, Option[Throwable]),
+      ) => String => Assertion,
+      assertSecondToThird: (
+          (PackageId, Option[Throwable]),
+          (PackageId, Option[Throwable]),
+      ) => String => Assertion,
+      assertFirstToThird: (
+          (PackageId, Option[Throwable]),
+          (PackageId, Option[Throwable]),
+      ) => String => Assertion,
+  ): Future[Assertion] = {
+    for {
+      firstUpload <- uploadPackage(first)
+      secondUpload <- uploadPackage(second)
+      thirdUpload <- uploadPackage(third)
+    } yield {
+      val cantonLog = Source.fromFile(s"$cantonTmpDir/canton.log")
+      try {
+        val rawCantonLog = cantonLog.mkString
+        forEvery(List(
+          assertFirstToSecond(firstUpload, secondUpload)(rawCantonLog),
+          assertSecondToThird(secondUpload, thirdUpload)(rawCantonLog),
+          assertFirstToThird(firstUpload, thirdUpload)(rawCantonLog),
+        )) { a => a }
       } finally {
         cantonLog.close()
       }

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/UpgradesSpec.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/UpgradesSpec.scala
@@ -373,7 +373,9 @@ trait LongTests { this: UpgradesSpec =>
         v1Upload <- uploadPackage("test-common/upgrades-SuccessUpgradingV2ThenV3-v1.dar")
         v2Upload <- uploadPackage("test-common/upgrades-SuccessUpgradingV2ThenV3-v2.dar")
         v3Upload <- uploadPackage("test-common/upgrades-SuccessUpgradingV2ThenV3-v3.dar")
-        rawCantonLog <- Future.fromTry(Using(Source.fromFile(s"$cantonTmpDir/canton.log"))(_.mkString))
+        rawCantonLog <- Future.fromTry(
+          Using(Source.fromFile(s"$cantonTmpDir/canton.log"))(_.mkString)
+        )
       } yield {
         forEvery(
           List(
@@ -389,7 +391,9 @@ trait LongTests { this: UpgradesSpec =>
         v1Upload <- uploadPackage("test-common/upgrades-SuccessUpgradingV3ThenV2-v1.dar")
         v3Upload <- uploadPackage("test-common/upgrades-SuccessUpgradingV3ThenV2-v3.dar")
         v2Upload <- uploadPackage("test-common/upgrades-SuccessUpgradingV3ThenV2-v2.dar")
-        rawCantonLog <- Future.fromTry(Using(Source.fromFile(s"$cantonTmpDir/canton.log"))(_.mkString))
+        rawCantonLog <- Future.fromTry(
+          Using(Source.fromFile(s"$cantonTmpDir/canton.log"))(_.mkString)
+        )
       } yield {
         forEvery(
           List(
@@ -405,7 +409,9 @@ trait LongTests { this: UpgradesSpec =>
         v1Upload <- uploadPackage("test-common/upgrades-FailsWhenUpgradingV2ThenV3-v1.dar")
         v2Upload <- uploadPackage("test-common/upgrades-FailsWhenUpgradingV2ThenV3-v2.dar")
         v3Upload <- uploadPackage("test-common/upgrades-FailsWhenUpgradingV2ThenV3-v3.dar")
-        rawCantonLog <- Future.fromTry(Using(Source.fromFile(s"$cantonTmpDir/canton.log"))(_.mkString))
+        rawCantonLog <- Future.fromTry(
+          Using(Source.fromFile(s"$cantonTmpDir/canton.log"))(_.mkString)
+        )
       } yield {
         forEvery(
           List(
@@ -423,16 +429,17 @@ trait LongTests { this: UpgradesSpec =>
         v1Upload <- uploadPackage("test-common/upgrades-FailsWhenUpgradingV3ThenV2-v1.dar")
         v3Upload <- uploadPackage("test-common/upgrades-FailsWhenUpgradingV3ThenV2-v3.dar")
         v2Upload <- uploadPackage("test-common/upgrades-FailsWhenUpgradingV3ThenV2-v2.dar")
-        rawCantonLog <- Future.fromTry(Using(Source.fromFile(s"$cantonTmpDir/canton.log"))(_.mkString))
-      } yield
-        forEvery(
-          List(
-            assertPackageUpgradeCheck(None)(v1Upload, v3Upload)(rawCantonLog),
-            assertPackageUpgradeCheck(
-              Some("The upgraded template T is missing some of its original fields.")
-            )(v1Upload, v2Upload)(rawCantonLog),
-          )
-        )(Predef.identity)
+        rawCantonLog <- Future.fromTry(
+          Using(Source.fromFile(s"$cantonTmpDir/canton.log"))(_.mkString)
+        )
+      } yield forEvery(
+        List(
+          assertPackageUpgradeCheck(None)(v1Upload, v3Upload)(rawCantonLog),
+          assertPackageUpgradeCheck(
+            Some("The upgraded template T is missing some of its original fields.")
+          )(v1Upload, v2Upload)(rawCantonLog),
+        )
+      )(Predef.identity)
     }
 
     "Fails when a top-level record adds a non-optional field" in {

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradingV2ThenV3/v2/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradingV2ThenV3/v2/Main.daml
@@ -12,8 +12,8 @@ data TKey = TKey { p : Party }
 
 template T with
     p: Party
-    new1: Int
-    new2: Int
+    new1: Optional Int
+    new2: Optional Int
   where
   signatory p
   key (TKey p) : TKey

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradingV2ThenV3/v3/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradingV2ThenV3/v3/Main.daml
@@ -12,7 +12,7 @@ data TKey = TKey { p : Party }
 
 template T with
     p: Party
-    new1: Int
+    new1: Optional Int
   where
   signatory p
   key (TKey p) : TKey

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradingV3ThenV2/v2/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradingV3ThenV2/v2/Main.daml
@@ -12,8 +12,8 @@ data TKey = TKey { p : Party }
 
 template T with
     p: Party
-    new1: Int
-    new2: Int
+    new1: Optional Int
+    new2: Optional Int
   where
   signatory p
   key (TKey p) : TKey

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradingV3ThenV2/v3/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradingV3ThenV2/v3/Main.daml
@@ -12,7 +12,7 @@ data TKey = TKey { p : Party }
 
 template T with
     p: Party
-    new1: Int
+    new1: Optional Int
   where
   signatory p
   key (TKey p) : TKey


### PR DESCRIPTION
Fixes from https://github.com/digital-asset/daml/pull/18977 to make the tests on v1-2-3 upgrades check what they're supposed to. Previously, we'd run two asynchronous assertions, but only the last one was being actually used. This fixes those tests.