### PR TITLE
fix main-2.x conformance tests by explicitly setting protocol-version=5

### DIFF
--- a/sdk/ledger-test-tool/tool/BUILD.bazel
+++ b/sdk/ledger-test-tool/tool/BUILD.bazel
@@ -201,6 +201,7 @@ conformance_test(
         ",".join([
             "dev-mode=no",
             "_shared.participant_ledger-api_tls.minimum-server-protocol-version=TLSv1.3",
+            "canton.domains.test_domain.init.domain-parameters.protocol-version=5",
         ]),
     ],
     tags = ["main-only"],
@@ -223,6 +224,7 @@ conformance_test(
         "-C",
         ",".join([
             "dev-mode=no",
+            "canton.domains.test_domain.init.domain-parameters.protocol-version=5",
         ]),
     ],
     tags = ["main-only"],

--- a/sdk/ledger-test-tool/tool/BUILD.bazel
+++ b/sdk/ledger-test-tool/tool/BUILD.bazel
@@ -204,7 +204,6 @@ conformance_test(
             "canton.domains.test_domain.init.domain-parameters.protocol-version=5",
         ]),
     ],
-    tags = ["main-only"],
     test_tool_args = conformance_test_tool_args_base + [
         "--exclude=" + ",".join(conformance_test_excluded_test),
         "--additional=TLSOnePointThreeIT",
@@ -227,7 +226,6 @@ conformance_test(
             "canton.domains.test_domain.init.domain-parameters.protocol-version=5",
         ]),
     ],
-    tags = ["main-only"],
     test_tool_args = conformance_test_tool_args_base + ["--include=TLSAtLeastOnePointTwoIT"],
 ) if not is_windows and is_intel else None
 


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
