### PR TITLE
JSON API Upgrades: ETX-500 require fully qualified template ids

### DIFF
--- a/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -162,7 +162,7 @@ damlStart tmpDir _disableUpgradeValidation = do
         (authorizationHeaders "Alice") -- dummy party here, not important
     scriptOutput <- readFileUTF8 (projDir </> scriptOutputFile)
     let alice = (read scriptOutput :: String)
-    -- TODO(raphael-speyer-da): Use a package name once fully supported.
+    -- TODO(raphael-speyer-da): Use a package name once supported by canton out of the box.
     let packageRef = "6310b9aa3d506211b592dd657afb167d63637453f31eae986fad5aa1b6d61401"
     pure $
         DamlStartResource

--- a/sdk/language-support/ts/codegen/tests/BUILD.bazel
+++ b/sdk/language-support/ts/codegen/tests/BUILD.bazel
@@ -23,8 +23,8 @@ daml_compile(
     name = "hidden",
     srcs = ["daml/Hidden.daml"],
     data_dependencies = ["//language-support/ts/codegen/tests:build-and-lint.dar"],
-    target = "1.dev",
     project_name = "hidden",
+    target = "1.dev",
 )
 
 # build-and-lint

--- a/sdk/language-support/ts/codegen/tests/BUILD.bazel
+++ b/sdk/language-support/ts/codegen/tests/BUILD.bazel
@@ -24,6 +24,7 @@ daml_compile(
     srcs = ["daml/Hidden.daml"],
     data_dependencies = ["//language-support/ts/codegen/tests:build-and-lint.dar"],
     target = "1.dev",
+    project_name = "hidden",
 )
 
 # build-and-lint

--- a/sdk/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/sdk/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -917,7 +917,7 @@ describe("interfaces", () => {
     // meaningful we *must not* codegen or load Hidden
     type NotVisibleInTs = { owner: Party };
     const NotVisibleInTs: Pick<Template<{ owner: Party }>, "templateId"> = {
-      templateId: "Hidden:NotVisibleInTs",
+      templateId: "#hidden:Hidden:NotVisibleInTs",
     };
     const initialPayload: NotVisibleInTs = { owner: ALICE_PARTY };
 

--- a/sdk/ledger-service/fetch-contracts/src/main/scala/fetchcontracts/domain/ContractTypeId.scala
+++ b/sdk/ledger-service/fetch-contracts/src/main/scala/fetchcontracts/domain/ContractTypeId.scala
@@ -61,6 +61,8 @@ sealed abstract class ContractTypeId[+PkgId]
     import scala.util.hashing.{MurmurHash3 => H}
     H.productHash(this, H.productSeed, ignorePrefix = true)
   }
+
+  def fqn: String = s"${packageId.toString}:${moduleName}:${entityName}"
 }
 
 object ResolvedQuery {

--- a/sdk/ledger-service/fetch-contracts/src/main/scala/fetchcontracts/domain/ContractTypeId.scala
+++ b/sdk/ledger-service/fetch-contracts/src/main/scala/fetchcontracts/domain/ContractTypeId.scala
@@ -240,9 +240,7 @@ object ContractTypeId extends ContractTypeIdLike[ContractTypeId] {
 
 /** A contract type ID companion. */
 sealed abstract class ContractTypeIdLike[CtId[T] <: ContractTypeId[T]] {
-  type OptionalPkg = CtId[Option[String]]
   type RequiredPkg = CtId[String]
-  type NoPkg = CtId[Unit]
   type Resolved = ContractTypeId.ResolvedOf[CtId]
 
   // treat the companion like a typeclass instance

--- a/sdk/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
+++ b/sdk/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
@@ -67,7 +67,7 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
   private val doNotReloadPackages = FiniteDuration(100, DAYS)
 
   // This may need to be updated if the Account.daml is updated.
-  val pkgIdAccount = "b3c9564bb7334bfd0f82099893eba518afc3b68a4d5c66cb2835498252db93e9"
+  val staticPkgIdAccount = "b3c9564bb7334bfd0f82099893eba518afc3b68a4d5c66cb2835498252db93e9"
 
   def withHttpService[A](
       testName: String,
@@ -488,7 +488,7 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
       number: String,
       time: v.Value.Sum.Timestamp = TimestampConversion.roundInstantToMicros(Instant.now),
   ): domain.CreateCommand[v.Record, domain.ContractTypeId.Template.RequiredPkg] = {
-    val templateId = domain.ContractTypeId.Template(pkgIdAccount, "Account", "Account")
+    val templateId = domain.ContractTypeId.Template(staticPkgIdAccount, "Account", "Account")
     val timeValue = v.Value(time)
     val enabledVariantValue =
       v.Value(v.Value.Sum.Variant(v.Variant(None, "Enabled", Some(timeValue))))
@@ -508,7 +508,7 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
       number: String,
       time: v.Value.Sum.Timestamp = TimestampConversion.roundInstantToMicros(Instant.now),
   ): domain.CreateCommand[v.Record, domain.ContractTypeId.Template.RequiredPkg] = {
-    val templateId = domain.ContractTypeId.Template(pkgIdAccount, "Account", "SharedAccount")
+    val templateId = domain.ContractTypeId.Template(staticPkgIdAccount, "Account", "SharedAccount")
     val timeValue = v.Value(time)
     val ownersEnc = v.Value(
       v.Value.Sum.List(v.List(domain.Party.unsubst(owners).map(o => v.Value(v.Value.Sum.Party(o)))))

--- a/sdk/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
+++ b/sdk/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
@@ -66,6 +66,9 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
 
   private val doNotReloadPackages = FiniteDuration(100, DAYS)
 
+  // This may need to be updated if the Account.daml is updated.
+  val pkgIdAccount = "b3c9564bb7334bfd0f82099893eba518afc3b68a4d5c66cb2835498252db93e9"
+
   def withHttpService[A](
       testName: String,
       ledgerPort: Port,
@@ -416,7 +419,7 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
     postJsonStringRequest(uri, json.prettyPrint, headers)
 
   def postCreateCommand(
-      cmd: domain.CreateCommand[v.Record, domain.ContractTypeId.Template.OptionalPkg],
+      cmd: domain.CreateCommand[v.Record, domain.ContractTypeId.Template.RequiredPkg],
       encoder: DomainJsonEncoder,
       uri: Uri,
       headers: List[HttpHeader],
@@ -484,8 +487,8 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
       owner: domain.Party,
       number: String,
       time: v.Value.Sum.Timestamp = TimestampConversion.roundInstantToMicros(Instant.now),
-  ): domain.CreateCommand[v.Record, domain.ContractTypeId.Template.OptionalPkg] = {
-    val templateId = domain.ContractTypeId.Template(None, "Account", "Account")
+  ): domain.CreateCommand[v.Record, domain.ContractTypeId.Template.RequiredPkg] = {
+    val templateId = domain.ContractTypeId.Template(pkgIdAccount, "Account", "Account")
     val timeValue = v.Value(time)
     val enabledVariantValue =
       v.Value(v.Value.Sum.Variant(v.Variant(None, "Enabled", Some(timeValue))))
@@ -504,8 +507,8 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
       owners: Seq[domain.Party],
       number: String,
       time: v.Value.Sum.Timestamp = TimestampConversion.roundInstantToMicros(Instant.now),
-  ): domain.CreateCommand[v.Record, domain.ContractTypeId.Template.OptionalPkg] = {
-    val templateId = domain.ContractTypeId.Template(None, "Account", "SharedAccount")
+  ): domain.CreateCommand[v.Record, domain.ContractTypeId.Template.RequiredPkg] = {
+    val templateId = domain.ContractTypeId.Template(pkgIdAccount, "Account", "SharedAccount")
     val timeValue = v.Value(time)
     val ownersEnc = v.Value(
       v.Value.Sum.List(v.List(domain.Party.unsubst(owners).map(o => v.Value(v.Value.Sum.Party(o)))))

--- a/sdk/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
+++ b/sdk/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
@@ -435,7 +435,7 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
   }
 
   def postArchiveCommand(
-      templateId: domain.ContractTypeId.OptionalPkg,
+      templateId: domain.ContractTypeId.RequiredPkg,
       contractId: domain.ContractId,
       encoder: DomainJsonEncoder,
       uri: Uri,

--- a/sdk/ledger-service/http-json/src/failurelib/scala/http/FailureTests.scala
+++ b/sdk/ledger-service/http-json/src/failurelib/scala/http/FailureTests.scala
@@ -212,7 +212,7 @@ abstract class FailureTests
         )
       )
       _ = status shouldBe StatusCodes.OK
-      query = jsObject(s"""{"templateIds": ["$pkgIdAccount:Account:Account"]}""")
+      query = jsObject(s"""{"templateIds": ["$staticPkgIdAccount:Account:Account"]}""")
       (status, output) <- headersWithParties(List(p)).flatMap(
         postRequest(
           uri = uri.withPath(Uri.Path("/v1/query")),
@@ -276,7 +276,7 @@ abstract class FailureTests
           )
         )
         _ = status shouldBe StatusCodes.OK
-        query = jsObject(s"""{"templateIds": ["$pkgIdAccount:Account:Account"]}""")
+        query = jsObject(s"""{"templateIds": ["$staticPkgIdAccount:Account:Account"]}""")
         (status, output) <- headersWithParties(List(p)).flatMap(
           postRequest(
             uri = uri.withPath(Uri.Path("/v1/query")),
@@ -340,7 +340,7 @@ abstract class FailureTests
     (uri, encoder, _, client) =>
       val query =
         s"""[
-          {"templateIds": ["$pkgIdAccount:Account:Account"]}
+          {"templateIds": ["$staticPkgIdAccount:Account:Account"]}
         ]"""
 
       val offset = Promise[Offset]()

--- a/sdk/ledger-service/http-json/src/failurelib/scala/http/FailureTests.scala
+++ b/sdk/ledger-service/http-json/src/failurelib/scala/http/FailureTests.scala
@@ -212,7 +212,7 @@ abstract class FailureTests
         )
       )
       _ = status shouldBe StatusCodes.OK
-      query = jsObject("""{"templateIds": ["Account:Account"]}""")
+      query = jsObject(s"""{"templateIds": ["$pkgIdAccount:Account:Account"]}""")
       (status, output) <- headersWithParties(List(p)).flatMap(
         postRequest(
           uri = uri.withPath(Uri.Path("/v1/query")),
@@ -276,7 +276,7 @@ abstract class FailureTests
           )
         )
         _ = status shouldBe StatusCodes.OK
-        query = jsObject("""{"templateIds": ["Account:Account"]}""")
+        query = jsObject(s"""{"templateIds": ["$pkgIdAccount:Account:Account"]}""")
         (status, output) <- headersWithParties(List(p)).flatMap(
           postRequest(
             uri = uri.withPath(Uri.Path("/v1/query")),
@@ -339,8 +339,8 @@ abstract class FailureTests
   "/v1/stream/query can reconnect" taggedAs availabilitySecurity in withHttpService {
     (uri, encoder, _, client) =>
       val query =
-        """[
-          {"templateIds": ["Account:Account"]}
+        s"""[
+          {"templateIds": ["$pkgIdAccount:Account:Account"]}
         ]"""
 
       val offset = Promise[Offset]()

--- a/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
@@ -210,10 +210,6 @@ abstract class HttpServiceIntegrationTest
       inside(exerciseTest) { case domain.OkResponse(er, None, StatusCodes.OK) =>
         inside(jdecode[String](er.exerciseResult)) { case \/-(decoded) => decoded }
       }
-    object Transferrable {
-      val Transferrable: domain.ContractTypeId.Interface.OptionalPkg =
-        domain.ContractTypeId.Interface(None, "Transferrable", "Transferrable")
-    }
 
     "templateId = interface ID" in withHttpService { fixture =>
       for {
@@ -248,7 +244,7 @@ abstract class HttpServiceIntegrationTest
           fixture,
           initialTplId = TpId.CIou.CIou.map(_.get),
           exerciseTid = TpId.CIou.CIou,
-          choice = tExercise(choiceInterfaceId = Some(TpId.IIou.IIou), choiceArgType = echoTextVA)(
+          choice = tExercise(choiceInterfaceId = Some(TpId.IIou.IIou.map(_.get)), choiceArgType = echoTextVA)(
             echoTextSample
           ),
         ) map exerciseSucceeded
@@ -278,7 +274,7 @@ abstract class HttpServiceIntegrationTest
             fixture,
             initialTplId = TpId.CIou.CIou.map(_.get),
             exerciseTid = TpId.CIou.CIou,
-            choice = tExercise(Some(Transferrable.Transferrable), "Overridden", echoTextVA)(
+            choice = tExercise(Some(TpId.Transferrable.Transferrable.map(_.get)), "Overridden", echoTextVA)(
               ShRecord(echo = "yesyes")
             ),
           ) map exerciseSucceeded
@@ -383,7 +379,7 @@ object HttpServiceIntegrationTest {
   private val echoTextSample: echoTextVA.Inj = ShRecord(echo = "Bob")
 
   private def tExercise(
-      choiceInterfaceId: Option[domain.ContractTypeId.Interface.OptionalPkg] = None,
+      choiceInterfaceId: Option[domain.ContractTypeId.Interface.RequiredPkg] = None,
       choiceName: String = "Transfer",
       choiceArgType: VA = echoTextVA,
   )(
@@ -392,7 +388,7 @@ object HttpServiceIntegrationTest {
     TExercise(choiceInterfaceId, choiceName, choiceArgType, choiceArg)
 
   private final case class TExercise[Inj](
-      choiceInterfaceId: Option[domain.ContractTypeId.Interface.OptionalPkg],
+      choiceInterfaceId: Option[domain.ContractTypeId.Interface.RequiredPkg],
       choiceName: String,
       choiceArgType: VA.Aux[Inj],
       choiceArg: Inj,

--- a/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
@@ -179,7 +179,7 @@ abstract class HttpServiceIntegrationTest
     def createIouAndExerciseTransfer(
         fixture: UriFixture with EncoderFixture,
         initialTplId: domain.ContractTypeId.Template.RequiredPkg,
-        exerciseTid: domain.ContractTypeId.OptionalPkg,
+        exerciseTid: domain.ContractTypeId.RequiredPkg,
         choice: TExercise[_] = tExercise(choiceArgType = echoTextVA)(echoTextSample),
     ) = for {
       aliceH <- fixture.getUniquePartyAndAuthHeaders("Alice")
@@ -218,7 +218,7 @@ abstract class HttpServiceIntegrationTest
           fixture,
           initialTplId = TpId.IIou.TestIIou.map(_.get),
           // whether we can exercise by interface-ID
-          exerciseTid = TpId.IIou.IIou,
+          exerciseTid = TpId.IIou.IIou.map(_.get),
         ) map exerciseSucceeded
       } yield result should ===("Bob invoked IIou.Transfer")
     }
@@ -232,7 +232,7 @@ abstract class HttpServiceIntegrationTest
           fixture,
           initialTplId = TpId.CIou.CIou.map(_.get),
           // whether we can exercise inherited by concrete template ID
-          exerciseTid = TpId.CIou.CIou,
+          exerciseTid = TpId.CIou.CIou.map(_.get),
         ) map exerciseSucceeded
       } yield result should ===("Bob invoked IIou.Transfer")
     }
@@ -243,7 +243,7 @@ abstract class HttpServiceIntegrationTest
         result <- createIouAndExerciseTransfer(
           fixture,
           initialTplId = TpId.CIou.CIou.map(_.get),
-          exerciseTid = TpId.CIou.CIou,
+          exerciseTid = TpId.CIou.CIou.map(_.get),
           choice = tExercise(choiceInterfaceId = Some(TpId.IIou.IIou.map(_.get)), choiceArgType = echoTextVA)(
             echoTextSample
           ),
@@ -258,7 +258,7 @@ abstract class HttpServiceIntegrationTest
           result <- createIouAndExerciseTransfer(
             fixture,
             initialTplId = TpId.CIou.CIou.map(_.get),
-            exerciseTid = TpId.CIou.CIou,
+            exerciseTid = TpId.CIou.CIou.map(_.get),
             choice = tExercise(choiceName = "Overridden", choiceArgType = echoTextPairVA)(
               ShRecord(echo = ShRecord(_1 = "yes", _2 = "no"))
             ),
@@ -273,7 +273,7 @@ abstract class HttpServiceIntegrationTest
           result <- createIouAndExerciseTransfer(
             fixture,
             initialTplId = TpId.CIou.CIou.map(_.get),
-            exerciseTid = TpId.CIou.CIou,
+            exerciseTid = TpId.CIou.CIou.map(_.get),
             choice = tExercise(Some(TpId.Transferrable.Transferrable.map(_.get)), "Overridden", echoTextVA)(
               ShRecord(echo = "yesyes")
             ),
@@ -287,7 +287,7 @@ abstract class HttpServiceIntegrationTest
         response <- createIouAndExerciseTransfer(
           fixture,
           initialTplId = TpId.CIou.CIou.map(_.get),
-          exerciseTid = TpId.CIou.CIou,
+          exerciseTid = TpId.CIou.CIou.map(_.get),
           choice = tExercise(choiceName = "Ambiguous", choiceArgType = echoTextVA)(
             ShRecord(echo = "ambiguous-test")
           ),
@@ -305,7 +305,7 @@ abstract class HttpServiceIntegrationTest
         result <- createIouAndExerciseTransfer(
           fixture,
           initialTplId = TpId.CIou.CIou.map(_.get),
-          exerciseTid = TpId.CIou.CIou,
+          exerciseTid = TpId.CIou.CIou.map(_.get),
           choice = tExercise(choiceName = "TransferPlease", choiceArgType = echoTextVA)(
             echoTextSample
           ),
@@ -333,7 +333,7 @@ abstract class HttpServiceIntegrationTest
           encodeExercise(encoder)(
             iouTransfer(
               domain.EnrichedContractKey(
-                TpId.unsafeCoerce[domain.ContractTypeId.Template, Option[String]](TpId.IIou.IIou),
+                TpId.unsafeCoerce[domain.ContractTypeId.Template, String](TpId.IIou.IIou.map(_.get)),
                 v.Value(v.Value.Sum.Party(domain.Party unwrap alice)),
               ),
               tExercise()(ShRecord(echo = "bob")),

--- a/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
@@ -40,7 +40,7 @@ abstract class HttpServiceIntegrationTest
     with BeforeAndAfterAll {
   import HttpServiceIntegrationTest._
   import json.JsonProtocol._
-  import AbstractHttpServiceIntegrationTestFuns.{ciouDar, TpId}
+  import AbstractHttpServiceIntegrationTestFuns.ciouDar
 
   private val staticContent: String = "static"
 

--- a/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
@@ -216,9 +216,9 @@ abstract class HttpServiceIntegrationTest
         _ <- uploadPackage(fixture)(ciouDar)
         result <- createIouAndExerciseTransfer(
           fixture,
-          initialTplId = TpId.IIou.TestIIou.map(_.get),
+          initialTplId = TpId.IIou.TestIIou,
           // whether we can exercise by interface-ID
-          exerciseTid = TpId.IIou.IIou.map(_.get),
+          exerciseTid = TpId.IIou.IIou,
         ) map exerciseSucceeded
       } yield result should ===("Bob invoked IIou.Transfer")
     }
@@ -230,9 +230,9 @@ abstract class HttpServiceIntegrationTest
         _ <- uploadPackage(fixture)(ciouDar)
         result <- createIouAndExerciseTransfer(
           fixture,
-          initialTplId = TpId.CIou.CIou.map(_.get),
+          initialTplId = TpId.CIou.CIou,
           // whether we can exercise inherited by concrete template ID
-          exerciseTid = TpId.CIou.CIou.map(_.get),
+          exerciseTid = TpId.CIou.CIou,
         ) map exerciseSucceeded
       } yield result should ===("Bob invoked IIou.Transfer")
     }
@@ -242,9 +242,9 @@ abstract class HttpServiceIntegrationTest
         _ <- uploadPackage(fixture)(ciouDar)
         result <- createIouAndExerciseTransfer(
           fixture,
-          initialTplId = TpId.CIou.CIou.map(_.get),
-          exerciseTid = TpId.CIou.CIou.map(_.get),
-          choice = tExercise(choiceInterfaceId = Some(TpId.IIou.IIou.map(_.get)), choiceArgType = echoTextVA)(
+          initialTplId = TpId.CIou.CIou,
+          exerciseTid = TpId.CIou.CIou,
+          choice = tExercise(choiceInterfaceId = Some(TpId.IIou.IIou), choiceArgType = echoTextVA)(
             echoTextSample
           ),
         ) map exerciseSucceeded
@@ -257,8 +257,8 @@ abstract class HttpServiceIntegrationTest
           _ <- uploadPackage(fixture)(ciouDar)
           result <- createIouAndExerciseTransfer(
             fixture,
-            initialTplId = TpId.CIou.CIou.map(_.get),
-            exerciseTid = TpId.CIou.CIou.map(_.get),
+            initialTplId = TpId.CIou.CIou,
+            exerciseTid = TpId.CIou.CIou,
             choice = tExercise(choiceName = "Overridden", choiceArgType = echoTextPairVA)(
               ShRecord(echo = ShRecord(_1 = "yes", _2 = "no"))
             ),
@@ -272,9 +272,9 @@ abstract class HttpServiceIntegrationTest
           _ <- uploadPackage(fixture)(ciouDar)
           result <- createIouAndExerciseTransfer(
             fixture,
-            initialTplId = TpId.CIou.CIou.map(_.get),
-            exerciseTid = TpId.CIou.CIou.map(_.get),
-            choice = tExercise(Some(TpId.Transferrable.Transferrable.map(_.get)), "Overridden", echoTextVA)(
+            initialTplId = TpId.CIou.CIou,
+            exerciseTid = TpId.CIou.CIou,
+            choice = tExercise(Some(TpId.Transferrable.Transferrable), "Overridden", echoTextVA)(
               ShRecord(echo = "yesyes")
             ),
           ) map exerciseSucceeded
@@ -286,8 +286,8 @@ abstract class HttpServiceIntegrationTest
         _ <- uploadPackage(fixture)(ciouDar)
         response <- createIouAndExerciseTransfer(
           fixture,
-          initialTplId = TpId.CIou.CIou.map(_.get),
-          exerciseTid = TpId.CIou.CIou.map(_.get),
+          initialTplId = TpId.CIou.CIou,
+          exerciseTid = TpId.CIou.CIou,
           choice = tExercise(choiceName = "Ambiguous", choiceArgType = echoTextVA)(
             ShRecord(echo = "ambiguous-test")
           ),
@@ -304,8 +304,8 @@ abstract class HttpServiceIntegrationTest
         _ <- uploadPackage(fixture)(ciouDar)
         result <- createIouAndExerciseTransfer(
           fixture,
-          initialTplId = TpId.CIou.CIou.map(_.get),
-          exerciseTid = TpId.CIou.CIou.map(_.get),
+          initialTplId = TpId.CIou.CIou,
+          exerciseTid = TpId.CIou.CIou,
           choice = tExercise(choiceName = "TransferPlease", choiceArgType = echoTextVA)(
             echoTextSample
           ),
@@ -322,7 +322,7 @@ abstract class HttpServiceIntegrationTest
       aliceH <- fixture.getUniquePartyAndAuthHeaders("Alice")
       (alice, aliceHeaders) = aliceH
       createTest <- postCreateCommand(
-        iouCommand(alice, TpId.CIou.CIou.map(_.get)),
+        iouCommand(alice, TpId.CIou.CIou),
         fixture,
         aliceHeaders,
       )
@@ -333,7 +333,7 @@ abstract class HttpServiceIntegrationTest
           encodeExercise(encoder)(
             iouTransfer(
               domain.EnrichedContractKey(
-                TpId.unsafeCoerce[domain.ContractTypeId.Template, String](TpId.IIou.IIou.map(_.get)),
+                TpId.unsafeCoerce[domain.ContractTypeId.Template, String](TpId.IIou.IIou),
                 v.Value(v.Value.Sum.Party(domain.Party unwrap alice)),
               ),
               tExercise()(ShRecord(echo = "bob")),
@@ -344,7 +344,7 @@ abstract class HttpServiceIntegrationTest
         .parseResponse[JsValue]
     } yield inside(exerciseTest) {
       case domain.ErrorResponse(Seq(lookup), None, StatusCodes.BadRequest, _) =>
-        lookup should include regex raw"Cannot resolve template ID, given: TemplateId\(Some\([a-z0-9]+\),IIou,IIou\)"
+        lookup should include regex raw"Cannot resolve template ID, given: TemplateId\([a-z0-9]+,IIou,IIou\)"
     }
   }
 

--- a/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresIntTest.scala
+++ b/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresIntTest.scala
@@ -20,11 +20,12 @@ abstract class HttpServiceWithPostgresIntTest
   override def wsConfig: Option[WebsocketConfig] = None
 
   "query persists all active contracts" in withHttpService { fixture =>
+    import AbstractHttpServiceIntegrationTestFuns.TpId
     fixture.getUniquePartyAndAuthHeaders("Alice").flatMap { case (party, headers) =>
       val searchDataSet = genSearchDataSet(party)
       searchExpectOk(
         searchDataSet,
-        jsObject("""{"templateIds": ["Iou:Iou"], "query": {"currency": "EUR"}}"""),
+        jsObject(s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "EUR"}}"""),
         fixture,
         headers,
       ).flatMap { searchResult =>

--- a/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresIntTest.scala
+++ b/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresIntTest.scala
@@ -26,7 +26,7 @@ abstract class HttpServiceWithPostgresIntTest
       searchExpectOk(
         searchDataSet,
         jsObject(
-          s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "EUR"}}"""
+          s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"], "query": {"currency": "EUR"}}"""
         ),
         fixture,
         headers,

--- a/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresIntTest.scala
+++ b/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresIntTest.scala
@@ -25,7 +25,9 @@ abstract class HttpServiceWithPostgresIntTest
       val searchDataSet = genSearchDataSet(party)
       searchExpectOk(
         searchDataSet,
-        jsObject(s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "EUR"}}"""),
+        jsObject(
+          s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "EUR"}}"""
+        ),
         fixture,
         headers,
       ).flatMap { searchResult =>

--- a/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresIntTest.scala
+++ b/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresIntTest.scala
@@ -20,7 +20,6 @@ abstract class HttpServiceWithPostgresIntTest
   override def wsConfig: Option[WebsocketConfig] = None
 
   "query persists all active contracts" in withHttpService { fixture =>
-    import AbstractHttpServiceIntegrationTestFuns.TpId
     fixture.getUniquePartyAndAuthHeaders("Alice").flatMap { case (party, headers) =>
       val searchDataSet = genSearchDataSet(party)
       searchExpectOk(

--- a/sdk/ledger-service/http-json/src/it/scala/http/WebSocketCloseTest.scala
+++ b/sdk/ledger-service/http-json/src/it/scala/http/WebSocketCloseTest.scala
@@ -4,6 +4,7 @@
 package com.daml.http
 
 import org.apache.pekko.http.scaladsl.model.Uri
+import com.daml.http.AbstractHttpServiceIntegrationTestFuns.TpId
 import com.daml.http.HttpServiceTestFixture.UseTls
 import com.daml.http.dbbackend.JdbcConfig
 import java.net.http.{HttpClient, WebSocket}
@@ -46,7 +47,7 @@ class WebSocketCloseTest
           .subprotocols(subprotocols.head, subprotocols.tail: _*)
           .buildAsync(wsUri, listener)
           .asScala
-        _ <- ws.sendText("""{"templateIds": ["Iou:Iou"]}""", true).asScala
+        _ <- ws.sendText(s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}""", true).asScala
         _ <- ws.sendClose(WebSocket.NORMAL_CLOSURE, "ok").asScala
         _ <- serverCloseReceived.future
       } yield {

--- a/sdk/ledger-service/http-json/src/it/scala/http/WebSocketCloseTest.scala
+++ b/sdk/ledger-service/http-json/src/it/scala/http/WebSocketCloseTest.scala
@@ -47,7 +47,7 @@ class WebSocketCloseTest
           .subprotocols(subprotocols.head, subprotocols.tail: _*)
           .buildAsync(wsUri, listener)
           .asScala
-        _ <- ws.sendText(s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}""", true).asScala
+        _ <- ws.sendText(s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"]}""", true).asScala
         _ <- ws.sendClose(WebSocket.NORMAL_CLOSURE, "ok").asScala
         _ <- serverCloseReceived.future
       } yield {

--- a/sdk/ledger-service/http-json/src/it/scala/http/WebSocketCloseTest.scala
+++ b/sdk/ledger-service/http-json/src/it/scala/http/WebSocketCloseTest.scala
@@ -4,7 +4,6 @@
 package com.daml.http
 
 import org.apache.pekko.http.scaladsl.model.Uri
-import com.daml.http.AbstractHttpServiceIntegrationTestFuns.TpId
 import com.daml.http.HttpServiceTestFixture.UseTls
 import com.daml.http.dbbackend.JdbcConfig
 import java.net.http.{HttpClient, WebSocket}

--- a/sdk/ledger-service/http-json/src/it/scala/http/WebsocketServiceOffsetTickIntTest.scala
+++ b/sdk/ledger-service/http-json/src/it/scala/http/WebsocketServiceOffsetTickIntTest.scala
@@ -37,11 +37,7 @@ abstract class WebsocketServiceOffsetTickIntTest
   "Given empty ACS, JSON API should emit only offset ticks" in withHttpService { (uri, _, _, _) =>
     for {
       jwt <- jwt(uri)
-      msgs <- singleClientQueryStream(
-        jwt,
-        uri,
-        s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}""",
-      )
+      msgs <- singleClientQueryStream(jwt, uri, s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"]}""")
         .take(10)
         .runWith(collectResultsAsTextMessage)
     } yield {
@@ -60,11 +56,7 @@ abstract class WebsocketServiceOffsetTickIntTest
         (party, headers) = aliceHeaders
         _ <- initialIouCreate(uri, party, headers)
         jwt <- jwtForParties(uri)(List(party), List(), config.ledgerIds.headOption.value)
-        msgs <- singleClientQueryStream(
-          jwt,
-          uri,
-          s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}""",
-        )
+        msgs <- singleClientQueryStream(jwt, uri, s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"]}""")
           .take(10)
           .runWith(collectResultsAsTextMessage)
       } yield {
@@ -86,7 +78,7 @@ abstract class WebsocketServiceOffsetTickIntTest
         msgs <- singleClientQueryStream(
           jwt,
           uri,
-          s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}""",
+          s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"]}""",
           offset = ledgerOffset,
         )
           .take(10)
@@ -109,9 +101,7 @@ abstract class WebsocketServiceOffsetTickIntTest
         msgs <- singleClientQueryStream(
           jwt,
           uri,
-          s"""[{"templateIds": ["${tidString(
-              TpId.Iou.Iou
-            )}"], "offset": "${ledgerOffset.value}"}]""",
+          s"""[{"templateIds": ["${TpId.Iou.Iou.fqn}"], "offset": "${ledgerOffset.value}"}]""",
         )
           .take(10)
           .runWith(collectResultsAsTextMessage)

--- a/sdk/ledger-service/http-json/src/it/scala/http/WebsocketServiceOffsetTickIntTest.scala
+++ b/sdk/ledger-service/http-json/src/it/scala/http/WebsocketServiceOffsetTickIntTest.scala
@@ -3,7 +3,6 @@
 
 package com.daml.http
 
-import com.daml.http.AbstractHttpServiceIntegrationTestFuns.TpId
 import com.daml.http.HttpServiceTestFixture.UseTls
 import com.daml.http.dbbackend.JdbcConfig
 import org.scalatest._

--- a/sdk/ledger-service/http-json/src/it/scala/http/WebsocketServiceOffsetTickIntTest.scala
+++ b/sdk/ledger-service/http-json/src/it/scala/http/WebsocketServiceOffsetTickIntTest.scala
@@ -37,7 +37,11 @@ abstract class WebsocketServiceOffsetTickIntTest
   "Given empty ACS, JSON API should emit only offset ticks" in withHttpService { (uri, _, _, _) =>
     for {
       jwt <- jwt(uri)
-      msgs <- singleClientQueryStream(jwt, uri, s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}""")
+      msgs <- singleClientQueryStream(
+        jwt,
+        uri,
+        s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}""",
+      )
         .take(10)
         .runWith(collectResultsAsTextMessage)
     } yield {
@@ -56,7 +60,11 @@ abstract class WebsocketServiceOffsetTickIntTest
         (party, headers) = aliceHeaders
         _ <- initialIouCreate(uri, party, headers)
         jwt <- jwtForParties(uri)(List(party), List(), config.ledgerIds.headOption.value)
-        msgs <- singleClientQueryStream(jwt, uri, s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}""")
+        msgs <- singleClientQueryStream(
+          jwt,
+          uri,
+          s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}""",
+        )
           .take(10)
           .runWith(collectResultsAsTextMessage)
       } yield {
@@ -101,7 +109,9 @@ abstract class WebsocketServiceOffsetTickIntTest
         msgs <- singleClientQueryStream(
           jwt,
           uri,
-          s"""[{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "offset": "${ledgerOffset.value}"}]""",
+          s"""[{"templateIds": ["${tidString(
+              TpId.Iou.Iou
+            )}"], "offset": "${ledgerOffset.value}"}]""",
         )
           .take(10)
           .runWith(collectResultsAsTextMessage)

--- a/sdk/ledger-service/http-json/src/it/scala/http/WebsocketServiceOffsetTickIntTest.scala
+++ b/sdk/ledger-service/http-json/src/it/scala/http/WebsocketServiceOffsetTickIntTest.scala
@@ -3,6 +3,7 @@
 
 package com.daml.http
 
+import com.daml.http.AbstractHttpServiceIntegrationTestFuns.TpId
 import com.daml.http.HttpServiceTestFixture.UseTls
 import com.daml.http.dbbackend.JdbcConfig
 import org.scalatest._
@@ -36,7 +37,7 @@ abstract class WebsocketServiceOffsetTickIntTest
   "Given empty ACS, JSON API should emit only offset ticks" in withHttpService { (uri, _, _, _) =>
     for {
       jwt <- jwt(uri)
-      msgs <- singleClientQueryStream(jwt, uri, """{"templateIds": ["Iou:Iou"]}""")
+      msgs <- singleClientQueryStream(jwt, uri, s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}""")
         .take(10)
         .runWith(collectResultsAsTextMessage)
     } yield {
@@ -55,7 +56,7 @@ abstract class WebsocketServiceOffsetTickIntTest
         (party, headers) = aliceHeaders
         _ <- initialIouCreate(uri, party, headers)
         jwt <- jwtForParties(uri)(List(party), List(), config.ledgerIds.headOption.value)
-        msgs <- singleClientQueryStream(jwt, uri, """{"templateIds": ["Iou:Iou"]}""")
+        msgs <- singleClientQueryStream(jwt, uri, s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}""")
           .take(10)
           .runWith(collectResultsAsTextMessage)
       } yield {
@@ -77,7 +78,7 @@ abstract class WebsocketServiceOffsetTickIntTest
         msgs <- singleClientQueryStream(
           jwt,
           uri,
-          """{"templateIds": ["Iou:Iou"]}""",
+          s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}""",
           offset = ledgerOffset,
         )
           .take(10)
@@ -100,7 +101,7 @@ abstract class WebsocketServiceOffsetTickIntTest
         msgs <- singleClientQueryStream(
           jwt,
           uri,
-          s"""[{"templateIds": ["Iou:Iou"], "offset": "${ledgerOffset.value}"}]""",
+          s"""[{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "offset": "${ledgerOffset.value}"}]""",
         )
           .take(10)
           .runWith(collectResultsAsTextMessage)

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -1985,7 +1985,6 @@ abstract class AbstractHttpServiceIntegrationTestQueryStoreIndependent
     extends QueryStoreAndAuthDependentIntegrationTest {
   import HttpServiceTestFixture.accountCreateCommand
   import json.JsonProtocol._
-  import scalaz.syntax.functor._
 
   "query GET" - {
     "empty results" in withHttpService { fixture =>

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -1796,7 +1796,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
       val numContracts: Long = 2000
       val helperId = TpId.Account.Helper.map(_.get)
       val payload = recordFromFields(ShRecord(owner = v.Value.Sum.Party(alice.unwrap)))
-      val createCmd: domain.CreateAndExerciseCommand.LAVUnresolved =
+      val createCmd: domain.CreateAndExerciseCommand.LAVResolved =
         domain.CreateAndExerciseCommand(
           templateId = helperId,
           payload = payload,
@@ -1807,7 +1807,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         )
 
       def encode(
-          cmd: domain.CreateAndExerciseCommand.LAVUnresolved
+          cmd: domain.CreateAndExerciseCommand.LAVResolved
       ): JsValue =
         encoder.encodeCreateAndExerciseCommand(cmd).valueOr(e => fail(e.shows))
 

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -161,7 +161,9 @@ trait WithQueryStoreSetTest extends QueryStoreAndAuthDependentIntegrationTest {
         contractIds <- searchExpectOk(
           searchDataSet,
           jsObject(
-            s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "EUR", "amount": "111.11"}}"""
+            s"""{"templateIds": ["${tidString(
+                TpId.Iou.Iou
+              )}"], "query": {"currency": "EUR", "amount": "111.11"}}"""
           ),
           fixture,
           aliceHeaders,
@@ -194,7 +196,9 @@ trait WithQueryStoreSetTest extends QueryStoreAndAuthDependentIntegrationTest {
         _ <- searchExpectOk(
           searchDataSet,
           jsObject(
-            s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "EUR", "amount": "111.11"}}"""
+            s"""{"templateIds": ["${tidString(
+                TpId.Iou.Iou
+              )}"], "query": {"currency": "EUR", "amount": "111.11"}}"""
           ),
           fixture,
           aliceHeaders,
@@ -494,7 +498,9 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
     "warns if some are known" in withHttpService { fixture =>
       val query =
         jsObject(
-          s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}", "UnknownPackage:UnknownModule:UnknownEntity"], "query": {"currency": "EUR"}}"""
+          s"""{"templateIds": ["${tidString(
+              TpId.Iou.Iou
+            )}", "UnknownPackage:UnknownModule:UnknownEntity"], "query": {"currency": "EUR"}}"""
         )
       fixture
         .getUniquePartyAndAuthHeaders("UnknownParty")
@@ -645,7 +651,9 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
             party = alice,
           ),
           jsObject(
-            s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": ${testCurrency.toJson}}}"""
+            s"""{"templateIds": ["${tidString(
+                TpId.Iou.Iou
+              )}"], "query": {"currency": ${testCurrency.toJson}}}"""
           ),
           fixture,
           headers,
@@ -675,7 +683,9 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           found <- searchExpectOk(
             List(pubSubCreateCommand(publisher, subscriberParties)),
             jsObject(
-              s"""{"templateIds": ["${tidString(TpId.Account.PubSub)}"], "query": {"publisher": "$publisher"}}"""
+              s"""{"templateIds": ["${tidString(
+                  TpId.Account.PubSub
+                )}"], "query": {"publisher": "$publisher"}}"""
             ),
             fixture,
             headers,
@@ -755,7 +765,9 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         val searchDataSet = genSearchDataSet(alice)
         searchExpectOk(
           searchDataSet,
-          jsObject(s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "EUR"}}"""),
+          jsObject(
+            s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "EUR"}}"""
+          ),
           fixture,
           headers,
         ).map { acl: List[domain.ActiveContract.ResolvedCtTyId[JsValue]] =>
@@ -775,7 +787,9 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
             rs.map(_.status) shouldBe List.fill(searchDataSet.size)(StatusCodes.OK)
 
             def queryAmountAs(s: String) =
-              jsObject(s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"amount": $s}}""")
+              jsObject(
+                s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"amount": $s}}"""
+              )
 
             val queryAmountAsString = queryAmountAs("\"111.11\"")
             val queryAmountAsNumber = queryAmountAs("111.11")
@@ -806,7 +820,9 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         searchExpectOk(
           searchDataSet,
           jsObject(
-            s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "EUR", "amount": "111.11"}}"""
+            s"""{"templateIds": ["${tidString(
+                TpId.Iou.Iou
+              )}"], "query": {"currency": "EUR", "amount": "111.11"}}"""
           ),
           fixture,
           headers,
@@ -824,7 +840,9 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         searchExpectOk(
           searchDataSet,
           jsObject(
-            s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "RUB", "amount": "666.66"}}"""
+            s"""{"templateIds": ["${tidString(
+                TpId.Iou.Iou
+              )}"], "query": {"currency": "RUB", "amount": "666.66"}}"""
           ),
           fixture,
           headers,

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -161,9 +161,7 @@ trait WithQueryStoreSetTest extends QueryStoreAndAuthDependentIntegrationTest {
         contractIds <- searchExpectOk(
           searchDataSet,
           jsObject(
-            s"""{"templateIds": ["${tidString(
-                TpId.Iou.Iou
-              )}"], "query": {"currency": "EUR", "amount": "111.11"}}"""
+            s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"], "query": {"currency": "EUR", "amount": "111.11"}}"""
           ),
           fixture,
           aliceHeaders,
@@ -196,9 +194,7 @@ trait WithQueryStoreSetTest extends QueryStoreAndAuthDependentIntegrationTest {
         _ <- searchExpectOk(
           searchDataSet,
           jsObject(
-            s"""{"templateIds": ["${tidString(
-                TpId.Iou.Iou
-              )}"], "query": {"currency": "EUR", "amount": "111.11"}}"""
+            s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"], "query": {"currency": "EUR", "amount": "111.11"}}"""
           ),
           fixture,
           aliceHeaders,
@@ -298,7 +294,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         val searchDataSet = genSearchDataSet(alice)
         searchExpectOk(
           searchDataSet,
-          jsObject(s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}"""),
+          jsObject(s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"]}"""),
           fixture,
           headers,
         ).map { acl: List[domain.ActiveContract.ResolvedCtTyId[JsValue]] =>
@@ -343,14 +339,14 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         _ = bobAccountResp.status shouldBe StatusCodes.OK
         _ <- searchExpectOk(
           List(),
-          jsObject(s"""{"templateIds": ["${tidString(TpId.Account.Account)}"]}"""),
+          jsObject(s"""{"templateIds": ["${TpId.Account.Account.fqn}"]}"""),
           fixture,
           aliceHeaders,
         )
           .map(acl => acl.size shouldBe 1)
         _ <- searchExpectOk(
           List(),
-          jsObject(s"""{"templateIds": ["${tidString(TpId.Account.Account)}"]}"""),
+          jsObject(s"""{"templateIds": ["${TpId.Account.Account.fqn}"]}"""),
           fixture,
           bobHeaders,
         )
@@ -360,7 +356,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           .flatMap(headers =>
             searchExpectOk(
               List(),
-              jsObject(s"""{"templateIds": ["${tidString(TpId.Account.Account)}"]}"""),
+              jsObject(s"""{"templateIds": ["${TpId.Account.Account.fqn}"]}"""),
               fixture,
               headers,
             )
@@ -498,9 +494,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
     "warns if some are known" in withHttpService { fixture =>
       val query =
         jsObject(
-          s"""{"templateIds": ["${tidString(
-              TpId.Iou.Iou
-            )}", "UnknownPackage:UnknownModule:UnknownEntity"], "query": {"currency": "EUR"}}"""
+          s"""{"templateIds": ["${TpId.Iou.Iou.fqn}", "UnknownPackage:UnknownModule:UnknownEntity"], "query": {"currency": "EUR"}}"""
         )
       fixture
         .getUniquePartyAndAuthHeaders("UnknownParty")
@@ -651,9 +645,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
             party = alice,
           ),
           jsObject(
-            s"""{"templateIds": ["${tidString(
-                TpId.Iou.Iou
-              )}"], "query": {"currency": ${testCurrency.toJson}}}"""
+            s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"], "query": {"currency": ${testCurrency.toJson}}}"""
           ),
           fixture,
           headers,
@@ -683,9 +675,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           found <- searchExpectOk(
             List(pubSubCreateCommand(publisher, subscriberParties)),
             jsObject(
-              s"""{"templateIds": ["${tidString(
-                  TpId.Account.PubSub
-                )}"], "query": {"publisher": "$publisher"}}"""
+              s"""{"templateIds": ["${TpId.Account.PubSub.fqn}"], "query": {"publisher": "$publisher"}}"""
             ),
             fixture,
             headers,
@@ -744,7 +734,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         List(createCommand(alice)),
         jsObject(
           s"""{
-              "templateIds": ["${tidString(TpId.Account.LongFieldNames)}"],
+              "templateIds": ["${TpId.Account.LongFieldNames.fqn}"],
               "query": {
                 "party": "$alice",
                 "$fieldName" : $jsonValue
@@ -766,7 +756,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         searchExpectOk(
           searchDataSet,
           jsObject(
-            s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "EUR"}}"""
+            s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"], "query": {"currency": "EUR"}}"""
           ),
           fixture,
           headers,
@@ -788,7 +778,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
 
             def queryAmountAs(s: String) =
               jsObject(
-                s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"amount": $s}}"""
+                s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"], "query": {"amount": $s}}"""
               )
 
             val queryAmountAsString = queryAmountAs("\"111.11\"")
@@ -820,9 +810,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         searchExpectOk(
           searchDataSet,
           jsObject(
-            s"""{"templateIds": ["${tidString(
-                TpId.Iou.Iou
-              )}"], "query": {"currency": "EUR", "amount": "111.11"}}"""
+            s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"], "query": {"currency": "EUR", "amount": "111.11"}}"""
           ),
           fixture,
           headers,
@@ -840,9 +828,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         searchExpectOk(
           searchDataSet,
           jsObject(
-            s"""{"templateIds": ["${tidString(
-                TpId.Iou.Iou
-              )}"], "query": {"currency": "RUB", "amount": "666.66"}}"""
+            s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"], "query": {"currency": "RUB", "amount": "666.66"}}"""
           ),
           fixture,
           headers,
@@ -1681,7 +1667,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           testFetchByCompositeKey(
             fixture,
             jsObject(s"""{
-            "templateId": "${tidString(TpId.Account.KeyedByVariantAndRecord)}",
+            "templateId": "${TpId.Account.KeyedByVariantAndRecord.fqn}",
             "key": [
               "$alice",
               {"tag": "Bar", "value": 42},
@@ -1699,7 +1685,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           testFetchByCompositeKey(
             fixture,
             jsObject(s"""{
-            "templateId": "${tidString(TpId.Account.KeyedByVariantAndRecord)}",
+            "templateId": "${TpId.Account.KeyedByVariantAndRecord.fqn}",
             "key": {
               "_1": "$alice",
               "_2": {"tag": "Bar", "value": "42"},
@@ -1736,11 +1722,11 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
       headers: List[HttpHeader],
   ) = {
     val createCommand = jsObject(s"""{
-      "templateId": "${tidString(TpId.Account.KeyedByDecimal)}",
+      "templateId": "${TpId.Account.KeyedByDecimal.fqn}",
       "payload": { "party": "$party", "amount": "$decimal" }
     }""")
     val fetchRequest = jsObject(s"""{
-      "templateId": "${tidString(TpId.Account.KeyedByDecimal)}",
+      "templateId": "${TpId.Account.KeyedByDecimal.fqn}",
       "key": [ "$party", "$decimal" ]
     }""")
 
@@ -1766,7 +1752,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
       headers: List[HttpHeader],
   ) = {
     val createCommand = jsObject(s"""{
-        "templateId": "${tidString(TpId.Account.KeyedByVariantAndRecord)}",
+        "templateId": "${TpId.Account.KeyedByVariantAndRecord.fqn}",
         "payload": {
           "name": "ABC DEF",
           "party": "${party.unwrap}",
@@ -1840,7 +1826,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
       def queryN(n: Long): Future[Assertion] = fixture
         .postJsonRequest(
           Uri.Path("/v1/query"),
-          jsObject(s"""{"templateIds": ["${tidString(TpId.Account.Account)}"]}"""),
+          jsObject(s"""{"templateIds": ["${TpId.Account.Account.fqn}"]}"""),
           headers,
         )
         .parseResponse[Vector[JsValue]]

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -384,7 +384,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         searchResp <- search(
           List.empty,
           Map(
-            "templateIds" -> Seq(TpId.IIou.IIou).toJson,
+            "templateIds" -> Seq(TpId.IIou.IIou.map(_.get)).toJson,
             "query" -> spray.json.JsObject(),
           ).toJson.asJsObject,
           fixture,
@@ -431,7 +431,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         }
         queryAsBoth <- queryHeaders(alice, aliceHeaders, exParties)
         queryAtCtId = {
-          (ctid: domain.ContractTypeId.OptionalPkg, amountKey: String, currencyKey: String) =>
+          (ctid: domain.ContractTypeId.RequiredPkg, amountKey: String, currencyKey: String) =>
             searchExpectOk(
               List.empty,
               Map("templateIds" -> List(ctid)).toJson.asJsObject,
@@ -459,11 +459,11 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         }
         // run (inserting when query store) on template ID; then interface ID
         // (thereby duplicating contract IDs)
-        _ <- queryAtCtId(TpId.Iou.Iou, "amount", "currency")
-        _ <- queryAtCtId(TpId.RIou.RIou, "iamount", "icurrency")
+        _ <- queryAtCtId(TpId.Iou.Iou.map(_.get), "amount", "currency")
+        _ <- queryAtCtId(TpId.RIou.RIou.map(_.get), "iamount", "icurrency")
         // then try template ID again, in case interface ID mangled the results
         // for template ID by way of stakeholder join or something even odder
-        _ <- queryAtCtId(TpId.Iou.Iou, "amount", "currency")
+        _ <- queryAtCtId(TpId.Iou.Iou.map(_.get), "amount", "currency")
       } yield succeed
 
       // multi-party and single-party are handled significantly differently
@@ -506,7 +506,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
               acl.size shouldBe 0
               warnings shouldBe Some(
                 domain.UnknownTemplateIds(
-                  List(domain.ContractTypeId(Some("UnknownPackage"), "UnknownModule", "UnknownEntity"))
+                  List(domain.ContractTypeId("UnknownPackage", "UnknownModule", "UnknownEntity"))
                 )
               )
             }
@@ -527,8 +527,8 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
               errors shouldBe List(ErrorMessages.cannotResolveAnyTemplateId)
               inside(warnings) { case Some(domain.UnknownTemplateIds(unknownTemplateIds)) =>
                 unknownTemplateIds.toSet shouldBe Set(
-                  domain.ContractTypeId(Some("ZZZ"), "AAA", "BBB"),
-                  domain.ContractTypeId(Some("ZZZ"), "XXX", "YYY"),
+                  domain.ContractTypeId("ZZZ", "AAA", "BBB"),
+                  domain.ContractTypeId("ZZZ", "XXX", "YYY"),
                 )
               }
           }

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
@@ -65,75 +65,27 @@ object AbstractHttpServiceIntegrationTestFuns {
   private[http] val fooV1Dar = requiredResource("ledger-service/http-json/FooV1.dar")
   private[http] val fooV2Dar = requiredResource("ledger-service/http-json/FooV2.dar")
 
-  object TpId {
-    import domain.{ContractTypeId => CtId}
-    import CtId.Template.{RequiredPkg => TId}
-    import CtId.Interface.{RequiredPkg => IId}
-
-    val pkgIdModelTests = packageIdOfDar(dar1)
-    val pkgIdAccount = packageIdOfDar(dar2)
-    val pkgIdUser = packageIdOfDar(userDar)
-    val pkgIdCiou = packageIdOfDar(ciouDar)
-    val pkgIdRiou = packageIdOfDar(riouDar)
-
-    object Iou {
-      val Dummy: TId = CtId.Template(pkgIdModelTests, "Iou", "Dummy")
-      val Iou: TId = CtId.Template(pkgIdModelTests, "Iou", "Iou")
-      val IouTransfer: TId = CtId.Template(pkgIdModelTests, "Iou", "IouTransfer")
-    }
-    object Test {
-      val MultiPartyContract: TId = CtId.Template(pkgIdModelTests, "Test", "MultiPartyContract")
-    }
-    object IAccount {
-      val IAccount: IId = CtId.Interface(pkgIdAccount, "IAccount", "IAccount")
-    }
-    object Account {
-      val Account: TId = CtId.Template(pkgIdAccount, "Account", "Account")
-      val SharedAccount: TId = CtId.Template(pkgIdAccount, "Account", "SharedAccount")
-      val PubSub: TId = CtId.Template(pkgIdAccount, "Account", "PubSub")
-      val KeyedByDecimal: TId = CtId.Template(pkgIdAccount, "Account", "KeyedByDecimal")
-      val KeyedByVariantAndRecord: TId =
-        CtId.Template(pkgIdAccount, "Account", "KeyedByVariantAndRecord")
-      val LongFieldNames: TId = CtId.Template(pkgIdAccount, "Account", "LongFieldNames")
-      val Helper: TId = CtId.Template(pkgIdAccount, "Account", "Helper")
-    }
-    object Disclosure {
-      val AnotherToDisclose: TId = CtId.Template(pkgIdAccount, "Disclosure", "AnotherToDisclose")
-      val HasGarbage: IId = CtId.Interface(pkgIdAccount, "Disclosure", "HasGarbage")
-      val ToDisclose: TId = CtId.Template(pkgIdAccount, "Disclosure", "ToDisclose")
-      val Viewport: TId = CtId.Template(pkgIdAccount, "Disclosure", "Viewport")
-    }
-    object User {
-      val User: TId = CtId.Template(pkgIdUser, "User", "User")
-    }
-    object CIou {
-      val CIou: TId = CtId.Template(pkgIdCiou, "CIou", "CIou")
-    }
-    object IIou {
-      val IIou: IId = CtId.Interface(pkgIdCiou, "IIou", "IIou")
-      val TestIIou: TId = CtId.Template(pkgIdCiou, "IIou", "TestIIou")
-    }
-    object RIou {
-      val RIou: IId = CtId.Interface(pkgIdRiou, "RIou", "RIou")
-    }
-    object RIIou {
-      val RIIou: IId = CtId.Interface(pkgIdCiou, "RIIou", "RIIou")
-    }
-    object Transferrable {
-      val Transferrable: IId = CtId.Interface(pkgIdCiou, "Transferrable", "Transferrable")
-    }
-
-    def unsafeCoerce[Like[T] <: CtId[T], T](ctId: CtId[T])(implicit
-        Like: CtId.Like[Like]
-    ): Like[T] =
-      Like(ctId.packageId, ctId.moduleName, ctId.entityName)
-  }
-
-  def packageIdOfDar(darFile: java.io.File): String = {
+  private[this] def packageIdOfDar(darFile: java.io.File): String = {
     import com.daml.lf.{archive, typesig}
     val dar = archive.UniversalArchiveReader.assertReadFile(darFile)
     typesig.PackageSignature.read(dar.main)._2.packageId
   }
+
+  val pkgIdAccount = {
+    val pkgId = packageIdOfDar(dar2)
+    assert(
+      pkgId == HttpServiceTestFixture.staticPkgIdAccount,
+      s"""Please update HttpServiceTestFixture.staticPkgIdAccount to "$pkgId"""",
+    )
+    pkgId
+  }
+
+  lazy val pkgIdCiou = packageIdOfDar(ciouDar)
+  lazy val pkgIdModelTests = packageIdOfDar(dar1)
+  lazy val pkgIdRiou = packageIdOfDar(riouDar)
+  lazy val pkgIdUser = packageIdOfDar(userDar)
+  lazy val pkgIdFooV1 = packageIdOfDar(fooV1Dar)
+  lazy val pkgIdFooV2 = packageIdOfDar(fooV2Dar)
 
   def sha256(source: Source[ByteString, Any])(implicit mat: Materializer): Try[String] = Try {
     import com.google.common.io.BaseEncoding
@@ -507,7 +459,63 @@ trait AbstractHttpServiceIntegrationTestFuns
     VA.record(Ref.Identifier assertFromString "ignored:Iou:Iou", iouT)
   }
 
-  import AbstractHttpServiceIntegrationTestFuns.TpId
+  protected[this] object TpId {
+    import domain.{ContractTypeId => CtId}
+    import CtId.Template.{RequiredPkg => TId}
+    import CtId.Interface.{RequiredPkg => IId}
+
+    object Iou {
+      val Dummy: TId = CtId.Template(pkgIdModelTests, "Iou", "Dummy")
+      val Iou: TId = CtId.Template(pkgIdModelTests, "Iou", "Iou")
+      val IouTransfer: TId = CtId.Template(pkgIdModelTests, "Iou", "IouTransfer")
+    }
+    object Test {
+      val MultiPartyContract: TId = CtId.Template(pkgIdModelTests, "Test", "MultiPartyContract")
+    }
+    object IAccount {
+      val IAccount: IId = CtId.Interface(pkgIdAccount, "IAccount", "IAccount")
+    }
+    object Account {
+      val Account: TId = CtId.Template(pkgIdAccount, "Account", "Account")
+      val Helper: TId = CtId.Template(pkgIdAccount, "Account", "Helper")
+      val KeyedByDecimal: TId = CtId.Template(pkgIdAccount, "Account", "KeyedByDecimal")
+      val KeyedByVariantAndRecord: TId =
+        CtId.Template(pkgIdAccount, "Account", "KeyedByVariantAndRecord")
+      val LongFieldNames: TId = CtId.Template(pkgIdAccount, "Account", "LongFieldNames")
+      val PubSub: TId = CtId.Template(pkgIdAccount, "Account", "PubSub")
+      val SharedAccount: TId = CtId.Template(pkgIdAccount, "Account", "SharedAccount")
+    }
+    object Disclosure {
+      val AnotherToDisclose: TId = CtId.Template(pkgIdAccount, "Disclosure", "AnotherToDisclose")
+      val HasGarbage: IId = CtId.Interface(pkgIdAccount, "Disclosure", "HasGarbage")
+      val ToDisclose: TId = CtId.Template(pkgIdAccount, "Disclosure", "ToDisclose")
+      val Viewport: TId = CtId.Template(pkgIdAccount, "Disclosure", "Viewport")
+    }
+    object User {
+      val User: TId = CtId.Template(pkgIdUser, "User", "User")
+    }
+    object CIou {
+      val CIou: TId = CtId.Template(pkgIdCiou, "CIou", "CIou")
+    }
+    object IIou {
+      val IIou: IId = CtId.Interface(pkgIdCiou, "IIou", "IIou")
+      val TestIIou: TId = CtId.Template(pkgIdCiou, "IIou", "TestIIou")
+    }
+    object RIou {
+      val RIou: IId = CtId.Interface(pkgIdRiou, "RIou", "RIou")
+    }
+    object RIIou {
+      val RIIou: IId = CtId.Interface(pkgIdCiou, "RIIou", "RIIou")
+    }
+    object Transferrable {
+      val Transferrable: IId = CtId.Interface(pkgIdCiou, "Transferrable", "Transferrable")
+    }
+
+    def unsafeCoerce[Like[T] <: CtId[T], T](ctId: CtId[T])(implicit
+        Like: CtId.Like[Like]
+    ): Like[T] =
+      Like(ctId.packageId, ctId.moduleName, ctId.entityName)
+  }
 
   protected def iouCreateCommand(
       party: domain.Party,

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
@@ -620,7 +620,7 @@ trait AbstractHttpServiceIntegrationTestFuns
     v.Record,
     v.Value,
     domain.ContractTypeId.Template.RequiredPkg,
-    domain.ContractTypeId.OptionalPkg,
+    domain.ContractTypeId.RequiredPkg,
   ] = {
     val targetParty = Ref.Party assertFromString target.unwrap
     val payload = argToApi(iouVA)(

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
@@ -90,14 +90,15 @@ object AbstractHttpServiceIntegrationTestFuns {
     object Account {
       val Account: TId = CtId.Template(pkgIdAccount, "Account", "Account")
       val PubSub: TId = CtId.Template(pkgIdAccount, "Account", "PubSub")
-      val KeyedByVariantAndRecord: TId with CtId.Ops[CtId.Template, Option[String]] = CtId.Template(pkgIdAccount, "Account", "KeyedByVariantAndRecord")
-      val KeyedByDecimal: TId with CtId.Ops[CtId.Template, Option[String]] = CtId.Template(pkgIdAccount, "Account", "KeyedByDecimal")
+      val KeyedByDecimal: TId = CtId.Template(pkgIdAccount, "Account", "KeyedByDecimal")
+      val KeyedByVariantAndRecord: TId = CtId.Template(pkgIdAccount, "Account", "KeyedByVariantAndRecord")
       val LongFieldNames: TId = CtId.Template(pkgIdAccount, "Account", "LongFieldNames")
+      val Helper: TId = CtId.Template(pkgIdAccount, "Account", "Helper")
     }
     object Disclosure {
       val AnotherToDisclose: TId = CtId.Template(pkgIdAccount, "Disclosure", "AnotherToDisclose")
-      val ToDisclose: TId = CtId.Template(pkgIdAccount, "Disclosure", "ToDisclose")
       val HasGarbage: IId = CtId.Interface(pkgIdAccount, "Disclosure", "HasGarbage")
+      val ToDisclose: TId = CtId.Template(pkgIdAccount, "Disclosure", "ToDisclose")
       val Viewport: TId = CtId.Template(pkgIdAccount, "Disclosure", "Viewport")
     }
     object User {
@@ -615,7 +616,7 @@ trait AbstractHttpServiceIntegrationTestFuns
   ): domain.CreateAndExerciseCommand[
     v.Record,
     v.Value,
-    domain.ContractTypeId.Template.OptionalPkg,
+    domain.ContractTypeId.Template.RequiredPkg,
     domain.ContractTypeId.OptionalPkg,
   ] = {
     val targetParty = Ref.Party assertFromString target.unwrap
@@ -634,7 +635,7 @@ trait AbstractHttpServiceIntegrationTestFuns
     val choice = lar.Choice("Iou_Transfer")
 
     domain.CreateAndExerciseCommand(
-      templateId = TpId.Iou.Iou,
+      templateId = TpId.Iou.Iou.map(_.get),
       payload = payload,
       choice = choice,
       argument = boxedRecord(arg),
@@ -819,15 +820,6 @@ trait AbstractHttpServiceIntegrationTestFuns
       jsPayload: JsValue
   ): Assertion = {
     (activeContract.payload: JsValue) shouldBe (jsPayload)
-  }
-
-  protected def assertTemplateId(
-      actual: domain.ContractTypeId.RequiredPkg,
-      expected: domain.ContractTypeId.OptionalPkg,
-  ): Future[Assertion] = Future {
-    expected.packageId.foreach(x => actual.packageId shouldBe x)
-    actual.moduleName shouldBe expected.moduleName
-    actual.entityName shouldBe expected.entityName
   }
 
   protected def getAllPackageIds(fixture: UriFixture): Future[domain.OkResponse[List[String]]] =

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
@@ -67,14 +67,14 @@ object AbstractHttpServiceIntegrationTestFuns {
 
   object TpId {
     import domain.{ContractTypeId => CtId}
-    import CtId.Template.{OptionalPkg => TId}
-    import CtId.Interface.{OptionalPkg => IId}
+    import CtId.Template.{RequiredPkg => TId}
+    import CtId.Interface.{RequiredPkg => IId}
 
-    val pkgIdModelTests = Some(packageIdOfDar(dar1))
-    val pkgIdAccount    = Some(packageIdOfDar(dar2))
-    val pkgIdUser       = Some(packageIdOfDar(userDar))
-    val pkgIdCiou       = Some(packageIdOfDar(ciouDar))
-    val pkgIdRiou       = Some(packageIdOfDar(riouDar))
+    val pkgIdModelTests = packageIdOfDar(dar1)
+    val pkgIdAccount    = packageIdOfDar(dar2)
+    val pkgIdUser       = packageIdOfDar(userDar)
+    val pkgIdCiou       = packageIdOfDar(ciouDar)
+    val pkgIdRiou       = packageIdOfDar(riouDar)
 
     object Iou {
       val Dummy: TId = CtId.Template(pkgIdModelTests, "Iou", "Dummy")
@@ -219,7 +219,7 @@ trait AbstractHttpServiceIntegrationTestFuns
 
   def wsConfig: Option[WebsocketConfig]
 
-  protected def tidString(id: domain.ContractTypeId[Option[String]]) = s"${id.packageId.get}:${id.moduleName}:${id.entityName}"
+  protected def tidString(id: domain.ContractTypeId[String]) = s"${id.packageId}:${id.moduleName}:${id.entityName}"
 
   protected def testId: String = this.getClass.getSimpleName
 
@@ -470,11 +470,6 @@ trait AbstractHttpServiceIntegrationTestFuns
 
   protected def removeRecordId(a: v.Record): v.Record = a.copy(recordId = None)
 
-  protected def removePackageId(
-      tmplId: domain.ContractTypeId.RequiredPkg
-  ): domain.ContractTypeId.OptionalPkg =
-    tmplId.copy(packageId = None)
-
   import com.daml.lf.data.{Numeric => LfNumeric}
   import shapeless.HList
 
@@ -532,7 +527,7 @@ trait AbstractHttpServiceIntegrationTestFuns
       )
     )
 
-    domain.CreateCommand(TpId.Iou.Iou.map(_.get), arg, meta)
+    domain.CreateCommand(TpId.Iou.Iou, arg, meta)
   }
 
   private[this] val (_, ciouVA) = {
@@ -565,7 +560,7 @@ trait AbstractHttpServiceIntegrationTestFuns
       )
     )
     domain.CreateCommand(
-      templateId = TpId.Account.PubSub.map(_.get),
+      templateId = TpId.Account.PubSub,
       payload = payload,
       meta = None,
     )
@@ -592,7 +587,7 @@ trait AbstractHttpServiceIntegrationTestFuns
       )
     )
     domain.CreateCommand(
-      templateId = TpId.Account.LongFieldNames.map(_.get),
+      templateId = TpId.Account.LongFieldNames,
       payload = payload,
       meta = None,
     )
@@ -602,7 +597,7 @@ trait AbstractHttpServiceIntegrationTestFuns
       contractId: lar.ContractId,
       partyName: domain.Party,
   ): domain.ExerciseCommand[Nothing, v.Value, domain.EnrichedContractId] = {
-    val reference = domain.EnrichedContractId(Some(TpId.Iou.Iou.map(_.get)), contractId)
+    val reference = domain.EnrichedContractId(Some(TpId.Iou.Iou), contractId)
     val party = Ref.Party assertFromString partyName.unwrap
     val arg =
       recordFromFields(ShRecord(newOwner = v.Value.Sum.Party(party)))
@@ -639,7 +634,7 @@ trait AbstractHttpServiceIntegrationTestFuns
     val choice = lar.Choice("Iou_Transfer")
 
     domain.CreateAndExerciseCommand(
-      templateId = TpId.Iou.Iou.map(_.get),
+      templateId = TpId.Iou.Iou,
       payload = payload,
       choice = choice,
       argument = boxedRecord(arg),
@@ -657,7 +652,7 @@ trait AbstractHttpServiceIntegrationTestFuns
       )
     )
     domain.CreateCommand(
-      templateId = TpId.Test.MultiPartyContract.map(_.get),
+      templateId = TpId.Test.MultiPartyContract,
       payload = payload,
       meta = None,
     )
@@ -667,7 +662,7 @@ trait AbstractHttpServiceIntegrationTestFuns
     val psv = lfToApi(VAx.seq(VAx.partyDomain).inj(ps)).sum
     val argument = boxedRecord(recordFromFields(ShRecord(newParties = psv)))
     domain.ExerciseCommand(
-      reference = domain.EnrichedContractId(Some(TpId.Test.MultiPartyContract.map(_.get)), cid),
+      reference = domain.EnrichedContractId(Some(TpId.Test.MultiPartyContract), cid),
       argument = argument,
       choiceInterfaceId = None,
       choice = lar.Choice("MPAddSignatories"),
@@ -691,7 +686,7 @@ trait AbstractHttpServiceIntegrationTestFuns
       )
     )
     domain.ExerciseCommand(
-      reference = domain.EnrichedContractId(Some(TpId.Test.MultiPartyContract.map(_.get)), cid),
+      reference = domain.EnrichedContractId(Some(TpId.Test.MultiPartyContract), cid),
       argument = argument,
       choiceInterfaceId = None,
       choice = lar.Choice("MPFetchOther"),
@@ -990,7 +985,7 @@ trait AbstractHttpServiceIntegrationTestFuns
       // make a contract and fetch the offset after it
       (cid, betweenOffset) <- offsetAfterCreate()
       // archive it
-      archive <- liftF(postArchiveCommand(TpId.Iou.Iou.map(_.get), cid, fixture, headers))
+      archive <- liftF(postArchiveCommand(TpId.Iou.Iou, cid, fixture, headers))
       _ = archive._1 shouldBe (StatusCodes.OK)
       // wait for the archival offset
       afterOffset <- readUntil[In] {

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
@@ -117,6 +117,9 @@ object AbstractHttpServiceIntegrationTestFuns {
     object RIIou {
       val RIIou: IId = CtId.Interface(pkgIdCiou, "RIIou", "RIIou")
     }
+    object Transferrable {
+      val Transferrable: IId = CtId.Interface(pkgIdCiou, "Transferrable", "Transferrable")
+    }
 
     def unsafeCoerce[Like[T] <: CtId[T], T](ctId: CtId[T])(implicit
         Like: CtId.Like[Like]
@@ -728,7 +731,7 @@ trait AbstractHttpServiceIntegrationTestFuns
   }
 
   protected def encodeExercise(encoder: DomainJsonEncoder)(
-      exercise: domain.ExerciseCommand.OptionalPkg[v.Value, domain.ContractLocator[v.Value]]
+      exercise: domain.ExerciseCommand.RequiredPkg[v.Value, domain.ContractLocator[v.Value]]
   ): JsValue =
     encoder.encodeExerciseCommand(exercise).getOrElse(fail(s"Cannot encode: $exercise"))
 
@@ -1014,7 +1017,7 @@ trait AbstractHttpServiceIntegrationTestFuns
 
   protected def assertExerciseResponseArchivedContract(
       exerciseResponse: domain.ExerciseResponse[JsValue],
-      exercise: domain.ExerciseCommand.OptionalPkg[v.Value, domain.EnrichedContractId],
+      exercise: domain.ExerciseCommand.RequiredPkg[v.Value, domain.EnrichedContractId],
   ): Assertion =
     inside(exerciseResponse) { case domain.ExerciseResponse(exerciseResult, List(contract1), _) =>
       exerciseResult shouldBe JsObject()

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
@@ -71,10 +71,10 @@ object AbstractHttpServiceIntegrationTestFuns {
     import CtId.Interface.{RequiredPkg => IId}
 
     val pkgIdModelTests = packageIdOfDar(dar1)
-    val pkgIdAccount    = packageIdOfDar(dar2)
-    val pkgIdUser       = packageIdOfDar(userDar)
-    val pkgIdCiou       = packageIdOfDar(ciouDar)
-    val pkgIdRiou       = packageIdOfDar(riouDar)
+    val pkgIdAccount = packageIdOfDar(dar2)
+    val pkgIdUser = packageIdOfDar(userDar)
+    val pkgIdCiou = packageIdOfDar(ciouDar)
+    val pkgIdRiou = packageIdOfDar(riouDar)
 
     object Iou {
       val Dummy: TId = CtId.Template(pkgIdModelTests, "Iou", "Dummy")
@@ -92,7 +92,8 @@ object AbstractHttpServiceIntegrationTestFuns {
       val SharedAccount: TId = CtId.Template(pkgIdAccount, "Account", "SharedAccount")
       val PubSub: TId = CtId.Template(pkgIdAccount, "Account", "PubSub")
       val KeyedByDecimal: TId = CtId.Template(pkgIdAccount, "Account", "KeyedByDecimal")
-      val KeyedByVariantAndRecord: TId = CtId.Template(pkgIdAccount, "Account", "KeyedByVariantAndRecord")
+      val KeyedByVariantAndRecord: TId =
+        CtId.Template(pkgIdAccount, "Account", "KeyedByVariantAndRecord")
       val LongFieldNames: TId = CtId.Template(pkgIdAccount, "Account", "LongFieldNames")
       val Helper: TId = CtId.Template(pkgIdAccount, "Account", "Helper")
     }
@@ -219,7 +220,8 @@ trait AbstractHttpServiceIntegrationTestFuns
 
   def wsConfig: Option[WebsocketConfig]
 
-  protected def tidString(id: domain.ContractTypeId[String]) = s"${id.packageId}:${id.moduleName}:${id.entityName}"
+  protected def tidString(id: domain.ContractTypeId[String]) =
+    s"${id.packageId}:${id.moduleName}:${id.entityName}"
 
   protected def testId: String = this.getClass.getSimpleName
 

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
@@ -220,9 +220,6 @@ trait AbstractHttpServiceIntegrationTestFuns
 
   def wsConfig: Option[WebsocketConfig]
 
-  protected def tidString(id: domain.ContractTypeId[String]) =
-    s"${id.packageId}:${id.moduleName}:${id.entityName}"
-
   protected def testId: String = this.getClass.getSimpleName
 
   lazy protected val metadata2: MetadataReader.LfMetadata =
@@ -854,7 +851,7 @@ trait AbstractHttpServiceIntegrationTestFuns
     val payload =
       s"""
          |{
-         |  "templateId": "${tidString(TpId.Iou.Iou)}",
+         |  "templateId": "${TpId.Iou.Iou.fqn}",
          |  "payload": {
          |    "observers": [],
          |    "issuer": $partyJson,
@@ -1002,7 +999,7 @@ trait AbstractHttpServiceIntegrationTestFuns
       _ = kill.shutdown()
     } yield (betweenOffset, afterOffset)
 
-    val query = s"""[{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}]"""
+    val query = s"""[{"templateIds": ["${TpId.Iou.Iou.fqn}"]}]"""
     for {
       jwt <- jwtForParties(uri)(List(party), List(), "participant0")
       (kill, source) =

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
@@ -89,6 +89,7 @@ object AbstractHttpServiceIntegrationTestFuns {
     }
     object Account {
       val Account: TId = CtId.Template(pkgIdAccount, "Account", "Account")
+      val SharedAccount: TId = CtId.Template(pkgIdAccount, "Account", "SharedAccount")
       val PubSub: TId = CtId.Template(pkgIdAccount, "Account", "PubSub")
       val KeyedByDecimal: TId = CtId.Template(pkgIdAccount, "Account", "KeyedByDecimal")
       val KeyedByVariantAndRecord: TId = CtId.Template(pkgIdAccount, "Account", "KeyedByVariantAndRecord")
@@ -425,7 +426,7 @@ trait AbstractHttpServiceIntegrationTestFuns
     }
 
   protected def postArchiveCommand(
-      templateId: domain.ContractTypeId.OptionalPkg,
+      templateId: domain.ContractTypeId.RequiredPkg,
       contractId: domain.ContractId,
       fixture: UriFixture with EncoderFixture,
       headers: List[HttpHeader],
@@ -439,7 +440,7 @@ trait AbstractHttpServiceIntegrationTestFuns
     )
 
   protected def postArchiveCommand(
-      templateId: domain.ContractTypeId.OptionalPkg,
+      templateId: domain.ContractTypeId.RequiredPkg,
       contractId: domain.ContractId,
       fixture: UriFixture with EncoderFixture,
   ): Future[(StatusCode, JsValue)] =
@@ -601,7 +602,7 @@ trait AbstractHttpServiceIntegrationTestFuns
       contractId: lar.ContractId,
       partyName: domain.Party,
   ): domain.ExerciseCommand[Nothing, v.Value, domain.EnrichedContractId] = {
-    val reference = domain.EnrichedContractId(Some(TpId.Iou.Iou), contractId)
+    val reference = domain.EnrichedContractId(Some(TpId.Iou.Iou.map(_.get)), contractId)
     val party = Ref.Party assertFromString partyName.unwrap
     val arg =
       recordFromFields(ShRecord(newOwner = v.Value.Sum.Party(party)))
@@ -666,7 +667,7 @@ trait AbstractHttpServiceIntegrationTestFuns
     val psv = lfToApi(VAx.seq(VAx.partyDomain).inj(ps)).sum
     val argument = boxedRecord(recordFromFields(ShRecord(newParties = psv)))
     domain.ExerciseCommand(
-      reference = domain.EnrichedContractId(Some(TpId.Test.MultiPartyContract), cid),
+      reference = domain.EnrichedContractId(Some(TpId.Test.MultiPartyContract.map(_.get)), cid),
       argument = argument,
       choiceInterfaceId = None,
       choice = lar.Choice("MPAddSignatories"),
@@ -690,7 +691,7 @@ trait AbstractHttpServiceIntegrationTestFuns
       )
     )
     domain.ExerciseCommand(
-      reference = domain.EnrichedContractId(Some(TpId.Test.MultiPartyContract), cid),
+      reference = domain.EnrichedContractId(Some(TpId.Test.MultiPartyContract.map(_.get)), cid),
       argument = argument,
       choiceInterfaceId = None,
       choice = lar.Choice("MPFetchOther"),
@@ -989,7 +990,7 @@ trait AbstractHttpServiceIntegrationTestFuns
       // make a contract and fetch the offset after it
       (cid, betweenOffset) <- offsetAfterCreate()
       // archive it
-      archive <- liftF(postArchiveCommand(TpId.Iou.Iou, cid, fixture, headers))
+      archive <- liftF(postArchiveCommand(TpId.Iou.Iou.map(_.get), cid, fixture, headers))
       _ = archive._1 shouldBe (StatusCodes.OK)
       // wait for the archival offset
       afterOffset <- readUntil[In] {

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractPruningTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractPruningTest.scala
@@ -9,7 +9,6 @@ abstract class AbstractPruningTest extends AbstractHttpServiceIntegrationTestFun
   override def useTls = HttpServiceTestFixture.UseTls.Tls
   override def wsConfig: Option[WebsocketConfig] = None
 
-  import AbstractHttpServiceIntegrationTestFuns.TpId
   import com.daml.ledger.api.v1.admin.{participant_pruning_service => PruneGrpc}
 
   "fail querying after pruned offset" in withHttpService { fixture =>

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractPruningTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractPruningTest.scala
@@ -11,6 +11,7 @@ abstract class AbstractPruningTest extends AbstractHttpServiceIntegrationTestFun
 
   import AbstractHttpServiceIntegrationTestFuns.TpId
   import com.daml.ledger.api.v1.admin.{participant_pruning_service => PruneGrpc}
+
   "fail querying after pruned offset" in withHttpService { fixture =>
     import scala.concurrent.duration._
     import com.daml.timer.RetryStrategy
@@ -98,7 +99,9 @@ abstract class AbstractPruningTest extends AbstractHttpServiceIntegrationTestFun
         // Query by Alice, to populate the contract into cache
         _ <- searchExpectOk(
           List.empty,
-          jsObject(s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "HKD"}}"""),
+          jsObject(
+            s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "HKD"}}"""
+          ),
           fixture,
           aliceHeaders,
         ).map { acl => acl.size shouldBe 1 }
@@ -118,7 +121,9 @@ abstract class AbstractPruningTest extends AbstractHttpServiceIntegrationTestFun
         // This should not get confused by the fact that the archival happened before this query.
         _ <- searchExpectOk(
           List.empty,
-          jsObject(s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "HKD"}}"""),
+          jsObject(
+            s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "HKD"}}"""
+          ),
           fixture,
           bobHeaders,
         ).map { acl => acl.size shouldBe 0 }

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractPruningTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractPruningTest.scala
@@ -9,6 +9,7 @@ abstract class AbstractPruningTest extends AbstractHttpServiceIntegrationTestFun
   override def useTls = HttpServiceTestFixture.UseTls.Tls
   override def wsConfig: Option[WebsocketConfig] = None
 
+  import AbstractHttpServiceIntegrationTestFuns.TpId
   import com.daml.ledger.api.v1.admin.{participant_pruning_service => PruneGrpc}
   "fail querying after pruned offset" in withHttpService { fixture =>
     import scala.concurrent.duration._

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractPruningTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractPruningTest.scala
@@ -17,7 +17,7 @@ abstract class AbstractPruningTest extends AbstractHttpServiceIntegrationTestFun
     import com.daml.timer.RetryStrategy
     for {
       (alice, aliceHeaders) <- fixture.getUniquePartyAndAuthHeaders("Alice")
-      query = jsObject(s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}""")
+      query = jsObject(s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"]}""")
 
       // do query to populate cache
       _ <- searchExpectOk(List(), query, fixture, aliceHeaders)
@@ -100,7 +100,7 @@ abstract class AbstractPruningTest extends AbstractHttpServiceIntegrationTestFun
         _ <- searchExpectOk(
           List.empty,
           jsObject(
-            s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "HKD"}}"""
+            s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"], "query": {"currency": "HKD"}}"""
           ),
           fixture,
           aliceHeaders,
@@ -122,7 +122,7 @@ abstract class AbstractPruningTest extends AbstractHttpServiceIntegrationTestFun
         _ <- searchExpectOk(
           List.empty,
           jsObject(
-            s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "HKD"}}"""
+            s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"], "query": {"currency": "HKD"}}"""
           ),
           fixture,
           bobHeaders,

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractPruningTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractPruningTest.scala
@@ -56,6 +56,7 @@ abstract class AbstractPruningTest extends AbstractHttpServiceIntegrationTestFun
       import com.daml.ledger.api.v1.admin.{participant_pruning_service => PruneGrpc}
       import com.daml.timer.RetryStrategy, scala.concurrent.duration._
       import org.apache.pekko.http.scaladsl.model._
+      import scalaz.syntax.functor._
       import spray.json._
       for {
         (alice, aliceHeaders) <- fixture.getUniquePartyAndAuthHeaders("Alice")
@@ -104,7 +105,7 @@ abstract class AbstractPruningTest extends AbstractHttpServiceIntegrationTestFun
         ).map { acl => acl.size shouldBe 1 }
 
         // Archive this contract on the ledger. The cache is not yet updated.
-        exercise = archiveCommand(domain.EnrichedContractId(Some(TpId.Iou.Iou), contractId))
+        exercise = archiveCommand(domain.EnrichedContractId(Some(TpId.Iou.Iou.map(_.get)), contractId))
         exerciseJson: JsValue = encodeExercise(fixture.encoder)(exercise)
 
         _ <- fixture

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractPruningTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractPruningTest.scala
@@ -56,7 +56,6 @@ abstract class AbstractPruningTest extends AbstractHttpServiceIntegrationTestFun
       import com.daml.ledger.api.v1.admin.{participant_pruning_service => PruneGrpc}
       import com.daml.timer.RetryStrategy, scala.concurrent.duration._
       import org.apache.pekko.http.scaladsl.model._
-      import scalaz.syntax.functor._
       import spray.json._
       for {
         (alice, aliceHeaders) <- fixture.getUniquePartyAndAuthHeaders("Alice")
@@ -105,7 +104,7 @@ abstract class AbstractPruningTest extends AbstractHttpServiceIntegrationTestFun
         ).map { acl => acl.size shouldBe 1 }
 
         // Archive this contract on the ledger. The cache is not yet updated.
-        exercise = archiveCommand(domain.EnrichedContractId(Some(TpId.Iou.Iou.map(_.get)), contractId))
+        exercise = archiveCommand(domain.EnrichedContractId(Some(TpId.Iou.Iou), contractId))
         exerciseJson: JsValue = encodeExercise(fixture.encoder)(exercise)
 
         _ <- fixture

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractPruningTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractPruningTest.scala
@@ -16,7 +16,7 @@ abstract class AbstractPruningTest extends AbstractHttpServiceIntegrationTestFun
     import com.daml.timer.RetryStrategy
     for {
       (alice, aliceHeaders) <- fixture.getUniquePartyAndAuthHeaders("Alice")
-      query = jsObject(s"""{"templateIds": ["Iou:Iou"]}""")
+      query = jsObject(s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}""")
 
       // do query to populate cache
       _ <- searchExpectOk(List(), query, fixture, aliceHeaders)
@@ -99,7 +99,7 @@ abstract class AbstractPruningTest extends AbstractHttpServiceIntegrationTestFun
         // Query by Alice, to populate the contract into cache
         _ <- searchExpectOk(
           List.empty,
-          jsObject("""{"templateIds": ["Iou:Iou"], "query": {"currency": "HKD"}}"""),
+          jsObject(s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "HKD"}}"""),
           fixture,
           aliceHeaders,
         ).map { acl => acl.size shouldBe 1 }
@@ -119,7 +119,7 @@ abstract class AbstractPruningTest extends AbstractHttpServiceIntegrationTestFun
         // This should not get confused by the fact that the archival happened before this query.
         _ <- searchExpectOk(
           List.empty,
-          jsObject("""{"templateIds": ["Iou:Iou"], "query": {"currency": "HKD"}}"""),
+          jsObject(s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "HKD"}}"""),
           fixture,
           bobHeaders,
         ).map { acl => acl.size shouldBe 0 }

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -55,7 +55,6 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
     with Inside
     with AbstractHttpServiceIntegrationTestFuns
     with BeforeAndAfterAll {
-  import AbstractHttpServiceIntegrationTestFuns.TpId
 
   // Guard tests which use features that are not available in Canton Community Edition
   private implicit final class EditionBranchingSupport(private val label: String) {

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -55,6 +55,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
     with Inside
     with AbstractHttpServiceIntegrationTestFuns
     with BeforeAndAfterAll {
+  import AbstractHttpServiceIntegrationTestFuns.TpId
 
   // Guard tests which use features that are not available in Canton Community Edition
   private implicit final class EditionBranchingSupport(private val label: String) {
@@ -328,7 +329,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
           AccountQuery(event) <- readOne
         } yield {
           event.created.record should ===(record)
-          event.created.templateId.copy(packageId = None) should ===(TpId.IAccount.IAccount)
+          event.created.templateId should ===(TpId.IAccount.IAccount.map(_.get))
           event.matchedQueries should ===(mq)
           event
         }
@@ -384,9 +385,9 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
                         )
                       ) =>
                     archivedContractId should ===(createdAccountEvent1.created.contractId)
-                    archivedTemplateId.copy(packageId = None) should ===(TpId.IAccount.IAccount)
+                    archivedTemplateId should ===(TpId.IAccount.IAccount.map(_.get))
 
-                    createdTemplateId.copy(packageId = None) should ===(TpId.IAccount.IAccount)
+                    createdTemplateId should ===(TpId.IAccount.IAccount.map(_.get))
 
                     createdRecord should ===(AccountRecord("abcxx", true, false))
                     matchedQueries shouldBe Vector(0)
@@ -1259,7 +1260,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
       import json.JsonProtocol._
       domain
         .CreateCommand(
-          TpId.Iou.Iou,
+          TpId.Iou.Iou.map(_.get),
           Map(
             "observers" -> List[String]().toJson,
             "issuer" -> partyName.toJson,
@@ -1380,7 +1381,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
       (alice, headers) = aliceHeaders
       jwt <- jwtForParties(uri)(List(alice), List(), "participant0")
       createIouCommand = (currency: String) => s"""{
-           |  "templateId": "Iou:Iou",
+           |  "templateId": "${tidString(TpId.Iou.Iou)}",
            |  "payload": {
            |    "observers": [],
            |    "issuer": "$alice",

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -306,7 +306,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
         def exerciseTransferPayload(cid: domain.ContractId) = {
           import json.JsonProtocol._
           val ecid: domain.ContractLocator[JsValue] =
-            domain.EnrichedContractId(Some(TpId.IAccount.IAccount.map(_.get)), cid)
+            domain.EnrichedContractId(Some(TpId.IAccount.IAccount), cid)
           domain
             .ExerciseCommand(
               ecid,
@@ -329,7 +329,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
           AccountQuery(event) <- readOne
         } yield {
           event.created.record should ===(record)
-          event.created.templateId should ===(TpId.IAccount.IAccount.map(_.get))
+          event.created.templateId should ===(TpId.IAccount.IAccount)
           event.matchedQueries should ===(mq)
           event
         }
@@ -385,9 +385,9 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
                         )
                       ) =>
                     archivedContractId should ===(createdAccountEvent1.created.contractId)
-                    archivedTemplateId should ===(TpId.IAccount.IAccount.map(_.get))
+                    archivedTemplateId should ===(TpId.IAccount.IAccount)
 
-                    createdTemplateId should ===(TpId.IAccount.IAccount.map(_.get))
+                    createdTemplateId should ===(TpId.IAccount.IAccount)
 
                     createdRecord should ===(AccountRecord("abcxx", true, false))
                     matchedQueries shouldBe Vector(0)
@@ -511,7 +511,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
     import json.JsonProtocol._
     domain
       .ExerciseCommand(
-        domain.EnrichedContractId(Some(TpId.Iou.Iou.map(_.get)), cid): domain.ContractLocator[JsValue],
+        domain.EnrichedContractId(Some(TpId.Iou.Iou), cid): domain.ContractLocator[JsValue],
         domain.Choice("Iou_Split"),
         Map("splitAmount" -> amount).toJson,
         Option.empty[domain.ContractTypeId.RequiredPkg],
@@ -812,7 +812,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
       for {
         aliceHeaders <- fixture.getUniquePartyAndAuthHeaders("Alice")
         (alice, headers) = aliceHeaders
-        templateId = TpId.Account.Account.map(_.get)
+        templateId = TpId.Account.Account
         fetchRequest = (contractIdAtOffset: Option[Option[domain.ContractId]]) => {
           import json.JsonProtocol._
           List(
@@ -928,7 +928,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
         (alice, aliceAuthHeaders) = aliceHeaders
         bobHeaders <- fixture.getUniquePartyAndAuthHeaders("Bob")
         (bob, bobAuthHeaders) = bobHeaders
-        templateId = TpId.Account.Account.map(_.get)
+        templateId = TpId.Account.Account
 
         f1 =
           postCreateCommand(
@@ -1034,7 +1034,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
       archive = (id: domain.ContractId) =>
         for {
           r <- postArchiveCommand(
-            TpId.Account.Account.map(_.get),
+            TpId.Account.Account,
             id,
             fixture,
             headers,
@@ -1260,7 +1260,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
       import json.JsonProtocol._
       domain
         .CreateCommand(
-          TpId.Iou.Iou.map(_.get),
+          TpId.Iou.Iou,
           Map(
             "observers" -> List[String]().toJson,
             "issuer" -> partyName.toJson,

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -84,12 +84,10 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
   override def wsConfig: Option[WebsocketConfig] = Some(WebsocketConfig())
 
   private val baseQueryInput: Source[Message, NotUsed] =
-    Source.single(
-      TextMessage.Strict(s"""{"templateIds": ["${tidString(TpId.Account.Account)}"]}""")
-    )
+    Source.single(TextMessage.Strict(s"""{"templateIds": ["${TpId.Account.Account.fqn}"]}"""))
 
   private val fetchRequest =
-    s"""[{"templateId": "${tidString(TpId.Account.Account)}", "key": ["Alice", "abc123"]}]"""
+    s"""[{"templateId": "${TpId.Account.Account.fqn}", "key": ["Alice", "abc123"]}]"""
 
   private val baseFetchInput: Source[Message, NotUsed] =
     Source.single(TextMessage.Strict(fetchRequest))
@@ -203,9 +201,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
     import AbstractHttpServiceIntegrationTestFuns.ciouDar
     val queryInput = Source.single(
       TextMessage.Strict(
-        s"""[{"templateIds": ["${tidString(
-            TpId.IAccount.IAccount
-          )}"]}, {"templateIds": ["${tidString(TpId.IIou.IIou)}"]}]"""
+        s"""[{"templateIds": ["${TpId.IAccount.IAccount.fqn}"]}, {"templateIds": ["${TpId.IIou.IIou.fqn}"]}]"""
       )
     )
     val scenario = SimpleScenario("", Uri.Path("/v1/stream/query"), queryInput)
@@ -225,9 +221,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
   "query error when queries with both template and interface id" in withHttpService { fixture =>
     val queryInput = Source.single(
       TextMessage.Strict(
-        s"""[{"templateIds": ["${tidString(
-            TpId.IAccount.IAccount
-          )}"]}, {"templateIds": ["${tidString(TpId.Account.Account)}"]}]"""
+        s"""[{"templateIds": ["${TpId.IAccount.IAccount.fqn}"]}, {"templateIds": ["${TpId.Account.Account.fqn}"]}]"""
       )
     )
     val scenario = SimpleScenario("", Uri.Path("/v1/stream/query"), queryInput)
@@ -254,7 +248,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
         clientMsg <- singleClientQueryStream(
           jwt,
           uri,
-          s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}""",
+          s"""{"templateIds": ["${TpId.Iou.Iou.fqn}"]}""",
         ).take(2)
           .runWith(collectResultsAsTextMessage)
       } yield inside(clientMsg) { case result +: heartbeats =>
@@ -271,9 +265,8 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
         (alice, headers) = aliceHeaders
         _ <- initialAccountCreate(fixture, alice, headers)
         jwt <- jwtForParties(uri)(List(alice), Nil, "participant0")
-        fetchRequest = s"""[{"templateId": "${tidString(
-            TpId.Account.Account
-          )}", "key": ["$alice", "abc123"]}]"""
+        fetchRequest =
+          s"""[{"templateId": "${TpId.Account.Account.fqn}", "key": ["$alice", "abc123"]}]"""
         clientMsg <- singleClientFetchStream(jwt, uri, fetchRequest)
           .take(2)
           .runWith(collectResultsAsTextMessage)
@@ -291,8 +284,8 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
       import fixture.uri
       val query =
         s"""[
-        {"templateIds": ["${tidString(TpId.IAccount.IAccount)}"], "query": {"isAbcPrefix": true}},
-        {"templateIds": ["${tidString(TpId.IAccount.IAccount)}"], "query": {"is123Suffix": true}}
+        {"templateIds": ["${TpId.IAccount.IAccount.fqn}"], "query": {"isAbcPrefix": true}},
+        {"templateIds": ["${TpId.IAccount.IAccount.fqn}"], "query": {"is123Suffix": true}}
       ]"""
 
       @nowarn("msg=pattern var evtsWrapper .* is never used")
@@ -447,7 +440,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
             singleClientQueryStream(
               _,
               uri,
-              s"""{"templateIds": ["${tidString(TpId.Iou.Iou)}", "UnknownPkg:Unknown:Template"]}""",
+              s"""{"templateIds": ["${TpId.Iou.Iou.fqn}", "UnknownPkg:Unknown:Template"]}""",
             )
               .take(3)
               .runWith(collectResultsAsTextMessage)
@@ -470,9 +463,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
           singleClientFetchStream(
             _,
             uri,
-            s"""[{"templateId": "${tidString(
-                TpId.Account.Account
-              )}", "key": ["$alice", "abc123"]}, {"templateId": "UnknownPkg:Unknown:Template", "key": ["$alice", "abc123"]}]""",
+            s"""[{"templateId": "${TpId.Account.Account.fqn}", "key": ["$alice", "abc123"]}, {"templateId": "UnknownPkg:Unknown:Template", "key": ["$alice", "abc123"]}]""",
           ).take(3)
             .runWith(collectResultsAsTextMessage)
         )
@@ -572,7 +563,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
       // initial query without offset
       val query =
         s"""[
-          {"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "USD"}}
+          {"templateIds": ["${TpId.Iou.Iou.fqn}"], "query": {"currency": "USD"}}
         ]"""
 
       for {
@@ -588,10 +579,8 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
 
         // construct a new multiquery with one of them having an offset while the other doesn't
         multiquery = s"""[
-          {"templateIds": ["${tidString(
-            TpId.Iou.Iou
-          )}"], "query": {"currency": "USD"}, "offset": "${lastSeen.unwrap}"},
-          {"templateIds": ["${tidString(TpId.Iou.Iou)}"]}
+          {"templateIds": ["${TpId.Iou.Iou.fqn}"], "query": {"currency": "USD"}, "offset": "${lastSeen.unwrap}"},
+          {"templateIds": ["${TpId.Iou.Iou.fqn}"]}
         ]"""
 
         clientMsg <- singleClientQueryStream(jwt, uri, multiquery)
@@ -681,9 +670,9 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
 
       val query =
         s"""[
-          {"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"amount": {"%lte": 50}}},
-          {"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"amount": {"%gt": 50}}},
-          {"templateIds": ["${tidString(TpId.Iou.Iou)}"]}
+          {"templateIds": ["${TpId.Iou.Iou.fqn}"], "query": {"amount": {"%lte": 50}}},
+          {"templateIds": ["${TpId.Iou.Iou.fqn}"], "query": {"amount": {"%gt": 50}}},
+          {"templateIds": ["${TpId.Iou.Iou.fqn}"]}
         ]"""
 
       for {
@@ -730,7 +719,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
 
         query =
           s"""[
-          {"templateIds": ["${tidString(TpId.Account.Account)}"]}
+          {"templateIds": ["${TpId.Account.Account.fqn}"]}
         ]"""
         resp = (
             cid1: domain.ContractId,
@@ -829,7 +818,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
           import json.JsonProtocol._
           List(
             Map(
-              "templateId" -> tidString(TpId.Account.Account).toJson,
+              "templateId" -> TpId.Account.Account.fqn.toJson,
               "key" -> List(alice.unwrap, "abc123").toJson,
             )
               ++ contractIdAtOffset
@@ -957,8 +946,8 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
 
         query =
           s"""[
-            {"templateId": "${tidString(TpId.Account.Account)}", "key": ["$alice", "abc123"]},
-            {"templateId": "${tidString(TpId.Account.Account)}", "key": ["$bob", "def456"]}
+            {"templateId": "${TpId.Account.Account.fqn}", "key": ["$alice", "abc123"]},
+            {"templateId": "${TpId.Account.Account.fqn}", "key": ["$bob", "def456"]}
           ]"""
 
         resp = (
@@ -1086,8 +1075,8 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
       }
       req =
         s"""
-               |[{"templateId": "${tidString(TpId.Account.Account)}", "key": ["$alice", "abc123"]},
-               | {"templateId": "${tidString(TpId.Account.Account)}", "key": ["$alice", "def456"]}]
+               |[{"templateId": "${TpId.Account.Account.fqn}", "key": ["$alice", "abc123"]},
+               | {"templateId": "${TpId.Account.Account.fqn}", "key": ["$alice", "def456"]}]
                |""".stripMargin
       (kill, source) = singleClientFetchStream(jwt, uri, req)
         .viaMat(KillSwitches.single)(Keep.right)
@@ -1189,7 +1178,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
 
         // now query again with a pruned offset
         jwt <- jwtForParties(uri)(List(alice), List(), "participant0")
-        query = s"""[{"templateIds": ["${tidString(TpId.Iou.Iou)}"]}]"""
+        query = s"""[{"templateIds": ["${TpId.Iou.Iou.fqn}"]}]"""
         results <- singleClientQueryStream(jwt, uri, query, Some(offsetBeforeArchive))
           .via(parseResp)
           .runWith(Sink.seq)
@@ -1213,7 +1202,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
         splitSample = SplitSeq.gen.map(_ map (BigDecimal(_))).sample.get
         query =
           s"""[
-            {"templateIds": ["${tidString(TpId.Iou.Iou)}"]}
+            {"templateIds": ["${TpId.Iou.Iou.fqn}"]}
           ]"""
         jwt <- jwtForParties(uri)(List(alice), List(), "participant0")
         (kill, source) =
@@ -1370,7 +1359,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
         (killSwitch, source) = singleClientQueryStream(
           jwt = jwtForAliceAndBob,
           serviceUri = uri,
-          query = s"""{"templateIds": ["${tidString(TpId.Account.SharedAccount)}"]}""",
+          query = s"""{"templateIds": ["${TpId.Account.SharedAccount.fqn}"]}""",
         )
           .viaMat(KillSwitches.single)(Keep.right)
           .preMaterialize()
@@ -1393,7 +1382,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
       (alice, headers) = aliceHeaders
       jwt <- jwtForParties(uri)(List(alice), List(), "participant0")
       createIouCommand = (currency: String) => s"""{
-           |  "templateId": "${tidString(TpId.Iou.Iou)}",
+           |  "templateId": "${TpId.Iou.Iou.fqn}",
            |  "payload": {
            |    "observers": [],
            |    "issuer": "$alice",
@@ -1411,11 +1400,9 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
           )
           .map(_._1 shouldBe a[StatusCodes.Success])
       contractsQuery = (currency: String) =>
-        s"""{"templateIds":["${tidString(TpId.Iou.Iou)}"], "query":{"currency":"$currency"}}"""
+        s"""{"templateIds":["${TpId.Iou.Iou.fqn}"], "query":{"currency":"$currency"}}"""
       contractsQueryWithOffset = (offset: domain.Offset, currency: String) =>
-        s"""{"templateIds":["${tidString(
-            TpId.Iou.Iou
-          )}"], "query":{"currency":"$currency"}, "offset":"${offset.unwrap}"}"""
+        s"""{"templateIds":["${TpId.Iou.Iou.fqn}"], "query":{"currency":"$currency"}, "offset":"${offset.unwrap}"}"""
       contracts = (currency: String, offset: Option[domain.Offset]) =>
         offset.fold(contractsQuery(currency))(contractsQueryWithOffset(_, currency))
       acsEnd = (expectedContracts: Int) => {
@@ -1429,7 +1416,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
             } yield offset
           )
         val (killSwitch, source) =
-          singleClientQueryStream(jwt, uri, s"""{"templateIds":["${tidString(TpId.Iou.Iou)}"]}""")
+          singleClientQueryStream(jwt, uri, s"""{"templateIds":["${TpId.Iou.Iou.fqn}"]}""")
             .viaMat(KillSwitches.single)(Keep.right)
             .preMaterialize()
         source.via(parseResp).runWith(go(killSwitch))

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -312,7 +312,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
               ecid,
               choice = domain.Choice("ChangeAmount"),
               argument = Map("newAmount" -> "abcxx").toJson,
-              Option.empty[domain.ContractTypeId.OptionalPkg],
+              Option.empty[domain.ContractTypeId.RequiredPkg],
               None,
             )
             .toJson
@@ -514,7 +514,7 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
         domain.EnrichedContractId(Some(TpId.Iou.Iou), cid): domain.ContractLocator[JsValue],
         domain.Choice("Iou_Split"),
         Map("splitAmount" -> amount).toJson,
-        Option.empty[domain.ContractTypeId.OptionalPkg],
+        Option.empty[domain.ContractTypeId.RequiredPkg],
         None,
       )
       .toJson

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -84,7 +84,9 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
   override def wsConfig: Option[WebsocketConfig] = Some(WebsocketConfig())
 
   private val baseQueryInput: Source[Message, NotUsed] =
-    Source.single(TextMessage.Strict(s"""{"templateIds": ["${tidString(TpId.Account.Account)}"]}"""))
+    Source.single(
+      TextMessage.Strict(s"""{"templateIds": ["${tidString(TpId.Account.Account)}"]}""")
+    )
 
   private val fetchRequest =
     s"""[{"templateId": "${tidString(TpId.Account.Account)}", "key": ["Alice", "abc123"]}]"""
@@ -201,7 +203,9 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
     import AbstractHttpServiceIntegrationTestFuns.ciouDar
     val queryInput = Source.single(
       TextMessage.Strict(
-        s"""[{"templateIds": ["${tidString(TpId.IAccount.IAccount)}"]}, {"templateIds": ["${tidString(TpId.IIou.IIou)}"]}]"""
+        s"""[{"templateIds": ["${tidString(
+            TpId.IAccount.IAccount
+          )}"]}, {"templateIds": ["${tidString(TpId.IIou.IIou)}"]}]"""
       )
     )
     val scenario = SimpleScenario("", Uri.Path("/v1/stream/query"), queryInput)
@@ -221,7 +225,9 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
   "query error when queries with both template and interface id" in withHttpService { fixture =>
     val queryInput = Source.single(
       TextMessage.Strict(
-        s"""[{"templateIds": ["${tidString(TpId.IAccount.IAccount)}"]}, {"templateIds": ["${tidString(TpId.Account.Account)}"]}]"""
+        s"""[{"templateIds": ["${tidString(
+            TpId.IAccount.IAccount
+          )}"]}, {"templateIds": ["${tidString(TpId.Account.Account)}"]}]"""
       )
     )
     val scenario = SimpleScenario("", Uri.Path("/v1/stream/query"), queryInput)
@@ -265,7 +271,9 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
         (alice, headers) = aliceHeaders
         _ <- initialAccountCreate(fixture, alice, headers)
         jwt <- jwtForParties(uri)(List(alice), Nil, "participant0")
-        fetchRequest = s"""[{"templateId": "${tidString(TpId.Account.Account)}", "key": ["$alice", "abc123"]}]"""
+        fetchRequest = s"""[{"templateId": "${tidString(
+            TpId.Account.Account
+          )}", "key": ["$alice", "abc123"]}]"""
         clientMsg <- singleClientFetchStream(jwt, uri, fetchRequest)
           .take(2)
           .runWith(collectResultsAsTextMessage)
@@ -462,7 +470,9 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
           singleClientFetchStream(
             _,
             uri,
-            s"""[{"templateId": "${tidString(TpId.Account.Account)}", "key": ["$alice", "abc123"]}, {"templateId": "UnknownPkg:Unknown:Template", "key": ["$alice", "abc123"]}]""",
+            s"""[{"templateId": "${tidString(
+                TpId.Account.Account
+              )}", "key": ["$alice", "abc123"]}, {"templateId": "UnknownPkg:Unknown:Template", "key": ["$alice", "abc123"]}]""",
           ).take(3)
             .runWith(collectResultsAsTextMessage)
         )
@@ -578,7 +588,9 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
 
         // construct a new multiquery with one of them having an offset while the other doesn't
         multiquery = s"""[
-          {"templateIds": ["${tidString(TpId.Iou.Iou)}"], "query": {"currency": "USD"}, "offset": "${lastSeen.unwrap}"},
+          {"templateIds": ["${tidString(
+            TpId.Iou.Iou
+          )}"], "query": {"currency": "USD"}, "offset": "${lastSeen.unwrap}"},
           {"templateIds": ["${tidString(TpId.Iou.Iou)}"]}
         ]"""
 
@@ -1401,7 +1413,9 @@ abstract class AbstractWebsocketServiceIntegrationTest(val integration: String)
       contractsQuery = (currency: String) =>
         s"""{"templateIds":["${tidString(TpId.Iou.Iou)}"], "query":{"currency":"$currency"}}"""
       contractsQueryWithOffset = (offset: domain.Offset, currency: String) =>
-        s"""{"templateIds":["${tidString(TpId.Iou.Iou)}"], "query":{"currency":"$currency"}, "offset":"${offset.unwrap}"}"""
+        s"""{"templateIds":["${tidString(
+            TpId.Iou.Iou
+          )}"], "query":{"currency":"$currency"}, "offset":"${offset.unwrap}"}"""
       contracts = (currency: String, offset: Option[domain.Offset]) =>
         offset.fold(contractsQuery(currency))(contractsQueryWithOffset(_, currency))
       acsEnd = (expectedContracts: Int) => {

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/FilterDiscriminatorScenario.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/FilterDiscriminatorScenario.scala
@@ -10,7 +10,7 @@ import spray.json.JsValue
   */
 class FilterDiscriminatorScenario[Inj](
     val label: String,
-    val ctId: domain.ContractTypeId.Template.OptionalPkg,
+    val ctId: domain.ContractTypeId.Template.RequiredPkg,
     val va: VA.Aux[Inj],
     val query: Map[String, JsValue],
     val matches: Seq[domain.Party => Inj],
@@ -20,7 +20,7 @@ class FilterDiscriminatorScenario[Inj](
 object FilterDiscriminatorScenario {
   def Scenario(
       label: String,
-      ctId: domain.ContractTypeId.Template.OptionalPkg,
+      ctId: domain.ContractTypeId.Template.RequiredPkg,
       va: VA,
       query: Map[String, JsValue],
   )(

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -699,7 +699,7 @@ class ContractsService(
       lc: LoggingContextOf[InstanceUUID with RequestID]
   ): Future[(Set[ContractTypeRef.Resolved], Set[Tid])] = {
     import scalaz.syntax.traverse._
-    import scalaz.std.list._ //, scalaz.syntax.functor._
+    import scalaz.std.list._ // , scalaz.syntax.functor._
 
     xs.toList.toNEF
       .traverse { x =>

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -97,11 +97,11 @@ class ContractsService(
   ): Future[Option[domain.ResolvedContractRef[LfValue]]] =
     contractLocator match {
       case domain.EnrichedContractKey(templateId, key) =>
-        resolveContractTypeId(jwt, ledgerId)(templateId).map(
+        resolveContractTypeId(jwt, ledgerId)(templateId.map(Some(_))).map(
           _.toOption.flatten.map(x => -\/(x.original -> key))
         )
       case domain.EnrichedContractId(Some(templateId), contractId) =>
-        resolveContractTypeId(jwt, ledgerId)(templateId).map(
+        resolveContractTypeId(jwt, ledgerId)(templateId.map(Some(_))).map(
           _.toOption.flatten.map(x => \/-(x.original -> contractId))
         )
       case domain.EnrichedContractId(None, contractId) =>
@@ -121,12 +121,12 @@ class ContractsService(
     val readAs = req.readAs.cata(_.toSet1, jwtPayload.parties)
     req.locator match {
       case domain.EnrichedContractKey(templateId, contractKey) =>
-        findByContractKey(jwt, readAs, templateId, ledgerId, contractKey)
+        findByContractKey(jwt, readAs, templateId.map(Some(_)), ledgerId, contractKey)
       case domain.EnrichedContractId(templateId, contractId) =>
         findByContractId(
           jwt,
           readAs,
-          templateId,
+          templateId.map(id => id.map(Some(_))),
           ledgerId,
           contractId,
         )

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -699,7 +699,7 @@ class ContractsService(
       lc: LoggingContextOf[InstanceUUID with RequestID]
   ): Future[(Set[ContractTypeRef.Resolved], Set[Tid])] = {
     import scalaz.syntax.traverse._
-    import scalaz.std.list._ // , scalaz.syntax.functor._
+    import scalaz.std.list._
 
     xs.toList.toNEF
       .traverse { x =>

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/PackageService.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/PackageService.scala
@@ -226,41 +226,38 @@ private class PackageService(
         result <- EitherT.pure(doSearch(latestMaps())): ET[ResultType]
         _ = logger.trace(s"Result: $result")
         finalResult <-
-          if ((x: C.RequiredPkg).packageId.startsWith("#")) {
+          if (x.packageId.startsWith("#")) { // Used package name, not package id
             if (result.isDefined)
-              // used package name and we do have the package, refresh if timeout
+              // no package id and we do have the package, refresh if timeout
               if (cache.packagesShouldBeFetchedAgain) {
                 logger.trace(
-                  s"package name supplied and we do have the package, refresh because of timeout: $x"
+                  "no package id and we do have the package, refresh because of timeout"
                 )
                 doReloadAndSearchAgain()
               } else {
                 logger.trace(
-                  s"package name supplied and we do have the package, -no timeout- no refresh: $x"
+                  "no package id and we do have the package, -no timeout- no refresh"
                 )
                 keep(result)
               }
-            // used package name and we don’t have the package, always refresh
+            // no package id and we don’t have the package, always refresh
             else {
-              logger.trace(
-                s"package name supplied and we don’t have the package, always refresh: $x"
-              )
+              logger.trace("no package id and we don’t have the package, always refresh")
               doReloadAndSearchAgain()
             }
           } else {
-            val packageId = (x: C.RequiredPkg).packageId
             if (result.isDefined) {
-              logger.trace(s"package id supplied & template id found, no refresh necessary: $x")
+              logger.trace("package id defined & template id found, no refresh necessary")
               keep(result)
             } else {
               // package id and we have the package, never refresh
-              if (state.packageIds.contains(packageId)) {
-                logger.trace(s"package id supplied and we have the package, never refresh: $x")
+              if (state.packageIds.contains(x.packageId)) {
+                logger.trace("package id and we have the package, never refresh")
                 keep(result)
               }
               // package id and we don’t have the package, always refresh
               else {
-                logger.trace("package id supplied and we don’t have the package, always refresh")
+                logger.trace("package id and we don’t have the package, always refresh")
                 doReloadAndSearchAgain()
               }
             }

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/PackageService.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/PackageService.scala
@@ -406,7 +406,7 @@ object PackageService {
       }.toSet
 
     private[http] def resolve(
-        a: ContractTypeId[String]
+        a: ContractTypeId.RequiredPkg
     )(implicit makeKey: ContractTypeId.Like[CtId]): Option[ContractTypeRef[ResolvedOf[CtId]]] =
       (all get makeKey(a.packageId, a.moduleName, a.entityName)).flatMap(toContractTypeRef)
   }
@@ -431,7 +431,6 @@ object PackageService {
       private val mapView: MapView[String, (KeyPackageName, Ref.PackageVersion)]
   ) {
     def get(pkgId: String) = mapView.get(pkgId)
-    override def toString = mapView.toMap.toString
   }
   object PackageNameMap {
     val empty = PackageNameMap(MapView.empty)

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/PackageService.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/PackageService.scala
@@ -409,11 +409,12 @@ object PackageService {
 
     private[http] def resolve(
         a: ContractTypeId[Option[String]]
-    )(implicit makeKey: ContractTypeId.Like[CtId]): Option[ContractTypeRef[ResolvedOf[CtId]]] =
+    )(implicit makeKey: ContractTypeId.Like[CtId]): Option[ContractTypeRef[ResolvedOf[CtId]]] = {
       (a.packageId match {
         case Some(p) => all get makeKey(p, a.moduleName, a.entityName)
         case None => unique get makeKey((), a.moduleName, a.entityName)
       }).flatMap(toContractTypeRef)
+    }
   }
 
   type TemplateIdMap = ContractTypeIdMap[ContractTypeId.Template]
@@ -436,6 +437,7 @@ object PackageService {
       private val mapView: MapView[String, (KeyPackageName, Ref.PackageVersion)]
   ) {
     def get(pkgId: String) = mapView.get(pkgId)
+    override def toString = mapView.toMap.toString
   }
   object PackageNameMap {
     val empty = PackageNameMap(MapView.empty)

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/PackageService.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/PackageService.scala
@@ -225,8 +225,9 @@ private class PackageService(
       for {
         result <- EitherT.pure(doSearch(latestMaps())): ET[ResultType]
         _ = logger.trace(s"Result: $result")
-        finalResult <-
-          if (x.packageId.startsWith("#")) { // Used package name, not package id
+        finalResult <- {
+          val packageId = (x: C.RequiredPkg).packageId
+          if (packageId.startsWith("#")) { // Used package name, not package id
             if (result.isDefined)
               // no package id and we do have the package, refresh if timeout
               if (cache.packagesShouldBeFetchedAgain) {
@@ -251,7 +252,7 @@ private class PackageService(
               keep(result)
             } else {
               // package id and we have the package, never refresh
-              if (state.packageIds.contains(x.packageId)) {
+              if (state.packageIds.contains(packageId)) {
                 logger.trace("package id and we have the package, never refresh")
                 keep(result)
               }
@@ -262,6 +263,7 @@ private class PackageService(
               }
             }
           }: ET[ResultType]
+        }
         _ = logger.trace(s"Final result: $finalResult")
       } yield finalResult
     }.run

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -610,8 +610,9 @@ object WebSocketService {
 
       request.toList
         .traverse { x: CKR[LfV] =>
-          resolveContractTypeId(jwt, ledgerId)(x.ekey.templateId)
-            .map(_.toOption.flatten.map(r => (r, x.ekey.key)).toLeft(x.ekey.templateId))
+          val tid = x.ekey.templateId.map(Some(_))
+          resolveContractTypeId(jwt, ledgerId)(tid)
+            .map(_.toOption.flatten.map(r => (r, x.ekey.key)).toLeft(tid))
         }
         .map { resolveTries =>
           val (resolvedWithKey, unresolved) = resolveTries

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -615,7 +615,7 @@ object WebSocketService {
         }
         .map { resolveTries =>
           val (resolvedWithKey, unresolved) = resolveTries
-            .toSet[Either[(ContractTypeRef.Resolved, LfV), domain.ContractTypeId.RequiredPkg]]
+            .toSet[Either[(ContractTypeRef.Resolved, LfV), RequiredPkg]]
             .partitionMap(identity)
           for {
             resolvedWithKey <- (NonEmpty from resolvedWithKey toRightDisjunction InvalidUserInput(

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -300,7 +300,7 @@ object WebSocketService {
             sfq: domain.SearchForeverQuery
         ): Future[(Set[ContractTypeRef.Resolved], Set[domain.ContractTypeId.RequiredPkg])] =
           sfq.templateIds.toList.toNEF
-            .traverse{ x =>
+            .traverse { x =>
               resolveContractTypeId(jwt, ledgerId)(x).map(_.toOption.flatten.toLeft(x))
             }
             .map(

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -300,9 +300,9 @@ object WebSocketService {
             sfq: domain.SearchForeverQuery
         ): Future[(Set[ContractTypeRef.Resolved], Set[domain.ContractTypeId.RequiredPkg])] =
           sfq.templateIds.toList.toNEF
-            .traverse { x =>
+            .traverse(x =>
               resolveContractTypeId(jwt, ledgerId)(x).map(_.toOption.flatten.toLeft(x))
-            }
+            )
             .map(
               _.toSet.partitionMap(
                 identity[

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -695,7 +695,7 @@ package domain {
     type LAVUnresolved = CreateAndExerciseCommand[
       lav1.value.Record,
       lav1.value.Value,
-      domain.ContractTypeId.Template.OptionalPkg,
+      domain.ContractTypeId.Template.RequiredPkg,
       domain.ContractTypeId.OptionalPkg,
     ]
 

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -164,7 +164,7 @@ package domain {
   )
 
   final case class GetActiveContractsRequest(
-      templateIds: NonEmpty[Set[ContractTypeId.OptionalPkg]],
+      templateIds: NonEmpty[Set[ContractTypeId.RequiredPkg]],
       query: Map[String, JsValue],
       readAs: Option[NonEmptyList[Party]],
   )
@@ -178,7 +178,7 @@ package domain {
   )
 
   final case class SearchForeverQuery(
-      templateIds: NonEmpty[Set[ContractTypeId.OptionalPkg]],
+      templateIds: NonEmpty[Set[ContractTypeId.RequiredPkg]],
       query: Map[String, JsValue],
       offset: Option[domain.Offset],
   )
@@ -693,13 +693,6 @@ package domain {
   }
 
   object CreateAndExerciseCommand {
-    type LAVUnresolved = CreateAndExerciseCommand[
-      lav1.value.Record,
-      lav1.value.Value,
-      domain.ContractTypeId.Template.RequiredPkg,
-      domain.ContractTypeId.OptionalPkg,
-    ]
-
     type LAVResolved = CreateAndExerciseCommand[
       lav1.value.Record,
       lav1.value.Value,
@@ -838,7 +831,7 @@ package domain {
 
   sealed abstract class ServiceWarning extends Serializable with Product
 
-  final case class UnknownTemplateIds(unknownTemplateIds: List[ContractTypeId.OptionalPkg])
+  final case class UnknownTemplateIds(unknownTemplateIds: List[ContractTypeId.RequiredPkg])
       extends ServiceWarning
 
   final case class UnknownParties(unknownParties: List[domain.Party]) extends ServiceWarning

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -530,10 +530,8 @@ package domain {
 
     val structure: ContractLocator <~> InputContractRef =
       new IsoFunctorTemplate[ContractLocator, InputContractRef] {
-        override def from[A](ga: InputContractRef[A]) = ga.fold(
-          { case (otid, cid) => EnrichedContractKey[A](otid, cid) },
-          { case (tid, key) => EnrichedContractId(tid, key) },
-        )
+        override def from[A](ga: InputContractRef[A]) =
+          ga.fold((EnrichedContractKey[A] _).tupled, EnrichedContractId.tupled)
 
         override def to[A](fa: ContractLocator[A]) = fa match {
           case EnrichedContractId(otid, cid) => \/-((otid, cid))

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -450,8 +450,8 @@ package domain {
     // only used in integration tests
     implicit val `AcC hasTemplateId`: HasTemplateId.Compat[ActiveContract.ResolvedCtTyId] =
       new HasTemplateId[ActiveContract.ResolvedCtTyId] {
-        override def templateId(fa: ActiveContract.ResolvedCtTyId[_]): ContractTypeId.OptionalPkg =
-          (fa.templateId: ContractTypeId.RequiredPkg).map(Some(_))
+        override def templateId(fa: ActiveContract.ResolvedCtTyId[_]): ContractTypeId.RequiredPkg =
+          fa.templateId
 
         type TypeFromCtId = LfType
 
@@ -554,8 +554,8 @@ package domain {
     implicit val hasTemplateId: HasTemplateId.Compat[EnrichedContractKey] =
       new HasTemplateId[EnrichedContractKey] {
 
-        override def templateId(fa: EnrichedContractKey[_]): ContractTypeId.OptionalPkg =
-          fa.templateId.map(Some(_))
+        override def templateId(fa: EnrichedContractKey[_]): ContractTypeId.RequiredPkg =
+          fa.templateId
 
         type TypeFromCtId = LfType
 
@@ -594,7 +594,7 @@ package domain {
   trait HasTemplateId[-F[_]] {
     protected[this] type FHuh = F[_] // how to pronounce "F[?]" or "F huh?"
 
-    def templateId(fa: F[_]): ContractTypeId.OptionalPkg
+    def templateId(fa: F[_]): ContractTypeId.RequiredPkg
 
     type TypeFromCtId
 
@@ -668,10 +668,10 @@ package domain {
       domain.ContractLocator[_],
     ], (Option[domain.ContractTypeId.Interface.Resolved], LfType)] =
       new HasTemplateId[RequiredPkg[+*, domain.ContractLocator[_]]] {
-        override def templateId(fab: FHuh): ContractTypeId.OptionalPkg =
-          fab.choiceInterfaceId.map(id => id.map(Some(_))) getOrElse (fab.reference match {
-            case EnrichedContractKey(templateId, _) => templateId.map(Some(_))
-            case EnrichedContractId(Some(templateId), _) => templateId.map(Some(_))
+        override def templateId(fab: FHuh): ContractTypeId.RequiredPkg =
+          fab.choiceInterfaceId getOrElse (fab.reference match {
+            case EnrichedContractKey(templateId, _) => templateId
+            case EnrichedContractId(Some(templateId), _) => templateId
             case EnrichedContractId(None, _) =>
               throw new IllegalArgumentException(
                 "Please specify templateId, optional templateId is not supported yet!"

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -632,6 +632,8 @@ package domain {
   }
 
   object CreateCommand {
+    type RequiredPkg[+LfV] = CreateCommand[LfV, ContractTypeId.Template.RequiredPkg]
+
     implicit val bitraverseInstance: Bitraverse[CreateCommand] = new Bitraverse[CreateCommand] {
       override def bitraverseImpl[G[_]: Applicative, A, B, C, D](
           fab: CreateCommand[A, B]

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonDecoder.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonDecoder.scala
@@ -173,7 +173,7 @@ class DomainJsonDecoder(
         domain.CreateAndExerciseCommand[
           JsValue,
           JsValue,
-          ContractTypeId.Template.OptionalPkg,
+          ContractTypeId.Template.RequiredPkg,
           ContractTypeId.OptionalPkg,
         ]
       ],
@@ -187,11 +187,11 @@ class DomainJsonDecoder(
           .decode[domain.CreateAndExerciseCommand[
             JsValue,
             JsValue,
-            ContractTypeId.Template.OptionalPkg,
+            ContractTypeId.Template.RequiredPkg,
             ContractTypeId.OptionalPkg,
           ]](a)
           .liftErrS(err)(JsonError)
-      ).flatMap(_.bitraverse(templateId_(_, jwt, ledgerId), templateId_(_, jwt, ledgerId)))
+      ).flatMap(_.bitraverse(id => templateId_(id.map(Some(_)), jwt, ledgerId), templateId_(_, jwt, ledgerId)))
 
       tId = fjj.templateId
       ciId = fjj.choiceInterfaceId

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonDecoder.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonDecoder.scala
@@ -232,7 +232,9 @@ class DomainJsonDecoder(
     }
   } yield meta map tpidToResolved map (_.asInstanceOf[R])
 
-  private def templateId_[CtId[T] <: domain.ContractTypeId[T] with domain.ContractTypeId.Ops[CtId, T]](
+  private def templateId_[
+      CtId[T] <: domain.ContractTypeId[T] with domain.ContractTypeId.Ops[CtId, T]
+  ](
       id: CtId[String],
       jwt: Jwt,
       ledgerId: LedgerApiDomain.LedgerId,

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonDecoder.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonDecoder.scala
@@ -174,7 +174,7 @@ class DomainJsonDecoder(
           JsValue,
           JsValue,
           ContractTypeId.Template.RequiredPkg,
-          ContractTypeId.OptionalPkg,
+          ContractTypeId.RequiredPkg,
         ]
       ],
       ec: ExecutionContext,
@@ -188,10 +188,10 @@ class DomainJsonDecoder(
             JsValue,
             JsValue,
             ContractTypeId.Template.RequiredPkg,
-            ContractTypeId.OptionalPkg,
+            ContractTypeId.RequiredPkg,
           ]](a)
           .liftErrS(err)(JsonError)
-      ).flatMap(_.bitraverse(id => templateId_(id.map(Some(_)), jwt, ledgerId), templateId_(_, jwt, ledgerId)))
+      ).flatMap(_.bitraverse(id => templateId_(id.map(Some(_)), jwt, ledgerId), id => templateId_(id.map(Some(_)), jwt, ledgerId)))
 
       tId = fjj.templateId
       ciId = fjj.choiceInterfaceId

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonDecoder.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonDecoder.scala
@@ -39,7 +39,7 @@ class DomainJsonDecoder(
 
   def decodeCreateCommand(a: JsValue, jwt: Jwt, ledgerId: LedgerApiDomain.LedgerId)(implicit
       ev1: JsonReader[
-        domain.CreateCommand[JsValue, ContractTypeId.Template.OptionalPkg]
+        domain.CreateCommand[JsValue, ContractTypeId.Template.RequiredPkg]
       ],
       ec: ExecutionContext,
       lc: LoggingContextOf[InstanceUUID],
@@ -48,11 +48,11 @@ class DomainJsonDecoder(
     for {
       fj <- either(
         SprayJson
-          .decode[domain.CreateCommand[JsValue, ContractTypeId.Template.OptionalPkg]](a)
+          .decode[domain.CreateCommand[JsValue, ContractTypeId.Template.RequiredPkg]](a)
           .liftErrS(err)(JsonError)
       )
 
-      tmplId <- templateId_(fj.templateId, jwt, ledgerId)
+      tmplId <- templateId_(fj.templateId.map(Some(_)), jwt, ledgerId)
       payloadT <- either(templateRecordType(tmplId))
 
       fv <- either(

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonEncoder.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonEncoder.scala
@@ -36,14 +36,14 @@ class DomainJsonEncoder(
     } yield y
 
   def encodeCreateCommand(
-      cmd: domain.CreateCommand[lav1.value.Record, domain.ContractTypeId.Template.RequiredPkg]
+      cmd: domain.CreateCommand.RequiredPkg[lav1.value.Record]
   )(implicit
-      ev: JsonWriter[domain.CreateCommand[JsValue, domain.ContractTypeId.Template.RequiredPkg]]
+      ev: JsonWriter[domain.CreateCommand.RequiredPkg[JsValue]]
   ): JsonError \/ JsValue =
     for {
       x <- cmd.traversePayload(
         apiRecordToJsObject(_)
-      ): JsonError \/ domain.CreateCommand[JsValue, domain.ContractTypeId.Template.RequiredPkg]
+      ): JsonError \/ domain.CreateCommand.RequiredPkg[JsValue]
       y <- SprayJson.encode(x).liftErr(JsonError)
 
     } yield y

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonEncoder.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonEncoder.scala
@@ -19,17 +19,17 @@ class DomainJsonEncoder(
   import com.daml.http.util.ErrorOps._
 
   def encodeExerciseCommand(
-      cmd: domain.ExerciseCommand.OptionalPkg[lav1.value.Value, domain.ContractLocator[
+      cmd: domain.ExerciseCommand.RequiredPkg[lav1.value.Value, domain.ContractLocator[
         lav1.value.Value
       ]]
   )(implicit
-      ev: JsonWriter[domain.ExerciseCommand.OptionalPkg[JsValue, domain.ContractLocator[JsValue]]]
+      ev: JsonWriter[domain.ExerciseCommand.RequiredPkg[JsValue, domain.ContractLocator[JsValue]]]
   ): JsonError \/ JsValue =
     for {
       x <- cmd.bitraverse(
         arg => apiValueToJsValue(arg),
         ref => ref.traverse(a => apiValueToJsValue(a)),
-      ): JsonError \/ domain.ExerciseCommand.OptionalPkg[JsValue, domain.ContractLocator[JsValue]]
+      ): JsonError \/ domain.ExerciseCommand.RequiredPkg[JsValue, domain.ContractLocator[JsValue]]
 
       y <- SprayJson.encode(x).liftErr(JsonError)
 

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonEncoder.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonEncoder.scala
@@ -35,15 +35,15 @@ class DomainJsonEncoder(
 
     } yield y
 
-  def encodeCreateCommand[CtId](
-      cmd: domain.CreateCommand[lav1.value.Record, CtId]
+  def encodeCreateCommand(
+      cmd: domain.CreateCommand[lav1.value.Record, domain.ContractTypeId.Template.RequiredPkg]
   )(implicit
-      ev: JsonWriter[domain.CreateCommand[JsValue, CtId]]
+      ev: JsonWriter[domain.CreateCommand[JsValue, domain.ContractTypeId.Template.RequiredPkg]]
   ): JsonError \/ JsValue =
     for {
       x <- cmd.traversePayload(
         apiRecordToJsObject(_)
-      ): JsonError \/ domain.CreateCommand[JsValue, CtId]
+      ): JsonError \/ domain.CreateCommand[JsValue, domain.ContractTypeId.Template.RequiredPkg]
       y <- SprayJson.encode(x).liftErr(JsonError)
 
     } yield y

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -455,10 +455,10 @@ object JsonProtocol extends JsonProtocolLow {
   }
 
   implicit val CreateCommandFormat: RootJsonFormat[
-    domain.CreateCommand[JsValue, domain.ContractTypeId.Template.OptionalPkg]
+    domain.CreateCommand[JsValue, domain.ContractTypeId.Template.RequiredPkg]
   ] =
     jsonFormat3(
-      domain.CreateCommand[JsValue, domain.ContractTypeId.Template.OptionalPkg]
+      domain.CreateCommand[JsValue, domain.ContractTypeId.Template.RequiredPkg]
     )
 
   implicit val ExerciseCommandFormat: RootJsonFormat[

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -513,7 +513,7 @@ object JsonProtocol extends JsonProtocolLow {
       JsValue,
       JsValue,
       domain.ContractTypeId.Template.RequiredPkg,
-      domain.ContractTypeId.OptionalPkg,
+      domain.ContractTypeId.RequiredPkg,
     ]
   ] =
     jsonFormat6(
@@ -521,7 +521,7 @@ object JsonProtocol extends JsonProtocolLow {
         JsValue,
         JsValue,
         domain.ContractTypeId.Template.RequiredPkg,
-        domain.ContractTypeId.OptionalPkg,
+        domain.ContractTypeId.RequiredPkg,
       ]
     )
 

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -512,7 +512,7 @@ object JsonProtocol extends JsonProtocolLow {
     domain.CreateAndExerciseCommand[
       JsValue,
       JsValue,
-      domain.ContractTypeId.Template.OptionalPkg,
+      domain.ContractTypeId.Template.RequiredPkg,
       domain.ContractTypeId.OptionalPkg,
     ]
   ] =
@@ -520,7 +520,7 @@ object JsonProtocol extends JsonProtocolLow {
       domain.CreateAndExerciseCommand[
         JsValue,
         JsValue,
-        domain.ContractTypeId.Template.OptionalPkg,
+        domain.ContractTypeId.Template.RequiredPkg,
         domain.ContractTypeId.OptionalPkg,
       ]
     )

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -217,9 +217,9 @@ object JsonProtocol extends JsonProtocolLow {
   ): domain.InputContractRef[JsValue] =
     (fields get "templateId", fields get "key", fields get "contractId") match {
       case (Some(templateId), Some(key), None) =>
-        -\/((templateId.convertTo[domain.ContractTypeId.Template.OptionalPkg], key))
+        -\/((templateId.convertTo[domain.ContractTypeId.Template.RequiredPkg], key))
       case (otid, None, Some(contractId)) =>
-        val a = otid map (_.convertTo[domain.ContractTypeId.OptionalPkg])
+        val a = otid map (_.convertTo[domain.ContractTypeId.RequiredPkg])
         val b = contractId.convertTo[domain.ContractId]
         \/-((a, b))
       case (None, Some(_), None) =>
@@ -462,13 +462,13 @@ object JsonProtocol extends JsonProtocolLow {
     )
 
   implicit val ExerciseCommandFormat: RootJsonFormat[
-    domain.ExerciseCommand.OptionalPkg[JsValue, domain.ContractLocator[JsValue]]
+    domain.ExerciseCommand.RequiredPkg[JsValue, domain.ContractLocator[JsValue]]
   ] =
     new RootJsonFormat[
-      domain.ExerciseCommand.OptionalPkg[JsValue, domain.ContractLocator[JsValue]]
+      domain.ExerciseCommand.RequiredPkg[JsValue, domain.ContractLocator[JsValue]]
     ] {
       override def write(
-          obj: domain.ExerciseCommand.OptionalPkg[JsValue, domain.ContractLocator[JsValue]]
+          obj: domain.ExerciseCommand.RequiredPkg[JsValue, domain.ContractLocator[JsValue]]
       ): JsValue = {
 
         val reference: JsObject =
@@ -487,12 +487,12 @@ object JsonProtocol extends JsonProtocolLow {
 
       override def read(
           json: JsValue
-      ): domain.ExerciseCommand.OptionalPkg[JsValue, domain.ContractLocator[JsValue]] = {
+      ): domain.ExerciseCommand.RequiredPkg[JsValue, domain.ContractLocator[JsValue]] = {
         val reference = ContractLocatorFormat.read(json)
         val choice = fromField[domain.Choice](json, "choice")
         val argument = fromField[JsValue](json, "argument")
         val meta =
-          fromField[Option[domain.CommandMeta[ContractTypeId.Template.OptionalPkg]]](
+          fromField[Option[domain.CommandMeta[ContractTypeId.Template.RequiredPkg]]](
             json,
             "meta",
           )
@@ -502,7 +502,7 @@ object JsonProtocol extends JsonProtocolLow {
           choice = choice,
           argument = argument,
           choiceInterfaceId =
-            fromField[Option[domain.ContractTypeId.OptionalPkg]](json, "choiceInterfaceId"),
+            fromField[Option[domain.ContractTypeId.RequiredPkg]](json, "choiceInterfaceId"),
           meta = meta,
         )
       }

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -185,32 +185,6 @@ object JsonProtocol extends JsonProtocolLow {
         deserializationError(s"Expected JsString(<packageId>:<module>:<entity>), got: $json")
     }
 
-  implicit def TemplateIdOptionalPkgFormat[CtId[T] <: domain.ContractTypeId[T]](implicit
-      CtId: domain.ContractTypeId.Like[CtId]
-  ): RootJsonFormat[CtId[Option[String]]] = {
-    import CtId.{OptionalPkg => IdO}
-    new RootJsonFormat[IdO] {
-
-      override def write(a: IdO): JsValue = a.packageId match {
-        case Some(p) => JsString(s"${p: String}:${a.moduleName: String}:${a.entityName: String}")
-        case None => JsString(s"${a.moduleName: String}:${a.entityName: String}")
-      }
-
-      override def read(json: JsValue): IdO = json match {
-        case JsString(str) =>
-          str.split(':') match {
-            case Array(p, m, e) => CtId(Some(p), m, e)
-            case Array(m, e) => CtId(None, m, e)
-            case _ => error(json)
-          }
-        case _ => error(json)
-      }
-
-      private def error(json: JsValue): Nothing =
-        deserializationError(s"Expected JsString([<packageId>:]<module>:<entity>), got: $json")
-    }
-  }
-
   private[this] def decodeContractRef(
       fields: Map[String, JsValue],
       what: String,

--- a/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
+++ b/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
@@ -164,7 +164,7 @@ object Generators {
 
   def genUnknownTemplateIds: Gen[domain.UnknownTemplateIds] =
     Gen
-      .listOf(genDomainTemplateIdO: Gen[domain.ContractTypeId.OptionalPkg])
+      .listOf(genDomainTemplateIdO: Gen[domain.ContractTypeId.RequiredPkg])
       .map(domain.UnknownTemplateIds)
 
   def genUnknownParties: Gen[domain.UnknownParties] =

--- a/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
+++ b/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
@@ -52,10 +52,6 @@ object Generators {
   final case class PackageIdGen[A](gen: Gen[A])
 
   implicit val RequiredPackageIdGen: PackageIdGen[String] = PackageIdGen(Gen.identifier)
-  implicit val NoPackageIdGen: PackageIdGen[Unit] = PackageIdGen(Gen.const(()))
-  implicit val OptionalPackageIdGen: PackageIdGen[Option[String]] = PackageIdGen(
-    Gen.option(RequiredPackageIdGen.gen)
-  )
 
   def contractIdGen: Gen[domain.ContractId] = domain.ContractId subst Gen.identifier
   def partyGen: Gen[domain.Party] = domain.Party subst Gen.identifier

--- a/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
+++ b/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
@@ -65,9 +65,9 @@ object Generators {
 
   def inputContractRefGen[LfV](lfv: Gen[LfV]): Gen[domain.InputContractRef[LfV]] =
     scalazEitherGen(
-      Gen.zip(genDomainTemplateIdO[domain.ContractTypeId.Template, Option[String]], lfv),
+      Gen.zip(genDomainTemplateIdO[domain.ContractTypeId.Template, String], lfv),
       Gen.zip(
-        Gen.option(genDomainTemplateIdO: Gen[domain.ContractTypeId.OptionalPkg]),
+        Gen.option(genDomainTemplateIdO: Gen[domain.ContractTypeId.RequiredPkg]),
         contractIdGen,
       ),
     )
@@ -114,22 +114,24 @@ object Generators {
 
   def enrichedContractKeyGen: Gen[domain.EnrichedContractKey[JsObject]] =
     for {
-      templateId <- genDomainTemplateIdO[domain.ContractTypeId.Template, Option[String]]
+      templateId <- genDomainTemplateIdO[domain.ContractTypeId.Template, String]
+      templateId2 = templateId.copy(packageId = Some(templateId.packageId))
       key <- genJsObj
-    } yield domain.EnrichedContractKey(templateId, key)
+    } yield domain.EnrichedContractKey(templateId2, key)
 
   def enrichedContractIdGen: Gen[domain.EnrichedContractId] =
     for {
-      templateId <- Gen.option(genDomainTemplateIdO: Gen[domain.ContractTypeId.OptionalPkg])
+      templateId <- Gen.option(genDomainTemplateIdO: Gen[domain.ContractTypeId.RequiredPkg])
+      templateId2 = templateId.map(tid => tid.copy(packageId = Some(tid.packageId)))
       contractId <- contractIdGen
-    } yield domain.EnrichedContractId(templateId, contractId)
+    } yield domain.EnrichedContractId(templateId2, contractId)
 
   def exerciseCmdGen
-      : Gen[domain.ExerciseCommand.OptionalPkg[JsValue, domain.ContractLocator[JsValue]]] =
+      : Gen[domain.ExerciseCommand.RequiredPkg[JsValue, domain.ContractLocator[JsValue]]] =
     for {
       ref <- contractLocatorGen
       arg <- genJsObj
-      cIfId <- Gen.option(genDomainTemplateIdO: Gen[domain.ContractTypeId.OptionalPkg])
+      cIfId <- Gen.option(genDomainTemplateIdO: Gen[domain.ContractTypeId.RequiredPkg])
       choice <- Gen.identifier.map(domain.Choice(_))
       meta <- Gen.option(metaGen)
     } yield domain.ExerciseCommand(

--- a/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
+++ b/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
@@ -115,16 +115,14 @@ object Generators {
   def enrichedContractKeyGen: Gen[domain.EnrichedContractKey[JsObject]] =
     for {
       templateId <- genDomainTemplateIdO[domain.ContractTypeId.Template, String]
-      templateId2 = templateId.copy(packageId = Some(templateId.packageId))
       key <- genJsObj
-    } yield domain.EnrichedContractKey(templateId2, key)
+    } yield domain.EnrichedContractKey(templateId, key)
 
   def enrichedContractIdGen: Gen[domain.EnrichedContractId] =
     for {
       templateId <- Gen.option(genDomainTemplateIdO: Gen[domain.ContractTypeId.RequiredPkg])
-      templateId2 = templateId.map(tid => tid.copy(packageId = Some(tid.packageId)))
       contractId <- contractIdGen
-    } yield domain.EnrichedContractId(templateId2, contractId)
+    } yield domain.EnrichedContractId(templateId, contractId)
 
   def exerciseCmdGen
       : Gen[domain.ExerciseCommand.RequiredPkg[JsValue, domain.ContractLocator[JsValue]]] =

--- a/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
+++ b/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
@@ -260,7 +260,7 @@ class JsonProtocolTest
 
     "roundtrips" in forAll(exerciseCmdGen) { a =>
       val b = a.toJson
-        .convertTo[domain.ExerciseCommand.OptionalPkg[JsValue, domain.ContractLocator[JsValue]]]
+        .convertTo[domain.ExerciseCommand.RequiredPkg[JsValue, domain.ContractLocator[JsValue]]]
       b should ===(a)
     }
   }

--- a/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
+++ b/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
@@ -147,20 +147,21 @@ class JsonProtocolTest
   }
 
   "domain.OkResponse" - {
-    "response with warnings" in forAll(listOf(genDomainTemplateIdO[domain.ContractTypeId.Template, String])) {
-      templateIds: List[domain.ContractTypeId.RequiredPkg] =>
-        val response: domain.OkResponse[Int] =
-          domain.OkResponse(result = 100, warnings = Some(domain.UnknownTemplateIds(templateIds)))
+    "response with warnings" in forAll(
+      listOf(genDomainTemplateIdO[domain.ContractTypeId.Template, String])
+    ) { templateIds: List[domain.ContractTypeId.RequiredPkg] =>
+      val response: domain.OkResponse[Int] =
+        domain.OkResponse(result = 100, warnings = Some(domain.UnknownTemplateIds(templateIds)))
 
-        val responseJsVal: domain.OkResponse[JsValue] = response.map(_.toJson)
+      val responseJsVal: domain.OkResponse[JsValue] = response.map(_.toJson)
 
-        discard {
-          responseJsVal.toJson shouldBe JsObject(
-            "result" -> JsNumber(100),
-            "warnings" -> JsObject("unknownTemplateIds" -> templateIds.toJson),
-            "status" -> JsNumber(200),
-          )
-        }
+      discard {
+        responseJsVal.toJson shouldBe JsObject(
+          "result" -> JsNumber(100),
+          "warnings" -> JsObject("unknownTemplateIds" -> templateIds.toJson),
+          "status" -> JsNumber(200),
+        )
+      }
     }
 
     "response without warnings" in forAll(identifier) { str =>

--- a/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
+++ b/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
@@ -147,21 +147,20 @@ class JsonProtocolTest
   }
 
   "domain.OkResponse" - {
-    "response with warnings" in forAll(
-      listOf(genDomainTemplateIdO[domain.ContractTypeId.Template, String])
-    ) { templateIds: List[domain.ContractTypeId.RequiredPkg] =>
-      val response: domain.OkResponse[Int] =
-        domain.OkResponse(result = 100, warnings = Some(domain.UnknownTemplateIds(templateIds)))
+    "response with warnings" in forAll(listOf(genDomainTemplateIdO)) {
+      templateIds: List[domain.ContractTypeId.RequiredPkg] =>
+        val response: domain.OkResponse[Int] =
+          domain.OkResponse(result = 100, warnings = Some(domain.UnknownTemplateIds(templateIds)))
 
-      val responseJsVal: domain.OkResponse[JsValue] = response.map(_.toJson)
+        val responseJsVal: domain.OkResponse[JsValue] = response.map(_.toJson)
 
-      discard {
-        responseJsVal.toJson shouldBe JsObject(
-          "result" -> JsNumber(100),
-          "warnings" -> JsObject("unknownTemplateIds" -> templateIds.toJson),
-          "status" -> JsNumber(200),
-        )
-      }
+        discard {
+          responseJsVal.toJson shouldBe JsObject(
+            "result" -> JsNumber(100),
+            "warnings" -> JsObject("unknownTemplateIds" -> templateIds.toJson),
+            "status" -> JsNumber(200),
+          )
+        }
     }
 
     "response without warnings" in forAll(identifier) { str =>

--- a/sdk/test-evidence/BUILD.bazel
+++ b/sdk/test-evidence/BUILD.bazel
@@ -39,7 +39,7 @@ write_scalatest_runpath(
         name = "generator",
         testonly = True,  # needed in order to depend on testonly targets
         data = [
-            "//ledger-service/http-json:integration-tests-ce", # For the dars files in data deps
+            "//ledger-service/http-json:integration-tests-ce",  # For the dars files in data deps
         ],
         main_class = "com.daml.test.evidence.generator.Main",
         tests = [

--- a/sdk/test-evidence/BUILD.bazel
+++ b/sdk/test-evidence/BUILD.bazel
@@ -3,6 +3,7 @@
 
 load("@os_info//:os_info.bzl", "is_linux_intel")
 load("//bazel_tools:scala.bzl", "da_scala_binary", "da_scala_library")
+load("//daml-lf/language:daml-lf.bzl", "lf_version_configuration")
 load(":test_evidence.bzl", "test_evidence_binary", "write_scalatest_runpath")
 
 write_scalatest_runpath(
@@ -37,6 +38,9 @@ write_scalatest_runpath(
     test_evidence_binary(
         name = "generator",
         testonly = True,  # needed in order to depend on testonly targets
+        data = [
+            "//ledger-service/http-json:integration-tests-ce", # For the dars files in data deps
+        ],
         main_class = "com.daml.test.evidence.generator.Main",
         tests = [
             "//ledger-service/http-json:failure-tests",


### PR DESCRIPTION
- update all instances of ContractTypeId.OptionalPkg to ContractTypeId.RequiredPkg
- removed ContractTypeId.OptionalPkg and ContractTypeId.NoPkg type aliases entirely
- update tests to use fully qualified template ids, i.e. including a package reference
- update integration tests which do json-api queries to include a package reference in template ids

We still need to distinguish package name vs package id at the point where we resolve contract type ids, so we keep the logic that we used on missing package id, and do the same thing in the case of a package name. This logic deals with the fact that new packages can get uploaded in the background, and so we need to be able to treat a package name as a dynamically late-bound mapping to specific package.