### PR TITLE
Fix fmt.sh directory issues, fix pre-commit copyright check in worktrees

### DIFF
--- a/sdk/.pre-commit-config.yaml
+++ b/sdk/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       description: Idempotently add DA copyright headers to source files.
       language: system
       pass_filenames: false
-      entry: "dade-copyright-headers update"
+      entry: "bash -c 'unset GIT_DIR; dade-copyright-headers update'"
       types: [text]
     - id: platform-independence-check
       name: platform-independence-check

--- a/sdk/dev-env/bin/dade-copyright-headers
+++ b/sdk/dev-env/bin/dade-copyright-headers
@@ -19,7 +19,6 @@ import os
 import string
 import sys
 
-
 #########################
 # File-type configuration
 # start: The start marker of the block.

--- a/sdk/fmt.sh
+++ b/sdk/fmt.sh
@@ -49,7 +49,7 @@ check_diff() {
   # $1 merge_base
   # $2 regex
   # "${@:3}" command
-  changed_files=$(git diff --name-only --diff-filter=ACMRT "$1" | grep $2 | grep -E -v '^canton(-3x)?/' || [[ $? == 1 ]])
+  changed_files=$(git diff --name-only --diff-filter=ACMRT "$1" | grep '^sdk/' | sed 's|^sdk/||' | grep $2 | grep -E -v '^canton(-3x)?/' || [[ $? == 1 ]])
   if [[ -n "$changed_files" ]]; then
     run "${@:3}" ${changed_files[@]:-}
   else


### PR DESCRIPTION
Fix a couple issues relating to the sdk/ directory change.
- `./fmt.sh --diff` from sdk directory had issues due to `git diff` providing all paths relative to root of repo, instead of `sdk/` subdir
- copyright header check in pre-commit hook doesn't work from within worktrees because of https://github.com/pre-commit/pre-commit/issues/2295. Fixed by unsetting env var.

Fixed both.