### PR TITLE
Fix DAML_SDK_VERSION causing a network lookup

### DIFF
--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -97,7 +97,8 @@ import DA.Daml.Project.Types
       ProjectPath(..),
       ProjectConfig,
       unsafeResolveReleaseVersion)
-import DA.Daml.Assistant.Version (resolveReleaseVersion)
+import DA.Daml.Assistant.Version (resolveReleaseVersionUnsafe)
+import DA.Daml.Assistant.Util (wrapErr)
 import qualified DA.Daml.Compiler.Repl as Repl
 import DA.Daml.Compiler.DocTest (docTest)
 import DA.Daml.Desugar (desugar)
@@ -937,7 +938,8 @@ installDepsAndInitPackageDb opts (InitPkgDb shouldInit) =
                   then do
                     damlPath <- getDamlPath
                     damlEnv <- getDamlEnv damlPath (LookForProjectPath False)
-                    resolveReleaseVersion (envUseCache damlEnv) pSdkVersion
+                    wrapErr "installing dependencies and initializing package database" $
+                      resolveReleaseVersionUnsafe (envUseCache damlEnv) pSdkVersion
                   else pure (unsafeResolveReleaseVersion pSdkVersion)
               installDependencies
                   (toNormalizedFilePath' projRoot)
@@ -1630,7 +1632,8 @@ execDocTest opts scriptDar (ImportSource importSource) files =
           then do
             damlPath <- getDamlPath
             damlEnv <- getDamlEnv damlPath (LookForProjectPath False)
-            resolveReleaseVersion (envUseCache damlEnv) SdkVersion.Class.unresolvedBuiltinSdkVersion
+            wrapErr "running doc test" $
+              resolveReleaseVersionUnsafe (envUseCache damlEnv) SdkVersion.Class.unresolvedBuiltinSdkVersion
           else pure (unsafeResolveReleaseVersion SdkVersion.Class.unresolvedBuiltinSdkVersion)
       installDependencies "." opts releaseVersion [scriptDar] []
       createProjectPackageDb "." opts mempty

--- a/sdk/daml-assistant/BUILD.bazel
+++ b/sdk/daml-assistant/BUILD.bazel
@@ -71,6 +71,7 @@ da_haskell_library(
         "tls",
         "typed-process",
         "unix-compat",
+        "uri-encode",
         "utf8-string",
         "yaml",
     ] + (["Win32"] if is_windows else []),

--- a/sdk/daml-assistant/daml-project-config/DA/Daml/Project/Types.hs
+++ b/sdk/daml-assistant/daml-project-config/DA/Daml/Project/Types.hs
@@ -83,6 +83,13 @@ defaultSdkPath damlPath releaseVersion =
         damlPath
         (V.toString (L.set V.metadata [] (releaseVersionFromReleaseVersion releaseVersion)))
 
+-- | Default way of constructing sdk paths.
+defaultSdkPathUnresolved :: DamlPath -> UnresolvedReleaseVersion -> SdkPath
+defaultSdkPathUnresolved damlPath unresolvedVersion =
+    mkSdkPath
+        damlPath
+        (V.toString (L.set V.metadata [] (unwrapUnresolvedReleaseVersion unresolvedVersion)))
+
 mkSdkPath :: DamlPath -> String -> SdkPath
 mkSdkPath (DamlPath root) str = SdkPath (root </> "sdk" </> str)
 

--- a/sdk/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/sdk/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -107,7 +107,7 @@ versionChecks Env{..} = do
     envFreshStableSdkVersionForCheck <- envFreshStableSdkVersionForCheck
     whenJust envFreshStableSdkVersionForCheck $ \latestVersion -> do
         let isHead = maybe False isHeadVersion envSdkVersion
-            projectSdkVersionIsOld = isJust envProjectPath && envSdkVersion < Just latestVersion
+            projectSdkVersionIsOld = isJust envProjectPath && envSdkVersion < Just (unresolvedVersionFromReleaseVersion latestVersion)
             assistantVersionIsOld = isJust envDamlAssistantSdkVersion &&
                 fmap unwrapDamlAssistantSdkVersion envDamlAssistantSdkVersion <
                 Just latestVersion
@@ -146,7 +146,9 @@ autoInstall env@Env{..} = do
     if doAutoInstall && isJust envSdkVersion && isNothing envSdkPath then do
         -- sdk is missing, so let's install it!
         let sdkVersion = fromJust envSdkVersion
-            options = InstallOptions
+            useCache = envUseCache env
+        releaseVersion <- resolveReleaseVersionUnsafe useCache sdkVersion
+        let options = InstallOptions
                 { iTargetM = Nothing
                 , iSnapshots = False
                 , iQuiet = QuietInstall False
@@ -162,8 +164,8 @@ autoInstall env@Env{..} = do
             installEnv = InstallEnv
                 { options = options
                 , damlPath = envDamlPath
-                , useCache = envUseCache env
-                , targetVersionM = sdkVersion
+                , useCache = useCache
+                , targetVersionM = releaseVersion
                 , missingAssistant = False
                 , installingFromOutside = False
                 , projectPathM = Nothing
@@ -177,7 +179,7 @@ autoInstall env@Env{..} = do
                     -- up by a pipe.
                 }
         versionInstall installEnv
-        pure env { envSdkPath = Just (defaultSdkPath envDamlPath sdkVersion) }
+        pure env { envSdkPath = Just (defaultSdkPathUnresolved envDamlPath sdkVersion) }
 
     else
         pure env
@@ -214,10 +216,11 @@ runCommand env@Env{..} = \case
         defaultVersionM <- tryAssistantM $ getDefaultSdkVersion envDamlPath
         projectVersionM <- mapM (getSdkVersionFromProjectPath useCache) envProjectPath
         envSelectedVersionM <- lookupEnv sdkVersionEnvVar
+        envSdkVersionResolved <- resolveReleaseVersionUnsafe useCache `traverse` envSdkVersion
 
         let asstVersion = unwrapDamlAssistantSdkVersion <$> envDamlAssistantSdkVersion
             envVersions = catMaybes
-                [ envSdkVersion
+                [ envSdkVersionResolved
                 , guard vAssistant >> asstVersion
                 , projectVersionM
                 , defaultVersionM
@@ -295,8 +298,8 @@ runCommand env@Env{..} = \case
                 args = unwrapSdkCommandArgs sdkCommandArgs ++ unwrapUserCommandArgs cmdArgs
             dispatchWithEnvVarWarning env path args
 
-envVarAddedVersion :: ReleaseVersion
-envVarAddedVersion = either throw id $ unsafeParseOldReleaseVersion "2.9.0-snapshot.20240210.0"
+envVarAddedVersion :: UnresolvedReleaseVersion
+envVarAddedVersion = either throw id $ parseUnresolvedVersion "2.9.0-snapshot.20240210.0"
 
 dispatchWithEnvVarWarning :: SdkVersioned => Env -> FilePath -> [String] -> IO ()
 dispatchWithEnvVarWarning env@Env{..} path args = do

--- a/sdk/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/sdk/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -201,7 +201,7 @@ runCommand env@Env{..} = \case
         let useCache =
               UseCache
                 { cachePath = envCachePath
-                , damlPath = envDamlPath
+                , damlPathUnsafe = envDamlPath
                 , overrideTimeout = if vForceRefresh then Just (CacheTimeout 1) else Nothing
                 }
         installedVersionsE <- tryAssistant $ getInstalledSdkVersions envDamlPath
@@ -280,8 +280,8 @@ runCommand env@Env{..} = \case
         install options envDamlPath (envUseCache env) envProjectPath envDamlAssistantSdkVersion
 
     Builtin (Uninstall unresolvedVersion) -> do
-        version <- resolveReleaseVersion (envUseCache env) unresolvedVersion
-        uninstallVersion env version
+        versionOrErr <- resolveReleaseVersion (envUseCache env) unresolvedVersion
+        uninstallVersion env versionOrErr
 
     Builtin (Exec cmd args) -> do
         wrapErr "Running executable in daml environment." $ do

--- a/sdk/daml-assistant/src/DA/Daml/Assistant/Cache.hs
+++ b/sdk/daml-assistant/src/DA/Daml/Assistant/Cache.hs
@@ -6,6 +6,7 @@ module DA.Daml.Assistant.Cache
     ( cacheAvailableSdkVersions
     , CacheAge (..)
     , UseCache (..)
+    , damlPath
     , cacheWith
     , loadFromCacheWith
     , saveToCacheWith
@@ -53,17 +54,21 @@ data UseCache
   = UseCache
       { overrideTimeout :: Maybe CacheTimeout
       , cachePath :: CachePath
-      , damlPath :: DamlPath
+      , damlPathUnsafe :: DamlPath
       }
   | DontUseCache
   deriving (Show, Eq)
+
+damlPath :: UseCache -> Maybe DamlPath
+damlPath DontUseCache = Nothing
+damlPath UseCache { damlPathUnsafe } = Just damlPathUnsafe
 
 cacheAvailableSdkVersions
     :: UseCache
     -> (Maybe [ReleaseVersion] -> IO [ReleaseVersion])
     -> IO ([ReleaseVersion], CacheAge)
 cacheAvailableSdkVersions DontUseCache getVersions = (, Fresh) <$> getVersions Nothing
-cacheAvailableSdkVersions UseCache { overrideTimeout, cachePath, damlPath } getVersions = do
+cacheAvailableSdkVersions UseCache { overrideTimeout, cachePath, damlPathUnsafe = damlPath } getVersions = do
     damlConfigE <- tryConfig $ readDamlConfig damlPath
     let configUpdateCheckM = join $ eitherToMaybe (queryDamlConfig ["update-check"] =<< damlConfigE)
         (neverRefresh, timeout)

--- a/sdk/daml-assistant/src/DA/Daml/Assistant/Env.hs
+++ b/sdk/daml-assistant/src/DA/Daml/Assistant/Env.hs
@@ -50,7 +50,7 @@ envUseCache Env {..} =
 
 mkUseCache :: CachePath -> DamlPath -> UseCache
 mkUseCache cachePath damlPath =
-  UseCache { cachePath, damlPath, overrideTimeout = Nothing }
+  UseCache { cachePath, damlPathUnsafe = damlPath, overrideTimeout = Nothing }
 
 -- | (internal) Override function with environment variable
 -- if it is available.
@@ -108,7 +108,7 @@ getFreshStableSdkVersionForCheck useCache = do
       parsed <- requiredE
         ("Invalid value for environment variable " <> pack sdkVersionLatestEnvVar <> ".")
         (parseVersion (pack value))
-      pure (Just <$> resolveReleaseVersion useCache parsed)
+      pure (Just <$> resolveReleaseVersionUnsafe useCache parsed)
 
 -- | Determine the viability of running sdk commands in the environment.
 -- Returns the first failing test's error message.
@@ -152,7 +152,7 @@ getDamlAssistantPathDefault (DamlPath damlPath) =
 getDamlAssistantSdkVersion :: UseCache -> IO (Maybe DamlAssistantSdkVersion)
 getDamlAssistantSdkVersion useCache =
     overrideWithEnvVarMaybeIO damlAssistantVersionEnvVar pure
-        (fmap (fmap DamlAssistantSdkVersion) . traverse (resolveReleaseVersion useCache) . parseVersion . pack)
+        (fmap (fmap DamlAssistantSdkVersion) . traverse (resolveReleaseVersionUnsafe useCache) . parseVersion . pack)
         (fmap DamlAssistantSdkVersion <$> tryAssistantM (getAssistantSdkVersion useCache))
 
 -- | Determine absolute path of daml home directory.
@@ -223,14 +223,23 @@ getSdk :: UseCache
        -> IO (Maybe ReleaseVersion, Maybe SdkPath)
 getSdk useCache damlPath projectPathM =
     wrapErr "Determining SDK version and path." $ do
-
-        releaseVersion <- overrideWithEnvVarMaybeIO sdkVersionEnvVar pure (traverse (resolveReleaseVersion useCache) . parseVersion . pack) $ firstJustM id
-            [ maybeM (pure Nothing)
-                (tryAssistantM . getReleaseVersionFromSdkPath useCache . SdkPath)
-                (getEnv sdkPathEnvVar)
-            , mapM (getSdkVersionFromProjectPath useCache) projectPathM
-            , tryAssistantM $ getDefaultSdkVersion damlPath
-            ]
+        releaseVersion <-
+            let parseAndResolve =
+                  traverse (resolveReleaseVersionUnsafe useCache) .
+                    parseVersion .
+                      pack
+            in
+            overrideWithEnvVarMaybeIO
+                sdkVersionEnvVar
+                pure
+                parseAndResolve $
+                firstJustM id
+                    [ maybeM (pure Nothing)
+                        (tryAssistantM . getReleaseVersionFromSdkPath useCache . SdkPath)
+                        (getEnv sdkPathEnvVar)
+                    , mapM (getSdkVersionFromProjectPath useCache) projectPathM
+                    , tryAssistantM $ getDefaultSdkVersion damlPath
+                    ]
 
         sdkPath <- overrideWithEnvVarMaybe @SomeException sdkPathEnvVar makeAbsolute (Right . SdkPath) $
             useInstalledPath damlPath releaseVersion

--- a/sdk/daml-assistant/src/DA/Daml/Assistant/Install.hs
+++ b/sdk/daml-assistant/src/DA/Daml/Assistant/Install.hs
@@ -22,7 +22,7 @@ import DA.Daml.Assistant.Util
 import qualified DA.Daml.Assistant.Version as DAVersion
 import DA.Daml.Assistant.Install.Path
 import DA.Daml.Assistant.Install.Completion
-import DA.Daml.Assistant.Version (getLatestSdkSnapshotVersion, getLatestReleaseVersion, UseCache (..), resolveSdkVersionToRelease)
+import DA.Daml.Assistant.Version (getLatestSdkSnapshotVersion, getLatestReleaseVersion, UseCache (..), resolveSdkVersionToRelease, CouldNotResolveReleaseVersion(..))
 import DA.Daml.Assistant.Cache (CacheTimeout (..))
 import DA.Daml.Project.Consts
 import DA.Daml.Project.Config
@@ -52,6 +52,7 @@ import Options.Applicative.Extended (determineAuto)
 import qualified Data.SemVer as V
 import qualified Data.Text as T
 import qualified Control.Exception
+import qualified Data.List.NonEmpty as NonEmpty
 
 -- unix specific
 import System.PosixCompat.Types ( FileMode )
@@ -371,19 +372,39 @@ httpInstall env@InstallEnv{targetVersionM = releaseVersion, ..} = do
         !firstEEVersion =
             let verStr = "1.12.0-snapshot.20210312.6498.0.707c86aa"
             in either Control.Exception.throw id (unsafeParseOldReleaseVersion verStr)
+
         downloadLocation :: DAVersion.InstallLocation -> IO ()
-        downloadLocation (DAVersion.HttpInstallLocation url headers) = do
-            request <- requiredAny "Failed to parse HTTPS request." $ parseRequest ("GET " <> unpack url)
-            withResponse (setRequestHeaders headers request) $ \response -> do
-                when (getResponseStatusCode response /= 200) $
-                    throwIO . assistantErrorBecause ("Failed to download release from " <> url <> ".")
-                            . pack . show $ getResponseStatus response
-                let totalSizeM = readMay . BS.UTF8.toString =<< headMay (getResponseHeader "Content-Length" response)
-                extractAndInstall (fmap Just env)
-                    . maybe id (\s -> (.| observeProgress s)) totalSizeM
-                    $ getResponseBody response
+        downloadLocation (DAVersion.HttpInstallLocations (location NonEmpty.:| alternatives)) = do
+            installationSucceeded <- go location alternatives
+            when (not installationSucceeded) $
+              throwIO $ assistantError "Could not download release from any of the following locations: "
+            where
+            go :: DAVersion.HttpInstallLocation -> [DAVersion.HttpInstallLocation] -> IO Bool
+            go location alternatives = do
+                location <- try (downloadHttpLocation location)
+                case location of
+                  Left err@AssistantError {} -> do
+                      hPutStrLn stderr $ displayException err
+                      case alternatives of
+                        [] -> pure False
+                        (next:rest) -> go next rest
+                  Right () -> pure True
+
+            downloadHttpLocation :: DAVersion.HttpInstallLocation -> IO ()
+            downloadHttpLocation (DAVersion.HttpInstallLocation url headers name) = do
+                hPutStrLn stderr $ "Trying to install version via HTTP from " <> T.unpack name
+                request <- requiredAny "Failed to parse HTTPS request." $ parseRequest ("GET " <> unpack url)
+                withResponse (setRequestHeaders headers request) $ \response -> do
+                    when (getResponseStatusCode response /= 200) $
+                        throwIO . assistantErrorBecause ("Failed to download release from " <> url <> ".")
+                                . pack . show $ getResponseStatus response
+                    let totalSizeM = readMay . BS.UTF8.toString =<< headMay (getResponseHeader "Content-Length" response)
+                    extractAndInstall (fmap Just env)
+                        . maybe id (\s -> (.| observeProgress s)) totalSizeM
+                        $ getResponseBody response
         downloadLocation (DAVersion.FileInstallLocation file) =
             extractAndInstall (fmap Just env) (sourceFileBS file)
+
         observeProgress :: MonadResource m =>
             Int -> ConduitT BS.ByteString BS.ByteString m ()
         observeProgress totalSize = do
@@ -468,24 +489,26 @@ versionInstall env@InstallEnv{targetVersionM = version, ..} = withInstallLock en
 
 -- | Install the latest version of the SDK.
 latestInstall :: InstallEnvWithoutVersion -> IO ()
-latestInstall env@InstallEnv{..} = do
-    version1 <- getLatestReleaseVersion useCache
-        -- override the cache if it's older than 1 day, even if daml-config.yaml says otherwise
-        { overrideTimeout = Just (CacheTimeout 86400)
-        }
-    version2M <- if iSnapshots options
-        then tryAssistantM $ getLatestSdkSnapshotVersion useCache
-        else pure Nothing
-    let version = maybe version1 (max version1) version2M
-    versionInstall env { targetVersionM = version }
+latestInstall env@InstallEnv{..} =
+    wrapErr "Installing latest daml version" $ do
+        version1 <- getLatestReleaseVersion useCache
+            -- override the cache if it's older than 1 day, even if daml-config.yaml says otherwise
+            { overrideTimeout = Just (CacheTimeout 86400)
+            }
+        version2M <- if iSnapshots options
+            then tryAssistantM $ getLatestSdkSnapshotVersion useCache
+            else pure Nothing
+        let version = maybe version1 (max version1) version2M
+        versionInstall env { targetVersionM = version }
 
 -- | Install the SDK version of the current project.
 projectInstall :: InstallEnvWithoutVersion -> ProjectPath -> IO ()
 projectInstall env projectPath = do
+    wrapErr "Installing daml version in project config (daml.yaml)" $ do
     projectConfig <- readProjectConfig projectPath
     unresolvedVersionM <- fromRightM throwIO $ releaseVersionFromProjectConfig projectConfig
     unresolvedVersion <- required "SDK version missing from project config (daml.yaml)." unresolvedVersionM
-    version <- DAVersion.resolveReleaseVersion (useCache env) unresolvedVersion
+    version <- DAVersion.resolveReleaseVersionUnsafe (useCache env) unresolvedVersion
     versionInstall env { targetVersionM = version }
 
 -- | Determine whether the assistant should be installed.
@@ -504,73 +527,77 @@ pattern RawInstallTarget_Latest = RawInstallTarget "latest"
 
 -- | Run install command.
 install :: InstallOptions -> DamlPath -> UseCache -> Maybe ProjectPath -> Maybe DamlAssistantSdkVersion -> IO ()
-install options damlPath useCache projectPathM assistantVersion = do
-    when (unActivateInstall (iActivate options)) $
-        hPutStr stderr . unlines $
-            [ "WARNING: --activate is deprecated, use --install-assistant=yes instead."
-            , ""
-            ]
-
-    missingAssistant <- not <$> doesFileExist (installedAssistantPath damlPath)
-    execPath <- getExecutablePath
-    damlConfigE <- tryConfig $ readDamlConfig damlPath
-    let installingFromOutside = not $
-            isPrefixOf (unwrapDamlPath damlPath </> "") execPath
-        targetVersionM = () -- determined later
-        output = putStrLn -- Output install messages to stdout.
-        artifactoryApiKeyM = DAVersion.queryArtifactoryApiKey =<< eitherToMaybe damlConfigE
-        env = InstallEnv {..}
-        warnAboutAnyInstallFlags command = do
-            when (unInstallWithInternalVersion (iInstallWithInternalVersion options)) $
-                hPutStrLn stderr $ unlines
-                    [ "WARNING: You have supplied --install-with-internal-version=yes, but `" <> command <> "` does not take that option."
-                    ]
-            case unInstallWithCustomVersion (iInstallWithCustomVersion options) of
-                Just customVersion ->
-                    hPutStrLn stderr $ unlines
-                        [ "WARNING: You have supplied --install-with-custom-version=" <> customVersion <> ", but `" <> command <> "` does not take that option."
-                        ]
-                Nothing -> pure ()
-
-    case iTargetM options of
-        Nothing -> do
-            hPutStrLn stderr $ unlines
-                [ "ERROR: daml install requires a target."
+install options damlPath useCache projectPathM assistantVersion =
+    wrapErr "Running daml install command" $ do
+        when (unActivateInstall (iActivate options)) $
+            hPutStr stderr . unlines $
+                [ "WARNING: --activate is deprecated, use --install-assistant=yes instead."
                 , ""
-                , "Available install targets:"
-                , "    daml install latest     Install the latest stable SDK version."
-                , "    daml install project    Install the project SDK version."
-                , "    daml install VERSION    Install a specific SDK version."
-                , "    daml install PATH       Install SDK from an SDK release tarball."
                 ]
-            exitFailure
 
-        Just RawInstallTarget_Project -> do
-            projectPath <- required "'daml install project' must be run from within a project."
-                projectPathM
-            warnAboutAnyInstallFlags "daml install project"
-            projectInstall env projectPath
+        missingAssistant <- not <$> doesFileExist (installedAssistantPath damlPath)
+        execPath <- getExecutablePath
+        damlConfigE <- tryConfig $ readDamlConfig damlPath
+        let installingFromOutside = not $
+                isPrefixOf (unwrapDamlPath damlPath </> "") execPath
+            targetVersionM = () -- determined later
+            output = putStrLn -- Output install messages to stdout.
+            artifactoryApiKeyM = DAVersion.queryArtifactoryApiKey =<< eitherToMaybe damlConfigE
+            env = InstallEnv {..}
+            warnAboutAnyInstallFlags command = do
+                when (unInstallWithInternalVersion (iInstallWithInternalVersion options)) $
+                    hPutStrLn stderr $ unlines
+                        [ "WARNING: You have supplied --install-with-internal-version=yes, but `" <> command <> "` does not take that option."
+                        ]
+                case unInstallWithCustomVersion (iInstallWithCustomVersion options) of
+                    Just customVersion ->
+                        hPutStrLn stderr $ unlines
+                            [ "WARNING: You have supplied --install-with-custom-version=" <> customVersion <> ", but `" <> command <> "` does not take that option."
+                            ]
+                    Nothing -> pure ()
 
-        Just RawInstallTarget_Latest -> do
-            warnAboutAnyInstallFlags "daml install latest"
-            latestInstall env
+        case iTargetM options of
+            Nothing -> do
+                hPutStrLn stderr $ unlines
+                    [ "ERROR: daml install requires a target."
+                    , ""
+                    , "Available install targets:"
+                    , "    daml install latest     Install the latest stable SDK version."
+                    , "    daml install project    Install the project SDK version."
+                    , "    daml install VERSION    Install a specific SDK version."
+                    , "    daml install PATH       Install SDK from an SDK release tarball."
+                    ]
+                exitFailure
 
-        Just (RawInstallTarget arg) | Right version <- parseVersion (pack arg) -> do
-            warnAboutAnyInstallFlags "daml install <version>"
-            releaseVersion <- DAVersion.resolveReleaseVersion useCache version
-            versionInstall env { targetVersionM = releaseVersion }
+            Just RawInstallTarget_Project -> do
+                projectPath <- required "'daml install project' must be run from within a project."
+                    projectPathM
+                warnAboutAnyInstallFlags "daml install project"
+                projectInstall env projectPath
 
-        Just (RawInstallTarget arg) -> do
-            testD <- doesDirectoryExist arg
-            testF <- doesFileExist arg
-            if testD || testF then
-                pathInstall env arg
-            else
-                throwIO (assistantErrorBecause "Invalid install target. Expected version, path, 'project' or 'latest'." ("target = " <> pack arg))
+            Just RawInstallTarget_Latest -> do
+                warnAboutAnyInstallFlags "daml install latest"
+                latestInstall env
+
+            Just (RawInstallTarget arg) | Right version <- parseVersion (pack arg) -> do
+                warnAboutAnyInstallFlags "daml install <version>"
+                releaseVersion <- DAVersion.resolveReleaseVersionUnsafe useCache version
+                versionInstall env { targetVersionM = releaseVersion }
+
+            Just (RawInstallTarget arg) -> do
+                testD <- doesDirectoryExist arg
+                testF <- doesFileExist arg
+                if testD || testF then
+                    pathInstall env arg
+                else
+                    throwIO (assistantErrorBecause "Invalid install target. Expected version, path, 'project' or 'latest'." ("target = " <> pack arg))
 
 -- | Uninstall a specific SDK version.
-uninstallVersion :: Env -> ReleaseVersion -> IO ()
-uninstallVersion Env{..} releaseVersion = wrapErr "Uninstalling SDK version." $ do
+uninstallVersion :: Env -> Either CouldNotResolveReleaseVersion ReleaseVersion -> IO ()
+uninstallVersion Env{} (Left (CouldNotResolveReleaseVersion _ unresolvedVersion)) =
+    wrapErr "Uninstalling SDK version." $ 
+        throwErr ("SDK version " <> unresolvedReleaseVersionToText unresolvedVersion <> " is not installed.")
+uninstallVersion Env{..} (Right releaseVersion) = wrapErr "Uninstalling SDK version." $ do
     let (SdkPath path) = defaultSdkPath envDamlPath releaseVersion
 
     exists <- doesDirectoryExist path

--- a/sdk/daml-assistant/src/DA/Daml/Assistant/Types.hs
+++ b/sdk/daml-assistant/src/DA/Daml/Assistant/Types.hs
@@ -23,7 +23,7 @@ data EnvF f = Env
     , envDamlAssistantSdkVersion :: Maybe DamlAssistantSdkVersion
     , envProjectPath   :: Maybe ProjectPath
     , envSdkPath       :: Maybe SdkPath
-    , envSdkVersion    :: Maybe ReleaseVersion
+    , envSdkVersion    :: Maybe UnresolvedReleaseVersion
     , envFreshStableSdkVersionForCheck :: f (Maybe ReleaseVersion)
     }
 

--- a/sdk/daml-assistant/src/DA/Daml/Assistant/Util.hs
+++ b/sdk/daml-assistant/src/DA/Daml/Assistant/Util.hs
@@ -22,25 +22,39 @@ throwErr msg = throwIO (assistantError msg)
 
 -- | Handle synchronous exceptions by wrapping them in an AssistantError,
 -- add context to any assistant errors that are missing context.
-wrapErr :: Text -> IO a -> IO a
-wrapErr ctx m = m `catches`
+wrapErrG :: (Text -> SomeException -> AssistantError) -> Text -> IO a -> IO a
+wrapErrG wrapSomeException ctx m = m `catches`
     [ Handler $ throwIO @IO @ExitCode
     , Handler $ \ExitCodeException{eceExitCode} -> exitWith eceExitCode
     , Handler $ throwIO . addErrorContext
-    , Handler $ throwIO . wrapException
+    , Handler $ throwIO . wrapSomeException ctx
     ]
     where
-        wrapException :: SomeException -> AssistantError
-        wrapException err =
-            AssistantError
-                { errContext  = Just ctx
-                , errMessage  = Nothing
-                , errInternal = Just (pack (show err))
-                }
-
         addErrorContext :: AssistantError -> AssistantError
         addErrorContext err =
             err { errContext = errContext err <|> Just ctx }
+
+wrapErr :: Text -> IO a -> IO a
+wrapErr = wrapErrG wrapSomeExceptionWithoutMsg
+
+wrapSomeExceptionWithoutMsg :: Text -> SomeException -> AssistantError
+wrapSomeExceptionWithoutMsg ctx err =
+    AssistantError
+        { errContext  = Just ctx
+        , errMessage  = Nothing
+        , errInternal = Just (pack (show err))
+        }
+
+wrapErrDisplay :: Text -> IO a -> IO a
+wrapErrDisplay = wrapErrG wrapSomeExceptionWithMsg
+
+wrapSomeExceptionWithMsg :: Text -> SomeException -> AssistantError
+wrapSomeExceptionWithMsg ctx err =
+    AssistantError
+        { errContext  = Just ctx
+        , errMessage  = Just (pack (displayException err))
+        , errInternal = Just (pack (show err))
+        }
 
 -- | Catch a config error.
 tryConfig :: IO t -> IO (Either ConfigError t)

--- a/sdk/daml-assistant/src/DA/Daml/Assistant/Version.hs
+++ b/sdk/daml-assistant/src/DA/Daml/Assistant/Version.hs
@@ -394,18 +394,12 @@ instance Exception CouldNotResolveReleaseVersion where
         "Could not resolve release version " <> T.unpack (V.toText (unwrapUnresolvedReleaseVersion version)) <> " from the internet. Reason: " <> displayException githubReleaseError
 
 resolveReleaseVersion :: HasCallStack => UseCache -> UnresolvedReleaseVersion -> IO (Either CouldNotResolveReleaseVersion ReleaseVersion)
-resolveReleaseVersion useCache unresolvedVersion = do
-    putStrLn "resolveReleaseVersion"
-    r <- try (resolveReleaseVersionInternal useCache unresolvedVersion)
-    putStrLn "resolveReleaseVersionDone"
-    pure r
+resolveReleaseVersion useCache unresolvedVersion =
+    try (resolveReleaseVersionInternal useCache unresolvedVersion)
 
 resolveReleaseVersionUnsafe :: HasCallStack => UseCache -> UnresolvedReleaseVersion -> IO ReleaseVersion
-resolveReleaseVersionUnsafe useCache targetVersion = do
-    putStrLn "resolveReleaseVersionUnsafe"
-    r <- mapException handle $ resolveReleaseVersionInternal useCache targetVersion
-    putStrLn "resolveReleaseVersionUnsafeDone"
-    pure r
+resolveReleaseVersionUnsafe useCache targetVersion =
+    mapException handle $ resolveReleaseVersionInternal useCache targetVersion
     where
     handle :: CouldNotResolveReleaseVersion -> AssistantError
     handle = wrapSomeExceptionWithMsg "Resolve SDK version from release version" . SomeException

--- a/sdk/daml-assistant/src/DA/Daml/Assistant/Version.hs
+++ b/sdk/daml-assistant/src/DA/Daml/Assistant/Version.hs
@@ -7,6 +7,7 @@ module DA.Daml.Assistant.Version
     , getSdkVersionFromSdkPath
     , getReleaseVersionFromSdkPath
     , getSdkVersionFromProjectPath
+    , getUnresolvedReleaseVersionFromProjectPath
     , getAssistantSdkVersion
     , getDefaultSdkVersion
     , getAvailableReleaseVersions
@@ -111,22 +112,13 @@ getSdkVersionFromSdkPath sdkPath = do
     requiredE "Failed to parse SDK version from SDK config." $
         sdkVersionFromSdkConfig config
 
--- | Determine SDK version from project root. Fails with an
--- AssistantError exception if the version cannot be determined.
-getSdkVersionFromProjectPath :: UseCache -> ProjectPath -> IO ReleaseVersion
-getSdkVersionFromProjectPath useCache projectPath =
+getUnresolvedReleaseVersionFromProjectPath :: ProjectPath -> IO UnresolvedReleaseVersion
+getUnresolvedReleaseVersionFromProjectPath projectPath =
     requiredIO ("Failed to read SDK version from " <> pack projectConfigName) $ do
         configE <- tryConfig $ readProjectConfig projectPath
         case releaseVersionFromProjectConfig =<< configE of
             Right (Just v) -> do
-                resolvedVersionOrErr <- resolveReleaseVersion useCache v
-                case resolvedVersionOrErr of
-                    Left resolveErr ->
-                        throwIO $ assistantErrorDetails
-                            ("sdk-version field in " <> projectConfigName <> " is not a valid Daml version. Validating version from the internet failed.")
-                            [("path", unwrapProjectPath projectPath </> projectConfigName)
-                            ,("internal", displayException resolveErr)]
-                    Right version -> pure version
+                pure v
             Left (ConfigFileInvalid _ raw) ->
                 throwIO $ assistantErrorDetails
                     (projectConfigName <> " is an invalid YAML file")
@@ -145,6 +137,21 @@ getSdkVersionFromProjectPath useCache projectPath =
                     ("sdk-version field is invalid in " <> projectConfigName)
                     [("path", unwrapProjectPath projectPath </> projectConfigName)
                     ,("internal", raw)]
+
+-- | Determine SDK version from project root. Fails with an
+-- AssistantError exception if the version cannot be determined.
+getSdkVersionFromProjectPath :: UseCache -> ProjectPath -> IO ReleaseVersion
+getSdkVersionFromProjectPath useCache projectPath =
+    requiredIO ("Failed to read SDK version from " <> pack projectConfigName) $ do
+        v <- getUnresolvedReleaseVersionFromProjectPath projectPath
+        resolvedVersionOrErr <- resolveReleaseVersion useCache v
+        case resolvedVersionOrErr of
+            Left resolveErr ->
+                throwIO $ assistantErrorDetails
+                    ("sdk-version field in " <> projectConfigName <> " is not a valid Daml version. Validating version from the internet failed.")
+                    [("path", unwrapProjectPath projectPath </> projectConfigName)
+                    ,("internal", displayException resolveErr)]
+            Right version -> pure version
 
 -- | Get the list of installed SDK versions. Returned list is
 -- in no particular order. Fails with an AssistantError exception
@@ -388,10 +395,17 @@ instance Exception CouldNotResolveReleaseVersion where
 
 resolveReleaseVersion :: HasCallStack => UseCache -> UnresolvedReleaseVersion -> IO (Either CouldNotResolveReleaseVersion ReleaseVersion)
 resolveReleaseVersion useCache unresolvedVersion = do
-    try (resolveReleaseVersionInternal useCache unresolvedVersion)
+    putStrLn "resolveReleaseVersion"
+    r <- try (resolveReleaseVersionInternal useCache unresolvedVersion)
+    putStrLn "resolveReleaseVersionDone"
+    pure r
 
 resolveReleaseVersionUnsafe :: HasCallStack => UseCache -> UnresolvedReleaseVersion -> IO ReleaseVersion
-resolveReleaseVersionUnsafe useCache targetVersion = mapException handle $ resolveReleaseVersionInternal useCache targetVersion
+resolveReleaseVersionUnsafe useCache targetVersion = do
+    putStrLn "resolveReleaseVersionUnsafe"
+    r <- mapException handle $ resolveReleaseVersionInternal useCache targetVersion
+    putStrLn "resolveReleaseVersionUnsafeDone"
+    pure r
     where
     handle :: CouldNotResolveReleaseVersion -> AssistantError
     handle = wrapSomeExceptionWithMsg "Resolve SDK version from release version" . SomeException
@@ -448,14 +462,22 @@ resolveReleaseVersionFromDamlPath damlPath targetVersion = do
   let isMatchingVersion releaseVersion =
           unwrapUnresolvedReleaseVersion targetVersion == releaseVersionFromReleaseVersion releaseVersion
   resolvedVersions <- getInstalledSdkVersions damlPath
-  pure (find isMatchingVersion resolvedVersions)
+  let matching = find isMatchingVersion resolvedVersions
+  case matching of
+    Just _ -> putStrLn "Got a version via daml path"
+    Nothing -> pure ()
+  pure matching
 
 resolveSdkVersionFromDamlPath :: DamlPath -> SdkVersion -> IO (Maybe ReleaseVersion)
 resolveSdkVersionFromDamlPath damlPath targetSdkVersion = do
   let isMatchingVersion releaseVersion =
           targetSdkVersion == sdkVersionFromReleaseVersion releaseVersion
   resolvedVersions <- getInstalledSdkVersions damlPath
-  pure (find isMatchingVersion resolvedVersions)
+  let matching = find isMatchingVersion resolvedVersions
+  case matching of
+    Just _ -> putStrLn "Got a version via daml path"
+    Nothing -> pure ()
+  pure matching
 
 -- | Subset of the github release response that we care about
 data GithubReleaseResponseSubset = GithubReleaseResponseSubset

--- a/sdk/daml-assistant/test/DA/Daml/Assistant/Tests.hs
+++ b/sdk/daml-assistant/test/DA/Daml/Assistant/Tests.hs
@@ -313,6 +313,7 @@ testGetDispatchEnv = Tasty.testGroup "DA.Daml.Assistant.Env.getDispatchEnv"
     [ Tasty.testCase "getDispatchEnv should be idempotent" $ do
         withSystemTempDirectory "test-getDispatchEnv" $ \base -> do
             version <- requiredE "testGetDispatchEnv: expected a valid version" $ unsafeParseOldReleaseVersion "1.0.1"
+            let unresolvedVersion = unresolvedVersionFromReleaseVersion version
             let cachePath = CachePath (base </> ".cache")
             createDirectoryIfMissing True (unwrapCachePath cachePath)
             writeFileUTF8 (unwrapCachePath cachePath </> "versions.txt") "1.0.1"
@@ -321,7 +322,7 @@ testGetDispatchEnv = Tasty.testGroup "DA.Daml.Assistant.Env.getDispatchEnv"
                     , envCachePath = cachePath
                     , envDamlAssistantPath = DamlAssistantPath (base </> ".daml" </> "bin" </> "strange-daml")
                     , envDamlAssistantSdkVersion = Just $ DamlAssistantSdkVersion version
-                    , envSdkVersion = Just version
+                    , envSdkVersion = Just unresolvedVersion
                     , envFreshStableSdkVersionForCheck = pure (Just version)
                     , envSdkPath = Just $ SdkPath (base </> "sdk")
                     , envProjectPath = Just $ ProjectPath (base </> "proj")
@@ -333,6 +334,7 @@ testGetDispatchEnv = Tasty.testGroup "DA.Daml.Assistant.Env.getDispatchEnv"
     , Tasty.testCase "getDispatchEnv should override getDamlEnv" $ do
         withSystemTempDirectory "test-getDispatchEnv" $ \base -> do
             version <- requiredE "testGetDispatchEnv: expected a valid version" $ unsafeParseOldReleaseVersion "1.0.1"
+            let unresolvedVersion = unresolvedVersionFromReleaseVersion version
             let cachePath = CachePath (base </> ".cache")
             createDirectoryIfMissing True (unwrapCachePath cachePath)
             writeFileUTF8 (unwrapCachePath cachePath </> "versions.txt") "1.0.1"
@@ -341,7 +343,7 @@ testGetDispatchEnv = Tasty.testGroup "DA.Daml.Assistant.Env.getDispatchEnv"
                     , envCachePath = cachePath
                     , envDamlAssistantPath = DamlAssistantPath (base </> ".daml" </> "bin" </> "strange-daml")
                     , envDamlAssistantSdkVersion = Just $ DamlAssistantSdkVersion version
-                    , envSdkVersion = Just version
+                    , envSdkVersion = Just unresolvedVersion
                     , envFreshStableSdkVersionForCheck = pure (Just version)
                     , envSdkPath = Just $ SdkPath (base </> "sdk")
                     , envProjectPath = Just $ ProjectPath (base </> "proj")

--- a/sdk/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/sdk/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -42,6 +42,7 @@ import DA.Daml.Project.Types
 import qualified DA.Daml.Project.Types as DATypes
 import qualified DA.Daml.Assistant.Version as DAVersion
 import qualified DA.Daml.Assistant.Env as DAEnv
+import qualified DA.Daml.Assistant.Util as DAUtil
 
 -- Version of the "@mojotech/json-type-validation" library we're using.
 jtvVersion :: T.Text
@@ -131,7 +132,7 @@ main = do
               Left _ -> fail "Invalid SDK version"
               Right v -> do
                 useCache <- DAEnv.mkUseCache <$> DAEnv.getCachePath <*> DAEnv.getDamlPath
-                DAVersion.resolveReleaseVersion useCache v
+                DAUtil.wrapErr "Getting SDK version for codegen" $ DAVersion.resolveReleaseVersionUnsafe useCache v
         pkgs <- readPackages optInputDars
         case mergePackageMap pkgs of
           Left err -> fail . T.unpack $ err

--- a/sdk/libs-haskell/da-version-types/src/DA/Daml/Version/Types.hs
+++ b/sdk/libs-haskell/da-version-types/src/DA/Daml/Version/Types.hs
@@ -87,6 +87,9 @@ sdkVersionToText = V.toText . unwrapSdkVersion
 unresolvedReleaseVersionToString :: UnresolvedReleaseVersion -> String
 unresolvedReleaseVersionToString = V.toString . unwrapUnresolvedReleaseVersion
 
+unresolvedReleaseVersionToText :: UnresolvedReleaseVersion -> Text
+unresolvedReleaseVersionToText = V.toText . unwrapUnresolvedReleaseVersion
+
 class IsVersion a where
     isHeadVersion :: a -> Bool
 

--- a/sdk/release/install.sh
+++ b/sdk/release/install.sh
@@ -4,6 +4,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 daml_version_file="$DIR/daml_version.txt"
 if [ -f "$daml_version_file" ]; then
+  echo "Installing with internal version file $daml_version_file: $(cat "$daml_version_file")" 1>&2
   flag=--install-with-custom-version=$(cat "$daml_version_file")
 fi
 "$DIR/daml/daml" install "$DIR" ${flag:-} $@


### PR DESCRIPTION
When the env var DAML_SDK_VERSION is set, a network lookup is triggered. Now, we defer this lookup only to places where it's necessary.

We also backport split release artifactory support to 2.x