### PR TITLE
JSON API: etx-500 add type information into the package ids of template ids

### DIFF
--- a/sdk/fmt.sh
+++ b/sdk/fmt.sh
@@ -24,7 +24,7 @@ prettier_args="--write"
 ## Functions ##
 
 run_pprettier() {
-    yarn pprettier ${@##sdk/}
+    yarn pprettier $@
 }
 
 log() {
@@ -51,7 +51,7 @@ check_diff() {
   # "${@:3}" command
   changed_files=$(git diff --name-only --diff-filter=ACMRT "$1" | grep $2 | grep -E -v '^canton(-3x)?/' || [[ $? == 1 ]])
   if [[ -n "$changed_files" ]]; then
-    run "${@:3}" ${changed_files[@]:-}
+    run "${@:3}" ${changed_files[@]##sdk/}
   else
     echo "No changed file to check matching '$2', skipping."
   fi
@@ -142,7 +142,7 @@ run dade-copyright-headers "$dade_copyright_arg" .
 # We do test hlint via Bazel rules but we run it separately
 # to get linting failures early.
 if [ "$diff_mode" = "true" ]; then
-  check_diff $merge_base '\.hs$' hlint -j4 --path=..
+  check_diff $merge_base '\.hs$' hlint -j4
   check_diff $merge_base '\.java$' javafmt "${javafmt_args[@]:-}"
   check_diff $merge_base '\.\(ts\|tsx\)$' run_pprettier ${prettier_args[@]:-}
 else

--- a/sdk/fmt.sh
+++ b/sdk/fmt.sh
@@ -24,7 +24,7 @@ prettier_args="--write"
 ## Functions ##
 
 run_pprettier() {
-    yarn pprettier $@
+    yarn pprettier ${@##sdk/}
 }
 
 log() {
@@ -142,7 +142,7 @@ run dade-copyright-headers "$dade_copyright_arg" .
 # We do test hlint via Bazel rules but we run it separately
 # to get linting failures early.
 if [ "$diff_mode" = "true" ]; then
-  check_diff $merge_base '\.hs$' hlint -j4
+  check_diff $merge_base '\.hs$' hlint -j4 --path=..
   check_diff $merge_base '\.java$' javafmt "${javafmt_args[@]:-}"
   check_diff $merge_base '\.\(ts\|tsx\)$' run_pprettier ${prettier_args[@]:-}
 else

--- a/sdk/fmt.sh
+++ b/sdk/fmt.sh
@@ -51,7 +51,7 @@ check_diff() {
   # "${@:3}" command
   changed_files=$(git diff --name-only --diff-filter=ACMRT "$1" | grep $2 | grep -E -v '^canton(-3x)?/' || [[ $? == 1 ]])
   if [[ -n "$changed_files" ]]; then
-    run "${@:3}" ${changed_files[@]##sdk/}
+    run "${@:3}" ${changed_files[@]:-}
   else
     echo "No changed file to check matching '$2', skipping."
   fi

--- a/sdk/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/sdk/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -167,14 +167,15 @@ sealed abstract class Queries(tablePrefix: String, tpIdCacheMaxEntries: Long)(im
 
   protected[http] def version()(implicit log: LogHandler): ConnectionIO[Option[Int]]
 
-  final def surrogateTemplateId(packageId: String, moduleName: String, entityName: String)(implicit
+  final def surrogateTemplateId(packageId: Ref.PackageId, moduleName: String, entityName: String)(
+      implicit
       log: LogHandler,
       lc: LoggingContextOf[InstanceUUID],
   ): ConnectionIO[SurrogateTpId] = surrogateTemplateId(None, packageId, moduleName, entityName)
 
   final def surrogateTemplateId(
       packageName: Option[String],
-      packageId: String,
+      packageId: Ref.PackageId,
       moduleName: String,
       entityName: String,
   )(implicit

--- a/sdk/ledger-service/fetch-contracts/src/main/scala/fetchcontracts/AcsTxStreams.scala
+++ b/sdk/ledger-service/fetch-contracts/src/main/scala/fetchcontracts/AcsTxStreams.scala
@@ -135,9 +135,9 @@ private[daml] object AcsTxStreams {
     (ContractStreamStep.Txn(partitionInsertsDeletes(tx.events), offset), offset)
   }
 
-  private[daml] def transactionFilter(
+  private[daml] def transactionFilter[Pkg](
       parties: domain.PartySet,
-      contractTypeIds: List[ContractTypeId.Resolved],
+      contractTypeIds: List[ContractTypeId.Definite[Pkg]],
   ): lav1.transaction_filter.TransactionFilter = {
     import lav1.transaction_filter._
 
@@ -145,7 +145,7 @@ private[daml] object AcsTxStreams {
     val filters = Filters(
       Some(
         lav1.transaction_filter.InclusiveFilters(
-          templateIds = templateIds.map(apiIdentifier),
+          templateIds = templateIds.map(apiIdentifier[Pkg]),
           interfaceFilters = interfaceIds.map(interfaceId =>
             InterfaceFilter(
               interfaceId = Some(apiIdentifier(interfaceId)),

--- a/sdk/ledger-service/fetch-contracts/src/main/scala/fetchcontracts/domain/ContractTypeId.scala
+++ b/sdk/ledger-service/fetch-contracts/src/main/scala/fetchcontracts/domain/ContractTypeId.scala
@@ -13,7 +13,7 @@ import scalaz.syntax.functor._
 import scala.collection.IterableOps
 
 /** A contract type ID that may be either a template or an interface ID.
-  * A [[ContractTypeId.Resolved]] ID will always be either [[ContractTypeId.Template]]
+  * A [[ContractTypeId.ResolvedPkg]] ID will always be either [[ContractTypeId.Template]]
   * or [[ContractTypeId.Interface]]; an
   * unresolved ID may be one of those, which indicates an expectation of what
   * the resolved ID will be, or neither, which indicates that resolving what
@@ -251,7 +251,7 @@ object ContractTypeId extends ContractTypeIdLike[ContractTypeId] {
 sealed abstract class ContractTypeIdLike[CtId[T] <: ContractTypeId[T]] {
   type RequiredPkg = CtId[Ref.PackageRef]
   type RequiredPkgId = CtId[Ref.PackageId]
-  type Resolved = ContractTypeId.ResolvedOf[CtId]
+  type ResolvedPkg = ContractTypeId.ResolvedOf[CtId]
   type ResolvedPkgId = ContractTypeId.ResolvedPkgIdOf[CtId]
 
   // treat the companion like a typeclass instance
@@ -314,7 +314,7 @@ object ContractTypeRef {
   }
 
   private[domain] final case class TemplateRef(
-      orig: ContractTypeId.Template.Resolved,
+      orig: ContractTypeId.Template.ResolvedPkg,
       pkgIds: NonEmpty[Seq[Ref.PackageId]],
       kpn: KeyPackageName,
   ) extends ContractTypeRef[ContractTypeId.Template](
@@ -324,7 +324,7 @@ object ContractTypeRef {
       )
 
   private[domain] final case class InterfaceRef(
-      orig: ContractTypeId.Interface.Resolved,
+      orig: ContractTypeId.Interface.ResolvedPkg,
       pkgIds: NonEmpty[Seq[Ref.PackageId]],
       kpn: KeyPackageName,
   ) extends ContractTypeRef[ContractTypeId.Interface](

--- a/sdk/ledger-service/fetch-contracts/src/main/scala/fetchcontracts/domain/ContractTypeId.scala
+++ b/sdk/ledger-service/fetch-contracts/src/main/scala/fetchcontracts/domain/ContractTypeId.scala
@@ -67,14 +67,14 @@ sealed abstract class ContractTypeId[+PkgId]
 
 object ResolvedQuery {
 
-  def apply(resolved: ContractTypeRef.Resolved): ResolvedQuery =
+  def apply[CtId[T] <: ContractTypeId[T]](resolved: ContractTypeRef[CtId]): ResolvedQuery =
     resolved match {
       case t: ContractTypeRef.TemplateRef => ByTemplateId(t)
       case i: ContractTypeRef.InterfaceRef => ByInterfaceId(i)
     }
 
   def apply(
-      resolved: Set[ContractTypeRef.Resolved]
+      resolved: Set[_ <: ContractTypeRef[ContractTypeId]]
   ): Unsupported \/ ResolvedQuery = {
     import com.daml.nonempty.{NonEmpty, Singleton}
     val (templateIds, interfaceIds) = partitionKPN(resolved)
@@ -93,16 +93,16 @@ object ResolvedQuery {
     }
   }
 
-  def partition[CC[_], C](
-      resolved: IterableOps[ContractTypeId.Resolved, CC, C]
-  ): (CC[ContractTypeId.Template.Resolved], CC[ContractTypeId.Interface.Resolved]) =
+  def partition[CC[_], C, Pkg](
+      resolved: IterableOps[ContractTypeId.Definite[Pkg], CC, C]
+  ): (CC[ContractTypeId.Template[Pkg]], CC[ContractTypeId.Interface[Pkg]]) =
     resolved.partitionMap {
       case t @ ContractTypeId.Template(_, _, _) => Left(t)
       case i @ ContractTypeId.Interface(_, _, _) => Right(i)
     }
 
   private def partitionKPN[CC[_], C](
-      resolved: IterableOps[ContractTypeRef[_], CC, C]
+      resolved: IterableOps[ContractTypeRef[ContractTypeId], CC, C]
   ): (
       CC[ContractTypeRef.TemplateRef],
       CC[ContractTypeRef.InterfaceRef],
@@ -224,9 +224,11 @@ object ContractTypeId extends ContractTypeIdLike[ContractTypeId] {
   // confirmed-present IDs only.  Can probably start by adding
   // `with Definite[Any]` here and seeing what happens
   /** A resolved [[ContractTypeId]], typed `CtTyId`. */
-  type ResolvedId[+CtTyId] = CtTyId
 
-  type ResolvedOf[+CtId[_]] = ResolvedId[CtId[String] with Definite[String]]
+  type WithDefiniteOps[+CtId[_], Pkg] = CtId[Pkg] with Definite[Pkg] with Ops[CtId, Pkg]
+
+  type ResolvedOf[+CtId[_]] = WithDefiniteOps[CtId, Ref.PackageRef]
+  type ResolvedPkgIdOf[+CtId[_]] = WithDefiniteOps[CtId, Ref.PackageId]
 
   type Like[CtId[T] <: ContractTypeId[T]] = ContractTypeIdLike[CtId]
 
@@ -236,22 +238,33 @@ object ContractTypeId extends ContractTypeIdLike[ContractTypeId] {
         packageId: PkgId0 = packageId,
         moduleName: String = moduleName,
         entityName: String = entityName,
-    ): CtId[PkgId0]
+    ): CtId[PkgId0] with Ops[CtId, PkgId0]
   }
+
+  def withPkgRef[CtId[T] <: ContractTypeId[T]](
+      id: CtId[Ref.PackageId] with Ops[CtId, Ref.PackageId]
+  ): CtId[Ref.PackageRef] =
+    id.copy(packageId = Ref.PackageRef.Id(id.packageId): Ref.PackageRef)
 }
 
 /** A contract type ID companion. */
 sealed abstract class ContractTypeIdLike[CtId[T] <: ContractTypeId[T]] {
-  type RequiredPkg = CtId[String]
+  type RequiredPkg = CtId[Ref.PackageRef]
+  type RequiredPkgId = CtId[Ref.PackageId]
   type Resolved = ContractTypeId.ResolvedOf[CtId]
+  type ResolvedPkgId = ContractTypeId.ResolvedPkgIdOf[CtId]
 
   // treat the companion like a typeclass instance
   implicit def `ContractTypeIdLike companion`: this.type = this
 
-  def apply[PkgId](packageId: PkgId, moduleName: String, entityName: String): CtId[PkgId]
+  def apply[PkgId](
+      packageId: PkgId,
+      moduleName: String,
+      entityName: String,
+  ): CtId[PkgId] with ContractTypeId.Ops[CtId, PkgId]
 
-  final def fromLedgerApi(in: lav1.value.Identifier): RequiredPkg =
-    apply(in.packageId, in.moduleName, in.entityName)
+  final def fromLedgerApi(in: lav1.value.Identifier): RequiredPkgId =
+    apply(Ref.PackageId.assertFromString(in.packageId), in.moduleName, in.entityName)
 
   private[this] def qualifiedName(a: CtId[_]): Ref.QualifiedName =
     Ref.QualifiedName(
@@ -259,10 +272,9 @@ sealed abstract class ContractTypeIdLike[CtId[T] <: ContractTypeId[T]] {
       Ref.DottedName.assertFromString(a.entityName),
     )
 
-  final def toLedgerApiValue(a: RequiredPkg): Ref.Identifier = {
+  final def toLedgerApiValue(a: RequiredPkgId): Ref.Identifier = {
     val qfName = qualifiedName(a)
-    val packageId = Ref.PackageId.assertFromString(a.packageId)
-    Ref.Identifier(packageId, qfName)
+    Ref.Identifier(a.packageId, qfName)
   }
 }
 
@@ -270,40 +282,42 @@ sealed abstract class ContractTypeIdLike[CtId[T] <: ContractTypeId[T]] {
 // i.e. `orig` may have a form or either "#foo:Bar:Baz" or "123:Bar:Baz".
 // If a package name is provided, then `allIds` may resolve to multiple values, for the relevant
 // template in each package id that shares the same package name.
-sealed abstract class ContractTypeRef[+CtTyId](
-    orig: CtTyId,
-    ids: NonEmpty[Seq[CtTyId]],
+sealed abstract class ContractTypeRef[+CtTyId[T] <: ContractTypeId[T]](
+    orig: ContractTypeId.ResolvedOf[CtTyId],
+    ids: NonEmpty[Seq[ContractTypeId.ResolvedPkgIdOf[CtTyId]]],
     val name: KeyPackageName,
 ) {
-  def allPkgIds: NonEmpty[Set[_ <: CtTyId]] = ids.toSet
-  def latestPkgId: CtTyId = ids.head
-  def original: CtTyId = orig
+  def allPkgIds: NonEmpty[Set[_ <: ContractTypeId.ResolvedPkgIdOf[CtTyId]]] = ids.toSet
+  def latestPkgId: ContractTypeId.ResolvedPkgIdOf[CtTyId] = ids.head
+  def original: ContractTypeId.ResolvedOf[CtTyId] = orig
 }
 
 object ContractTypeRef {
-  type Resolved = ContractTypeRef[ContractTypeId.Resolved]
+  type Resolved = ContractTypeRef[ContractTypeId]
 
-  def unnamed[CtTyId <: ContractTypeId.Resolved](
-      id: CtTyId
-  ): ContractTypeRef[CtTyId] =
-    apply(id, NonEmpty(Seq, id.packageId), KeyPackageName.empty)
+  def unnamed[CtTyId[T] <: ContractTypeId[T]](
+      id: ContractTypeId.ResolvedPkgIdOf[CtTyId]
+  ): ContractTypeRef[CtTyId] = {
+    val idWithRef = id.copy(packageId = Ref.PackageRef.Id(id.packageId): Ref.PackageRef)
+    apply[CtTyId](idWithRef, NonEmpty(Seq, id.packageId), KeyPackageName.empty)
+  }
 
-  def apply[CtId <: ContractTypeId.Resolved](
-      id: CtId, // The original template/interface id.
-      pkgIds: NonEmpty[Seq[String]], // Package ids with same name, ordered by version, descending
+  def apply[CtId[T] <: ContractTypeId[T]](
+      id: ContractTypeId.ResolvedOf[CtId], // The original template/interface id.
+      pkgIds: NonEmpty[Seq[Ref.PackageId]], // Package ids with same name, by version, descending
       name: KeyPackageName, // The package name info
   ): ContractTypeRef[CtId] = {
-    (id match {
+    ((id: ContractTypeId.Definite[Ref.PackageRef]) match {
       case t @ ContractTypeId.Template(_, _, _) => TemplateRef(t, pkgIds, name)
       case i @ ContractTypeId.Interface(_, _, _) => InterfaceRef(i, pkgIds, name)
-    }).asInstanceOf[ContractTypeRef[CtId]]
+    }).asInstanceOf[ContractTypeRef[CtId]] // CtId <: Definite, because id is resolved
   }
 
   private[domain] final case class TemplateRef(
       orig: ContractTypeId.Template.Resolved,
-      pkgIds: NonEmpty[Seq[String]],
+      pkgIds: NonEmpty[Seq[Ref.PackageId]],
       kpn: KeyPackageName,
-  ) extends ContractTypeRef[ContractTypeId.Template.Resolved](
+  ) extends ContractTypeRef[ContractTypeId.Template](
         orig,
         pkgIds.map(pkgId => orig.copy(packageId = pkgId)),
         kpn,
@@ -311,9 +325,9 @@ object ContractTypeRef {
 
   private[domain] final case class InterfaceRef(
       orig: ContractTypeId.Interface.Resolved,
-      pkgIds: NonEmpty[Seq[String]],
+      pkgIds: NonEmpty[Seq[Ref.PackageId]],
       kpn: KeyPackageName,
-  ) extends ContractTypeRef[ContractTypeId.Interface.Resolved](
+  ) extends ContractTypeRef[ContractTypeId.Interface](
         orig,
         pkgIds.map(pkgId => orig.copy(packageId = pkgId)),
         kpn,

--- a/sdk/ledger-service/fetch-contracts/src/main/scala/fetchcontracts/util/IdentifierConverters.scala
+++ b/sdk/ledger-service/fetch-contracts/src/main/scala/fetchcontracts/util/IdentifierConverters.scala
@@ -15,9 +15,9 @@ private[daml] object IdentifierConverters {
       entityName = a.qualifiedName.name.dottedName,
     )
 
-  def apiIdentifier(a: domain.ContractTypeId.RequiredPkg): lav1.value.Identifier =
+  def apiIdentifier[Pkg](a: domain.ContractTypeId[Pkg]): lav1.value.Identifier =
     lav1.value.Identifier(
-      packageId = a.packageId,
+      packageId = a.packageId.toString,
       moduleName = a.moduleName,
       entityName = a.entityName,
     )

--- a/sdk/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
+++ b/sdk/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
@@ -68,11 +68,11 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
   private val doNotReloadPackages = FiniteDuration(100, DAYS)
 
   // TODO(paulbrauner-da): Use a package name once supported by canton out of the box.
-  lazy val staticPkgIdAccount = {
+  lazy val staticPkgIdAccount: Ref.PackageRef = {
     import com.daml.lf.{archive, typesig}
     val darFile = requiredResource("ledger-service/http-json/Account.dar")
     val dar = archive.UniversalArchiveReader.assertReadFile(darFile)
-    typesig.PackageSignature.read(dar.main)._2.packageId
+    Ref.PackageRef.assertFromString(typesig.PackageSignature.read(dar.main)._2.packageId)
   }
 
   def withHttpService[A](

--- a/sdk/ledger-service/http-json-testing/src/main/scala/com/daml/http/WebsocketTestFixture.scala
+++ b/sdk/ledger-service/http-json-testing/src/main/scala/com/daml/http/WebsocketTestFixture.scala
@@ -93,7 +93,8 @@ private[http] object WebsocketTestFixture extends StrictLogging with Assertions 
 
         createPairs = creates map { add =>
           import json.JsonProtocol.ActiveContractFormat
-          val ac = add.convertTo[domain.ActiveContract[domain.ContractTypeId.Resolved, JsValue]]
+          val ac =
+            add.convertTo[domain.ActiveContract[domain.ContractTypeId.ResolvedPkgId, JsValue]]
           (ac.contractId, ac.payload)
         }: Vector[(domain.ContractId, JsValue)]
 
@@ -137,12 +138,12 @@ private[http] object WebsocketTestFixture extends StrictLogging with Assertions 
   )
   private[http] final case class CreatedAccountContract(
       contractId: domain.ContractId,
-      templateId: domain.ContractTypeId.Unknown[String],
+      templateId: domain.ContractTypeId.Unknown[Ref.PackageId],
       record: AccountRecord,
   )
 
   private[http] object ContractTypeId {
-    def unapply(jsv: JsValue): Option[domain.ContractTypeId.Unknown[String]] = for {
+    def unapply(jsv: JsValue): Option[domain.ContractTypeId.Unknown[Ref.PackageId]] = for {
       JsString(templateIdStr) <- Some(jsv)
       templateId <- Ref.Identifier.fromString(templateIdStr).toOption
     } yield domain.ContractTypeId.Unknown(

--- a/sdk/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/ContractDaoBenchmark.scala
+++ b/sdk/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/ContractDaoBenchmark.scala
@@ -75,7 +75,7 @@ abstract class ContractDaoBenchmark {
     agreementText = "",
   )
 
-  protected def insertTemplate(tpid: ContractTypeId.RequiredPkg): SurrogateTpId = {
+  protected def insertTemplate(tpid: ContractTypeId.RequiredPkgId): SurrogateTpId = {
     instanceUUIDLogCtx(implicit lc =>
       dao
         .transact(

--- a/sdk/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/InsertBenchmark.scala
+++ b/sdk/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/InsertBenchmark.scala
@@ -6,6 +6,7 @@ package com.daml.http.dbbackend
 import cats.instances.list._
 import com.daml.http.dbbackend.Queries.{DBContract, SurrogateTpId}
 import com.daml.http.domain.ContractTypeId
+import com.daml.lf.data.Ref.PackageId
 import org.openjdk.jmh.annotations._
 import scalaz.std.list._
 import spray.json._
@@ -27,7 +28,7 @@ trait InsertBenchmark extends ContractDaoBenchmark {
   private var tpid: SurrogateTpId = _
 
   override def trialSetupPostInitialize(): Unit = {
-    tpid = insertTemplate(ContractTypeId.Template("-pkg-", "M", "T"))
+    tpid = insertTemplate(ContractTypeId.Template(PackageId.assertFromString("-pkg-"), "M", "T"))
     contracts = (1 until numContracts + 1).map { i =>
       // Use negative cids to avoid collisions with other contracts
       contract(-i, "Alice", tpid)

--- a/sdk/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryBenchmark.scala
+++ b/sdk/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryBenchmark.scala
@@ -6,6 +6,7 @@ package com.daml.http.dbbackend
 import com.daml.http.dbbackend.Queries.SurrogateTpId
 import com.daml.http.domain.{Party, ContractTypeId}
 import com.daml.http.util.Logging.instanceUUIDLogCtx
+import com.daml.lf.data.Ref.PackageId
 import com.daml.nonempty.NonEmpty
 import doobie.implicits._
 import org.openjdk.jmh.annotations._
@@ -19,15 +20,18 @@ trait QueryBenchmark extends ContractDaoBenchmark {
   @Param(Array("1", "10"))
   var extraTemplates: Int = _
 
-  private val tpid: ContractTypeId.Resolved = ContractTypeId.Template("-pkg-", "M", "T")
+  private val tpid: ContractTypeId.ResolvedPkgId = newTemplateId("T")
   private var surrogateTpid: SurrogateTpId = _
   val party = "Alice"
+
+  private def newTemplateId(template: String) =
+    ContractTypeId.Template(PackageId.assertFromString("-pkg-"), "M", template)
 
   override def trialSetupPostInitialize(): Unit = {
     surrogateTpid = insertTemplate(tpid)
 
     val surrogateTpids = surrogateTpid :: (0 until extraTemplates)
-      .map(i => insertTemplate(ContractTypeId.Template("-pkg-", "M", s"T$i")))
+      .map(i => insertTemplate(newTemplateId(s"T$i")))
       .toList
 
     val parties: List[String] = party :: (0 until extraParties).map(i => s"p$i").toList

--- a/sdk/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryPayloadBenchmark.scala
+++ b/sdk/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryPayloadBenchmark.scala
@@ -23,7 +23,8 @@ trait QueryPayloadBenchmark extends ContractDaoBenchmark {
   @Param(Array("1", "10"))
   var extraPayloadValues: Int = _
 
-  private val tpid: ContractTypeId.Resolved = ContractTypeId.Template("-pkg-", "M", "T")
+  private val tpid: ContractTypeId.ResolvedPkgId =
+    ContractTypeId.Template(Ref.PackageId.assertFromString("-pkg-"), "M", "T")
   private var surrogateTpid: SurrogateTpId = _
   val party = "Alice"
 

--- a/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
@@ -333,7 +333,7 @@ abstract class HttpServiceIntegrationTest
           encodeExercise(encoder)(
             iouTransfer(
               domain.EnrichedContractKey(
-                TpId.unsafeCoerce[domain.ContractTypeId.Template, String](TpId.IIou.IIou),
+                TpId.unsafeCoerce[domain.ContractTypeId.Template, Ref.PackageRef](TpId.IIou.IIou),
                 v.Value(v.Value.Sum.Party(domain.Party unwrap alice)),
               ),
               tExercise()(ShRecord(echo = "bob")),

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -2179,7 +2179,7 @@ abstract class AbstractHttpServiceIntegrationTestQueryStoreIndependent
                 domain.Contract(\/-(created1)),
               ) =>
             domain.ContractTypeId.withPkgRef(created0.templateId) shouldBe cmd.templateId
-            archived0.templateId shouldBe cmd.templateId
+            domain.ContractTypeId.withPkgRef(archived0.templateId) shouldBe cmd.templateId
             archived0.contractId shouldBe created0.contractId
             domain.ContractTypeId.withPkgRef(created1.templateId) shouldBe TpId.Iou.IouTransfer
             asContractId(result.exerciseResult) shouldBe created1.contractId

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -502,7 +502,13 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
               acl.size shouldBe 0
               warnings shouldBe Some(
                 domain.UnknownTemplateIds(
-                  List(domain.ContractTypeId("UnknownPackage", "UnknownModule", "UnknownEntity"))
+                  List(
+                    domain.ContractTypeId(
+                      Ref.PackageRef.assertFromString("UnknownPackage"),
+                      "UnknownModule",
+                      "UnknownEntity",
+                    )
+                  )
                 )
               )
             }
@@ -523,8 +529,8 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
               errors shouldBe List(ErrorMessages.cannotResolveAnyTemplateId)
               inside(warnings) { case Some(domain.UnknownTemplateIds(unknownTemplateIds)) =>
                 unknownTemplateIds.toSet shouldBe Set(
-                  domain.ContractTypeId("ZZZ", "AAA", "BBB"),
-                  domain.ContractTypeId("ZZZ", "XXX", "YYY"),
+                  domain.ContractTypeId(Ref.PackageRef.assertFromString("ZZZ"), "AAA", "BBB"),
+                  domain.ContractTypeId(Ref.PackageRef.assertFromString("ZZZ"), "XXX", "YYY"),
                 )
               }
           }
@@ -1187,33 +1193,30 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
       import lav1.commands.{Commands, Command}
       import domain.{DisclosedContract => DC}
 
-      // we assume Disclosed is in the main dalf
-      lazy val inferredPkgId = AbstractHttpServiceIntegrationTestFuns.pkgIdAccount
-
-      def inDar2Main[CtId[P] <: domain.ContractTypeId.Ops[CtId, P]](
-          tid: CtId[String]
-      ): CtId[String] =
-        tid.copy(packageId = inferredPkgId)
-
-      lazy val ToDisclose = inDar2Main(TpId.Disclosure.ToDisclose)
-      lazy val AnotherToDisclose = inDar2Main(TpId.Disclosure.AnotherToDisclose)
-      lazy val HasGarbage = inDar2Main(TpId.Disclosure.HasGarbage)
+      def unwrapPkgId(ctid: ContractTypeId.RequiredPkg): ContractTypeId.RequiredPkgId =
+        inside(ctid.packageId) { case Ref.PackageRef.Id(pid) => ctid.copy(packageId = pid) }
 
       lazy val (_, toDiscloseVA) =
-        VA.record(lfIdentifier(ToDisclose), ShRecord(owner = VAx.partyDomain, junk = VA.text))
+        VA.record(
+          lfIdentifier(unwrapPkgId(TpId.Disclosure.ToDisclose)),
+          ShRecord(owner = VAx.partyDomain, junk = VA.text),
+        )
 
       lazy val (_, anotherToDiscloseVA) =
-        VA.record(lfIdentifier(ToDisclose), ShRecord(owner = VAx.partyDomain, garbage = VA.text))
+        VA.record(
+          lfIdentifier(unwrapPkgId(TpId.Disclosure.ToDisclose)),
+          ShRecord(owner = VAx.partyDomain, garbage = VA.text),
+        )
 
       val (_, viewportVA) =
         VA.record(
-          lfIdentifier(TpId.Disclosure.Viewport.copy(packageId = "ignored")),
+          lfIdentifier(unwrapPkgId(TpId.Disclosure.Viewport)),
           ShRecord(owner = VAx.partyDomain),
         )
 
       val (_, checkVisibilityVA) =
         VA.record(
-          Ref.Identifier assertFromString "ignored:Disclosure:CheckVisibility",
+          lfIdentifier(unwrapPkgId(TpId.Disclosure.CheckVisibility)),
           ShRecord(disclosed = VAx.contractIdDomain, ifaceDisclosed = VAx.contractIdDomain),
         )
 
@@ -1226,8 +1229,8 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
       )
 
       def filterWithBlobsFor(
-          interfaceId: ContractTypeId.Interface[String],
-          templateId: ContractTypeId.Template[String],
+          interfaceId: ContractTypeId.Interface.RequiredPkg,
+          templateId: ContractTypeId.Template.RequiredPkg,
           party: domain.Party,
       ) = {
         TransactionFilter(
@@ -1266,8 +1269,8 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           ShRecord(owner = alice, garbage = garbageMessage)
         )
         createCommands = Seq(
-          (ToDisclose, toDisclosePayload),
-          (AnotherToDisclose, anotherToDisclosePayload),
+          (TpId.Disclosure.ToDisclose, toDisclosePayload),
+          (TpId.Disclosure.AnotherToDisclose, anotherToDisclosePayload),
         ) map { case (tpid, payload) =>
           Command(util.Commands.create(refApiIdentifier(tpid), payload))
         }
@@ -1287,8 +1290,8 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         (ceAtOffset, (toDiscloseCid, atdCid)) = inside(createResp.transaction) { case Some(tx) =>
           import lav1.event.Event, Event.Event.Created
           inside(tx.events) { case Seq(Event(Created(ce0)), Event(Created(ce1))) =>
-            val EntityTD = ToDisclose.entityName
-            val EntityATD = AnotherToDisclose.entityName
+            val EntityTD = TpId.Disclosure.ToDisclose.entityName
+            val EntityATD = TpId.Disclosure.AnotherToDisclose.entityName
             val orderedCes = inside((ce0, ce1) umap (_.templateId.map(_.entityName))) {
               case (Some(EntityTD), Some(EntityATD)) => (ce0, ce1)
               case (Some(EntityATD), Some(EntityTD)) => (ce1, ce0)
@@ -1308,7 +1311,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
             .getTransactions(
               LedgerBegin.toLedgerApi,
               Some(AbsoluteBookmark(domain.Offset(ceAtOffset)).toLedgerApi),
-              filterWithBlobsFor(HasGarbage, ToDisclose, alice),
+              filterWithBlobsFor(TpId.Disclosure.HasGarbage, TpId.Disclosure.ToDisclose, alice),
               com.daml.ledger.api.domain.LedgerId(""),
               token = Some(jwt.value),
             )
@@ -2175,10 +2178,10 @@ abstract class AbstractHttpServiceIntegrationTestQueryStoreIndependent
                 domain.Contract(-\/(archived0)),
                 domain.Contract(\/-(created1)),
               ) =>
-            created0.templateId shouldBe cmd.templateId
+            domain.ContractTypeId.withPkgRef(created0.templateId) shouldBe cmd.templateId
             archived0.templateId shouldBe cmd.templateId
             archived0.contractId shouldBe created0.contractId
-            created1.templateId shouldBe TpId.Iou.IouTransfer
+            domain.ContractTypeId.withPkgRef(created1.templateId) shouldBe TpId.Iou.IouTransfer
             asContractId(result.exerciseResult) shouldBe created1.contractId
         }
       }

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
@@ -65,10 +65,11 @@ object AbstractHttpServiceIntegrationTestFuns {
   private[http] val fooV1Dar = requiredResource("ledger-service/http-json/FooV1.dar")
   private[http] val fooV2Dar = requiredResource("ledger-service/http-json/FooV2.dar")
 
-  private[this] def packageIdOfDar(darFile: java.io.File): String = {
+  private[this] def packageIdOfDar(darFile: java.io.File): Ref.PackageId = {
     import com.daml.lf.{archive, typesig}
     val dar = archive.UniversalArchiveReader.assertReadFile(darFile)
-    typesig.PackageSignature.read(dar.main)._2.packageId
+    val pkgId = typesig.PackageSignature.read(dar.main)._2.packageId
+    Ref.PackageId.assertFromString(pkgId)
   }
 
   lazy val pkgIdCiou = packageIdOfDar(ciouDar)
@@ -455,52 +456,61 @@ trait AbstractHttpServiceIntegrationTestFuns
     import domain.{ContractTypeId => CtId}
     import CtId.Template.{RequiredPkg => TId}
     import CtId.Interface.{RequiredPkg => IId}
+    import Ref.PackageRef.{Id => PkgId}
 
     object Iou {
-      val Dummy: TId = CtId.Template(pkgIdModelTests, "Iou", "Dummy")
-      val Iou: TId = CtId.Template(pkgIdModelTests, "Iou", "Iou")
-      val IouTransfer: TId = CtId.Template(pkgIdModelTests, "Iou", "IouTransfer")
+      val Dummy: TId = CtId.Template(PkgId(pkgIdModelTests), "Iou", "Dummy")
+      val Iou: TId = CtId.Template(PkgId(pkgIdModelTests), "Iou", "Iou")
+      val IouTransfer: TId = CtId.Template(PkgId(pkgIdModelTests), "Iou", "IouTransfer")
     }
     object Test {
-      val MultiPartyContract: TId = CtId.Template(pkgIdModelTests, "Test", "MultiPartyContract")
+      val MultiPartyContract: TId =
+        CtId.Template(PkgId(pkgIdModelTests), "Test", "MultiPartyContract")
     }
     object IAccount {
-      val IAccount: IId = CtId.Interface(pkgIdAccount, "IAccount", "IAccount")
+      val IAccount: IId = CtId.Interface(PkgId(pkgIdAccount), "IAccount", "IAccount")
     }
     object Account {
-      val Account: TId = CtId.Template(pkgIdAccount, "Account", "Account")
-      val Helper: TId = CtId.Template(pkgIdAccount, "Account", "Helper")
-      val KeyedByDecimal: TId = CtId.Template(pkgIdAccount, "Account", "KeyedByDecimal")
+      val Account: TId = CtId.Template(PkgId(pkgIdAccount), "Account", "Account")
+      val Helper: TId = CtId.Template(PkgId(pkgIdAccount), "Account", "Helper")
+      val KeyedByDecimal: TId =
+        CtId.Template(PkgId(pkgIdAccount), "Account", "KeyedByDecimal")
       val KeyedByVariantAndRecord: TId =
-        CtId.Template(pkgIdAccount, "Account", "KeyedByVariantAndRecord")
-      val LongFieldNames: TId = CtId.Template(pkgIdAccount, "Account", "LongFieldNames")
-      val PubSub: TId = CtId.Template(pkgIdAccount, "Account", "PubSub")
-      val SharedAccount: TId = CtId.Template(pkgIdAccount, "Account", "SharedAccount")
+        CtId.Template(PkgId(pkgIdAccount), "Account", "KeyedByVariantAndRecord")
+      val LongFieldNames: TId =
+        CtId.Template(PkgId(pkgIdAccount), "Account", "LongFieldNames")
+      val PubSub: TId = CtId.Template(PkgId(pkgIdAccount), "Account", "PubSub")
+      val SharedAccount: TId =
+        CtId.Template(PkgId(pkgIdAccount), "Account", "SharedAccount")
     }
     object Disclosure {
-      val AnotherToDisclose: TId = CtId.Template(pkgIdAccount, "Disclosure", "AnotherToDisclose")
-      val HasGarbage: IId = CtId.Interface(pkgIdAccount, "Disclosure", "HasGarbage")
-      val ToDisclose: TId = CtId.Template(pkgIdAccount, "Disclosure", "ToDisclose")
-      val Viewport: TId = CtId.Template(pkgIdAccount, "Disclosure", "Viewport")
+      val AnotherToDisclose: TId =
+        CtId.Template(PkgId(pkgIdAccount), "Disclosure", "AnotherToDisclose")
+      val HasGarbage: IId = CtId.Interface(PkgId(pkgIdAccount), "Disclosure", "HasGarbage")
+      val ToDisclose: TId = CtId.Template(PkgId(pkgIdAccount), "Disclosure", "ToDisclose")
+      val Viewport: TId = CtId.Template(PkgId(pkgIdAccount), "Disclosure", "Viewport")
+      val CheckVisibility: TId =
+        CtId.Template(PkgId(pkgIdAccount), "Disclosure", "CheckVisibility")
     }
     object User {
-      val User: TId = CtId.Template(pkgIdUser, "User", "User")
+      val User: TId = CtId.Template(PkgId(pkgIdUser), "User", "User")
     }
     object CIou {
-      val CIou: TId = CtId.Template(pkgIdCiou, "CIou", "CIou")
+      val CIou: TId = CtId.Template(PkgId(pkgIdCiou), "CIou", "CIou")
     }
     object IIou {
-      val IIou: IId = CtId.Interface(pkgIdCiou, "IIou", "IIou")
-      val TestIIou: TId = CtId.Template(pkgIdCiou, "IIou", "TestIIou")
+      val IIou: IId = CtId.Interface(PkgId(pkgIdCiou), "IIou", "IIou")
+      val TestIIou: TId = CtId.Template(PkgId(pkgIdCiou), "IIou", "TestIIou")
     }
     object RIou {
-      val RIou: IId = CtId.Interface(pkgIdRiou, "RIou", "RIou")
+      val RIou: IId = CtId.Interface(PkgId(pkgIdRiou), "RIou", "RIou")
     }
     object RIIou {
-      val RIIou: IId = CtId.Interface(pkgIdCiou, "RIIou", "RIIou")
+      val RIIou: IId = CtId.Interface(PkgId(pkgIdCiou), "RIIou", "RIIou")
     }
     object Transferrable {
-      val Transferrable: IId = CtId.Interface(pkgIdCiou, "Transferrable", "Transferrable")
+      val Transferrable: IId =
+        CtId.Interface(PkgId(pkgIdCiou), "Transferrable", "Transferrable")
     }
 
     def unsafeCoerce[Like[T] <: CtId[T], T](ctId: CtId[T])(implicit

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -257,7 +257,7 @@ class CommandService(
 
   private def exactlyOneActiveContract(
       response: lav1.command_service.SubmitAndWaitForTransactionResponse
-  ): Error \/ ActiveContract[ContractTypeId.Template.Resolved, lav1.value.Value] =
+  ): Error \/ ActiveContract[ContractTypeId.Template.ResolvedPkgId, lav1.value.Value] =
     activeContracts(response).flatMap {
       case Seq(x) => \/-(x)
       case xs @ _ =>
@@ -271,7 +271,7 @@ class CommandService(
 
   private def activeContracts(
       response: lav1.command_service.SubmitAndWaitForTransactionResponse
-  ): Error \/ ImmArraySeq[ActiveContract[ContractTypeId.Template.Resolved, lav1.value.Value]] =
+  ): Error \/ ImmArraySeq[ActiveContract[ContractTypeId.Template.ResolvedPkgId, lav1.value.Value]] =
     response.transaction
       .toRightDisjunction(
         InternalError(
@@ -283,7 +283,9 @@ class CommandService(
 
   private def activeContracts(
       tx: lav1.transaction.Transaction
-  ): Error \/ ImmArraySeq[ActiveContract[ContractTypeId.Template.Resolved, lav1.value.Value]] = {
+  ): Error \/ ImmArraySeq[
+    ActiveContract[ContractTypeId.Template.ResolvedPkgId, lav1.value.Value]
+  ] = {
     Transactions
       .allCreatedEvents(tx)
       .traverse(ActiveContract.fromLedgerApi(domain.ActiveContract.ExtractAs.Template, _))

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/PackageService.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/PackageService.scala
@@ -181,7 +181,8 @@ private class PackageService(
       latestMaps: () => (TemplateIdMap, InterfaceIdMap)
   )(implicit ec: ExecutionContext): ResolveContractTypeId = new ResolveContractTypeId {
     import ResolveContractTypeId.{Overload => O}, domain.{ContractTypeId => C}
-    override def apply[U, R <: ContractTypeId.Resolved](
+
+    override def apply[U, R[T] <: ContractTypeId[T]](
         jwt: Jwt,
         ledgerId: LedgerApiDomain.LedgerId,
     )(
@@ -225,9 +226,8 @@ private class PackageService(
       for {
         result <- EitherT.pure(doSearch(latestMaps())): ET[ResultType]
         _ = logger.trace(s"Result: $result")
-        finalResult <- {
-          val packageId = (x: C.RequiredPkg).packageId
-          if (packageId.startsWith("#")) { // Used package name, not package id
+        finalResult <- ((x: C.RequiredPkg).packageId match {
+          case Ref.PackageRef.Name(_) => // Used package name, not package id
             if (result.isDefined)
               // no package id and we do have the package, refresh if timeout
               if (cache.packagesShouldBeFetchedAgain) {
@@ -246,7 +246,7 @@ private class PackageService(
               logger.trace("no package id and we don’t have the package, always refresh")
               doReloadAndSearchAgain()
             }
-          } else {
+          case Ref.PackageRef.Id(packageId) =>
             if (result.isDefined) {
               logger.trace("package id defined & template id found, no refresh necessary")
               keep(result)
@@ -262,8 +262,7 @@ private class PackageService(
                 doReloadAndSearchAgain()
               }
             }
-          }: ET[ResultType]
-        }
+        }): ET[ResultType]
         _ = logger.trace(s"Final result: $finalResult")
       } yield finalResult
     }.run
@@ -275,7 +274,7 @@ private class PackageService(
         state.templateIdMap
           .toContractTypeRef(templateId)
           .map(_.latestPkgId)
-          .getOrElse(templateId)
+          .get
       \/-(
         typesig
           .TypeCon(
@@ -297,8 +296,8 @@ private class PackageService(
       f.map(_ => state.templateIdMap.allIds)
   }
 
-  val resolvePackageName: ResolvePackageName = templateId =>
-    state.packageNameMap.get(templateId).get._1
+  val resolvePackageName: ResolvePackageName = packageId =>
+    state.packageNameMap.get(Ref.PackageRef.Id(packageId)).get._1
 
   // See the above comment on resolveTemplateId
   def resolveChoiceArgType: ResolveChoiceArgType =
@@ -326,7 +325,8 @@ object PackageService {
 
   sealed abstract class ResolveContractTypeId {
     import ResolveContractTypeId.Overload
-    def apply[U, R <: ContractTypeId.Resolved](jwt: Jwt, ledgerId: LedgerApiDomain.LedgerId)(
+
+    def apply[U, R[T] <: ContractTypeId[T]](jwt: Jwt, ledgerId: LedgerApiDomain.LedgerId)(
         x: U with ContractTypeId.RequiredPkg
     )(implicit lc: LoggingContextOf[InstanceUUID], overload: Overload[U, R]): Future[
       PackageService.Error \/ Option[ContractTypeRef[R]]
@@ -334,20 +334,20 @@ object PackageService {
   }
 
   object ResolveContractTypeId {
-    sealed abstract class Overload[-Unresolved, +Resolved]
+    sealed abstract class Overload[-Unresolved, +Resolved[_]]
 
     import domain.{ContractTypeId => C}
 
     object Overload extends LowPriority {
-      implicit case object Template extends Overload[C.Template.RequiredPkg, C.Template.Resolved]
-      case object Top extends Overload[C.RequiredPkg, C.ResolvedId[C.Definite[String]]]
+      implicit case object Template extends Overload[C.Template.RequiredPkg, C.Template]
+      case object Top extends Overload[C.RequiredPkg, C.Definite]
     }
 
     // TODO #15293 if the request model has .Unknown included, then LowPriority and Top are
     // no longer needed and can be replaced with Overload.Unknown above
     sealed abstract class LowPriority { this: Overload.type =>
       // needs to be low priority so it doesn't win against Template
-      implicit def `fallback Top`: Overload[C.RequiredPkg, C.ResolvedId[C.Definite[String]]] = Top
+      implicit def `fallback Top`: Overload[C.RequiredPkg, C.Definite] = Top
     }
   }
 
@@ -360,7 +360,7 @@ object PackageService {
     ] => (
         Jwt,
         LedgerApiDomain.LedgerId,
-    ) => Future[Set[ContractTypeRef[ContractTypeId.Template.Resolved]]]
+    ) => Future[Set[ContractTypeRef[ContractTypeId.Template]]]
 
   type ResolveChoiceArgType =
     (
@@ -372,42 +372,40 @@ object PackageService {
     ContractTypeId.Template.RequiredPkg => Error \/ typesig.Type
 
   final case class ContractTypeIdMap[CtId[T] <: ContractTypeId[T]](
-      all: Map[RequiredPkg[CtId], ResolvedOf[CtId]],
-      nameIds: Map[Ref.PackageName, NonEmpty[Seq[String]]],
+      all: Map[CtId[Ref.PackageRef], ResolvedOf[CtId]],
+      nameIds: Map[Ref.PackageName, NonEmpty[Seq[Ref.PackageId]]],
       idNames: PackageNameMap,
   ) {
-    private[http] def toContractTypeRef[R <: ContractTypeId.Resolved](
-        id: R
-    ): Option[ContractTypeRef[R]] = {
+    private[http] def toContractTypeRef(
+        id: ContractTypeId.ResolvedOf[CtId]
+    ): Option[ContractTypeRef[CtId]] = {
       id.packageId match {
-        case s"#${name}" =>
+        case Ref.PackageRef.Name(pname) =>
           for {
-            pkgIdsForName <- nameIds.get(asPackageName(name))
+            pkgIdsForName <- nameIds.get(pname)
             pkgIdsForCtId <- NonEmpty.from(
-              pkgIdsForName.filter(pkgId =>
-                all.contains(id.copy(packageId = pkgId).asInstanceOf[RequiredPkg[CtId]])
-              )
+              pkgIdsForName.filter(pId => all.contains(id.copy(packageId = Ref.PackageRef.Id(pId))))
             )
-            (kpn, _) <- idNames.get(id.packageId)
+            (kpn, _) <- idNames.get(Ref.PackageRef.Name(pname))
           } yield ContractTypeRef(id, pkgIdsForCtId, kpn)
-        case _ =>
-          Some(ContractTypeRef.unnamed(id))
+        case Ref.PackageRef.Id(pid) =>
+          Some(ContractTypeRef.unnamed[CtId](id.copy(packageId = pid)))
       }
     }
 
-    def allIds: Set[ContractTypeRef[ResolvedOf[CtId]]] =
+    def allIds: Set[ContractTypeRef[CtId]] =
       all.values.flatMap { case id =>
         // If the package has a name, use the package name instead of package id.
         val useId = idNames
           .get(id.packageId)
           .flatMap { case (kpn, _) => kpn.toOption }
-          .fold(id)(name => id.copy(packageId = s"#${name}").asInstanceOf[ResolvedOf[CtId]])
+          .fold(id)(name => id.copy(packageId = Ref.PackageRef.Name(name)))
         toContractTypeRef(useId)
       }.toSet
 
     private[http] def resolve(
         a: ContractTypeId.RequiredPkg
-    )(implicit makeKey: ContractTypeId.Like[CtId]): Option[ContractTypeRef[ResolvedOf[CtId]]] =
+    )(implicit makeKey: ContractTypeId.Like[CtId]): Option[ContractTypeRef[CtId]] =
       (all get makeKey(a.packageId, a.moduleName, a.entityName)).flatMap(toContractTypeRef)
   }
 
@@ -415,7 +413,7 @@ object PackageService {
   private type InterfaceIdMap = ContractTypeIdMap[ContractTypeId.Interface]
 
   object TemplateIdMap {
-    def Empty[CtId[T] <: ContractTypeId[T]]: ContractTypeIdMap[CtId] =
+    def Empty[CtId[T] <: ContractTypeId.Definite[T]]: ContractTypeIdMap[CtId] =
       ContractTypeIdMap(Map.empty, Map.empty, PackageNameMap.empty)
   }
 
@@ -425,35 +423,33 @@ object PackageService {
 
   type KeyTypeMap = Map[ContractTypeId.Template.Resolved, typesig.Type]
 
-  type ResolvePackageName = String => KeyPackageName
+  type ResolvePackageName = Ref.PackageId => KeyPackageName
 
   case class PackageNameMap(
-      private val mapView: MapView[String, (KeyPackageName, Ref.PackageVersion)]
+      private val mapView: MapView[Ref.PackageRef, (KeyPackageName, Ref.PackageVersion)]
   ) {
-    def get(pkgId: String) = mapView.get(pkgId)
+    def get(pkgId: Ref.PackageRef) = mapView.get(pkgId)
   }
   object PackageNameMap {
     val empty = PackageNameMap(MapView.empty)
   }
 
-  private def asPackageName(name: String): Ref.PackageName = Ref.PackageName.assertFromString(name)
-
   private def buildPackageNameMap(packageStore: PackageStore): PackageNameMap = {
-    import com.daml.lf.language.LanguageVersion
-
-    // We make two entries per package: one by package id and another by package name.
-    def entries(pkgId: String, lv: LanguageVersion, m: typesig.PackageMetadata) =
-      List(
-        (pkgId, (KeyPackageName(Some(asPackageName(m.name)), lv), m.version)),
-        (s"#${m.name}", (KeyPackageName(Some(asPackageName(m.name)), lv), m.version)),
-      )
-
     PackageNameMap(
       packageStore.view
         .flatMap { case ((pkgId, p)) =>
-          p.metadata.toList.flatMap(entries(pkgId, p.languageVersion, _))
+          p.metadata.toList.flatMap { m =>
+            // We make two entries per package: one by package id and another by package name.
+            val pId = Ref.PackageId.assertFromString(pkgId)
+            val pName = Ref.PackageName.assertFromString(m.name)
+            val nameInfo = (KeyPackageName(Some(pName), p.languageVersion), m.version)
+            List(
+              (Ref.PackageRef.Id(pId), nameInfo),
+              (Ref.PackageRef.Name(pName), nameInfo),
+            )
+          }
         }
-        .toMap
+        .toMap[Ref.PackageRef, (KeyPackageName, Ref.PackageVersion)]
         .view
     )
   }
@@ -478,43 +474,47 @@ object PackageService {
 
   def buildTemplateIdMap[CtId[T] <: ContractTypeId.Definite[T] with ContractTypeId.Ops[CtId, T]](
       idName: PackageNameMap,
-      ids: Set[RequiredPkg[CtId]],
+      ids: Set[CtId[Ref.PackageId]],
   ): ContractTypeIdMap[CtId] = {
     import com.daml.nonempty.NonEmptyReturningOps._
-    val all = ids.view.map(k => (k, k)).toMap
+    val all: Map[CtId[Ref.PackageRef], ResolvedOf[CtId]] = ids.view.map { id =>
+      val k = id.copy(packageId = Ref.PackageRef.Id(id.packageId): Ref.PackageRef)
+      (k, k)
+    }.toMap
 
-    val idPkgNamePkgVer: Set[(RequiredPkg[CtId], Ref.PackageName, Ref.PackageVersion)] =
+    val idPkgNamePkgVer: Set[(CtId[Ref.PackageId], Ref.PackageName, Ref.PackageVersion)] =
       ids
         .flatMap { id =>
           idName
-            .get(id.packageId)
+            .get(Ref.PackageRef.Id(id.packageId))
             .flatMap { case (kpn, v) => kpn.toOption.map(nm => (id, nm, v)) }
         }
 
-    val nameIds = idPkgNamePkgVer
+    val nameIds: Map[Ref.PackageName, NonEmpty[Seq[Ref.PackageId]]] = idPkgNamePkgVer
       .groupBy1(_._2) // group by package name
       .map {
         case (name, idNameVers) => {
           // Sort the package ids by version, descending
-          val orderedPkgIds: NonEmpty[Seq[String]] = idNameVers
+          val orderedPkgIds: NonEmpty[Seq[Ref.PackageId]] = idNameVers
             .map { case (id, _, ver) => (id.packageId, ver) }
             .toSeq
-            .sorted(Ordering.by((pkgIdVer: (String, Ref.PackageVersion)) => pkgIdVer._2).reverse)
+            .sorted(
+              Ordering.by((pkgIdVer: (Ref.PackageId, Ref.PackageVersion)) => pkgIdVer._2).reverse
+            )
             .map(_._1)
           (name, orderedPkgIds)
         }
       }
       .toMap
 
-    val allByPkgName = idPkgNamePkgVer.map { case (id, name, _) =>
-      val idWithPkgName = id.copy(packageId = s"#${name.toString}")
-      (idWithPkgName, idWithPkgName)
+    val allByPkgName: Map[CtId[Ref.PackageRef], ResolvedOf[CtId]] = idPkgNamePkgVer.map {
+      case (id, name, _) =>
+        val idWithPkgName = id.copy(packageId = Ref.PackageRef.Name(name): Ref.PackageRef)
+        (idWithPkgName, idWithPkgName)
     }.toMap
 
     ContractTypeIdMap(all ++ allByPkgName, nameIds, idName)
   }
-
-  private type RequiredPkg[CtId[_]] = CtId[String]
 
   private def resolveChoiceArgType(
       choiceIdMap: ChoiceTypeMap
@@ -555,7 +555,7 @@ object PackageService {
       pkgId: Ref.PackageId,
       qn: Ref.QualifiedName,
   ): b.Resolved =
-    b(pkgId, qn.module.dottedName, qn.name.dottedName)
+    b(Ref.PackageRef.Id(pkgId): Ref.PackageRef, qn.module.dottedName, qn.name.dottedName)
 
   // TODO (Leo): merge getChoiceTypeMap and getKeyTypeMap, so we build them in one iteration over all templates
   private def getChoiceTypeMap(packageStore: PackageStore): ChoiceTypeMap =
@@ -631,7 +631,11 @@ object PackageService {
               .Template(_, typesig.DefTemplate(_, Some(keyType), _)),
           ) =>
         val templateId =
-          ContractTypeId.Template(interface.packageId, qn.module.dottedName, qn.name.dottedName)
+          ContractTypeId.Template(
+            Ref.PackageRef.Id(interface.packageId),
+            qn.module.dottedName,
+            qn.name.dottedName,
+          )
         (templateId, keyType)
     }
 }

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/PackageService.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/PackageService.scala
@@ -364,9 +364,9 @@ object PackageService {
 
   type ResolveChoiceArgType =
     (
-        ContractTypeId.Resolved,
+        ContractTypeId.ResolvedPkg,
         Choice,
-    ) => Error \/ (Option[ContractTypeId.Interface.Resolved], typesig.Type)
+    ) => Error \/ (Option[ContractTypeId.Interface.ResolvedPkg], typesig.Type)
 
   type ResolveKeyType =
     ContractTypeId.Template.RequiredPkg => Error \/ typesig.Type
@@ -417,11 +417,11 @@ object PackageService {
       ContractTypeIdMap(Map.empty, Map.empty, PackageNameMap.empty)
   }
 
-  private type ChoiceTypeMap = Map[ContractTypeId.Resolved, NonEmpty[
-    Map[Choice, NonEmpty[Map[Option[ContractTypeId.Interface.Resolved], typesig.Type]]]
+  private type ChoiceTypeMap = Map[ContractTypeId.ResolvedPkg, NonEmpty[
+    Map[Choice, NonEmpty[Map[Option[ContractTypeId.Interface.ResolvedPkg], typesig.Type]]]
   ]]
 
-  type KeyTypeMap = Map[ContractTypeId.Template.Resolved, typesig.Type]
+  type KeyTypeMap = Map[ContractTypeId.Template.ResolvedPkg, typesig.Type]
 
   type ResolvePackageName = Ref.PackageId => KeyPackageName
 
@@ -519,9 +519,9 @@ object PackageService {
   private def resolveChoiceArgType(
       choiceIdMap: ChoiceTypeMap
   )(
-      ctId: ContractTypeId.Resolved,
+      ctId: ContractTypeId.ResolvedPkg,
       choice: Choice,
-  ): Error \/ (Option[ContractTypeId.Interface.Resolved], typesig.Type) = {
+  ): Error \/ (Option[ContractTypeId.Interface.ResolvedPkg], typesig.Type) = {
     // TODO #14727 skip indirect resolution if ctId is an interface ID
     val resolution = for {
       choices <- choiceIdMap get ctId
@@ -546,7 +546,7 @@ object PackageService {
   private[this] def fromIdentifier[CtId[T] <: ContractTypeId.Definite[T]](
       b: ContractTypeId.Like[CtId],
       id: Ref.Identifier,
-  ): b.Resolved =
+  ): b.ResolvedPkg =
     fromQualifiedName(b, id.packageId, id.qualifiedName)
 
   // assert that the given identifier is resolved
@@ -554,7 +554,7 @@ object PackageService {
       b: ContractTypeId.Like[CtId],
       pkgId: Ref.PackageId,
       qn: Ref.QualifiedName,
-  ): b.Resolved =
+  ): b.ResolvedPkg =
     b(Ref.PackageRef.Id(pkgId): Ref.PackageRef, qn.module.dottedName, qn.name.dottedName)
 
   // TODO (Leo): merge getChoiceTypeMap and getKeyTypeMap, so we build them in one iteration over all templates
@@ -581,7 +581,7 @@ object PackageService {
     })
 
   private[this] type ChoicesByInterface[Ty] =
-    Map[Choice, NonEmpty[Map[Option[ContractTypeId.Interface.Resolved], Ty]]]
+    Map[Choice, NonEmpty[Map[Option[ContractTypeId.Interface.ResolvedPkg], Ty]]]
 
   private def getTChoices[Ty](
       choices: Map[Ref.ChoiceName, NonEmpty[
@@ -603,7 +603,7 @@ object PackageService {
       choices: Map[Ref.ChoiceName, typesig.TemplateChoice[Ty]]
   ): ChoicesByInterface[Ty] =
     choices.map { case (name, typesig.TemplateChoice(pTy, _, _)) =>
-      (Choice(name: String), NonEmpty(Map, none[ContractTypeId.Interface.Resolved] -> pTy))
+      (Choice(name: String), NonEmpty(Map, none[ContractTypeId.Interface.ResolvedPkg] -> pTy))
     }
 
   // flatten two levels of partiality into one
@@ -623,7 +623,7 @@ object PackageService {
 
   private def getKeys(
       interface: typesig.PackageSignature
-  ): Map[ContractTypeId.Template.Resolved, typesig.Type] =
+  ): Map[ContractTypeId.Template.ResolvedPkg, typesig.Type] =
     interface.typeDecls.collect {
       case (
             qn,

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -138,7 +138,7 @@ object ContractDao {
   def initialize(implicit log: LogHandler, sjd: SupportedJdbcDriver.TC): ConnectionIO[Unit] =
     sjd.q.queries.dropAllTablesIfExist *> sjd.q.queries.initDatabase
 
-  def lastOffset(parties: domain.PartySet, templateId: domain.ContractTypeId.RequiredPkg)(implicit
+  def lastOffset(parties: domain.PartySet, templateId: domain.ContractTypeId.RequiredPkgId)(implicit
       log: LogHandler,
       sjd: SupportedJdbcDriver.TC,
       lc: LoggingContextOf[InstanceUUID],
@@ -154,8 +154,10 @@ object ContractDao {
     }
   }
 
-  def oldestVisibleOffset(parties: domain.PartySet, templateId: domain.ContractTypeId.RequiredPkg)(
-      implicit
+  def oldestVisibleOffset(
+      parties: domain.PartySet,
+      templateId: domain.ContractTypeId.RequiredPkgId,
+  )(implicit
       log: LogHandler,
       sjd: SupportedJdbcDriver.TC,
       lc: LoggingContextOf[InstanceUUID],
@@ -184,7 +186,7 @@ object ContractDao {
     * @return Any template IDs that are lagging, and the offset to catch them up to, if defined;
     *         otherwise everything is fine.
     */
-  def laggingOffsets[CtId <: domain.ContractTypeId.RequiredPkg](
+  def laggingOffsets[CtId <: domain.ContractTypeId.RequiredPkgId](
       parties: Set[domain.Party],
       expectedOffset: domain.Offset,
       templateIds: NonEmpty[Set[CtId]],
@@ -283,7 +285,7 @@ object ContractDao {
 
   def updateOffset(
       parties: domain.PartySet,
-      templateId: domain.ContractTypeId.RequiredPkg,
+      templateId: domain.ContractTypeId.RequiredPkgId,
       newOffset: domain.Offset,
       lastOffsets: Map[domain.Party, domain.Offset],
   )(implicit
@@ -315,7 +317,7 @@ object ContractDao {
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   def selectContracts(
       parties: domain.PartySet,
-      templateIds: NonEmpty[Set[_ <: domain.ContractTypeId.Resolved]],
+      templateIds: NonEmpty[Set[_ <: domain.ContractTypeId.ResolvedPkgId]],
       predicate: doobie.Fragment,
   )(implicit
       log: LogHandler,
@@ -335,7 +337,7 @@ object ContractDao {
 
   private[http] def selectContractsMultiTemplate[Pos](
       parties: domain.PartySet,
-      predicates: NonEmpty[Seq[(domain.ContractTypeId.Resolved, doobie.Fragment)]],
+      predicates: NonEmpty[Seq[(domain.ContractTypeId.ResolvedPkgId, doobie.Fragment)]],
       trackMatchIndices: MatchedQueryMarker[Pos],
   )(implicit
       log: LogHandler,
@@ -388,7 +390,7 @@ object ContractDao {
     case object Unused extends MatchedQueryMarker[Unit]
   }
 
-  private def surrogateTemplateIds[CtId <: domain.ContractTypeId.RequiredPkg](
+  private def surrogateTemplateIds[CtId <: domain.ContractTypeId.RequiredPkgId](
       templateIds: NonEmpty[Set[_ <: CtId]]
   )(implicit
       log: LogHandler,
@@ -403,7 +405,7 @@ object ContractDao {
 
   private[http] def fetchById(
       parties: domain.PartySet,
-      templateIds: NonEmpty[Set[_ <: domain.ContractTypeId.Resolved]],
+      templateIds: NonEmpty[Set[_ <: domain.ContractTypeId.ResolvedPkgId]],
       contractId: domain.ContractId,
   )(implicit
       log: LogHandler,
@@ -423,7 +425,7 @@ object ContractDao {
 
   private[http] def fetchByKey(
       parties: domain.PartySet,
-      templateIds: NonEmpty[Set[_ <: domain.ContractTypeId.Template.Resolved]],
+      templateIds: NonEmpty[Set[_ <: domain.ContractTypeId.Template.ResolvedPkgId]],
       key: Hash,
   )(implicit
       log: LogHandler,
@@ -437,7 +439,7 @@ object ContractDao {
     } yield dbContracts.map(toDomain(tpIds))
   }
 
-  private[this] def surrogateTemplateId(templateId: domain.ContractTypeId.RequiredPkg)(implicit
+  private[this] def surrogateTemplateId(templateId: domain.ContractTypeId.RequiredPkgId)(implicit
       log: LogHandler,
       sjd: SupportedJdbcDriver.TC,
       lc: LoggingContextOf[InstanceUUID],
@@ -448,7 +450,7 @@ object ContractDao {
       templateId.entityName,
     )
 
-  private def toDomain[TpId](templateId: TpId => domain.ContractTypeId.Resolved)(
+  private def toDomain[TpId](templateId: TpId => domain.ContractTypeId.ResolvedPkgId)(
       a: Queries.DBContract[TpId, JsValue, JsValue, Vector[String]]
   ): domain.ActiveContract.ResolvedCtTyId[JsValue] =
     domain.ActiveContract(
@@ -468,7 +470,7 @@ object ContractDao {
 
   final case class StaleOffsetException(
       parties: domain.PartySet,
-      templateId: domain.ContractTypeId.RequiredPkg,
+      templateId: domain.ContractTypeId.RequiredPkgId,
       newOffset: domain.Offset,
       lastOffset: Map[domain.Party, domain.Offset],
   ) extends java.sql.SQLException(

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -457,14 +457,14 @@ package domain {
 
         override def lfType(
             fa: ActiveContract.ResolvedCtTyId[_],
-            templateId: ContractTypeId.Resolved,
+            templateId: ContractTypeId.ResolvedPkg,
             f: PackageService.ResolveTemplateRecordType,
             g: PackageService.ResolveChoiceArgType,
             h: PackageService.ResolveKeyType,
         ): Error \/ LfType =
           templateId match {
             case tid @ ContractTypeId.Template(_, _, _) =>
-              f(tid: ContractTypeId.Template.Resolved)
+              f(tid: ContractTypeId.Template.ResolvedPkg)
                 .leftMap(e => Error(Symbol("ActiveContract_hasTemplateId_lfType"), e.shows))
             case other =>
               val errorMsg = s"Expect contract type Id to be template Id, got otherwise: $other"
@@ -563,14 +563,14 @@ package domain {
 
         override def lfType(
             fa: EnrichedContractKey[_],
-            templateId: ContractTypeId.Resolved,
+            templateId: ContractTypeId.ResolvedPkg,
             f: PackageService.ResolveTemplateRecordType,
             g: PackageService.ResolveChoiceArgType,
             h: PackageService.ResolveKeyType,
         ): Error \/ LfType = {
           templateId match {
             case tid @ ContractTypeId.Template(_, _, _) =>
-              h(tid: ContractTypeId.Template.Resolved)
+              h(tid: ContractTypeId.Template.ResolvedPkg)
                 .leftMap(e => Error(Symbol("EnrichedContractKey_hasTemplateId_lfType"), e.shows))
             case other =>
               val errorMsg = s"Expect contract type Id to be template Id, got otherwise: $other"
@@ -602,7 +602,7 @@ package domain {
 
     def lfType(
         fa: F[_],
-        templateId: ContractTypeId.Resolved,
+        templateId: ContractTypeId.ResolvedPkg,
         f: PackageService.ResolveTemplateRecordType,
         g: PackageService.ResolveChoiceArgType,
         h: PackageService.ResolveKeyType,
@@ -626,7 +626,7 @@ package domain {
 
           override def lfType(
               fa: F[_],
-              templateId: ContractTypeId.Resolved,
+              templateId: ContractTypeId.ResolvedPkg,
               f: PackageService.ResolveTemplateRecordType,
               g: PackageService.ResolveChoiceArgType,
               h: PackageService.ResolveKeyType,
@@ -670,7 +670,7 @@ package domain {
     implicit val hasTemplateId: HasTemplateId.Aux[RequiredPkg[
       +*,
       domain.ContractLocator[_],
-    ], (Option[domain.ContractTypeId.Interface.Resolved], LfType)] =
+    ], (Option[domain.ContractTypeId.Interface.ResolvedPkg], LfType)] =
       new HasTemplateId[RequiredPkg[+*, domain.ContractLocator[_]]] {
         override def templateId(fab: FHuh): ContractTypeId.RequiredPkg =
           fab.choiceInterfaceId getOrElse (fab.reference match {
@@ -682,11 +682,11 @@ package domain {
               )
           })
 
-        type TypeFromCtId = (Option[domain.ContractTypeId.Interface.Resolved], LfType)
+        type TypeFromCtId = (Option[domain.ContractTypeId.Interface.ResolvedPkg], LfType)
 
         override def lfType(
             fa: FHuh,
-            templateId: ContractTypeId.Resolved,
+            templateId: ContractTypeId.ResolvedPkg,
             f: PackageService.ResolveTemplateRecordType,
             g: PackageService.ResolveChoiceArgType,
             h: PackageService.ResolveKeyType,

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonDecoder.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonDecoder.scala
@@ -268,8 +268,8 @@ class DomainJsonDecoder(
       ledgerId: LedgerApiDomain.LedgerId,
   ): ET[domain.LfType] =
     templateId_(id, jwt, ledgerId).flatMap {
-      case it: domain.ContractTypeId.Template.Resolved =>
-        either(resolveKeyType(it: ContractTypeId.Template.Resolved).liftErr(JsonError))
+      case it: domain.ContractTypeId.Template.ResolvedPkg =>
+        either(resolveKeyType(it: ContractTypeId.Template.ResolvedPkg).liftErr(JsonError))
       case other =>
         either(-\/(JsonError(s"Expect contract type Id to be template Id, got otherwise: $other")))
     }

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonDecoder.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonDecoder.scala
@@ -11,6 +11,7 @@ import com.daml.http.util.Logging.InstanceUUID
 import com.daml.http.{PackageService, domain}
 import com.daml.jwt.domain.Jwt
 import com.daml.ledger.api.{v1 => lav1}
+import com.daml.lf.data.Ref
 import com.daml.logging.LoggingContextOf
 import scalaz.std.option._
 import scalaz.syntax.bitraverse._
@@ -217,7 +218,7 @@ class DomainJsonDecoder(
   private[this] def resolveMetaTemplateIds[
       CtId[T] <: ContractTypeId[T] with ContractTypeId.Ops[CtId, T]
   ](
-      meta: domain.CommandMeta[CtId[String]],
+      meta: domain.CommandMeta[CtId[Ref.PackageRef]],
       jwt: Jwt,
       ledgerId: LedgerApiDomain.LedgerId,
   )(implicit
@@ -237,7 +238,7 @@ class DomainJsonDecoder(
   private def templateId_[
       CtId[T] <: ContractTypeId[T] with ContractTypeId.Ops[CtId, T]
   ](
-      id: CtId[String],
+      id: CtId[Ref.PackageRef],
       jwt: Jwt,
       ledgerId: LedgerApiDomain.LedgerId,
   )(implicit

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/query/ValuePredicate.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/query/ValuePredicate.scala
@@ -215,7 +215,7 @@ object ValuePredicate {
 
   private[http] def fromTemplateJsObject(
       it: Map[String, JsValue],
-      typ: domain.ContractTypeId.RequiredPkg,
+      typ: domain.ContractTypeId.RequiredPkgId,
       defs: TypeLookup,
   ): ValuePredicate =
     fromJsObject(

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/IdentifierConverters.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/IdentifierConverters.scala
@@ -25,10 +25,10 @@ object IdentifierConverters {
     )
   }
 
-  def lfIdentifier(a: http.domain.ContractTypeId.RequiredPkg): lf.data.Ref.Identifier = {
+  def lfIdentifier(a: http.domain.ContractTypeId.RequiredPkgId): lf.data.Ref.Identifier = {
     import lf.data.Ref
     Ref.Identifier(
-      Ref.PackageId.assertFromString(a.packageId),
+      a.packageId,
       Ref.QualifiedName(
         Ref.ModuleName.assertFromString(a.moduleName),
         Ref.DottedName.assertFromString(a.entityName),

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Transactions.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Transactions.scala
@@ -22,7 +22,7 @@ object Transactions {
   @deprecated("use AcsTxStreams.transactionFilter instead", since = "2.4.0")
   def transactionFilterFor(
       parties: PartySet,
-      contractTypeIds: List[ContractTypeId.Resolved],
+      contractTypeIds: List[ContractTypeId.ResolvedPkg],
   ): TransactionFilter =
     transactionFilter(parties, contractTypeIds)
 }

--- a/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/CommandServiceTest.scala
+++ b/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/CommandServiceTest.scala
@@ -84,7 +84,12 @@ object CommandServiceTest {
     readAs = multiPartyJwp.readAs,
     ledgerId = Some(multiPartyJwp.ledgerId.unwrap),
   )
-  private val tplId = domain.ContractTypeId.Template("Foo", "Bar", "Baz")
+  private val tplId =
+    domain.ContractTypeId.Template(
+      com.daml.lf.data.Ref.PackageRef.assertFromString("Foo"),
+      "Bar",
+      "Baz",
+    )
 
   implicit private val ignoredLoggingContext
       : LoggingContextOf[HLogging.InstanceUUID with HLogging.RequestID] =

--- a/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
+++ b/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
@@ -108,7 +108,7 @@ object Generators {
   def archivedContractGen: Gen[domain.ArchivedContract] =
     for {
       contractId <- contractIdGen
-      templateId <- Generators.genDomainTemplateIdO: Gen[domain.ContractTypeId.RequiredPkg]
+      templateId <- Generators.genDomainTemplateIdO: Gen[domain.ContractTypeId.RequiredPkgId]
     } yield domain.ArchivedContract(
       contractId = contractId,
       templateId = templateId,

--- a/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
+++ b/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
@@ -4,6 +4,7 @@
 package com.daml.http
 
 import com.daml.fetchcontracts.domain.ContractTypeId
+import com.daml.lf.data.Ref
 import com.daml.ledger.api.{v1 => lav1}
 import org.scalacheck.Gen
 import scalaz.{-\/, \/, \/-}
@@ -12,18 +13,16 @@ import spray.json.{JsNumber, JsObject, JsString, JsValue}
 object Generators {
   def genApiIdentifier: Gen[lav1.value.Identifier] =
     for {
-      p <- Gen.identifier
+      p <- genPkgIdentifier
       m <- Gen.identifier
       e <- Gen.identifier
     } yield lav1.value.Identifier(packageId = p, moduleName = m, entityName = e)
 
-  def genDomainTemplateId: Gen[domain.ContractTypeId.Template.RequiredPkg] =
-    genDomainContractTypeId[domain.ContractTypeId.Template]
+  def genDomainTemplateIdPkgId: Gen[domain.ContractTypeId.Template.RequiredPkgId] =
+    genDomainTemplateIdO[domain.ContractTypeId.Template, Ref.PackageId]
 
-  private def genDomainContractTypeId[CtId[T] <: domain.ContractTypeId[T]](implicit
-      CtId: domain.ContractTypeId.Like[CtId]
-  ): Gen[CtId.RequiredPkg] =
-    genApiIdentifier.map(CtId.fromLedgerApi)
+  def genDomainTemplateId: Gen[domain.ContractTypeId.Template.RequiredPkg] =
+    genDomainTemplateIdO[domain.ContractTypeId.Template, Ref.PackageRef]
 
   def genDomainTemplateIdO[CtId[T] <: domain.ContractTypeId[T], A](implicit
       CtId: domain.ContractTypeId.Like[CtId],
@@ -41,17 +40,27 @@ object Generators {
   def genDuplicateModuleEntityApiIdentifiers: Gen[Set[lav1.value.Identifier]] =
     for {
       id0 <- genApiIdentifier
-      otherPackageIds <- nonEmptySetOf(Gen.identifier.filter(x => x != id0.packageId))
+      otherPackageIds <- nonEmptySetOf(genPkgIdentifier.filter(x => x != id0.packageId))
     } yield Set(id0) ++ otherPackageIds.map(a => id0.copy(packageId = a))
 
-  def genDuplicateModuleEntityTemplateIds: Gen[Set[domain.ContractTypeId.Template.RequiredPkg]] =
+  def genDuplicateModuleEntityTemplateIds: Gen[Set[domain.ContractTypeId.Template.RequiredPkgId]] =
     genDuplicateModuleEntityApiIdentifiers.map(xs =>
       xs.map(domain.ContractTypeId.Template.fromLedgerApi)
     )
 
   final case class PackageIdGen[A](gen: Gen[A])
 
-  implicit val RequiredPackageIdGen: PackageIdGen[String] = PackageIdGen(Gen.identifier)
+  private val genPkgIdentifier = Gen.identifier.map(s => s.substring(0, 64 min s.length))
+
+  implicit val RequiredPackageIdGen: PackageIdGen[Ref.PackageId] = PackageIdGen(
+    genPkgIdentifier.map(Ref.PackageId.assertFromString)
+  )
+  implicit val RequiredPackageRefGen: PackageIdGen[Ref.PackageRef] = PackageIdGen(
+    Gen.oneOf(
+      genPkgIdentifier.map(s => Ref.PackageRef.Id(Ref.PackageId.assertFromString(s))),
+      genPkgIdentifier.map(s => Ref.PackageRef.Name(Ref.PackageName.assertFromString(s))),
+    )
+  )
 
   def contractIdGen: Gen[domain.ContractId] = domain.ContractId subst Gen.identifier
   def partyGen: Gen[domain.Party] = domain.Party subst Gen.identifier
@@ -61,7 +70,7 @@ object Generators {
 
   def inputContractRefGen[LfV](lfv: Gen[LfV]): Gen[domain.InputContractRef[LfV]] =
     scalazEitherGen(
-      Gen.zip(genDomainTemplateIdO[domain.ContractTypeId.Template, String], lfv),
+      Gen.zip(genDomainTemplateIdO[domain.ContractTypeId.Template, Ref.PackageRef], lfv),
       Gen.zip(
         Gen.option(genDomainTemplateIdO: Gen[domain.ContractTypeId.RequiredPkg]),
         contractIdGen,
@@ -78,15 +87,15 @@ object Generators {
     for {
       contractId <- contractIdGen
       templateId <- Gen.oneOf(
-        genDomainTemplateIdO[domain.ContractTypeId.Template, String],
-        genDomainTemplateIdO[domain.ContractTypeId.Interface, String],
+        genDomainTemplateIdO[domain.ContractTypeId.Template, Ref.PackageId],
+        genDomainTemplateIdO[domain.ContractTypeId.Interface, Ref.PackageId],
       )
       key <- Gen.option(Gen.identifier.map(JsString(_)))
       argument <- Gen.identifier.map(JsString(_))
       signatories <- Gen.listOf(partyGen)
       observers <- Gen.listOf(partyGen)
       agreementText <- Gen.identifier
-    } yield domain.ActiveContract[ContractTypeId.Resolved, JsValue](
+    } yield domain.ActiveContract[ContractTypeId.ResolvedPkgId, JsValue](
       contractId = contractId,
       templateId = templateId,
       key = key,
@@ -99,7 +108,7 @@ object Generators {
   def archivedContractGen: Gen[domain.ArchivedContract] =
     for {
       contractId <- contractIdGen
-      templateId <- Generators.genDomainTemplateId
+      templateId <- Generators.genDomainTemplateIdO: Gen[domain.ContractTypeId.RequiredPkg]
     } yield domain.ArchivedContract(
       contractId = contractId,
       templateId = templateId,
@@ -110,7 +119,7 @@ object Generators {
 
   def enrichedContractKeyGen: Gen[domain.EnrichedContractKey[JsObject]] =
     for {
-      templateId <- genDomainTemplateIdO[domain.ContractTypeId.Template, String]
+      templateId <- genDomainTemplateIdO[domain.ContractTypeId.Template, Ref.PackageRef]
       key <- genJsObj
     } yield domain.EnrichedContractKey(templateId, key)
 

--- a/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/PackageServiceTest.scala
+++ b/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/PackageServiceTest.scala
@@ -4,7 +4,7 @@
 package com.daml.http
 
 import com.daml.http.Generators.{
-  genDomainTemplateId,
+  genDomainTemplateIdPkgId,
   genDuplicateModuleEntityTemplateIds,
   nonEmptySetOf,
 }
@@ -25,6 +25,10 @@ class PackageServiceTest
     with ScalaCheckDrivenPropertyChecks {
 
   import Shrink.shrinkAny
+  import domain.ContractTypeId.withPkgRef
+
+  def pkgRefName(s: String): Ref.PackageRef =
+    Ref.PackageRef.Name(Ref.PackageName.assertFromString(s))
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 100)
@@ -35,43 +39,44 @@ class PackageServiceTest
       val id0 = domain.ContractTypeId.Template.fromLedgerApi(lav1.value.Identifier("a", "f4", "x"))
       val id1 = domain.ContractTypeId.Template.fromLedgerApi(lav1.value.Identifier("b", "f4", "x"))
       val map = PackageService.buildTemplateIdMap(noPackageNames, Set(id0, id1))
-      map.all.keySet shouldBe Set(id0, id1)
+      map.all.keySet shouldBe Set(id0, id1).map(withPkgRef)
     }
 
     "TemplateIdMap.all should contain dups and unique identifiers" in
       forAll(
-        nonEmptySetOf(genDomainTemplateId),
+        nonEmptySetOf(genDomainTemplateIdPkgId),
         genDuplicateModuleEntityTemplateIds,
       ) { (xs, dups) =>
         val map = PackageService.buildTemplateIdMap(noPackageNames, (xs ++ dups))
-        map.all.keySet should ===(xs ++ dups)
-        map.all.keySet should contain allElementsOf dups
-        map.all.keySet should contain allElementsOf xs
+        map.all.keySet should ===((xs ++ dups).map(withPkgRef))
+        map.all.keySet should contain allElementsOf dups.map(withPkgRef)
+        map.all.keySet should contain allElementsOf xs.map(withPkgRef)
       }
   }
 
   "PackageService.resolveContractTypeId" - {
 
-    "should resolve fully qualified Template ID" in forAll(nonEmptySetOf(genDomainTemplateId)) {
-      ids =>
-        val map = PackageService.buildTemplateIdMap(noPackageNames, ids)
-        ids.foreach { id =>
-          val unresolvedId: domain.ContractTypeId.Template.RequiredPkg = id
-          val Some(resolved) = map resolve unresolvedId
-          resolved.original shouldBe id
-          resolved.latestPkgId shouldBe id
-          resolved.allPkgIds shouldBe Set(id)
-        }
+    "should resolve fully qualified Template ID" in forAll(
+      nonEmptySetOf(genDomainTemplateIdPkgId)
+    ) { ids =>
+      val map = PackageService.buildTemplateIdMap(noPackageNames, ids)
+      ids.foreach { id =>
+        val unresolvedId: domain.ContractTypeId.Template.RequiredPkg = withPkgRef(id)
+        val Some(resolved) = map resolve unresolvedId
+        resolved.original shouldBe withPkgRef(id)
+        resolved.latestPkgId shouldBe id
+        resolved.allPkgIds shouldBe Set(id)
+      }
     }
 
     "should resolve by package name when single package id" in forAll(
-      nonEmptySetOf(genDomainTemplateId)
+      nonEmptySetOf(genDomainTemplateIdPkgId)
     ) { ids =>
       def pkgNameForPkgId(pkgId: String) = pkgId + "_name"
       val idName = buildPackageNameMap(pkgNameForPkgId)(ids) // package_id:package_name is 1:1
       val map = PackageService.buildTemplateIdMap(idName, ids)
       ids.foreach { id =>
-        val pkgName = "#" + pkgNameForPkgId(id.packageId)
+        val pkgName = pkgRefName(pkgNameForPkgId(id.packageId))
         val unresolvedId: domain.ContractTypeId.Template.RequiredPkg = id.copy(packageId = pkgName)
         val Some(resolved) = map resolve unresolvedId
         resolved.original shouldBe id.copy(packageId = pkgName)
@@ -87,9 +92,10 @@ class PackageServiceTest
       val idWithMaxVer = ids.maxBy(id => packageVersionForId(id.packageId))
       val map = PackageService.buildTemplateIdMap(idName, ids)
       ids.foreach { id =>
-        val unresolvedId: domain.ContractTypeId.Template.RequiredPkg = id.copy(packageId = "#foo")
+        val unresolvedId: domain.ContractTypeId.Template.RequiredPkg =
+          id.copy(packageId = pkgRefName("foo"))
         val Some(resolved) = map resolve unresolvedId
-        resolved.original shouldBe id.copy(packageId = "#foo")
+        resolved.original shouldBe id.copy(packageId = pkgRefName("foo"))
         resolved.latestPkgId shouldBe idWithMaxVer
         resolved.allPkgIds shouldBe ids
       }
@@ -98,24 +104,24 @@ class PackageServiceTest
     "should return None for unknown Template ID" in forAll(
       Generators.genDomainTemplateIdO: org.scalacheck.Gen[domain.ContractTypeId.RequiredPkg]
     ) { templateId: domain.ContractTypeId.RequiredPkg =>
-      val map = TemplateIdMap.Empty[domain.ContractTypeId]
+      val map = TemplateIdMap.Empty[domain.ContractTypeId.Template]
       map resolve templateId shouldBe None
     }
   }
 
   "PackageService.allTemplateIds" - {
     "when no package names, should resolve to input ids" in forAll(
-      nonEmptySetOf(genDomainTemplateId)
+      nonEmptySetOf(genDomainTemplateIdPkgId)
     ) { ids =>
       val map = PackageService.buildTemplateIdMap(noPackageNames, ids)
       map.allIds.size shouldBe ids.size
-      map.allIds.map(_.original) shouldBe ids
+      map.allIds.map(_.original) shouldBe ids.map(withPkgRef)
       map.allIds.map(_.latestPkgId) shouldBe ids
       map.allIds.flatMap(_.allPkgIds) shouldBe ids
     }
 
     "when has single package name per package id, each has has its own item" in forAll(
-      nonEmptySetOf(genDomainTemplateId)
+      nonEmptySetOf(genDomainTemplateIdPkgId)
     ) { ids =>
       def pkgNameForPkgId(pkgId: String) = pkgId + "_name"
       val idName = buildPackageNameMap(pkgNameForPkgId)(ids) // package_id:package_name is 1:1
@@ -123,7 +129,7 @@ class PackageServiceTest
 
       map.allIds.size shouldBe ids.size
       map.allIds.map(_.original) shouldBe ids.map { id =>
-        id.copy(packageId = s"#${pkgNameForPkgId(id.packageId)}")
+        id.copy(packageId = pkgRefName(pkgNameForPkgId(id.packageId)))
       }
       map.allIds.map(_.latestPkgId) shouldBe ids
       map.allIds.map(_.allPkgIds) shouldBe ids.map(Set(_))
@@ -137,7 +143,7 @@ class PackageServiceTest
       val map = PackageService.buildTemplateIdMap(idName, ids)
 
       map.allIds.size shouldBe 1
-      map.allIds.head.original shouldBe ids.head.copy(packageId = "#foo")
+      map.allIds.head.original shouldBe ids.head.copy(packageId = pkgRefName("foo"))
       map.allIds.head.latestPkgId shouldBe idWithMaxVer
       map.allIds.head.allPkgIds shouldBe ids
     }
@@ -150,19 +156,19 @@ class PackageServiceTest
 
   private def buildPackageNameMap(
       pkgNameForPkgId: (String => String)
-  )(ids: Set[_ <: domain.ContractTypeId.RequiredPkg]): PackageService.PackageNameMap = {
+  )(ids: Set[_ <: domain.ContractTypeId.RequiredPkgId]): PackageService.PackageNameMap = {
     import com.daml.lf.crypto.Hash.KeyPackageName
     import com.daml.lf.language.LanguageVersion
     PackageService.PackageNameMap(
       ids
-        .flatMap((id: domain.ContractTypeId.RequiredPkg) => {
-          val pkgName = pkgNameForPkgId(id.packageId)
+        .flatMap((id: domain.ContractTypeId.RequiredPkgId) => {
+          val pkgName = Ref.PackageName.assertFromString(pkgNameForPkgId(id.packageId.toString))
           val pkgVersion = packageVersionForId(id.packageId)
           val kpn =
-            KeyPackageName(Some(Ref.PackageName.assertFromString(pkgName)), LanguageVersion.v1_dev)
+            KeyPackageName(Some(pkgName), LanguageVersion.v1_dev)
           Set(
-            (id.packageId, (kpn, pkgVersion)),
-            ("#" + pkgName, (kpn, pkgVersion)),
+            (Ref.PackageRef.Id(id.packageId), (kpn, pkgVersion)),
+            (Ref.PackageRef.Name(pkgName), (kpn, pkgVersion)),
           )
         })
         .toMap

--- a/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
+++ b/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
@@ -10,7 +10,6 @@ import com.daml.http.Generators.{
   contractLocatorGen,
   exerciseCmdGen,
   genDomainTemplateId,
-  genDomainTemplateIdO,
   genServiceWarning,
   genUnknownParties,
   genUnknownTemplateIds,
@@ -147,7 +146,7 @@ class JsonProtocolTest
   }
 
   "domain.OkResponse" - {
-    "response with warnings" in forAll(listOf(genDomainTemplateIdO)) {
+    "response with warnings" in forAll(listOf(genDomainTemplateId)) {
       templateIds: List[domain.ContractTypeId.RequiredPkg] =>
         val response: domain.OkResponse[Int] =
           domain.OkResponse(result = 100, warnings = Some(domain.UnknownTemplateIds(templateIds)))
@@ -188,7 +187,7 @@ class JsonProtocolTest
       inside(decode1[domain.SyncResponse, List[JsValue]](str)) {
         case \/-(domain.OkResponse(List(), Some(warning), StatusCodes.OK)) =>
           warning shouldBe domain.UnknownTemplateIds(
-            List(domain.ContractTypeId("ZZZ", "AAA", "BBB"))
+            List(domain.ContractTypeId(Ref.PackageRef.assertFromString("ZZZ"), "AAA", "BBB"))
           )
       }
     }
@@ -273,7 +272,8 @@ class JsonProtocolTest
       val utf8 = java.nio.charset.Charset forName "UTF-8"
       val expected = DisclosedContract(
         contractId = domain.ContractId("abcd"),
-        templateId = domain.ContractTypeId.Template("Pkg", "Mod", "Tmpl"),
+        templateId =
+          domain.ContractTypeId.Template(Ref.PackageRef.assertFromString("Pkg"), "Mod", "Tmpl"),
         createdEventBlob = domain.Base64(ByteString.copyFrom("some create event payload", utf8)),
       )
       val encoded =


### PR DESCRIPTION
A template/interface id (`ContractTypeId`) consists of three parts: package, module and entity.

So far the package portion has been modeled with a `String`, where that string could represent either a package name or a package id, depending on whether it started with a `"#"` prefix or not, respectively. However there are parts of the code, namely those that deal with the db cache, that are designed to work with contract type ids whose package portion is only a *package id*. The type system was not helping us to ensure this so far.

Fortunately the `ContractTypeId` class is parameterised with the type of the package, so this PR replaces all existing instantiations which used `String` packages, with either [PackageId](https://github.com/digital-asset/daml/blob/7ffc096fa857700fe510c41f299c7ce06f5bbb4f/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala#L37) or [PackageRef](https://github.com/digital-asset/daml/blob/7ffc096fa857700fe510c41f299c7ce06f5bbb4f/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala#L292) (which is a sum type which can contain either a `PackageId` or a `PackageName`).

The `ContractTypeRef` type contains all the package info we have about a contract type id. Its `original` field now returns a `ContractTypeId[PackageRef]`, whereas its `latestPkgId` returns a `ContractTypeId[PackageId]`. This helps us to ensure that we are passing around the right kind of package specifiers to the parts of the code that need one or the other.

There are some type aliases used, that may be useful to help read and understand the changes, which tend to look like
```
   type RequiredPkg = CtId[Ref.PackageRef]
   type RequiredPkgId = CtId[Ref.PackageId]
```
i.e. if it ends with Pkg it uses a `PackgeRef` and if it ends with PkgId uses a `PackageId`. 
Note also that the `Resolved` terminology is an orthogonal concern which refers to whether this id has been determined to belong to a template vs interface (i.e. it extends `Definite`), or whether that is not yet known.