### PR TITLE
Fix IJ project sync

### DIFF
--- a/sdk/daml-assistant/integration-tests/BUILD.bazel
+++ b/sdk/daml-assistant/integration-tests/BUILD.bazel
@@ -14,8 +14,8 @@ genrule(
         "//canton:bindings-java_pom.xml",
         "//language-support/java/bindings-rxjava:libbindings-rxjava.jar",
         "//language-support/java/bindings-rxjava:bindings-rxjava_pom.xml",
-        "//language-support/java/codegen:shaded_binary.jar",
-        "//language-support/java/codegen:shaded_binary_pom.xml",
+        "//language-support/java/codegen:binary.jar",
+        "//language-support/java/codegen:binary_pom.xml",
         "//libs-scala/rs-grpc-bridge:librs-grpc-bridge.jar",
         "//libs-scala/rs-grpc-bridge:rs-grpc-bridge_pom.xml",
         "//docs:quickstart-java.tar.gz",
@@ -52,8 +52,8 @@ genrule(
         $(location //language-support/java/bindings-rxjava:bindings-rxjava_pom.xml)
       install_mvn \\
         "com.daml" "codegen-java" \\
-        $(location //language-support/java/codegen:shaded_binary.jar) \\
-        $(location //language-support/java/codegen:shaded_binary_pom.xml)
+        $(location //language-support/java/codegen:binary.jar) \\
+        $(location //language-support/java/codegen:binary_pom.xml)
       install_mvn \\
         "com.daml" "rs-grpc-bridge" \\
         $(location //libs-scala/rs-grpc-bridge:librs-grpc-bridge.jar) \\

--- a/sdk/language-support/codegen-main/BUILD.bazel
+++ b/sdk/language-support/codegen-main/BUILD.bazel
@@ -8,12 +8,9 @@ load(
     "scala_source_jar",
     "scaladoc_jar",
 )
-load(
-    "@com_github_johnynek_bazel_jar_jar//:jar_jar.bzl",
-    "jar_jar",
-)
 load("//bazel_tools:pom_file.bzl", "pom_file")
 load("@os_info//:os_info.bzl", "is_windows")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 
 da_scala_library(
     name = "codegen-main-lib",
@@ -52,23 +49,24 @@ da_scala_binary(
     ],
 )
 
-jar_jar(
-    name = "shaded_binary",
-    input_jar = "//language-support/codegen-main:codegen-main_distribute.jar",
-    rules = "shade_rule",
+copy_file(
+    name = "binary",
+    src = "//language-support/codegen-main:codegen-main_distribute.jar",
+    out = "binary.jar",
+    allow_symlink = True,
     tags = ["maven_coordinates=com.daml:codegen-jvm-main:__VERSION__"],
     visibility = ["//visibility:public"],
 )
 
 pom_file(
-    name = "shaded_binary_pom",
-    target = ":shaded_binary",
+    name = "binary_pom",
+    target = ":binary",
     visibility = ["//visibility:public"],
 )
 
 # Create empty Scaladoc JAR for uploading to Maven Central
 scaladoc_jar(
-    name = "shaded_binary_scaladoc",
+    name = "binary_scaladoc",
     srcs = [],
     tags = ["scaladoc"],
     deps = [],
@@ -76,6 +74,6 @@ scaladoc_jar(
 
 # Create empty Sources JAR for uploading to Maven Central
 scala_source_jar(
-    name = "shaded_binary_src",
+    name = "binary_src",
     srcs = [],
 )

--- a/sdk/language-support/codegen-main/shade_rule
+++ b/sdk/language-support/codegen-main/shade_rule
@@ -1,8 +1,0 @@
-zap grpc.health.v1.**
-zap io.grpc.**
-zap io.netty.**
-zap io.reactivex.**
-zap org.reactivestreams.**
-zap com.sun.**
-zap javax.**
-zap sun.**

--- a/sdk/language-support/java/codegen/BUILD.bazel
+++ b/sdk/language-support/java/codegen/BUILD.bazel
@@ -28,12 +28,9 @@ load(
     "lf_version_default_or_latest",
     "lf_version_is_dev",
 )
-load(
-    "@com_github_johnynek_bazel_jar_jar//:jar_jar.bzl",
-    "jar_jar",
-)
 load("//bazel_tools:pom_file.bzl", "pom_file")
 load("@os_info//:os_info.bzl", "is_windows")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 
 da_scala_binary(
     name = "codegen",
@@ -168,23 +165,24 @@ dar_to_java(
     package_prefix = "ut",
 )
 
-jar_jar(
-    name = "shaded_binary",
-    input_jar = "//language-support/java/codegen:codegen_distribute.jar",
-    rules = "shade_rule",
+copy_file(
+    name = "binary",
+    src = "//language-support/java/codegen:codegen_distribute.jar",
+    out = "binary.jar",
+    allow_symlink = True,
     tags = ["maven_coordinates=com.daml:codegen-java:__VERSION__"],
     visibility = ["//visibility:public"],
 )
 
 pom_file(
-    name = "shaded_binary_pom",
-    target = ":shaded_binary",
+    name = "binary_pom",
+    target = ":binary",
     visibility = ["//visibility:public"],
 )
 
 # Create empty Scaladoc JAR for uploading to Maven Central
 scaladoc_jar(
-    name = "shaded_binary_scaladoc",
+    name = "binary_scaladoc",
     srcs = [],
     tags = ["scaladoc"],
     deps = [],
@@ -192,7 +190,7 @@ scaladoc_jar(
 
 # Create empty Sources JAR for uploading to Maven Central
 scala_source_jar(
-    name = "shaded_binary_src",
+    name = "binary_src",
     srcs = [],
 )
 

--- a/sdk/language-support/java/codegen/shade_rule
+++ b/sdk/language-support/java/codegen/shade_rule
@@ -1,8 +1,0 @@
-zap grpc.health.v1.**
-zap io.grpc.**
-zap io.netty.**
-zap io.reactivex.**
-zap org.reactivestreams.**
-zap com.sun.**
-zap javax.**
-zap sun.**

--- a/sdk/release/artifacts.yaml
+++ b/sdk/release/artifacts.yaml
@@ -53,7 +53,7 @@
   type: jar-scala
 - target: //language-support/codegen-common:codegen-common
   type: jar-scala
-- target: //language-support/codegen-main:shaded_binary
+- target: //language-support/codegen-main:binary
   type: jar-jarjar
 - target: //canton:bindings-java
   type: jar-lib
@@ -61,7 +61,7 @@
   type: jar-lib
 - target: //language-support/java/codegen:lib
   type: jar-scala
-- target: //language-support/java/codegen:shaded_binary
+- target: //language-support/java/codegen:binary
   type: jar-jarjar
 - target: //language-support/java/json:json
   type: jar-scala


### PR DESCRIPTION
After the [switch to JDK 17](https://github.com/digital-asset/daml/pull/19229), we're hitting [this issue](https://github.com/bazelbuild/bazel/issues/14645) when running `Bazel > Sync > Sync project with BUILD files` in intellij. Namely, ijar segfaults when trying to extract the interface of some jars.

Fortunately, the only affected jars are the ones produced by `jar_jar` for [obsolete historical reasons](https://github.com/DACH-NY/daml/pull/775). The goal was to get a smaller jar, but it is no longer really the case: we're only saving 4% of the size.

The only remaining (legitimate) [usage of jar_jar](https://github.com/digital-asset/daml/blob/1064fff281e8f08e6184143f9ae90602ce3f45ea/sdk/canton/BUILD.bazel#L105) in our codebase is fortunately not affected by this bug.