### PR TITLE
Raise size of max inbound msg size - 2.8

### DIFF
--- a/sdk/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/DamlLedgerClient.java
+++ b/sdk/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/DamlLedgerClient.java
@@ -46,6 +46,8 @@ public final class DamlLedgerClient implements LedgerClient {
     private Optional<String> accessToken = Optional.empty();
     private Optional<Duration> timeout = Optional.empty();
 
+    public static final int DefaultMaxInboundMessageSize = 10 * 1024 * 1024;
+
     private Builder(@NonNull NettyChannelBuilder channelBuilder) {
       this.builder = channelBuilder;
       this.builder.usePlaintext();
@@ -79,6 +81,11 @@ public final class DamlLedgerClient implements LedgerClient {
       return this;
     }
 
+    public Builder withMaxInboundMessageSize(int maxInboundMessageSize) {
+      this.builder.maxInboundMessageSize(maxInboundMessageSize);
+      return this;
+    }
+
     public DamlLedgerClient build() {
       return new DamlLedgerClient(
           this.builder, this.expectedLedgerId, this.accessToken, this.timeout);
@@ -97,7 +104,9 @@ public final class DamlLedgerClient implements LedgerClient {
    * builder's capabilities
    */
   public static Builder newBuilder(@NonNull String host, int port) {
-    return new Builder(NettyChannelBuilder.forAddress(host, port));
+    return new Builder(
+        NettyChannelBuilder.forAddress(host, port)
+            .maxInboundMessageSize(Builder.DefaultMaxInboundMessageSize));
   }
 
   /**

--- a/sdk/language-support/scala/bindings-pekko/src/main/scala/com/digitalasset/ledger/client/binding/LedgerClientBinding.scala
+++ b/sdk/language-support/scala/bindings-pekko/src/main/scala/com/digitalasset/ledger/client/binding/LedgerClientBinding.scala
@@ -22,7 +22,10 @@ import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.binding.DomainTransactionMapper.DecoderType
 import com.daml.ledger.client.binding.retrying.CommandRetryFlow
 import com.daml.ledger.client.binding.util.Slf4JLogger
-import com.daml.ledger.client.configuration.LedgerClientConfiguration
+import com.daml.ledger.client.configuration.{
+  LedgerClientChannelConfiguration,
+  LedgerClientConfiguration,
+}
 import com.daml.ledger.client.services.commands.CommandSubmission
 import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
   CompletionFailure,
@@ -30,8 +33,6 @@ import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
 }
 import com.daml.util.Ctx
 import io.grpc.ManagedChannel
-import io.grpc.netty.NegotiationType.TLS
-import io.grpc.netty.NettyChannelBuilder
 import io.netty.handler.ssl.SslContext
 import org.slf4j.LoggerFactory
 import scalaz.syntax.tag._
@@ -146,14 +147,9 @@ class LedgerClientBinding(
 object LedgerClientBinding {
 
   def createChannel(host: String, port: Int, sslContext: Option[SslContext]): ManagedChannel = {
-    val builder = NettyChannelBuilder.forAddress(host, port)
-
-    sslContext match {
-      case Some(context) => builder.sslContext(context).negotiationType(TLS)
-      case None => builder.usePlaintext()
-    }
-
-    builder.build()
+    LedgerClientChannelConfiguration(sslContext)
+      .builderFor(host, port)
+      .build()
   }
 
   @nowarn(

--- a/sdk/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerClientChannelConfiguration.scala
+++ b/sdk/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerClientChannelConfiguration.scala
@@ -14,7 +14,7 @@ import io.netty.handler.ssl.SslContext
 final case class LedgerClientChannelConfiguration(
     sslContext: Option[SslContext],
     maxInboundMetadataSize: Int = GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE,
-    maxInboundMessageSize: Int = GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE,
+    maxInboundMessageSize: Int = LedgerClientChannelConfiguration.DefaultMaxInboundMessageSize,
 ) {
 
   def builderFor(host: String, port: Int): NettyChannelBuilder = {
@@ -29,6 +29,7 @@ final case class LedgerClientChannelConfiguration(
 
 object LedgerClientChannelConfiguration {
 
+  val DefaultMaxInboundMessageSize: Int = 10 * 1024 * 1024
   val InsecureDefaults: LedgerClientChannelConfiguration =
     LedgerClientChannelConfiguration(sslContext = None)
 


### PR DESCRIPTION
* Raise the default size of inbound message size in java bindings (#19325)

* max inbound buffers in scala client and deafult ledger client

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
