### PR TITLE
Switch `daml sandbox` to Domain PV6

### DIFF
--- a/sdk/canton/BUILD.bazel
+++ b/sdk/canton/BUILD.bazel
@@ -39,11 +39,11 @@ cat << EOF > $@
 package com.digitalasset.canton.buildinfo
 
 case object BuildInfo {{
-  val version: String = "2.7.0-SNAPSHOT"
+  val version: String = "2.9.0-SNAPSHOT"
   val scalaVersion: String = "{scala_version}"
   val sbtVersion: String = "bazel"
   val damlLibrariesVersion: String = "{sdk_version}"
-  val protocolVersions = List("5")
+  val protocolVersions = List("5", "6")
   override val toString: String = {{
     "version: %s, scalaVersion: %s, sbtVersion: %s, damlLibrariesVersion: %s, protocolVersions: %s".format(
       version, scalaVersion, sbtVersion, damlLibrariesVersion, protocolVersions

--- a/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -334,7 +334,7 @@ cantonConfig CantonOptions{..} =
                      , "admin-api" Aeson..= port cantonDomainAdminApi
                      , "init" Aeson..= Aeson.object
                            [ "domain-parameters" Aeson..= Aeson.object
-                               [ "protocol-version" Aeson..= ("6" :: T.Text) ]
+                               [ "protocol-version" Aeson..= ("latest" :: T.Text) ]
                            ]
                      ]
                 ]

--- a/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -334,7 +334,7 @@ cantonConfig CantonOptions{..} =
                      , "admin-api" Aeson..= port cantonDomainAdminApi
                      , "init" Aeson..= Aeson.object
                            [ "domain-parameters" Aeson..= Aeson.object
-                               [ "protocol-version" Aeson..= ("5" :: T.Text) ]
+                               [ "protocol-version" Aeson..= ("6" :: T.Text) ]
                            ]
                      ]
                 ]

--- a/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -334,7 +334,7 @@ cantonConfig CantonOptions{..} =
                      , "admin-api" Aeson..= port cantonDomainAdminApi
                      , "init" Aeson..= Aeson.object
                            [ "domain-parameters" Aeson..= Aeson.object
-                               [ "protocol-version" Aeson..= ("latest" :: T.Text) ]
+                               [ "protocol-version" Aeson..= ("6" :: T.Text) ]
                            ]
                      ]
                 ]

--- a/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/QuickstartTests.hs
+++ b/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/QuickstartTests.hs
@@ -64,7 +64,7 @@ data QuickSandboxResource = QuickSandboxResource
 
 quickSandbox :: FilePath -> IO QuickSandboxResource
 quickSandbox projDir = do
-    withDevNull $ \devNull -> do
+    withDevNull $ \_ -> do
         callCommandSilent $ unwords ["daml", "new", projDir, "--template=quickstart-java"]
         callCommandSilentIn projDir "daml build"
         ports <- sandboxPorts
@@ -83,8 +83,9 @@ quickSandbox projDir = do
                         , "--dar", darFile
                         , "--static-time"
                         ])
-                    {std_out = UseHandle devNull, create_group = True, cwd = Just projDir}
+                    {std_out = UseHandle stderr, create_group = True, cwd = Just projDir}
         (_, _, _, sandboxPh) <- createProcess sandboxProc
+
         _ <- readPortFile sandboxPh maxRetries (projDir </> portFile)
         pure $
             QuickSandboxResource


### PR DESCRIPTION
Also updates our Canton fork to use daml libraries version 2.9-SNAPSHOT, so that it'll accept PV-6
There is a ticket in the code to automate this:
https://github.com/DACH-NY/canton/issues/15106