### PR TITLE
Pipe upload error to dry-run

### DIFF
--- a/sdk/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Ledger.hs
+++ b/sdk/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Ledger.hs
@@ -221,6 +221,8 @@ main = do
                 ""
               exitCode == ExitFailure 1 @? "Dry-run of a wrong update unexpectedely succeeded"
               assertBool "Error message did not contain expected DAR_NOT_VALID_UPGRADE" ("DAR_NOT_VALID_UPGRADE" `L.isInfixOf` out)
+              assertBool "Error message did not contain expected reason" $
+                "Reason: The upgraded data type T has added new fields, but those fields are not Optional." `L.isInfixOf` out
           ]
       , testGroup "fetch-dar"
           [ testCase "succeeds against HTTP JSON API" $ do

--- a/sdk/language-support/hs/bindings/src/DA/Ledger/Services/PackageManagementService.hs
+++ b/sdk/language-support/hs/bindings/src/DA/Ledger/Services/PackageManagementService.hs
@@ -83,5 +83,5 @@ validateDarFile bytes =
         let LL.PackageManagementService {packageManagementServiceValidateDarFile=rpc} = service
         let request = LL.ValidateDarFileRequest bytes TL.empty {- let server allocate submission id -}
         rpc (ClientNormalRequest request timeout mdm)
-            >>= unwrapWithInvalidArgument
-            <&> fmap (\LL.ValidateDarFileResponse{} -> ())
+            >>= unwrapWithInvalidArgumentAndMetadata
+            <&> bimap collapseUploadError (\LL.ValidateDarFileResponse{} -> ())


### PR DESCRIPTION
After #19417, ensures that #19421 also works for `--dry-run`