### PR TITLE
Fix non-internal deps for split release

### DIFF
--- a/sdk/compiler/damlc/BUILD.bazel
+++ b/sdk/compiler/damlc/BUILD.bazel
@@ -207,6 +207,7 @@ da_haskell_library(
         "regex-tdfa",
         "safe",
         "safe-exceptions",
+        "semver",
         "shake",
         "some",
         "split",


### PR DESCRIPTION
The issue was that dars like daml-script are built using internal version, as release isn't known
external dars are built using release version

Dependencies was fixed for only internal packages, so expected the sdk version, but not the release version
This updates the check to allow both