### PR TITLE
Revert "Add location to engine logger (#19104)"

### DIFF
--- a/sdk/daml-lf/engine/src/main/scala/com/daml/lf/engine/Engine.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/daml/lf/engine/Engine.scala
@@ -34,9 +34,7 @@ import com.daml.scalautil.Statement.discard
 // TODO once the ContextualizedLogger is replaced with the NamedLogger and Speedy doesn't use its
 //   own logger, we can remove this import
 trait EngineLogger {
-  def add(message: String, optLocation: Option[com.daml.lf.data.Ref.Location])(implicit
-      loggingContext: LoggingContext
-  ): Unit
+  def add(message: String)(implicit loggingContext: LoggingContext): Unit
 }
 
 object EngineLogger {
@@ -45,7 +43,7 @@ object EngineLogger {
       new TraceLog {
         override def add(message: String, optLocation: Option[com.daml.lf.data.Ref.Location])(
             implicit loggingContext: LoggingContext
-        ): Unit = value.add(message, optLocation)
+        ): Unit = value.add(message)
         override def iterator: Iterator[(String, Option[com.daml.lf.data.Ref.Location])] =
           Iterator.empty
       }


### PR DESCRIPTION
This reverts commit ce507d9959917cededbde2d9c33beaec5b970e2b.

Reverting as the location is always the internal prelude function. So it's not really useful.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
