### PR TITLE
Simplify paging test case for too large page request

### DIFF
--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/PartyManagementServiceIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/PartyManagementServiceIT.scala
@@ -947,10 +947,7 @@ final class PartyManagementServiceIT extends PartyManagementITBase {
     runConcurrently = false,
   )(implicit ec => { case Participants(Participant(ledger)) =>
     val maxPartiesPageSize = ledger.features.partyManagement.maxPartiesPageSize
-    val parties = 1.to(maxPartiesPageSize + 1).map(_ => ledger.nextPartyId())
     for {
-      // create lots of parties
-      _ <- Future.sequence(parties.map(u => ledger.allocateParty(AllocatePartyRequest(u))))
       // request page size greater than the server's limit
       onTooLargePageSizeError <- ledger
         .listKnownParties(


### PR DESCRIPTION
Actually we don't need to create many parties, it is enough to ask for too many