### PR TITLE
Multi-IDE Sdk install managament

### DIFF
--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/Handlers.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/Handlers.hs
@@ -201,7 +201,7 @@ clientMessageHandler miState unblock bs = do
            in traverse_ (`unsafeSendSubIdeSTM` newMsg) $ mIde >>= ideDataMain
 
     LSP.FromClientMess (LSP.SCustomMethod t) (LSP.NotMess notif) | t == damlSdkInstallCancelMethod ->
-      handleSdkInstallCancelled miState notif
+      handleSdkInstallClientCancelled miState notif
 
     -- Special handing for STextDocumentDefinition to ask multiple IDEs (the W approach)
     -- When a getDefinition is requested, we cast this request into a tryGetDefinition
@@ -238,7 +238,7 @@ clientMessageHandler miState unblock bs = do
             let home = PackageHome $ takeDirectory changedPath
             logInfo miState $ "daml.yaml change in " <> unPackageHome home <> ". Shutting down IDE"
             atomically $ sourceFileHomeHandleDamlYamlChanged miState home
-            allowSdkInstall miState home
+            allowIdeSdkInstall miState home
             case changeType of
               LSP.FcDeleted -> do
                 shutdownIdeByHome miState home
@@ -315,5 +315,5 @@ clientMessageHandler miState unblock bs = do
       case (method, _id) of
         (LSP.SClientRegisterCapability, Just (LSP.IdString "MultiIdeWatchedFiles")) ->
           either (\err -> logError miState $ "Watched file registration failed with " <> show err) (const $ logDebug miState "Successfully registered watched files") _result
-        (LSP.SWindowShowMessageRequest, Just lspId) -> handleShowMessageResponse miState lspId _result
+        (LSP.SWindowShowMessageRequest, Just lspId) -> handleSdkInstallPromptResponse miState lspId _result
         _ -> pure ()

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/OpenFiles.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/OpenFiles.hs
@@ -6,6 +6,7 @@ module DA.Cli.Damlc.Command.MultiIde.OpenFiles (
   removeOpenFile,
   handleRemovedPackageOpenFiles,
   handleCreatedPackageOpenFiles,
+  sendPackageDiagnostic,
 ) where
 
 import Control.Monad
@@ -18,15 +19,26 @@ import Data.Foldable (traverse_)
 import Data.List (isPrefixOf)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import qualified Data.Text as T
 import qualified Data.Text.Extended as TE
 import GHC.Conc (unsafeIOToSTM)
+import System.FilePath ((</>))
+
+ideDiagnosticFiles :: SubIdeData -> [FilePath]
+ideDiagnosticFiles ideData = (unPackageHome (ideDataHome ideData) </> "daml.yaml") : fmap unDamlFile (Set.toList $ ideDataOpenFiles ideData)
+
+sendPackageDiagnostic :: MultiIdeState -> SubIdeData -> STM ()
+sendPackageDiagnostic miState ideData@SubIdeData {ideDataDisabled = IdeDataDisabled {iddSeverity, iddMessage}} =
+  traverse_ (sendClientSTM miState) $ fullFileDiagnostic iddSeverity (T.unpack iddMessage) <$> ideDiagnosticFiles ideData
+sendPackageDiagnostic miState ideData =
+  traverse_ (sendClientSTM miState) $ clearDiagnostics <$> ideDiagnosticFiles ideData
 
 onOpenFiles :: MultiIdeState -> PackageHome -> (Set.Set DamlFile -> Set.Set DamlFile) -> STM ()
-onOpenFiles miState home f = modifyTMVarM (misSubIdesVar miState) $ \subIdes -> do
-  let ideData = lookupSubIde home subIdes
+onOpenFiles miState home f = modifyTMVarM (misSubIdesVar miState) $ \ides -> do
+  let ideData = lookupSubIde home ides
       ideData' = ideData {ideDataOpenFiles = f $ ideDataOpenFiles ideData}
-  when (ideDataDisabled ideData') $ traverse_ (sendClientSTM miState) $ disableIdeDiagnosticMessages ideData'
-  pure $ Map.insert home ideData' subIdes
+  sendPackageDiagnostic miState ideData'
+  pure $ Map.insert home ideData' ides
 
 addOpenFile :: MultiIdeState -> PackageHome -> DamlFile -> STM ()
 addOpenFile miState home file = do
@@ -53,7 +65,7 @@ handleRemovedPackageOpenFiles miState home = withIDEsAtomic_ miState $ \ides -> 
         let newHomeIdeData = lookupSubIde newHome ides
             newHomeIdeData' = newHomeIdeData {ideDataOpenFiles = Set.insert openFile $ ideDataOpenFiles newHomeIdeData}
         -- If we're moving the file to a disabled IDE, it should get the new warning
-        when (ideDataDisabled newHomeIdeData') $ traverse_ (sendClientSTM miState) $ disableIdeDiagnosticMessages newHomeIdeData'
+        sendPackageDiagnostic miState newHomeIdeData'
         forM_ (ideDataMain newHomeIdeData) $ \ide -> do
           -- Acceptable IO as read only operation
           content <- unsafeIOToSTM $ TE.readFileUtf8 $ unDamlFile openFile

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/PackageData.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/PackageData.hs
@@ -105,11 +105,11 @@ updatePackageData miState = do
         -- load cache with all multi-package dars, so they'll be present in darUnitIds
         traverse_ getDarUnitId darPaths
         fmap (bimap catMaybes catMaybes . unzip) $ forM packagePaths $ \packagePath -> do
-          mUnitIdAndDeps <- lift $ fmap eitherToMaybe $ unitIdAndDepsFromDamlYaml packagePath
-          case mUnitIdAndDeps of
-            Just (unitId, deps) -> do
-              allDepsValid <- isJust . sequence <$> traverse getDarUnitId deps
-              pure (if allDepsValid then Nothing else Just packagePath, Just (packagePath, unitId, deps))
+          mPackageSummary <- lift $ fmap eitherToMaybe $ packageSummaryFromDamlYaml packagePath
+          case mPackageSummary of
+            Just packageSummary -> do
+              allDepsValid <- isJust . sequence <$> traverse getDarUnitId (psDeps packageSummary)
+              pure (if allDepsValid then Nothing else Just packagePath, Just (packagePath, psUnitId packageSummary, psDeps packageSummary))
             _ -> pure (Just packagePath, Nothing)
 
       let invalidHomes :: [PackageHome]

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/PackageData.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/PackageData.hs
@@ -24,6 +24,7 @@ import Data.Foldable (traverse_)
 import qualified Data.Map as Map
 import Data.Maybe (catMaybes, isJust)
 import qualified Data.Set as Set
+import qualified Language.LSP.Types as LSP
 import System.Directory (doesFileExist)
 import System.FilePath.Posix ((</>))
 
@@ -80,7 +81,7 @@ updatePackageData miState = do
             void $ tryPutTMVar (misMultiPackageMappingVar miState) Map.empty
             void $ tryPutTMVar (misDarDependentPackagesVar miState) Map.empty
           -- Show the failure as a diagnostic on the multi-package.yaml
-          sendClient miState $ fullFileDiagnostic ("Error reading multi-package.yaml:\n" <> displayException err) multiPackagePath
+          sendClient miState $ fullFileDiagnostic LSP.DsError ("Error reading multi-package.yaml:\n" <> displayException err) multiPackagePath
           pure []
   where
     -- Gets the unit id of a dar if it can, caches result in stateT

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/SdkInstall.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/SdkInstall.hs
@@ -15,7 +15,7 @@ module DA.Cli.Damlc.Command.MultiIde.SdkInstall (
 import Control.Concurrent.Async
 import Control.Concurrent.MVar
 import Control.Concurrent.STM.TMVar
-import Control.Exception (SomeException, tryJust, displayException, fromException)
+import Control.Exception (SomeException, displayException)
 import Control.Lens ((^.))
 import Control.Monad (foldM, forM_)
 import Control.Monad.STM
@@ -29,6 +29,7 @@ import DA.Cli.Damlc.Command.MultiIde.OpenFiles
 import DA.Cli.Damlc.Command.MultiIde.Parsing
 import DA.Cli.Damlc.Command.MultiIde.Types
 import DA.Cli.Damlc.Command.MultiIde.Util
+import DA.Daml.Assistant.Cache (CacheTimeout (..))
 import DA.Daml.Assistant.Env
 import DA.Daml.Assistant.Install
 import DA.Daml.Assistant.Types
@@ -187,7 +188,7 @@ installSdk unresolvedVersion outputLogVar report = do
   damlPath <- getDamlPath
   cachePath <- getCachePath
   -- Override the cache timeout to 5 minutes, to be sure we have a recent cache
-  let useCache = mkUseCache cachePath damlPath {overrideTimeout = Just $ CacheTimeout 300}
+  let useCache = (mkUseCache cachePath damlPath) {overrideTimeout = Just $ CacheTimeout 300}
 
   version <- resolveReleaseVersionUnsafe useCache unresolvedVersion
   damlConfigE <- tryConfig $ readDamlConfig damlPath

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/SdkInstall.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/SdkInstall.hs
@@ -1,0 +1,254 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+
+module DA.Cli.Damlc.Command.MultiIde.SdkInstall (
+  allowSdkInstall,
+  ensureSdkInstalled,
+  handleSdkInstallCancelled,
+  handleShowMessageResponse,
+  untrackPackageSdkInstall,
+) where
+
+import Control.Concurrent.Async
+import Control.Concurrent.MVar
+import Control.Concurrent.STM.TMVar
+import Control.Exception (SomeException, tryJust, displayException, fromException)
+import Control.Lens ((^.))
+import Control.Monad (foldM, forM_)
+import Control.Monad.STM
+import Data.Aeson (fromJSON, toJSON)
+import Data.Either.Extra (eitherToMaybe)
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import DA.Cli.Damlc.Command.MultiIde.ClientCommunication
+import DA.Cli.Damlc.Command.MultiIde.OpenFiles
+import DA.Cli.Damlc.Command.MultiIde.Parsing
+import DA.Cli.Damlc.Command.MultiIde.Types
+import DA.Cli.Damlc.Command.MultiIde.Util
+import DA.Daml.Assistant.Env
+import DA.Daml.Assistant.Install
+import DA.Daml.Assistant.Types
+import DA.Daml.Assistant.Util (tryConfig)
+import DA.Daml.Assistant.Version
+import DA.Daml.Project.Config
+import qualified Language.LSP.Types as LSP
+import qualified Language.LSP.Types.Lens as LSP
+
+-- Check if an ask is installed, transform the subIDE data to disable it if needed
+ensureSdkInstalled :: MultiIdeState -> UnresolvedReleaseVersion -> PackageHome -> SubIdeData -> IO SubIdeData
+ensureSdkInstalled miState ver home ideData = do
+  installDatas <- atomically $ takeTMVar $ misSdkInstallDatasVar miState
+  let installData = getSdkInstallData ver installDatas
+  (newInstallDatas, mDisableDiagnostic) <- case sidStatus installData of
+    SISCanAsk -> do
+      damlPath <- getDamlPath
+      installedVersions <- getInstalledSdkVersions damlPath
+      let versionIsInstalled = any ((unwrapUnresolvedReleaseVersion ver==) . releaseVersionFromReleaseVersion) installedVersions
+
+      if versionIsInstalled
+        then pure (installDatas, Nothing)
+        else do
+          -- Ask the user if they want to install
+          let verStr = T.pack $ unresolvedReleaseVersionToString ver
+              lspId = LSP.IdString $ verStr <> "-sdk-install-request"
+              messageContent = "This package uses the release version " <> verStr <> " which is not installed on this system.\n"
+                <> "The IDE cannot give intelligence on this package without this SDK. Would you like to install it?"
+              message = showMessageRequest lspId LSP.MtError messageContent ["Install SDK " <> verStr, "Do not install"]
+              installData' = 
+                installData
+                  { sidPendingHomes = Set.insert home $ sidPendingHomes installData
+                  , sidStatus = SISAsking
+                  }
+
+          putFromServerCoordinatorMessage miState message
+          sendClient miState message
+          pure (Map.insert ver installData' installDatas, Just (LSP.DsError, missingSdkIdeDiagnosticMessage ver))
+    -- If the home is already in the set, the diagnostic has already been sent
+    _ | Set.member home $ sidPendingHomes installData -> pure (installDatas, Nothing)
+    _ ->
+      let message = 
+            case sidStatus installData of
+              SISInstalling _ -> (LSP.DsInfo, installingSdkIdeDiagnosticMessage ver)
+              SISFailed log err -> (LSP.DsError, failedInstallIdeDiagnosticMessage ver log err)
+              _ -> (LSP.DsError, missingSdkIdeDiagnosticMessage ver)
+       in pure (Map.insert ver (installData {sidPendingHomes = Set.insert home $ sidPendingHomes installData}) installDatas, Just message)
+  atomically $ do
+    putTMVar (misSdkInstallDatasVar miState) newInstallDatas
+    case mDisableDiagnostic of
+      Just (severity, message) -> do
+        let ideData' = ideData {ideDataDisabled = IdeDataDisabled severity message}
+        sendPackageDiagnostic miState ideData'
+        pure ideData'
+      Nothing -> pure ideData
+
+missingSdkIdeDiagnosticMessage :: UnresolvedReleaseVersion -> T.Text
+missingSdkIdeDiagnosticMessage ver =
+  let verText = T.pack $ unresolvedReleaseVersionToString ver
+   in "Missing required Daml SDK version " <> verText <> " to create development environment.\n"
+        <> "Install this version via `daml install " <> verText <> "`, or save the daml.yaml to be prompted"
+
+installingSdkIdeDiagnosticMessage :: UnresolvedReleaseVersion -> T.Text
+installingSdkIdeDiagnosticMessage ver =
+  "Installing Daml SDK version " <> T.pack (unresolvedReleaseVersionToString ver)
+
+failedInstallIdeDiagnosticMessage :: UnresolvedReleaseVersion -> T.Text -> SomeException -> T.Text
+failedInstallIdeDiagnosticMessage ver outputLog err =
+  "Failed to install Daml SDK version " <> T.pack (unresolvedReleaseVersionToString ver) <> " due to the following:\n"
+    <> (if outputLog == "" then "" else outputLog <> "\n")
+    <> T.pack (displayException err)
+
+updateSdkStatus :: MultiIdeState -> SdkInstallDatas -> UnresolvedReleaseVersion -> LSP.DiagnosticSeverity -> T.Text -> SdkInstallStatus -> IO SdkInstallDatas
+updateSdkStatus miState installDatas ver severity message newStatus = do
+  let installData = getSdkInstallData ver installDatas
+      homes = sidPendingHomes installData
+      disableIde :: SubIdes -> PackageHome -> STM SubIdes
+      disableIde ides home = do
+        let ideData = (lookupSubIde home ides) {ideDataDisabled = IdeDataDisabled severity message}
+        sendPackageDiagnostic miState ideData
+        pure $ Map.insert home ideData ides
+  withIDEsAtomic miState $ \ides -> do
+    ides' <- foldM disableIde ides homes
+    pure (ides', Map.insert ver (installData {sidStatus = newStatus}) installDatas)
+
+releaseVersionFromLspId :: LSP.LspId 'LSP.WindowShowMessageRequest -> Maybe UnresolvedReleaseVersion
+releaseVersionFromLspId (LSP.IdString lspIdStr) = T.stripSuffix "-sdk-install-request" lspIdStr >>= eitherToMaybe . parseUnresolvedVersion
+releaseVersionFromLspId _ = Nothing
+
+handleShowMessageResponse :: MultiIdeState -> LSP.LspId 'LSP.WindowShowMessageRequest -> Either LSP.ResponseError (Maybe LSP.MessageActionItem) -> IO ()
+handleShowMessageResponse miState (releaseVersionFromLspId -> Just ver) res = do
+  installDatas <- atomically $ takeTMVar $ misSdkInstallDatasVar miState
+  let installData = getSdkInstallData ver installDatas
+      changeSdkStatus :: LSP.DiagnosticSeverity -> T.Text -> SdkInstallStatus -> IO ()
+      changeSdkStatus severity message newStatus = do
+        installDatas' <- updateSdkStatus miState installDatas ver severity message newStatus
+        atomically $ putTMVar (misSdkInstallDatasVar miState) installDatas'
+      disableSdk = changeSdkStatus LSP.DsError (missingSdkIdeDiagnosticMessage ver) SISDenied
+
+  case (sidStatus installData, res) of
+    (SISAsking, Right (Just (LSP.MessageActionItem (T.stripPrefix "Install SDK" -> Just _)))) -> do
+      -- Install accepted, start install process
+      installThread <- async $ do
+        setupSdkInstallReporter miState ver
+        outputLogVar <- newMVar ""
+        res <- tryForwardAsync $ installSdk ver outputLogVar $ updateSdkInstallReporter miState ver
+        handleInstallResult miState ver outputLogVar $ either Just (const Nothing) res
+        finishSdkInstallReporter miState ver
+      changeSdkStatus LSP.DsInfo (installingSdkIdeDiagnosticMessage ver) (SISInstalling installThread)
+    (SISAsking, _) -> disableSdk
+    (_, _) -> atomically $ putTMVar (misSdkInstallDatasVar miState) installDatas
+handleShowMessageResponse _ _ _ = pure ()
+
+-- try @SomeException that doesn't catch AsyncCancelled exceptions
+tryForwardAsync :: IO a -> IO (Either SomeException a)
+tryForwardAsync = tryJust @SomeException $ \case
+  (fromException -> Just AsyncCancelled) -> Nothing
+  e -> Just e
+
+handleSdkInstallCancelled :: MultiIdeState -> LSP.NotificationMessage 'LSP.CustomMethod -> IO ()
+handleSdkInstallCancelled miState notif = do
+  forM_ (fromJSON $ notif ^. LSP.params) $ \message -> do
+    let ver = sicSdkVersion message
+    installDatas <- atomically $ takeTMVar $ misSdkInstallDatasVar miState
+    let installData = getSdkInstallData ver installDatas
+    installDatas' <- case sidStatus installData of
+      SISInstalling thread -> do
+        logDebug miState $ "Killing install thread for " <> unresolvedReleaseVersionToString ver
+        cancel thread
+        updateSdkStatus miState installDatas ver LSP.DsError (missingSdkIdeDiagnosticMessage ver) SISDenied
+      _ -> pure installDatas
+    atomically $ putTMVar (misSdkInstallDatasVar miState) installDatas'
+
+handleInstallResult :: MultiIdeState -> UnresolvedReleaseVersion -> MVar T.Text -> Maybe SomeException -> IO ()
+handleInstallResult miState ver outputLogVar mError = do
+  installDatas <- atomically $ takeTMVar $ misSdkInstallDatasVar miState
+  let installData = getSdkInstallData ver installDatas
+  case mError of
+    Nothing -> do
+      let homes = sidPendingHomes installData
+          installDatas' = Map.delete ver installDatas
+          disableIde :: SubIdes -> PackageHome -> IO SubIdes
+          disableIde ides home =
+            let ides' = Map.insert home ((lookupSubIde home ides) {ideDataDisabled = IdeDataNotDisabled}) ides
+             in misUnsafeAddNewSubIdeAndSend miState ides' home Nothing
+      atomically $ putTMVar (misSdkInstallDatasVar miState) installDatas'
+      withIDEs_ miState $ \ides -> foldM disableIde ides homes
+    Just err -> do
+      outputLog <- takeMVar outputLogVar
+      let errText = failedInstallIdeDiagnosticMessage ver outputLog err
+      installDatas' <- updateSdkStatus miState installDatas ver LSP.DsError errText (SISFailed outputLog err)
+      sendClient miState $ showMessage LSP.MtError errText
+      atomically $ putTMVar (misSdkInstallDatasVar miState) installDatas'
+
+-- Given a version, and a progress computation, install an sdk (blocking)
+installSdk :: UnresolvedReleaseVersion -> MVar Text -> (Int -> IO ()) -> IO ()
+installSdk unresolvedVersion outputLogVar report = do
+  damlPath <- getDamlPath
+  cachePath <- getCachePath
+  let useCache = mkUseCache cachePath damlPath
+
+  version <- resolveReleaseVersionUnsafe useCache unresolvedVersion
+  damlConfigE <- tryConfig $ readDamlConfig damlPath
+  let env = InstallEnv
+        { options = InstallOptions
+            { iTargetM = Nothing
+            , iSnapshots = False
+            , iAssistant = InstallAssistant No
+            , iForce = ForceInstall True
+            , iQuiet = QuietInstall False
+            , iSetPath = SetPath No
+            , iBashCompletions = BashCompletions No
+            , iZshCompletions = ZshCompletions No
+            , iInstallWithInternalVersion = InstallWithInternalVersion False
+            , iInstallWithCustomVersion = InstallWithCustomVersion Nothing
+            }
+        , targetVersionM = version
+        , assistantVersion = Nothing
+        , damlPath = damlPath
+        , useCache = useCache
+        , missingAssistant = False
+        , installingFromOutside = False
+        , projectPathM = Nothing
+        , artifactoryApiKeyM = queryArtifactoryApiKey =<< eitherToMaybe damlConfigE
+        , output = \str -> modifyMVar_ outputLogVar $ pure . (<> T.pack str)
+        , downloadProgressObserver = Just report
+        }
+  versionInstall env
+
+sendSdkInstallProgress :: MultiIdeState -> UnresolvedReleaseVersion -> DamlSdkInstallProgressNotificationKind -> Int -> IO ()
+sendSdkInstallProgress miState ver kind progress =
+  sendClient miState $ LSP.FromServerMess (LSP.SCustomMethod damlSdkInstallProgressMethod) $ LSP.NotMess $
+    LSP.NotificationMessage "2.0" (LSP.SCustomMethod damlSdkInstallProgressMethod) $ toJSON $ DamlSdkInstallProgressNotification
+      { sipSdkVersion = ver
+      , sipKind = kind
+      , sipProgress = progress
+      }
+
+setupSdkInstallReporter :: MultiIdeState -> UnresolvedReleaseVersion -> IO ()
+setupSdkInstallReporter miState ver = sendSdkInstallProgress miState ver InstallProgressBegin 0
+  
+updateSdkInstallReporter :: MultiIdeState -> UnresolvedReleaseVersion -> Int -> IO ()
+updateSdkInstallReporter miState ver = sendSdkInstallProgress miState ver InstallProgressReport
+
+finishSdkInstallReporter :: MultiIdeState -> UnresolvedReleaseVersion -> IO ()
+finishSdkInstallReporter miState ver = sendSdkInstallProgress miState ver InstallProgressEnd 100
+
+untrackPackageSdkInstall :: MultiIdeState -> PackageHome -> IO ()
+untrackPackageSdkInstall miState home = atomically $ modifyTMVar (misSdkInstallDatasVar miState) $
+  fmap $ \installData -> installData {sidPendingHomes = Set.delete home $ sidPendingHomes installData}
+
+allowSdkInstall :: MultiIdeState -> PackageHome -> IO ()
+allowSdkInstall miState home = do
+  ePackageSummary <- packageSummaryFromDamlYaml home
+  forM_ ePackageSummary $ \ps ->
+    atomically $ modifyTMVar (misSdkInstallDatasVar miState) $ Map.adjust (\installData ->
+      installData 
+        { sidStatus = case sidStatus installData of
+            SISDenied -> SISCanAsk
+            SISFailed _ _ -> SISCanAsk
+            _ -> sidStatus installData
+        }
+    ) (psReleaseVersion ps)

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/SubIdeCommunication.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/SubIdeCommunication.hs
@@ -17,23 +17,10 @@ import DA.Cli.Damlc.Command.MultiIde.Util
 import DA.Cli.Damlc.Command.MultiIde.Types
 import qualified Data.Map as Map
 import Data.Maybe (fromMaybe, mapMaybe)
-import qualified Data.Set as Set
 import GHC.Conc (unsafeIOToSTM)
 import qualified Language.LSP.Types as LSP
 import System.Directory (doesFileExist)
-import System.FilePath.Posix (takeDirectory, (</>))
-
-disableIdeDiagnosticMessages :: SubIdeData -> [LSP.FromServerMessage]
-disableIdeDiagnosticMessages ideData =
-  fullFileDiagnostic 
-    ( "Daml IDE environment failed to start with the following error:\n"
-    <> fromMaybe "No information" (ideDataLastError ideData)
-    )
-    <$> ((unPackageHome (ideDataHome ideData) </> "daml.yaml") : fmap unDamlFile (Set.toList $ ideDataOpenFiles ideData))
-
-clearIdeDiagnosticMessages :: SubIdeData -> [LSP.FromServerMessage]
-clearIdeDiagnosticMessages ideData =
-  clearDiagnostics <$> ((unPackageHome (ideDataHome ideData) </> "daml.yaml") : fmap unDamlFile (Set.toList $ ideDataOpenFiles ideData))
+import System.FilePath.Posix (takeDirectory)
 
 -- Communication logic
 

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/SubIdeManagement.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/SubIdeManagement.hs
@@ -82,7 +82,7 @@ unsafeAddNewSubIdeAndSend miState ides home mMsg = do
   let unCheckedIdeData = lookupSubIde home ides
 
   ideData <- case ePackageSummary of 
-    Right packageSummary -> ensureSdkInstalled miState (psReleaseVersion packageSummary) home unCheckedIdeData
+    Right packageSummary -> ensureIdeSdkInstalled miState (psReleaseVersion packageSummary) home unCheckedIdeData
     Left _ -> pure unCheckedIdeData
 
   let disableIdeWithError :: T.Text -> IO SubIdes

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/Types.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/Types.hs
@@ -17,7 +17,7 @@ import Control.Concurrent.STM.TMVar
 import Control.Concurrent.MVar
 import Control.Monad (void)
 import Control.Monad.STM
-import DA.Daml.Project.Types (ProjectPath (..))
+import DA.Daml.Project.Types (ProjectPath (..), UnresolvedReleaseVersion)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BSL
 import Data.Function (on)
@@ -305,4 +305,10 @@ type ResponseCombiner (m :: LSP.Method 'LSP.FromClient 'LSP.Request) =
 data SMethodWithSender (m :: LSP.Method 'LSP.FromServer t) = SMethodWithSender
   { smsMethod :: LSP.SMethod m
   , smsSender :: Maybe PackageHome
+  }
+
+data PackageSummary = PackageSummary
+  { psUnitId :: UnitId
+  , psDeps :: [DarFile]
+  , psReleaseVersion :: UnresolvedReleaseVersion
   }

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/Util.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/Util.hs
@@ -325,3 +325,9 @@ toPosixFilePath = uncurry joinDrive . first lower . NativeFilePath.splitDrive . 
 -- Attempts to exact the percent amount from a string containing strings like 30%
 extractPercentFromText :: T.Text -> Maybe Integer
 extractPercentFromText = readMaybe . T.unpack . T.dropWhile (==' ') . T.takeEnd 3 . T.dropEnd 1 . fst . T.breakOnEnd "%"
+
+-- try @SomeException that doesn't catch AsyncCancelled exceptions
+tryForwardAsync :: IO a -> IO (Either SomeException a)
+tryForwardAsync = tryJust @SomeException $ \case
+  (fromException -> Just AsyncCancelled) -> Nothing
+  e -> Just e

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/Util.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/Util.hs
@@ -9,9 +9,10 @@ module DA.Cli.Damlc.Command.MultiIde.Util (
   module DA.Cli.Damlc.Command.MultiIde.Util
 ) where
 
+import Control.Concurrent.Async (AsyncCancelled (..))
 import Control.Concurrent.MVar
 import Control.Concurrent.STM.TMVar
-import Control.Exception (SomeException, handle, try)
+import Control.Exception (SomeException, fromException, handle, try, tryJust)
 import Control.Lens ((^.))
 import Control.Monad (void)
 import Control.Monad.STM

--- a/sdk/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/sdk/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -176,6 +176,7 @@ autoInstall env@Env{..} = do
                     -- and we don't want to mess up the other command's
                     -- output / have the install messages be gobbled
                     -- up by a pipe.
+                , downloadProgressObserver = Nothing
                 }
         versionInstall installEnv
         pure env { envSdkPath = Just (defaultSdkPathUnresolved envDamlPath sdkVersion) }

--- a/sdk/daml-assistant/src/DA/Daml/Assistant/Install.hs
+++ b/sdk/daml-assistant/src/DA/Daml/Assistant/Install.hs
@@ -16,6 +16,7 @@ module DA.Daml.Assistant.Install
     , pattern RawInstallTarget_Project
     ) where
 
+import Control.Concurrent.MVar (newMVar, modifyMVar_)
 import DA.Directory
 import DA.Daml.Assistant.Types
 import DA.Daml.Assistant.Util
@@ -94,6 +95,8 @@ data InstallEnvF a = InstallEnv
         -- ^ Artifactoyr API key used to fetch SDK EE tarball.
     , output :: String -> IO ()
         -- ^ output an informative message
+    , downloadProgressObserver :: Maybe (Int -> IO ())
+        -- ^ optional alternative handler for http download progresss
     }
 
 instance Functor InstallEnvF where
@@ -407,11 +410,25 @@ httpInstall env@InstallEnv{targetVersionM = releaseVersion, ..} = do
 
         observeProgress :: MonadResource m =>
             Int -> ConduitT BS.ByteString BS.ByteString m ()
-        observeProgress totalSize = do
-            pb <- liftIO $ newProgressBar defStyle 10 (Progress 0 totalSize ())
-            List.mapM $ \bs -> do
-                liftIO $ incProgress pb (BS.length bs)
-                pure bs
+        observeProgress totalSize =
+            case downloadProgressObserver of
+                -- When no explicit observer, use the progressBar library (which prints to stderr and cannot not use `output`)
+                Nothing -> do
+                    pb <- liftIO $ newProgressBar defStyle 10 (Progress 0 totalSize ())
+                    List.mapM $ \bs -> do
+                        liftIO $ incProgress pb (BS.length bs)
+                        pure bs
+                -- When an observer is given, track state and call observer whenever percent int changes
+                Just observer -> do
+                    progressVar <- liftIO $ newMVar (0, 0)
+                    List.mapM $ \bs -> do
+                        liftIO $ modifyMVar_ progressVar $ \(lastProgress, lastReportedPercent) -> do
+                          let newProgress = lastProgress + BS.length bs
+                              newPercent = (newProgress * 100) `div` totalSize
+                          if newPercent - lastReportedPercent > 0
+                            then (newProgress, newPercent) <$ observer newPercent
+                            else pure (newProgress, lastReportedPercent)
+                        pure bs
 
 -- | Perform an action with a file lock from DAML_HOME/sdk/.lock
 -- This function blocks until the lock has been obtained.
@@ -536,6 +553,7 @@ install options damlPath useCache projectPathM assistantVersion =
             targetVersionM = () -- determined later
             output = putStrLn -- Output install messages to stdout.
             artifactoryApiKeyM = DAVersion.queryArtifactoryApiKey =<< eitherToMaybe damlConfigE
+            downloadProgressObserver = Nothing
             env = InstallEnv {..}
             warnAboutAnyInstallFlags command = do
                 when (unInstallWithInternalVersion (iInstallWithInternalVersion options)) $


### PR DESCRIPTION
The multi-IDE now manages the SDK version install, and will ask the user if they want to install an SDK before using it.
Support a progress bar, cancellation, not repeating the request over several SDKs, reasonable install failure diagnostics

Resolves #19078
Depends on #19198