### PR TITLE
Upgrade validation warnings to errors flag

### DIFF
--- a/sdk/compiler/daml-lf-tools/BUILD.bazel
+++ b/sdk/compiler/daml-lf-tools/BUILD.bazel
@@ -28,6 +28,7 @@ da_haskell_library(
     deps = [
         "//compiler/daml-lf-ast",
         "//compiler/damlc/daml-lf-util",
+        "//compiler/damlc/daml-opts:daml-opts-types",
         "//libs-haskell/da-hs-base",
     ],
 )

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -64,7 +64,7 @@ import           DA.Daml.LF.TypeChecker.Error
 
 
 -- | Check that a list does /not/ contain duplicate elements.
-checkUnique :: (MonadGamma m, Eq a, Hashable a) => (a -> Error) -> [a] -> m ()
+checkUnique :: (MonadGamma m, Eq a, Hashable a) => (a -> UnwarnableError) -> [a] -> m ()
 checkUnique mkDuplicateError xs = void (foldlM step HS.empty xs)
   where
     step acc x
@@ -338,7 +338,7 @@ typeOfRecUpd typ0 field record update = do
   fieldType <- match _Just (EUnknownField field typ1) (lookup field recordType)
   checkExpr record typ1
   catchAndRethrow
-    (\case
+    (overUnwarnable $ \case
       ETypeMismatch { foundType, expectedType, expr } ->
         EFieldTypeMismatch
           { targetRecord = typ1
@@ -1019,7 +1019,7 @@ checkInterfaceInstance tmplParam iiHead iiBody = do
         Nothing -> throwWithContext (EUnknownMethodInInterfaceInstance iiInterface iiTemplate iiMethodName)
         Just InterfaceMethod{ifmType} ->
           catchAndRethrow
-            (\case
+            (overUnwarnable $ \case
               ETypeMismatch { foundType, expectedType, expr } ->
                 EMethodTypeMismatch
                   { emtmIfaceName = iiInterface
@@ -1034,7 +1034,7 @@ checkInterfaceInstance tmplParam iiHead iiBody = do
 
     -- check view result type matches interface result type
     catchAndRethrow
-      (\case
+      (overUnwarnable $ \case
           ETypeMismatch { foundType, expectedType, expr } ->
             EViewTypeMismatch
               { evtmIfaceName = iiInterface

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
@@ -199,17 +199,7 @@ instance SomeErrorOrWarning Warning where
     shouldSwap <- getDiagnosticSwapIndicatorF getter
     if shouldSwap (Right warning)
        then do
-        throwWithContextFRaw getter (EWarnableError (WEWarningToError warning))
+        throwWithContextFRaw getter (EWarningToError warning)
        else do
         ctx <- view $ getter . locCtx
         modify' (WContext ctx warning :)
-
---diagnosticWithContextF :: forall m gamma d. (SomeErrorOrWarning d, MonadGammaF gamma m) => Getter gamma Gamma -> d -> m ()
---diagnosticWithContextF getter d = do
---  swapIndicator <- getDiagnosticSwapIndicatorF @m @gamma getter
---  let diagnostic = toErrorOrWarning d
---  case (diagnostic, swapIndicator diagnostic) of
---    (Left err, True) -> warnWithContextF @m @gamma getter $ WErrorToWarning err
---    (Right warn, True) -> throwWithContextF @m @gamma getter $ EWarningToError warn
---    (Left err, False) -> throwWithContextF @m @gamma getter err
---    (Right warn, False) -> warnWithContextF @m @gamma getter warn

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
@@ -192,14 +192,14 @@ instance SomeErrorOrWarning WarnableError where
         ctx <- view $ getter . locCtx
         modify' (WContext ctx (WErrorToWarning err) :)
        else do
-        undefined
+        throwWithContextFRaw getter (EWarnableError err)
 
 instance SomeErrorOrWarning Warning where
   diagnosticWithContextF getter warning = do
     shouldSwap <- getDiagnosticSwapIndicatorF getter
     if shouldSwap (Right warning)
        then do
-        undefined
+        throwWithContextFRaw getter (EWarnableError (EWarningToError warning))
        else do
         ctx <- view $ getter . locCtx
         modify' (WContext ctx warning :)

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
@@ -28,7 +28,7 @@ module DA.Daml.LF.TypeChecker.Env(
     getLfVersion,
     getWorld,
     runGamma, runGammaF,
-    Gamma,
+    Gamma(..),
     emptyGamma,
     SomeErrorOrWarning(..),
     addDiagnosticSwapIndicator,
@@ -199,7 +199,7 @@ instance SomeErrorOrWarning Warning where
     shouldSwap <- getDiagnosticSwapIndicatorF getter
     if shouldSwap (Right warning)
        then do
-        throwWithContextFRaw getter (EWarnableError (EWarningToError warning))
+        throwWithContextFRaw getter (EWarnableError (WEWarningToError warning))
        else do
         ctx <- view $ getter . locCtx
         modify' (WContext ctx warning :)

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -207,6 +207,7 @@ data WarnableError
   = EUpgradeShouldDefineIfacesAndTemplatesSeparately
   | EUpgradeShouldDefineIfaceWithoutImplementation !TypeConName ![TypeConName]
   | EUpgradeShouldDefineTplInSeparatePackage !TypeConName !TypeConName
+  | EWarningToError !Warning
   deriving (Show)
 
 instance Pretty WarnableError where
@@ -228,6 +229,7 @@ instance Pretty WarnableError where
         [ "The template " <> pPrint tpl <> " has implemented interface " <> pPrint iface <> ", which is defined in a previous version of this package."
         , "However, it is recommended that interfaces are defined in their own package separate from their implementations."
         ]
+    EWarningToError warning -> pPrint warning
 
 data UpgradedRecordOrigin
   = TemplateBody TypeConName

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -98,6 +98,7 @@ data UnserializabilityReason
 data Error
   = EUnwarnableError !UnwarnableError
   | EWarnableError !WarnableError
+  | EWarningToError !Warning
   | EContext !Context !Error
   deriving (Show)
 
@@ -207,7 +208,6 @@ data WarnableError
   = WEUpgradeShouldDefineIfacesAndTemplatesSeparately
   | WEUpgradeShouldDefineIfaceWithoutImplementation !TypeConName ![TypeConName]
   | WEUpgradeShouldDefineTplInSeparatePackage !TypeConName !TypeConName
-  | WEWarningToError !Warning
   deriving (Show)
 
 instance Pretty WarnableError where
@@ -229,7 +229,6 @@ instance Pretty WarnableError where
         [ "The template " <> pPrint tpl <> " has implemented interface " <> pPrint iface <> ", which is defined in a previous version of this package."
         , "However, it is recommended that interfaces are defined in their own package separate from their implementations."
         ]
-    WEWarningToError warning -> pPrint warning
 
 data UpgradedRecordOrigin
   = TemplateBody TypeConName
@@ -358,6 +357,7 @@ instance Pretty Error where
   pPrint = \case
     EUnwarnableError err -> pPrint err
     EWarnableError err -> pPrint err
+    EWarningToError warning -> pPrint warning
     EContext ctx err ->
       vcat
       [ "error type checking " <> pretty ctx <> ":"

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -204,32 +204,32 @@ data UnwarnableError
   deriving (Show)
 
 data WarnableError
-  = EUpgradeShouldDefineIfacesAndTemplatesSeparately
-  | EUpgradeShouldDefineIfaceWithoutImplementation !TypeConName ![TypeConName]
-  | EUpgradeShouldDefineTplInSeparatePackage !TypeConName !TypeConName
-  | EWarningToError !Warning
+  = WEUpgradeShouldDefineIfacesAndTemplatesSeparately
+  | WEUpgradeShouldDefineIfaceWithoutImplementation !TypeConName ![TypeConName]
+  | WEUpgradeShouldDefineTplInSeparatePackage !TypeConName !TypeConName
+  | WEWarningToError !Warning
   deriving (Show)
 
 instance Pretty WarnableError where
   pPrint = \case
-    EUpgradeShouldDefineIfacesAndTemplatesSeparately ->
+    WEUpgradeShouldDefineIfacesAndTemplatesSeparately ->
       vsep
         [ "This package defines both interfaces and templates."
         , "This is not recommended - templates are upgradeable, but interfaces are not, which means that this version of the package and its templates can never be uninstalled."
         , "It is recommended that interfaces are defined in their own package separate from their implementations."
         ]
-    EUpgradeShouldDefineIfaceWithoutImplementation iface implementingTemplates ->
+    WEUpgradeShouldDefineIfaceWithoutImplementation iface implementingTemplates ->
       vsep $ concat
         [ [ "The interface " <> pPrint iface <> " was defined in this package and implemented in this package by the following templates:" ]
         , map (quotes . pPrint) implementingTemplates
         , [ "However, it is recommended that interfaces are defined in their own package separate from their implementations." ]
         ]
-    EUpgradeShouldDefineTplInSeparatePackage tpl iface ->
+    WEUpgradeShouldDefineTplInSeparatePackage tpl iface ->
       vsep
         [ "The template " <> pPrint tpl <> " has implemented interface " <> pPrint iface <> ", which is defined in a previous version of this package."
         , "However, it is recommended that interfaces are defined in their own package separate from their implementations."
         ]
-    EWarningToError warning -> pPrint warning
+    WEWarningToError warning -> pPrint warning
 
 data UpgradedRecordOrigin
   = TemplateBody TypeConName

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -214,20 +214,24 @@ instance Pretty WarnableError where
   pPrint = \case
     WEUpgradeShouldDefineIfacesAndTemplatesSeparately ->
       vsep
-        [ "This package defines both interfaces and templates."
-        , "This is not recommended - templates are upgradeable, but interfaces are not, which means that this version of the package and its templates can never be uninstalled."
+        [ "This package defines both interfaces and templates. This may make this package and its dependents not upgradeable."
         , "It is recommended that interfaces are defined in their own package separate from their implementations."
+        , "Ignore this error message with the --warn-bad-interface-instances=yes flag."
         ]
     WEUpgradeShouldDefineIfaceWithoutImplementation iface implementingTemplates ->
       vsep $ concat
         [ [ "The interface " <> pPrint iface <> " was defined in this package and implemented in this package by the following templates:" ]
         , map (quotes . pPrint) implementingTemplates
-        , [ "However, it is recommended that interfaces are defined in their own package separate from their implementations." ]
+        , [ "This may make this package and its dependents not upgradeable." ]
+        , [ "It is recommended that interfaces are defined in their own package separate from their implementations." ]
+        , [ "Ignore this error message with the --warn-bad-interface-instances=yes flag." ]
         ]
     WEUpgradeShouldDefineTplInSeparatePackage tpl iface ->
       vsep
         [ "The template " <> pPrint tpl <> " has implemented interface " <> pPrint iface <> ", which is defined in a previous version of this package."
-        , "However, it is recommended that interfaces are defined in their own package separate from their implementations."
+        , "This may make this package and its dependents not upgradeable."
+        , "It is recommended that interfaces are defined in their own package separate from their implementations."
+        , "Ignore this error message with the --warn-bad-interface-instances=yes flag."
         ]
 
 data UpgradedRecordOrigin

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Recursion.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Recursion.hs
@@ -77,8 +77,8 @@ checkModule mod0 = do
 -- | Check whether a directed graph given by its adjacency list is acyclic. If
 -- it is not, throw an error.
 checkAcyclic
-  :: (Ord k, MonadGamma m)
-  => ([k] -> Error)  -- ^ Make an error from the names of nodes forming a cycle.
+  :: (Ord k, MonadGamma m, SomeErrorOrWarning e)
+  => ([k] -> e)  -- ^ Make an error from the names of nodes forming a cycle.
   -> (a -> k)    -- ^ Map a node to its name.
   -> (a -> [k])  -- ^ Map a node to the names of its adjacent nodes.
   -> [a]         -- ^ Nodes of the graph.
@@ -87,4 +87,4 @@ checkAcyclic mkError name adjacent objs = do
   let graph = map (\obj -> (obj, name obj, nubOrd (adjacent obj))) objs
   for_ (G.stronglyConnComp graph) $ \case
     G.AcyclicSCC _ -> pure ()
-    G.CyclicSCC cycle -> throwWithContext (mkError (map name cycle))
+    G.CyclicSCC cycle -> diagnosticWithContext (mkError (map name cycle))

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -92,10 +92,11 @@ checkUpgrade version shouldTypecheckUpgrades warnBadInterfaceInstances presentPk
         singlePkgDiagnostics =
             let world = initWorldSelf [] presentPkg
             in
-            runGamma world version $ do
-                local addBadIfaceSwapIndicator $ do
-                    checkNewInterfacesAreUnused presentPkg
-                    checkNewInterfacesHaveNoTemplates presentPkg
+            runGamma world version $
+                local addBadIfaceSwapIndicator $
+                    when shouldTypecheckUpgrades $ do
+                        checkNewInterfacesAreUnused presentPkg
+                        checkNewInterfacesHaveNoTemplates presentPkg
 
         extractDiagnostics :: Either Error ((), [Warning]) -> [Diagnostic]
         extractDiagnostics result =

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -62,8 +62,8 @@ runGammaUnderUpgrades Upgrading{ _past = pastAction, _present = presentAction } 
     presentResult <- withReaderT _present presentAction
     pure Upgrading { _past = pastResult, _present = presentResult }
 
-checkUpgrade :: Version -> Bool -> LF.Package -> Maybe (LF.PackageId, LF.Package) -> WarnBadInterfaceInstances -> [Diagnostic]
-checkUpgrade version shouldTypecheckUpgrades presentPkg mbUpgradedPackage warnBadInterfaceInstances =
+checkUpgrade :: Version -> Bool -> WarnBadInterfaceInstances -> LF.Package -> Maybe (LF.PackageId, LF.Package) -> [Diagnostic]
+checkUpgrade version shouldTypecheckUpgrades warnBadInterfaceInstances presentPkg mbUpgradedPackage =
     let bothPkgDiagnostics :: Either Error ((), [Warning])
         bothPkgDiagnostics =
             case mbUpgradedPackage of

--- a/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -112,8 +112,9 @@ buildDar ::
     -> PackageConfigFields
     -> NormalizedFilePath
     -> FromDalf
+    -> WarnBadInterfaceInstances
     -> IO (Maybe (Zip.ZipArchive (), Maybe LF.PackageId))
-buildDar service PackageConfigFields {..} ifDir dalfInput = do
+buildDar service PackageConfigFields {..} ifDir dalfInput warnBadInterfaceInstances = do
     liftIO $
         IdeLogger.logDebug (ideLogger service) $
         "Creating dar: " <> T.pack pSrc
@@ -152,7 +153,7 @@ buildDar service PackageConfigFields {..} ifDir dalfInput = do
 
                  MaybeT $
                      runDiagnosticCheck $ diagsToIdeResult (toNormalizedFilePath' pSrc) $
-                         TypeChecker.Upgrade.checkUpgrade lfVersion pTypecheckUpgrades pkg mbUpgradedPackage
+                         TypeChecker.Upgrade.checkUpgrade lfVersion pTypecheckUpgrades warnBadInterfaceInstances pkg mbUpgradedPackage
                  MaybeT $ finalPackageCheck (toNormalizedFilePath' pSrc) pkg
 
                  let pkgModuleNames = map (Ghc.mkModuleName . T.unpack) $ LF.packageModuleNames pkg

--- a/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -10,6 +10,7 @@ module DA.Daml.Options.Types
     , EnableScenarios(..)
     , EnableInterfaces(..)
     , AllowLargeTuples(..)
+    , WarnBadInterfaceInstances(..)
     , StudioAutorunAllScenarios(..)
     , SkipScenarioValidation(..)
     , DlintRulesFile(..)
@@ -127,6 +128,8 @@ data Options = Options
   -- packages from remote ledgers.
   , optAllowLargeTuples :: AllowLargeTuples
   -- ^ Do not warn when tuples of size > 5 are used
+  , optWarnBadInterfaceInstances :: WarnBadInterfaceInstances
+  -- ^ Do not warn when tuples of size > 5 are used
   }
 
 newtype IncrementalBuild = IncrementalBuild { getIncrementalBuild :: Bool }
@@ -186,6 +189,9 @@ newtype EnableScenarios = EnableScenarios { getEnableScenarios :: Bool }
 
 newtype AllowLargeTuples = AllowLargeTuples { getAllowLargeTuples :: Bool }
     deriving Show
+
+newtype WarnBadInterfaceInstances = WarnBadInterfaceInstances { getWarnBadInterfaceInstances :: Bool }
+  deriving Show
 
 newtype StudioAutorunAllScenarios = StudioAutorunAllScenarios { getStudioAutorunAllScenarios :: Bool }
     deriving Show
@@ -271,6 +277,7 @@ defaultOptions mbVersion =
         , optEnableOfInterestRule = False
         , optAccessTokenPath = Nothing
         , optAllowLargeTuples = AllowLargeTuples False
+        , optWarnBadInterfaceInstances = WarnBadInterfaceInstances False
         }
 
 pkgNameVersion :: LF.PackageName -> Maybe LF.PackageVersion -> UnitId

--- a/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -129,7 +129,7 @@ data Options = Options
   , optAllowLargeTuples :: AllowLargeTuples
   -- ^ Do not warn when tuples of size > 5 are used
   , optWarnBadInterfaceInstances :: WarnBadInterfaceInstances
-  -- ^ Do not warn when tuples of size > 5 are used
+  -- ^ Warn for bad interface instances instead of erroring out
   }
 
 newtype IncrementalBuild = IncrementalBuild { getIncrementalBuild :: Bool }

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -981,6 +981,7 @@ buildEffect relativize pkgConfig@PackageConfigFields{..} opts mbOutFile incremen
               pkgConfig
               (toNormalizedFilePath' $ fromMaybe ifaceDir $ optIfaceDir opts)
               (FromDalf False)
+              (optWarnBadInterfaceInstances opts)
       (dar, mPkgId) <- mbErr "ERROR: Creation of DAR file failed." mbDar
       fp <- targetFilePath relativize $ unitIdString (pkgNameVersion pName pVersion)
       createDarFile loggerH fp dar

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -137,6 +137,7 @@ import DA.Daml.Options.Types (EnableScenarioService(..),
                               optScenarioService,
                               optSkipScenarioValidation,
                               optThreads,
+                              optWarnBadInterfaceInstances,
                               pkgNameVersion,
                               projectPackageDatabase)
 import DA.Daml.Package.Config (MultiPackageConfigFields(..),
@@ -1339,6 +1340,7 @@ execPackage projectOpts filePath opts mbOutFile dalfInput =
                               }
                             (toNormalizedFilePath' $ fromMaybe ifaceDir $ optIfaceDir opts)
                             dalfInput
+                            (optWarnBadInterfaceInstances opts)
           case mbDar of
             Nothing -> do
                 hPutStrLn stderr "ERROR: Creation of DAR file failed."

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -446,6 +446,7 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
     optEnableInterfaces <- enableInterfacesOpt
     optAllowLargeTuples <- allowLargeTuplesOpt
     optTestFilter <- compilePatternExpr <$> optTestPattern
+    optWarnBadInterfaceInstances <- warnBadInterfaceInstancesOpt
 
     return Options{..}
   where
@@ -571,6 +572,15 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
         <> long "cpp"
         <> help "Set path to CPP."
         <> internal
+
+optWarnBadInterfaceInstances :: Parser WarnBadInterfaceInstances
+optWarnBadInterfaceInstances =
+  WarnBadInterfaceInstances <$>
+  flagYesNoAuto
+    "warn-bad-interface-instances"
+    False
+    "Convert errors about bad, non-upgradeable interface instances into warnings."
+    idm
 
 optGhcCustomOptions :: Parser [String]
 optGhcCustomOptions =

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -573,8 +573,8 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
         <> help "Set path to CPP."
         <> internal
 
-optWarnBadInterfaceInstances :: Parser WarnBadInterfaceInstances
-optWarnBadInterfaceInstances =
+warnBadInterfaceInstancesOpt :: Parser WarnBadInterfaceInstances
+warnBadInterfaceInstancesOpt =
   WarnBadInterfaceInstances <$>
   flagYesNoAuto
     "warn-bad-interface-instances"

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -34,282 +34,350 @@ tests :: SdkVersioned => FilePath -> TestTree
 tests damlc =
     testGroup
         "Upgrade"
-        [ test
+        ([ test
               "WarnsWhenTemplateChangesSignatories"
               (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A signatories:\n  The upgraded template A has changed the definition of its signatories.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "WarnsWhenTemplateChangesObservers"
               (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A observers:\n  The upgraded template A has changed the definition of its observers.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "SucceedsWhenATopLevelEnumChanges"
               Succeed
               LF.versionDefault
               NoDependencies
+              False
         , test
               "WarnsWhenTemplateChangesEnsure"
               (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A precondition:\n  The upgraded template A has changed the definition of its precondition.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "WarnsWhenTemplateChangesKeyExpression"
               (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A key:\n  The upgraded template A has changed the expression for computing its key.")
               contractKeysMinVersion
               NoDependencies
+              False
         , test
               "WarnsWhenTemplateChangesKeyMaintainers"
               (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A key:\n  The upgraded template A has changed the maintainers for its key.")
               contractKeysMinVersion
               NoDependencies
+              False
         , test
               "FailsWhenTemplateChangesKeyType"
               (FailWithError "\ESC\\[0;91merror type checking template Main.A key:\n  The upgraded template A cannot change its key type.")
               contractKeysMinVersion
               NoDependencies
+              False
         , test
               "FailsWhenTemplateRemovesKeyType"
               (FailWithError "\ESC\\[0;91merror type checking template Main.A key:\n  The upgraded template A cannot remove its key.")
               contractKeysMinVersion
               NoDependencies
+              False
         , test
               "FailsWhenTemplateAddsKeyType"
               (FailWithError "\ESC\\[0;91merror type checking template Main.A key:\n  The upgraded template A cannot add a key where it didn't have one previously.")
               contractKeysMinVersion
               NoDependencies
+              False
         , test
               "FailsWhenNewFieldIsAddedToTemplateWithoutOptionalType"
               (FailWithError "\ESC\\[0;91merror type checking template Main.A :\n  The upgraded template A has added new fields, but those fields are not Optional.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "FailsWhenOldFieldIsDeletedFromTemplate"
               (FailWithError "\ESC\\[0;91merror type checking template Main.A :\n  The upgraded template A is missing some of its original fields.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "FailsWhenExistingFieldInTemplateIsChanged"
               (FailWithError "\ESC\\[0;91merror type checking template Main.A :\n  The upgraded template A has changed the types of some of its original fields.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "SucceedsWhenNewFieldWithOptionalTypeIsAddedToTemplate"
               Succeed
               LF.versionDefault
               NoDependencies
+              False
         , test
               "FailsWhenNewFieldIsAddedToTemplateChoiceWithoutOptionalType"
               (FailWithError "\ESC\\[0;91merror type checking template Main.A choice C:\n  The upgraded input type of choice C on template A has added new fields, but those fields are not Optional.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "FailsWhenOldFieldIsDeletedFromTemplateChoice"
               (FailWithError "\ESC\\[0;91merror type checking template Main.A choice C:\n  The upgraded input type of choice C on template A is missing some of its original fields.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "FailsWhenExistingFieldInTemplateChoiceIsChanged"
               (FailWithError "\ESC\\[0;91merror type checking template Main.A choice C:\n  The upgraded input type of choice C on template A has changed the types of some of its original fields.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "WarnsWhenControllersOfTemplateChoiceAreChanged"
               (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A choice C:\n  The upgraded choice C has changed the definition of controllers.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "WarnsWhenObserversOfTemplateChoiceAreChanged"
               (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A choice C:\n  The upgraded choice C has changed the definition of observers.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "FailsWhenTemplateChoiceChangesItsReturnType"
               (FailWithError "\ESC\\[0;91merror type checking template Main.A choice C:\n  The upgraded choice C cannot change its return type.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "SucceedsWhenTemplateChoiceReturnsATemplateWhichHasChanged"
               Succeed
               LF.versionDefault
               NoDependencies
+              False
         , test
               "SucceedsWhenTemplateChoiceInputArgumentHasChanged"
               Succeed
               LF.versionDefault
               NoDependencies
+              False
         , test
               "SucceedsWhenNewFieldWithOptionalTypeIsAddedToTemplateChoice"
               Succeed
               LF.versionDefault
               NoDependencies
+              False
         , test
               "FailsWhenATopLevelRecordAddsANonOptionalField"
               (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded data type A has added new fields, but those fields are not Optional.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "SucceedsWhenATopLevelRecordAddsAnOptionalFieldAtTheEnd"
               Succeed
               LF.versionDefault
               NoDependencies
+              False
         , test
               "FailsWhenATopLevelRecordAddsAnOptionalFieldBeforeTheEnd"
               (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded data type A has changed the order of its fields - any new fields must be added at the end of the record.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "SucceedsWhenATopLevelVariantAddsAVariant"
               Succeed
               LF.versionDefault
               NoDependencies
+              False
         , test
               "FailsWhenATopLevelVariantRemovesAVariant"
               (FailWithError "\ESC\\[0;91merror type checking <none>:\n  Data type A.Z appears in package that is being upgraded, but does not appear in this package.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "FailWhenATopLevelVariantChangesChangesTheOrderOfItsVariants"
               (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded data type A has changed the order of its variants - any new variant must be added at the end of the variant.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "FailsWhenATopLevelVariantAddsAFieldToAVariantsType"
               (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded variant constructor Y from variant A has added a field.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "SucceedsWhenATopLevelVariantAddsAnOptionalFieldToAVariantsType"
               Succeed
               LF.versionDefault
               NoDependencies
+              False
         , test
               "SucceedWhenATopLevelEnumAddsAField"
               Succeed
               LF.versionDefault
               NoDependencies
+              False
         , test
               "FailWhenATopLevelEnumChangesChangesTheOrderOfItsVariants"
               (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded data type A has changed the order of its variants - any new variant must be added at the end of the enum.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "SucceedsWhenATopLevelTypeSynonymChanges"
               Succeed
               LF.versionDefault
               NoDependencies
+              False
         , test
               "SucceedsWhenTwoDeeplyNestedTypeSynonymsResolveToTheSameDatatypes"
               Succeed
               LF.versionDefault
               NoDependencies
+              False
         , test
               "FailsWhenTwoDeeplyNestedTypeSynonymsResolveToDifferentDatatypes"
               (FailWithError "\ESC\\[0;91merror type checking template Main.A :\n  The upgraded template A has changed the types of some of its original fields.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "SucceedsWhenAnInterfaceIsOnlyDefinedInTheInitialPackage"
               Succeed
               LF.versionDefault
               NoDependencies
+              False
         , test
               "FailsWhenAnInterfaceIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage"
               (FailWithError "\ESC\\[0;91merror type checking interface Main.I :\n  Tried to upgrade interface I, but interfaces cannot be upgraded. They should be removed in any upgrading package.")
               LF.versionDefault
               NoDependencies
-        , test
-              "WarnsWhenAnInterfaceAndATemplateAreDefinedInTheSamePackage"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking module Main:\n  This package defines both interfaces and templates.\n  \n  This is not recommended - templates are upgradeable, but interfaces are not, which means that this version of the package and its templates can never be uninstalled.\n  \n  It is recommended that interfaces are defined in their own package separate from their implementations.")
-              LF.versionDefault
-              NoDependencies
-        , test
-              "WarnsWhenAnInterfaceIsUsedInThePackageThatItsDefinedIn"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking interface Main.I :\n  The interface I was defined in this package and implemented in this package by the following templates:\n  \n  'T'\n  \n  However, it is recommended that interfaces are defined in their own package separate from their implementations.")
-              LF.versionDefault
-              NoDependencies
-        , test
-              "WarnsWhenAnInterfaceIsDefinedAndThenUsedInAPackageThatUpgradesIt"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.T interface instance [0-9a-f]+:Main:I for Main:T:\n  The template T has implemented interface I, which is defined in a previous version of this package.")
-              LF.versionDefault
-              DependOnV1
+              False
         , test
               "FailsWhenAnInstanceIsDropped"
               (FailWithError "\ESC\\[0;91merror type checking template Main.T :\n  Implementation of interface I by template T appears in package that is being upgraded, but does not appear in this package.")
               LF.versionDefault
               SeparateDep
+              False
         , test
               "SucceedsWhenAnInstanceIsAddedSeparateDep"
               Succeed
               LF.versionDefault
               SeparateDep
+              False
         , test
               "SucceedsWhenAnInstanceIsAddedUpgradedPackage"
               Succeed
               LF.versionDefault
               DependOnV1
+              True
         , test
               "CannotUpgradeView"
               (FailWithError ".*Tried to implement a view of type (‘|\915\199\255)IView(’|\915\199\214) on interface (‘|\915\199\255)V1.I(’|\915\199\214), but the definition of interface (‘|\915\199\255)V1.I(’|\915\199\214) requires a view of type (‘|\915\199\255)V1.IView(’|\915\199\214)")
               LF.versionDefault
               DependOnV1
+              True
         , test
               "ValidUpgrade"
               Succeed
               contractKeysMinVersion
               NoDependencies
+              False
         , test
               "MissingModule"
               (FailWithError "\ESC\\[0;91merror type checking <none>:\n  Module Other appears in package that is being upgraded, but does not appear in this package.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "MissingTemplate"
               (FailWithError "\ESC\\[0;91merror type checking <none>:\n  Template U appears in package that is being upgraded, but does not appear in this package.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "MissingDataCon"
               (FailWithError "\ESC\\[0;91merror type checking <none>:\n  Data type U appears in package that is being upgraded, but does not appear in this package.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "MissingChoice"
               (FailWithError "\ESC\\[0;91merror type checking template Main.T :\n  Choice C2 appears in package that is being upgraded, but does not appear in this package.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "TemplateChangedKeyType"
               (FailWithError "\ESC\\[0;91merror type checking template Main.T key:\n  The upgraded template T cannot change its key type.")
               contractKeysMinVersion
               NoDependencies
+              False
         , test
               "RecordFieldsNewNonOptional"
               (FailWithError "\ESC\\[0;91merror type checking data type Main.Struct:\n  The upgraded data type Struct has added new fields, but those fields are not Optional.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "FailsWithSynonymReturnTypeChange"
               (FailWithError "\ESC\\[0;91merror type checking template Main.T choice C:\n  The upgraded choice C cannot change its return type.")
               LF.versionDefault
               NoDependencies
+              False
         , test
               "FailsWithSynonymReturnTypeChangeInSeparatePackage"
               (FailWithError "\ESC\\[0;91merror type checking template Main.T choice C:\n  The upgraded choice C cannot change its return type.")
               LF.versionDefault
               SeparateDeps
+              False
         , test
               "SucceedsWhenUpgradingADependency"
               Succeed
               LF.versionDefault
               SeparateDeps
+              False
         , test
               "FailsOnlyInModuleNotInReexports"
               (FailWithError "\ESC\\[0;91merror type checking data type Other.A:\n  The upgraded data type A has added new fields, but those fields are not Optional.")
               LF.versionDefault
               NoDependencies
-        ]
+              False
+        ] ++
+        concat
+          [ [ testGeneral
+                  (prefix <> "WhenAnInterfaceAndATemplateAreDefinedInTheSamePackage")
+                  "WarnsWhenAnInterfaceAndATemplateAreDefinedInTheSamePackage"
+                  (expectation "type checking module Main:\n  This package defines both interfaces and templates.\n  \n  This is not recommended - templates are upgradeable, but interfaces are not, which means that this version of the package and its templates can never be uninstalled.\n  \n  It is recommended that interfaces are defined in their own package separate from their implementations.")
+                  LF.versionDefault
+                  NoDependencies
+                  warnBadInterfaceInstances
+            , testGeneral
+                  (prefix <> "WhenAnInterfaceIsUsedInThePackageThatItsDefinedIn")
+                  "WarnsWhenAnInterfaceIsUsedInThePackageThatItsDefinedIn"
+                  (expectation "type checking interface Main.I :\n  The interface I was defined in this package and implemented in this package by the following templates:\n  \n  'T'\n  \n  However, it is recommended that interfaces are defined in their own package separate from their implementations.")
+                  LF.versionDefault
+                  NoDependencies
+                  warnBadInterfaceInstances
+            , testGeneral
+                  (prefix <> "WhenAnInterfaceIsDefinedAndThenUsedInAPackageThatUpgradesIt")
+                  "WarnsWhenAnInterfaceIsDefinedAndThenUsedInAPackageThatUpgradesIt"
+                  (expectation "type checking template Main.T interface instance [0-9a-f]+:Main:I for Main:T:\n  The template T has implemented interface I, which is defined in a previous version of this package.")
+                  LF.versionDefault
+                  DependOnV1
+                  warnBadInterfaceInstances
+            ]
+          | warnBadInterfaceInstances <- [True, False]
+          , let prefix = if warnBadInterfaceInstances then "Warns" else "Fail"
+          , let expectation msg =
+                    if warnBadInterfaceInstances
+                       then SucceedWithWarning ("\ESC\\[0;93mwarning while " <> msg)
+                       else FailWithError ("\ESC\\[0;91merror " <> msg)
+          ]
+      )
   where
     contractKeysMinVersion :: LF.Version
     contractKeysMinVersion = 
@@ -317,13 +385,25 @@ tests damlc =
             "Expected at least one LF 2.x version to support contract keys." 
             (LF.featureMinVersion LF.featureContractKeys LF.V2)
 
-    test ::
-           String
+    test
+        :: String
         -> Expectation
         -> LF.Version
         -> Dependency
+        -> Bool
         -> TestTree
-    test name expectation lfVersion sharedDep =
+    test name expectation lfVersion sharedDep warnBadInterfaceInstances =
+        testGeneral name name expectation lfVersion sharedDep warnBadInterfaceInstances
+
+    testGeneral
+        :: String
+        -> String
+        -> Expectation
+        -> LF.Version
+        -> Dependency
+        -> Bool
+        -> TestTree
+    testGeneral name location expectation lfVersion sharedDep warnBadInterfaceInstances =
         testCase name $
         withTempDir $ \dir -> do
             let newDir = dir </> "newVersion"
@@ -333,48 +413,48 @@ tests damlc =
 
             let testRunfile path = locateRunfiles (mainWorkspace </> "test-common/src/main/daml/upgrades" </> path)
 
-            v1FilePaths <- listDirectory =<< testRunfile (name </> "v1")
+            v1FilePaths <- listDirectory =<< testRunfile (location </> "v1")
             let oldVersion = flip map v1FilePaths $ \path ->
                   ( "daml" </> path
-                  , readFile =<< testRunfile (name </> "v1" </> path)
+                  , readFile =<< testRunfile (location </> "v1" </> path)
                   )
-            v2FilePaths <- listDirectory =<< testRunfile (name </> "v2")
+            v2FilePaths <- listDirectory =<< testRunfile (location </> "v2")
             let newVersion = flip map v2FilePaths $ \path ->
                   ( "daml" </> path
-                  , readFile =<< testRunfile (name </> "v2" </> path)
+                  , readFile =<< testRunfile (location </> "v2" </> path)
                   )
 
             (depV1Dar, depV2Dar) <- case sharedDep of
               SeparateDep -> do
-                depFilePaths <- listDirectory =<< testRunfile (name </> "dep")
+                depFilePaths <- listDirectory =<< testRunfile (location </> "dep")
                 let sharedDepFiles = flip map depFilePaths $ \path ->
                       ( "daml" </> path
-                      , readFile =<< testRunfile (name </> "dep" </> path)
+                      , readFile =<< testRunfile (location </> "dep" </> path)
                       )
                 let sharedDir = dir </> "shared"
                 let sharedDar = sharedDir </> "out.dar"
-                writeFiles sharedDir (projectFile lfVersion ("upgrades-example-" <> name <> "-dep") Nothing Nothing : sharedDepFiles)
+                writeFiles sharedDir (projectFile ("upgrades-example-" <> location <> "-dep") Nothing Nothing : sharedDepFiles)
                 callProcessSilent damlc ["build", "--project-root", sharedDir, "-o", sharedDar]
                 pure (Just sharedDar, Just sharedDar)
               SeparateDeps -> do
-                depV1FilePaths <- listDirectory =<< testRunfile (name </> "dep-v1")
+                depV1FilePaths <- listDirectory =<< testRunfile (location </> "dep-v1")
                 let depV1Files = flip map depV1FilePaths $ \path ->
                       ( "daml" </> path
-                      , readFile =<< testRunfile (name </> "dep-v1" </> path)
+                      , readFile =<< testRunfile (location </> "dep-v1" </> path)
                       )
                 let depV1Dir = dir </> "shared-v1"
                 let depV1Dar = depV1Dir </> "out.dar"
-                writeFiles depV1Dir (projectFile lfVersion ("upgrades-example-" <> name <> "-dep-v1") Nothing Nothing : depV1Files)
+                writeFiles depV1Dir (projectFile ("upgrades-example-" <> location <> "-dep-v1") Nothing Nothing : depV1Files)
                 callProcessSilent damlc ["build", "--project-root", depV1Dir, "-o", depV1Dar]
 
-                depV2FilePaths <- listDirectory =<< testRunfile (name </> "dep-v2")
+                depV2FilePaths <- listDirectory =<< testRunfile (location </> "dep-v2")
                 let depV2Files = flip map depV2FilePaths $ \path ->
                       ( "daml" </> path
-                      , readFile =<< testRunfile (name </> "dep-v2" </> path)
+                      , readFile =<< testRunfile (location </> "dep-v2" </> path)
                       )
                 let depV2Dir = dir </> "shared-v2"
                 let depV2Dar = depV2Dir </> "out.dar"
-                writeFiles depV2Dir (projectFile lfVersion ("upgrades-example-" <> name <> "-dep-v2") Nothing Nothing : depV2Files)
+                writeFiles depV2Dir (projectFile ("upgrades-example-" <> location <> "-dep-v2") Nothing Nothing : depV2Files)
                 callProcessSilent damlc ["build", "--project-root", depV2Dir, "-o", depV2Dar]
 
                 pure (Just depV1Dar, Just depV2Dar)
@@ -383,10 +463,10 @@ tests damlc =
               _ ->
                 pure (Nothing, Nothing)
 
-            writeFiles oldDir (projectFile lfVersion ("upgrades-example-" <> name) Nothing depV1Dar : oldVersion)
+            writeFiles oldDir (projectFile ("upgrades-example-" <> location) Nothing depV1Dar : oldVersion)
             callProcessSilent damlc ["build", "--project-root", oldDir, "-o", oldDar]
 
-            writeFiles newDir (projectFile lfVersion ("upgrades-example-" <> name <> "-v2") (Just oldDar) depV2Dar : newVersion)
+            writeFiles newDir (projectFile ("upgrades-example-" <> location <> "-v2") (Just oldDar) depV2Dar : newVersion)
             case expectation of
               Succeed ->
                   callProcessSilent damlc ["build", "--project-root", newDir, "-o", newDar]
@@ -404,30 +484,32 @@ tests damlc =
                       compiledRegex = makeRegexOpts defaultCompOpt { multiline = False } defaultExecOpt regexWithSeverity
                   unless (matchTest compiledRegex stderr) $
                       assertFailure ("`daml build` succeeded, but did not give a warning matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
+      where
+          projectFile name upgradedFile mbDep =
+              ( "daml.yaml"
+              , unlines $
+                [ "sdk-version: " <> sdkVersion
+                , "name: " <> name
+                , "source: daml"
+                , "version: 0.0.1"
+                , "dependencies:"
+                , "  - daml-prim"
+                , "  - daml-stdlib"
+                , "typecheck-upgrades: true"
+                , "build-options:"
+                , "  - --target=" <> LF.renderVersion lfVersion
+                , "  - --enable-interfaces=yes"
+                ]
+                  ++ ["  - --warn-bad-interface-instances=yes" | warnBadInterfaceInstances]
+                  ++ ["upgrades: '" <> path <> "'" | Just path <- pure upgradedFile]
+                  ++ ["data-dependencies:\n -  '" <> path <> "'" | Just path <- pure mbDep]
+              )
 
     writeFiles dir fs =
         for_ fs $ \(file, ioContent) -> do
             content <- ioContent
             createDirectoryIfMissing True (takeDirectory $ dir </> file)
             writeFileUTF8 (dir </> file) content
-
-    projectFile lfVersion name upgradedFile mbDep =
-        ( "daml.yaml"
-        , unlines $
-          [ "sdk-version: " <> sdkVersion
-          , "name: " <> name
-          , "source: daml"
-          , "version: 0.0.1"
-          , "dependencies:"
-          , "  - daml-prim"
-          , "  - daml-stdlib"
-          , "typecheck-upgrades: true"
-          , "build-options:"
-          , "  - --target=" <> LF.renderVersion lfVersion
-          , "  - --enable-interfaces=yes"
-          ] ++ ["upgrades: '" <> path <> "'" | Just path <- pure upgradedFile]
-            ++ ["data-dependencies:\n -  '" <> path <> "'" | Just path <- pure mbDep]
-        )
 
 data Expectation
   = Succeed

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -34,350 +34,414 @@ tests :: SdkVersioned => FilePath -> TestTree
 tests damlc =
     testGroup
         "Upgrade"
-        ([ test
-              "WarnsWhenTemplateChangesSignatories"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A signatories:\n  The upgraded template A has changed the definition of its signatories.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "WarnsWhenTemplateChangesObservers"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A observers:\n  The upgraded template A has changed the definition of its observers.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "SucceedsWhenATopLevelEnumChanges"
-              Succeed
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "WarnsWhenTemplateChangesEnsure"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A precondition:\n  The upgraded template A has changed the definition of its precondition.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "WarnsWhenTemplateChangesKeyExpression"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A key:\n  The upgraded template A has changed the expression for computing its key.")
-              contractKeysMinVersion
-              NoDependencies
-              False
-        , test
-              "WarnsWhenTemplateChangesKeyMaintainers"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A key:\n  The upgraded template A has changed the maintainers for its key.")
-              contractKeysMinVersion
-              NoDependencies
-              False
-        , test
-              "FailsWhenTemplateChangesKeyType"
-              (FailWithError "\ESC\\[0;91merror type checking template Main.A key:\n  The upgraded template A cannot change its key type.")
-              contractKeysMinVersion
-              NoDependencies
-              False
-        , test
-              "FailsWhenTemplateRemovesKeyType"
-              (FailWithError "\ESC\\[0;91merror type checking template Main.A key:\n  The upgraded template A cannot remove its key.")
-              contractKeysMinVersion
-              NoDependencies
-              False
-        , test
-              "FailsWhenTemplateAddsKeyType"
-              (FailWithError "\ESC\\[0;91merror type checking template Main.A key:\n  The upgraded template A cannot add a key where it didn't have one previously.")
-              contractKeysMinVersion
-              NoDependencies
-              False
-        , test
-              "FailsWhenNewFieldIsAddedToTemplateWithoutOptionalType"
-              (FailWithError "\ESC\\[0;91merror type checking template Main.A :\n  The upgraded template A has added new fields, but those fields are not Optional.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailsWhenOldFieldIsDeletedFromTemplate"
-              (FailWithError "\ESC\\[0;91merror type checking template Main.A :\n  The upgraded template A is missing some of its original fields.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailsWhenExistingFieldInTemplateIsChanged"
-              (FailWithError "\ESC\\[0;91merror type checking template Main.A :\n  The upgraded template A has changed the types of some of its original fields.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "SucceedsWhenNewFieldWithOptionalTypeIsAddedToTemplate"
-              Succeed
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailsWhenNewFieldIsAddedToTemplateChoiceWithoutOptionalType"
-              (FailWithError "\ESC\\[0;91merror type checking template Main.A choice C:\n  The upgraded input type of choice C on template A has added new fields, but those fields are not Optional.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailsWhenOldFieldIsDeletedFromTemplateChoice"
-              (FailWithError "\ESC\\[0;91merror type checking template Main.A choice C:\n  The upgraded input type of choice C on template A is missing some of its original fields.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailsWhenExistingFieldInTemplateChoiceIsChanged"
-              (FailWithError "\ESC\\[0;91merror type checking template Main.A choice C:\n  The upgraded input type of choice C on template A has changed the types of some of its original fields.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "WarnsWhenControllersOfTemplateChoiceAreChanged"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A choice C:\n  The upgraded choice C has changed the definition of controllers.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "WarnsWhenObserversOfTemplateChoiceAreChanged"
-              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A choice C:\n  The upgraded choice C has changed the definition of observers.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailsWhenTemplateChoiceChangesItsReturnType"
-              (FailWithError "\ESC\\[0;91merror type checking template Main.A choice C:\n  The upgraded choice C cannot change its return type.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "SucceedsWhenTemplateChoiceReturnsATemplateWhichHasChanged"
-              Succeed
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "SucceedsWhenTemplateChoiceInputArgumentHasChanged"
-              Succeed
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "SucceedsWhenNewFieldWithOptionalTypeIsAddedToTemplateChoice"
-              Succeed
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailsWhenATopLevelRecordAddsANonOptionalField"
-              (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded data type A has added new fields, but those fields are not Optional.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "SucceedsWhenATopLevelRecordAddsAnOptionalFieldAtTheEnd"
-              Succeed
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailsWhenATopLevelRecordAddsAnOptionalFieldBeforeTheEnd"
-              (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded data type A has changed the order of its fields - any new fields must be added at the end of the record.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "SucceedsWhenATopLevelVariantAddsAVariant"
-              Succeed
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailsWhenATopLevelVariantRemovesAVariant"
-              (FailWithError "\ESC\\[0;91merror type checking <none>:\n  Data type A.Z appears in package that is being upgraded, but does not appear in this package.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailWhenATopLevelVariantChangesChangesTheOrderOfItsVariants"
-              (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded data type A has changed the order of its variants - any new variant must be added at the end of the variant.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailsWhenATopLevelVariantAddsAFieldToAVariantsType"
-              (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded variant constructor Y from variant A has added a field.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "SucceedsWhenATopLevelVariantAddsAnOptionalFieldToAVariantsType"
-              Succeed
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "SucceedWhenATopLevelEnumAddsAField"
-              Succeed
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailWhenATopLevelEnumChangesChangesTheOrderOfItsVariants"
-              (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded data type A has changed the order of its variants - any new variant must be added at the end of the enum.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "SucceedsWhenATopLevelTypeSynonymChanges"
-              Succeed
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "SucceedsWhenTwoDeeplyNestedTypeSynonymsResolveToTheSameDatatypes"
-              Succeed
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailsWhenTwoDeeplyNestedTypeSynonymsResolveToDifferentDatatypes"
-              (FailWithError "\ESC\\[0;91merror type checking template Main.A :\n  The upgraded template A has changed the types of some of its original fields.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "SucceedsWhenAnInterfaceIsOnlyDefinedInTheInitialPackage"
-              Succeed
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailsWhenAnInterfaceIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage"
-              (FailWithError "\ESC\\[0;91merror type checking interface Main.I :\n  Tried to upgrade interface I, but interfaces cannot be upgraded. They should be removed in any upgrading package.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailsWhenAnInstanceIsDropped"
-              (FailWithError "\ESC\\[0;91merror type checking template Main.T :\n  Implementation of interface I by template T appears in package that is being upgraded, but does not appear in this package.")
-              LF.versionDefault
-              SeparateDep
-              False
-        , test
-              "SucceedsWhenAnInstanceIsAddedSeparateDep"
-              Succeed
-              LF.versionDefault
-              SeparateDep
-              False
-        , test
-              "SucceedsWhenAnInstanceIsAddedUpgradedPackage"
-              Succeed
-              LF.versionDefault
-              DependOnV1
-              True
-        , test
-              "CannotUpgradeView"
-              (FailWithError ".*Tried to implement a view of type (‘|\915\199\255)IView(’|\915\199\214) on interface (‘|\915\199\255)V1.I(’|\915\199\214), but the definition of interface (‘|\915\199\255)V1.I(’|\915\199\214) requires a view of type (‘|\915\199\255)V1.IView(’|\915\199\214)")
-              LF.versionDefault
-              DependOnV1
-              True
-        , test
-              "ValidUpgrade"
-              Succeed
-              contractKeysMinVersion
-              NoDependencies
-              False
-        , test
-              "MissingModule"
-              (FailWithError "\ESC\\[0;91merror type checking <none>:\n  Module Other appears in package that is being upgraded, but does not appear in this package.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "MissingTemplate"
-              (FailWithError "\ESC\\[0;91merror type checking <none>:\n  Template U appears in package that is being upgraded, but does not appear in this package.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "MissingDataCon"
-              (FailWithError "\ESC\\[0;91merror type checking <none>:\n  Data type U appears in package that is being upgraded, but does not appear in this package.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "MissingChoice"
-              (FailWithError "\ESC\\[0;91merror type checking template Main.T :\n  Choice C2 appears in package that is being upgraded, but does not appear in this package.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "TemplateChangedKeyType"
-              (FailWithError "\ESC\\[0;91merror type checking template Main.T key:\n  The upgraded template T cannot change its key type.")
-              contractKeysMinVersion
-              NoDependencies
-              False
-        , test
-              "RecordFieldsNewNonOptional"
-              (FailWithError "\ESC\\[0;91merror type checking data type Main.Struct:\n  The upgraded data type Struct has added new fields, but those fields are not Optional.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailsWithSynonymReturnTypeChange"
-              (FailWithError "\ESC\\[0;91merror type checking template Main.T choice C:\n  The upgraded choice C cannot change its return type.")
-              LF.versionDefault
-              NoDependencies
-              False
-        , test
-              "FailsWithSynonymReturnTypeChangeInSeparatePackage"
-              (FailWithError "\ESC\\[0;91merror type checking template Main.T choice C:\n  The upgraded choice C cannot change its return type.")
-              LF.versionDefault
-              SeparateDeps
-              False
-        , test
-              "SucceedsWhenUpgradingADependency"
-              Succeed
-              LF.versionDefault
-              SeparateDeps
-              False
-        , test
-              "FailsOnlyInModuleNotInReexports"
-              (FailWithError "\ESC\\[0;91merror type checking data type Other.A:\n  The upgraded data type A has added new fields, but those fields are not Optional.")
-              LF.versionDefault
-              NoDependencies
-              False
-        ] ++
-        concat
-          [ [ testGeneral
-                  (prefix <> "WhenAnInterfaceAndATemplateAreDefinedInTheSamePackage")
-                  "WarnsWhenAnInterfaceAndATemplateAreDefinedInTheSamePackage"
-                  (expectation "type checking module Main:\n  This package defines both interfaces and templates.\n  \n  This is not recommended - templates are upgradeable, but interfaces are not, which means that this version of the package and its templates can never be uninstalled.\n  \n  It is recommended that interfaces are defined in their own package separate from their implementations.")
-                  LF.versionDefault
-                  NoDependencies
-                  warnBadInterfaceInstances
-            , testGeneral
-                  (prefix <> "WhenAnInterfaceIsUsedInThePackageThatItsDefinedIn")
-                  "WarnsWhenAnInterfaceIsUsedInThePackageThatItsDefinedIn"
-                  (expectation "type checking interface Main.I :\n  The interface I was defined in this package and implemented in this package by the following templates:\n  \n  'T'\n  \n  However, it is recommended that interfaces are defined in their own package separate from their implementations.")
-                  LF.versionDefault
-                  NoDependencies
-                  warnBadInterfaceInstances
-            , testGeneral
-                  (prefix <> "WhenAnInterfaceIsDefinedAndThenUsedInAPackageThatUpgradesIt")
-                  "WarnsWhenAnInterfaceIsDefinedAndThenUsedInAPackageThatUpgradesIt"
-                  (expectation "type checking template Main.T interface instance [0-9a-f]+:Main:I for Main:T:\n  The template T has implemented interface I, which is defined in a previous version of this package.")
-                  LF.versionDefault
-                  DependOnV1
-                  warnBadInterfaceInstances
+        (
+            [ test
+                "CannotUpgradeView"
+                (FailWithError ".*Tried to implement a view of type (‘|\915\199\255)IView(’|\915\199\214) on interface (‘|\915\199\255)V1.I(’|\915\199\214), but the definition of interface (‘|\915\199\255)V1.I(’|\915\199\214) requires a view of type (‘|\915\199\255)V1.IView(’|\915\199\214)")
+                LF.versionDefault
+                DependOnV1
+                True
+                True
+            ] ++
+            concat [
+                [ test
+                      "WarnsWhenTemplateChangesSignatories"
+                      (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A signatories:\n  The upgraded template A has changed the definition of its signatories.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "WarnsWhenTemplateChangesObservers"
+                      (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A observers:\n  The upgraded template A has changed the definition of its observers.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "SucceedsWhenATopLevelEnumChanges"
+                      Succeed
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "WarnsWhenTemplateChangesEnsure"
+                      (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A precondition:\n  The upgraded template A has changed the definition of its precondition.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "WarnsWhenTemplateChangesKeyExpression"
+                      (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A key:\n  The upgraded template A has changed the expression for computing its key.")
+                      contractKeysMinVersion
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "WarnsWhenTemplateChangesKeyMaintainers"
+                      (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A key:\n  The upgraded template A has changed the maintainers for its key.")
+                      contractKeysMinVersion
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenTemplateChangesKeyType"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.A key:\n  The upgraded template A cannot change its key type.")
+                      contractKeysMinVersion
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenTemplateRemovesKeyType"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.A key:\n  The upgraded template A cannot remove its key.")
+                      contractKeysMinVersion
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenTemplateAddsKeyType"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.A key:\n  The upgraded template A cannot add a key where it didn't have one previously.")
+                      contractKeysMinVersion
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenNewFieldIsAddedToTemplateWithoutOptionalType"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.A :\n  The upgraded template A has added new fields, but those fields are not Optional.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenOldFieldIsDeletedFromTemplate"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.A :\n  The upgraded template A is missing some of its original fields.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenExistingFieldInTemplateIsChanged"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.A :\n  The upgraded template A has changed the types of some of its original fields.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "SucceedsWhenNewFieldWithOptionalTypeIsAddedToTemplate"
+                      Succeed
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenNewFieldIsAddedToTemplateChoiceWithoutOptionalType"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.A choice C:\n  The upgraded input type of choice C on template A has added new fields, but those fields are not Optional.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenOldFieldIsDeletedFromTemplateChoice"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.A choice C:\n  The upgraded input type of choice C on template A is missing some of its original fields.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenExistingFieldInTemplateChoiceIsChanged"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.A choice C:\n  The upgraded input type of choice C on template A has changed the types of some of its original fields.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "WarnsWhenControllersOfTemplateChoiceAreChanged"
+                      (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A choice C:\n  The upgraded choice C has changed the definition of controllers.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "WarnsWhenObserversOfTemplateChoiceAreChanged"
+                      (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.A choice C:\n  The upgraded choice C has changed the definition of observers.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenTemplateChoiceChangesItsReturnType"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.A choice C:\n  The upgraded choice C cannot change its return type.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "SucceedsWhenTemplateChoiceReturnsATemplateWhichHasChanged"
+                      Succeed
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "SucceedsWhenTemplateChoiceInputArgumentHasChanged"
+                      Succeed
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "SucceedsWhenNewFieldWithOptionalTypeIsAddedToTemplateChoice"
+                      Succeed
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenATopLevelRecordAddsANonOptionalField"
+                      (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded data type A has added new fields, but those fields are not Optional.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "SucceedsWhenATopLevelRecordAddsAnOptionalFieldAtTheEnd"
+                      Succeed
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenATopLevelRecordAddsAnOptionalFieldBeforeTheEnd"
+                      (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded data type A has changed the order of its fields - any new fields must be added at the end of the record.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "SucceedsWhenATopLevelVariantAddsAVariant"
+                      Succeed
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenATopLevelVariantRemovesAVariant"
+                      (FailWithError "\ESC\\[0;91merror type checking <none>:\n  Data type A.Z appears in package that is being upgraded, but does not appear in this package.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailWhenATopLevelVariantChangesChangesTheOrderOfItsVariants"
+                      (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded data type A has changed the order of its variants - any new variant must be added at the end of the variant.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenATopLevelVariantAddsAFieldToAVariantsType"
+                      (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded variant constructor Y from variant A has added a field.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "SucceedsWhenATopLevelVariantAddsAnOptionalFieldToAVariantsType"
+                      Succeed
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "SucceedWhenATopLevelEnumAddsAField"
+                      Succeed
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailWhenATopLevelEnumChangesChangesTheOrderOfItsVariants"
+                      (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded data type A has changed the order of its variants - any new variant must be added at the end of the enum.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "SucceedsWhenATopLevelTypeSynonymChanges"
+                      Succeed
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "SucceedsWhenTwoDeeplyNestedTypeSynonymsResolveToTheSameDatatypes"
+                      Succeed
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenTwoDeeplyNestedTypeSynonymsResolveToDifferentDatatypes"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.A :\n  The upgraded template A has changed the types of some of its original fields.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "SucceedsWhenAnInterfaceIsOnlyDefinedInTheInitialPackage"
+                      Succeed
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenAnInterfaceIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage"
+                      (FailWithError "\ESC\\[0;91merror type checking interface Main.I :\n  Tried to upgrade interface I, but interfaces cannot be upgraded. They should be removed in any upgrading package.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenAnInstanceIsDropped"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.T :\n  Implementation of interface I by template T appears in package that is being upgraded, but does not appear in this package.")
+                      LF.versionDefault
+                      SeparateDep
+                      False
+                      setUpgradeField
+                , test
+                      "SucceedsWhenAnInstanceIsAddedSeparateDep"
+                      Succeed
+                      LF.versionDefault
+                      SeparateDep
+                      False
+                      setUpgradeField
+                , test
+                      "SucceedsWhenAnInstanceIsAddedUpgradedPackage"
+                      Succeed
+                      LF.versionDefault
+                      DependOnV1
+                      True
+                      setUpgradeField
+                , test
+                      "ValidUpgrade"
+                      Succeed
+                      contractKeysMinVersion
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "MissingModule"
+                      (FailWithError "\ESC\\[0;91merror type checking <none>:\n  Module Other appears in package that is being upgraded, but does not appear in this package.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "MissingTemplate"
+                      (FailWithError "\ESC\\[0;91merror type checking <none>:\n  Template U appears in package that is being upgraded, but does not appear in this package.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "MissingDataCon"
+                      (FailWithError "\ESC\\[0;91merror type checking <none>:\n  Data type U appears in package that is being upgraded, but does not appear in this package.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "MissingChoice"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.T :\n  Choice C2 appears in package that is being upgraded, but does not appear in this package.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "TemplateChangedKeyType"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.T key:\n  The upgraded template T cannot change its key type.")
+                      contractKeysMinVersion
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "RecordFieldsNewNonOptional"
+                      (FailWithError "\ESC\\[0;91merror type checking data type Main.Struct:\n  The upgraded data type Struct has added new fields, but those fields are not Optional.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWithSynonymReturnTypeChange"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.T choice C:\n  The upgraded choice C cannot change its return type.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWithSynonymReturnTypeChangeInSeparatePackage"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.T choice C:\n  The upgraded choice C cannot change its return type.")
+                      LF.versionDefault
+                      SeparateDeps
+                      False
+                      setUpgradeField
+                , test
+                      "SucceedsWhenUpgradingADependency"
+                      Succeed
+                      LF.versionDefault
+                      SeparateDeps
+                      False
+                      setUpgradeField
+                , test
+                      "FailsOnlyInModuleNotInReexports"
+                      (FailWithError "\ESC\\[0;91merror type checking data type Other.A:\n  The upgraded data type A has added new fields, but those fields are not Optional.")
+                      LF.versionDefault
+                      NoDependencies
+                      False
+                      setUpgradeField
+                ]
+            | setUpgradeField <- [True, False]
+            ] ++
+            concat [
+                [ testGeneral
+                      (prefix <> "WhenAnInterfaceAndATemplateAreDefinedInTheSamePackage")
+                      "WarnsWhenAnInterfaceAndATemplateAreDefinedInTheSamePackage"
+                      (expectation "type checking module Main:\n  This package defines both interfaces and templates.\n  \n  This is not recommended - templates are upgradeable, but interfaces are not, which means that this version of the package and its templates can never be uninstalled.\n  \n  It is recommended that interfaces are defined in their own package separate from their implementations.")
+                      LF.versionDefault
+                      NoDependencies
+                      warnBadInterfaceInstances
+                      True
+                      doTypecheck
+                , testGeneral
+                      (prefix <> "WhenAnInterfaceIsUsedInThePackageThatItsDefinedIn")
+                      "WarnsWhenAnInterfaceIsUsedInThePackageThatItsDefinedIn"
+                      (expectation "type checking interface Main.I :\n  The interface I was defined in this package and implemented in this package by the following templates:\n  \n  'T'\n  \n  However, it is recommended that interfaces are defined in their own package separate from their implementations.")
+                      LF.versionDefault
+                      NoDependencies
+                      warnBadInterfaceInstances
+                      True
+                      doTypecheck
+                , testGeneral
+                      (prefix <> "WhenAnInterfaceIsDefinedAndThenUsedInAPackageThatUpgradesIt")
+                      "WarnsWhenAnInterfaceIsDefinedAndThenUsedInAPackageThatUpgradesIt"
+                      (expectation "type checking template Main.T interface instance [0-9a-f]+:Main:I for Main:T:\n  The template T has implemented interface I, which is defined in a previous version of this package.")
+                      LF.versionDefault
+                      DependOnV1
+                      warnBadInterfaceInstances
+                      True
+                      doTypecheck
+                ]
+            | warnBadInterfaceInstances <- [True, False]
+            , let prefix = if warnBadInterfaceInstances then "Warns" else "Fail"
+            , let expectation msg =
+                      if warnBadInterfaceInstances
+                         then SucceedWithWarning ("\ESC\\[0;93mwarning while " <> msg)
+                         else FailWithError ("\ESC\\[0;91merror " <> msg)
+            , doTypecheck <- [True, False]
             ]
-          | warnBadInterfaceInstances <- [True, False]
-          , let prefix = if warnBadInterfaceInstances then "Warns" else "Fail"
-          , let expectation msg =
-                    if warnBadInterfaceInstances
-                       then SucceedWithWarning ("\ESC\\[0;93mwarning while " <> msg)
-                       else FailWithError ("\ESC\\[0;91merror " <> msg)
-          ]
-      )
+       )
   where
     contractKeysMinVersion :: LF.Version
     contractKeysMinVersion = 
@@ -391,9 +455,10 @@ tests damlc =
         -> LF.Version
         -> Dependency
         -> Bool
+        -> Bool
         -> TestTree
-    test name expectation lfVersion sharedDep warnBadInterfaceInstances =
-        testGeneral name name expectation lfVersion sharedDep warnBadInterfaceInstances
+    test name expectation lfVersion sharedDep warnBadInterfaceInstances setUpgradeField =
+            testGeneral name name expectation lfVersion sharedDep warnBadInterfaceInstances setUpgradeField True
 
     testGeneral
         :: String
@@ -402,9 +467,13 @@ tests damlc =
         -> LF.Version
         -> Dependency
         -> Bool
+        -> Bool
+        -> Bool
         -> TestTree
-    testGeneral name location expectation lfVersion sharedDep warnBadInterfaceInstances =
-        testCase name $
+    testGeneral name location expectation lfVersion sharedDep warnBadInterfaceInstances setUpgradeField doTypecheck =
+        let upgradeFieldTrailer = if not setUpgradeField then " (no upgrades field)" else ""
+            doTypecheckTrailer = if not doTypecheck then " (disable typechecking)" else ""
+        testCase (name <> upgradeFieldTrailer <> doTypecheckTrailer) $
         withTempDir $ \dir -> do
             let newDir = dir </> "newVersion"
             let oldDir = dir </> "oldVersion"
@@ -466,9 +535,12 @@ tests damlc =
             writeFiles oldDir (projectFile ("upgrades-example-" <> location) Nothing depV1Dar : oldVersion)
             callProcessSilent damlc ["build", "--project-root", oldDir, "-o", oldDar]
 
-            writeFiles newDir (projectFile ("upgrades-example-" <> location <> "-v2") (Just oldDar) depV2Dar : newVersion)
+            writeFiles newDir (projectFile ("upgrades-example-" <> location <> "-v2") (if setUpgradeField then Just oldDar else Nothing) depV2Dar : newVersion)
+
             case expectation of
               Succeed ->
+                  callProcessSilent damlc ["build", "--project-root", newDir, "-o", newDar]
+              FailWithError _ | not (doTypecheck && setUpgradeField) ->
                   callProcessSilent damlc ["build", "--project-root", newDir, "-o", newDar]
               FailWithError regex -> do
                   stderr <- callProcessForStderr damlc ["build", "--project-root", newDir, "-o", newDar]
@@ -482,9 +554,12 @@ tests damlc =
                   let regexWithSeverity = "Severity: DsWarning\nMessage: \n" <> regex
                   let compiledRegex :: Regex
                       compiledRegex = makeRegexOpts defaultCompOpt { multiline = False } defaultExecOpt regexWithSeverity
-                  unless (matchTest compiledRegex stderr) $
-                      assertFailure ("`daml build` succeeded, but did not give a warning matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
-      where
+                  if setUpgradeField && doTypecheck
+                      then unless (matchTest compiledRegex stderr) $
+                            assertFailure ("`daml build` succeeded, but did not give a warning matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
+                      else when (matchTest compiledRegex stderr) $
+                            assertFailure ("`daml build` succeeded, did not `upgrade:` field set, should NOT give a warning matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
+          where
           projectFile name upgradedFile mbDep =
               ( "daml.yaml"
               , unlines $
@@ -495,14 +570,14 @@ tests damlc =
                 , "dependencies:"
                 , "  - daml-prim"
                 , "  - daml-stdlib"
-                , "typecheck-upgrades: true"
                 , "build-options:"
                 , "  - --target=" <> LF.renderVersion lfVersion
                 , "  - --enable-interfaces=yes"
                 ]
-                  ++ ["  - --warn-bad-interface-instances=yes" | warnBadInterfaceInstances]
+                  ++ ["  - --warn-bad-interface-instances=yes" | warnBadInterfaceInstances ]
                   ++ ["upgrades: '" <> path <> "'" | Just path <- pure upgradedFile]
                   ++ ["data-dependencies:\n -  '" <> path <> "'" | Just path <- pure mbDep]
+                  ++ ["typecheck-upgrades: False" | not doTypecheck]
               )
 
     writeFiles dir fs =

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -408,7 +408,7 @@ tests damlc =
                 [ testGeneral
                       (prefix <> "WhenAnInterfaceAndATemplateAreDefinedInTheSamePackage")
                       "WarnsWhenAnInterfaceAndATemplateAreDefinedInTheSamePackage"
-                      (expectation "type checking module Main:\n  This package defines both interfaces and templates.\n  \n  This is not recommended - templates are upgradeable, but interfaces are not, which means that this version of the package and its templates can never be uninstalled.\n  \n  It is recommended that interfaces are defined in their own package separate from their implementations.")
+                      (expectation "type checking module Main:\n  This package defines both interfaces and templates.")
                       LF.versionDefault
                       NoDependencies
                       warnBadInterfaceInstances
@@ -417,7 +417,7 @@ tests damlc =
                 , testGeneral
                       (prefix <> "WhenAnInterfaceIsUsedInThePackageThatItsDefinedIn")
                       "WarnsWhenAnInterfaceIsUsedInThePackageThatItsDefinedIn"
-                      (expectation "type checking interface Main.I :\n  The interface I was defined in this package and implemented in this package by the following templates:\n  \n  'T'\n  \n  However, it is recommended that interfaces are defined in their own package separate from their implementations.")
+                      (expectation "type checking interface Main.I :\n  The interface I was defined in this package and implemented in this package by the following templates:")
                       LF.versionDefault
                       NoDependencies
                       warnBadInterfaceInstances
@@ -473,6 +473,7 @@ tests damlc =
     testGeneral name location expectation lfVersion sharedDep warnBadInterfaceInstances setUpgradeField doTypecheck =
         let upgradeFieldTrailer = if not setUpgradeField then " (no upgrades field)" else ""
             doTypecheckTrailer = if not doTypecheck then " (disable typechecking)" else ""
+        in
         testCase (name <> upgradeFieldTrailer <> doTypecheckTrailer) $
         withTempDir $ \dir -> do
             let newDir = dir </> "newVersion"

--- a/sdk/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -2707,6 +2707,7 @@ tests TestArgs{..} =
         { buildOptions =
             [ "--target=" <> LF.renderVersion targetDevVersion
             , "--enable-interfaces=yes"
+            , "--warn-bad-interface-instances=yes"
             ]
         , extraDeps = []
         }

--- a/sdk/compiler/damlc/tests/src/DamlcTest.hs
+++ b/sdk/compiler/damlc/tests/src/DamlcTest.hs
@@ -103,7 +103,9 @@ testsForDamlcValidate damlc = testGroup "damlc validate-dar"
         , "version: 0.0.1"
         , "source: ."
         , "dependencies: [daml-prim, daml-stdlib]"
-        , "build-options: [--enable-interfaces=yes]"
+        , "build-options:"
+        , "- --enable-interfaces=yes"
+        , "- --warn-bad-interface-instances=yes"
         ]
       writeFileUTF8 (projDir </> "Good.daml") $ unlines
         [ "module Good where"
@@ -129,7 +131,9 @@ testsForDamlcValidate damlc = testGroup "damlc validate-dar"
         , "version: 0.0.1"
         , "source: ."
         , "dependencies: [daml-prim, daml-stdlib]"
-        , "build-options: [--enable-interfaces=yes]"
+        , "build-options:"
+        , "- --enable-interfaces=yes"
+        , "- --warn-bad-interface-instances=yes"
         ]
       writeFileUTF8 (projDir </> "Interface.daml") $ unlines
         [ "module Interface where"

--- a/sdk/daml-assistant/integration-tests/BUILD.bazel
+++ b/sdk/daml-assistant/integration-tests/BUILD.bazel
@@ -107,7 +107,7 @@ da_haskell_test(
         "//compiler/damlc/tests:generate-simple-dalf",
     ] + ([] if is_windows else ts_libraries + ["@script_nix//:bin/script"]),
     # marked flaky for mvn originally; still flaky now? #14281
-    flaky = True,
+    flaky = False,
     hackage_deps = [
         "aeson",
         "base",

--- a/sdk/daml-assistant/integration-tests/BUILD.bazel
+++ b/sdk/daml-assistant/integration-tests/BUILD.bazel
@@ -107,7 +107,7 @@ da_haskell_test(
         "//compiler/damlc/tests:generate-simple-dalf",
     ] + ([] if is_windows else ts_libraries + ["@script_nix//:bin/script"]),
     # marked flaky for mvn originally; still flaky now? #14281
-    flaky = False,
+    flaky = True,
     hackage_deps = [
         "aeson",
         "base",

--- a/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -124,7 +124,7 @@ damlStart tmpDir disableUpgradeValidation = do
             , "    output-directory: ui/java"
             , "build-options:"
             , "- --target=2.1"
-            ] ++ ["- --warn-bad-interface-instances=yes" |  disableUpgradeValidation ]
+            ] ++ [ "- --warn-bad-interface-instances=yes" |  disableUpgradeValidation ]
     writeFileUTF8 (projDir </> "daml/Main.daml") $
         unlines
             [ "module Main where"

--- a/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -536,7 +536,7 @@ cantonTests = testGroup "daml sandbox"
             let outputLines = lines output
             -- NOTE (Sofia): We use `isInfixOf` extensively because
             --   the REPL output is full of color codes.
-            res0 <- case (find (isInfixOf "res0") outputLines) of
+            res0 <- case find (isInfixOf "res0") outputLines of
                       Just res0 -> pure res0
                       _ -> fail output
             assertBool "sandbox participant is not running" ("true" `isInfixOf` res0)

--- a/sdk/daml-script/test/BUILD.bazel
+++ b/sdk/daml-script/test/BUILD.bazel
@@ -72,6 +72,7 @@ dependencies:
 build-options:
   - --target={target}
   - --enable-interfaces=yes
+typecheck-upgrades: false
 EOF
       $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location script{scriptVersion}-test-v{name}.dar)
       rm -rf $$TMP_DIR

--- a/sdk/docs/source/daml-script/template-root/daml.yaml.template
+++ b/sdk/docs/source/daml-script/template-root/daml.yaml.template
@@ -6,6 +6,7 @@ version: 0.0.1
 build-options:
   - --target=2.1
   - --enable-interfaces=yes
+  - --warn-bad-interface-instances=yes
 # script-build-options-end
 # script-dependencies-begin
 dependencies:


### PR DESCRIPTION
Turns interface warnings into errors, provides flag to downgrade them.

Before we do this for expressions, we need to fix expression errors to be less eager.

In the long term I'd like a similar system to that for GHC, where we can downgrade most errors to warnings and upgrade most warnings to errors