### PR TITLE
backport upgrade validation compare deps pt1

### DIFF
--- a/sdk/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeCommon.scala
+++ b/sdk/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeCommon.scala
@@ -68,8 +68,9 @@ private[archive] class DecodeCommon(languageVersion: LV) {
     val internedTypes = Work.run(decodeInternedTypes(env0, lfPackage))
     val env = env0.copy(internedTypes = internedTypes)
 
+    val modules = lfPackage.getModulesList.asScala.map(env.decodeModule(_))
     Package.build(
-      modules = lfPackage.getModulesList.asScala.map(env.decodeModule(_)),
+      modules = modules,
       directDeps = dependencyTracker.getDependencies,
       languageVersion = languageVersion,
       metadata = metadata,

--- a/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
+++ b/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
@@ -167,6 +167,15 @@ object UpgradeError {
     override def message: String =
       s"The upgraded package uses an older LF version (${presentVersion.pretty} < ${pastVersion.pretty})"
   }
+
+  final case class DependencyHasLowerVersionDespiteUpgrade(
+      depName: Ref.PackageName,
+      depPresentVersion: Ref.PackageVersion,
+      depPastVersion: Ref.PackageVersion,
+  ) extends Error {
+    override def message: String =
+      s"Dependency $depName has version $depPresentVersion on the upgrading package, which is older than version $depPastVersion on the upgraded package.\nDependency versions of upgrading packages must always be greater or equal to the dependency versions on upgraded packages."
+  }
 }
 
 sealed abstract class UpgradedRecordOrigin
@@ -303,24 +312,48 @@ object TypecheckUpgrades {
     Try(t.map(f(_).get).toSeq)
 
   def typecheckUpgrades(
-      present: (Ref.PackageId, Ast.Package),
+      present: (
+          Ref.PackageId,
+          Ast.Package,
+          Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)],
+      ),
       pastPackageId: Ref.PackageId,
-      mbPastPkg: Option[Ast.Package],
+      mbPastPkg: Option[(Ast.Package, Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)])],
   ): Try[Unit] = {
     mbPastPkg match {
       case None =>
         fail(UpgradeError.CouldNotResolveUpgradedPackageId(Upgrading(pastPackageId, present._1)));
-      case Some(pastPkg) =>
-        val tc = TypecheckUpgrades(Upgrading((pastPackageId, pastPkg), present))
+      case Some((pastPkg, pastPkgDeps)) =>
+        val tc = TypecheckUpgrades(Upgrading((pastPackageId, pastPkg, pastPkgDeps), present))
         tc.check()
     }
   }
+
+  def typecheckUpgrades(
+      present: (
+          Ref.PackageId,
+          Ast.Package,
+      ),
+      pastPackageId: Ref.PackageId,
+      mbPastPkg: Option[Ast.Package],
+  ): Try[Unit] = {
+    val emptyPackageMap: Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)] = Map.empty
+    val presentWithNoDeps = (present._1, present._2, emptyPackageMap)
+    val mbPastPkgWithNoDeps = mbPastPkg.map((_, emptyPackageMap))
+    TypecheckUpgrades.typecheckUpgrades(presentWithNoDeps, pastPackageId, mbPastPkgWithNoDeps)
+  }
 }
 
-case class TypecheckUpgrades(packagesAndIds: Upgrading[(Ref.PackageId, Ast.Package)]) {
+case class TypecheckUpgrades(
+    packages: Upgrading[
+      (Ref.PackageId, Ast.Package, Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)])
+    ]
+) {
   import TypecheckUpgrades._
 
-  private lazy val _package: Upgrading[Ast.Package] = packagesAndIds.map(_._2)
+  private lazy val _package: Upgrading[Ast.Package] = packages.map(_._2)
+  private lazy val dependencies
+      : Upgrading[Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)]] = packages.map(_._3)
 
   private def check(): Try[Unit] = {
     for {
@@ -330,8 +363,26 @@ case class TypecheckUpgrades(packagesAndIds: Upgrading[(Ref.PackageId, Ast.Packa
           _package.map(_.modules),
           (name: Ref.ModuleName, _: Ast.Module) => UpgradeError.MissingModule(name),
         )
+      _ <- checkDeps()
       _ <- tryAll(upgradedModules.values, checkModule(_))
     } yield ()
+  }
+
+  private def checkDeps(): Try[Unit] = {
+    val (_new @ _, existing, _deleted @ _) = extractDelExistNew(dependencies.map(_.values.toMap))
+    tryAll(existing, checkDep).map(_ => ())
+  }
+
+  private def checkDep(dep: (Ref.PackageName, Upgrading[Ref.PackageVersion])): Try[Unit] = {
+    val (depName, depVersions) = dep
+    failIf(
+      depVersions.present < depVersions.past,
+      UpgradeError.DependencyHasLowerVersionDespiteUpgrade(
+        depName,
+        depVersions.present,
+        depVersions.past,
+      ),
+    )
   }
 
   private def checkModule(module: Upgrading[Ast.Module]): Try[Unit] = {


### PR DESCRIPTION
Backport of https://github.com/digital-asset/daml/pull/19274/files to `main-2.x`.