### PR TITLE
make Timestamp parsing consistent across Java versions

### DIFF
--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/meteringreport/MeteringReport.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/meteringreport/MeteringReport.scala
@@ -9,6 +9,9 @@ import spray.json.{DefaultJsonProtocol, RootJsonFormat, *}
 
 import DefaultJsonProtocol.*
 
+import java.time.Instant
+import scala.util.Try
+
 object MeteringReport {
 
   type Scheme = String
@@ -35,7 +38,11 @@ object MeteringReport {
   final case class ApplicationReport(application: ApplicationId, events: Long)
 
   implicit val TimestampFormat: RootJsonFormat[Timestamp] =
-    stringJsonFormat(Timestamp.fromString(_))(_.toString)
+    stringJsonFormat(v => for {
+      instant <- Try(Instant.parse(v)).toEither.left.map(_.getMessage)
+      timestamp <- Timestamp.fromInstant(instant)
+    } yield timestamp
+    )(_.toString)
 
   implicit val ApplicationIdFormat: RootJsonFormat[ApplicationId] =
     stringJsonFormat(ApplicationId.fromString)(identity)

--- a/sdk/canton/community/ledger/ledger-json-api/src/test/scala/com/digitalasset/canton/daml/lf/value/json/ApiCodecCompressedSpec.scala
+++ b/sdk/canton/community/ledger/ledger-json-api/src/test/scala/com/digitalasset/canton/daml/lf/value/json/ApiCodecCompressedSpec.scala
@@ -340,6 +340,7 @@ class ApiCodecCompressedSpec
     )
 
     // For Java 17+, we expect Instant.parse to succeed for these cases when parsing ISO 8601 timestamps
+    // - see https://bugs.openjdk.org/browse/JDK-8166138
     val java17Successes = Seq(
       c("\"1969-12-31T23:00:00Z\"", VA.timestamp)(Time.Timestamp.assertFromLong(-3600000000L), "\"1970-01-01T00:00:00+01:00\""),
     )
@@ -379,6 +380,7 @@ class ApiCodecCompressedSpec
     )
 
     // For Java 11, we expect Instant.parse to fail for these cases when parsing ISO 8601 timestamps
+    // - see https://bugs.openjdk.org/browse/JDK-8166138
     val java11Failures = Seq(
       ("\"1970-01-01T00:00:00+01:00\"", VA.timestamp, ""),
     )

--- a/sdk/canton/community/ledger/ledger-json-api/src/test/scala/com/digitalasset/canton/daml/lf/value/json/ApiCodecCompressedSpec.scala
+++ b/sdk/canton/community/ledger/ledger-json-api/src/test/scala/com/digitalasset/canton/daml/lf/value/json/ApiCodecCompressedSpec.scala
@@ -22,7 +22,6 @@ import shapeless.record.Record as HRecord
 import spray.json.*
 import scalaz.syntax.show.*
 
-import scala.annotation.nowarn
 import scala.util.{Success, Try}
 import scala.util.Random.shuffle
 
@@ -259,7 +258,6 @@ class ApiCodecCompressedSpec
 
     val numCodec = ApiCodecCompressed.copy(false, false)
 
-    @nowarn("cat=lint-infer-any")
     val commonSuccesses = Seq(
       c(
         "\"0000000000000000000000000000000000000000000000000000000000000000000123\"",
@@ -342,9 +340,8 @@ class ApiCodecCompressedSpec
     )
 
     // For Java 17+, we expect Instant.parse to succeed for these cases when parsing ISO 8601 timestamps
-    @nowarn("cat=lint-infer-any")
     val java17Successes = Seq(
-      c("\"1970-01-01T00:00:00+01:00\"", VA.timestamp)(Time.Timestamp assertFromLong -3600000000L),
+      c("\"1969-12-31T23:00:00Z\"", VA.timestamp)(Time.Timestamp.assertFromLong(-3600000000L), "\"1970-01-01T00:00:00+01:00\""),
     )
 
     val successes = if (Runtime.version().feature() >= 17) {

--- a/sdk/canton/community/ledger/ledger-json-api/src/test/scala/com/digitalasset/canton/http/endpoints/MeteringReportEndpointTest.scala
+++ b/sdk/canton/community/ledger/ledger-json-api/src/test/scala/com/digitalasset/canton/http/endpoints/MeteringReportEndpointTest.scala
@@ -35,7 +35,7 @@ class MeteringReportEndpointTest extends AnyFreeSpec with Matchers {
     }
 
     "should convert to timestamp to protobuf timestamp" in {
-      val expected = Timestamp.fromInstant(Instant.parse("2022-02-03T00:00:00Z"))
+      val expected = Timestamp.assertFromInstant(Instant.parse("2022-02-03T00:00:00Z"))
       val actual = toTimestamp(LocalDate.of(2022, 2, 3))
       actual shouldBe expected
     }

--- a/sdk/canton/community/ledger/ledger-json-api/src/test/scala/com/digitalasset/canton/http/endpoints/MeteringReportEndpointTest.scala
+++ b/sdk/canton/community/ledger/ledger-json-api/src/test/scala/com/digitalasset/canton/http/endpoints/MeteringReportEndpointTest.scala
@@ -13,7 +13,7 @@ import org.scalatest.matchers.should.Matchers
 import scalaz.\/-
 import spray.json.enrichAny
 
-import java.time.LocalDate
+import java.time.{Instant, LocalDate}
 
 class MeteringReportEndpointTest extends AnyFreeSpec with Matchers {
 
@@ -35,7 +35,7 @@ class MeteringReportEndpointTest extends AnyFreeSpec with Matchers {
     }
 
     "should convert to timestamp to protobuf timestamp" in {
-      val expected = Timestamp.assertFromString("2022-02-03T00:00:00Z")
+      val expected = Timestamp.fromInstant(Instant.parse("2022-02-03T00:00:00Z"))
       val actual = toTimestamp(LocalDate.of(2022, 2, 3))
       actual shouldBe expected
     }

--- a/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
+++ b/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
@@ -1,7 +1,8 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.lf.data
+package com.daml.lf
+package data
 
 import java.math.{RoundingMode, BigDecimal}
 import java.time.format.DateTimeFormatter
@@ -175,10 +176,13 @@ object Time {
     ): Either[String, Timestamp] =
       safely(assertFromInstant(i, rounding), s"cannot convert instant $i into Timestamp")
 
-    def assertFromString(str: String, rounding: RoundingMode = DefaultRounding): Timestamp =
+    private[lf] def assertFromString(
+        str: String,
+        rounding: RoundingMode = DefaultRounding,
+    ): Timestamp =
       assertFromLong(assertMicrosFromString(str, rounding))
 
-    final def fromString(
+    private[lf] final def fromString(
         s: String,
         rounding: RoundingMode = DefaultRounding,
     ): Either[String, Timestamp] =

--- a/sdk/daml-script/export/src/test/scala/com/daml/script/export/ActionsFromTreesSpec.scala
+++ b/sdk/daml-script/export/src/test/scala/com/daml/script/export/ActionsFromTreesSpec.scala
@@ -5,9 +5,11 @@ package com.daml.script.export
 
 import com.daml.ledger.api.refinements.ApiTypes.ContractId
 import com.daml.lf.data.Time.Timestamp
-import com.daml.script.export.TreeUtils.{SetTime, SubmitSimpleSingle, Action}
+import com.daml.script.export.TreeUtils.{Action, SetTime, SubmitSimpleSingle}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
 
 class ActionsFromTreesSpec extends AnyFreeSpec with Matchers {
   "fromTrees" - {
@@ -16,7 +18,7 @@ class ActionsFromTreesSpec extends AnyFreeSpec with Matchers {
         Action.fromTrees(Seq.empty, setTime = true) shouldBe empty
       }
       "single transaction" in {
-        val t1 = Timestamp.assertFromString("1990-01-01T01:00:00Z")
+        val t1 = Timestamp.assertFromInstant(Instant.parse("1990-01-01T01:00:00Z"))
         val trees = Seq(
           TestData
             .Tree(
@@ -33,7 +35,7 @@ class ActionsFromTreesSpec extends AnyFreeSpec with Matchers {
         actions(1) shouldBe a[SubmitSimpleSingle]
       }
       "multipe transaction at same time" in {
-        val t1 = Timestamp.assertFromString("1990-01-01T01:00:00Z")
+        val t1 = Timestamp.assertFromInstant(Instant.parse("1990-01-01T01:00:00Z"))
         val trees = Seq(
           TestData
             .Tree(
@@ -59,8 +61,8 @@ class ActionsFromTreesSpec extends AnyFreeSpec with Matchers {
         actions(2) shouldBe a[SubmitSimpleSingle]
       }
       "multipe transaction at different times" in {
-        val t1 = Timestamp.assertFromString("1990-01-01T01:00:00Z")
-        val t2 = Timestamp.assertFromString("1990-01-02T01:00:00Z")
+        val t1 = Timestamp.assertFromInstant(Instant.parse("1990-01-01T01:00:00Z"))
+        val t2 = Timestamp.assertFromInstant(Instant.parse("1990-01-02T01:00:00Z"))
         val trees = Seq(
           TestData
             .Tree(
@@ -89,8 +91,8 @@ class ActionsFromTreesSpec extends AnyFreeSpec with Matchers {
     }
     "setTime disabled" - {
       "multipe transaction at different times" in {
-        val t1 = Timestamp.assertFromString("1990-01-01T01:00:00Z")
-        val t2 = Timestamp.assertFromString("1990-01-02T01:00:00Z")
+        val t1 = Timestamp.assertFromInstant(Instant.parse("1990-01-01T01:00:00Z"))
+        val t2 = Timestamp.assertFromInstant(Instant.parse("1990-01-02T01:00:00Z"))
         val trees = Seq(
           TestData
             .Tree(

--- a/sdk/daml-script/export/src/test/scala/com/daml/script/export/EncodeSetTimeSpec.scala
+++ b/sdk/daml-script/export/src/test/scala/com/daml/script/export/EncodeSetTimeSpec.scala
@@ -7,10 +7,13 @@ import com.daml.lf.data.Time.Timestamp
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.time.Instant
+
 class EncodeSetTimeSpec extends AnyFreeSpec with Matchers {
   import Encode._
   "encodeSetTime" in {
-    encodeSetTime(Timestamp.assertFromString("1990-11-09T04:30:23.123456Z")).render(80) shouldBe
+    encodeSetTime(Timestamp.assertFromInstant(Instant.parse("1990-11-09T04:30:23.123456Z")))
+      .render(80) shouldBe
       """setTime (DA.Time.time (DA.Date.date 1990 DA.Date.Nov 9) 4 30 23)"""
   }
 }

--- a/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/endpoints/MeteringReportEndpointTest.scala
+++ b/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/endpoints/MeteringReportEndpointTest.scala
@@ -14,7 +14,7 @@ import org.scalatest.matchers.should.Matchers
 import scalaz.\/-
 import spray.json.enrichAny
 
-import java.time.LocalDate
+import java.time.{Instant, LocalDate}
 
 class MeteringReportEndpointTest extends AnyFreeSpec with Matchers {
 
@@ -36,7 +36,7 @@ class MeteringReportEndpointTest extends AnyFreeSpec with Matchers {
     }
 
     "should convert to timestamp to protobuf timestamp" in {
-      val expected = Timestamp.assertFromString("2022-02-03T00:00:00Z")
+      val expected = Timestamp.fromInstant(Instant.parse("2022-02-03T00:00:00Z"))
       val actual = toTimestamp(LocalDate.of(2022, 2, 3))
       actual shouldBe expected
     }

--- a/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/endpoints/MeteringReportEndpointTest.scala
+++ b/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/endpoints/MeteringReportEndpointTest.scala
@@ -36,7 +36,7 @@ class MeteringReportEndpointTest extends AnyFreeSpec with Matchers {
     }
 
     "should convert to timestamp to protobuf timestamp" in {
-      val expected = Timestamp.fromInstant(Instant.parse("2022-02-03T00:00:00Z"))
+      val expected = Timestamp.assertFromInstant(Instant.parse("2022-02-03T00:00:00Z"))
       val actual = toTimestamp(LocalDate.of(2022, 2, 3))
       actual shouldBe expected
     }

--- a/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
+++ b/sdk/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
@@ -23,6 +23,8 @@ import org.scalatest.wordspec.AnyWordSpec
 import scalaz.\/
 import spray.json._
 
+import java.time.Instant
+
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class ValuePredicateTest
     extends AnyWordSpec
@@ -140,7 +142,7 @@ class ValuePredicateTest
         true,
       ),
       c("""{"%gte": "1980-01-01T00:00:00Z", "%lt": "2000-01-01T00:00:00Z"}""", VA.timestamp)(
-        Time.Timestamp assertFromString "1986-06-21T00:00:00Z",
+        Time.Timestamp.assertFromInstant(Instant.parse("1986-06-21T00:00:00Z")),
         true,
       ),
     )

--- a/sdk/ledger-service/lf-value-json/src/test/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressedSpec.scala
+++ b/sdk/ledger-service/lf-value-json/src/test/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressedSpec.scala
@@ -341,6 +341,7 @@ class ApiCodecCompressedSpec
     )
 
     // For Java 17+, we expect Instant.parse to succeed for these cases when parsing ISO 8601 timestamps
+    // - see https://bugs.openjdk.org/browse/JDK-8166138
     val java17Successes = Seq(
       c("\"1969-12-31T23:00:00Z\"", VA.timestamp)(
         Time.Timestamp.assertFromLong(-3600000000L),
@@ -383,6 +384,7 @@ class ApiCodecCompressedSpec
     )
 
     // For Java 11, we expect Instant.parse to fail for these cases when parsing ISO 8601 timestamps
+    // - see https://bugs.openjdk.org/browse/JDK-8166138
     val java11Failures = Seq(
       ("\"1970-01-01T00:00:00+01:00\"", VA.timestamp, "")
     )

--- a/sdk/ledger-service/lf-value-json/src/test/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressedSpec.scala
+++ b/sdk/ledger-service/lf-value-json/src/test/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressedSpec.scala
@@ -23,7 +23,6 @@ import shapeless.record.{Record => HRecord}
 import spray.json._
 import scalaz.syntax.show._
 
-import scala.annotation.nowarn
 import scala.util.{Success, Try}
 import scala.util.Random.shuffle
 
@@ -260,7 +259,6 @@ class ApiCodecCompressedSpec
 
     val numCodec = ApiCodecCompressed.copy(false, false)
 
-    @nowarn("cat=lint-infer-any")
     val commonSuccesses = Seq(
       c(
         "\"0000000000000000000000000000000000000000000000000000000000000000000123\"",
@@ -343,9 +341,11 @@ class ApiCodecCompressedSpec
     )
 
     // For Java 17+, we expect Instant.parse to succeed for these cases when parsing ISO 8601 timestamps
-    @nowarn("cat=lint-infer-any")
     val java17Successes = Seq(
-      c("\"1970-01-01T00:00:00+01:00\"", VA.timestamp)(Time.Timestamp assertFromLong -3600000000L)
+      c("\"1969-12-31T23:00:00Z\"", VA.timestamp)(
+        Time.Timestamp.assertFromLong(-3600000000L),
+        "\"1970-01-01T00:00:00+01:00\"",
+      )
     )
 
     val successes = if (Runtime.version().feature() >= 17) {


### PR DESCRIPTION
Fixes #19195

Backport of #19244

This PR needs to ensure that `ApiCodecCompressedSpec` passes when ran using **both** Java 11 and 17. Because of this, we need some additional test changes to:
- include `1970-01-01T00:00:00+01:00` as a parse failure when using java 11
- include `1970-01-01T00:00:00+01:00` as a parse success when using java 17

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
