### PR TITLE
[Speedy] recompute contract metadata when using different pkg versions 

### DIFF
--- a/sdk/daml-lf/interpreter/src/main/scala/com/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/daml/lf/speedy/SBuiltinFun.scala
@@ -2293,8 +2293,10 @@ private[lf] object SBuiltinFun {
       templateArg: SValue,
       keyOpt: SValue,
   )(f: ContractInfo => Control[Question.Update]): Control[Question.Update] = {
-    machine.lookupContractInfoCache(coid) match {
+    machine.contractInfoCache.get((coid, templateId.packageId)) match {
       case Some(contract) =>
+        // sanity check
+        assert(contract.templateId == templateId)
         f(contract)
       case None =>
         computeContractInfo(machine, templateId, templateArg, keyOpt) { contract =>

--- a/sdk/daml-lf/interpreter/src/main/scala/com/daml/lf/speedy/Speedy.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/daml/lf/speedy/Speedy.scala
@@ -491,8 +491,10 @@ private[lf] object Speedy {
       */
     // TODO: https://github.com/digital-asset/daml/issues/17082
     // - Must be template-id aware when we support ResultNeedUpgradeVerification
-    private[speedy] var contractInfoCache_ : Map[(V.ContractId, PackageId), ContractInfo] = Map.empty
-    private[speedy] def contractInfoCache: Map[(V.ContractId, PackageId), ContractInfo] = contractInfoCache_
+    private[speedy] var contractInfoCache_ : Map[(V.ContractId, PackageId), ContractInfo] =
+      Map.empty
+    private[speedy] def contractInfoCache: Map[(V.ContractId, PackageId), ContractInfo] =
+      contractInfoCache_
     private[speedy] def insertContractInfoCache(
         coid: V.ContractId,
         contract: ContractInfo,

--- a/sdk/daml-lf/interpreter/src/main/scala/com/daml/lf/speedy/Speedy.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/daml/lf/speedy/Speedy.scala
@@ -491,15 +491,14 @@ private[lf] object Speedy {
       */
     // TODO: https://github.com/digital-asset/daml/issues/17082
     // - Must be template-id aware when we support ResultNeedUpgradeVerification
-    private[speedy] var contractInfoCache: Map[V.ContractId, ContractInfo] = Map.empty
-    private[speedy] def lookupContractInfoCache(coid: V.ContractId): Option[ContractInfo] = {
-      contractInfoCache.get(coid)
-    }
+    private[speedy] var contractInfoCache_ : Map[(V.ContractId, PackageId), ContractInfo] = Map.empty
+    private[speedy] def contractInfoCache: Map[(V.ContractId, PackageId), ContractInfo] = contractInfoCache_
     private[speedy] def insertContractInfoCache(
         coid: V.ContractId,
         contract: ContractInfo,
     ): Unit = {
-      contractInfoCache = contractInfoCache + (coid -> contract)
+      val pkgId = contract.templateId.packageId
+      contractInfoCache_ = contractInfoCache_.updated((coid, pkgId), contract)
     }
 
     private[speedy] def isLocalContract(contractId: V.ContractId): Boolean = {

--- a/sdk/daml-lf/interpreter/src/test/scala/com/daml/lf/speedy/UpgradeTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/daml/lf/speedy/UpgradeTest.scala
@@ -322,6 +322,22 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
     }
   }
 
+  "upgrade" - {
+    "be able to fetch a same contract using different version" in {
+      // The following code is not properly type, but emulate two commands that fetch a same contract using different versions.
+      val res = go(
+        e"""\(cid: ContractId '-pkg1-':M:T) ->
+               ubind
+                 x1: Unit <- '-pkg2-':M:do_fetch cid;
+                 x2: Unit <- '-pkg3-':M:do_fetch cid
+               in upure @Unit ()
+          """,
+        ContractInstance(pkgName, i"'-pkg1-':M:T", v1_base),
+      )
+      res shouldBe a[Right[_, _]]
+    }
+  }
+
   "Correct calls to ResultNeedUpgradeVerification" in {
 
     implicit val pkgId: Ref.PackageId = Ref.PackageId.assertFromString("-no-pkg-")

--- a/sdk/daml-lf/interpreter/src/test/scala/com/daml/lf/speedy/UpgradeTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/daml/lf/speedy/UpgradeTest.scala
@@ -104,7 +104,7 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
       template (this: T) = {
         precondition True;
         signatories '-pkg1-':M:mkList (M:T {sig} this) (M:T {optSig} this);
-         observers '-pkg1-':M:mkList (M:T {obs} this) (None @Party);
+        observers '-pkg1-':M:mkList (M:T {obs} this) (None @Party);
         key @Party (M:T {sig} this) (\ (p: Party) -> Cons @Party [p] Nil @Party);
       };
 
@@ -118,7 +118,7 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
 
   val pkgId4: Ref.PackageId = Ref.PackageId.assertFromString("-pkg4-")
   private lazy val pkg4 = {
-    // add an optional additional signatory
+    // swap signatories and observers with respect to pkg2
     implicit def pkgId: Ref.PackageId = pkgId4
     p""" metadata ( '-upgrade-test-' : '4.0.0' )
       module M {
@@ -359,7 +359,7 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
 
   "upgrade" - {
     "be able to fetch a same contract using different versions" in {
-      // The following code is not properly type, but emulate two commands that fetch a same contract using different versions.
+      // The following code is not properly typed, but emulates two commands that fetch a same contract using different versions.
       val res = go(
         e"""\(cid: ContractId '-pkg1-':M:T) ->
                ubind
@@ -372,7 +372,7 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
       res shouldBe a[Right[_, _]]
     }
     "do recompute and check immutability of meta data when using different versions" in {
-      // The following code is not properly type, but emulate two commands that fetch a same contract using different versions.
+      // The following code is not properly typed, but emulates two commands that fetch a same contract using different versions.
       val res: Either[SError, (Value, List[UpgradeVerificationRequest])] = go(
         e"""\(cid: ContractId '-pkg1-':M:T) ->
                ubind

--- a/sdk/daml-lf/interpreter/src/test/scala/com/daml/lf/speedy/UpgradeTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/daml/lf/speedy/UpgradeTest.scala
@@ -98,7 +98,7 @@ class UpgradeTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChec
       template (this: T) = {
         precondition True;
         signatories '-pkg1-':M:sigs (M:T {sig} this) (M:T {optSig} this);
-         observers '-pkg1-':M:sigs (M:T {obs} this) (None @Party);
+        observers '-pkg1-':M:sigs (M:T {obs} this) (None @Party);
         key @Party (M:T {sig} this) (\ (p: Party) -> Cons @Party [p] Nil @Party);
       };
 
@@ -112,7 +112,7 @@ class UpgradeTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChec
 
   val pkgId4: Ref.PackageId = Ref.PackageId.assertFromString("-pkg4-")
   private lazy val pkg4 = {
-    // add an optional additional signatory
+    // swap signatories and observers with respect to pkg2
     implicit def pkgId: Ref.PackageId = pkgId4
     p""" metadata ( '-upgrade-test-' : '4.0.0' )
       module M {
@@ -353,7 +353,7 @@ class UpgradeTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChec
 
   "upgrade" - {
     "be able to fetch a same contract using different versions" in {
-      // The following code is not properly type, but emulate two commands that fetch a same contract using different versions.
+      // The following code is not properly typed, but emulates two commands that fetch a same contract using different versions.
       val res = go(
         e"""\(cid: ContractId '-pkg1-':M:T) ->
                ubind
@@ -366,7 +366,7 @@ class UpgradeTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChec
       res shouldBe a[Right[_, _]]
     }
     "do recompute and check immutability of meta data when using different versions" in {
-      // The following code is not properly type, but emulate two commands that fetch a same contract using different versions.
+      // The following code is not properly typed, but emulates two commands that fetch a same contract using different versions.
       val res: Either[SError, (Value, List[UpgradeVerificationRequest])] = go(
         e"""\(cid: ContractId '-pkg1-':M:T) ->
                ubind

--- a/sdk/daml-lf/interpreter/src/test/scala/com/daml/lf/speedy/UpgradeTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/daml/lf/speedy/UpgradeTest.scala
@@ -383,21 +383,15 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
         ContractInstance(pkgName, i"'-pkg1-':M:T", v1_base),
       )
       inside(res) { case Right((_, verificationRequests)) =>
+        val v4_key = GlobalKeyWithMaintainers.assertBuild(
+          i"'-pkg1-':M:T",
+          ValueParty(bob),
+          Set(bob),
+          pkgName,
+        )
         verificationRequests shouldBe List(
           UpgradeVerificationRequest(theCid, Set(alice), Set(bob), Some(v1_key)),
-          UpgradeVerificationRequest(
-            theCid,
-            Set(bob),
-            Set(alice),
-            Some(
-              GlobalKeyWithMaintainers.assertBuild(
-                i"'-pkg1-':M:T",
-                ValueParty(bob),
-                Set(bob),
-                pkgName,
-              )
-            ),
-          ),
+          UpgradeVerificationRequest(theCid, Set(bob), Set(alice), Some(v4_key)),
         )
       }
     }

--- a/sdk/daml-lf/interpreter/src/test/scala/com/daml/lf/speedy/UpgradeTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/daml/lf/speedy/UpgradeTest.scala
@@ -25,11 +25,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 
 import java.util
 
-class UpgradeTest
-    extends AnyFreeSpec
-    with Matchers
-    with TableDrivenPropertyChecks
-    with Inside {
+class UpgradeTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks with Inside {
 
   implicit val pkgId: Ref.PackageId = Ref.PackageId.assertFromString("-no-pkg-")
 
@@ -219,7 +215,8 @@ class UpgradeTest
       ValueInt64(100),
     )
 
-  val v1_key = GlobalKeyWithMaintainers.assertBuild(i"'-pkg1-':M:T", ValueParty(alice), Set(alice), pkgName)
+  val v1_key =
+    GlobalKeyWithMaintainers.assertBuild(i"'-pkg1-':M:T", ValueParty(alice), Set(alice), pkgName)
 
   "upgrade attempted" - {
 
@@ -379,12 +376,23 @@ class UpgradeTest
           """,
         ContractInstance(pkgName, i"'-pkg1-':M:T", v1_base),
       )
-      inside(res){
-        case Right((_, verificationRequests)) =>
-          verificationRequests shouldBe List(
-            UpgradeVerificationRequest(theCid, Set(alice), Set(bob), Some(v1_key)),
-            UpgradeVerificationRequest(theCid, Set(bob), Set(alice), Some(GlobalKeyWithMaintainers.assertBuild(i"'-pkg1-':M:T", ValueParty(bob), Set(bob), pkgName))),
-          )
+      inside(res) { case Right((_, verificationRequests)) =>
+        verificationRequests shouldBe List(
+          UpgradeVerificationRequest(theCid, Set(alice), Set(bob), Some(v1_key)),
+          UpgradeVerificationRequest(
+            theCid,
+            Set(bob),
+            Set(alice),
+            Some(
+              GlobalKeyWithMaintainers.assertBuild(
+                i"'-pkg1-':M:T",
+                ValueParty(bob),
+                Set(bob),
+                pkgName,
+              )
+            ),
+          ),
+        )
       }
     }
   }


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
