### PR TITLE
fix stable protobuf check

### DIFF
--- a/sdk/buf-ledger-api.yaml
+++ b/sdk/buf-ledger-api.yaml
@@ -5,10 +5,10 @@ version: v1beta1
 
 build:
   roots:
-    - canton/community/ledger-api/src/main/protobuf
-    - 3rdparty/protobuf
+    - sdk/canton/community/ledger-api/src/main/protobuf
+    - sdk/3rdparty/protobuf
   excludes:
-    - canton/community/ledger-api/src/main/protobuf/com/daml/ledger/api/scalapb
+    - sdk/canton/community/ledger-api/src/main/protobuf/com/daml/ledger/api/scalapb
 
 breaking:
   use:


### PR DESCRIPTION
We check against the latest stable release. We have just published 2.8.4, which is the first "latest stable release" that is in the sdk subdir.