### PR TITLE
Force that upgrading types must belong to identically-named packages

### DIFF
--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/admin/PackageUpgradeValidator.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/admin/PackageUpgradeValidator.scala
@@ -113,6 +113,7 @@ class PackageUpgradeValidator(
           )
           _ <- typecheckUpgrades(
             TypecheckUpgrades.MaximalDarCheck,
+            packageMap,
             optUpgradingDar,
             optMaximalDar,
           )
@@ -121,6 +122,7 @@ class PackageUpgradeValidator(
           )
           r <- typecheckUpgrades(
             TypecheckUpgrades.MinimalDarCheck,
+            packageMap,
             optMinimalDar,
             optUpgradingDar,
           )
@@ -188,6 +190,7 @@ class PackageUpgradeValidator(
 
   private def strictTypecheckUpgrades(
       phase: TypecheckUpgrades.UploadPhaseCheck,
+      packageMap: PackageMap,
       optNewDar1: Option[(Ref.PackageId, Ast.Package)],
       oldPkgId2: Ref.PackageId,
       optOldPkg2: Option[Ast.Package],
@@ -205,7 +208,7 @@ class PackageUpgradeValidator(
           EitherT(
             Future(
               TypecheckUpgrades
-                .typecheckUpgrades((newPkgId1, newPkg1), oldPkgId2, optOldPkg2)
+                .typecheckUpgrades(packageMap, (newPkgId1, newPkg1), oldPkgId2, optOldPkg2)
                 .toEither
             )
           ).leftMap[DamlError] {
@@ -222,6 +225,7 @@ class PackageUpgradeValidator(
 
   private def typecheckUpgrades(
       typecheckPhase: TypecheckUpgrades.UploadPhaseCheck,
+      packageMap: PackageMap,
       optNewDar1: Option[(Ref.PackageId, Ast.Package)],
       optOldDar2: Option[(Ref.PackageId, Ast.Package)],
   )(implicit
@@ -233,6 +237,7 @@ class PackageUpgradeValidator(
       case (Some((newPkgId1, newPkg1)), Some((oldPkgId2, oldPkg2))) =>
         strictTypecheckUpgrades(
           typecheckPhase,
+          packageMap,
           Some((newPkgId1, newPkg1)),
           oldPkgId2,
           Some(oldPkg2),

--- a/sdk/daml-lf/validation/BUILD.bazel
+++ b/sdk/daml-lf/validation/BUILD.bazel
@@ -166,6 +166,8 @@ da_scala_test_suite(
             "//test-common:upgrades-UploadFailsWhenDepsAreInvalidUpgrades-v2.dar",
             "//test-common:upgrades-SucceedsWhenNonSerializableTypesAreIncompatible-v1.dar",
             "//test-common:upgrades-SucceedsWhenNonSerializableTypesAreIncompatible-v2.dar",
+            "//test-common:upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-v1.dar",
+            "//test-common:upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-v2.dar",
 
             # Ported from DamlcUpgrades.hs
             "//test-common:upgrades-FailsWhenExistingFieldInTemplateChoiceIsChanged-v1.dar",

--- a/sdk/daml-lf/validation/BUILD.bazel
+++ b/sdk/daml-lf/validation/BUILD.bazel
@@ -168,6 +168,8 @@ da_scala_test_suite(
             "//test-common:upgrades-SucceedsWhenNonSerializableTypesAreIncompatible-v2.dar",
             "//test-common:upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-v1.dar",
             "//test-common:upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-v2.dar",
+            "//test-common:upgrades-FailsWhenUpgradedFieldPackagesAreNotUpgradable-v1.dar",
+            "//test-common:upgrades-FailsWhenUpgradedFieldPackagesAreNotUpgradable-v2.dar",
 
             # Ported from DamlcUpgrades.hs
             "//test-common:upgrades-FailsWhenExistingFieldInTemplateChoiceIsChanged-v1.dar",

--- a/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
+++ b/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
@@ -275,8 +275,8 @@ private case class Env(
 ) {
   def extend(varName1: TypeVarName, varName2: TypeVarName) = Env(
     currentDepth + 1,
-    binderDepthLhs + (varName1 -> currentDepth),
-    binderDepthRhs + (varName2 -> currentDepth),
+    binderDepthLhs.updated(varName1, currentDepth),
+    binderDepthRhs.updated(varName2, currentDepth),
   )
 }
 

--- a/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
+++ b/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
@@ -423,18 +423,21 @@ case class TypecheckUpgrades(
   }
 
   private def checkIdentifiers(past: Ref.Identifier, present: Ref.Identifier): Boolean = {
-    (packageMap.get(past.packageId), packageMap.get(present.packageId)) match {
-      // The two packages have LF versions < 1.16.
-      // They must be the exact same package as LF < 1.16 don't support upgrades.
-      case (None, None) => past.packageId == present.packageId
-      // The two packages have LF versions >= 1.16.
-      // The present package must be a valid upgrade of the past package. Since we validate uploaded packages in
-      // topological order, the package version ordering is a proxy for the "upgrades" relationship.
-      case (Some((pastName, pastVersion)), Some((presentName, presentVersion))) =>
-        pastName == presentName && pastVersion <= presentVersion && past.qualifiedName == present.qualifiedName
-      // LF versions < 1.16 and >= 1.16 are not comparable.
-      case (_, _) => false
-    }
+    val compatibleNames = past.qualifiedName == present.qualifiedName
+    val compatiblePackages =
+      (packageMap.get(past.packageId), packageMap.get(present.packageId)) match {
+        // The two packages have LF versions < 1.16.
+        // They must be the exact same package as LF < 1.16 don't support upgrades.
+        case (None, None) => past.packageId == present.packageId
+        // The two packages have LF versions >= 1.16.
+        // The present package must be a valid upgrade of the past package. Since we validate uploaded packages in
+        // topological order, the package version ordering is a proxy for the "upgrades" relationship.
+        case (Some((pastName, pastVersion)), Some((presentName, presentVersion))) =>
+          pastName == presentName && pastVersion <= presentVersion
+        // LF versions < 1.16 and >= 1.16 are not comparable.
+        case (_, _) => false
+      }
+    compatibleNames && compatiblePackages
   }
 
   @tailrec

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesSpecBase.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesSpecBase.scala
@@ -601,6 +601,16 @@ trait LongTests { this: UpgradesSpec =>
         ),
       )
     }
+
+    "Fails when comparing types from packages with different names" in {
+      testPackagePair(
+        "test-common/upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-v1.dar",
+        "test-common/upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-v2.dar",
+        assertPackageUpgradeCheck(
+          Some("")
+        ),
+      )
+    }
   }
 }
 

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesSpecBase.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesSpecBase.scala
@@ -611,6 +611,16 @@ trait LongTests { this: UpgradesSpec =>
         ),
       )
     }
+
+    "Fails when comparing type constructors from other packages that resolve to incompatible types" in {
+      testPackagePair(
+        "test-common/upgrades-FailsWhenUpgradedFieldPackagesAreNotUpgradable-v1.dar",
+        "test-common/upgrades-FailsWhenUpgradedFieldPackagesAreNotUpgradable-v2.dar",
+        assertPackageUpgradeCheck(
+          Some("The upgraded data type T has changed the types of some of its original fields.")
+        ),
+      )
+    }
   }
 }
 

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesSpecBase.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesSpecBase.scala
@@ -607,7 +607,7 @@ trait LongTests { this: UpgradesSpec =>
         "test-common/upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-v1.dar",
         "test-common/upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-v2.dar",
         assertPackageUpgradeCheck(
-          Some("")
+          Some("The upgraded data type A has changed the types of some of its original fields.")
         ),
       )
     }

--- a/sdk/test-common/BUILD.bazel
+++ b/sdk/test-common/BUILD.bazel
@@ -106,6 +106,22 @@ da_scala_dar_resources_library(
     visibility = ["//visibility:public"],
 )
 
+# Compiles FailsWhenUpgradedFieldFromDifferentPackageName/dep/Dep.daml to two packages with different names.
+[
+    daml_compile(
+        name = "upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-v{}dep".format(name),
+        srcs = glob(["src/main/daml/upgrades/FailsWhenUpgradedFieldFromDifferentPackageName/dep/Dep.daml"]),
+        project_name = "upgrades-example-FailsWhenUpgradedFieldFromDifferentPackageName-v{}dep".format(name),
+        target = "1.dev",
+        version = "1.0.0",
+        visibility = ["//visibility:public"],
+    )
+    for name in [
+        1,
+        2,
+    ]
+]
+
 [
     [
         daml_compile(
@@ -168,6 +184,11 @@ da_scala_dar_resources_library(
         ("SucceedsWhenTemplateChoiceInputArgumentHasChanged", [], []),
         ("SucceedsWhenTemplateChoiceReturnsATemplateWhichHasChanged", [], []),
         ("SucceedsWhenNonSerializableTypesAreIncompatible", [], []),
+        (
+            "FailsWhenUpgradedFieldFromDifferentPackageName",
+            ["//test-common:upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-v1dep.dar"],
+            ["//test-common:upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-v2dep.dar"],
+        ),
 
         # More tests ported from DamlcUpgrades.hs
         ("FailsWhenATopLevelEnumChanges", [], []),

--- a/sdk/test-common/BUILD.bazel
+++ b/sdk/test-common/BUILD.bazel
@@ -189,6 +189,11 @@ da_scala_dar_resources_library(
             ["//test-common:upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-v1dep.dar"],
             ["//test-common:upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-v2dep.dar"],
         ),
+        (
+            "FailsWhenUpgradedFieldPackagesAreNotUpgradable",
+            ["//test-common:upgrades-SucceedsWhenATopLevelRecordAddsAnOptionalFieldAtTheEnd-v2.dar"],
+            ["//test-common:upgrades-SucceedsWhenATopLevelRecordAddsAnOptionalFieldAtTheEnd-v1.dar"],
+        ),
 
         # More tests ported from DamlcUpgrades.hs
         ("FailsWhenATopLevelEnumChanges", [], []),

--- a/sdk/test-common/BUILD.bazel
+++ b/sdk/test-common/BUILD.bazel
@@ -109,16 +109,16 @@ da_scala_dar_resources_library(
 # Compiles FailsWhenUpgradedFieldFromDifferentPackageName/dep/Dep.daml to two packages with different names.
 [
     daml_compile(
-        name = "upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-v{}dep".format(name),
+        name = "upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-dep-{}".format(project_name),
         srcs = glob(["src/main/daml/upgrades/FailsWhenUpgradedFieldFromDifferentPackageName/dep/Dep.daml"]),
-        project_name = "upgrades-example-FailsWhenUpgradedFieldFromDifferentPackageName-v{}dep".format(name),
+        project_name = project_name,
         target = "1.dev",
         version = "1.0.0",
         visibility = ["//visibility:public"],
     )
-    for name in [
-        1,
-        2,
+    for project_name in [
+        "name1",
+        "name2",
     ]
 ]
 
@@ -186,8 +186,8 @@ da_scala_dar_resources_library(
         ("SucceedsWhenNonSerializableTypesAreIncompatible", [], []),
         (
             "FailsWhenUpgradedFieldFromDifferentPackageName",
-            ["//test-common:upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-v1dep.dar"],
-            ["//test-common:upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-v2dep.dar"],
+            ["//test-common:upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-dep-name1.dar"],
+            ["//test-common:upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-dep-name2.dar"],
         ),
         (
             "FailsWhenUpgradedFieldPackagesAreNotUpgradable",

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradedFieldFromDifferentPackageName/dep/Dep.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradedFieldFromDifferentPackageName/dep/Dep.daml
@@ -1,0 +1,6 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Dep where
+
+data T = MkT

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradedFieldFromDifferentPackageName/v1/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradedFieldFromDifferentPackageName/v1/Main.daml
@@ -1,0 +1,9 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+import qualified Dep
+
+data A = A { x : Dep.T }
+

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradedFieldFromDifferentPackageName/v2/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradedFieldFromDifferentPackageName/v2/Main.daml
@@ -1,0 +1,10 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+import qualified Dep
+
+-- This definition is identical to v1:A, but "Dep" is from package with a
+-- different name that the one imported by v1:Main.
+data A = A { x : Dep.T }

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradedFieldPackagesAreNotUpgradable/v1/ProjectMain.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradedFieldPackagesAreNotUpgradable/v1/ProjectMain.daml
@@ -1,0 +1,10 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module ProjectMain where
+
+-- Imported from SucceedsWhenATopLevelRecordAddsAnOptionalFieldAtTheEnd v2
+import qualified Main
+
+data T = T { x: Main.A }
+

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradedFieldPackagesAreNotUpgradable/v2/ProjectMain.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenUpgradedFieldPackagesAreNotUpgradable/v2/ProjectMain.daml
@@ -1,0 +1,16 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module ProjectMain where
+
+-- Imported from SucceedsWhenATopLevelRecordAddsAnOptionalFieldAtTheEnd v1
+import qualified Main
+
+-- This Main.A refers to SucceedsWhenATopLevelRecordAddsAnOptionalFieldAtTheEnd-v1.Main.A,
+-- while the T.x field in v1 of this package refers to
+-- SucceedsWhenATopLevelRecordAddsAnOptionalFieldAtTheEnd-v2.Main.A.
+-- Thus in both versions 1 and 2 of this package, the T.x field have types that:
+--  - have the same package name,
+--  - have the same qualified name,
+--  - and come from two packages that are in an upgrade relationship, but in the wrong order
+data T = T { x: Main.A }


### PR DESCRIPTION
Force that upgrading types must belong to identically-named packages