### PR TITLE
HOTFIX: remove `sdk/` prefix from files passed to `./fmt.sh --diff`

### DIFF
--- a/sdk/fmt.sh
+++ b/sdk/fmt.sh
@@ -49,11 +49,11 @@ check_diff() {
   # $1 merge_base
   # $2 regex
   # "${@:3}" command
-  changed_files=$(git diff --name-only --diff-filter=ACMRT "$1" | grep $2 | grep -E -v '^canton(-3x)?/' || [[ $? == 1 ]])
-  if [[ -n "$changed_files" ]]; then
-    run "${@:3}" ${changed_files[@]:-}
-  else
+  readarray -t changed_files < <(git diff --name-only --diff-filter=ACMRT "$1" | grep $2 | grep -E -v '^sdk/canton(-3x)?/' || [[ $? == 1 ]])
+  if [[ -z "${changed_files[@]}" ]]; then
     echo "No changed file to check matching '$2', skipping."
+  else
+    run "${@:3}" ${changed_files[@]##sdk/}
   fi
 }
 


### PR DESCRIPTION
As a developer, we now run `./fmt.sh --diff` from within the `sdk/` dir, but git still returns a list of changed files with a sdk prefix. This change removes the sdk/ prefix from those paths.

Incidentally, we were previously referring to `${changed_files[@]}` as though it were a bash array, but it was a regular scalar variable. This makes it actually an array, which allows us to use bash builtin syntax to strip the prefixes.