### PR TITLE
Update the Daml Finance quickstart / tutorial version (#19465)

### DIFF
--- a/sdk/daml_finance_dep.bzl
+++ b/sdk/daml_finance_dep.bzl
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 quickstart = {
-    "version": "576adbc8a51e75f1c9faf1217478ce96b193d735",
-    "sha256": "582a4cc40a1c94178fd3bdbda2af681b584725f5481fa6079749ee9bfe64de06",
+    "version": "8c34f87ff7899e92028d74afabdd9312db752393",
+    "sha256": "be65c06b2c5796d138c12e4aeed3352b99d639c5873447616c648af78d0101ef",
 }


### PR DESCRIPTION
Cherry-picked from main:

* update version and sha256

* use commit from main rather from pr

Currently, one of the Daml Finance tutorials (Payoff Modeling) has a minor problem with the 2.9.0-rc1. This has been fixed in the Daml Finance repo. Now, we would like to get this into 2.9.0-rc2.

This PR updates the quickstart version so that users get the corrected version of the tutorial when they run daml new finance-payoff-modeling --template finance-payoff-modeling
