### PR TITLE
Pipe GrpcStatus error metadata through to upload dar

### DIFF
--- a/sdk/bazel-haskell-deps.bzl
+++ b/sdk/bazel-haskell-deps.bzl
@@ -26,8 +26,11 @@ JS_DGTABLE_VERSION = "0.5.2"
 JS_FLOT_VERSION = "0.8.3"
 SHAKE_VERSION = "0.19.6"
 ZIP_VERSION = "1.7.1"
-GRPC_HASKELL_REV = "2f30434fe3526b306dcdb0da78dadf84efa315fc"
-GRPC_HASKELL_SHA256 = "5c5cb24f76a48b4641b3a9230ca13e32d7f27049e1365eb76ec9fec55f2fd83c"
+GRPC_HASKELL_REV = "4b3b04d0ac9d1db53033fb4f0b6864f25b6e945d"
+GRPC_HASKELL_SHA256 = ""
+GRPC_HASKELL_PATCHES = [
+    "@com_github_digital_asset_daml//bazel_tools:grpc-haskell-core-bad-status-meta.patch",
+]
 XML_CONDUIT_VERSION = "1.9.1.1"
 LSP_TYPES_VERSION = "1.4.0.0"
 LSP_TYPES_SHA256 = "7ae8a3bad0e91d4a2af9b93e3ad207e3f4c3dace40d420e0592f6323ac93fb67"
@@ -153,6 +156,7 @@ c2hs_suite(
 )
 """,
         patch_args = ["-p1"],
+        patches = GRPC_HASKELL_PATCHES,
         sha256 = GRPC_HASKELL_SHA256,
         strip_prefix = "gRPC-haskell-{}/core".format(GRPC_HASKELL_REV),
         urls = ["https://github.com/awakesecurity/gRPC-haskell/archive/{}.tar.gz".format(GRPC_HASKELL_REV)],
@@ -185,6 +189,7 @@ cc_library(
 )
 """,
         patch_args = ["-p1"],
+        patches = GRPC_HASKELL_PATCHES,
         sha256 = GRPC_HASKELL_SHA256,
         strip_prefix = "gRPC-haskell-{}/core".format(GRPC_HASKELL_REV),
         urls = ["https://github.com/awakesecurity/gRPC-haskell/archive/{}.tar.gz".format(GRPC_HASKELL_REV)],

--- a/sdk/bazel_tools/googleapis-status-proto.patch
+++ b/sdk/bazel_tools/googleapis-status-proto.patch
@@ -6,7 +6,7 @@ index 9c7900ce7..a7a256a16 100644
  load("@rules_proto//proto:defs.bzl", "proto_library")
  load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
-+exports_files(["status.proto"])
++exports_files(["status.proto", "error_details.proto"])
 +
  proto_library(
      name = "code_proto",

--- a/sdk/bazel_tools/grpc-haskell-core-bad-status-meta.patch
+++ b/sdk/bazel_tools/grpc-haskell-core-bad-status-meta.patch
@@ -1,0 +1,79 @@
+diff --git a/src/Network/GRPC/LowLevel/Client.hs b/src/Network/GRPC/LowLevel/Client.hs
+index b617d91..74adbd4 100644
+--- a/src/Network/GRPC/LowLevel/Client.hs
++++ b/src/Network/GRPC/LowLevel/Client.hs
+@@ -277,8 +277,8 @@ compileNormalRequestResults
+ compileNormalRequestResults x =
+   case extractStatusInfo x of
+     Nothing -> Left GRPCIOUnknownError
+-    Just (_meta, status, details) ->
+-      Left (GRPCIOBadStatusCode status (StatusDetails details))
++    Just (meta, status, details) ->
++      Left (GRPCIOBadStatusCode status (StatusDetails details) meta)
+ 
+ --------------------------------------------------------------------------------
+ -- clientReader (client side of server streaming mode)
+diff --git a/src/Network/GRPC/LowLevel/GRPC.hs b/src/Network/GRPC/LowLevel/GRPC.hs
+index 1f1a532..84f5d20 100644
+--- a/src/Network/GRPC/LowLevel/GRPC.hs
++++ b/src/Network/GRPC/LowLevel/GRPC.hs
+@@ -64,7 +64,7 @@ data GRPCIOError
+     -- reasonable amount of time.
+     GRPCIOShutdownFailure
+   | GRPCIOUnknownError
+-  | GRPCIOBadStatusCode C.StatusCode C.StatusDetails
++  | GRPCIOBadStatusCode C.StatusCode C.StatusDetails MetadataMap
+   | GRPCIODecodeError String
+   | GRPCIOInternalUnexpectedRecv String -- debugging description
+   | GRPCIOHandlerException String
+diff --git a/tests/LowLevelTests.hs b/tests/LowLevelTests.hs
+index 7e82e27..e2708ac 100644
+--- a/tests/LowLevelTests.hs
++++ b/tests/LowLevelTests.hs
+@@ -233,7 +233,7 @@ testServerAuthProcessorCancel =
+       rm <- clientRegisterMethodNormal c "/foo"
+       r <- clientRequest c rm 10 "hi" mempty
+       -- TODO: using checkReqRslt on this first result causes the test to hang!
+-      r @?= Left (GRPCIOBadStatusCode StatusUnauthenticated "denied!")
++      r @?= Left (GRPCIOBadStatusCode StatusUnauthenticated "denied!" mempty)
+       clientRequest c rm 10 "hi" [("foo", "bar")] >>= do
+         checkReqRslt $ \NormalRequestResult{..} -> do
+           rspCode @?= StatusOk
+@@ -442,7 +442,7 @@ testServerCancel =
+   where
+     client c = do
+       rm <- clientRegisterMethodNormal c "/foo"
+-      Left (GRPCIOBadStatusCode s _) <- clientRequest c rm 10 "" mempty
++      Left (GRPCIOBadStatusCode s _ _) <- clientRequest c rm 10 "" mempty
+       s @?= StatusCancelled
+     server s = do
+       let rm = head (normalMethods s)
+@@ -678,8 +678,8 @@ testGoaway =
+       clientRequest c rm 10 "" mempty
+       eer <- clientRequest c rm 1 "" mempty
+       assertBool "Client handles server shutdown gracefully" $ case eer of
+-        Left (GRPCIOBadStatusCode StatusUnavailable _) -> True
+-        Left (GRPCIOBadStatusCode StatusDeadlineExceeded "Deadline Exceeded") -> True
++        Left (GRPCIOBadStatusCode StatusUnavailable _ _) -> True
++        Left (GRPCIOBadStatusCode StatusDeadlineExceeded "Deadline Exceeded" _) -> True
+         Left GRPCIOTimeout -> True
+         _ -> False
+ 
+@@ -696,7 +696,7 @@ testSlowServer =
+     client c = do
+       rm <- clientRegisterMethodNormal c "/foo"
+       result <- clientRequest c rm 1 "" mempty
+-      result @?= Left (GRPCIOBadStatusCode StatusDeadlineExceeded "Deadline Exceeded")
++      result @?= Left (GRPCIOBadStatusCode StatusDeadlineExceeded "Deadline Exceeded" mempty)
+     server s = do
+       let rm = head (normalMethods s)
+       serverHandleNormalCall s rm mempty $ \_ -> do
+@@ -875,7 +875,7 @@ testClientMaxReceiveMessageLengthChannelArg = do
+     -- Expect failure when the max recv payload size is set to 3 bytes, and we
+     -- are sent 4.
+     shouldFail = clientMax 3 $ \case
+-      Left (GRPCIOBadStatusCode StatusResourceExhausted _) ->
++      Left (GRPCIOBadStatusCode StatusResourceExhausted _ _) ->
+         pure ()
+       rsp ->
+         clientFail ("Expected failure response, but got: " ++ show rsp)

--- a/sdk/canton/BUILD.bazel
+++ b/sdk/canton/BUILD.bazel
@@ -1405,11 +1405,12 @@ genrule(
 )
 
 google_rpc_src = "external/go_googleapis"
+
 filegroup(
     name = "google-rpc-source-protos",
     srcs = [
-      "@go_googleapis//google/rpc:status.proto",
-      "@go_googleapis//google/rpc:error_details.proto",
+        "@go_googleapis//google/rpc:error_details.proto",
+        "@go_googleapis//google/rpc:status.proto",
     ],
     visibility = ["//visibility:private"],
 )
@@ -1420,7 +1421,10 @@ genrule(
         ":google-rpc-source-protos",
         "@com_google_protobuf//:well_known_type_protos",
     ],
-    outs = ["Google/Rpc/Status.hs", "Google/Rpc/ErrorDetails.hs"],
+    outs = [
+        "Google/Rpc/Status.hs",
+        "Google/Rpc/ErrorDetails.hs",
+    ],
     cmd = """
         for src in $(locations :google-rpc-source-protos); do
             $(location @proto3-suite//:compile-proto-file) \

--- a/sdk/canton/BUILD.bazel
+++ b/sdk/canton/BUILD.bazel
@@ -1405,21 +1405,30 @@ genrule(
 )
 
 google_rpc_src = "external/go_googleapis"
+filegroup(
+    name = "google-rpc-source-protos",
+    srcs = [
+      "@go_googleapis//google/rpc:status.proto",
+      "@go_googleapis//google/rpc:error_details.proto",
+    ],
+    visibility = ["//visibility:private"],
+)
 
 genrule(
     name = "google-rpc-haskellpb-sources",
     srcs = [
-        "@go_googleapis//google/rpc:status.proto",
+        ":google-rpc-source-protos",
         "@com_google_protobuf//:well_known_type_protos",
     ],
-    outs = ["Google/Rpc/Status.hs"],
+    outs = ["Google/Rpc/Status.hs", "Google/Rpc/ErrorDetails.hs"],
     cmd = """
-        $(location @proto3-suite//:compile-proto-file) \
-            --includeDir """ + google_protobuf_src + """ \
-            --includeDir """ + google_rpc_src + """ \
-            --proto google/rpc/status.proto \
-            --out $$(dirname $$(dirname $(@D)))
-               #2x dirname because @D works differently for a single output
+        for src in $(locations :google-rpc-source-protos); do
+            $(location @proto3-suite//:compile-proto-file) \
+                --includeDir """ + google_protobuf_src + """ \
+                --includeDir """ + google_rpc_src + """ \
+                --proto google/rpc/$$(basename $$src) \
+                --out $(@D)
+        done
     """,
     tools = [
         "@proto3-suite//:compile-proto-file",

--- a/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -242,7 +242,7 @@ runLedgerUploadDar' args darPathM  = do
       exitFailure
   case result of
     Left err -> do
-      putStrLn $ "upload-dar did not succeed: " <> show err
+      putStrLn $ "upload-dar did not succeed: " <> err
       exitFailure
     Right () -> putStrLn "DAR upload succeeded."
 

--- a/sdk/language-support/hs/bindings/src/DA/Ledger/Retry.hs
+++ b/sdk/language-support/hs/bindings/src/DA/Ledger/Retry.hs
@@ -22,7 +22,7 @@ recover = Retry.recovering policy [
     \_ -> Handler $ \(e::GRPCIOError) ->
         return $ case e of
             GRPCIOTimeout -> True
-            GRPCIOBadStatusCode StatusUnavailable _ -> True
+            GRPCIOBadStatusCode StatusUnavailable _ _ -> True
             _ -> False
     ]
 

--- a/sdk/language-support/hs/bindings/src/DA/Ledger/Types.hs
+++ b/sdk/language-support/hs/bindings/src/DA/Ledger/Types.hs
@@ -55,6 +55,7 @@ module DA.Ledger.Types( -- High Level types for communication over Ledger API
     SubmissionId(..),
     LL.Duration(..),
     LL.Status(..),
+    LL.ErrorInfo(..),
     DeduplicationPeriod(..),
     ParticipantId(..),
     IsoTime(..),
@@ -69,6 +70,7 @@ import Prelude hiding(Enum)
 import qualified Data.Text.Lazy as Text(unpack)
 import qualified Google.Protobuf.Duration as LL
 import qualified Google.Rpc.Status as LL
+import qualified Google.Rpc.ErrorDetails as LL
 import qualified Data.Time.Format.ISO8601 as ISO8601
 import qualified Data.Time.Clock as Clock
 import qualified Text.ParserCombinators.ReadP as ReadP


### PR DESCRIPTION
`daml ledger upload-dar` Upgrade errors go from looking like this:
```
Uploading ./v2.dar to localhost:6865
upload-dar did not succeed: "\"DAR_NOT_VALID_UPGRADE(8,487a6369): The DAR contains a package which claims to upgrade another package, but basic checks indicate the package is not a valid upgrade\""
```
To looking like this:
```
Uploading ./v2.dar to localhost:6865
upload-dar did not succeed: DAR_NOT_VALID_UPGRADE(8,87ab3611): The DAR contains a package which claims to upgrade another package, but basic checks indicate the package is not a valid upgrade
  Reason: The upgraded template T has added new fields, but those fields are not Optional.
  When upgrading from package a997627c1dcca83a1e2033338254bdbe1a22d26c2219b6c22f683b2f13d69fb4 to package 7db64de03f160fabde33294ffacec3470f09fece5723622e25d24bfcb75be67e
```