### PR TITLE
Sw/daml script 2.9 changes 2.x

### DIFF
--- a/sdk/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/sdk/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -561,6 +561,9 @@ expandSdkPackages logger lfVersion dars = do
     expand mbSdkPath fp
       | fp `elem` basePackages = pure fp
       | isSdkPackage fp = case mbSdkPath of
+            Just sdkPath | fp == "daml-script-beta" -> do
+              Logger.logWarning logger "daml-script-beta is unstable and may change without warning. Use at your own risk."
+              pure $ sdkPath </> "daml-libs" </> "daml3-script" <> sdkSuffix <.> "dar"
             Just sdkPath -> do
               when (fp == "daml3-script")
                 $ Logger.logWarning logger

--- a/sdk/daml-script/daml3/Daml/Script.daml
+++ b/sdk/daml-script/daml3/Daml/Script.daml
@@ -102,6 +102,7 @@ module Daml.Script
   , listUserRightsOn
   , submitUser
   , submitUserOn
+  , tryToEither
   ) where
 
 import Daml.Script.Internal.LowLevel

--- a/sdk/daml-script/daml3/Daml/Script.daml
+++ b/sdk/daml-script/daml3/Daml/Script.daml
@@ -5,7 +5,9 @@ module Daml.Script
 
   -- Main submits
   , submit
+  , submitWithOptions
   , submitMustFail
+  , submitMustFailWithOptions
   , submitResultAndTree
   , submitTree
   , submitWithError

--- a/sdk/daml-script/daml3/Daml/Script/Internal.daml
+++ b/sdk/daml-script/daml3/Daml/Script/Internal.daml
@@ -24,6 +24,10 @@ module Daml.Script.Internal
   , unvetDarOnParticipant
   , unsafeUnvetDarOnParticipant
 
+  , -- Upgrades EA features
+    PackageId (..)  
+  , packagePreference
+
   , -- Concurrent submit
     concurrently
   , trySubmitConcurrently

--- a/sdk/daml-script/daml3/Daml/Script/Internal.daml
+++ b/sdk/daml-script/daml3/Daml/Script/Internal.daml
@@ -28,9 +28,7 @@ module Daml.Script.Internal
     concurrently
   , trySubmitConcurrently
 
-  , -- Exceptions
-    -- TODO: consider exposing this normally.
-    tryToEither
+    -- Exceptions
   , throwAnyException
 
   , -- Internal submit error

--- a/sdk/daml-script/daml3/Daml/Script/Internal/Questions/Exceptions.daml
+++ b/sdk/daml-script/daml3/Daml/Script/Internal/Questions/Exceptions.daml
@@ -16,6 +16,10 @@ data Catch = Catch with
   dummy : ()
 instance IsQuestion Catch (Either AnyException x) where command = "Catch"
 
+-- | Named version of the `try catch` behaviour of Daml-Script.
+-- Note that this is no more powerful than `try catch` in daml-script, and will not catch exceptions in submissions.
+-- (Use `trySubmit` for this)
+-- Input computation is deferred to catch pure exceptions
 tryToEither : forall t. (() -> Script t) -> Script (Either AnyException t)
 tryToEither act = lift Catch with
   act = \() -> toLedgerValue $ act ()

--- a/sdk/daml-script/daml3/Daml/Script/Internal/Questions/Submit.daml
+++ b/sdk/daml-script/daml3/Daml/Script/Internal/Questions/Submit.daml
@@ -62,7 +62,7 @@ instance Semigroup SubmitOptions where
 -- Set Party
 -- Optional Party
 -- ```
-actAs : IsParties p => p -> SubmitOptions
+actAs : IsParties parties => parties -> SubmitOptions
 actAs p = SubmitOptions (toParties p) [] []
 
 -- | Builds a SubmitOptions with given readAs parties.
@@ -75,7 +75,7 @@ actAs p = SubmitOptions (toParties p) [] []
 -- Set Party
 -- Optional Party
 -- ```
-readAs : IsParties p => p -> SubmitOptions
+readAs : IsParties parties => parties -> SubmitOptions
 readAs p = SubmitOptions [] (toParties p) []
 
 -- | Provides many Explicit Disclosures to the transaction.
@@ -87,8 +87,8 @@ disclose : Disclosure -> SubmitOptions
 disclose d = discloseMany [d]
 
 -- | Defines a type that can be transformed into a SubmitOptions
-class IsSubmitOptions a where
-  toSubmitOptions : a -> SubmitOptions
+class IsSubmitOptions options where
+  toSubmitOptions : options -> SubmitOptions
 
 instance IsSubmitOptions SubmitOptions where
   toSubmitOptions = identity
@@ -132,13 +132,24 @@ actAsNonEmpty ps = case ps of
 -- | Allows for concurrent submission of transactions, using an applicative, similar to Commands.
 -- Concurrently takes a computation in `ConcurrentSubmits`, which supports all the existing `submitWithOptions` functions
 -- that `Script` supports. It however does not implement `Action`, and thus does not support true binding and computation interdependence
+-- NOTE: The submission order of transactions within `concurrently` is deterministic, this function is not intended to test contention.
+-- It is only intended to allow faster submission of many unrelated transactions, by not waiting for completion for each transaction before
+-- sending the next.
+-- Example:
+-- ```
+-- exerciseResult <- concurrently $ do
+--   alice `submit` createCmd ...
+--   res <- alice `submit` exerciseCmd ...
+--   bob `submit` createCmd ...
+--   pure res
+-- ```
 concurrently : HasCallStack => ConcurrentSubmits a -> Script a
 concurrently submissions = fmap submissions.continue $ lift $ Submit with
   submissions = submissions.submits
 
 -- | Defines an applicative that can run transaction submissions. Usually this is simply `Script`.
-class Applicative m => ScriptSubmit m where
-  liftSubmission : HasCallStack => ConcurrentSubmits a -> m a
+class Applicative script => ScriptSubmit script where
+  liftSubmission : HasCallStack => ConcurrentSubmits a -> script a
 
 instance ScriptSubmit ConcurrentSubmits where
   liftSubmission : HasCallStack => ConcurrentSubmits a -> ConcurrentSubmits a
@@ -148,7 +159,7 @@ instance ScriptSubmit Script where
   liftSubmission : HasCallStack => ConcurrentSubmits a -> Script a
   liftSubmission = concurrently
 
-submitInternal : (HasCallStack, ScriptSubmit m) => SubmitOptions -> ErrorBehaviour -> Commands a -> m (Either SubmitError (a, TransactionTree))
+submitInternal : (HasCallStack, ScriptSubmit script) => SubmitOptions -> ErrorBehaviour -> Commands a -> script (Either SubmitError (a, TransactionTree))
 submitInternal opts errorBehaviour cmds = liftSubmission $ ConcurrentSubmits with
   submits =
     [ Submission with
@@ -177,44 +188,47 @@ mustFail = \case
 
 -- ##### Main API #####
 -- | Equivalent to `submitWithOptions` but returns the result and the full transaction tree.
-submitResultAndTree : (HasCallStack, ScriptSubmit m, IsSubmitOptions o) => o -> Commands a -> m (a, TransactionTree)
+submitResultAndTree : (HasCallStack, ScriptSubmit script, IsSubmitOptions options) => options -> Commands a -> script (a, TransactionTree)
 submitResultAndTree opts cmds = mustSucceed <$> submitInternal (toSubmitOptions opts) MustSucceed cmds
 
 -- | Equivalent to `trySubmit` but returns the result and the full transaction tree.
-trySubmitResultAndTree : (HasCallStack, ScriptSubmit m, IsSubmitOptions o) => o -> Commands a -> m (Either SubmitError (a, TransactionTree))
+trySubmitResultAndTree : (HasCallStack, ScriptSubmit script, IsSubmitOptions options) => options -> Commands a -> script (Either SubmitError (a, TransactionTree))
 trySubmitResultAndTree opts cmds = submitInternal (toSubmitOptions opts) Try cmds
 
 -- | Equivalent to `submitMustFailWithOptions` but returns the error thrown.
-submitWithError : (HasCallStack, ScriptSubmit m, IsSubmitOptions o) => o -> Commands a -> m SubmitError
+submitWithError : (HasCallStack, ScriptSubmit script, IsSubmitOptions options) => options -> Commands a -> script SubmitError
 submitWithError opts cmds = mustFail <$> submitInternal (toSubmitOptions opts) MustFail cmds
 
 -- | `submitWithOptions p cmds` submits the commands `cmds` as a single transaction
 -- from party `p` and returns the value returned by `cmds`.
+-- The `options` field can either be any "Parties" like type (See `IsParties`) or `SubmitOptions`
+-- which allows for finer control over parameters of the submission.
 --
 -- If the transaction fails, `submitWithOptions` also fails.
 -- Will be renammed to `submit` in Daml 3
-submitWithOptions : (HasCallStack, ScriptSubmit m, IsSubmitOptions o) => o -> Commands a -> m a
+submitWithOptions : (HasCallStack, ScriptSubmit script, IsSubmitOptions options) => options -> Commands a -> script a
 submitWithOptions opts cmds = fst <$> submitResultAndTree opts cmds
 
 -- | Equivalent to `submitWithOptions` but returns the full transaction tree.
-submitTree : (HasCallStack, ScriptSubmit m, IsSubmitOptions o) => o -> Commands a -> m TransactionTree
+submitTree : (HasCallStack, ScriptSubmit script, IsSubmitOptions options) => options -> Commands a -> script TransactionTree
 submitTree opts cmds = snd <$> submitResultAndTree opts cmds
 
 -- | Submit a transaction and recieve back either the result, or a `SubmitError`.
 -- In the majority of failures, this will not crash at runtime.
-trySubmit : (HasCallStack, ScriptSubmit m, IsSubmitOptions o) => o -> Commands a -> m (Either SubmitError a)
+trySubmit : (HasCallStack, ScriptSubmit script, IsSubmitOptions options) => options -> Commands a -> script (Either SubmitError a)
 trySubmit opts cmds = fmap fst <$> trySubmitResultAndTree opts cmds
 
 -- | Equivalent to `trySubmit` but returns the full transaction tree.
-trySubmitTree : (HasCallStack, ScriptSubmit m, IsSubmitOptions o) => o -> Commands a -> m (Either SubmitError TransactionTree)
+trySubmitTree : (HasCallStack, ScriptSubmit script, IsSubmitOptions options) => options -> Commands a -> script (Either SubmitError TransactionTree)
 trySubmitTree opts cmds = fmap snd <$> trySubmitResultAndTree opts cmds
 
 -- | `submitMustFailWithOptions p cmds` submits the commands `cmds` as a single transaction
 -- from party `p`.
+-- See submitWithOptions for details on the `options` field
 --
 -- It only succeeds if the submitting the transaction fails.
 -- Will be renamed to `submitMustFail` in Daml 3
-submitMustFailWithOptions : (HasCallStack, ScriptSubmit m, IsSubmitOptions o) => o -> Commands a -> m ()
+submitMustFailWithOptions : (HasCallStack, ScriptSubmit script, IsSubmitOptions options) => options -> Commands a -> script ()
 submitMustFailWithOptions opts cmds = void $ submitWithError opts cmds
 
 -- ##### Old compatibility conveniences #####
@@ -225,7 +239,7 @@ submitMustFailWithOptions opts cmds = void $ submitWithError opts cmds
 -- 
 -- Note: This behaviour can be achieved using `submitWithOptions (actAs actors <> readAs readers) cmds`
 -- and is only provided for backwards compatibility.
-submitMulti : (HasCallStack, ScriptSubmit m) => [Party] -> [Party] -> Commands a -> m a
+submitMulti : (HasCallStack, ScriptSubmit script) => [Party] -> [Party] -> Commands a -> script a
 submitMulti actors readers cmds = submitWithOptions (actAs actors <> readAs readers) cmds
 
 -- | `submitMultiMustFail actAs readAs cmds` behaves like `submitMulti actAs readAs cmds`
@@ -233,21 +247,21 @@ submitMulti actors readers cmds = submitWithOptions (actAs actors <> readAs read
 --
 -- Note: This behaviour can be achieved using `submitMustFailWithOptions (actAs actors <> readAs readers) cmds`
 -- and is only provided for backwards compatibility.
-submitMultiMustFail : (HasCallStack, ScriptSubmit m) => [Party] -> [Party] -> Commands a -> m ()
+submitMultiMustFail : (HasCallStack, ScriptSubmit script) => [Party] -> [Party] -> Commands a -> script ()
 submitMultiMustFail actors readers cmds = submitMustFailWithOptions (actAs actors <> readAs readers) cmds
 
 -- | Equivalent to `submitMulti` but returns the full transaction tree.
 -- 
 -- Note: This behaviour can be achieved using `submitTree (actAs actors <> readAs readers) cmds`
 -- and is only provided for backwards compatibility.
-submitTreeMulti : (HasCallStack, ScriptSubmit m) => [Party] -> [Party] -> Commands a -> m TransactionTree
+submitTreeMulti : (HasCallStack, ScriptSubmit script) => [Party] -> [Party] -> Commands a -> script TransactionTree
 submitTreeMulti actors readers cmds = submitTree (actAs actors <> readAs readers) cmds
 
 -- | Alternate version of `trySubmit` that allows specifying the actAs and readAs parties.
 -- 
 -- Note: This behaviour can be achieved using `trySubmit (actAs actors <> readAs readers) cmds`
 -- and is only provided for backwards compatibility.
-trySubmitMulti : (HasCallStack, ScriptSubmit m) => [Party] -> [Party] -> Commands a -> m (Either SubmitError a)
+trySubmitMulti : (HasCallStack, ScriptSubmit script) => [Party] -> [Party] -> Commands a -> script (Either SubmitError a)
 trySubmitMulti actors readers cmds = trySubmit (actAs actors <> readAs readers) cmds
 
 -- #### Provided for testing for now, likely to be removed #####

--- a/sdk/daml-script/daml3/Daml/Script/Internal/Questions/Submit.daml
+++ b/sdk/daml-script/daml3/Daml/Script/Internal/Questions/Submit.daml
@@ -26,11 +26,15 @@ data Submission = Submission with
   sActAs : NonEmpty Party
   sReadAs : [Party]
   sDisclosures : [Disclosure]
+  sPackagePreference : Optional [PackageId]
   sErrorBehaviour : ErrorBehaviour
   sCommands : [CommandWithMeta]
   sLocation : Optional (Text, SrcLoc)
 
 data ErrorBehaviour = MustSucceed | MustFail | Try
+
+-- | HIDE Package-id newtype for package preference
+newtype PackageId = PackageId Text deriving (Show, Eq)
 
 -- | Options to detemine the stakeholders of a transaction, as well as disclosures.
 -- Intended to be specified using the `actAs`, `readAs` and `disclose` builders, combined using the Semigroup concat `(<>)` operator.
@@ -47,10 +51,17 @@ data SubmitOptions = SubmitOptions with
   soActAs : [Party]
   soReadAs : [Party]
   soDisclosures : [Disclosure]
+  soPackagePreference : Optional [PackageId]
+
+-- Optional doesn't have Semigroup instance?
+combineOptional : Semigroup a => Optional a -> Optional a -> Optional a
+combineOptional (Some a) (Some b) = Some (a <> b)
+combineOptional None r = r
+combineOptional l _ = l
 
 -- | Semigroup instance allowing for combination via (<>)
 instance Semigroup SubmitOptions where
-  SubmitOptions a b c <> SubmitOptions a' b' c' = SubmitOptions (a <> a') (b <> b') (c <> c')
+  SubmitOptions a b c d <> SubmitOptions a' b' c' d' = SubmitOptions (a <> a') (b <> b') (c <> c') (d `combineOptional` d')
 
 -- | Builds a SubmitOptions with given actAs parties.
 -- Any given submission must include at least one actAs party.
@@ -63,7 +74,7 @@ instance Semigroup SubmitOptions where
 -- Optional Party
 -- ```
 actAs : IsParties parties => parties -> SubmitOptions
-actAs p = SubmitOptions (toParties p) [] []
+actAs p = SubmitOptions (toParties p) [] [] None
 
 -- | Builds a SubmitOptions with given readAs parties.
 -- A given submission may omit any readAs parties and still be valid.
@@ -76,15 +87,19 @@ actAs p = SubmitOptions (toParties p) [] []
 -- Optional Party
 -- ```
 readAs : IsParties parties => parties -> SubmitOptions
-readAs p = SubmitOptions [] (toParties p) []
+readAs p = SubmitOptions [] (toParties p) [] None
 
 -- | Provides many Explicit Disclosures to the transaction.
 discloseMany : [Disclosure] -> SubmitOptions
-discloseMany ds = SubmitOptions [] [] ds
+discloseMany ds = SubmitOptions [] [] ds None
 
 -- | Provides an Explicit Disclosure to the transaction.
 disclose : Disclosure -> SubmitOptions
 disclose d = discloseMany [d]
+
+-- | Provide a package id selection preference for upgrades for a submission
+packagePreference : [PackageId] -> SubmitOptions
+packagePreference = SubmitOptions [] [] [] . Some
 
 -- | Defines a type that can be transformed into a SubmitOptions
 class IsSubmitOptions options where
@@ -166,6 +181,7 @@ submitInternal opts errorBehaviour cmds = liftSubmission $ ConcurrentSubmits wit
         sActAs = actAsNonEmpty opts.soActAs
         sReadAs = opts.soReadAs
         sDisclosures = opts.soDisclosures
+        sPackagePreference = opts.soPackagePreference
         sErrorBehaviour = errorBehaviour
         sCommands = cmds.commands
         sLocation = head getExposedCallStack

--- a/sdk/daml-script/daml3/Daml/Script/Internal/Questions/TransactionTree.daml
+++ b/sdk/daml-script/daml3/Daml/Script/Internal/Questions/TransactionTree.daml
@@ -9,19 +9,16 @@ import Daml.Script.Internal.Questions.Util
 import DA.Optional
 import DA.List.Total
 
--- | HIDE This is an early access feature.
 data TransactionTree = TransactionTree
   with
     rootEvents: [TreeEvent]
   deriving Show
 
--- | HIDE This is an early access feature.
 data TreeEvent
   = CreatedEvent Created
   | ExercisedEvent Exercised
   deriving Show
 
--- | HIDE This is an early access feature.
 data Created = Created
   with
     contractId : AnyContractId
@@ -35,7 +32,6 @@ instance Show Created where
     showsPrec 0 contractId .
     showString "}"
 
--- | HIDE This is an early access feature.
 data Exercised = Exercised
   with
     contractId : AnyContractId
@@ -58,18 +54,15 @@ instance Show Exercised where
     showsPrec 0 childEvents .
     showString "}"
 
--- | HIDE This is an early access feature.
 data TreeIndex t
   = CreatedIndex (CreatedIndexPayload t)
   | ExercisedIndex (ExercisedIndexPayload t)
 
--- | HIDE This is an early access feature.
 data CreatedIndexPayload t = CreatedIndexPayload
   with
     templateId : TemplateTypeRep
     offset : Int
 
--- | HIDE This is an early access feature.
 data ExercisedIndexPayload t = ExercisedIndexPayload
   with
     templateId : TemplateTypeRep
@@ -77,7 +70,12 @@ data ExercisedIndexPayload t = ExercisedIndexPayload
     offset : Int
     child : TreeIndex t
 
--- | HIDE This is an early access feature.
+-- | Finds the contract id of an event within a tree given a tree index
+-- Tree indices are created using the `created(N)` and `exercised(N)` builders
+-- which allow building "paths" within a transaction to a create node
+-- For example, `exercisedN @MyTemplate1 "MyChoice" 2 $ createdN @MyTemplate2 1`
+-- would find the `ContractId MyTemplate2` of the second (0 index) create event under
+-- the 3rd exercise event of `MyChoice` from `MyTemplate1`
 fromTree : Template t => TransactionTree -> TreeIndex t -> ContractId t
 fromTree tree index = fromTreeGo index tree.rootEvents
 
@@ -110,22 +108,28 @@ fromTreeGo (ExercisedIndex index) events =
       | otherwise
       = None
 
--- | HIDE This is an early access feature.
+-- | Index for the first create event of a given template
+-- e.g. `created @MyTemplate`
 created : forall t. HasTemplateTypeRep t => TreeIndex t
 created = createdN 0
 
--- | HIDE This is an early access feature.
+-- | Index for the Nth create event of a given template
+-- e.g. `createdN 2 @MyTemplate`
+-- `created = createdN 0`
 createdN : forall t. HasTemplateTypeRep t => Int -> TreeIndex t
 createdN offset = CreatedIndex CreatedIndexPayload
   with
     templateId = templateTypeRep @t
     offset
 
--- | HIDE This is an early access feature.
+-- | Index for the first exercise of a given choice on a given template
+-- e.g. `exercised @MyTemplate "MyChoice"
 exercised : forall t t'. HasTemplateTypeRep t => Text -> TreeIndex t' -> TreeIndex t'
 exercised choice = exercisedN @t choice 0
 
--- | HIDE This is an early access feature.
+-- | Index for the Nth exercise of a given choice on a given template
+-- e.g. `exercisedN @MyTemplate "MyChoice" 2
+-- `exercised c = exercisedN c 0`
 exercisedN : forall t t'. HasTemplateTypeRep t => Text -> Int -> TreeIndex t' -> TreeIndex t'
 exercisedN choice offset child = ExercisedIndex ExercisedIndexPayload
   with

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Converter.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Converter.scala
@@ -313,6 +313,13 @@ object Converter extends script.ConverterMethods(StablePackagesV2) {
     override def description = name.toString
   }
 
+  def toPackageId(v: SValue): Either[String, PackageId] =
+    v match {
+      case SRecord(_, _, ArrayList(SText(packageId))) =>
+        Right(PackageId.assertFromString(packageId))
+      case _ => Left(s"Expected PackageId but got $v")
+    }
+
   def unrollFree(ctx: ScriptF.Ctx, v: SValue): ErrorOr[SValue Either Question[SValue]] =
     // ScriptF is a newtype over the question with its payload, locations and continue. It's modelled as a record with a single field.
     // Thus the extra SRecord

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
@@ -161,6 +161,7 @@ object ScriptF {
       actAs: OneAnd[Set, Party],
       readAs: Set[Party],
       cmds: List[ScriptLedgerClient.CommandWithMeta],
+      optPackagePreference: Option[List[PackageId]],
       disclosures: List[Disclosure],
       errorBehaviour: ScriptLedgerClient.SubmissionErrorBehaviour,
       optLocation: Option[Location],
@@ -195,6 +196,7 @@ object ScriptF {
           submission.actAs,
           submission.readAs,
           submission.disclosures,
+          submission.optPackagePreference,
           submission.cmds,
           submission.optLocation,
           env.lookupLanguageVersion,
@@ -841,6 +843,7 @@ object ScriptF {
               SRecord(_, _, ArrayList(hdAct, SList(tlAct))),
               SList(readAs),
               SList(disclosures),
+              SOptional(optPackagePreference),
               SEnum(_, name, _),
               SList(cmds),
               SOptional(optLocation),
@@ -850,6 +853,9 @@ object ScriptF {
           actAs <- OneAnd(hdAct, tlAct.toList).traverse(Converter.toParty)
           readAs <- readAs.traverse(Converter.toParty)
           disclosures <- disclosures.toImmArray.toList.traverse(Converter.toDisclosure)
+          optPackagePreference <- optPackagePreference.traverse(
+            Converter.toList(_, Converter.toPackageId)
+          )
           errorBehaviour <- parseErrorBehaviour(name)
           cmds <- cmds.toList.traverse(Converter.toCommandWithMeta)
           optLocation <- optLocation.traverse(Converter.toLocation(knownPackages.pkgs, _))
@@ -857,6 +863,7 @@ object ScriptF {
           actAs = toOneAndSet(actAs),
           readAs = readAs.toSet,
           disclosures = disclosures,
+          optPackagePreference = optPackagePreference,
           errorBehaviour = errorBehaviour,
           cmds = cmds,
           optLocation = optLocation,

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -610,6 +610,7 @@ class IdeLedgerClient(
       actAs: OneAnd[Set, Ref.Party],
       readAs: Set[Ref.Party],
       disclosures: List[Disclosure],
+      optPackagePreference: Option[List[PackageId]],
       commands: List[ScriptLedgerClient.CommandWithMeta],
       optLocation: Option[Location],
       languageVersionLookup: PackageId => Either[String, LanguageVersion],
@@ -622,6 +623,9 @@ class IdeLedgerClient(
     ScriptLedgerClient.SubmitFailure,
     (Seq[ScriptLedgerClient.CommandResult], ScriptLedgerClient.TransactionTree),
   ]] = Future {
+    optPackagePreference.foreach(_ =>
+      throw new IllegalArgumentException("IDE Ledger does not support Package Preference")
+    )
     synchronized {
       unsafeSubmit(actAs, readAs, disclosures, commands, optLocation) match {
         case Right(ScenarioRunner.Commit(result, _, tx)) =>

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
@@ -169,6 +169,7 @@ trait ScriptLedgerClient {
       actAs: OneAnd[Set, Ref.Party],
       readAs: Set[Ref.Party],
       disclosures: List[Disclosure],
+      optPackagePreference: Option[List[PackageId]],
       commands: List[ScriptLedgerClient.CommandWithMeta],
       optLocation: Option[Location],
       languageVersionLookup: PackageId => Either[String, LanguageVersion],

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
@@ -288,6 +288,7 @@ class GrpcLedgerClient(
       actAs: OneAnd[Set, Ref.Party],
       readAs: Set[Ref.Party],
       disclosures: List[Disclosure],
+      optPackagePreference: Option[List[PackageId]],
       commands: List[ScriptLedgerClient.CommandWithMeta],
       optLocation: Option[Location],
       languageVersionLookup: PackageId => Either[String, LanguageVersion],
@@ -325,6 +326,7 @@ class GrpcLedgerClient(
           applicationId = applicationId.getOrElse(""),
           commandId = UUID.randomUUID.toString,
           disclosedContracts = ledgerDisclosures,
+          packageIdSelectionPreference = optPackagePreference.getOrElse(List.empty),
         )
         request = SubmitAndWaitRequest(Some(apiCommands))
         resp <- grpcClient.commandServiceClient


### PR DESCRIPTION
Backport of #19223

Doesn't include the package preference tests, as we don't have the testing structure backported yet
Also adds `daml-script-beta` as an alias to `daml3-script` in the daml.yaml, with a slightly different warning