### PR TITLE
Upgrade validation compare deps

### DIFF
--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/admin/PackageUpgradeValidator.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/admin/PackageUpgradeValidator.scala
@@ -193,7 +193,7 @@ class PackageUpgradeValidator(
       typecheckPhase: TypecheckUpgrades.UploadPhaseCheck,
       optNewDar1: Option[(Ref.PackageId, Ast.Package)],
       optOldDar2: Option[(Ref.PackageId, Ast.Package)],
-      packageMap: Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)],
+      packageMap: PackageMap,
   )(implicit
       loggingContext: LoggingContextWithTrace
   ): Future[Unit] = {

--- a/sdk/compiler/damlc/tests/BUILD.bazel
+++ b/sdk/compiler/damlc/tests/BUILD.bazel
@@ -446,7 +446,6 @@ da_haskell_test(
 da_haskell_test(
     name = "upgrades",
     srcs = ["src/DA/Test/DamlcUpgrades.hs"],
-    compiler_flags = ["-Wno-unused-local-binds", "-Wno-unused-top-binds"],
     data = [
         "//compiler/damlc",
         "//daml-script/daml:daml-script.dar",

--- a/sdk/compiler/damlc/tests/BUILD.bazel
+++ b/sdk/compiler/damlc/tests/BUILD.bazel
@@ -446,7 +446,7 @@ da_haskell_test(
 da_haskell_test(
     name = "upgrades",
     srcs = ["src/DA/Test/DamlcUpgrades.hs"],
-    compiler_flags = ["-Wno-unused-local-binds"],
+    compiler_flags = ["-Wno-unused-local-binds", "-Wno-unused-top-binds"],
     data = [
         "//compiler/damlc",
         "//daml-script/daml:daml-script.dar",
@@ -462,6 +462,7 @@ da_haskell_test(
         "//test-common:upgrades-FailsWhenATopLevelVariantRemovesAVariant-files",
         "//test-common:upgrades-FailsWhenAnInstanceIsDropped-files",
         "//test-common:upgrades-FailsWhenAnInterfaceIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-files",
+        "//test-common:upgrades-FailsWhenDepsDowngradeVersions-files",
         "//test-common:upgrades-FailsWhenExistingFieldInTemplateChoiceIsChanged-files",
         "//test-common:upgrades-FailsWhenExistingFieldInTemplateIsChanged-files",
         "//test-common:upgrades-FailsWhenNewFieldIsAddedToTemplateChoiceWithoutOptionalType-files",

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -298,17 +298,22 @@ tests damlc =
               "FailsWithSynonymReturnTypeChangeInSeparatePackage"
               (FailWithError "\ESC\\[0;91merror type checking template Main.T choice C:\n  The upgraded choice C cannot change its return type.")
               LF.versionDefault
-              SeparateDeps
+              (SeparateDeps False)
         , test
               "SucceedsWhenUpgradingADependency"
               Succeed
               LF.versionDefault
-              SeparateDeps
+              (SeparateDeps False)
         , test
               "FailsOnlyInModuleNotInReexports"
               (FailWithError "\ESC\\[0;91merror type checking data type Other.A:\n  The upgraded data type A has added new fields, but those fields are not Optional.")
               LF.versionDefault
               NoDependencies
+        , test
+              "FailsWhenDepsDowngradeVersions"
+              (FailWithError "\ESC\\[0;91merror type checking <none>:\n  Dependency upgrades-example-FailsWhenDepsDowngradeVersions-dep has version 0.0.1 on the upgrading package, which is older than version 0.0.2 on the upgraded package.\n  Dependency versions of upgrading packages must always be greater or equal to the dependency versions on upgraded packages.")
+              LF.versionDefault
+              (SeparateDeps True)
         ]
   where
     contractKeysMinVersion :: LF.Version
@@ -323,9 +328,11 @@ tests damlc =
         -> LF.Version
         -> Dependency
         -> TestTree
-    test name expectation lfVersion sharedDep =
-        testCase name $
-        withTempDir $ \dir -> do
+    test name expectation lfVersion sharedDep = testCase name $ do
+            (dir, _) <- newTempDir
+        --withTempDir $ \dir -> do
+            putStrLn "TEMPORARY DIRECTORY"
+            putStrLn dir
             let newDir = dir </> "newVersion"
             let oldDir = dir </> "oldVersion"
             let newDar = newDir </> "out.dar"
@@ -353,10 +360,10 @@ tests damlc =
                       )
                 let sharedDir = dir </> "shared"
                 let sharedDar = sharedDir </> "out.dar"
-                writeFiles sharedDir (projectFile lfVersion ("upgrades-example-" <> name <> "-dep") Nothing Nothing : sharedDepFiles)
+                writeFiles sharedDir (projectFile lfVersion "0.0.1" ("upgrades-example-" <> name <> "-dep") Nothing Nothing : sharedDepFiles)
                 callProcessSilent damlc ["build", "--project-root", sharedDir, "-o", sharedDar]
                 pure (Just sharedDar, Just sharedDar)
-              SeparateDeps -> do
+              SeparateDeps { shouldSwap } -> do
                 depV1FilePaths <- listDirectory =<< testRunfile (name </> "dep-v1")
                 let depV1Files = flip map depV1FilePaths $ \path ->
                       ( "daml" </> path
@@ -364,7 +371,7 @@ tests damlc =
                       )
                 let depV1Dir = dir </> "shared-v1"
                 let depV1Dar = depV1Dir </> "out.dar"
-                writeFiles depV1Dir (projectFile lfVersion ("upgrades-example-" <> name <> "-dep-v1") Nothing Nothing : depV1Files)
+                writeFiles depV1Dir (projectFile lfVersion "0.0.1" ("upgrades-example-" <> name <> "-dep") Nothing Nothing : depV1Files)
                 callProcessSilent damlc ["build", "--project-root", depV1Dir, "-o", depV1Dar]
 
                 depV2FilePaths <- listDirectory =<< testRunfile (name </> "dep-v2")
@@ -374,19 +381,21 @@ tests damlc =
                       )
                 let depV2Dir = dir </> "shared-v2"
                 let depV2Dar = depV2Dir </> "out.dar"
-                writeFiles depV2Dir (projectFile lfVersion ("upgrades-example-" <> name <> "-dep-v2") Nothing Nothing : depV2Files)
+                writeFiles depV2Dir (projectFile lfVersion "0.0.2" ("upgrades-example-" <> name <> "-dep") Nothing Nothing : depV2Files)
                 callProcessSilent damlc ["build", "--project-root", depV2Dir, "-o", depV2Dar]
 
-                pure (Just depV1Dar, Just depV2Dar)
+                if shouldSwap
+                   then pure (Just depV2Dar, Just depV1Dar)
+                   else pure (Just depV1Dar, Just depV2Dar)
               DependOnV1 ->
                 pure (Nothing, Just oldDar)
               _ ->
                 pure (Nothing, Nothing)
 
-            writeFiles oldDir (projectFile lfVersion ("upgrades-example-" <> name) Nothing depV1Dar : oldVersion)
+            writeFiles oldDir (projectFile lfVersion "0.0.1" ("upgrades-example-" <> name) Nothing depV1Dar : oldVersion)
             callProcessSilent damlc ["build", "--project-root", oldDir, "-o", oldDar]
 
-            writeFiles newDir (projectFile lfVersion ("upgrades-example-" <> name <> "-v2") (Just oldDar) depV2Dar : newVersion)
+            writeFiles newDir (projectFile lfVersion "0.0.2" ("upgrades-example-" <> name <> "-v2") (Just oldDar) depV2Dar : newVersion)
             case expectation of
               Succeed ->
                   callProcessSilent damlc ["build", "--project-root", newDir, "-o", newDar]
@@ -411,13 +420,13 @@ tests damlc =
             createDirectoryIfMissing True (takeDirectory $ dir </> file)
             writeFileUTF8 (dir </> file) content
 
-    projectFile lfVersion name upgradedFile mbDep =
+    projectFile lfVersion version name upgradedFile mbDep =
         ( "daml.yaml"
         , unlines $
           [ "sdk-version: " <> sdkVersion
           , "name: " <> name
           , "source: daml"
-          , "version: 0.0.1"
+          , "version: " <> version
           , "dependencies:"
           , "  - daml-prim"
           , "  - daml-stdlib"
@@ -439,4 +448,4 @@ data Dependency
   = NoDependencies
   | DependOnV1
   | SeparateDep
-  | SeparateDeps
+  | SeparateDeps { shouldSwap :: Bool }

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -328,11 +328,9 @@ tests damlc =
         -> LF.Version
         -> Dependency
         -> TestTree
-    test name expectation lfVersion sharedDep = testCase name $ do
-            (dir, _) <- newTempDir
-        --withTempDir $ \dir -> do
-            putStrLn "TEMPORARY DIRECTORY"
-            putStrLn dir
+    test name expectation lfVersion sharedDep =
+        testCase name $
+        withTempDir $ \dir -> do
             let newDir = dir </> "newVersion"
             let oldDir = dir </> "oldVersion"
             let newDar = newDir </> "out.dar"

--- a/sdk/daml-lf/archive/src/main/scala/com/daml/lf/archive/DecodeV2.scala
+++ b/sdk/daml-lf/archive/src/main/scala/com/daml/lf/archive/DecodeV2.scala
@@ -58,11 +58,13 @@ private[archive] class DecodeV2(minor: LV.Minor) {
       None,
       onlySerializableDataDefs,
     )
+
     val internedTypes = Work.run(decodeInternedTypes(env0, lfPackage))
     val env = env0.copy(internedTypes = internedTypes)
 
+    val modules = lfPackage.getModulesList.asScala.map(env.decodeModule(_))
     Package.build(
-      modules = lfPackage.getModulesList.asScala.map(env.decodeModule(_)),
+      modules = modules,
       directDeps = dependencyTracker.getDependencies,
       languageVersion = languageVersion,
       metadata = metadata,

--- a/sdk/daml-lf/validation/BUILD.bazel
+++ b/sdk/daml-lf/validation/BUILD.bazel
@@ -234,6 +234,7 @@ da_scala_test_suite(
             "//test-common:upgrades-SucceedsWhenATopLevelVariantAddsAVariant-v1.dar",
             "//test-common:upgrades-SucceedsWhenATopLevelVariantAddsAVariant-v2.dar",
 
+            # Test for dependency upgrades
             "//test-common:upgrades-FailsWhenDepsDowngradeVersions-dep-v1.dar",
             "//test-common:upgrades-FailsWhenDepsDowngradeVersions-dep-v2.dar",
             "//test-common:upgrades-FailsWhenDepsDowngradeVersions-v1.dar",

--- a/sdk/daml-lf/validation/BUILD.bazel
+++ b/sdk/daml-lf/validation/BUILD.bazel
@@ -233,6 +233,11 @@ da_scala_test_suite(
             "//test-common:upgrades-SucceedsWhenAnInstanceIsAddedUpgradedPackage-v2.dar",
             "//test-common:upgrades-SucceedsWhenATopLevelVariantAddsAVariant-v1.dar",
             "//test-common:upgrades-SucceedsWhenATopLevelVariantAddsAVariant-v2.dar",
+
+            "//test-common:upgrades-FailsWhenDepsDowngradeVersions-dep-v1.dar",
+            "//test-common:upgrades-FailsWhenDepsDowngradeVersions-dep-v2.dar",
+            "//test-common:upgrades-FailsWhenDepsDowngradeVersions-v1.dar",
+            "//test-common:upgrades-FailsWhenDepsDowngradeVersions-v2.dar",
         ],
         flaky = True,
         scala_deps = [

--- a/sdk/daml-lf/validation/src/main/scala/com/daml/lf/validation/Upgrading.scala
+++ b/sdk/daml-lf/validation/src/main/scala/com/daml/lf/validation/Upgrading.scala
@@ -320,6 +320,20 @@ object TypecheckUpgrades {
         tc.check()
     }
   }
+
+  def typecheckUpgrades(
+      present: (
+          Ref.PackageId,
+          Ast.Package,
+      ),
+      pastPackageId: Ref.PackageId,
+      mbPastPkg: Option[Ast.Package],
+  ): Try[Unit] = {
+    val emptyPackageMap: Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)] = Map.empty
+    val presentWithNoDeps = (present._1, present._2, emptyPackageMap)
+    val mbPastPkgWithNoDeps = mbPastPkg.map((_, emptyPackageMap))
+    TypecheckUpgrades.typecheckUpgrades(presentWithNoDeps, pastPackageId, mbPastPkgWithNoDeps)
+  }
 }
 
 case class TypecheckUpgrades(

--- a/sdk/daml-lf/validation/src/main/scala/com/daml/lf/validation/Upgrading.scala
+++ b/sdk/daml-lf/validation/src/main/scala/com/daml/lf/validation/Upgrading.scala
@@ -170,8 +170,11 @@ object UpgradeError {
       s"Implementation of interface $iface by template $tpl appears in package that is being upgraded, but does not appear in this package."
   }
 
-  final case class DependencyHasLowerVersionDespiteUpgrade(depName: Ref.PackageName, depPresentVersion: Ref.PackageVersion, depPastVersion: Ref.PackageVersion)
-      extends Error {
+  final case class DependencyHasLowerVersionDespiteUpgrade(
+      depName: Ref.PackageName,
+      depPresentVersion: Ref.PackageVersion,
+      depPastVersion: Ref.PackageVersion,
+  ) extends Error {
     override def message: String =
       s"Dependency $depName has version $depPresentVersion on the upgrading package, which is older than version $depPastVersion on the upgraded package.\nDependency versions of upgrading packages must always be greater or equal to the dependency versions on upgraded packages."
   }
@@ -301,7 +304,11 @@ object TypecheckUpgrades {
     Try(t.map(f(_).get).toSeq)
 
   def typecheckUpgrades(
-      present: (Ref.PackageId, Ast.Package, Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)]),
+      present: (
+          Ref.PackageId,
+          Ast.Package,
+          Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)],
+      ),
       pastPackageId: Ref.PackageId,
       mbPastPkg: Option[(Ast.Package, Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)])],
   ): Try[Unit] = {
@@ -315,11 +322,16 @@ object TypecheckUpgrades {
   }
 }
 
-case class TypecheckUpgrades(packages: Upgrading[(Ref.PackageId, Ast.Package, Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)])]) {
+case class TypecheckUpgrades(
+    packages: Upgrading[
+      (Ref.PackageId, Ast.Package, Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)])
+    ]
+) {
   import TypecheckUpgrades._
 
   private lazy val _package: Upgrading[Ast.Package] = packages.map(_._2)
-  private lazy val dependencies: Upgrading[Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)]] = packages.map(_._3)
+  private lazy val dependencies
+      : Upgrading[Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)]] = packages.map(_._3)
 
   private def check(): Try[Unit] = {
     for {
@@ -334,7 +346,7 @@ case class TypecheckUpgrades(packages: Upgrading[(Ref.PackageId, Ast.Package, Ma
   }
 
   private def checkDeps(): Try[Unit] = {
-    val (_new@_, existing, _deleted@_) = extractDelExistNew(dependencies.map(_.values.toMap))
+    val (_new @ _, existing, _deleted @ _) = extractDelExistNew(dependencies.map(_.values.toMap))
     tryAll(existing, checkDep).map(_ => ())
   }
 
@@ -342,7 +354,11 @@ case class TypecheckUpgrades(packages: Upgrading[(Ref.PackageId, Ast.Package, Ma
     val (depName, depVersions) = dep
     failIf(
       depVersions.present < depVersions.past,
-      UpgradeError.DependencyHasLowerVersionDespiteUpgrade(depName, depVersions.present, depVersions.past)
+      UpgradeError.DependencyHasLowerVersionDespiteUpgrade(
+        depName,
+        depVersions.present,
+        depVersions.past,
+      ),
     )
   }
 

--- a/sdk/daml-lf/validation/src/main/scala/com/daml/lf/validation/Upgrading.scala
+++ b/sdk/daml-lf/validation/src/main/scala/com/daml/lf/validation/Upgrading.scala
@@ -343,7 +343,7 @@ case class TypecheckUpgrades(
 ) {
   import TypecheckUpgrades._
 
-  private lazy val _package: Upgrading[Ast.Package] = packages.map(_._2)
+  private lazy val `package`: Upgrading[Ast.Package] = packages.map(_._2)
   private lazy val dependencies
       : Upgrading[Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)]] = packages.map(_._3)
 
@@ -351,7 +351,7 @@ case class TypecheckUpgrades(
     for {
       (upgradedModules, newModules @ _) <-
         checkDeleted(
-          _package.map(_.modules),
+          `package`.map(_.modules),
           (name: Ref.ModuleName, _: Ast.Module) => UpgradeError.MissingModule(name),
         )
       _ <- checkDeps()
@@ -360,7 +360,7 @@ case class TypecheckUpgrades(
   }
 
   private def checkDeps(): Try[Unit] = {
-    val (_new @ _, existing, _deleted @ _) = extractDelExistNew(dependencies.map(_.values.toMap))
+    val (_deleted @ _, existing, _new @ _) = extractDelExistNew(dependencies.map(_.values.toMap))
     tryAll(existing, checkDep).map(_ => ())
   }
 

--- a/sdk/daml-lf/validation/src/main/scala/com/daml/lf/validation/Upgrading.scala
+++ b/sdk/daml-lf/validation/src/main/scala/com/daml/lf/validation/Upgrading.scala
@@ -169,6 +169,12 @@ object UpgradeError {
     override def message: String =
       s"Implementation of interface $iface by template $tpl appears in package that is being upgraded, but does not appear in this package."
   }
+
+  final case class DependencyHasLowerVersionDespiteUpgrade(depName: Ref.PackageName, depPresentVersion: Ref.PackageVersion, depPastVersion: Ref.PackageVersion)
+      extends Error {
+    override def message: String =
+      s"Dependency $depName has version $depPresentVersion on the upgrading package, which is older than version $depPastVersion on the upgraded package.\nDependency versions of upgrading packages must always be greater or equal to the dependency versions on upgraded packages."
+  }
 }
 
 sealed abstract class UpgradedRecordOrigin
@@ -295,24 +301,25 @@ object TypecheckUpgrades {
     Try(t.map(f(_).get).toSeq)
 
   def typecheckUpgrades(
-      present: (Ref.PackageId, Ast.Package),
+      present: (Ref.PackageId, Ast.Package, Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)]),
       pastPackageId: Ref.PackageId,
-      mbPastPkg: Option[Ast.Package],
+      mbPastPkg: Option[(Ast.Package, Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)])],
   ): Try[Unit] = {
     mbPastPkg match {
       case None =>
         fail(UpgradeError.CouldNotResolveUpgradedPackageId(Upgrading(pastPackageId, present._1)));
-      case Some(pastPkg) =>
-        val tc = TypecheckUpgrades(Upgrading((pastPackageId, pastPkg), present))
+      case Some((pastPkg, pastPkgDeps)) =>
+        val tc = TypecheckUpgrades(Upgrading((pastPackageId, pastPkg, pastPkgDeps), present))
         tc.check()
     }
   }
 }
 
-case class TypecheckUpgrades(packagesAndIds: Upgrading[(Ref.PackageId, Ast.Package)]) {
+case class TypecheckUpgrades(packages: Upgrading[(Ref.PackageId, Ast.Package, Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)])]) {
   import TypecheckUpgrades._
 
-  private lazy val _package: Upgrading[Ast.Package] = packagesAndIds.map(_._2)
+  private lazy val _package: Upgrading[Ast.Package] = packages.map(_._2)
+  private lazy val dependencies: Upgrading[Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)]] = packages.map(_._3)
 
   private def check(): Try[Unit] = {
     for {
@@ -321,8 +328,22 @@ case class TypecheckUpgrades(packagesAndIds: Upgrading[(Ref.PackageId, Ast.Packa
           _package.map(_.modules),
           (name: Ref.ModuleName, _: Ast.Module) => UpgradeError.MissingModule(name),
         )
+      _ <- checkDeps()
       _ <- tryAll(upgradedModules.values, checkModule(_))
     } yield ()
+  }
+
+  private def checkDeps(): Try[Unit] = {
+    val (_new@_, existing, _deleted@_) = extractDelExistNew(dependencies.map(_.values.toMap))
+    tryAll(existing, checkDep).map(_ => ())
+  }
+
+  private def checkDep(dep: (Ref.PackageName, Upgrading[Ref.PackageVersion])): Try[Unit] = {
+    val (depName, depVersions) = dep
+    failIf(
+      depVersions.present < depVersions.past,
+      UpgradeError.DependencyHasLowerVersionDespiteUpgrade(depName, depVersions.present, depVersions.past)
+    )
   }
 
   private def splitModuleDts(

--- a/sdk/daml-lf/validation/src/test/scala/com/daml/lf/validation/upgrade/UpgradesSpecBase.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/daml/lf/validation/upgrade/UpgradesSpecBase.scala
@@ -569,6 +569,20 @@ trait LongTests { this: UpgradesSpec =>
         ),
       )
     }
+
+    "Fails when adding deps downgrade versions." in {
+      for {
+        _ <- uploadPackage("test-common/upgrades-FailsWhenDepsDowngradeVersions-dep-v1.dar")
+        _ <- uploadPackage("test-common/upgrades-FailsWhenDepsDowngradeVersions-dep-v2.dar")
+        result <- testPackagePair(
+          "test-common/upgrades-FailsWhenDepsDowngradeVersions-v1.dar",
+          "test-common/upgrades-FailsWhenDepsDowngradeVersions-v2.dar",
+          assertPackageUpgradeCheck(
+            Some("Dependency upgrades-example-FailsWhenDepsDowngradeVersions-dep has version 1.0.0 on the upgrading package, which is older than version 2.0.0 on the upgraded package.")
+          ),
+        )
+      } yield result
+    }
   }
 }
 

--- a/sdk/daml-lf/validation/src/test/scala/com/daml/lf/validation/upgrade/UpgradesSpecBase.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/daml/lf/validation/upgrade/UpgradesSpecBase.scala
@@ -578,7 +578,9 @@ trait LongTests { this: UpgradesSpec =>
           "test-common/upgrades-FailsWhenDepsDowngradeVersions-v1.dar",
           "test-common/upgrades-FailsWhenDepsDowngradeVersions-v2.dar",
           assertPackageUpgradeCheck(
-            Some("Dependency upgrades-example-FailsWhenDepsDowngradeVersions-dep has version 1.0.0 on the upgrading package, which is older than version 2.0.0 on the upgraded package.")
+            Some(
+              "Dependency upgrades-example-FailsWhenDepsDowngradeVersions-dep has version 1.0.0 on the upgrading package, which is older than version 2.0.0 on the upgraded package."
+            )
           ),
         )
       } yield result

--- a/sdk/test-common/BUILD.bazel
+++ b/sdk/test-common/BUILD.bazel
@@ -253,6 +253,74 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-v1".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/v1/*.daml".format(identifier)]),
+            data_dependencies = ["//test-common:upgrades-{}-dep-v2.dar".format(identifier)],
+            dependencies = ["//daml-script/daml:daml-script-2.dev.dar"],
+            enable_interfaces = True,
+            ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
+            project_name = "upgrades-example-{}".format(identifier),
+            target = "2.dev",
+            version = "1.0.0",
+            visibility = ["//visibility:public"],
+        ),
+        daml_compile(
+            name = "upgrades-{}-v2".format(identifier),
+            srcs = glob(["src/main/daml/upgrades/{}/v2/*.daml".format(identifier)]),
+            data_dependencies = ["//test-common:upgrades-{}-dep-v1.dar".format(identifier)],
+            dependencies = ["//daml-script/daml:daml-script-2.dev.dar"],
+            enable_interfaces = True,
+            ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
+            project_name = "upgrades-example-{}".format(identifier),
+            target = "2.dev",
+            # We want to check the validity of this upgrade on the ledger
+            # client, not during compilation
+            typecheck_upgrades = False,
+            upgrades = "//test-common:upgrades-{}-v1.dar".format(identifier),
+            version = "2.0.0",
+            visibility = ["//visibility:public"],
+        ),
+    ]
+    for identifier in [
+        # More more more tests ported from DamlcUpgrades.hs
+        "FailsWhenDepsDowngradeVersions",
+    ]
+]
+
+[
+    [
+        filegroup(
+            name = "upgrades-{}-files".format(identifier),
+            srcs = glob(["src/main/daml/upgrades/{}/*/*.daml".format(identifier)]),
+            visibility = ["//visibility:public"],
+        ),
+        daml_compile(
+            name = "upgrades-{}-dep-v1".format(identifier),
+            srcs = glob(["src/main/daml/upgrades/{}/dep-v1/*.daml".format(identifier)]),
+            dependencies = ["//daml-script/daml:daml-script-2.dev.dar"],
+            enable_interfaces = True,
+            ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
+            project_name = "upgrades-example-{}-dep".format(identifier),
+            target = "2.dev",
+            version = "1.0.0",
+            visibility = ["//visibility:public"],
+        ),
+        daml_compile(
+            name = "upgrades-{}-dep-v2".format(identifier),
+            srcs = glob(["src/main/daml/upgrades/{}/dep-v2/*.daml".format(identifier)]),
+            dependencies = ["//daml-script/daml:daml-script-2.dev.dar"],
+            enable_interfaces = True,
+            ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
+            project_name = "upgrades-example-{}-dep".format(identifier),
+            target = "2.dev",
+            # We want to check the validity of this upgrade on the ledger
+            # client, not during compilation
+            typecheck_upgrades = False,
+            upgrades = "//test-common:upgrades-{}-dep-v1.dar".format(identifier),
+            version = "2.0.0",
+            visibility = ["//visibility:public"],
+        ),
+        daml_compile(
+            name = "upgrades-{}-v1".format(identifier),
+            srcs = glob(["src/main/daml/upgrades/{}/v1/*.daml".format(identifier)]),
             data_dependencies = ["//test-common:upgrades-{}-dep-v1.dar".format(identifier)],
             dependencies = ["//daml-script/daml:daml-script-2.dev.dar"],
             enable_interfaces = True,

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/dep-v1/Dep.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/dep-v1/Dep.daml
@@ -3,3 +3,5 @@
 
 module Dep where
 
+dep : Text
+dep = "dep-v1"

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/dep-v1/Dep.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/dep-v1/Dep.daml
@@ -1,0 +1,1 @@
+module Dep where

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/dep-v1/Dep.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/dep-v1/Dep.daml
@@ -1,1 +1,5 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module Dep where
+

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/dep-v2/Dep.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/dep-v2/Dep.daml
@@ -3,3 +3,5 @@
 
 module Dep where
 
+dep : Text
+dep = "dep-v2"

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/dep-v2/Dep.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/dep-v2/Dep.daml
@@ -1,0 +1,1 @@
+module Dep where

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/dep-v2/Dep.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/dep-v2/Dep.daml
@@ -1,1 +1,5 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module Dep where
+

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/v1/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/v1/Main.daml
@@ -5,3 +5,5 @@ module Main where
 
 import Dep
 
+self : Text
+self = "v1 with " <> dep

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/v1/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/v1/Main.daml
@@ -1,0 +1,3 @@
+module Main where
+
+import Dep

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/v1/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/v1/Main.daml
@@ -1,3 +1,7 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module Main where
 
 import Dep
+

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/v2/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/v2/Main.daml
@@ -5,3 +5,5 @@ module Main where
 
 import Dep
 
+self : Text
+self = "v2 with " <> dep

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/v2/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/v2/Main.daml
@@ -1,0 +1,3 @@
+module Main where
+
+import Dep

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/v2/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/v2/Main.daml
@@ -1,3 +1,7 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module Main where
 
 import Dep
+


### PR DESCRIPTION
> If package2 upgrades package1, all of package2's dependencies should also upgrade their corresponding package1's dependencies

So if mylib-1.0.0 depends on mydep-1.0.0, then mylib-2.0.0 must depend on a mydep >= 1.0.0. If mydep has a version strictly less than 1.0.0, then the dependency downgrades while the package itself upgrades, in which case we should error out.

~~Will be rebased on top of https://github.com/digital-asset/daml/pull/19123, we should complete a review of that first~~ done