### PR TITLE
Add location to engine logger

### DIFF
--- a/sdk/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
+++ b/sdk/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
@@ -516,31 +516,31 @@ unzip3 = foldr (\(a,b,c) ~(as,bs,cs) -> (a::as,b::bs,c::cs))
 
 -- | `traceRaw msg a` prints `msg` and returns `a`, for debugging purposes.
 --
--- Note that on some ledgers, those messages are not displayed at the default log level. For Sandbox, you can use `--log-level=debug` to include them.
+-- The default configuration on the participant logs these messages at DEBUG level.
 traceRaw : Text -> a -> a
 traceRaw = primitive @"BETrace"
 
 -- | `trace b a` prints `b` and returns `a`, for debugging purposes.
 --
--- Note that on some ledgers, those messages are not displayed at the default log level. For Sandbox, you can use `--log-level=debug` to include them.
+-- The default configuration on the participant logs these messages at DEBUG level.
 trace : Show b => b -> a -> a
 trace = traceRaw . show
 
 -- | `traceId a` prints `a` and returns `a`, for debugging purposes.
 --
--- Note that on some ledgers, those messages are not displayed at the default log level. For Sandbox, you can use `--log-level=debug` to include them.
+-- The default configuration on the participant logs these messages at DEBUG level.
 traceId : Show b => b -> b
 traceId x = trace x x
 
 -- | `debug x` prints `x` for debugging purposes.
 --
--- Note that on some ledgers, those messages are not displayed at the default log level. For Sandbox, you can use `--log-level=debug` to include them.
+-- The default configuration on the participant logs these messages at DEBUG level.
 debug : (Show b, Action m) => b -> m ()
 debug x = debugRaw (show x)
 
 -- | `debugRaw msg` prints `msg` for debugging purposes.
 --
--- Note that on some ledgers, those messages are not displayed at the default log level. For Sandbox, you can use `--log-level=debug` to include them.
+-- The default configuration on the participant logs these messages at DEBUG level.
 debugRaw : Action m => Text -> m ()
 debugRaw x =
   -- NOTE (MK): We introduce an explicit indirection via >>=

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -34,7 +34,9 @@ import com.daml.scalautil.Statement.discard
 // TODO once the ContextualizedLogger is replaced with the NamedLogger and Speedy doesn't use its
 //   own logger, we can remove this import
 trait EngineLogger {
-  def add(message: String)(implicit loggingContext: LoggingContext): Unit
+  def add(message: String, optLocation: Option[com.daml.lf.data.Ref.Location])(implicit
+      loggingContext: LoggingContext
+  ): Unit
 }
 
 object EngineLogger {
@@ -43,7 +45,7 @@ object EngineLogger {
       new TraceLog {
         override def add(message: String, optLocation: Option[com.daml.lf.data.Ref.Location])(
             implicit loggingContext: LoggingContext
-        ): Unit = value.add(message)
+        ): Unit = value.add(message, optLocation)
         override def iterator: Iterator[(String, Option[com.daml.lf.data.Ref.Location])] =
           Iterator.empty
       }


### PR DESCRIPTION
Before this change, we were not able to filter the engine logging by location. Now, we do.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
