### PR TITLE
Temporarily revert "Moved metrics classes from canton to daml after rewrite (#19265)

### DIFF
--- a/sdk/canton/community/app-base/src/main/scala/com/digitalasset/canton/config/CantonConfig.scala
+++ b/sdk/canton/community/app-base/src/main/scala/com/digitalasset/canton/config/CantonConfig.scala
@@ -82,7 +82,7 @@ import com.digitalasset.canton.pureconfigutils.HttpServerConfig
 import com.digitalasset.canton.pureconfigutils.SharedConfigReaders.catchConvertError
 import com.digitalasset.canton.sequencing.authentication.AuthenticationTokenManagerConfig
 import com.digitalasset.canton.sequencing.client.SequencerClientConfig
-import com.daml.metrics.HistogramDefinition
+import com.digitalasset.canton.telemetry.HistogramDefinition
 import com.digitalasset.canton.time.EnrichedDurations.RichNonNegativeFiniteDurationConfig
 import com.digitalasset.canton.tracing.TracingConfig
 import com.typesafe.config.ConfigException.UnresolvedSubstitution

--- a/sdk/canton/community/app-base/src/main/scala/com/digitalasset/canton/environment/Environment.scala
+++ b/sdk/canton/community/app-base/src/main/scala/com/digitalasset/canton/environment/Environment.scala
@@ -6,10 +6,15 @@ package com.digitalasset.canton.environment
 import cats.data.EitherT
 import cats.syntax.either.*
 import com.daml.grpc.adapter.ExecutionSequencerFactory
-import com.daml.metrics.api.{MetricsInfoFilter, HistogramInventory}
 import com.digitalasset.canton.concurrent.*
 import com.digitalasset.canton.config.*
-import com.digitalasset.canton.console.{ConsoleEnvironment, ConsoleOutput, GrpcAdminCommandRunner, HealthDumpGenerator, StandardConsoleOutput}
+import com.digitalasset.canton.console.{
+  ConsoleEnvironment,
+  ConsoleOutput,
+  GrpcAdminCommandRunner,
+  HealthDumpGenerator,
+  StandardConsoleOutput,
+}
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.discard.Implicits.DiscardOps
 import com.digitalasset.canton.domain.mediator.{MediatorNodeBootstrap, MediatorNodeParameters}
@@ -20,11 +25,15 @@ import com.digitalasset.canton.environment.Environment.*
 import com.digitalasset.canton.lifecycle.Lifecycle
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.metrics.MetricsConfig.JvmMetrics
-import com.digitalasset.canton.metrics.{CantonHistograms, MetricsRegistry}
+import com.digitalasset.canton.metrics.{CantonHistograms, HistogramInventory, MetricsRegistry}
 import com.digitalasset.canton.networking.grpc.CantonGrpcUtil
 import com.digitalasset.canton.participant.*
 import com.digitalasset.canton.resource.DbMigrationsFactory
-import com.digitalasset.canton.telemetry.{ConfiguredOpenTelemetry, OpenTelemetryFactory}
+import com.digitalasset.canton.telemetry.{
+  ConfiguredOpenTelemetry,
+  MetricsInfoFilter,
+  OpenTelemetryFactory,
+}
 import com.digitalasset.canton.time.EnrichedDurations.*
 import com.digitalasset.canton.time.*
 import com.digitalasset.canton.tracing.TraceContext.withNewTraceContext

--- a/sdk/canton/community/app-base/src/main/scala/com/digitalasset/canton/metrics/CantonHistograms.scala
+++ b/sdk/canton/community/app-base/src/main/scala/com/digitalasset/canton/metrics/CantonHistograms.scala
@@ -3,12 +3,132 @@
 
 package com.digitalasset.canton.metrics
 
-import com.daml.metrics.api.{HistogramInventory, MetricName}
+import com.daml.metrics.api.MetricHandle.Histogram
+import com.daml.metrics.api.MetricQualification.Debug
+import com.daml.metrics.api.{MetricName, MetricQualification}
 import com.digitalasset.canton.domain.metrics.{MediatorHistograms, SequencerHistograms}
+import com.digitalasset.canton.metrics.HistogramInventory.Item
 import com.digitalasset.canton.participant.metrics.ParticipantHistograms
 
+// TODO(#17917) move upstream
+class DamlHttpHistograms(implicit
+    inventory: HistogramInventory
+) {
+  private val httpMetricsPrefix = MetricName.Daml :+ "http"
 
+  val latency: Item =
+    Item(
+      httpMetricsPrefix :+ "requests",
+      "The duration of the HTTP requests.",
+      MetricQualification.Debug,
+    )
+  val requestsPayloadBytes: Item =
+    Item(
+      httpMetricsPrefix :+ "requests" :+ "payload" :+ Histogram.Bytes,
+      "Distribution of the sizes of payloads received in HTTP requests.",
+      MetricQualification.Debug,
+    )
+  val responsesPayloadBytes: Item =
+    Item(
+      httpMetricsPrefix :+ "responses" :+ "payload" :+ Histogram.Bytes,
+      "Distribution of the sizes of payloads sent in HTTP responses.",
+      MetricQualification.Debug,
+    )
+}
 
+// TODO(#17917) move upstream
+class DamlWebSocketsHistograms(implicit
+    inventory: HistogramInventory
+) {
+  private val httpMetricsPrefix = MetricName.Daml :+ "http"
+
+  val messagesReceivedBytes: Item =
+    Item(
+      httpMetricsPrefix :+ "websocket" :+ "messages" :+ "received" :+ Histogram.Bytes,
+      "Distribution of the size of received WebSocket messages.",
+      MetricQualification.Debug,
+    )
+
+  val messagesSentBytes: Item =
+    Item(
+      httpMetricsPrefix :+ "websocket" :+ "messages" :+ "sent" :+ Histogram.Bytes,
+      "Distribution of the size of sent WebSocket messages.",
+      MetricQualification.Debug,
+    )
+
+}
+
+// TODO(#17917) move to upstream
+class DatabaseMetricsHistograms(implicit
+    inventory: HistogramInventory
+) {
+
+  private val dbPrefix: MetricName = MetricName.Daml :+ "db"
+  private lazy val labelsWithDescription = Map(
+    "name" -> "The operation/pool for which the metric is registered."
+  )
+  val waitTimer: Item = Item(
+    dbPrefix :+ "wait",
+    summary = "The time needed to acquire a connection to the database.",
+    description = """SQL statements are run in a dedicated executor. This metric measures the time
+                      |it takes between creating the SQL statement corresponding to the <operation>
+                      |and the point when it starts running on the dedicated executor.""",
+    qualification = Debug,
+    labelsWithDescription = labelsWithDescription,
+  )
+
+  val executionTimer: Item = Item(
+    dbPrefix :+ "exec",
+    summary = "The time needed to run the SQL query and read the result.",
+    description = """This metric encompasses the time measured by `query` and `commit` metrics.
+                      |Additionally it includes the time needed to obtain the DB connection,
+                      |optionally roll it back and close the connection at the end.""",
+    qualification = Debug,
+    labelsWithDescription = labelsWithDescription,
+  )
+
+  val translationTimer: Item = Item(
+    dbPrefix :+ "translation",
+    summary = "The time needed to turn serialized Daml-LF values into in-memory objects.",
+    description = """Some index database queries that target contracts and transactions involve a
+                      |Daml-LF translation step. For such queries this metric stands for the time it
+                      |takes to turn the serialized Daml-LF values into in-memory representation.""",
+    qualification = Debug,
+    labelsWithDescription = labelsWithDescription,
+  )
+
+  val compressionTimer: Item = Item(
+    dbPrefix :+ "compression",
+    summary = "The time needed to decompress the SQL query result.",
+    description = """Some index database queries that target contracts involve a decompression
+                      |step. For such queries this metric represents the time it takes to decompress
+                      |contract arguments retrieved from the database.""",
+    qualification = Debug,
+    labelsWithDescription = labelsWithDescription,
+  )
+
+  val commitTimer: Item = Item(
+    dbPrefix :+ "commit",
+    summary = "The time needed to perform the SQL query commit.",
+    description = """This metric measures the time it takes to commit an SQL transaction relating
+                      |to the <operation>. It roughly corresponds to calling `commit()` on a DB
+                      |connection.""",
+    qualification = Debug,
+    labelsWithDescription = labelsWithDescription,
+  )
+
+  val queryTimer: Item = Item(
+    dbPrefix :+ "query",
+    summary = "The time needed to run the SQL query.",
+    description = """This metric measures the time it takes to execute a block of code (on a
+                      |dedicated executor) related to the <operation> that can issue multiple SQL
+                      |statements such that all run in a single DB transaction (either committed or
+                      |aborted).""",
+    qualification = Debug,
+    labelsWithDescription = labelsWithDescription,
+  )
+
+}
 
 /** Pre-register histogram metrics
   *
@@ -23,5 +143,11 @@ class CantonHistograms()(implicit val inventory: HistogramInventory) {
   private[metrics] val mediator: MediatorHistograms = new MediatorHistograms(prefix)
   private[metrics] val sequencer: SequencerHistograms = new SequencerHistograms(prefix)
 
+  // TODO(#17917) move everything below to upstream
+  private val _http: DamlHttpHistograms = new DamlHttpHistograms()
+  private val _webSockets: DamlWebSocketsHistograms =
+    new DamlWebSocketsHistograms()
+  private val _grpc = new DamlGrpcServerHistograms()
+  private val _db = new DatabaseMetricsHistograms()
 
 }

--- a/sdk/canton/community/app-base/src/main/scala/com/digitalasset/canton/metrics/MetricsRegistry.scala
+++ b/sdk/canton/community/app-base/src/main/scala/com/digitalasset/canton/metrics/MetricsRegistry.scala
@@ -4,10 +4,13 @@
 package com.digitalasset.canton.metrics
 
 import com.daml.metrics.api.MetricHandle.LabeledMetricsFactory
-import com.daml.metrics.api.{MetricQualification, MetricsContext, MetricsInfoFilter}
-import com.daml.metrics.api.opentelemetry.{OpenTelemetryMetricsFactory, QualificationFilteringMetricsFactory}
+import com.daml.metrics.api.opentelemetry.{
+  OpenTelemetryMetricsFactory,
+  QualificationFilteringMetricsFactory,
+}
+import com.daml.metrics.api.{MetricQualification, MetricsContext}
 import com.daml.metrics.grpc.DamlGrpcServerMetrics
-import com.daml.metrics.{HealthMetrics, HistogramDefinition, MetricsFilterConfig}
+import com.daml.metrics.{HealthMetrics, MetricsFilterConfig}
 import com.digitalasset.canton.config.NonNegativeFiniteDuration
 import com.digitalasset.canton.config.RequireTypes.Port
 import com.digitalasset.canton.discard.Implicits.DiscardOps
@@ -16,6 +19,7 @@ import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.metrics.MetricsConfig.JvmMetrics
 import com.digitalasset.canton.metrics.MetricsReporterConfig.{Csv, Logging, Prometheus}
 import com.digitalasset.canton.participant.metrics.ParticipantMetrics
+import com.digitalasset.canton.telemetry.{HistogramDefinition, MetricsInfoFilter}
 import com.typesafe.scalalogging.LazyLogging
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.metrics.Meter
@@ -210,7 +214,8 @@ final case class MetricsRegistry(
               if (testingSupportAdhocMetrics) Some(logger.underlying) else None,
             globalMetricsContext = extraContext,
           ),
-          baseFilter
+          baseFilter.qualifications,
+          baseFilter.filters,
         )
     }
   }

--- a/sdk/canton/community/base/src/main/scala/com/digitalasset/canton/metrics/DbStorageMetrics.scala
+++ b/sdk/canton/community/base/src/main/scala/com/digitalasset/canton/metrics/DbStorageMetrics.scala
@@ -4,8 +4,8 @@
 package com.digitalasset.canton.metrics
 
 import com.daml.metrics.api.MetricHandle.{Counter, LabeledMetricsFactory, Timer}
-import com.daml.metrics.api.{HistogramInventory, MetricInfo, MetricName, MetricQualification, MetricsContext}
-import com.daml.metrics.api.HistogramInventory.Item
+import com.daml.metrics.api.{MetricInfo, MetricName, MetricQualification, MetricsContext}
+import com.digitalasset.canton.metrics.HistogramInventory.Item
 
 class DbStorageHistograms(val parent: MetricName)(implicit
     inventory: HistogramInventory

--- a/sdk/canton/community/base/src/main/scala/com/digitalasset/canton/metrics/SequencerClientMetrics.scala
+++ b/sdk/canton/community/base/src/main/scala/com/digitalasset/canton/metrics/SequencerClientMetrics.scala
@@ -5,9 +5,9 @@ package com.digitalasset.canton.metrics
 
 import cats.Eval
 import com.daml.metrics.api.MetricHandle.{Counter, Gauge, LabeledMetricsFactory, Timer}
-import com.daml.metrics.api.{HistogramInventory, MetricInfo, MetricName, MetricQualification, MetricsContext}
+import com.daml.metrics.api.{MetricInfo, MetricName, MetricQualification, MetricsContext}
 import com.digitalasset.canton.SequencerAlias
-import com.daml.metrics.api.HistogramInventory.Item
+import com.digitalasset.canton.metrics.HistogramInventory.Item
 
 import scala.collection.concurrent.TrieMap
 

--- a/sdk/canton/community/domain/src/main/scala/com/digitalasset/canton/domain/metrics/BlockMetrics.scala
+++ b/sdk/canton/community/domain/src/main/scala/com/digitalasset/canton/domain/metrics/BlockMetrics.scala
@@ -56,14 +56,12 @@ class BlockMetrics(
       )
     )(MetricsContext.Empty)
 
-  private val ackGaugeInfo = MetricInfo(prefix :+ "acknowledgments_micros", "Acknowledgments by senders in Micros", MetricQualification.Latency, labelsWithDescription = Map("sender" -> "The sender of the acknowledgment"))
-
   def updateAcknowledgementGauge(sender: String, value: Long): Unit =
     acknowledgments
       .getOrElseUpdate(
         sender, {
           Eval.later(
-            openTelemetryMetricsFactory.gauge(ackGaugeInfo, value)(
+            openTelemetryMetricsFactory.gauge(prefix :+ "acknowledgments_micros", value)(
               MetricsContext("sender" -> sender)
             )
           )

--- a/sdk/canton/community/domain/src/main/scala/com/digitalasset/canton/domain/metrics/DomainMetrics.scala
+++ b/sdk/canton/community/domain/src/main/scala/com/digitalasset/canton/domain/metrics/DomainMetrics.scala
@@ -5,13 +5,14 @@ package com.digitalasset.canton.domain.metrics
 
 import com.daml.metrics.api.MetricHandle.*
 import com.daml.metrics.api.noop.NoOpMetricsFactory
-import com.daml.metrics.api.{MetricInfo, MetricName, MetricQualification, MetricsContext, HistogramInventory}
+import com.daml.metrics.api.{MetricInfo, MetricName, MetricQualification, MetricsContext}
 import com.daml.metrics.grpc.{DamlGrpcServerMetrics, GrpcServerMetrics}
 import com.daml.metrics.{CacheMetrics, HealthMetrics}
 import com.digitalasset.canton.environment.BaseMetrics
 import com.digitalasset.canton.metrics.{
   DbStorageHistograms,
   DbStorageMetrics,
+  HistogramInventory,
   SequencerClientHistograms,
   SequencerClientMetrics,
 }

--- a/sdk/canton/community/domain/src/test/scala/com/digitalasset/canton/domain/metrics/DomainTestMetrics.scala
+++ b/sdk/canton/community/domain/src/test/scala/com/digitalasset/canton/domain/metrics/DomainTestMetrics.scala
@@ -7,7 +7,7 @@ import com.daml.metrics.HealthMetrics
 import com.daml.metrics.api.MetricName
 import com.daml.metrics.api.noop.NoOpMetricsFactory
 import com.daml.metrics.grpc.DamlGrpcServerMetrics
-import com.daml.metrics.api.HistogramInventory
+import com.digitalasset.canton.metrics.HistogramInventory
 
 object SequencerTestMetrics
     extends SequencerMetrics(

--- a/sdk/canton/community/drivers/reference/src/main/scala/com/digitalasset/canton/domain/sequencing/sequencer/reference/BaseReferenceSequencerDriverFactory.scala
+++ b/sdk/canton/community/drivers/reference/src/main/scala/com/digitalasset/canton/domain/sequencing/sequencer/reference/BaseReferenceSequencerDriverFactory.scala
@@ -4,15 +4,23 @@
 package com.digitalasset.canton.domain.sequencing.sequencer.reference
 
 import com.daml.metrics.api.noop.NoOpMetricsFactory
-import com.daml.metrics.api.{HistogramInventory, MetricName, MetricsContext}
-import com.digitalasset.canton.config.{BatchAggregatorConfig, BatchingConfig, ConnectionAllocation, DbParametersConfig, ProcessingTimeout, QueryCostMonitoringConfig, StorageConfig}
+import com.daml.metrics.api.{MetricName, MetricsContext}
+import com.digitalasset.canton.config.{
+  BatchAggregatorConfig,
+  BatchingConfig,
+  ConnectionAllocation,
+  DbParametersConfig,
+  ProcessingTimeout,
+  QueryCostMonitoringConfig,
+  StorageConfig,
+}
 import com.digitalasset.canton.domain.block.BlockFormat.DefaultFirstBlockHeight
 import com.digitalasset.canton.domain.block.{SequencerDriver, SequencerDriverFactory}
 import com.digitalasset.canton.domain.sequencing.sequencer.reference.BaseReferenceSequencerDriverFactory.createClock
 import com.digitalasset.canton.domain.sequencing.sequencer.reference.store.ReferenceBlockOrderingStore
 import com.digitalasset.canton.lifecycle.{CloseContext, FlagCloseable}
 import com.digitalasset.canton.logging.NamedLoggerFactory
-import com.digitalasset.canton.metrics.{DbStorageHistograms, DbStorageMetrics}
+import com.digitalasset.canton.metrics.{DbStorageHistograms, DbStorageMetrics, HistogramInventory}
 import com.digitalasset.canton.resource.Storage
 import com.digitalasset.canton.time.{Clock, TimeProvider, TimeProviderClock}
 import com.digitalasset.canton.tracing.TraceContext

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/metrics/CommandMetrics.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/metrics/CommandMetrics.scala
@@ -4,8 +4,8 @@
 package com.digitalasset.canton.metrics
 
 import com.daml.metrics.api.MetricHandle.{Counter, LabeledMetricsFactory, Meter, Timer}
-import com.daml.metrics.api.{HistogramInventory, MetricInfo, MetricName, MetricQualification}
-import com.daml.metrics.api.HistogramInventory.Item
+import com.daml.metrics.api.{MetricInfo, MetricName, MetricQualification}
+import com.digitalasset.canton.metrics.HistogramInventory.Item
 
 class CommandHistograms(val prefix: MetricName)(implicit
     inventory: HistogramInventory

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/metrics/ExecutionMetrics.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/metrics/ExecutionMetrics.scala
@@ -5,8 +5,8 @@ package com.digitalasset.canton.metrics
 
 import com.daml.metrics.CacheMetrics
 import com.daml.metrics.api.MetricHandle.*
-import com.daml.metrics.api.{HistogramInventory, MetricInfo, MetricName, MetricQualification}
-import com.daml.metrics.api.HistogramInventory.Item
+import com.daml.metrics.api.{MetricInfo, MetricName, MetricQualification}
+import com.digitalasset.canton.metrics.HistogramInventory.Item
 
 class ExecutionHistograms(val prefix: MetricName)(implicit
     inventory: HistogramInventory

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/metrics/IndexDBMetrics.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/metrics/IndexDBMetrics.scala
@@ -5,8 +5,8 @@ package com.digitalasset.canton.metrics
 
 import com.daml.metrics.DatabaseMetrics
 import com.daml.metrics.api.MetricHandle.{Counter, Histogram, LabeledMetricsFactory, Timer}
-import com.daml.metrics.api.{HistogramInventory, MetricInfo, MetricName, MetricQualification, MetricsContext}
-import com.daml.metrics.api.HistogramInventory.Item
+import com.daml.metrics.api.{MetricInfo, MetricName, MetricQualification, MetricsContext}
+import com.digitalasset.canton.metrics.HistogramInventory.Item
 
 trait TransactionStreamsDbHistograms {
 

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/metrics/IndexMetrics.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/metrics/IndexMetrics.scala
@@ -4,8 +4,8 @@
 package com.digitalasset.canton.metrics
 
 import com.daml.metrics.api.MetricHandle.{Counter, Gauge, LabeledMetricsFactory, Timer}
-import com.daml.metrics.api.{HistogramInventory, MetricInfo, MetricName, MetricQualification, MetricsContext}
-import com.daml.metrics.api.HistogramInventory.Item
+import com.daml.metrics.api.{MetricInfo, MetricName, MetricQualification, MetricsContext}
+import com.digitalasset.canton.metrics.HistogramInventory.Item
 
 class IndexHistograms(val prefix: MetricName)(implicit
     inventory: HistogramInventory

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/metrics/LedgerApiServerMetrics.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/metrics/LedgerApiServerMetrics.scala
@@ -3,12 +3,13 @@
 
 package com.digitalasset.canton.metrics
 
-import com.daml.metrics.api.MetricHandle.LabeledMetricsFactory
+import com.daml.metrics.HealthMetrics
+import com.daml.metrics.api.MetricHandle.{Histogram, LabeledMetricsFactory}
 import com.daml.metrics.api.noop.NoOpMetricsFactory
 import com.daml.metrics.api.opentelemetry.OpenTelemetryMetricsFactory
-import com.daml.metrics.api.{HistogramInventory, MetricName}
-import com.daml.metrics.grpc.{DamlGrpcServerHistograms, DamlGrpcServerMetrics}
-import com.daml.metrics.{DatabaseMetricsHistograms, HealthMetrics}
+import com.daml.metrics.api.{MetricName, MetricQualification}
+import com.daml.metrics.grpc.DamlGrpcServerMetrics
+import com.digitalasset.canton.metrics.HistogramInventory.Item
 import com.typesafe.scalalogging.LazyLogging
 import io.opentelemetry.api.metrics.Meter
 
@@ -98,11 +99,30 @@ final class LedgerApiServerMetrics(
 
 }
 
+// TODO(#17917) move upstream
+class DamlGrpcServerHistograms(implicit
+    inventory: HistogramInventory
+) {
+  private val prefix = MetricName.Daml :+ "grpc"
+
+  val damlGrpcServerCallTimer: Item = Item(
+    prefix,
+    MetricName("server"),
+    summary = "Distribution of the durations of serving gRPC requests.",
+    qualification = MetricQualification.Latency,
+  )
+  val damlGrpcServerReceived: Item = Item(
+    prefix :+ "server" :+ "messages" :+ "received",
+    Histogram.Bytes,
+    summary = "Distribution of payload sizes in gRPC messages received (both unary and streaming).",
+    qualification = MetricQualification.Traffic,
+  )
+
+}
+
 class LedgerApiServerHistograms(val prefix: MetricName)(implicit
     inventory: HistogramInventory
 ) {
-
-
 
   private[metrics] val services = new ServicesHistograms(prefix :+ "services")
   private[metrics] val commands = new CommandHistograms(prefix :+ "commands")
@@ -110,10 +130,6 @@ class LedgerApiServerHistograms(val prefix: MetricName)(implicit
   private[metrics] val index = new IndexHistograms(prefix :+ "index")
   private[metrics] val parallelIndexer = new ParallelIndexerHistograms(prefix :+ "parallel_indexer")
 
+  // TODO(#17917) move upstream
   private val _grpc = new DamlGrpcServerHistograms()
-  // the ledger api server creates these metrics all over the place, but their prefix
-  // is anyway hardcoded
-  private val _db = new DatabaseMetricsHistograms()
-
-
 }

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/metrics/ParallelIndexerMetrics.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/metrics/ParallelIndexerMetrics.scala
@@ -5,8 +5,8 @@ package com.digitalasset.canton.metrics
 
 import com.daml.metrics.DatabaseMetrics
 import com.daml.metrics.api.MetricHandle.*
-import com.daml.metrics.api.{HistogramInventory, MetricInfo, MetricName, MetricQualification, MetricsContext}
-import com.daml.metrics.api.HistogramInventory.Item
+import com.daml.metrics.api.{MetricInfo, MetricName, MetricQualification, MetricsContext}
+import com.digitalasset.canton.metrics.HistogramInventory.Item
 
 class ParallelIndexerHistograms(val prefix: MetricName)(implicit
     inventory: HistogramInventory

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/metrics/ServicesMetrics.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/metrics/ServicesMetrics.scala
@@ -4,8 +4,8 @@
 package com.digitalasset.canton.metrics
 
 import com.daml.metrics.api.MetricHandle.*
-import com.daml.metrics.api.{HistogramInventory, MetricInfo, MetricName, MetricQualification, MetricsContext}
-import com.daml.metrics.api.HistogramInventory.Item
+import com.daml.metrics.api.{MetricInfo, MetricName, MetricQualification, MetricsContext}
+import com.digitalasset.canton.metrics.HistogramInventory.Item
 
 class ServicesHistograms(val prefix: MetricName)(implicit
     inventory: HistogramInventory

--- a/sdk/canton/community/ledger/ledger-json-api/src/main/scala/com/digitalasset/canton/http/metrics/HttpApiMetrics.scala
+++ b/sdk/canton/community/ledger/ledger-json-api/src/main/scala/com/digitalasset/canton/http/metrics/HttpApiMetrics.scala
@@ -7,10 +7,9 @@ import com.daml.metrics.HealthMetrics
 import com.daml.metrics.api.MetricHandle.{Counter, LabeledMetricsFactory, Timer}
 import com.daml.metrics.api.noop.NoOpMetricsFactory
 import com.daml.metrics.api.{MetricInfo, MetricName, MetricQualification}
-import com.daml.metrics.http.{DamlHttpHistograms, DamlHttpMetrics, DamlWebSocketMetrics, DamlWebSocketsHistograms}
-import com.daml.metrics.api.HistogramInventory
-import com.daml.metrics.api.HistogramInventory.Item
-import com.digitalasset.canton.http.metrics.HttpApiMetrics.ComponentName
+import com.daml.metrics.http.{DamlHttpMetrics, DamlWebSocketMetrics}
+import com.digitalasset.canton.metrics.HistogramInventory
+import com.digitalasset.canton.metrics.HistogramInventory.Item
 
 object HttpApiMetrics {
   lazy val ForTesting =
@@ -25,10 +24,6 @@ object HttpApiMetrics {
 class HttpApiHistograms(parent: MetricName)(implicit
     inventory: HistogramInventory
 ) {
-
-  private val _http: DamlHttpHistograms = new DamlHttpHistograms()
-  private val _webSockets: DamlWebSocketsHistograms = new DamlWebSocketsHistograms()
-
   val prefix: MetricName = parent :+ "http_json_api"
 
   // Meters how long parsing and decoding of an incoming json payload takes

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/metrics/CommitmentMetrics.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/metrics/CommitmentMetrics.scala
@@ -5,8 +5,8 @@ package com.digitalasset.canton.participant.metrics
 
 import com.daml.metrics.api.MetricHandle.{Gauge, LabeledMetricsFactory, Meter, Timer}
 import com.daml.metrics.api.{MetricInfo, MetricName, MetricQualification, MetricsContext}
-import com.daml.metrics.api.HistogramInventory
-import com.daml.metrics.api.HistogramInventory.Item
+import com.digitalasset.canton.metrics.HistogramInventory
+import com.digitalasset.canton.metrics.HistogramInventory.Item
 
 class CommitmentHistograms(parent: MetricName)(implicit inventory: HistogramInventory) {
   private[metrics] val prefix = parent :+ "commitments"

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/metrics/ParticipantMetrics.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/metrics/ParticipantMetrics.scala
@@ -8,13 +8,13 @@ import com.daml.metrics.HealthMetrics
 import com.daml.metrics.api.MetricHandle.Gauge.CloseableGauge
 import com.daml.metrics.api.MetricHandle.{Counter, Gauge, Histogram, LabeledMetricsFactory, Meter}
 import com.daml.metrics.api.noop.NoOpGauge
-import com.daml.metrics.api.{HistogramInventory, MetricInfo, MetricName, MetricQualification, MetricsContext}
+import com.daml.metrics.api.{MetricInfo, MetricName, MetricQualification, MetricsContext}
 import com.daml.metrics.grpc.GrpcServerMetrics
 import com.digitalasset.canton.DomainAlias
 import com.digitalasset.canton.data.TaskSchedulerMetrics
 import com.digitalasset.canton.environment.BaseMetrics
 import com.digitalasset.canton.http.metrics.{HttpApiHistograms, HttpApiMetrics}
-import com.daml.metrics.api.HistogramInventory.Item
+import com.digitalasset.canton.metrics.HistogramInventory.Item
 import com.digitalasset.canton.metrics.*
 import com.digitalasset.canton.participant.metrics.PruningMetrics as ParticipantPruningMetrics
 

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/metrics/PruningMetrics.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/metrics/PruningMetrics.scala
@@ -5,8 +5,8 @@ package com.digitalasset.canton.participant.metrics
 
 import com.daml.metrics.api.MetricHandle.{Gauge, LabeledMetricsFactory, Timer}
 import com.daml.metrics.api.{MetricInfo, MetricName, MetricQualification, MetricsContext}
-import com.daml.metrics.api.HistogramInventory
-import com.daml.metrics.api.HistogramInventory.Item
+import com.digitalasset.canton.metrics.HistogramInventory
+import com.digitalasset.canton.metrics.HistogramInventory.Item
 
 class PruningHistograms(parent: MetricName)(implicit inventory: HistogramInventory) {
   private[metrics] val prefix = parent :+ "pruning"

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/metrics/TransactionProcessingMetrics.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/metrics/TransactionProcessingMetrics.scala
@@ -5,8 +5,8 @@ package com.digitalasset.canton.participant.metrics
 
 import com.daml.metrics.api.MetricHandle.{Histogram, LabeledMetricsFactory, Timer}
 import com.daml.metrics.api.{MetricName, MetricQualification, MetricsContext}
-import com.daml.metrics.api.HistogramInventory
-import com.daml.metrics.api.HistogramInventory.Item
+import com.digitalasset.canton.metrics.HistogramInventory
+import com.digitalasset.canton.metrics.HistogramInventory.Item
 
 class TransactionProcessingHistograms(val prefix: MetricName)(implicit
     inventory: HistogramInventory

--- a/sdk/canton/community/participant/src/test/scala/com/digitalasset/canton/participant/metrics/ParticipantTestMetrics.scala
+++ b/sdk/canton/community/participant/src/test/scala/com/digitalasset/canton/participant/metrics/ParticipantTestMetrics.scala
@@ -6,7 +6,7 @@ package com.digitalasset.canton.participant.metrics
 import com.daml.metrics.api.MetricName
 import com.daml.metrics.api.noop.NoOpMetricsFactory
 import com.digitalasset.canton.DomainAlias
-import com.daml.metrics.api.HistogramInventory
+import com.digitalasset.canton.metrics.HistogramInventory
 
 object ParticipantTestMetrics
     extends ParticipantMetrics(

--- a/sdk/canton/community/util-logging/src/main/scala/com/digitalasset/canton/metrics/HistogramInventory.scala
+++ b/sdk/canton/community/util-logging/src/main/scala/com/digitalasset/canton/metrics/HistogramInventory.scala
@@ -1,27 +1,18 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.metrics.api
+package com.digitalasset.canton.metrics
 
-import com.daml.metrics.api.HistogramInventory.Item
+import com.daml.metrics.api.{MetricInfo, MetricName, MetricQualification}
+import com.digitalasset.canton.metrics.HistogramInventory.Item
+import com.typesafe.scalalogging.LazyLogging
+
 import java.util.concurrent.atomic.AtomicBoolean
 
-/** A helper class to register histogram items
-  *
-  * This class is used to register histogram items in a lazy way. It is used to ensure that all
-  * histogram items are registered before the actual metrics are created.
-  * This is necessary as open telemetry needs to know about the histogram views before
-  * the actual metrics are created.
-  *
-  * Therefore, metrics definitions are split into two parts:
-  *   - first, define the histogram names
-  *   - seconds, pass that definition into the actual metric definition
-  */
-class HistogramInventory {
+class HistogramInventory extends LazyLogging {
 
   private val items = collection.mutable.ListBuffer[Item]()
   private val complete = new AtomicBoolean(false)
-  private lazy val logger = org.slf4j.LoggerFactory.getLogger(getClass)
 
   def register(item: Item): Unit = {
     if (complete.get()) {

--- a/sdk/canton/community/util-logging/src/main/scala/com/digitalasset/canton/telemetry/OpenTelemetryFactory.scala
+++ b/sdk/canton/community/util-logging/src/main/scala/com/digitalasset/canton/telemetry/OpenTelemetryFactory.scala
@@ -3,27 +3,78 @@
 
 package com.digitalasset.canton.telemetry
 
-import com.daml.metrics.HistogramDefinition
-import com.daml.metrics.api.opentelemetry.OpenTelemetryUtil
-import com.daml.metrics.api.{HistogramInventory, MetricsInfoFilter}
+import com.daml.metrics.api.MetricHandle.Histogram
+import com.daml.metrics.api.opentelemetry.OpenTelemetryTimer
+import com.daml.metrics.api.{MetricInfo, MetricName, MetricQualification}
+import com.daml.metrics.{MetricsFilter, MetricsFilterConfig}
 import com.digitalasset.canton.logging.{NamedLoggerFactory, TracedLogger}
 import com.digitalasset.canton.metrics.OnDemandMetricsReader.NoOpOnDemandMetricsReader$
-import com.digitalasset.canton.metrics.OpenTelemetryOnDemandMetricsReader
+import com.digitalasset.canton.metrics.{HistogramInventory, OpenTelemetryOnDemandMetricsReader}
+import com.digitalasset.canton.telemetry.HistogramDefinition.AggregationType
 import com.digitalasset.canton.tracing.{NoopSpanExporter, TraceContext, TracingConfig}
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.propagation.ContextPropagators
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter
 import io.opentelemetry.sdk.OpenTelemetrySdk
-import io.opentelemetry.sdk.metrics.{SdkMeterProvider, SdkMeterProviderBuilder}
-import io.opentelemetry.sdk.trace.`export`.{BatchSpanProcessor, BatchSpanProcessorBuilder, SpanExporter}
+import io.opentelemetry.sdk.metrics.{
+  Aggregation,
+  InstrumentSelector,
+  InstrumentType,
+  SdkMeterProvider,
+  SdkMeterProviderBuilder,
+  View,
+}
+import io.opentelemetry.sdk.trace.`export`.{
+  BatchSpanProcessor,
+  BatchSpanProcessorBuilder,
+  SpanExporter,
+}
 import io.opentelemetry.sdk.trace.samplers.Sampler
 import io.opentelemetry.sdk.trace.{SdkTracerProvider, SdkTracerProviderBuilder}
 
 import scala.concurrent.duration.FiniteDuration
+import scala.jdk.CollectionConverters.SeqHasAsJava
 import scala.jdk.DurationConverters.ScalaDurationOps
 import scala.util.chaining.scalaUtilChainingOps
 
+// TODO(#17917) Move to daml repository
+final case class HistogramDefinition(
+    name: String,
+    aggregation: AggregationType,
+    viewName: Option[String] = None,
+) {
+
+  private lazy val hasWildcards = name.contains("*") || name.contains("?")
+  private lazy val asRegex = name.replace("*", ".*").replace("?", ".")
+
+  def matches(metric: MetricName): Boolean = {
+    if (hasWildcards) {
+      metric.matches(asRegex)
+    } else { metric.toString == name }
+  }
+}
+
+object HistogramDefinition {
+  sealed trait AggregationType
+  final case class Buckets(boundaries: Seq[Double]) extends AggregationType
+  final case class Exponential(maxBuckets: Int, maxScale: Int) extends AggregationType
+}
+
+// TODO(#17917) move to daml repository and adapt QualificationFilteringMetricsFactory
+//   and ensure we add a MetricQualification.All variable
+class MetricsInfoFilter(
+    val filters: Seq[MetricsFilterConfig], // move back to non val when moved to daml repository
+    val qualifications: Set[MetricQualification],
+) {
+
+  private val nameFilter = new MetricsFilter(filters)
+
+  def includeMetric(info: MetricInfo): Boolean = {
+    nameFilter.includeMetric(info.name.toString()) && qualifications.contains(info.qualification)
+  }
+
+}
 
 object OpenTelemetryFactory {
 
@@ -75,13 +126,14 @@ object OpenTelemetryFactory {
       else builder
 
     val meterProviderBuilder =
-      OpenTelemetryUtil.addViewsToProvider(
+      addViewsToProvider(
         SdkMeterProvider.builder,
         testingSupportAdhocMetrics,
         histogramInventory,
         histogramFilter,
         histogramConfigs,
-      ).pipe(setMetricsReader)
+      )
+        .pipe(setMetricsReader)
 
     val configuredSdk = OpenTelemetrySdk.builder
       .setTracerProvider(tracerProviderBuilder.build)
@@ -127,5 +179,99 @@ object OpenTelemetryFactory {
     if (config.parentBased) Sampler.parentBased(sampler) else sampler
   }
 
+  // TODO(#17917) move to daml repository
+  def addViewsToProvider(
+      builder: SdkMeterProviderBuilder,
+      testingSupportAdhocMetrics: Boolean,
+      histogramInventory: HistogramInventory,
+      histogramFilter: MetricsInfoFilter,
+      histogramConfigs: Seq[HistogramDefinition],
+  ): SdkMeterProviderBuilder = {
+    val timeHistograms = (
+      s"*${OpenTelemetryTimer.TimerUnitAndSuffix}",
+      HistogramDefinition.Buckets(
+        Seq(
+          0.01d, 0.025d, 0.050d, 0.075d, 0.1d, 0.15d, 0.2d, 0.25d, 0.35d, 0.5d, 0.75d, 1d, 2.5d, 5d,
+          10d,
+        )
+      ),
+    )
+    val byteHistograms = (
+      s"*${Histogram.Bytes}",
+      HistogramDefinition.Buckets(
+        Seq(
+          kilobytes(10),
+          kilobytes(50),
+          kilobytes(100),
+          kilobytes(500),
+          megabytes(1),
+          megabytes(5),
+          megabytes(10),
+          megabytes(50),
+        )
+      ),
+    )
+    if (testingSupportAdhocMetrics || histogramConfigs.isEmpty) {
+      // If there are no custom histogram configurations, register our default timers and byte histograms
+      Seq(timeHistograms, byteHistograms).foldLeft(builder) { case (builder, (name, aggregation)) =>
+        builder.registerView(
+          histogramSelectorByName(name),
+          explicitHistogramBucketsView(name, aggregation),
+        )
+      }
+    } else {
+      // due to https://opentelemetry.io/docs/specs/otel/metrics/sdk/#measurement-processing
+      // we need to have exactly one view definition per instrument name and not multiple
+      // otherwise you get lots of error messages dumped into the logs
+      val configs = histogramConfigs ++ Seq(timeHistograms, byteHistograms).map {
+        case (name, buckets) => HistogramDefinition(name, buckets)
+      }
+      // for each known histogram, register a view
+      histogramInventory
+        .registered()
+        .filter(item => histogramFilter.includeMetric(item.info))
+        .foldLeft(builder) { case (builder, item) =>
+          // find the histogram config that matches the name
+          val config = configs
+            .find(_.matches(item.name))
+            .getOrElse(HistogramDefinition(item.name, HistogramDefinition.Buckets(Seq.empty)))
+          builder.registerView(
+            histogramSelectorByName(item.name),
+            explicitHistogramBucketsView(item.summary, config.aggregation),
+          )
+        }
+    }
+  }
+
+  private def histogramSelectorByName(stringWithWildcards: String) = InstrumentSelector
+    .builder()
+    .setType(InstrumentType.HISTOGRAM)
+    .setName(stringWithWildcards)
+    .build()
+
+  private def explicitHistogramBucketsView(
+      description: String,
+      aggregationType: AggregationType,
+  ) = {
+    val aggregation = aggregationType match {
+      case HistogramDefinition.Buckets(buckets) =>
+        if (buckets.nonEmpty)
+          Aggregation.explicitBucketHistogram(
+            buckets.map(Double.box).asJava
+          )
+        else Aggregation.explicitBucketHistogram()
+      case HistogramDefinition.Exponential(maxBuckets, maxScale) =>
+        Aggregation.base2ExponentialBucketHistogram(maxBuckets, maxScale)
+    }
+    View
+      .builder()
+      .setAggregation(aggregation)
+      .setDescription(description)
+      .build()
+  }
+
+  private def kilobytes(value: Int): Double = value * 1024d
+
+  private def megabytes(value: Int): Double = value * 1024d * 1024d
 
 }

--- a/sdk/libs-scala/caching/src/main/scala/com/daml/caching/CaffeineCache.scala
+++ b/sdk/libs-scala/caching/src/main/scala/com/daml/caching/CaffeineCache.scala
@@ -23,7 +23,7 @@ object CaffeineCache {
     metrics match {
       case None => new SimpleCaffeineCache(builder.build[Key, Value])
       case Some(metrics) =>
-        builder.recordStats(() => new CaffeineMetricsStatsCounter(metrics))
+        builder.recordStats(() => new DropwizardStatsCounter(metrics))
         new InstrumentedCaffeineCache(builder.build[Key, Value], metrics)
     }
 

--- a/sdk/libs-scala/caching/src/main/scala/com/daml/caching/DropwizardStatsCounter.scala
+++ b/sdk/libs-scala/caching/src/main/scala/com/daml/caching/DropwizardStatsCounter.scala
@@ -8,7 +8,7 @@ import com.daml.metrics.api.MetricsContext
 import com.github.benmanes.caffeine.cache.RemovalCause
 import com.github.benmanes.caffeine.cache.stats.{CacheStats, StatsCounter}
 
-private[caching] final class CaffeineMetricsStatsCounter(
+private[caching] final class DropwizardStatsCounter(
     metrics: CacheMetrics
 ) extends StatsCounter {
 

--- a/sdk/observability/metrics/BUILD.bazel
+++ b/sdk/observability/metrics/BUILD.bazel
@@ -30,6 +30,7 @@ da_scala_library(
         "@maven//:io_grpc_grpc_api",
         "@maven//:io_opentelemetry_opentelemetry_api",
         "@maven//:io_opentelemetry_opentelemetry_context",
+        "@maven//:io_opentelemetry_opentelemetry_sdk_common",
         "@maven//:io_opentelemetry_opentelemetry_sdk_metrics",
         "@maven//:org_slf4j_slf4j_api",
     ],

--- a/sdk/observability/metrics/src/main/scala/com/daml/metrics/DatabaseMetrics.scala
+++ b/sdk/observability/metrics/src/main/scala/com/daml/metrics/DatabaseMetrics.scala
@@ -6,102 +6,91 @@ package com.daml.metrics
 import com.daml.metrics.api.MetricQualification.Debug
 import com.daml.metrics.api.MetricHandle.{LabeledMetricsFactory, Timer}
 import com.daml.metrics.api.noop.NoOpMetricsFactory
-import com.daml.metrics.api.{MetricName, MetricsContext}
-import com.daml.metrics.api.HistogramInventory
-import com.daml.metrics.api.HistogramInventory.Item
-
-class DatabaseMetricsHistograms(implicit
-    inventory: HistogramInventory
-) {
-
-  private val dbPrefix: MetricName = MetricName.Daml :+ "db"
-  private lazy val labelsWithDescription = Map(
-    "name" -> "The operation/pool for which the metric is registered."
-  )
-  val waitTimer: Item = Item(
-    dbPrefix :+ "wait",
-    summary = "The time needed to acquire a connection to the database.",
-    description = """SQL statements are run in a dedicated executor. This metric measures the time
-                    |it takes between creating the SQL statement corresponding to the <operation>
-                    |and the point when it starts running on the dedicated executor.""",
-    qualification = Debug,
-    labelsWithDescription = labelsWithDescription,
-  )
-
-  val executionTimer: Item = Item(
-    dbPrefix :+ "exec",
-    summary = "The time needed to run the SQL query and read the result.",
-    description = """This metric encompasses the time measured by `query` and `commit` metrics.
-                    |Additionally it includes the time needed to obtain the DB connection,
-                    |optionally roll it back and close the connection at the end.""",
-    qualification = Debug,
-    labelsWithDescription = labelsWithDescription,
-  )
-
-  val translationTimer: Item = Item(
-    dbPrefix :+ "translation",
-    summary = "The time needed to turn serialized Daml-LF values into in-memory objects.",
-    description = """Some index database queries that target contracts and transactions involve a
-                    |Daml-LF translation step. For such queries this metric stands for the time it
-                    |takes to turn the serialized Daml-LF values into in-memory representation.""",
-    qualification = Debug,
-    labelsWithDescription = labelsWithDescription,
-  )
-
-  val compressionTimer: Item = Item(
-    dbPrefix :+ "compression",
-    summary = "The time needed to decompress the SQL query result.",
-    description = """Some index database queries that target contracts involve a decompression
-                    |step. For such queries this metric represents the time it takes to decompress
-                    |contract arguments retrieved from the database.""",
-    qualification = Debug,
-    labelsWithDescription = labelsWithDescription,
-  )
-
-  val commitTimer: Item = Item(
-    dbPrefix :+ "commit",
-    summary = "The time needed to perform the SQL query commit.",
-    description = """This metric measures the time it takes to commit an SQL transaction relating
-                    |to the <operation>. It roughly corresponds to calling `commit()` on a DB
-                    |connection.""",
-    qualification = Debug,
-    labelsWithDescription = labelsWithDescription,
-  )
-
-  val queryTimer: Item = Item(
-    dbPrefix :+ "query",
-    summary = "The time needed to run the SQL query.",
-    description = """This metric measures the time it takes to execute a block of code (on a
-                    |dedicated executor) related to the <operation> that can issue multiple SQL
-                    |statements such that all run in a single DB transaction (either committed or
-                    |aborted).""",
-    qualification = Debug,
-    labelsWithDescription = labelsWithDescription,
-  )
-
-}
+import com.daml.metrics.api.{MetricInfo, MetricName, MetricsContext}
 
 class DatabaseMetrics(
     val name: String,
     val factory: LabeledMetricsFactory,
 ) {
-  // as the path is static, we can mock the inventory here as long as they get
-  // included in the app histogram inventory
-  private val histograms = new DatabaseMetricsHistograms()(new HistogramInventory)
 
+  private val dbPrefix: MetricName = MetricName.Daml :+ "db"
   private implicit val mc: MetricsContext = MetricsContext("name" -> name)
+  private lazy val labelsWithDescription = Map(
+    "name" -> "The operation/pool for which the metric is registered."
+  )
 
-  val waitTimer: Timer = factory.timer(histograms.waitTimer.info)
+  val waitTimer: Timer = factory.timer(
+    MetricInfo(
+      dbPrefix :+ "wait",
+      summary = "The time needed to acquire a connection to the database.",
+      description = """SQL statements are run in a dedicated executor. This metric measures the time
+                    |it takes between creating the SQL statement corresponding to the <operation>
+                    |and the point when it starts running on the dedicated executor.""",
+      qualification = Debug,
+      labelsWithDescription = labelsWithDescription,
+    )
+  )
 
-  val executionTimer: Timer = factory.timer(histograms.executionTimer.info)
+  val executionTimer: Timer = factory.timer(
+    MetricInfo(
+      dbPrefix :+ "exec",
+      summary = "The time needed to run the SQL query and read the result.",
+      description = """This metric encompasses the time measured by `query` and `commit` metrics.
+                    |Additionally it includes the time needed to obtain the DB connection,
+                    |optionally roll it back and close the connection at the end.""",
+      qualification = Debug,
+      labelsWithDescription = labelsWithDescription,
+    )
+  )
 
-  val translationTimer: Timer = factory.timer(histograms.translationTimer.info)
+  val translationTimer: Timer = factory.timer(
+    MetricInfo(
+      dbPrefix :+ "translation",
+      summary = "The time needed to turn serialized Daml-LF values into in-memory objects.",
+      description = """Some index database queries that target contracts and transactions involve a
+                    |Daml-LF translation step. For such queries this metric stands for the time it
+                    |takes to turn the serialized Daml-LF values into in-memory representation.""",
+      qualification = Debug,
+      labelsWithDescription = labelsWithDescription,
+    )
+  )
 
-  val compressionTimer: Timer = factory.timer(histograms.compressionTimer.info)
+  val compressionTimer: Timer = factory.timer(
+    MetricInfo(
+      dbPrefix :+ "compression",
+      summary = "The time needed to decompress the SQL query result.",
+      description = """Some index database queries that target contracts involve a decompression
+                    |step. For such queries this metric represents the time it takes to decompress
+                    |contract arguments retrieved from the database.""",
+      qualification = Debug,
+      labelsWithDescription = labelsWithDescription,
+    )
+  )
 
-  val commitTimer: Timer = factory.timer(histograms.commitTimer.info)
+  val commitTimer: Timer = factory.timer(
+    MetricInfo(
+      dbPrefix :+ "commit",
+      summary = "The time needed to perform the SQL query commit.",
+      description = """This metric measures the time it takes to commit an SQL transaction relating
+                    |to the <operation>. It roughly corresponds to calling `commit()` on a DB
+                    |connection.""",
+      qualification = Debug,
+      labelsWithDescription = labelsWithDescription,
+    )
+  )
 
-  val queryTimer: Timer = factory.timer(histograms.queryTimer.info)
+  val queryTimer: Timer = factory.timer(
+    MetricInfo(
+      dbPrefix :+ "query",
+      summary = "The time needed to run the SQL query.",
+      description = """This metric measures the time it takes to execute a block of code (on a
+                    |dedicated executor) related to the <operation> that can issue multiple SQL
+                    |statements such that all run in a single DB transaction (either committed or
+                    |aborted).""",
+      qualification = Debug,
+      labelsWithDescription = labelsWithDescription,
+    )
+  )
 }
 
 object DatabaseMetrics {

--- a/sdk/observability/metrics/src/main/scala/com/daml/metrics/MetricsConfig.scala
+++ b/sdk/observability/metrics/src/main/scala/com/daml/metrics/MetricsConfig.scala
@@ -3,7 +3,6 @@
 
 package com.daml.metrics
 
-import com.daml.metrics.HistogramDefinition.AggregationType
 import com.daml.metrics.api.MetricName
 
 import scala.collection.concurrent.TrieMap
@@ -11,13 +10,9 @@ import scala.collection.concurrent.TrieMap
 /** Bucket boundary definitions for histograms
   *
   * @param name Instrument name that may contain the wildcard characters * and ?
-  * @param aggregation The aggregation type for the boundaries of the histogram buckets
+  * @param bucketBoundaries The boundaries of the histogram buckets
   */
-final case class HistogramDefinition(
-    name: String,
-    aggregation: AggregationType,
-    viewName: Option[String] = None,
-) {
+final case class HistogramDefinition(name: String, bucketBoundaries: Seq[Double]) {
 
   private lazy val hasWildcards = name.contains("*") || name.contains("?")
   private lazy val asRegex = name.replace("*", ".*").replace("?", ".")
@@ -27,12 +22,6 @@ final case class HistogramDefinition(
       metric.matches(asRegex)
     } else { metric.toString == name }
   }
-}
-
-object HistogramDefinition {
-  sealed trait AggregationType
-  final case class Buckets(boundaries: Seq[Double]) extends AggregationType
-  final case class Exponential(maxBuckets: Int, maxScale: Int) extends AggregationType
 }
 
 /** Metrics filter */

--- a/sdk/observability/metrics/src/main/scala/com/daml/metrics/api/MetricHandle.scala
+++ b/sdk/observability/metrics/src/main/scala/com/daml/metrics/api/MetricHandle.scala
@@ -3,7 +3,6 @@
 
 package com.daml.metrics.api
 
-import com.daml.metrics.{MetricsFilter, MetricsFilterConfig}
 import com.daml.metrics.api.MetricQualification
 
 import java.time.Duration
@@ -12,6 +11,7 @@ import com.daml.metrics.api.MetricHandle.Gauge.CloseableGauge
 import com.daml.metrics.api.MetricHandle.Timer.TimerHandle
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.language.implicitConversions
 
 /** Information about a metric used for documentation and online help
   *
@@ -29,18 +29,11 @@ final case class MetricInfo(
   def extend(extension: String): MetricInfo = copy(name = name :+ extension)
 }
 
-/** Small utility class to filter metrics according to configuration */
-class MetricsInfoFilter(
-    filters: Seq[MetricsFilterConfig],
-    qualifications: Set[MetricQualification],
-) {
+object MetricInfo {
 
-  private val nameFilter = new MetricsFilter(filters)
-
-  def includeMetric(info: MetricInfo): Boolean = {
-    nameFilter.includeMetric(info.name.toString()) && qualifications.contains(info.qualification)
-  }
-
+  /** temporary implicit conversion to enable refactoring */
+  implicit def fromName(name: MetricName): MetricInfo =
+    MetricInfo(name, "", MetricQualification.Debug)
 }
 
 trait MetricHandle {
@@ -68,6 +61,11 @@ object MetricHandle {
         context: MetricsContext
     ): Gauge[T]
 
+    // TODO(#17917) remove once migration to MetricInfo is completed
+    def gauge[T](name: MetricName, initial: T, description: String)(implicit
+        context: MetricsContext
+    ): Gauge[T] = gauge(MetricInfo(name, "", MetricQualification.Debug, description), initial)
+
     /** Same as a gauge, but the value is read using the `gaugeSupplier` only when the metrics are observed.
       */
     def gaugeWithSupplier[T](
@@ -77,6 +75,16 @@ object MetricHandle {
         context: MetricsContext
     ): CloseableGauge
 
+    // TODO(#17917) remove once migration to MetricInfo is completed
+    def gaugeWithSupplier[T](
+        name: MetricName,
+        gaugeSupplier: () => T,
+        description: String,
+    )(implicit
+        context: MetricsContext
+    ): CloseableGauge =
+      gaugeWithSupplier(MetricInfo(name, "", MetricQualification.Debug, description), gaugeSupplier)
+
     /** A meter represents a monotonically increasing value.
       * In Prometheus this is actually represented by a `Counter`.
       * Note that meters should never decrease as the data is then skewed and unusable!
@@ -84,6 +92,11 @@ object MetricHandle {
     def meter(info: MetricInfo)(implicit
         context: MetricsContext
     ): Meter
+
+    // TODO(#17917) remove once migration to MetricInfo is completed
+    def meter(name: MetricName, description: String)(implicit
+        context: MetricsContext = MetricsContext.Empty
+    ): Meter = meter(MetricInfo(name, "", MetricQualification.Debug, description))
 
     /** A counter represents a value that can go up and down.
       *  A counter is actually represented as a gauge.

--- a/sdk/observability/metrics/src/main/scala/com/daml/metrics/api/MetricsContext.scala
+++ b/sdk/observability/metrics/src/main/scala/com/daml/metrics/api/MetricsContext.scala
@@ -7,6 +7,8 @@ import io.opentelemetry.api.common.Attributes
 
 /** *
   * Represents labels that are added to metrics.
+  * Please note that labels are only being supported by the OpenTelemetry metrics implementation,
+  * the Dropwizard implementation just ignores them as it supports metric names only.
   */
 case class MetricsContext(labels: Map[String, String]) {
 

--- a/sdk/observability/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryUtil.scala
+++ b/sdk/observability/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryUtil.scala
@@ -3,135 +3,16 @@
 
 package com.daml.metrics.api.opentelemetry
 
-import com.daml.metrics.HistogramDefinition
-import com.daml.metrics.HistogramDefinition.AggregationType
-import com.daml.metrics.api.MetricHandle.Histogram
-import com.daml.metrics.api.opentelemetry.OpenTelemetryTimer
-import com.daml.metrics.api.{HistogramInventory, MetricsInfoFilter}
-import io.opentelemetry.sdk.metrics._
+import io.opentelemetry.sdk.common.CompletableResultCode
 
-import scala.jdk.CollectionConverters.SeqHasAsJava
+import scala.concurrent.{Future, Promise}
 
 object OpenTelemetryUtil {
 
-  /** Add views to providers
-    *
-    * In open telemetry, you have to define the histogram views separately from the metric itself. Even worse,
-    * you need to define it before you define the metrics. If you define two views that match to the same metrics,
-    * you end up with ugly warning messages and errors: https://opentelemetry.io/docs/specs/otel/metrics/sdk/#measurement-processing
-    *
-    * The solution to this is to statically define all the metric names in advance separately, create appropriate views
-    * and then, on each histogram definition check that an appropriate static definition exists.
-    */
-  def addViewsToProvider(
-      builder: SdkMeterProviderBuilder,
-      testingSupportAdhocMetrics: Boolean,
-      histogramInventory: HistogramInventory,
-      histogramFilter: MetricsInfoFilter,
-      histogramConfigs: Seq[HistogramDefinition],
-  ): SdkMeterProviderBuilder = {
-    val timeHistograms = (
-      s"*${OpenTelemetryTimer.TimerUnitAndSuffix}",
-      HistogramDefinition.Buckets(
-        Seq(
-          0.01d, 0.025d, 0.050d, 0.075d, 0.1d, 0.15d, 0.2d, 0.25d, 0.35d, 0.5d, 0.75d, 1d, 2.5d, 5d,
-          10d,
-        )
-      ),
-    )
-    val byteHistograms = (
-      s"*${Histogram.Bytes}",
-      HistogramDefinition.Buckets(
-        Seq(
-          kilobytes(10),
-          kilobytes(50),
-          kilobytes(100),
-          kilobytes(500),
-          megabytes(1),
-          megabytes(5),
-          megabytes(10),
-          megabytes(50),
-        )
-      ),
-    )
-    if (testingSupportAdhocMetrics) {
-      // Register our default timers and byte histograms
-      Seq(timeHistograms, byteHistograms).foldLeft(builder) { case (builder, (name, aggregation)) =>
-        builder.registerView(
-          histogramSelectorByName(name),
-          explicitHistogramBucketsView(name, aggregation, None),
-        )
-      }
-    } else {
-      // due to https://opentelemetry.io/docs/specs/otel/metrics/sdk/#measurement-processing
-      // we need to have exactly one view definition per instrument name and not multiple
-      // otherwise you get lots of error messages dumped into the logs
-      val configs = histogramConfigs ++ Seq(timeHistograms, byteHistograms).map {
-        case (name, buckets) => HistogramDefinition(name, buckets)
-      }
-      // for each known histogram, register a view
-      histogramInventory
-        .registered()
-        .filter(item => histogramFilter.includeMetric(item.info))
-        .flatMap { item =>
-          // find the histogram configs that matches the name
-          // there might be multiple views for the same instrument
-          val instrumentConfigs = configs
-            .filter(_.matches(item.name))
-            .groupBy(_.viewName.getOrElse(item.name.toString))
-            .toSeq
-            .flatMap { case (_, allMatchingDefinitions) =>
-              allMatchingDefinitions.headOption.map { first => (item, first) }
-            }
-          if (instrumentConfigs.nonEmpty) instrumentConfigs
-          else
-            Seq(
-              (
-                item,
-                HistogramDefinition(item.name, HistogramDefinition.Buckets(Seq.empty)),
-              )
-            )
-        }
-        .foldLeft(builder) { case (builder, (item, definition)) =>
-          builder.registerView(
-            histogramSelectorByName(item.name),
-            explicitHistogramBucketsView(item.summary, definition.aggregation, definition.viewName),
-          )
-        }
-    }
+  def completionCodeToFuture(completion: CompletableResultCode): Future[Unit] = {
+    val promise = Promise[Unit]()
+    completion.whenComplete(() => promise.success(()))
+    promise.future
   }
-
-  private def histogramSelectorByName(stringWithWildcards: String) = InstrumentSelector
-    .builder()
-    .setType(InstrumentType.HISTOGRAM)
-    .setName(stringWithWildcards)
-    .build()
-
-  private def explicitHistogramBucketsView(
-      summary: String,
-      aggregationType: AggregationType,
-      viewName: Option[String],
-  ) = {
-    val aggregation = aggregationType match {
-      case HistogramDefinition.Buckets(buckets) =>
-        if (buckets.nonEmpty)
-          Aggregation.explicitBucketHistogram(
-            buckets.map(Double.box).asJava
-          )
-        else Aggregation.explicitBucketHistogram()
-      case HistogramDefinition.Exponential(maxBuckets, maxScale) =>
-        Aggregation.base2ExponentialBucketHistogram(maxBuckets, maxScale)
-    }
-    val tmp = View
-      .builder()
-      .setAggregation(aggregation)
-      .setDescription(summary)
-    viewName.foreach(tmp.setName)
-    tmp.build()
-  }
-
-  private def kilobytes(value: Int): Double = value * 1024d
-
-  private def megabytes(value: Int): Double = value * 1024d * 1024d
 
 }

--- a/sdk/observability/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/Slf4jMetricExporter.scala
+++ b/sdk/observability/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/Slf4jMetricExporter.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.metrics.api.opentelemetry
+
+import java.util
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.metrics.InstrumentType
+import io.opentelemetry.sdk.metrics.`export`.MetricExporter
+import io.opentelemetry.sdk.metrics.data.{AggregationTemporality, MetricData}
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
+class Slf4jMetricExporter(
+    logAsInfo: Boolean,
+    logger: Logger = LoggerFactory.getLogger("logging-metrics-exporter"),
+) extends MetricExporter {
+
+  override def `export`(
+      metrics: util.Collection[MetricData]
+  ): CompletableResultCode = {
+    metrics.asScala.foreach(metricData =>
+      if (logAsInfo) logger.info(s"$metricData")
+      else logger.debug(s"$metricData")
+    )
+    CompletableResultCode.ofSuccess()
+  }
+
+  override def flush(): CompletableResultCode = CompletableResultCode.ofSuccess()
+
+  override def shutdown(): CompletableResultCode = CompletableResultCode.ofSuccess()
+
+  override def getAggregationTemporality(instrumentType: InstrumentType): AggregationTemporality =
+    AggregationTemporality.CUMULATIVE
+}

--- a/sdk/observability/metrics/src/main/scala/com/daml/metrics/grpc/DamlGrpcServerMetrics.scala
+++ b/sdk/observability/metrics/src/main/scala/com/daml/metrics/grpc/DamlGrpcServerMetrics.scala
@@ -3,41 +3,13 @@
 
 package com.daml.metrics.grpc
 
-import com.daml.metrics.api.HistogramInventory.Item
-import com.daml.metrics.api.{
-  HistogramInventory,
-  MetricHandle,
-  MetricInfo,
-  MetricName,
-  MetricQualification,
-  MetricsContext,
-}
+import com.daml.metrics.api.MetricQualification
 import com.daml.metrics.api.MetricHandle.{Histogram, LabeledMetricsFactory}
+import com.daml.metrics.api.{MetricHandle, MetricInfo, MetricName, MetricsContext}
+import com.daml.metrics.grpc.DamlGrpcServerMetrics.GrpcServerMetricsPrefix
 
-class DamlGrpcServerHistograms(implicit
-    inventory: HistogramInventory
-) {
-  private[grpc] val prefix = MetricName.Daml :+ "grpc" :+ "server"
-
-  val damlGrpcServerCallTimer: Item = Item(
-    MetricName.Daml :+ "grpc",
-    MetricName("server"),
-    summary = "Distribution of the durations of serving gRPC requests.",
-    qualification = MetricQualification.Latency,
-  )
-  val damlGrpcServerReceived: Item = Item(
-    prefix :+ "server" :+ "messages" :+ "received",
-    Histogram.Bytes,
-    summary = "Distribution of payload sizes in gRPC messages received (both unary and streaming).",
-    qualification = MetricQualification.Traffic,
-  )
-  val damlGrpcServerSent: Item = Item(
-    prefix :+ "server" :+ "messages" :+ "sent",
-    Histogram.Bytes,
-    summary = "Distribution of payload sizes in gRPC messages sent (both unary and streaming).",
-    qualification = MetricQualification.Traffic,
-  )
-
+object DamlGrpcServerMetrics {
+  val GrpcServerMetricsPrefix = MetricName.Daml :+ "grpc" :+ "server"
 }
 
 class DamlGrpcServerMetrics(
@@ -45,44 +17,56 @@ class DamlGrpcServerMetrics(
     service: String,
 ) extends GrpcServerMetrics {
 
-  private val histograms = new DamlGrpcServerHistograms()(new HistogramInventory)
-
   private implicit val metricsContext: MetricsContext = MetricsContext(
     Map("service" -> service)
   )
 
-  override val callTimer: MetricHandle.Timer =
-    metricsFactory.timer(histograms.damlGrpcServerCallTimer.info)
+  override val callTimer: MetricHandle.Timer = metricsFactory.timer(
+    MetricInfo(
+      GrpcServerMetricsPrefix,
+      summary = "Distribution of the durations of serving gRPC requests.",
+      qualification = MetricQualification.Traffic,
+    )
+  )
   override val messagesSent: MetricHandle.Meter = metricsFactory.meter(
     MetricInfo(
-      histograms.prefix :+ "messages" :+ "sent",
+      GrpcServerMetricsPrefix :+ "messages" :+ "sent",
       summary = "Total number of gRPC messages sent (on either type of connection).",
       qualification = MetricQualification.Traffic,
     )
   )
   override val messagesReceived: MetricHandle.Meter = metricsFactory.meter(
     MetricInfo(
-      histograms.prefix :+ "messages" :+ "received",
+      GrpcServerMetricsPrefix :+ "messages" :+ "received",
       summary = "Total number of gRPC messages received (on either type of connection).",
       qualification = MetricQualification.Traffic,
     )
   )
   override val messagesSentSize: MetricHandle.Histogram = metricsFactory.histogram(
-    histograms.damlGrpcServerSent.info
+    MetricInfo(
+      GrpcServerMetricsPrefix :+ "messages" :+ "sent" :+ Histogram.Bytes,
+      summary = "Distribution of payload sizes in gRPC messages sent (both unary and streaming).",
+      qualification = MetricQualification.Traffic,
+    )
   )
   override val messagesReceivedSize: MetricHandle.Histogram = metricsFactory.histogram(
-    histograms.damlGrpcServerReceived.info
+    MetricInfo(
+      GrpcServerMetricsPrefix :+ "messages" :+ "received" :+ Histogram.Bytes,
+      summary =
+        "Distribution of payload sizes in gRPC messages received (both unary and streaming).",
+      qualification = MetricQualification.Traffic,
+    )
   )
   override val callsStarted: MetricHandle.Meter = metricsFactory.meter(
     MetricInfo(
-      histograms.prefix :+ "started",
+      GrpcServerMetricsPrefix :+ "started",
       summary = "Total number of started gRPC requests (on either type of connection).",
       qualification = MetricQualification.Traffic,
     )
   )
   override val callsHandled: MetricHandle.Meter = metricsFactory.meter(
     MetricInfo(
-      histograms.prefix :+ "handled",
+      GrpcServerMetricsPrefix :+ "handled",
       summary = "Total number of handled gRPC requests.",
       qualification = MetricQualification.Traffic,
     )

--- a/sdk/observability/pekko-http-metrics/src/main/scala/com/daml/metrics/http/DamlHttpMetrics.scala
+++ b/sdk/observability/pekko-http-metrics/src/main/scala/com/daml/metrics/http/DamlHttpMetrics.scala
@@ -6,40 +6,11 @@ package com.daml.metrics.http
 import com.daml.metrics.api.MetricQualification
 import com.daml.metrics.api.MetricHandle.{Histogram, LabeledMetricsFactory, Meter, Timer}
 import com.daml.metrics.api.{MetricInfo, MetricName, MetricsContext}
-import com.daml.metrics.api.HistogramInventory
-import com.daml.metrics.api.HistogramInventory.Item
 
-class DamlHttpHistograms(implicit
-    inventory: HistogramInventory
-) {
-  private[http] val httpMetricsPrefix = MetricName.Daml :+ "http"
+class DamlHttpMetrics(metricsFactory: LabeledMetricsFactory, component: String)
+    extends HttpMetrics {
 
-  val latency: Item =
-    Item(
-      httpMetricsPrefix :+ "requests",
-      "The duration of the HTTP requests.",
-      MetricQualification.Debug,
-    )
-  val requestsPayloadBytes: Item =
-    Item(
-      httpMetricsPrefix :+ "requests" :+ "payload" :+ Histogram.Bytes,
-      "Distribution of the sizes of payloads received in HTTP requests.",
-      MetricQualification.Debug,
-    )
-  val responsesPayloadBytes: Item =
-    Item(
-      httpMetricsPrefix :+ "responses" :+ "payload" :+ Histogram.Bytes,
-      "Distribution of the sizes of payloads sent in HTTP responses.",
-      MetricQualification.Debug,
-    )
-}
-
-class DamlHttpMetrics(
-    metricsFactory: LabeledMetricsFactory,
-    component: String,
-) extends HttpMetrics {
-
-  private val histograms = new DamlHttpHistograms()(new HistogramInventory)
+  private val httpMetricsPrefix = MetricName.Daml :+ "http"
 
   private implicit val metricsContext: MetricsContext = MetricsContext(
     Map(Labels.ServiceLabel -> component)
@@ -48,16 +19,34 @@ class DamlHttpMetrics(
   override val requestsTotal: Meter =
     metricsFactory.meter(
       MetricInfo(
-        histograms.httpMetricsPrefix :+ "requests",
+        httpMetricsPrefix :+ "requests",
         "Total number of HTTP requests received.",
         MetricQualification.Debug,
       )
     )
-  override val latency: Timer = metricsFactory.timer(histograms.latency.info)
+  override val latency: Timer =
+    metricsFactory.timer(
+      MetricInfo(
+        httpMetricsPrefix :+ "requests",
+        "The duration of the HTTP requests.",
+        MetricQualification.Debug,
+      )
+    )
   override val requestsPayloadBytes: Histogram =
-    metricsFactory.histogram(histograms.requestsPayloadBytes.info)
-
+    metricsFactory.histogram(
+      MetricInfo(
+        httpMetricsPrefix :+ "requests" :+ "payload" :+ Histogram.Bytes,
+        "Distribution of the sizes of payloads received in HTTP requests.",
+        MetricQualification.Debug,
+      )
+    )
   override val responsesPayloadBytes: Histogram =
-    metricsFactory.histogram(histograms.responsesPayloadBytes.info)
+    metricsFactory.histogram(
+      MetricInfo(
+        httpMetricsPrefix :+ "responses" :+ "payload" :+ Histogram.Bytes,
+        "Distribution of the sizes of payloads sent in HTTP responses.",
+        MetricQualification.Debug,
+      )
+    )
 
 }

--- a/sdk/observability/pekko-http-metrics/src/main/scala/com/daml/metrics/http/DamlWebSocketMetrics.scala
+++ b/sdk/observability/pekko-http-metrics/src/main/scala/com/daml/metrics/http/DamlWebSocketMetrics.scala
@@ -6,36 +6,11 @@ package com.daml.metrics.http
 import com.daml.metrics.api.MetricQualification
 import com.daml.metrics.api.MetricHandle.{Histogram, LabeledMetricsFactory, Meter}
 import com.daml.metrics.api.{MetricInfo, MetricName, MetricsContext}
-import com.daml.metrics.api.HistogramInventory
-import com.daml.metrics.api.HistogramInventory.Item
 
-class DamlWebSocketsHistograms(implicit
-    inventory: HistogramInventory
-) {
-  private[http] val websocketMetricsPrefix = MetricName.Daml :+ "http" :+ "websocket" :+ "messages"
+class DamlWebSocketMetrics(metricsFactory: LabeledMetricsFactory, component: String)
+    extends WebSocketMetrics {
 
-  val messagesReceivedBytes: Item =
-    Item(
-      websocketMetricsPrefix :+ "received" :+ Histogram.Bytes,
-      "Distribution of the size of received WebSocket messages.",
-      MetricQualification.Debug,
-    )
-
-  val messagesSentBytes: Item =
-    Item(
-      websocketMetricsPrefix :+ "sent" :+ Histogram.Bytes,
-      "Distribution of the size of sent WebSocket messages.",
-      MetricQualification.Debug,
-    )
-
-}
-
-class DamlWebSocketMetrics(
-    metricsFactory: LabeledMetricsFactory,
-    component: String,
-) extends WebSocketMetrics {
-
-  private val histograms = new DamlWebSocketsHistograms()(new HistogramInventory)
+  private val httpMetricsPrefix = MetricName.Daml :+ "http"
 
   private implicit val metricsContext: MetricsContext = MetricsContext(
     Map(Labels.ServiceLabel -> component)
@@ -44,23 +19,34 @@ class DamlWebSocketMetrics(
   override val messagesReceivedTotal: Meter =
     metricsFactory.meter(
       MetricInfo(
-        histograms.websocketMetricsPrefix :+ "received",
+        httpMetricsPrefix :+ "websocket" :+ "messages" :+ "received",
         "Total number of received WebSocket messages.",
         MetricQualification.Debug,
       )
     )
   override val messagesReceivedBytes: Histogram =
-    metricsFactory.histogram(histograms.messagesReceivedBytes.info)
-
+    metricsFactory.histogram(
+      MetricInfo(
+        httpMetricsPrefix :+ "websocket" :+ "messages" :+ "received" :+ Histogram.Bytes,
+        "Distribution of the size of received WebSocket messages.",
+        MetricQualification.Debug,
+      )
+    )
   override val messagesSentTotal: Meter =
     metricsFactory.meter(
       MetricInfo(
-        histograms.websocketMetricsPrefix :+ "sent",
+        httpMetricsPrefix :+ "websocket" :+ "messages" :+ "sent",
         "Total number of sent WebSocket messages.",
         MetricQualification.Debug,
       )
     )
   override val messagesSentBytes: Histogram =
-    metricsFactory.histogram(histograms.messagesSentBytes.info)
+    metricsFactory.histogram(
+      MetricInfo(
+        httpMetricsPrefix :+ "websocket" :+ "messages" :+ "sent" :+ Histogram.Bytes,
+        "Distribution of the size of sent WebSocket messages.",
+        MetricQualification.Debug,
+      )
+    )
 
 }

--- a/sdk/observability/telemetry/BUILD.bazel
+++ b/sdk/observability/telemetry/BUILD.bazel
@@ -1,0 +1,24 @@
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_library",
+)
+
+da_scala_library(
+    name = "telemetry",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    resources = glob(["src/main/resources/**/*"]),
+    scala_deps = [
+    ],
+    tags = ["maven_coordinates=com.daml:telemetry:__VERSION__"],
+    visibility = [
+        "//visibility:public",
+    ],
+    runtime_deps = [],
+    deps = [
+        "//observability/metrics",
+        "@maven//:io_opentelemetry_opentelemetry_sdk_metrics",
+    ],
+)

--- a/sdk/observability/telemetry/src/main/scala/com/daml/telemetry/OpenTelemetryOwner.scala
+++ b/sdk/observability/telemetry/src/main/scala/com/daml/telemetry/OpenTelemetryOwner.scala
@@ -1,0 +1,103 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.telemetry
+
+import com.daml.metrics.{ExecutorServiceMetrics, HistogramDefinition}
+import com.daml.metrics.api.MetricHandle.Histogram
+import com.daml.metrics.api.MetricName
+import com.daml.metrics.api.opentelemetry.OpenTelemetryTimer
+import com.daml.metrics.grpc.DamlGrpcServerMetrics
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder
+import io.opentelemetry.sdk.metrics.InstrumentType
+import io.opentelemetry.sdk.metrics.{Aggregation, InstrumentSelector, View}
+
+import scala.jdk.CollectionConverters.SeqHasAsJava
+
+object OpenTelemetryOwner {
+
+  /** Add views to providers
+    *
+    * In open telemetry, you have to define the histogram views separately from the metric itself. Even worse,
+    * you need to define it before you define the metrics. If you define two views that match to the same metrics,
+    * you end up with ugly warning messages and errors: https://opentelemetry.io/docs/specs/otel/metrics/sdk/#measurement-processing
+    *
+    * The solution to this is to statically define all the metric names in advance separately, create appropriate views
+    * and then, on each histogram definition check that an appropriate static definition exists.
+    */
+  def addViewsToProvider(
+      builder: SdkMeterProviderBuilder,
+      configs: Seq[HistogramDefinition],
+      metrics: Set[MetricName],
+  ): SdkMeterProviderBuilder = {
+
+    val candidates = configs ++ Seq(
+      // use smaller buckets for the executor services (must be declared before the generic timing buckets)
+      HistogramDefinition(
+        s"${ExecutorServiceMetrics.Prefix}*${OpenTelemetryTimer.TimerUnitAndSuffix}",
+        Seq(
+          0.0005d, 0.001d, 0.002d, 0.005d, 0.01d, 0.025d, 0.05d, 0.1d, 0.25d, 0.5d, 0.75d, 1d, 2.5d,
+        ),
+      ),
+      // timing buckets for gRPC server latency measurements with more precise granularity on latencies up to 5s
+      HistogramDefinition(
+        s"${DamlGrpcServerMetrics.GrpcServerMetricsPrefix}*${OpenTelemetryTimer.TimerUnitAndSuffix}",
+        Seq(
+          0.01d, 0.025d, 0.050d, 0.075d, 0.1d, 0.15d, 0.2d, 0.25d, 0.35d, 0.5d, 0.75d, 1d, 1.25d,
+          1.5d, 1.75d, 2d, 2.25d, 2.5d, 2.75d, 3d, 3.5d, 4d, 4.5d, 5d, 10d,
+        ),
+      ),
+      // generic timing buckets
+      HistogramDefinition(
+        s"*${OpenTelemetryTimer.TimerUnitAndSuffix}",
+        Seq(
+          0.01d, 0.025d, 0.050d, 0.075d, 0.1d, 0.15d, 0.2d, 0.25d, 0.35d, 0.5d, 0.75d, 1d, 2.5d, 5d,
+          10d,
+        ),
+      ),
+      // use size specific buckets
+      HistogramDefinition(
+        s"*${Histogram.Bytes}",
+        Seq(
+          kilobytes(10),
+          kilobytes(50),
+          kilobytes(100),
+          kilobytes(500),
+          megabytes(1),
+          megabytes(5),
+          megabytes(10),
+          megabytes(50),
+        ),
+      ),
+    )
+
+    metrics.foreach { metric =>
+      candidates.find(_.name.matches(metric)).foreach { histogram =>
+        builder.registerView(
+          InstrumentSelector
+            .builder()
+            .setType(InstrumentType.HISTOGRAM)
+            .setMeterName(metric)
+            .build(),
+          explicitHistogramBucketsView(histogram.bucketBoundaries),
+        )
+      }
+      builder
+    }
+    builder
+  }
+
+  private def explicitHistogramBucketsView(buckets: Seq[Double]) = View
+    .builder()
+    .setAggregation(
+      Aggregation.explicitBucketHistogram(
+        buckets.map(Double.box).asJava
+      )
+    )
+    .build()
+
+  private def kilobytes(value: Int): Double = value * 1024d
+
+  private def megabytes(value: Int): Double = value * 1024d * 1024d
+
+}

--- a/sdk/release/artifacts.yaml
+++ b/sdk/release/artifacts.yaml
@@ -149,6 +149,8 @@
   type: jar-scala
 - target: //observability/tracing:tracing-test-lib
   type: jar-scala
+- target: //observability/telemetry:telemetry
+  type: jar-scala
 - target: //observability/pekko-http-metrics:pekko-http-metrics
   type: jar-scala
 - target: //canton:community_ledger_ledger-common


### PR DESCRIPTION
This reverts commit 076ddc1321158c8ee1e00a799bb4f3b00e7d16d5.

Only merge if necessary to unblock the sdk-canton sync. 

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
