### PR TITLE
Script should rely on the ledger to manager max message size

### DIFF
--- a/sdk/compiler/scenario-service/server/src/main/scala/com/daml/lf/scenario/ScenarioServiceMain.scala
+++ b/sdk/compiler/scenario-service/server/src/main/scala/com/daml/lf/scenario/ScenarioServiceMain.scala
@@ -38,8 +38,8 @@ private final case class ScenarioServiceConfig(
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 private object ScenarioServiceConfig {
-  // default to 128MB
-  val DefaultMaxInboundMessageSize: Int = 128 * 1024 * 1024
+  // We default to MAXINT as we rely on the ledger to manage the message size
+  val DefaultMaxInboundMessageSize: Int = Int.MaxValue
 
   val parser = new scopt.OptionParser[ScenarioServiceConfig]("scenario-service") {
     head("scenario-service")

--- a/sdk/daml-script/runner/src/main/scala/com/daml/lf/engine/script/RunnerMainConfig.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/daml/lf/engine/script/RunnerMainConfig.scala
@@ -28,7 +28,8 @@ case class RunnerMainConfig(
 
 object RunnerMainConfig {
   val DefaultTimeMode: ScriptTimeMode = ScriptTimeMode.WallClock
-  val DefaultMaxInboundMessageSize: Int = 4194304
+  // We default to MAXINT as we rely on the ledger to manage the message size
+  val DefaultMaxInboundMessageSize: Int = Int.MaxValue
 
   sealed trait RunMode
   object RunMode {


### PR DESCRIPTION
We configure script so that its max message size is MAXINT. The intent is that by convention we will manage the max message size on the ledger/canton side.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
