### PR TITLE
[main-2.x] Allow injecting custom logger into engine (#19051)

### DIFF
--- a/sdk/.pre-commit-config.yaml
+++ b/sdk/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 
-exclude: '^canton(-3x)?/'
+exclude: '^sdk/canton(-3x)?/'
 repos:
 - repo: local
   hooks:


### PR DESCRIPTION
Before this change, we couldn't inject a custom logger into the engine. As such, debug output of commands would not be associated to the Canton trace-id, making the feature not very useful. Now, the API is extended such that the custom logger can be easily added.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
