### PR TITLE
Run canton in dev mode in 'daml start'

### DIFF
--- a/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -309,6 +309,8 @@ cantonConfig CantonOptions{..} =
                 , [ "clock" Aeson..= Aeson.object
                         [ "type" Aeson..= ("sim-clock" :: T.Text) ]
                   | StaticTime True <- [cantonStaticTime] ]
+                , [ "dev-version-support" Aeson..= True]
+                , [ "non-standard-config" Aeson..= True]
                 ] )
             , "participants" Aeson..= Aeson.object
                 [ "sandbox" Aeson..= Aeson.object
@@ -320,7 +322,7 @@ cantonConfig CantonOptions{..} =
                          , "user-management-service" Aeson..= Aeson.object [ "enabled" Aeson..= True ]
                          -- Can be dropped once user mgmt is enabled by default
                          ]
-
+                     , "parameters" Aeson..= Aeson.object [ "dev-version-support" Aeson..= True ]
                      ] <>
                      [ "testing-time" Aeson..= Aeson.object [ "type" Aeson..= ("monotonic-time" :: T.Text) ]
                      | StaticTime True <- [cantonStaticTime]
@@ -334,7 +336,7 @@ cantonConfig CantonOptions{..} =
                      , "admin-api" Aeson..= port cantonDomainAdminApi
                      , "init" Aeson..= Aeson.object
                            [ "domain-parameters" Aeson..= Aeson.object
-                               [ "protocol-version" Aeson..= ("6" :: T.Text) ]
+                               [ "protocol-version" Aeson..= ("dev" :: T.Text) ]
                            ]
                      ]
                 ]


### PR DESCRIPTION
LF version 1.16 is a 'preview' version. In order for our users to be able to test it out with `daml start`, we need to start canton in dev mode for now. Once https://github.com/DACH-NY/canton/pull/19553 is merged to the daml repo via code drop, we can change it to run in "preview" mode.

In the meantime we default to dev to make sure we have something that works asap.