### PR TITLE
[2.9] restore ability to make releases

### DIFF
--- a/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -496,6 +496,7 @@ damlStartTestsWithoutValidation getDamlStart =
         untilM_ (pure ()) $ do
             line <- atomically $ readTChan stdoutReadChan
             pure ("Rebuild complete" `isInfixOf` line)
+        -- TODO(paulbrauner-da): Use a package name once supported by canton out of the box.
         newPackageRef <- extractPackageRefFromDar projDir
         initialRequest <-
             parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/query"

--- a/sdk/ledger-service/http-json-testing/BUILD.bazel
+++ b/sdk/ledger-service/http-json-testing/BUILD.bazel
@@ -39,6 +39,9 @@ load("//ledger-service/utils:scalaopts.bzl", "hj_scalacopts")
         ],
         deps = [
             "//bazel_tools/runfiles:scala_runfiles",
+            "//daml-lf/api-type-signature",
+            "//daml-lf/archive:daml_lf_archive_reader",
+            "//daml-lf/archive:daml_lf_dev_archive_proto_java",
             "//daml-lf/transaction",
             "//language-support/scala/bindings-pekko",
             "//ledger-service/fetch-contracts",

--- a/sdk/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
+++ b/sdk/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
@@ -11,6 +11,7 @@ import org.apache.pekko.http.scaladsl.model.headers.{Authorization, OAuth2Bearer
 import org.apache.pekko.stream.Materializer
 import com.daml.api.util.TimestampConversion
 import com.daml.bazeltools.BazelRunfiles.rlocation
+import com.daml.bazeltools.BazelRunfiles.requiredResource
 import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.daml.http.HttpService.doLoad
 import com.daml.http.dbbackend.{ContractDao, JdbcConfig}
@@ -66,8 +67,13 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
 
   private val doNotReloadPackages = FiniteDuration(100, DAYS)
 
-  // This may need to be updated if the Account.daml is updated.
-  val staticPkgIdAccount = "b3c9564bb7334bfd0f82099893eba518afc3b68a4d5c66cb2835498252db93e9"
+  // TODO(paulbrauner-da): Use a package name once supported by canton out of the box.
+  lazy val staticPkgIdAccount = {
+    import com.daml.lf.{archive, typesig}
+    val darFile = requiredResource("ledger-service/http-json/Account.dar")
+    val dar = archive.UniversalArchiveReader.assertReadFile(darFile)
+    typesig.PackageSignature.read(dar.main)._2.packageId
+  }
 
   def withHttpService[A](
       testName: String,

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
@@ -71,21 +71,13 @@ object AbstractHttpServiceIntegrationTestFuns {
     typesig.PackageSignature.read(dar.main)._2.packageId
   }
 
-  val pkgIdAccount = {
-    val pkgId = packageIdOfDar(dar2)
-    assert(
-      pkgId == HttpServiceTestFixture.staticPkgIdAccount,
-      s"""Please update HttpServiceTestFixture.staticPkgIdAccount to "$pkgId"""",
-    )
-    pkgId
-  }
-
   lazy val pkgIdCiou = packageIdOfDar(ciouDar)
   lazy val pkgIdModelTests = packageIdOfDar(dar1)
   lazy val pkgIdRiou = packageIdOfDar(riouDar)
   lazy val pkgIdUser = packageIdOfDar(userDar)
   lazy val pkgIdFooV1 = packageIdOfDar(fooV1Dar)
   lazy val pkgIdFooV2 = packageIdOfDar(fooV2Dar)
+  lazy val pkgIdAccount = packageIdOfDar(dar2)
 
   def sha256(source: Source[ByteString, Any])(implicit mat: Materializer): Try[String] = Try {
     import com.google.common.io.BaseEncoding


### PR DESCRIPTION
Releases were broken by [#19149] because package IDs include the SDK version in what they hash.

[#19149]: https://github.com/digital-asset/daml/pull/19149