### PR TITLE
Backport DarUtil

### DIFF
--- a/sdk/daml-script/test/BUILD.bazel
+++ b/sdk/daml-script/test/BUILD.bazel
@@ -174,8 +174,10 @@ da_scala_library(
     unused_dependency_checker_mode = "warn",
     visibility = ["//visibility:public"],
     deps = [
+        "//:sdk-version-scala-lib",
         "//bazel_tools/runfiles:scala_runfiles",
         "//daml-lf/archive:daml_lf_archive_reader",
+        "//daml-lf/archive:daml_lf_dev_archive_proto_java",
         "//daml-lf/data",
         "//daml-lf/engine",
         "//daml-lf/interpreter",
@@ -193,6 +195,7 @@ da_scala_library(
         "//test-common/canton/it-lib",
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:ch_qos_logback_logback_core",
+        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_grpc_grpc_api",
         "@maven//:org_scalatest_scalatest_compatible",
     ],

--- a/sdk/daml-script/test/src/test-utils/scala/com/daml/lf/engine/script/test/DarUtil.scala
+++ b/sdk/daml-script/test/src/test-utils/scala/com/daml/lf/engine/script/test/DarUtil.scala
@@ -1,0 +1,106 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.engine.script
+package test
+
+import com.daml.bazeltools.BazelRunfiles.requiredResource
+import com.daml.lf.archive.DarParser
+import com.daml.lf.data.Ref.PackageId
+import com.daml.lf.language.LanguageVersion
+import com.daml.SdkVersion
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths}
+import scala.sys.process._
+
+object DarUtil {
+  private val exe = if (sys.props("os.name").toLowerCase.contains("windows")) ".exe" else ""
+  private val damlc = requiredResource(s"compiler/damlc/damlc$exe")
+
+  def dummy(): Unit = {
+    print(s"${exe}, ${damlc}")
+  }
+
+  case class DataDep(
+      path: Path,
+      prefix: Option[(String, String)] = None,
+  )
+
+  case class Dar(
+      versionedName: String,
+      version: Int,
+      path: Path,
+      mainPackageId: PackageId,
+  )
+
+  def buildDar(
+      name: String,
+      version: Int = 1,
+      lfVersion: LanguageVersion,
+      modules: Map[String, String],
+      deps: Seq[Path] = Seq.empty,
+      dataDeps: Seq[DataDep] = Seq.empty,
+      opts: Seq[String] = Seq(),
+      logger: ProcessLogger = ProcessLogger(_ => (), _ => ()),
+      tmpDir: Option[Path] = None,
+  ): Either[Int, Dar] = {
+
+    def writeDamlYaml(pkgRoot: Path) = {
+      val fileContent =
+        s"""sdk-version: ${SdkVersion.sdkVersion}
+          |build-options: [--target=${lfVersion.pretty}]
+          |name: $name
+          |source: .
+          |version: $version.0.0
+          |dependencies:
+          |  - daml-prim
+          |  - daml-stdlib
+          |${deps.map(d => "  - " + d.toString).mkString("\n")}
+          |data-dependencies:
+          |${dataDeps.map(d => "  - " + d.path.toString).mkString("\n")}
+          |module-prefixes:
+          |${dataDeps
+            .collect { d =>
+              d.prefix match {
+                case Some(prefix) => s"  ${prefix._1}: ${prefix._2}"
+              }
+            }
+            .mkString("\n")}
+          |""".stripMargin
+      Files.write(pkgRoot.resolve("daml.yaml"), fileContent.getBytes(StandardCharsets.UTF_8))
+    }
+
+    def writeModule(pkgRoot: Path, modFullName: String, fileContent: String) = {
+      val path = pkgRoot.resolve(Paths.get(modFullName.replace(".", "/") + ".daml"))
+      val _ = Files.createDirectories(path.getParent())
+      Files.write(path, fileContent.getBytes(StandardCharsets.UTF_8))
+    }
+
+    def damlBuild(pkgRoot: Path): Int = {
+      (Seq(damlc.toString, "build", "--project-root", pkgRoot.toString) ++ opts).!(logger)
+    }
+
+    val versionedName = s"${name}-${version}.0.0"
+    val pkgRoot = Files.createDirectory(
+      tmpDir.getOrElse(Files.createTempDirectory("dar-util")).resolve(versionedName)
+    )
+    val _ = writeDamlYaml(pkgRoot)
+    modules.foreachEntry(writeModule(pkgRoot, _, _))
+    val exitCode = damlBuild(pkgRoot)
+    if (exitCode == 0) {
+      val darPath = pkgRoot.resolve(s".daml/dist/${versionedName}.dar")
+      Right(
+        Dar(
+          versionedName,
+          version,
+          path = darPath,
+          mainPackageId = PackageId.assertFromString(
+            DarParser.assertReadArchiveFromFile(darPath.toFile).main.getHash
+          ),
+        )
+      )
+    } else {
+      Left(exitCode)
+    }
+  }
+}


### PR DESCRIPTION
This was used in the main branch to test daml-script upgrades over gRPC. Now I need it on the 2.x branch to test daml-script upgrades on the IDE ledger.