### PR TITLE
[Engine] lookup for disclosed contracts after looking in the cache.

### DIFF
--- a/sdk/daml-lf/interpreter/src/main/scala/com/daml/lf/speedy/Speedy.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/daml/lf/speedy/Speedy.scala
@@ -347,23 +347,21 @@ private[lf] object Speedy {
 
     private[speedy] def lookupContract(coid: V.ContractId)(
         f: V.ContractInstance => Control[Question.Update]
-    ): Control[Question.Update] = {
-
-      disclosedContracts.get(coid) match {
-        case Some(contractInfo) =>
-          markDisclosedcontractAsUsed(coid)
-          f(
-            V.ContractInstance(
-              contractInfo.packageName,
-              contractInfo.templateId,
-              contractInfo.value.toUnnormalizedValue,
-            )
-          )
-
+    ): Control[Question.Update] =
+      contractsCache.get(coid) match {
+        case Some(res) =>
+          f(res)
         case None =>
-          contractsCache.get(coid) match {
-            case Some(res) =>
-              f(res)
+          disclosedContracts.get(coid) match {
+            case Some(contractInfo) =>
+              markDisclosedcontractAsUsed(coid)
+              f(
+                V.ContractInstance(
+                  contractInfo.packageName,
+                  contractInfo.templateId,
+                  contractInfo.value.toUnnormalizedValue,
+                )
+              )
             case None =>
               needContract(
                 NameOf.qualifiedNameOfCurrentFunc,
@@ -375,7 +373,6 @@ private[lf] object Speedy {
               )
           }
       }
-    }
 
     private[speedy] override def asUpdateMachine(location: String)(
         f: UpdateMachine => Control[Question.Update]


### PR DESCRIPTION
This is a cosmetic change to clarify search strategy (local -> disclosed -> other).
Since local and disclosed contract does not have same format of contract ID (the later is suffixed while the former is not), it should not change the behavior. 

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
