### PR TITLE
daml script runner fails sooner if provided ledger host lacks a protocol when using the JSON API

### DIFF
--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMainConfig.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMainConfig.scala
@@ -9,6 +9,8 @@ import java.io.File
 import com.daml.lf.data.Ref
 import com.daml.ledger.api.tls.{TlsConfiguration, TlsConfigurationCli}
 
+import org.apache.pekko.http.scaladsl.model.Uri
+
 case class RunnerMainConfig(
     darPath: File,
     runMode: RunnerMainConfig.RunMode,
@@ -307,6 +309,10 @@ private[script] object RunnerMainConfigIntermediate {
         )
       } else if (c.isIdeLedger && c.jsonApi) {
         failure("Cannot specify --json-api with --ide-ledger, as ide-ledger is run locally.")
+      } else if (c.jsonApi && c.ledgerHost.exists(host => Uri(host).scheme == "")) {
+        failure(
+          "The argument of --ledger-host must include the protocol (e.g. `http://` or `https://`) because --json-api was specified."
+        )
       } else {
         success
       }

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMainConfig.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMainConfig.scala
@@ -311,7 +311,7 @@ private[script] object RunnerMainConfigIntermediate {
         failure("Cannot specify --json-api with --ide-ledger, as ide-ledger is run locally.")
       } else if (c.jsonApi && c.ledgerHost.exists(host => Uri(host).scheme == "")) {
         failure(
-          "The argument of --ledger-host must include the protocol (e.g. `http://` or `https://`) because --json-api was specified."
+          "The argument of --ledger-host must include the protocol (e.g. \"http://\" or \"https://\") because --json-api was specified."
         )
       } else {
         success

--- a/sdk/daml-script/runner/src/test/resources/TestScript.daml
+++ b/sdk/daml-script/runner/src/test/resources/TestScript.daml
@@ -5,18 +5,18 @@ module TestScript where
 
 import Daml.Script
 
--- Each script gets the time to ensure the ledger is called
+-- Each script lists the known parties to ensure the ledger is called
 myScript : Script ()
 myScript = do
-  _ <- getTime
+  _ <- listKnownParties
   debug "Ran myScript"
 
 myOtherScript : Script ()
 myOtherScript = do
-  _ <- getTime
+  _ <- listKnownParties
   debug "Ran myOtherScript"
 
 inputScript : Int -> Script ()
 inputScript i = do
-  _ <- getTime
+  _ <- listKnownParties
   debug $ "Got " <> show i

--- a/sdk/daml-script/runner/src/test/scala/com/daml/lf/engine/script/NonTlsRunnerMainTest.scala
+++ b/sdk/daml-script/runner/src/test/scala/com/daml/lf/engine/script/NonTlsRunnerMainTest.scala
@@ -140,7 +140,7 @@ final class NonTlsRunnerMainTest extends AsyncFreeSpec with RunnerMainTestBaseCa
           dars(4),
           Seq(
             "--ledger-host",
-            "localhost",
+            "http://localhost",
             "--ledger-port",
             jsonApiPort.toString,
             "--access-token-file",
@@ -156,7 +156,7 @@ final class NonTlsRunnerMainTest extends AsyncFreeSpec with RunnerMainTestBaseCa
           dars(4),
           Seq(
             "--ledger-host",
-            "localhost",
+            "http://localhost",
             "--ledger-port",
             jsonApiPort.toString,
             "--access-token-file",
@@ -176,7 +176,7 @@ final class NonTlsRunnerMainTest extends AsyncFreeSpec with RunnerMainTestBaseCa
           dars(4),
           Seq(
             "--ledger-host",
-            "localhost",
+            "http://localhost",
             "--ledger-port",
             jsonApiPort.toString,
             "--access-token-file",
@@ -209,7 +209,7 @@ final class NonTlsRunnerMainTest extends AsyncFreeSpec with RunnerMainTestBaseCa
           failingDar,
           Seq(
             "--ledger-host",
-            "localhost",
+            "http://localhost",
             "--ledger-port",
             jsonApiPort.toString,
             "--access-token-file",
@@ -225,7 +225,7 @@ final class NonTlsRunnerMainTest extends AsyncFreeSpec with RunnerMainTestBaseCa
           failingDar,
           Seq(
             "--ledger-host",
-            "localhost",
+            "http://localhost",
             "--ledger-port",
             jsonApiPort.toString,
             "--access-token-file",

--- a/sdk/daml-script/runner/src/test/scala/com/daml/lf/engine/script/NonTlsRunnerMainTest.scala
+++ b/sdk/daml-script/runner/src/test/scala/com/daml/lf/engine/script/NonTlsRunnerMainTest.scala
@@ -188,6 +188,22 @@ final class NonTlsRunnerMainTest extends AsyncFreeSpec with RunnerMainTestBaseCa
           ),
           Left(Seq("Cannot upload dar via JSON API")),
         )
+      "Fails when missing ledger-host protocol" in
+        testDamlScriptCanton(
+          dars(4),
+          Seq(
+            "--ledger-host",
+            "localhost",
+            "--ledger-port",
+            jsonApiPort.toString,
+            "--access-token-file",
+            jwt.toString,
+            "--json-api",
+            "--script-name",
+            "TestScript:myScript",
+          ),
+          Left(Seq("The argument of --ledger-host must include the protocol")),
+        )
       "Succeeds using --participant-config" in
         withJsonParticipantConfig { path =>
           testDamlScriptCanton(

--- a/sdk/daml-script/runner/src/test/scala/com/daml/lf/engine/script/RunnerMainTestBaseCanton.scala
+++ b/sdk/daml-script/runner/src/test/scala/com/daml/lf/engine/script/RunnerMainTestBaseCanton.scala
@@ -96,12 +96,17 @@ trait RunnerMainTestBaseCanton extends CantonFixtureWithResource[Port] with Runn
   def withJsonParticipantConfig[A](f: Path => Future[A]): Future[A] =
     withParticipantConfig(Some("http"), jsonApiPort, f)
 
-  def withParticipantConfig[A](protocol: Option[String], port: Port, f: Path => Future[A]): Future[A] = {
+  def withParticipantConfig[A](
+      protocol: Option[String],
+      port: Port,
+      f: Path => Future[A],
+  ): Future[A] = {
     implicit val ec: ExecutionContext = ExecutionContext.global
     val path = Files.createTempFile("participantConfig", ".json")
+    val schema = protocol.fold("")(_ + "://")
     val content =
       s"""{
-         |  "default_participant": {"host": "${protocol.fold("")(_ + "://")}localhost", "port": ${port.toString}},
+         |  "default_participant": {"host": "${schema}localhost", "port": ${port.toString}},
          |  "participants": {},
          |  "party_participants": {}
          |}

--- a/sdk/daml-script/runner/src/test/scala/com/daml/lf/engine/script/RunnerMainTestBaseCanton.scala
+++ b/sdk/daml-script/runner/src/test/scala/com/daml/lf/engine/script/RunnerMainTestBaseCanton.scala
@@ -91,17 +91,17 @@ trait RunnerMainTestBaseCanton extends CantonFixtureWithResource[Port] with Runn
   }
 
   def withGrpcParticipantConfig[A](f: Path => Future[A]): Future[A] =
-    withParticipantConfig(ports.head, f)
+    withParticipantConfig(None, ports.head, f)
 
   def withJsonParticipantConfig[A](f: Path => Future[A]): Future[A] =
-    withParticipantConfig(jsonApiPort, f)
+    withParticipantConfig(Some("http"), jsonApiPort, f)
 
-  def withParticipantConfig[A](port: Port, f: Path => Future[A]): Future[A] = {
+  def withParticipantConfig[A](protocol: Option[String], port: Port, f: Path => Future[A]): Future[A] = {
     implicit val ec: ExecutionContext = ExecutionContext.global
     val path = Files.createTempFile("participantConfig", ".json")
     val content =
       s"""{
-         |  "default_participant": {"host": "localhost", "port": ${port.toString}},
+         |  "default_participant": {"host": "${protocol.fold("")(_ + "://")}localhost", "port": ${port.toString}},
          |  "participants": {},
          |  "party_participants": {}
          |}

--- a/sdk/daml-script/runner/src/test/scala/com/daml/lf/engine/script/TlsRunnerMainTest.scala
+++ b/sdk/daml-script/runner/src/test/scala/com/daml/lf/engine/script/TlsRunnerMainTest.scala
@@ -193,6 +193,22 @@ final class TlsRunnerMainTest extends AsyncFreeSpec with RunnerMainTestBaseCanto
           ) ++ tlsArgs,
           Left(Seq("Cannot upload dar via JSON API")),
         )
+      "Fails when missing ledger-host protocol" in
+        testDamlScriptCanton(
+          dars(4),
+          Seq(
+            "--ledger-host",
+            "localhost",
+            "--ledger-port",
+            jsonApiPort.toString,
+            "--access-token-file",
+            jwt.toString,
+            "--json-api",
+            "--script-name",
+            "TestScript:myScript",
+          ) ++ tlsArgs,
+          Left(Seq("The argument of --ledger-host must include the protocol")),
+        )
       "Succeeds using --participant-config" in
         withJsonParticipantConfig { path =>
           testDamlScriptCanton(

--- a/sdk/daml-script/runner/src/test/scala/com/daml/lf/engine/script/TlsRunnerMainTest.scala
+++ b/sdk/daml-script/runner/src/test/scala/com/daml/lf/engine/script/TlsRunnerMainTest.scala
@@ -145,7 +145,7 @@ final class TlsRunnerMainTest extends AsyncFreeSpec with RunnerMainTestBaseCanto
           dars(4),
           Seq(
             "--ledger-host",
-            "localhost",
+            "http://localhost",
             "--ledger-port",
             jsonApiPort.toString,
             "--access-token-file",
@@ -161,7 +161,7 @@ final class TlsRunnerMainTest extends AsyncFreeSpec with RunnerMainTestBaseCanto
           dars(4),
           Seq(
             "--ledger-host",
-            "localhost",
+            "http://localhost",
             "--ledger-port",
             jsonApiPort.toString,
             "--access-token-file",
@@ -181,7 +181,7 @@ final class TlsRunnerMainTest extends AsyncFreeSpec with RunnerMainTestBaseCanto
           dars(4),
           Seq(
             "--ledger-host",
-            "localhost",
+            "http://localhost",
             "--ledger-port",
             jsonApiPort.toString,
             "--access-token-file",
@@ -194,7 +194,7 @@ final class TlsRunnerMainTest extends AsyncFreeSpec with RunnerMainTestBaseCanto
           Left(Seq("Cannot upload dar via JSON API")),
         )
       "Succeeds using --participant-config" in
-        withGrpcParticipantConfig { path =>
+        withJsonParticipantConfig { path =>
           testDamlScriptCanton(
             dars(4),
             Seq(


### PR DESCRIPTION
Fixes https://github.com/digital-asset/daml/issues/19174