### PR TITLE
Script should rely on the ledger to manager max message size

### DIFF
--- a/sdk/daml-script/export/src/main/scala/com/daml/script/export/Config.scala
+++ b/sdk/daml-script/export/src/main/scala/com/daml/script/export/Config.scala
@@ -41,7 +41,8 @@ final case class PartyConfig(
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 object Config {
-  val DefaultMaxInboundMessageSize: Int = 4194304
+  // We default to MAXINT as we rely on the ledger to manage the message size
+  val DefaultMaxInboundMessageSize: Int = Int.MaxValue
 
   def parse(args: Array[String]): Option[Config] =
     parser.parse(args, Empty)

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMainConfig.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMainConfig.scala
@@ -31,6 +31,7 @@ case class RunnerMainConfig(
 
 object RunnerMainConfig {
   val DefaultTimeMode: ScriptTimeMode = ScriptTimeMode.WallClock
+  // We default to MAXINT as we rely on the ledger to manage the message size
   val DefaultMaxInboundMessageSize: Int = Int.MaxValue
 
   sealed trait RunMode

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMainConfig.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMainConfig.scala
@@ -31,7 +31,7 @@ case class RunnerMainConfig(
 
 object RunnerMainConfig {
   val DefaultTimeMode: ScriptTimeMode = ScriptTimeMode.WallClock
-  val DefaultMaxInboundMessageSize: Int = 4194304
+  val DefaultMaxInboundMessageSize: Int = Int.MaxValue
 
   sealed trait RunMode
   object RunMode {


### PR DESCRIPTION
We configure script so that its max message size is MAXINT. The intent is that by convention we will manage the max message size on the ledger/canton side.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
