### PR TITLE
[3.0] fix protobuf check

### DIFF
--- a/sdk/buf-ledger-api.yaml
+++ b/sdk/buf-ledger-api.yaml
@@ -5,10 +5,10 @@ version: v1beta1
 
 build:
   roots:
-    - canton/community/ledger-api/src/main/protobuf
-    - 3rdparty/protobuf
+    - sdk/canton/community/ledger-api/src/main/protobuf
+    - sdk/3rdparty/protobuf
   excludes:
-    - canton/community/ledger-api/src/main/protobuf/com/daml/ledger/api/scalapb
+    - sdk/canton/community/ledger-api/src/main/protobuf/com/daml/ledger/api/scalapb
 
 breaking:
   use:


### PR DESCRIPTION
Now that 2.8.4 is published, the branch we compare with is in a subdir and the script needs to deal with that.