### PR TITLE
Temporarly disable m1 

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -98,13 +98,6 @@ jobs:
     assignment: default
     test_mode: ${{parameters.test_mode}}
 
-- template: macOS.yml
-  parameters:
-    job_name: m1
-    name: m1
-    assignment: m1-builds
-    test_mode: ${{parameters.test_mode}}
-
 - template: blackduck.yml
 
 - job: Windows


### PR DESCRIPTION
As of April 25th our m1 machine does not seem to work.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
