### PR TITLE
do not use the same temp dir for test cases run in parallel

### DIFF
--- a/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -188,8 +188,8 @@ tests tmpDir =
             , testCase "daml new --list" $
                 callCommandSilentIn tmpDir "daml new --list"
             , packagingTests tmpDir
-            , withResource (damlStart (tmpDir </> "sandbox-canton") False) stop damlStartTests
-            , withResource (damlStart (tmpDir </> "sandbox-canton") True) stop damlStartTestsWithoutValidation
+            , withResource (damlStart (tmpDir </> "sandbox-canton-1") False) stop damlStartTests
+            , withResource (damlStart (tmpDir </> "sandbox-canton-2") True) stop damlStartTestsWithoutValidation
             , cleanTests cleanDir
             , templateTests
             , codegenTests codegenDir


### PR DESCRIPTION
We use the [same temp directory for both daml start projects](https://github.com/digital-asset/daml/blob/609171a25787d2dd578c7e7a045578fc7a85edeb/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs#L191-L192) to run two test cases that are allowed to run in parallel. This PR changes the test cases to use different directories.