### PR TITLE
Ignore 2.8.7 in UpdateVersions for compatibility tests

### DIFF
--- a/ci/prs.yml
+++ b/ci/prs.yml
@@ -131,6 +131,7 @@ jobs:
       var_name: bash-lib
   - bash: |
       set -euo pipefail
+      cd sdk
       eval "$(./dev-env/bin/dade-assist)"
       source $(bash-lib)
       COMMIT=$(git rev-parse HEAD^2)

--- a/sdk/compatibility/versions/UpdateVersions.hs
+++ b/sdk/compatibility/versions/UpdateVersions.hs
@@ -160,6 +160,9 @@ getMinor v = show (view SemVer.major v) <> "." <> show (view SemVer.minor v)
 unsupportedMinors :: Set String
 unsupportedMinors = Set.fromList ["2.0", "2.1", "2.2", "2.4", "2.5", "2.6"]
 
+unsupportedPatches :: Set String
+unsupportedPatches = Set.fromList ["2.8.7"]
+
 getVersionsFromTags :: IO (Set Version)
 getVersionsFromTags = do
     tags <- lines <$> System.Process.readProcess "git" ["tag"] ""
@@ -167,6 +170,7 @@ getVersionsFromTags = do
            & mapMaybe (fmap (SemVer.fromText . T.pack) . stripPrefix "v")
            & rights
            & filter (null . view SemVer.release)
+           & filter (\v -> Set.notMember (SemVer.toString v) unsupportedPatches)
            & latestPatchVersions
            & filter (\v -> Set.notMember (getMinor v) unsupportedMinors)
            & Set.fromList


### PR DESCRIPTION
as it uses 2.8.6 artifacts.
