### PR TITLE
re-enable temporarily disabled tests

### DIFF
--- a/sdk/daml-lf/validation/src/test/scala/com/daml/lf/validation/upgrade/UpgradesSpecBase.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/daml/lf/validation/upgrade/UpgradesSpecBase.scala
@@ -624,9 +624,8 @@ abstract class UpgradesSpec(val suffix: String)
     val (testPackageV1Id, uploadV1Result) = v1
     val (testPackageV2Id, uploadV2Result) = v2
     if (disableUpgradeValidation) {
-      // TODO: Re-enable these checks once # goes in
-      // cantonLogSrc should include(s"Skipping upgrade validation for package $testPackageV1Id")
-      // cantonLogSrc should include(s"Skipping upgrade validation for package $testPackageV2Id")
+      cantonLogSrc should include(s"Skipping upgrade validation for package $testPackageV1Id")
+      cantonLogSrc should include(s"Skipping upgrade validation for package $testPackageV2Id")
       cantonLogSrc should not include regex(
         s"The DAR contains a package which claims to upgrade another package, but basic checks indicate the package is not a valid upgrade."
       )


### PR DESCRIPTION
These tests had been disabled in https://github.com/digital-asset/daml/pull/19277/commits/d572884b79db4e15d15a9ef1e7095dca39e85787, waiting for https://github.com/DACH-NY/canton/pull/19354 to get in. It now has been code-dropped into daml.