### PR TITLE
stop hardcoding lf2 stable packages in daml3-script

### DIFF
--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -9,7 +9,6 @@ import com.daml.ledger.api.domain.{PartyDetails, User, UserRight}
 import com.daml.ledger.api.v1.value
 import com.daml.lf.data.Ref._
 import com.daml.lf.data._
-import com.daml.lf.engine.script.v2.Converter
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.{LanguageMajorVersion, StablePackages}
 import com.daml.lf.speedy.SBuiltin._

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -10,7 +10,6 @@ import com.daml.ledger.api.v1.value
 import com.daml.lf.data.Ref._
 import com.daml.lf.data._
 import com.daml.lf.language.Ast._
-import com.daml.lf.language.LanguageMajorVersion.{V1, V2}
 import com.daml.lf.language.{LanguageMajorVersion, StablePackages}
 import com.daml.lf.speedy.SBuiltin._
 import com.daml.lf.speedy.SExpr._
@@ -23,8 +22,8 @@ import com.daml.lf.value.Value.ContractId
 import com.daml.platform.participant.util.LfEngineToApi.toApiIdentifier
 import com.daml.script.converter.ConverterException
 import io.grpc.StatusRuntimeException
-import scalaz.std.list._
 import scalaz.std.either._
+import scalaz.std.list._
 import scalaz.std.option._
 import scalaz.std.vector._
 import scalaz.syntax.traverse._
@@ -72,17 +71,10 @@ final case class AnyContractKey(templateId: Identifier, ty: Type, key: SValue)
 
 final case class Disclosure(templatedId: TypeConName, contractId: ContractId, blob: Bytes)
 
-object Converter {
-  def apply(majorLanguageVersion: LanguageMajorVersion): ConverterMethods = {
-    majorLanguageVersion match {
-      case V1 => com.daml.lf.engine.script.v1.Converter
-      case V2 => com.daml.lf.engine.script.v2.Converter
-    }
-  }
-}
-
-abstract class ConverterMethods(stablePackages: StablePackages) {
+class ConverterMethods(majorLanguageVersion: LanguageMajorVersion) {
   import com.daml.script.converter.Converter._
+
+  val stablePackages = StablePackages(majorLanguageVersion)
 
   private def toNonEmptySet[A](as: OneAnd[FrontStack, A]): OneAnd[Set, A] = {
     import scalaz.syntax.foldable._
@@ -553,4 +545,10 @@ abstract class ConverterMethods(stablePackages: StablePackages) {
       "Explicit disclosures not supported",
     )
   )
+
+  def makeTuple(v1: SValue, v2: SValue): SValue =
+    record(stablePackages.Tuple2, ("_1", v1), ("_2", v2))
+
+  def makeTuple(v1: SValue, v2: SValue, v3: SValue): SValue =
+    record(stablePackages.Tuple3, ("_1", v1), ("_2", v2), ("_3", v3))
 }

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -9,6 +9,7 @@ import com.daml.ledger.api.domain.{PartyDetails, User, UserRight}
 import com.daml.ledger.api.v1.value
 import com.daml.lf.data.Ref._
 import com.daml.lf.data._
+import com.daml.lf.engine.script.v2.Converter
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.{LanguageMajorVersion, StablePackages}
 import com.daml.lf.speedy.SBuiltin._
@@ -71,7 +72,14 @@ final case class AnyContractKey(templateId: Identifier, ty: Type, key: SValue)
 
 final case class Disclosure(templatedId: TypeConName, contractId: ContractId, blob: Bytes)
 
-class ConverterMethods(majorLanguageVersion: LanguageMajorVersion) {
+object Converter {
+  private val converters = LanguageMajorVersion.All.map(v => v -> new Converter(v)).toMap
+
+  def apply(majorLanguageVersion: LanguageMajorVersion): Converter =
+    converters(majorLanguageVersion)
+}
+
+class Converter(majorLanguageVersion: LanguageMajorVersion) {
   import com.daml.script.converter.Converter._
 
   val stablePackages = StablePackages(majorLanguageVersion)

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/Converter.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/Converter.scala
@@ -26,7 +26,7 @@ import scalaz.syntax.traverse._
 
 import scala.annotation.tailrec
 
-object Converter extends script.ConverterMethods(LanguageMajorVersion.V1) {
+object Converter extends script.Converter(LanguageMajorVersion.V1) {
   import com.daml.script.converter.Converter._
 
   def translateExerciseResult(

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/Converter.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/Converter.scala
@@ -12,22 +12,21 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.data._
 import com.daml.lf.engine.script.v1.ledgerinteraction.ScriptLedgerClient
 import com.daml.lf.language.Ast._
-import com.daml.lf.language.StablePackagesV1
+import com.daml.lf.language.{LanguageMajorVersion, StablePackagesV1}
 import com.daml.lf.speedy.SExpr._
-import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SResult._
+import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.{Pretty, SValue, Speedy}
-import com.daml.lf.speedy.SExpr.SExpr
 import com.daml.lf.value.Value.ContractId
 import com.daml.platform.participant.util.LfEngineToApi.toApiIdentifier
-import scalaz.std.list._
 import scalaz.std.either._
+import scalaz.std.list._
 import scalaz.std.option._
 import scalaz.syntax.traverse._
 
 import scala.annotation.tailrec
 
-object Converter extends script.ConverterMethods(StablePackagesV1) {
+object Converter extends script.ConverterMethods(LanguageMajorVersion.V1) {
   import com.daml.script.converter.Converter._
 
   def translateExerciseResult(
@@ -401,10 +400,5 @@ object Converter extends script.ConverterMethods(StablePackagesV1) {
       }
     }
     iter(freeAp, List())
-  }
-
-  def makePair(v1: SValue, v2: SValue): SValue = {
-    import com.daml.script.converter.Converter.record
-    record(StablePackagesV1.Tuple2, ("_1", v1), ("_2", v2))
   }
 }

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ScriptF.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ScriptF.scala
@@ -253,7 +253,7 @@ object ScriptF {
           if (asDisclosure)
             Right(
               optR.map(c =>
-                Converter.makePair(
+                Converter.makeTuple(
                   Converter.fromTemplateTypeRep(c.templateId),
                   SValue.SText(c.blob.toHexString),
                 )
@@ -289,7 +289,7 @@ object ScriptF {
             .traverse { case (cid, optView) =>
               optView match {
                 case None =>
-                  Right(Converter.makePair(SContractId(cid), SOptional(None)))
+                  Right(Converter.makeTuple(SContractId(cid), SOptional(None)))
                 case Some(view) =>
                   for {
                     view <- Converter.fromInterfaceView(
@@ -298,7 +298,7 @@ object ScriptF {
                       view,
                     )
                   } yield {
-                    Converter.makePair(SContractId(cid), SOptional(Some(view)))
+                    Converter.makeTuple(SContractId(cid), SOptional(Some(view)))
                   }
               }
             }

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Converter.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Converter.scala
@@ -22,8 +22,15 @@ import scalaz.std.list._
 import scalaz.std.option._
 import scalaz.syntax.traverse._
 
+object Converter {
+  private val converters = LanguageMajorVersion.All.map(v => v -> new Converter(v)).toMap
+
+  def apply(majorLanguageVersion: LanguageMajorVersion): Converter =
+    converters(majorLanguageVersion)
+}
+
 final class Converter(majorLanguageVersion: LanguageMajorVersion)
-    extends script.ConverterMethods(majorLanguageVersion) {
+    extends script.Converter(majorLanguageVersion) {
   import com.daml.script.converter.Converter._
 
   def translateExerciseResult(

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Runner.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Runner.scala
@@ -32,7 +32,7 @@ private[lf] class Runner(
   import Free.Result
   import SExpr.SExpr
 
-  val scriptF = new ScriptF(
+  val scriptF = ScriptF(
     unversionedRunner.compiledPackages.compilerConfig.allowedLanguageVersions.majorVersion
   )
 

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Runner.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Runner.scala
@@ -6,7 +6,6 @@ package engine
 package script
 package v2
 
-import org.apache.pekko.stream.Materializer
 import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.daml.lf.engine.free.Free
 import com.daml.lf.engine.script.Runner.IdeLedgerContext
@@ -14,9 +13,11 @@ import com.daml.lf.engine.script.ledgerinteraction.{
   ScriptLedgerClient => UnversionedScriptLedgerClient
 }
 import com.daml.lf.engine.script.v2.ledgerinteraction.ScriptLedgerClient
+import com.daml.lf.language.LanguageVersionRangeOps._
 import com.daml.lf.scenario.{ScenarioLedger, ScenarioRunner}
-import com.daml.lf.speedy.{SValue, SExpr, Profile, WarningLog, Speedy, TraceLog}
+import com.daml.lf.speedy._
 import com.daml.script.converter.ConverterException
+import org.apache.pekko.stream.Materializer
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -28,7 +29,12 @@ private[lf] class Runner(
     profile: Profile = Speedy.Machine.newProfile,
     canceled: () => Option[RuntimeException] = () => None,
 ) {
-  import Free.Result, SExpr.SExpr
+  import Free.Result
+  import SExpr.SExpr
+
+  val scriptF = new ScriptF(
+    unversionedRunner.compiledPackages.compilerConfig.allowedLanguageVersions.majorVersion
+  )
 
   private val initialClientsV2 = initialClients.map(
     ScriptLedgerClient.realiseScriptLedgerClient(
@@ -46,7 +52,7 @@ private[lf] class Runner(
       unversionedRunner.extendedCompiledPackages,
     )
 
-  private val knownPackages = ScriptF.KnownPackages(unversionedRunner.knownPackages)
+  private val knownPackages = scriptF.KnownPackages(unversionedRunner.knownPackages)
 
   private val ideLedgerContext: Option[IdeLedgerContext] =
     initialClientsV2.default_participant.collect {
@@ -58,9 +64,9 @@ private[lf] class Runner(
         }
     }
 
-  def remapQ[X](result: Result[X, Free.Question, SExpr]): Result[X, ScriptF.Cmd, SExpr] =
+  def remapQ[X](result: Result[X, Free.Question, SExpr]): Result[X, scriptF.Cmd, SExpr] =
     result.remapQ { case Free.Question(name, version, payload, stackTrace) =>
-      ScriptF.parse(name, version, payload, knownPackages) match {
+      scriptF.parse(name, version, payload, knownPackages) match {
         case Right(cmd) =>
           Result.Ask(
             cmd,
@@ -95,7 +101,7 @@ private[lf] class Runner(
         profile,
         Script.DummyLoggingContext,
       )
-    ).runF[ScriptF.Cmd, SExpr](
+    ).runF[scriptF.Cmd, SExpr](
       _.executeWithRunner(env, this)
         .map(Result.successful)
         .recover { case err: RuntimeException => Result.failed(err) },

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
@@ -36,6 +36,11 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 object ScriptF {
+  private val scriptFs = LanguageMajorVersion.All.map(v => v -> new ScriptF(v)).toMap
+
+  def apply(majorLanguageVersion: LanguageMajorVersion): ScriptF =
+    scriptFs(majorLanguageVersion)
+
   final case class Ctx(knownPackages: Map[String, PackageId], compiledPackages: CompiledPackages)
 
   // The environment that the `execute` function gets access to.
@@ -96,7 +101,7 @@ object ScriptF {
 class ScriptF(majorLanguageVersion: LanguageMajorVersion) {
   import ScriptF._
 
-  val converter = new Converter(majorLanguageVersion)
+  val converter = Converter(majorLanguageVersion)
   val stablePackages = StablePackages(majorLanguageVersion)
 
   val left = SEBuiltin(

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
@@ -33,7 +33,7 @@ class SubmitErrors(majorLanguageVersion: LanguageMajorVersion) {
   import ScriptF.Env
   import com.daml.script.converter.Converter._
 
-  val converter = new Converter(majorLanguageVersion)
+  val converter = Converter(majorLanguageVersion)
   import converter._
 
   case class SubmitErrorConverters(env: ScriptF.Env) {

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcErrorParser.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcErrorParser.scala
@@ -19,6 +19,13 @@ import io.grpc.StatusRuntimeException
 import scala.reflect.ClassTag
 import scala.util.Try
 
+object GrpcErrorParser {
+  private val parsers = LanguageMajorVersion.All.map(v => v -> new GrpcErrorParser(v)).toMap
+
+  def apply(majorLanguageVersion: LanguageMajorVersion): GrpcErrorParser =
+    parsers(majorLanguageVersion)
+}
+
 class GrpcErrorParser(majorVersion: LanguageMajorVersion) {
   val submitErrors = new SubmitErrors(majorVersion)
 

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcErrorParser.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcErrorParser.scala
@@ -44,7 +44,7 @@ class GrpcErrorParser(majorVersion: LanguageMajorVersion) {
 
   val parseList = (s: String) => s.tail.init.split(", ").toSeq
 
-  // Converts a given SubmitError into a submitErrors. Wraps in an UnknownError if its not what we expect, wraps in a TruncatedError if we're missing resources
+  // Converts a given SubmitError into a SubmitError. Wraps in an UnknownError if its not what we expect, wraps in a TruncatedError if we're missing resources
   def convertStatusRuntimeException(
       s: StatusRuntimeException,
       keyPackageNameLookup: PackageId => Either[String, KeyPackageName],

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
@@ -61,8 +61,8 @@ class GrpcLedgerClient(
 
   private val majorLanguageVersion =
     compiledPackages.compilerConfig.allowedLanguageVersions.majorVersion
-  private val converter = new Converter(majorLanguageVersion)
-  private val grpcErrorParser = new GrpcErrorParser(majorLanguageVersion)
+  private val converter = Converter(majorLanguageVersion)
+  private val grpcErrorParser = GrpcErrorParser(majorLanguageVersion)
 
   override def query(
       parties: OneAnd[Set, Ref.Party],

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
@@ -5,10 +5,6 @@ package com.daml.lf.engine.script
 package v2.ledgerinteraction
 package grpcLedgerClient
 
-import java.time.Instant
-import java.util.UUID
-import org.apache.pekko.stream.Materializer
-import org.apache.pekko.stream.scaladsl.Sink
 import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.daml.grpc.adapter.client.pekko.ClientAdapter
 import com.daml.ledger.api.domain.{User, UserRight}
@@ -18,26 +14,20 @@ import com.daml.ledger.api.v1.commands._
 import com.daml.ledger.api.v1.event.{CreatedEvent, InterfaceView}
 import com.daml.ledger.api.v1.testing.time_service.TimeServiceGrpc.TimeServiceStub
 import com.daml.ledger.api.v1.testing.time_service.{GetTimeRequest, SetTimeRequest, TimeServiceGrpc}
-import com.daml.ledger.api.v1.transaction_filter.{
-  Filters,
-  InclusiveFilters,
-  InterfaceFilter,
-  TemplateFilter,
-  TransactionFilter,
-}
+import com.daml.ledger.api.v1.transaction_filter._
 import com.daml.ledger.api.v1.{value => api}
 import com.daml.ledger.api.validation.NoLoggingValueValidator
 import com.daml.ledger.client.LedgerClient
-import com.daml.lf.CompiledPackages
-import com.daml.lf.command
 import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{Bytes, Ref, Time}
 import com.daml.lf.engine.script.v2.Converter
+import com.daml.lf.language.LanguageVersionRangeOps._
 import com.daml.lf.language.{Ast, LanguageVersion}
 import com.daml.lf.speedy.{SValue, svalue}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
+import com.daml.lf.{CompiledPackages, command}
 import com.daml.platform.participant.util.LfEngineToApi.{
   lfValueToApiRecord,
   lfValueToApiValue,
@@ -46,6 +36,8 @@ import com.daml.platform.participant.util.LfEngineToApi.{
 }
 import com.daml.script.converter.ConverterException
 import io.grpc.{Status, StatusRuntimeException}
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Sink
 import scalaz.OneAnd
 import scalaz.OneAnd._
 import scalaz.std.either._
@@ -54,6 +46,8 @@ import scalaz.std.set._
 import scalaz.syntax.foldable._
 import scalaz.syntax.tag._
 
+import java.time.Instant
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
 class GrpcLedgerClient(
@@ -64,6 +58,11 @@ class GrpcLedgerClient(
     val compiledPackages: CompiledPackages,
 ) extends ScriptLedgerClient {
   override val transport = "gRPC API"
+
+  private val majorLanguageVersion =
+    compiledPackages.compilerConfig.allowedLanguageVersions.majorVersion
+  private val converter = new Converter(majorLanguageVersion)
+  private val grpcErrorParser = new GrpcErrorParser(majorLanguageVersion)
 
   override def query(
       parties: OneAnd[Set, Ref.Party],
@@ -162,7 +161,7 @@ class GrpcLedgerClient(
           val blob =
             Bytes.fromByteString(createdEvent.createdEventBlob)
           val disclosureTemplateId =
-            Converter
+            converter
               .fromApiIdentifier(
                 createdEvent.templateId.getOrElse(
                   throw new ConverterException("missing required template_id in CreatedEvent")
@@ -272,7 +271,7 @@ class GrpcLedgerClient(
     for {
       activeContracts <- queryWithKey(parties, templateId)
       speedyContracts <- activeContracts.traverse { case (t, kOpt) =>
-        Converter.toFuture(kOpt.traverse(translateKey(templateId, _)).map(k => (t, k)))
+        converter.toFuture(kOpt.traverse(translateKey(templateId, _)).map(k => (t, k)))
       }
     } yield {
       // Note that the Equal instance on Value performs structural equality
@@ -312,7 +311,7 @@ class GrpcLedgerClient(
       }
     val resultFuture =
       for {
-        ledgerCommands <- Converter.toFuture(commands.traverse(toCommand(_)))
+        ledgerCommands <- converter.toFuture(commands.traverse(toCommand(_)))
         // We need to remember the original package ID for each command result, so we can reapply them
         // after we get the results (for upgrades)
         commandResultPackageIds = commands.flatMap(toCommandPackageIds(_))
@@ -331,8 +330,8 @@ class GrpcLedgerClient(
         request = SubmitAndWaitRequest(Some(apiCommands))
         resp <- grpcClient.commandServiceClient
           .submitAndWaitForTransactionTree(request)
-        tree <- Converter.toFuture(
-          Converter.fromTransactionTree(resp.getTransaction, commandResultPackageIds)
+        tree <- converter.toFuture(
+          converter.fromTransactionTree(resp.getTransaction, commandResultPackageIds)
         )
         results = ScriptLedgerClient.transactionTreeToCommandResults(tree)
       } yield Right((results, tree))
@@ -342,7 +341,7 @@ class GrpcLedgerClient(
           Left(
             ScriptLedgerClient.SubmitFailure(
               s,
-              GrpcErrorParser.convertStatusRuntimeException(s, keyPackageNameLookup),
+              grpcErrorParser.convertStatusRuntimeException(s, keyPackageNameLookup),
             )
           )
         )


### PR DESCRIPTION
I went back and forth between indexing everything by the major language version and doing proper "manual dependency injection" where each class receives exactly the thing it needs and not more (like stable packages, instead of the major language version). In the end I settled on indexing everything by the major language version because I think it makes it clearer to the reader why everything is parameterized. I made sure to cache the instances of what used to be objects and are now classes in order to avoid re-allocating identical objects again and again.

The reason for changing `final` to `sealed` on many case classes in `ScriptF` is because of ["semantics out of a nightmare"](https://groups.google.com/g/scala-internals/c/vw8Kek4zlZ8/m/LAeakfeR3RoJ) which I learned about today via [this stack overflow answer](https://stackoverflow.com/a/16466541). If an inner class inside a class is marked as final then you get a warning that the pattern matcher won't be able to verify that the outer value is the one it should actually be. You can either suppress the warning or make it non-final. I went for the latter because even if in our case I think it's safe to ignore the outer value, it is hard to understand why this warning should be suppressed.  
One consequence of this is that the outer class can no longer be GCd while instances of the inner class are still in use, but in our case we don't care as the outer class is long-lived.  
The reason for `sealed` is because the compiler complains that sublasses of sealed traits must be either final or sealed.