### PR TITLE
ignore non serializable types during upgrade validation

### DIFF
--- a/sdk/daml-lf/validation/BUILD.bazel
+++ b/sdk/daml-lf/validation/BUILD.bazel
@@ -164,6 +164,8 @@ da_scala_test_suite(
             "//test-common:upgrades-UploadSucceedsWhenDepsAreValidUpgrades-v2.dar",
             "//test-common:upgrades-UploadFailsWhenDepsAreInvalidUpgrades-v1.dar",
             "//test-common:upgrades-UploadFailsWhenDepsAreInvalidUpgrades-v2.dar",
+            "//test-common:upgrades-SucceedsWhenNonSerializableTypesAreIncompatible-v1.dar",
+            "//test-common:upgrades-SucceedsWhenNonSerializableTypesAreIncompatible-v2.dar",
 
             # Ported from DamlcUpgrades.hs
             "//test-common:upgrades-FailsWhenExistingFieldInTemplateChoiceIsChanged-v1.dar",

--- a/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
+++ b/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
@@ -495,7 +495,11 @@ case class TypecheckUpgrades(
   ): Try[Unit] = {
     val (name, datatype) = nameAndDatatype
     val origin = moduleWithMetadata.map(_.dataTypeOrigin(name))
-    if (unifyUpgradedRecordOrigin(origin.present) != unifyUpgradedRecordOrigin(origin.past)) {
+    if (!datatype.past.serializable || !datatype.present.serializable) {
+      Success(())
+    } else if (
+      unifyUpgradedRecordOrigin(origin.present) != unifyUpgradedRecordOrigin(origin.past)
+    ) {
       fail(UpgradeError.RecordChangedOrigin(name, origin))
     } else {
       datatype.map(_.cons) match {

--- a/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
+++ b/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
@@ -388,7 +388,7 @@ case class TypecheckUpgrades(
   private def checkModule(module: Upgrading[Ast.Module]): Try[Unit] = {
     def datatypes(module: Ast.Module): Map[Ref.DottedName, Ast.DDataType] =
       module.definitions.collect {
-        case (k, v: Ast.DDataType) if v.serializable => (k, v);
+        case (k, v: Ast.DDataType) if v.serializable => (k, v)
       }
 
     val moduleWithMetadata = module.map(ModuleWithMetadata)

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesSpecBase.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesSpecBase.scala
@@ -591,6 +591,16 @@ trait LongTests { this: UpgradesSpec =>
           Some("The upgraded template A has changed the types of some of its original fields."),
         ),
       )
+
+    "Succeeds even when non-serializable types are incompatible" in {
+      testPackagePair(
+        "test-common/upgrades-SucceedsWhenNonSerializableTypesAreIncompatible-v1.dar",
+        "test-common/upgrades-SucceedsWhenNonSerializableTypesAreIncompatible-v2.dar",
+        assertPackageUpgradeCheck(
+          None
+        ),
+      )
+    }
   }
 }
 

--- a/sdk/test-common/BUILD.bazel
+++ b/sdk/test-common/BUILD.bazel
@@ -167,6 +167,7 @@ da_scala_dar_resources_library(
         ("SucceedsWhenNewFieldWithOptionalTypeIsAddedToTemplateChoice", [], []),
         ("SucceedsWhenTemplateChoiceInputArgumentHasChanged", [], []),
         ("SucceedsWhenTemplateChoiceReturnsATemplateWhichHasChanged", [], []),
+        ("SucceedsWhenNonSerializableTypesAreIncompatible", [], []),
 
         # More tests ported from DamlcUpgrades.hs
         ("FailsWhenATopLevelEnumChanges", [], []),

--- a/sdk/test-common/src/main/daml/upgrades/SucceedsWhenNonSerializableTypesAreIncompatible/v1/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/SucceedsWhenNonSerializableTypesAreIncompatible/v1/Main.daml
@@ -5,7 +5,3 @@ module Main where
 
 -- v1:A is not serializable and should not be compared to v2:A
 data A = A { f : Int -> Int }
-
--- v1:B is serializable, but v2:B is not and thus they should not be compared
-data B = B { x : Int }
-

--- a/sdk/test-common/src/main/daml/upgrades/SucceedsWhenNonSerializableTypesAreIncompatible/v1/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/SucceedsWhenNonSerializableTypesAreIncompatible/v1/Main.daml
@@ -1,0 +1,11 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+-- v1:A is not serializable and should not be compared to v2:A
+data A = A { f : Int -> Int }
+
+-- v1:B is serializable, but v2:B is not and thus they should not be compared
+data B = B { x : Int }
+

--- a/sdk/test-common/src/main/daml/upgrades/SucceedsWhenNonSerializableTypesAreIncompatible/v2/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/SucceedsWhenNonSerializableTypesAreIncompatible/v2/Main.daml
@@ -5,6 +5,3 @@ module Main where
 
 -- v2:A is serializable, but v1:A is not and thus they should not be compared
 data A = A { x : Int }
-
--- v2:B is not serializable and should not be compared to v1:B
-data B = B { x : Int -> Int }

--- a/sdk/test-common/src/main/daml/upgrades/SucceedsWhenNonSerializableTypesAreIncompatible/v2/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/SucceedsWhenNonSerializableTypesAreIncompatible/v2/Main.daml
@@ -1,0 +1,10 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+-- v2:A is serializable, but v1:A is not and thus they should not be compared
+data A = A { x : Int }
+
+-- v2:B is not serializable and should not be compared to v1:B
+data B = B { x : Int -> Int }


### PR DESCRIPTION
Part of https://github.com/digital-asset/daml/issues/19338

Ignore non-serializable types when validating a package for upgrades.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
