### PR TITLE
Update the Daml Finance quickstart / tutorial version

### DIFF
--- a/sdk/daml_finance_dep.bzl
+++ b/sdk/daml_finance_dep.bzl
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 quickstart = {
-    "version": "00a9d74967831a33407077443a2d8abe2d0cae5a",
-    "sha256": "5ee56ec0bc8728629ee2007f6efb7732c8cff839b4a5a6fc7a58546ed41d24d9",
+    "version": "8c34f87ff7899e92028d74afabdd9312db752393",
+    "sha256": "be65c06b2c5796d138c12e4aeed3352b99d639c5873447616c648af78d0101ef",
 }

--- a/sdk/daml_finance_dep.bzl
+++ b/sdk/daml_finance_dep.bzl
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 quickstart = {
-    "version": "576adbc8a51e75f1c9faf1217478ce96b193d735",
-    "sha256": "582a4cc40a1c94178fd3bdbda2af681b584725f5481fa6079749ee9bfe64de06",
+    "version": "00a9d74967831a33407077443a2d8abe2d0cae5a",
+    "sha256": "5ee56ec0bc8728629ee2007f6efb7732c8cff839b4a5a6fc7a58546ed41d24d9",
 }


### PR DESCRIPTION
Currently, one of the Daml Finance tutorials (Payoff Modeling) has a minor problem with the `2.9.0-rc1`. This has been fixed in the Daml Finance repo. 

This PR updates the quickstart version so that users get the corrected version of the tutorial when they run `daml new finance-payoff-modeling --template finance-payoff-modeling`