### PR TITLE
Fix typo in help message of daml build --all

### DIFF
--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -164,7 +164,7 @@ enableMultiPackageOpt = EnableMultiPackage <$> flagYesNoAuto "enable-multi-packa
 
 newtype MultiPackageBuildAll = MultiPackageBuildAll {getMultiPackageBuildAll :: Bool}
 multiPackageBuildAllOpt :: Parser MultiPackageBuildAll
-multiPackageBuildAllOpt = MultiPackageBuildAll <$> switch (long "all" <> help "Build all packages in multi-package.daml")
+multiPackageBuildAllOpt = MultiPackageBuildAll <$> switch (long "all" <> help "Build all packages in multi-package.yaml")
 
 newtype MultiPackageNoCache = MultiPackageNoCache {getMultiPackageNoCache :: Bool}
 multiPackageNoCacheOpt :: Parser MultiPackageNoCache


### PR DESCRIPTION
Fixes a tiny typo. Similar to #18996 but this time this is for `daml build --all`.