### PR TITLE
Triggers should rely on the ledger to manager max message size

### DIFF
--- a/sdk/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
+++ b/sdk/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
@@ -156,7 +156,8 @@ object RunnerConfig {
     Ref.UserId.fromString(s).fold(e => throw new IllegalArgumentException(e), identity)
   }
 
-  private[trigger] val DefaultMaxInboundMessageSize: Int = 4194304
+  // We default to MAXINT as we rely on the ledger to manage the message size
+  private[trigger] val DefaultMaxInboundMessageSize: Int = Int.MaxValue
   private[trigger] val DefaultTimeProviderType: TimeProviderType = TimeProviderType.WallClock
   private[trigger] val DefaultApplicationId: Some[Ref.ApplicationId] =
     Some(Ref.ApplicationId.assertFromString("daml-trigger"))


### PR DESCRIPTION
We configure triggers so that their max message size is MAXINT. The intent is that by convention we will manage the max message size on the ledger/canton side.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
