### PR TITLE
Fix disclosure bug in the presence of upgrades in 2.x

### DIFF
--- a/sdk/daml-script/daml/Daml/Script.daml
+++ b/sdk/daml-script/daml/Daml/Script.daml
@@ -302,7 +302,7 @@ data QueryDisclosurePayload a = QueryDisclosurePayload
   { parties : [Party]
   , tplId : TemplateTypeRep
   , cid : ContractId ()
-  , continue : Optional Text -> a
+  , continue : Optional (TemplateTypeRep, Text) -> a
   , locations : [(Text, SrcLoc)]
   } deriving Functor
 
@@ -317,7 +317,7 @@ queryDisclosure p c = lift $ Free $ QueryDisclosure QueryDisclosurePayload with
     parties = toParties p
     tplId = templateTypeRep @t
     cid = cid
-    continue = pure . fmap \blob -> Disclosure tplId cid blob
+    continue = pure . fmap \(actualTplId, blob) -> Disclosure actualTplId cid blob
     locations = getCallStack callStack
   where
     tplId = templateTypeRep @t

--- a/sdk/daml-script/daml3/Daml/Script/Questions/Query.daml
+++ b/sdk/daml-script/daml3/Daml/Script/Questions/Query.daml
@@ -36,11 +36,15 @@ data QueryContractId = QueryContractId with
   parties : [Party]
   tplId : TemplateTypeRep
   cid : ContractId ()
-instance IsQuestion QueryContractId (Optional (AnyTemplate, Text)) where command = "QueryContractId"
+instance IsQuestion QueryContractId (Optional (AnyTemplate, TemplateTypeRep, Text)) where command = "QueryContractId"
 
 -- | Query for the contract with the given contract id.
 --
 -- Returns `None` if there is no active contract the party is a stakeholder on.
+-- Otherwise returns a triplet (anyTemplate, templateId, blob) where anyTemplate
+-- is the contract upgraded or downgraded to `t`, templateId is the ID of the
+-- template as stored in the ledger (may be different from `t`), and blob is the
+-- disclosure of the template as stored in the ledger (of type templateId).
 --
 -- WARNING: Over the gRPC and with the JSON API
 -- in-memory backend this performs a linear search so only use this if the number of
@@ -48,8 +52,7 @@ instance IsQuestion QueryContractId (Optional (AnyTemplate, Text)) where command
 --
 -- This is semantically equivalent to calling `query`
 -- and filtering on the client side.
-queryContractId_ : forall t p. (Template t, IsParties p) => HasCallStack => p -> ContractId t -> Script (Optional (AnyTemplate, Text))
--- The 'HasAgreement t' constraint prevents this function from being used on interface types.
+queryContractId_ : forall t p. (Template t, IsParties p) => HasCallStack => p -> ContractId t -> Script (Optional (AnyTemplate, TemplateTypeRep, Text))
 queryContractId_ p c = lift $ QueryContractId with
     parties = toParties p
     tplId = templateTypeRep @t
@@ -59,14 +62,13 @@ queryContractId_ p c = lift $ QueryContractId with
 --    convert = fmap $ fromSome . fromAnyTemplate
 
 queryContractId: forall t p. (Template t, HasAgreement t, IsParties p) => HasCallStack => p -> ContractId t -> Script (Optional t)
-queryContractId p c = fmap (fmap $ fromSome . fromAnyTemplate . fst) $ queryContractId_ p c
+queryContractId p c = fmap (fmap $ \(anyTpl, _, _) -> fromSome (fromAnyTemplate anyTpl)) $ queryContractId_ p c
 
 -- TODO https://github.com/digital-asset/daml/issues/17755
 --  clean the API for different query function
 queryDisclosure: forall t p. (Template t, IsParties p) => HasCallStack => p -> ContractId t -> Script (Optional Disclosure)
-queryDisclosure p c = fmap (fmap  $ \(_, blob) -> Disclosure tplId cid blob) $ queryContractId_ p c
+queryDisclosure p c = fmap (fmap  $ \(_, tplId, blob) -> Disclosure tplId cid blob) $ queryContractId_ p c
  where
-    tplId = templateTypeRep @t
     cid = coerceContractId c
 
 data QueryInterface = QueryInterface with

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -103,8 +103,14 @@ abstract class ConverterMethods(stablePackages: StablePackages) {
     )
   }
 
+  private[lf] def fromTemplateTypeRep(templateId: SValue): SValue =
+    record(stablePackages.TemplateTypeRep, ("getTemplateTypeRep", templateId))
+
   private[lf] def fromTemplateTypeRep(templateId: value.Identifier): SValue =
-    record(stablePackages.TemplateTypeRep, ("getTemplateTypeRep", fromIdentifier(templateId)))
+    fromTemplateTypeRep(fromIdentifier(templateId))
+
+  private[lf] def fromTemplateTypeRep(templateId: Identifier): SValue =
+    fromTemplateTypeRep(STypeRep(TTyCon(templateId)))
 
   private[lf] def fromAnyContractId(
       scriptIds: ScriptIds,
@@ -245,10 +251,7 @@ abstract class ConverterMethods(stablePackages: StablePackages) {
       ("getAnyContractKey", SAny(key.ty, key.key)),
       (
         "getAnyContractKeyTemplateTypeRep",
-        record(
-          stablePackages.TemplateTypeRep,
-          ("getTemplateTypeRep", STypeRep(TTyCon(key.templateId))),
-        ),
+        fromTemplateTypeRep(key.templateId),
       ),
     )
 

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/Converter.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/Converter.scala
@@ -402,4 +402,9 @@ object Converter extends script.ConverterMethods(StablePackagesV1) {
     }
     iter(freeAp, List())
   }
+
+  def makePair(v1: SValue, v2: SValue): SValue = {
+    import com.daml.script.converter.Converter.record
+    record(StablePackagesV1.Tuple2, ("_1", v1), ("_2", v2))
+  }
 }

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Converter.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Converter.scala
@@ -218,26 +218,23 @@ object Converter extends script.ConverterMethods(StablePackagesV2) {
       )
       .map { xs => SList(xs.to(FrontStack)) }
 
-  // Convert an active contract to AnyTemplate
-  def fromContract(
-      translator: preprocessing.ValueTranslator,
-      contract: ScriptLedgerClient.ActiveContract,
-      enableContractUpgrading: Boolean = false,
-  ): Either[String, SValue] =
-    fromAnyTemplate(translator, contract.templateId, contract.argument, enableContractUpgrading)
-
   // Convert a Created event to a pair of (ContractId (), AnyTemplate)
   def fromCreated(
       translator: preprocessing.ValueTranslator,
       contract: ScriptLedgerClient.ActiveContract,
+      targetTemplateId: Identifier,
       enableContractUpgrading: Boolean = false,
   ): Either[String, SValue] = {
     for {
-      anyTpl <- fromContract(translator, contract, enableContractUpgrading)
-    } yield record(
-      StablePackagesV2.Tuple2,
-      ("_1", SContractId(contract.contractId)),
-      ("_2", anyTpl),
+      anyTpl <- fromAnyTemplate(
+        translator,
+        targetTemplateId,
+        contract.argument,
+        enableContractUpgrading,
+      )
+    } yield makeTuple(
+      SContractId(contract.contractId),
+      anyTpl,
     )
   }
 
@@ -417,4 +414,10 @@ object Converter extends script.ConverterMethods(StablePackagesV2) {
       ("version", SText(packageName.version.toString)),
     )
   }
+
+  def makeTuple(v1: SValue, v2: SValue): SValue =
+    record(StablePackagesV2.Tuple2, ("_1", v1), ("_2", v2))
+
+  def makeTuple(v1: SValue, v2: SValue, v3: SValue): SValue =
+    record(StablePackagesV2.Tuple3, ("_1", v1), ("_2", v2), ("_3", v3))
 }

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
@@ -6,42 +6,32 @@ package engine
 package script
 package v2
 
-import java.time.Clock
-import org.apache.pekko.stream.Materializer
 import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.daml.ledger.api.domain.{User, UserRight}
-import com.daml.lf.data.FrontStack
 import com.daml.lf.CompiledPackages
 import com.daml.lf.crypto.Hash.KeyPackageName
-import com.daml.lf.data.Ref.{
-  Identifier,
-  Location,
-  Name,
-  PackageId,
-  PackageName,
-  PackageVersion,
-  Party,
-  UserId,
-}
+import com.daml.lf.data.FrontStack
+import com.daml.lf.data.Ref._
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.preprocessing.ValueTranslator
 import com.daml.lf.engine.script.v2.ledgerinteraction.ScriptLedgerClient
+import com.daml.lf.interpretation.{Error => IE}
 import com.daml.lf.language.{Ast, LanguageVersion, StablePackagesV2}
-import com.daml.lf.speedy.{ArrayList, SError, SValue}
-import com.daml.lf.speedy.SBuiltin.SBVariantCon
+import com.daml.lf.speedy.SBuiltin.{SBToAny, SBVariantCon}
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.{ArrayList, SError, SValue}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
-import scalaz.{Foldable, OneAnd}
-import scalaz.syntax.traverse._
+import com.daml.script.converter.Converter.{toContractId, toText}
+import org.apache.pekko.stream.Materializer
 import scalaz.std.either._
 import scalaz.std.list._
 import scalaz.std.option._
-import com.daml.script.converter.Converter.{toContractId, toText}
-import com.daml.lf.interpretation.{Error => IE}
-import com.daml.lf.speedy.SBuiltin.SBToAny
+import scalaz.syntax.traverse._
+import scalaz.{Foldable, OneAnd}
 
+import java.time.Clock
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
@@ -247,7 +237,7 @@ object ScriptF {
                     StablePackagesV2.Either,
                     Name.assertFromString("Right"),
                     1,
-                    makePair(SList(rs), tree),
+                    Converter.makeTuple(SList(rs), tree),
                   )
                 }
             )
@@ -283,7 +273,7 @@ object ScriptF {
             .to(FrontStack)
             .traverse(
               Converter
-                .fromCreated(env.valueTranslator, _, client.enableContractUpgrading)
+                .fromCreated(env.valueTranslator, _, tplId, client.enableContractUpgrading)
             )
         )
       } yield SEValue(SList(res))
@@ -305,16 +295,22 @@ object ScriptF {
         optR <- Converter.toFuture(
           optR.traverse(c =>
             Converter
-              .fromContract(env.valueTranslator, c, client.enableContractUpgrading)
-              .map(makePair(_, SText(c.blob.toHexString)))
+              .fromAnyTemplate(
+                env.valueTranslator,
+                tplId,
+                c.argument,
+                client.enableContractUpgrading,
+              )
+              .map(
+                Converter.makeTuple(
+                  _,
+                  Converter.fromTemplateTypeRep(c.templateId),
+                  SText(c.blob.toHexString),
+                )
+              )
           )
         )
       } yield SEValue(SOptional(optR))
-  }
-
-  private[this] def makePair(v1: SValue, v2: SValue): SValue = {
-    import com.daml.script.converter.Converter.record
-    record(StablePackagesV2.Tuple2, ("_1", v1), ("_2", v2))
   }
 
   final case class QueryInterface(
@@ -337,7 +333,7 @@ object ScriptF {
             .traverse { case (cid, optView) =>
               optView match {
                 case None =>
-                  Right(makePair(SContractId(cid), SOptional(None)))
+                  Right(Converter.makeTuple(SContractId(cid), SOptional(None)))
                 case Some(view) =>
                   for {
                     view <- Converter.fromInterfaceView(
@@ -346,7 +342,7 @@ object ScriptF {
                       view,
                     )
                   } yield {
-                    makePair(SContractId(cid), SOptional(Some(view)))
+                    Converter.makeTuple(SContractId(cid), SOptional(Some(view)))
                   }
               }
             }
@@ -411,7 +407,7 @@ object ScriptF {
         )
         optR <- Converter.toFuture(
           optR.traverse(
-            Converter.fromCreated(env.valueTranslator, _, client.enableContractUpgrading)
+            Converter.fromCreated(env.valueTranslator, _, tplId, client.enableContractUpgrading)
           )
         )
       } yield SEValue(SOptional(optR))
@@ -789,7 +785,7 @@ object ScriptF {
         case Failure(
               Script.FailedCmd(cmdName, _, err)
             ) =>
-          import com.daml.lf.scenario.{Pretty, Error}
+          import com.daml.lf.scenario.{Error, Pretty}
           val msg = err match {
             case e: Error => Pretty.prettyError(e).render(10000)
             case e => e.getMessage
@@ -800,17 +796,14 @@ object ScriptF {
               iErr.getClass.getSimpleName
             case e => e.getClass.getSimpleName
           }
-
-          import com.daml.script.converter.Converter.record
           Future.successful(
             SEApp(
               left,
               Array(
-                record(
-                  StablePackagesV2.Tuple3,
-                  ("_1", SText(cmdName)),
-                  ("_2", SText(name)),
-                  ("_3", SText(msg)),
+                Converter.makeTuple(
+                  SText(cmdName),
+                  SText(name),
+                  SText(msg),
                 )
               ),
             )

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
@@ -161,7 +161,23 @@ class GrpcLedgerClient(
               )
           val blob =
             Bytes.fromByteString(createdEvent.createdEventBlob)
-          (ScriptLedgerClient.ActiveContract(templateId, cid, argument, blob), key)
+          val disclosureTemplateId =
+            Converter
+              .fromApiIdentifier(
+                createdEvent.templateId.getOrElse(
+                  throw new ConverterException("missing required template_id in CreatedEvent")
+                )
+              )
+              .getOrElse(throw new ConverterException("invalid template_id in CreatedEvent"))
+          (
+            ScriptLedgerClient.ActiveContract(
+              disclosureTemplateId,
+              cid,
+              argument,
+              blob,
+            ),
+            key,
+          )
         })
       )
     )

--- a/sdk/daml-script/test/daml/upgrades/UpgradesTest.daml
+++ b/sdk/daml-script/test/daml/upgrades/UpgradesTest.daml
@@ -8,6 +8,7 @@ module UpgradesTest where
 import DA.Assert
 import DA.Exception
 import DA.Foldable
+import DA.Optional
 import DA.Text
 import DA.Time
 import Daml.Script
@@ -154,6 +155,9 @@ tests = mconcat
     , ("ExerciseByKey command an unchanged old key for a new contract", exerciseCmdKeyUnchanged)
     , ("Fetching an unchanged old key for a new contract", fetchKeyUnchanged)
     , ("ExerciseByKey in Update an unchanged old key for a new contract", exerciseUpdateKeyUnchanged)
+
+    , -- Disclosures
+      ("Disclosure retrieved with an upgraded template ID are valid disclosures" , queriedDisclosuresAreValid)
   
     , -- Edge behaviour
       -- https://github.com/DACH-NY/canton/issues/14718
@@ -642,6 +646,16 @@ exerciseUpdateKeyUnchanged = do
   _ <- a `submit` createCmd (V1.UnchangedKey a 1)
   res <- a `submit` createAndExerciseCmd (V2.UnchangedKeyHelper a) (V2.UnchangedKeyExercise $ V2.UnchangedKeyKey a 1)
   res === "V2"
+
+queriedDisclosuresAreValid : Script ()
+queriedDisclosuresAreValid = do
+  a <- allocatePartyOn "alice" participant0
+  b <- allocatePartyOn "bob" participant0
+
+  cid <- a `submit` createExactCmd V1.ValidUpgrade with party = a
+  let v2Cid = coerceContractId @V1.ValidUpgrade @V2.ValidUpgrade cid
+  disclosure <- fromSome <$> queryDisclosure a v2Cid
+  submitWithDisclosures b [disclosure] $ exerciseCmd v2Cid (V2.Noop b)
 
 packageSelectionChoosesUnvettedPackages : Script ()
 packageSelectionChoosesUnvettedPackages = do

--- a/sdk/daml-script/test/daml/upgrades/v1/MyTemplates.daml
+++ b/sdk/daml-script/test/daml/upgrades/v1/MyTemplates.daml
@@ -42,6 +42,11 @@ template ValidUpgrade
       controller party
       do pure "V1"
 
+    nonconsuming choice Noop : () with
+        ctl : Party
+      controller ctl
+      do pure ()
+
 -- This upgrade will be invalid at runtime based on signatories and observers, not the datatype, so we may test those individually
 -- replacement signatories + observers are ignored in v1, added in v2, to test them changing in upgrade
 template InvalidUpgradeStakeholders

--- a/sdk/daml-script/test/daml/upgrades/v2/MyTemplates.daml
+++ b/sdk/daml-script/test/daml/upgrades/v2/MyTemplates.daml
@@ -50,6 +50,11 @@ template ValidUpgrade
       controller party
       do pure "V2"
 
+    nonconsuming choice Noop : () with
+        ctl : Party
+      controller ctl
+      do pure ()
+
 -- This upgrade is invalid at runtime based on signatories and observers, not the datatype, so we may test those individually
 -- replacement signatories + observers are ignored in v1, added in v2, to test them changing in upgrade
 template InvalidUpgradeStakeholders


### PR DESCRIPTION
Backport of #19167.

This time around I put `toTuple` in v1/Converter and v2/Converter classes because they need different stable packages.