### PR TITLE
ETX-500: ensure types are always looked up via package id, not package name

### DIFF
--- a/sdk/ledger-service/http-json/src/it/daml/upgrades/v2/Foo.daml
+++ b/sdk/ledger-service/http-json/src/it/daml/upgrades/v2/Foo.daml
@@ -6,6 +6,26 @@ module Foo where
 -- This template is an upgrade on the Bar in v1/Foo.daml
 template Bar with
     owner : Party
-    extra : Optional Int
+    extra : Optional Int -- new optional field
   where
     signatory owner
+
+-- A new template with custom types for key, choice arg and choice return type
+-- Ensure all these types can be resolved via package name.
+data Key = Key with value : Party deriving (Show, Eq)
+data Arg = Arg with value : Int deriving (Show, Eq)
+data Ret = Ret with value : Int deriving (Show, Eq)
+
+template Quux
+  with
+    owner : Party
+  where
+    signatory owner
+    key (Key owner) : Key
+    maintainer key.value
+
+    choice Incr: Ret
+      with a : Arg
+      controller owner
+      do
+        pure Ret with value = a.value + 1

--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -457,14 +457,14 @@ package domain {
 
         override def lfType(
             fa: ActiveContract.ResolvedCtTyId[_],
-            templateId: ContractTypeId.ResolvedPkg,
+            templateId: ContractTypeId.ResolvedPkgId,
             f: PackageService.ResolveTemplateRecordType,
             g: PackageService.ResolveChoiceArgType,
             h: PackageService.ResolveKeyType,
         ): Error \/ LfType =
           templateId match {
             case tid @ ContractTypeId.Template(_, _, _) =>
-              f(tid: ContractTypeId.Template.ResolvedPkg)
+              f(tid: ContractTypeId.Template.ResolvedPkgId)
                 .leftMap(e => Error(Symbol("ActiveContract_hasTemplateId_lfType"), e.shows))
             case other =>
               val errorMsg = s"Expect contract type Id to be template Id, got otherwise: $other"
@@ -563,14 +563,14 @@ package domain {
 
         override def lfType(
             fa: EnrichedContractKey[_],
-            templateId: ContractTypeId.ResolvedPkg,
+            templateId: ContractTypeId.ResolvedPkgId,
             f: PackageService.ResolveTemplateRecordType,
             g: PackageService.ResolveChoiceArgType,
             h: PackageService.ResolveKeyType,
         ): Error \/ LfType = {
           templateId match {
             case tid @ ContractTypeId.Template(_, _, _) =>
-              h(tid: ContractTypeId.Template.ResolvedPkg)
+              h(tid: ContractTypeId.Template.ResolvedPkgId)
                 .leftMap(e => Error(Symbol("EnrichedContractKey_hasTemplateId_lfType"), e.shows))
             case other =>
               val errorMsg = s"Expect contract type Id to be template Id, got otherwise: $other"
@@ -602,7 +602,7 @@ package domain {
 
     def lfType(
         fa: F[_],
-        templateId: ContractTypeId.ResolvedPkg,
+        templateId: ContractTypeId.ResolvedPkgId,
         f: PackageService.ResolveTemplateRecordType,
         g: PackageService.ResolveChoiceArgType,
         h: PackageService.ResolveKeyType,
@@ -626,7 +626,7 @@ package domain {
 
           override def lfType(
               fa: F[_],
-              templateId: ContractTypeId.ResolvedPkg,
+              templateId: ContractTypeId.ResolvedPkgId,
               f: PackageService.ResolveTemplateRecordType,
               g: PackageService.ResolveChoiceArgType,
               h: PackageService.ResolveKeyType,
@@ -670,7 +670,7 @@ package domain {
     implicit val hasTemplateId: HasTemplateId.Aux[RequiredPkg[
       +*,
       domain.ContractLocator[_],
-    ], (Option[domain.ContractTypeId.Interface.ResolvedPkg], LfType)] =
+    ], (Option[domain.ContractTypeId.Interface.ResolvedPkgId], LfType)] =
       new HasTemplateId[RequiredPkg[+*, domain.ContractLocator[_]]] {
         override def templateId(fab: FHuh): ContractTypeId.RequiredPkg =
           fab.choiceInterfaceId getOrElse (fab.reference match {
@@ -682,11 +682,11 @@ package domain {
               )
           })
 
-        type TypeFromCtId = (Option[domain.ContractTypeId.Interface.ResolvedPkg], LfType)
+        type TypeFromCtId = (Option[domain.ContractTypeId.Interface.ResolvedPkgId], LfType)
 
         override def lfType(
             fa: FHuh,
-            templateId: ContractTypeId.ResolvedPkg,
+            templateId: ContractTypeId.ResolvedPkgId,
             f: PackageService.ResolveTemplateRecordType,
             g: PackageService.ResolveChoiceArgType,
             h: PackageService.ResolveKeyType,


### PR DESCRIPTION
tl;dr: The types exist in packages which are indexed by id, so we need to use package ids when doing type lookups.

We load type information from packages, which internally identify themselves by ids.
When a request comes in, it will specify a template id, and when decoding we internally use that id to look up the relevant type in the appropriate package, to know how to decode the JSON.

However, now template ids can use a package name in as their package specifier instead of a package id, so we need to ensure that when doing the type lookups, we are always using the package id to find the relevant package.

Concretely, this involves changing the keys for those lookups from accepting a `ContractTypeId[Ref.PackageRef]` to a `ContractTypeId[Ref.PackageId]`. 

run-all-tests: true