### PR TITLE
remove garyverhaegen-da mentions across entire repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,19 +7,19 @@ CODEOWNERS   @gerolf-da @remyhaemmerle-da
 LATEST       @gerolf-da @bame-da
 
 # Build / CI / environment
-/ci/                @garyverhaegen-da
-/dev-env/           @garyverhaegen-da
-/nix/               @garyverhaegen-da
-azure-pipelines.yml @garyverhaegen-da
-azure-cron.yml      @garyverhaegen-da
-/release/           @garyverhaegen-da
-/release.sh         @garyverhaegen-da
+/ci/                @paulbrauner-da
+/dev-env/           @paulbrauner-da
+/nix/               @paulbrauner-da
+azure-pipelines.yml @paulbrauner-da
+azure-cron.yml      @paulbrauner-da
+/release/           @paulbrauner-da
+/release.sh         @paulbrauner-da
 
 # Blackduck
-NOTICES     @garyverhaegen-da @dasormeter
+NOTICES     @paulbrauner-da @dasormeter
 
 # Compatibility test
-/compatibility/     @basvangijzel-DA @garyverhaegen-da @gerolf-da @remyhaemmerle-da
+/compatibility/     @basvangijzel-DA @paulbrauner-da @gerolf-da @remyhaemmerle-da
 
 # Language
 /daml-assistant/    @remyhaemmerle-da @filmackay
@@ -49,7 +49,7 @@ NOTICES     @garyverhaegen-da @dasormeter
 /language-support/hs/       @remyhaemmerle-da
 /language-support/java/     @filmackay
 /language-support/scala/    @filmackay
-/language-support/ts/       @garyverhaegen-da @filmackay
+/language-support/ts/       @paulbrauner-da @filmackay
 
 # Application Runtime
 /ledger-service/       @filmackay

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,6 +100,9 @@ jobs:
         GPG_KEY: $(gpg-code-signing)
     - task: GitHubRelease@0
       inputs:
+        # I have no idea how dependent this is on the existence of my GitHub
+        # account or if this is just the name of the connection in Azure
+        # Pipelines. This is already mentioned in my transtiion document.
         gitHubConnection: 'garyverhaegen-da'
         repositoryName: '$(Build.Repository.Name)'
         action: 'create'

--- a/sdk/release/rotation
+++ b/sdk/release/rotation
@@ -8,5 +8,4 @@ U03SJDAU3BQ basvangijzel-DA
 U04M62HVADS samuel-williams-da
 U02DAFHFXUN moisesackerman-da
 U5LC1FB6D gerolf-da
-UEHSF89AQ garyverhaegen-da
 UEGT3JT0Q remyhaemmerle-da


### PR DESCRIPTION
Almost, at least: my name still appears in the `sdk/compatibility/releases-github-api.json` file.