### PR TITLE
ETX-453: Typescript bindings: support package names in commands

### DIFF
--- a/sdk/language-support/ts/codegen/tests/build-and-lint.sh
+++ b/sdk/language-support/ts/codegen/tests/build-and-lint.sh
@@ -91,4 +91,4 @@ $YARN run build
 $YARN run lint
 # Invoke 'yarn test'. Control is thereby passed to
 # 'language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts'.
-JAVA=$JAVA CANTON=$CANTON JSON_API=$JSON_API DAR=$DAR UPLOAD_DAR=$UPLOAD_DAR HIDDEN_DAR=$HIDDEN_DAR $YARN test
+JAVA=$JAVA CANTON=$CANTON JSON_API=$JSON_API DAR=$DAR UPLOAD_DAR=$UPLOAD_DAR HIDDEN_DAR=$HIDDEN_DAR $YARN test -t "${BUILD_AND_LINT_TEST_NAME_PATTERN:-.*}"

--- a/sdk/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/sdk/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -237,369 +237,416 @@ describe("decoders for recursive types do not loop", () => {
   });
 });
 
-test("create + fetch & exercise", async () => {
-  const aliceLedger = new Ledger({
-    token: ALICE_TOKEN,
-    httpBaseUrl: httpBaseUrl(),
-  });
-  const bobLedger = new Ledger({
-    token: BOB_TOKEN,
-    httpBaseUrl: httpBaseUrl(),
-  });
-  const aliceRawStream = aliceLedger.streamQuery(buildAndLint.Main.Person, {
-    party: ALICE_PARTY,
-  });
-  const aliceStream = promisifyStream(aliceRawStream);
-  // TODO(MH): Move this live marker into `promisifyStream`. Unfortunately,
-  // it didn't work the straightforward way and we need to spend more time
-  // figuring out what's going wrong before we can do it. There are two more
-  // instances of this pattern below.
-  const aliceStreamLive = pEvent(aliceRawStream, "live");
-  expect(await aliceStreamLive).toEqual([]);
+function doCreateFetchAndExercise<Pkg extends string>(
+  Person: Template<buildAndLint.Main.Person, buildAndLint.Main.Person.Key, Pkg>,
+  AllTypes: Template<buildAndLint.Main.AllTypes, undefined, Pkg>,
+  NonTopLevel: Template<buildAndLint.Lib.Mod.NonTopLevel, undefined, Pkg>,
+) {
+  return async () => {
+    const aliceLedger = new Ledger({
+      token: ALICE_TOKEN,
+      httpBaseUrl: httpBaseUrl(),
+    });
+    const bobLedger = new Ledger({
+      token: BOB_TOKEN,
+      httpBaseUrl: httpBaseUrl(),
+    });
+    const aliceRawStream = aliceLedger.streamQuery(Person, {
+      party: ALICE_PARTY,
+    });
+    const aliceStream = promisifyStream(aliceRawStream);
+    // TODO(MH): Move this live marker into `promisifyStream`. Unfortunately,
+    // it didn't work the straightforward way and we need to spend more time
+    // figuring out what's going wrong before we can do it. There are two more
+    // instances of this pattern below.
+    const aliceStreamLive = pEvent(aliceRawStream, "live");
+    expect(await aliceStreamLive).toEqual([]);
 
-  const alice5: buildAndLint.Main.Person = {
-    name: "Alice from Wonderland",
-    party: ALICE_PARTY,
-    age: "5",
-    friends: [],
-  };
-  const bob4: buildAndLint.Main.Person = {
-    name: "Bob the Builder",
-    party: BOB_PARTY,
-    age: "4",
-    friends: [ALICE_PARTY],
-  };
-  const alice5Key = { _1: alice5.party, _2: alice5.age };
-  const bob4Key = { _1: bob4.party, _2: bob4.age };
-  const alice5Contract = await aliceLedger.create(
-    buildAndLint.Main.Person,
-    alice5,
-  );
-  expect(alice5Contract.payload).toEqual(alice5);
-  expect(alice5Contract.key).toEqual(alice5Key);
-  expect(await aliceStream.next()).toEqual([
-    [alice5Contract],
-    [{ created: alice5Contract, matchedQueries: [0] }],
-  ]);
+    const alice5: buildAndLint.Main.Person = {
+      name: "Alice from Wonderland",
+      party: ALICE_PARTY,
+      age: "5",
+      friends: [],
+    };
+    const bob4: buildAndLint.Main.Person = {
+      name: "Bob the Builder",
+      party: BOB_PARTY,
+      age: "4",
+      friends: [ALICE_PARTY],
+    };
+    const alice5Key = { _1: alice5.party, _2: alice5.age };
+    const bob4Key = { _1: bob4.party, _2: bob4.age };
+    const alice5Contract = await aliceLedger.create(Person, alice5);
+    expect(alice5Contract.payload).toEqual(alice5);
+    expect(alice5Contract.key).toEqual(alice5Key);
+    expect(await aliceStream.next()).toEqual([
+      [alice5Contract],
+      [{ created: alice5Contract, matchedQueries: [0] }],
+    ]);
 
-  let personContracts = await aliceLedger.query(buildAndLint.Main.Person);
-  expect(personContracts).toEqual([alice5Contract]);
+    let personContracts = await aliceLedger.query(Person);
+    expect(personContracts).toEqual([alice5Contract]);
 
-  const aliceContracts = await aliceLedger.query(buildAndLint.Main.Person, {
-    party: ALICE_PARTY,
-  });
-  expect(aliceContracts).toEqual(personContracts);
-  const bobContracts = await aliceLedger.query(buildAndLint.Main.Person, {
-    party: BOB_PARTY,
-  });
-  expect(bobContracts).toEqual([]);
+    const aliceContracts = await aliceLedger.query(Person, {
+      party: ALICE_PARTY,
+    });
+    expect(aliceContracts).toEqual(personContracts);
+    const bobContracts = await aliceLedger.query(Person, {
+      party: BOB_PARTY,
+    });
+    expect(bobContracts).toEqual([]);
 
-  let alice5ContractById = await aliceLedger.fetch(
-    buildAndLint.Main.Person,
-    alice5Contract.contractId,
-  );
-  expect(alice5ContractById).toEqual(alice5Contract);
-
-  const alice5ContractByKey = await aliceLedger.fetchByKey(
-    buildAndLint.Main.Person,
-    alice5Key,
-  );
-  expect(alice5ContractByKey).toEqual(alice5Contract);
-
-  const bobByKey = await aliceLedger.fetchByKey(
-    buildAndLint.Main.Person,
-    bob4Key,
-  );
-  expect(bobByKey).toBeNull();
-
-  // Alice has a birthday and turns 6. The choice returns the new contract id.
-  // There are two events: the archival of the old contract and the creation of
-  // the new contract.
-  let [result, events] = await aliceLedger.exercise(
-    buildAndLint.Main.Person.Birthday,
-    alice5Contract.contractId,
-    {},
-  );
-  expect(result).not.toEqual(alice5Contract.contractId);
-  expect(events).toHaveLength(2);
-  expect(events[0]).toHaveProperty("archived");
-  expect(events[1]).toHaveProperty("created");
-  const alice5Archived = (
-    events[0] as { archived: buildAndLint.Main.Person.ArchiveEvent }
-  ).archived;
-  const alice6Contract = (
-    events[1] as { created: buildAndLint.Main.Person.CreateEvent }
-  ).created;
-  expect(alice5Archived.contractId).toEqual(alice5Contract.contractId);
-  expect(alice6Contract.contractId).toEqual(result);
-  expect(alice6Contract.payload).toEqual({ ...alice5, age: "6" });
-  expect(alice6Contract.key).toEqual({ ...alice5Key, _2: "6" });
-  expect(await aliceStream.next()).toEqual([
-    [alice6Contract],
-    [
-      { archived: alice5Archived },
-      { created: alice6Contract, matchedQueries: [0] },
-    ],
-  ]);
-
-  alice5ContractById = await aliceLedger.fetch(
-    buildAndLint.Main.Person,
-    alice5Contract.contractId,
-  );
-  expect(alice5ContractById).toBeNull();
-
-  personContracts = await aliceLedger.query(buildAndLint.Main.Person);
-  expect(personContracts).toEqual([alice6Contract]);
-
-  const alice6Key = { ...alice5Key, _2: "6" };
-  const alice6KeyRawStream = aliceLedger.streamFetchByKey(
-    buildAndLint.Main.Person,
-    alice6Key,
-  );
-  const alice6KeyStream = promisifyStream(alice6KeyRawStream);
-  const alice6KeyStreamLive = pEvent(alice6KeyRawStream, "live");
-  expect(await alice6KeyStream.next()).toEqual([
-    alice6Contract,
-    [{ created: alice6Contract }],
-  ]);
-
-  const personRawStream = aliceLedger.streamQuery(buildAndLint.Main.Person);
-  const personStream = promisifyStream(personRawStream);
-  const personStreamLive = pEvent(personRawStream, "live");
-  expect(await personStream.next()).toEqual([
-    [alice6Contract],
-    [{ created: alice6Contract, matchedQueries: [0] }],
-  ]);
-
-  // end of non-live data, first offset
-  expect(await personStreamLive).toEqual([alice6Contract]);
-  expect(await alice6KeyStreamLive).toEqual(alice6Contract);
-
-  // Bob enters the scene.
-  const bob4Contract = await bobLedger.create(buildAndLint.Main.Person, bob4);
-  expect(bob4Contract.payload).toEqual(bob4);
-  expect(bob4Contract.key).toEqual(bob4Key);
-  expect(await personStream.next()).toEqual([
-    [alice6Contract, bob4Contract],
-    [{ created: bob4Contract, matchedQueries: [0] }],
-  ]);
-
-  // Alice changes her name.
-  [result, events] = await aliceLedger.exerciseByKey(
-    buildAndLint.Main.Person.Rename,
-    alice6Contract.key,
-    { newName: "Alice Cooper" },
-  );
-  expect(result).not.toEqual(alice6Contract.contractId);
-  expect(events).toHaveLength(2);
-  expect(events[0]).toHaveProperty("archived");
-  expect(events[1]).toHaveProperty("created");
-  const alice6Archived = (
-    events[0] as { archived: buildAndLint.Main.Person.ArchiveEvent }
-  ).archived;
-  const cooper6Contract = (
-    events[1] as { created: buildAndLint.Main.Person.CreateEvent }
-  ).created;
-  expect(alice6Archived.contractId).toEqual(alice6Contract.contractId);
-  expect(cooper6Contract.contractId).toEqual(result);
-  expect(cooper6Contract.payload).toEqual({
-    ...alice5,
-    name: "Alice Cooper",
-    age: "6",
-  });
-  expect(cooper6Contract.key).toEqual(alice6Key);
-  expect(await aliceStream.next()).toEqual([
-    [cooper6Contract],
-    [
-      { archived: alice6Archived },
-      { created: cooper6Contract, matchedQueries: [0] },
-    ],
-  ]);
-  expect(await alice6KeyStream.next()).toEqual([
-    cooper6Contract,
-    [{ archived: alice6Archived }, { created: cooper6Contract }],
-  ]);
-  expect(await personStream.next()).toEqual([
-    [bob4Contract, cooper6Contract],
-    [
-      { archived: alice6Archived },
-      { created: cooper6Contract, matchedQueries: [0] },
-    ],
-  ]);
-
-  personContracts = await aliceLedger.query(buildAndLint.Main.Person);
-  expect(personContracts).toEqual([bob4Contract, cooper6Contract]);
-
-  // Alice gets archived.
-  const cooper7Archived = await aliceLedger.archiveByKey(
-    buildAndLint.Main.Person,
-    cooper6Contract.key,
-  );
-  expect(cooper7Archived.contractId).toEqual(cooper6Contract.contractId);
-  expect(await aliceStream.next()).toEqual([
-    [],
-    [{ archived: cooper7Archived }],
-  ]);
-  expect(await alice6KeyStream.next()).toEqual([
-    null,
-    [{ archived: cooper7Archived }],
-  ]);
-  expect(await personStream.next()).toEqual([
-    [bob4Contract],
-    [{ archived: cooper7Archived }],
-  ]);
-
-  personContracts = await aliceLedger.query(buildAndLint.Main.Person);
-  expect(personContracts).toEqual([bob4Contract]);
-
-  // Bob gets archived.
-  const bob4Archived = await bobLedger.archive(
-    buildAndLint.Main.Person,
-    bob4Contract.contractId,
-  );
-  expect(bob4Archived.contractId).toEqual(bob4Contract.contractId);
-  expect(await personStream.next()).toEqual([[], [{ archived: bob4Archived }]]);
-
-  personContracts = await aliceLedger.query(buildAndLint.Main.Person);
-  expect(personContracts).toEqual([]);
-
-  aliceStream.close();
-  alice6KeyStream.close();
-  personStream.close();
-
-  const map: Map<buildAndLint.Main.Expr2<Int>, Int> = emptyMap<
-    buildAndLint.Main.Expr2<Int>,
-    Int
-  >()
-    .set(
-      {
-        tag: "Add2",
-        value: {
-          lhs: { tag: "Lit2", value: "1" },
-          rhs: { tag: "Lit2", value: "2" },
-        },
-      },
-      "3",
-    )
-    .set(
-      {
-        tag: "Add2",
-        value: {
-          lhs: { tag: "Lit2", value: "5" },
-          rhs: { tag: "Lit2", value: "4" },
-        },
-      },
-      "9",
-    )
-    .set(
-      {
-        tag: "Add2",
-        value: {
-          lhs: { tag: "Lit2", value: "2" },
-          rhs: { tag: "Lit2", value: "1" },
-        },
-      },
-      "3",
-    )
-    .set(
-      {
-        tag: "Add2",
-        value: {
-          lhs: { tag: "Lit2", value: "3" },
-          rhs: { tag: "Lit2", value: "1" },
-        },
-      },
-      "4",
+    let alice5ContractById = await aliceLedger.fetch(
+      Person,
+      alice5Contract.contractId,
     );
-  const allTypes: buildAndLint.Main.AllTypes = {
-    unit: {},
-    bool: true,
-    int: "5",
-    text: "Hello",
-    date: "2019-04-04",
-    time: "2019-12-31T12:34:56.789Z",
-    party: ALICE_PARTY,
-    contractId: alice5Contract.contractId,
-    optional: "5", // Some 5
-    optional2: null, // None
-    optionalOptionalInt: ["5"], // Some (Some 5)
-    optionalOptionalInt2: [], // Some (None)
-    optionalOptionalInt3: null, // None
-    list: [true, false],
-    textMap: { alice: "2", "bob & carl": "3" },
-    monoRecord: alice5,
-    polyRecord: { one: "10", two: "XYZ" },
-    imported: { field: { something: "pqr" } },
-    archiveX: {},
-    either: { tag: "Right", value: "really?" },
-    tuple: { _1: "12", _2: "mmm" },
-    enum: buildAndLint.Main.Color.Red,
-    enumList: [
-      buildAndLint.Main.Color.Red,
-      buildAndLint.Main.Color.Blue,
-      buildAndLint.Main.Color.Yellow,
-    ],
-    enumList2: ["Red", "Blue", "Yellow"],
-    optcol1: { tag: "Transparent1", value: {} },
-    optcol2: { tag: "Color2", value: { color2: "Red" } }, // 'Red' is of type Color
-    optcol3: { tag: "Color2", value: { color2: buildAndLint.Main.Color.Blue } }, // Color.Blue is of type 'Color'
-    variant: {
-      tag: "Add",
-      value: { _1: { tag: "Lit", value: "1" }, _2: { tag: "Lit", value: "2" } },
-    },
-    optionalVariant: {
-      tag: "Add",
-      value: { _1: { tag: "Lit", value: "1" }, _2: { tag: "Lit", value: "2" } },
-    },
-    sumProd: { tag: "Corge", value: { x: "1", y: "Garlpy" } },
-    optionalSumProd: { tag: "Corge", value: { x: "1", y: "Garlpy" } },
-    parametericSumProd: {
-      tag: "Add2",
-      value: {
-        lhs: { tag: "Lit2", value: "1" },
-        rhs: { tag: "Lit2", value: "2" },
+    expect(alice5ContractById).toEqual(alice5Contract);
+
+    const alice5ContractByKey = await aliceLedger.fetchByKey(Person, alice5Key);
+    expect(alice5ContractByKey).toEqual(alice5Contract);
+
+    const bobByKey = await aliceLedger.fetchByKey(Person, bob4Key);
+    expect(bobByKey).toBeNull();
+
+    // Alice has a birthday and turns 6. The choice returns the new contract id.
+    // There are two events: the archival of the old contract and the creation of
+    // the new contract.
+    let [result, events] = await aliceLedger.exercise(
+      buildAndLint.Main.Person.Birthday,
+      alice5Contract.contractId,
+      {},
+    );
+    expect(result).not.toEqual(alice5Contract.contractId);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toHaveProperty("archived");
+    expect(events[1]).toHaveProperty("created");
+    const alice5Archived = (
+      events[0] as { archived: buildAndLint.Main.Person.ArchiveEvent }
+    ).archived;
+    const alice6Contract = (
+      events[1] as { created: buildAndLint.Main.Person.CreateEvent }
+    ).created;
+    expect(alice5Archived.contractId).toEqual(alice5Contract.contractId);
+    expect(alice6Contract.contractId).toEqual(result);
+    expect(alice6Contract.payload).toEqual({ ...alice5, age: "6" });
+    expect(alice6Contract.key).toEqual({ ...alice5Key, _2: "6" });
+    expect(await aliceStream.next()).toEqual([
+      [alice6Contract],
+      [
+        { archived: alice5Archived },
+        { created: alice6Contract, matchedQueries: [0] },
+      ],
+    ]);
+
+    alice5ContractById = await aliceLedger.fetch(
+      Person,
+      alice5Contract.contractId,
+    );
+    expect(alice5ContractById).toBeNull();
+
+    personContracts = await aliceLedger.query(Person);
+    expect(personContracts).toEqual([alice6Contract]);
+
+    const alice6Key = { ...alice5Key, _2: "6" };
+    const alice6KeyRawStream = aliceLedger.streamFetchByKey(Person, alice6Key);
+    const alice6KeyStream = promisifyStream(alice6KeyRawStream);
+    const alice6KeyStreamLive = pEvent(alice6KeyRawStream, "live");
+    expect(await alice6KeyStream.next()).toEqual([
+      alice6Contract,
+      [{ created: alice6Contract }],
+    ]);
+
+    const personRawStream = aliceLedger.streamQuery(Person);
+    const personStream = promisifyStream(personRawStream);
+    const personStreamLive = pEvent(personRawStream, "live");
+    expect(await personStream.next()).toEqual([
+      [alice6Contract],
+      [{ created: alice6Contract, matchedQueries: [0] }],
+    ]);
+
+    // end of non-live data, first offset
+    expect(await personStreamLive).toEqual([alice6Contract]);
+    expect(await alice6KeyStreamLive).toEqual(alice6Contract);
+
+    // Bob enters the scene.
+    const bob4Contract = await bobLedger.create(Person, bob4);
+    expect(bob4Contract.payload).toEqual(bob4);
+    expect(bob4Contract.key).toEqual(bob4Key);
+    expect(await personStream.next()).toEqual([
+      [alice6Contract, bob4Contract],
+      [{ created: bob4Contract, matchedQueries: [0] }],
+    ]);
+
+    // Alice changes her name.
+    [result, events] = await aliceLedger.exerciseByKey(
+      buildAndLint.Main.Person.Rename,
+      alice6Contract.key,
+      { newName: "Alice Cooper" },
+    );
+    expect(result).not.toEqual(alice6Contract.contractId);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toHaveProperty("archived");
+    expect(events[1]).toHaveProperty("created");
+    const alice6Archived = (
+      events[0] as { archived: buildAndLint.Main.Person.ArchiveEvent }
+    ).archived;
+    const cooper6Contract = (
+      events[1] as { created: buildAndLint.Main.Person.CreateEvent }
+    ).created;
+    expect(alice6Archived.contractId).toEqual(alice6Contract.contractId);
+    expect(cooper6Contract.contractId).toEqual(result);
+    expect(cooper6Contract.payload).toEqual({
+      ...alice5,
+      name: "Alice Cooper",
+      age: "6",
+    });
+    expect(cooper6Contract.key).toEqual(alice6Key);
+    expect(await aliceStream.next()).toEqual([
+      [cooper6Contract],
+      [
+        { archived: alice6Archived },
+        { created: cooper6Contract, matchedQueries: [0] },
+      ],
+    ]);
+    expect(await alice6KeyStream.next()).toEqual([
+      cooper6Contract,
+      [{ archived: alice6Archived }, { created: cooper6Contract }],
+    ]);
+    expect(await personStream.next()).toEqual([
+      [bob4Contract, cooper6Contract],
+      [
+        { archived: alice6Archived },
+        { created: cooper6Contract, matchedQueries: [0] },
+      ],
+    ]);
+
+    personContracts = await aliceLedger.query(Person);
+    expect(personContracts).toEqual([bob4Contract, cooper6Contract]);
+
+    // Alice gets archived.
+    const cooper7Archived = await aliceLedger.archiveByKey(
+      Person,
+      cooper6Contract.key,
+    );
+    expect(cooper7Archived.contractId).toEqual(cooper6Contract.contractId);
+    expect(await aliceStream.next()).toEqual([
+      [],
+      [{ archived: cooper7Archived }],
+    ]);
+    expect(await alice6KeyStream.next()).toEqual([
+      null,
+      [{ archived: cooper7Archived }],
+    ]);
+    expect(await personStream.next()).toEqual([
+      [bob4Contract],
+      [{ archived: cooper7Archived }],
+    ]);
+
+    personContracts = await aliceLedger.query(Person);
+    expect(personContracts).toEqual([bob4Contract]);
+
+    // Bob gets archived.
+    const bob4Archived = await bobLedger.archive(
+      Person,
+      bob4Contract.contractId,
+    );
+    expect(bob4Archived.contractId).toEqual(bob4Contract.contractId);
+    expect(await personStream.next()).toEqual([
+      [],
+      [{ archived: bob4Archived }],
+    ]);
+
+    personContracts = await aliceLedger.query(Person);
+    expect(personContracts).toEqual([]);
+
+    aliceStream.close();
+    alice6KeyStream.close();
+    personStream.close();
+
+    const map: Map<buildAndLint.Main.Expr2<Int>, Int> = emptyMap<
+      buildAndLint.Main.Expr2<Int>,
+      Int
+    >()
+      .set(
+        {
+          tag: "Add2",
+          value: {
+            lhs: { tag: "Lit2", value: "1" },
+            rhs: { tag: "Lit2", value: "2" },
+          },
+        },
+        "3",
+      )
+      .set(
+        {
+          tag: "Add2",
+          value: {
+            lhs: { tag: "Lit2", value: "5" },
+            rhs: { tag: "Lit2", value: "4" },
+          },
+        },
+        "9",
+      )
+      .set(
+        {
+          tag: "Add2",
+          value: {
+            lhs: { tag: "Lit2", value: "2" },
+            rhs: { tag: "Lit2", value: "1" },
+          },
+        },
+        "3",
+      )
+      .set(
+        {
+          tag: "Add2",
+          value: {
+            lhs: { tag: "Lit2", value: "3" },
+            rhs: { tag: "Lit2", value: "1" },
+          },
+        },
+        "4",
+      );
+    const allTypes: buildAndLint.Main.AllTypes = {
+      unit: {},
+      bool: true,
+      int: "5",
+      text: "Hello",
+      date: "2019-04-04",
+      time: "2019-12-31T12:34:56.789Z",
+      party: ALICE_PARTY,
+      contractId: alice5Contract.contractId,
+      optional: "5", // Some 5
+      optional2: null, // None
+      optionalOptionalInt: ["5"], // Some (Some 5)
+      optionalOptionalInt2: [], // Some (None)
+      optionalOptionalInt3: null, // None
+      list: [true, false],
+      textMap: { alice: "2", "bob & carl": "3" },
+      monoRecord: alice5,
+      polyRecord: { one: "10", two: "XYZ" },
+      imported: { field: { something: "pqr" } },
+      archiveX: {},
+      either: { tag: "Right", value: "really?" },
+      tuple: { _1: "12", _2: "mmm" },
+      enum: buildAndLint.Main.Color.Red,
+      enumList: [
+        buildAndLint.Main.Color.Red,
+        buildAndLint.Main.Color.Blue,
+        buildAndLint.Main.Color.Yellow,
+      ],
+      enumList2: ["Red", "Blue", "Yellow"],
+      optcol1: { tag: "Transparent1", value: {} },
+      optcol2: { tag: "Color2", value: { color2: "Red" } }, // 'Red' is of type Color
+      optcol3: {
+        tag: "Color2",
+        value: { color2: buildAndLint.Main.Color.Blue },
+      }, // Color.Blue is of type 'Color'
+      variant: {
+        tag: "Add",
+        value: {
+          _1: { tag: "Lit", value: "1" },
+          _2: { tag: "Lit", value: "2" },
+        },
       },
-    },
-    optionalOptionalParametericSumProd: [
-      {
+      optionalVariant: {
+        tag: "Add",
+        value: {
+          _1: { tag: "Lit", value: "1" },
+          _2: { tag: "Lit", value: "2" },
+        },
+      },
+      sumProd: { tag: "Corge", value: { x: "1", y: "Garlpy" } },
+      optionalSumProd: { tag: "Corge", value: { x: "1", y: "Garlpy" } },
+      parametericSumProd: {
         tag: "Add2",
         value: {
           lhs: { tag: "Lit2", value: "1" },
           rhs: { tag: "Lit2", value: "2" },
         },
       },
-    ],
-    n0: "3.0", // Numeric 0
-    n5: "3.14159", // Numeric 5
-    n10: "3.1415926536", // Numeric 10
-    rec: { recOptional: null, recList: [], recTextMap: {} },
-    voidRecord: null,
-    voidEnum: null,
-    genMap: map,
-  };
-  const allTypesContract = await aliceLedger.create(
-    buildAndLint.Main.AllTypes,
-    allTypes,
-  );
-  expect(allTypesContract.payload).toEqual(allTypes);
-  expect(allTypesContract.key).toBeUndefined();
+      optionalOptionalParametericSumProd: [
+        {
+          tag: "Add2",
+          value: {
+            lhs: { tag: "Lit2", value: "1" },
+            rhs: { tag: "Lit2", value: "2" },
+          },
+        },
+      ],
+      n0: "3.0", // Numeric 0
+      n5: "3.14159", // Numeric 5
+      n10: "3.1415926536", // Numeric 10
+      rec: { recOptional: null, recList: [], recTextMap: {} },
+      voidRecord: null,
+      voidEnum: null,
+      genMap: map,
+    };
+    const allTypesContract = await aliceLedger.create(AllTypes, allTypes);
+    expect(allTypesContract.payload).toEqual(allTypes);
+    expect(allTypesContract.key).toBeUndefined();
 
-  const allTypesContracts = await aliceLedger.query(buildAndLint.Main.AllTypes);
-  expect(allTypesContracts).toEqual([allTypesContract]);
+    const allTypesContracts = await aliceLedger.query(AllTypes);
+    expect(allTypesContracts).toEqual([allTypesContract]);
 
-  const nonTopLevel: buildAndLint.Lib.Mod.NonTopLevel = {
-    party: ALICE_PARTY,
+    const allTypesArchived = await aliceLedger.archive(
+      AllTypes,
+      allTypesContract.contractId,
+    );
+    expect(allTypesArchived.contractId).toEqual(allTypesContract.contractId);
+
+    const nonTopLevel: buildAndLint.Lib.Mod.NonTopLevel = {
+      party: ALICE_PARTY,
+    };
+    const nonTopLevelContract = await aliceLedger.create(
+      NonTopLevel,
+      nonTopLevel,
+    );
+    expect(nonTopLevelContract.payload).toEqual(nonTopLevel);
+    const nonTopLevelContracts = await aliceLedger.query(NonTopLevel);
+    expect(nonTopLevelContracts).toEqual([nonTopLevelContract]);
+
+    const nonTopLevelArchived = await aliceLedger.archive(
+      NonTopLevel,
+      nonTopLevelContract.contractId,
+    );
+    expect(nonTopLevelArchived.contractId).toEqual(
+      nonTopLevelContract.contractId,
+    );
   };
-  const nonTopLevelContract = await aliceLedger.create(
-    buildAndLint.Lib.Mod.NonTopLevel,
-    nonTopLevel,
-  );
-  expect(nonTopLevelContract.payload).toEqual(nonTopLevel);
-  const nonTopLevelContracts = await aliceLedger.query(
-    buildAndLint.Lib.Mod.NonTopLevel,
-  );
-  expect(nonTopLevelContracts).toEqual([nonTopLevelContract]);
-});
+}
+
+test(
+  "create, fetch and exercise with package id",
+  doCreateFetchAndExercise(
+    {
+      ...buildAndLint.Main.Person,
+      templateId: `${buildAndLint.packageId}:Main:Person`,
+    },
+    {
+      ...buildAndLint.Main.AllTypes,
+      templateId: `${buildAndLint.packageId}:Main:AllTypes`,
+    },
+    {
+      ...buildAndLint.Lib.Mod.NonTopLevel,
+      templateId: `${buildAndLint.packageId}:Lib.Mod:NonTopLevel`,
+    },
+  ),
+);
+test(
+  "create, fetch and exercise with package name",
+  doCreateFetchAndExercise(
+    { ...buildAndLint.Main.Person, templateId: "#build-and-lint:Main:Person" },
+    {
+      ...buildAndLint.Main.AllTypes,
+      templateId: "#build-and-lint:Main:AllTypes",
+    },
+    {
+      ...buildAndLint.Lib.Mod.NonTopLevel,
+      templateId: "#build-and-lint:Lib.Mod:NonTopLevel",
+    },
+  ),
+);
 
 test("exercise using explicit disclosure", async () => {
   const aliceLedger = new Ledger({


### PR DESCRIPTION
- run the "create + fetch & exercise" tests twice, once using package ids in the template ids, and again using package names 
- removed some cases where the decoder expected the template id in the response to exactly match the one in the request. Now the request template ids can contain package names, whereas the ones in the response will contain a package id.
- Allow filtering tests in the build-and-lint tests with env var `BUILD_AND_LINT_TEST_NAME_PATTERN`

Diff best viewed with "Hide whitespace"