### PR TITLE
Java Codegen: ETX-534 support package names

### DIFF
--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/admin/PingService.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/admin/PingService.scala
@@ -144,7 +144,7 @@ class PingService(
       .unlessShutdown(
         performUnlessClosingF("wait-for-admin-workflows-to-appear-on-ledger-api")(
           connection
-            .getPackageStatus(M.Ping.TEMPLATE_ID.getPackageId)
+            .getPackageStatus(M.Ping.PACKAGE_ID)
             .map(_.packageStatus.isRegistered)
         ),
         AllExnRetryable,

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/admin/workflows/PackageID.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/admin/workflows/PackageID.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.canton.participant.admin.workflows.java
 
 object PackageID {
-  val PingPong: String = pingpong.Ping.TEMPLATE_ID.getPackageId
-  val PingPongVacuum: String = pingpongvacuum.PingCleanup.TEMPLATE_ID.getPackageId
-  val DarDistribution: String = dardistribution.AcceptedDar.TEMPLATE_ID.getPackageId
+  val PingPong: String = pingpong.Ping.PACKAGE_ID
+  val PingPongVacuum: String = pingpongvacuum.PingCleanup.PACKAGE_ID
+  val DarDistribution: String = dardistribution.AcceptedDar.PACKAGE_ID
 }

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/sync/EventTranslationStrategy.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/sync/EventTranslationStrategy.scala
@@ -55,9 +55,9 @@ final class EventTranslationStrategy(
   private val excludedPackageIds: Set[LfPackageId] =
     if (excludeInfrastructureTransactions) {
       Set(
-        LfPackageId.assertFromString(pingpong.Ping.TEMPLATE_ID.getPackageId),
-        LfPackageId.assertFromString(dardistribution.AcceptedDar.TEMPLATE_ID.getPackageId),
-        LfPackageId.assertFromString(pingpongvacuum.PingCleanup.TEMPLATE_ID.getPackageId),
+        LfPackageId.assertFromString(pingpong.Ping.PACKAGE_ID),
+        LfPackageId.assertFromString(dardistribution.AcceptedDar.PACKAGE_ID),
+        LfPackageId.assertFromString(pingpongvacuum.PingCleanup.PACKAGE_ID),
       )
     } else {
       Set.empty[LfPackageId]

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
@@ -66,6 +66,7 @@ object ClassForType extends StrictLogging {
             typeWithContext.auxiliarySignatures,
             typeWithContext.interface.packageId,
             interfaceName,
+            typeWithContext.interface.languageVersion,
             typeWithContext.interface.metadata,
           )
     } yield javaFile(packageName, interfaceClass)

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
@@ -4,7 +4,7 @@
 package com.daml.lf.codegen.backend.java.inner
 
 import com.daml.lf.data.Ref
-import Ref.{ChoiceName, PackageId, PackageName, PackageVersion}
+import Ref.{ChoiceName, PackageId, PackageName, PackageRef, PackageVersion}
 import com.daml.lf.typesig.{DefDataType, Record, TypeCon}
 import com.daml.lf.typesig.PackageSignature.TypeDecl
 
@@ -52,12 +52,13 @@ private[inner] object ClassGenUtils {
   }
 
   val templateIdFieldName = "TEMPLATE_ID"
+  val packageIdFieldName = "PACKAGE_ID"
   val packageNameFieldName = "PACKAGE_NAME"
   val packageVersionFieldName = "PACKAGE_VERSION"
   val companionFieldName = "COMPANION"
   val archiveChoiceName = ChoiceName assertFromString "Archive"
 
-  def generateTemplateIdField(packageId: PackageId, moduleName: String, name: String) =
+  def generateTemplateIdField(packageRef: PackageRef, moduleName: String, name: String) =
     FieldSpec
       .builder(
         ClassName.get(classOf[javaapi.data.Identifier]),
@@ -69,10 +70,22 @@ private[inner] object ClassGenUtils {
       .initializer(
         "new $T($S, $S, $S)",
         classOf[javaapi.data.Identifier],
-        packageId,
+        packageRef,
         moduleName,
         name,
       )
+      .build()
+
+  def generatePackageIdField(packageId: PackageId) =
+    FieldSpec
+      .builder(
+        ClassName.get(classOf[String]),
+        packageIdFieldName,
+        Modifier.STATIC,
+        Modifier.FINAL,
+        Modifier.PUBLIC,
+      )
+      .initializer("$S", packageId)
       .build()
 
   def generatePackageNameField(packageName: PackageName) =

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
@@ -62,7 +62,7 @@ private[inner] object ClassGenUtils {
   val companionFieldName = "COMPANION"
   val archiveChoiceName = ChoiceName assertFromString "Archive"
 
-  def generateTemplateIdField(
+  def generateTemplateIdFields(
       pkgId: PackageId,
       pkgName: Option[PackageName],
       lfVer: LanguageVersion,

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
@@ -55,6 +55,7 @@ private[inner] object ClassGenUtils {
   }
 
   val templateIdFieldName = "TEMPLATE_ID"
+  val templateIdWithPackageIdFieldName = "TEMPLATE_ID_WITH_PACKAGE_ID"
   val packageIdFieldName = "PACKAGE_ID"
   val packageNameFieldName = "PACKAGE_NAME"
   val packageVersionFieldName = "PACKAGE_VERSION"
@@ -67,27 +68,32 @@ private[inner] object ClassGenUtils {
       lfVer: LanguageVersion,
       moduleName: String,
       name: String,
-  ) = {
+  ): Seq[FieldSpec] = {
     val packageRef = pkgName match {
       case Some(name) if lfVer >= LanguageVersion.Features.packageUpgrades => PackageRef.Name(name)
       case _ => PackageRef.Id(pkgId)
     }
-    FieldSpec
-      .builder(
-        ClassName.get(classOf[javaapi.data.Identifier]),
-        templateIdFieldName,
-        Modifier.STATIC,
-        Modifier.FINAL,
-        Modifier.PUBLIC,
-      )
-      .initializer(
-        "new $T($S, $S, $S)",
-        classOf[javaapi.data.Identifier],
-        packageRef,
-        moduleName,
-        name,
-      )
-      .build()
+    def idField(fieldName: String, pkg: String) =
+      FieldSpec
+        .builder(
+          ClassName.get(classOf[javaapi.data.Identifier]),
+          fieldName,
+          Modifier.STATIC,
+          Modifier.FINAL,
+          Modifier.PUBLIC,
+        )
+        .initializer(
+          "new $T($S, $S, $S)",
+          classOf[javaapi.data.Identifier],
+          pkg,
+          moduleName,
+          name,
+        )
+        .build()
+    Seq(
+      idField(templateIdFieldName, packageRef.toString),
+      idField(templateIdWithPackageIdFieldName, pkgId.toString),
+    )
   }
 
   def generatePackageIdField(packageId: PackageId) =

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
@@ -5,6 +5,7 @@ package com.daml.lf.codegen.backend.java.inner
 
 import com.daml.lf.data.Ref
 import Ref.{ChoiceName, PackageId, PackageName, PackageRef, PackageVersion}
+import com.daml.lf.language.LanguageVersion
 import com.daml.lf.typesig.{DefDataType, Record, TypeCon}
 import com.daml.lf.typesig.PackageSignature.TypeDecl
 
@@ -15,6 +16,8 @@ import com.daml.ledger.javaapi
 import com.daml.lf.codegen.NodeWithContext.AuxiliarySignatures
 
 import javax.lang.model.element.Modifier
+
+import scala.math.Ordering.Implicits.infixOrderingOps
 
 private[inner] object ClassGenUtils {
 
@@ -58,7 +61,17 @@ private[inner] object ClassGenUtils {
   val companionFieldName = "COMPANION"
   val archiveChoiceName = ChoiceName assertFromString "Archive"
 
-  def generateTemplateIdField(packageRef: PackageRef, moduleName: String, name: String) =
+  def generateTemplateIdField(
+      pkgId: PackageId,
+      pkgName: Option[PackageName],
+      lfVer: LanguageVersion,
+      moduleName: String,
+      name: String,
+  ) = {
+    val packageRef = pkgName match {
+      case Some(name) if lfVer >= LanguageVersion.Features.packageUpgrades => PackageRef.Name(name)
+      case _ => PackageRef.Id(pkgId)
+    }
     FieldSpec
       .builder(
         ClassName.get(classOf[javaapi.data.Identifier]),
@@ -75,6 +88,7 @@ private[inner] object ClassGenUtils {
         name,
       )
       .build()
+  }
 
   def generatePackageIdField(packageId: PackageId) =
     FieldSpec

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
@@ -34,7 +34,7 @@ object InterfaceClass extends StrictLogging {
       val interfaceType = TypeSpec
         .classBuilder(interfaceName)
         .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
-        .addField(generateTemplateIdField(packageId, interfaceId, languageVersion))
+        .addFields(generateTemplateIdField(packageId, interfaceId, languageVersion).asJava)
         .addField(ClassGenUtils.generatePackageIdField(packageId))
         .addFields(
           TemplateClass
@@ -156,7 +156,7 @@ object InterfaceClass extends StrictLogging {
       packageId: PackageId,
       name: QualifiedName,
       lfVer: LanguageVersion,
-  ): FieldSpec =
+  ): Seq[FieldSpec] =
     ClassGenUtils.generateTemplateIdField(
       pkgId = packageId,
       pkgName = None, // For now, interfaces must always be identified by package id.

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
@@ -34,7 +34,7 @@ object InterfaceClass extends StrictLogging {
       val interfaceType = TypeSpec
         .classBuilder(interfaceName)
         .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
-        .addField(generateTemplateIdField(packageId, interfaceId, languageVersion, packageMetadata))
+        .addField(generateTemplateIdField(packageId, interfaceId, languageVersion))
         .addField(ClassGenUtils.generatePackageIdField(packageId))
         .addFields(
           TemplateClass
@@ -156,14 +156,13 @@ object InterfaceClass extends StrictLogging {
       packageId: PackageId,
       name: QualifiedName,
       lfVer: LanguageVersion,
-      meta: Option[PackageMetadata],
   ): FieldSpec =
     ClassGenUtils.generateTemplateIdField(
-      packageId,
-      meta.map(_.name),
-      lfVer,
-      name.module.toString,
-      name.name.toString,
+      pkgId = packageId,
+      pkgName = None, // For now, interfaces must always be identified by package id.
+      lfVer = lfVer,
+      moduleName = name.module.toString,
+      name = name.name.toString,
     )
 
   private def generateContractFilterMethod(

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
@@ -34,7 +34,7 @@ object InterfaceClass extends StrictLogging {
       val interfaceType = TypeSpec
         .classBuilder(interfaceName)
         .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
-        .addFields(generateTemplateIdField(packageId, interfaceId, languageVersion).asJava)
+        .addFields(generateTemplateIdFields(packageId, interfaceId, languageVersion).asJava)
         .addField(ClassGenUtils.generatePackageIdField(packageId))
         .addFields(
           TemplateClass
@@ -152,12 +152,12 @@ object InterfaceClass extends StrictLogging {
       .build()
   }
 
-  private def generateTemplateIdField(
+  private def generateTemplateIdFields(
       packageId: PackageId,
       name: QualifiedName,
       lfVer: LanguageVersion,
   ): Seq[FieldSpec] =
-    ClassGenUtils.generateTemplateIdField(
+    ClassGenUtils.generateTemplateIdFields(
       pkgId = packageId,
       pkgName = None, // For now, interfaces must always be identified by package id.
       lfVer = lfVer,

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
@@ -7,7 +7,7 @@ import com.daml.ledger.javaapi.data.ContractFilter
 import com.daml.ledger.javaapi.data.codegen.{Contract, InterfaceCompanion}
 import com.daml.lf.codegen.NodeWithContext.AuxiliarySignatures
 import com.daml.lf.codegen.backend.java.inner.TemplateClass.toChoiceNameField
-import com.daml.lf.data.Ref.{ChoiceName, PackageId, PackageRef, QualifiedName}
+import com.daml.lf.data.Ref.{ChoiceName, PackageId, QualifiedName}
 import com.daml.lf.language.LanguageVersion
 import com.daml.lf.typesig.{DefInterface, PackageMetadata}
 import com.squareup.javapoet._
@@ -16,7 +16,6 @@ import scalaz.-\/
 
 import javax.lang.model.element.Modifier
 import scala.jdk.CollectionConverters._
-import scala.math.Ordering.Implicits.infixOrderingOps
 
 object InterfaceClass extends StrictLogging {
 
@@ -158,17 +157,14 @@ object InterfaceClass extends StrictLogging {
       name: QualifiedName,
       lfVer: LanguageVersion,
       meta: Option[PackageMetadata],
-  ): FieldSpec = {
-    val packageRef = meta match {
-      case Some(m) if lfVer >= LanguageVersion.Features.packageUpgrades => PackageRef.Name(m.name)
-      case _ => PackageRef.Id(packageId)
-    }
+  ): FieldSpec =
     ClassGenUtils.generateTemplateIdField(
-      packageRef,
+      packageId,
+      meta.map(_.name),
+      lfVer,
       name.module.toString,
       name.name.toString,
     )
-  }
 
   private def generateContractFilterMethod(
       interfaceName: ClassName,

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -45,7 +45,7 @@ private[inner] object TemplateClass extends StrictLogging {
         .classBuilder(className)
         .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
         .superclass(classOf[javaapi.data.Template])
-        .addFields(generateTemplateIdField(typeWithContext).asJava)
+        .addFields(generateTemplateIdFields(typeWithContext).asJava)
         .addField(ClassGenUtils.generatePackageIdField(typeWithContext.packageId))
         .addMethod(generateCreateMethod(className))
         .addMethods(
@@ -502,8 +502,8 @@ private[inner] object TemplateClass extends StrictLogging {
       )
     )
 
-  private def generateTemplateIdField(typeWithContext: TypeWithContext): Seq[FieldSpec] =
-    ClassGenUtils.generateTemplateIdField(
+  private def generateTemplateIdFields(typeWithContext: TypeWithContext): Seq[FieldSpec] =
+    ClassGenUtils.generateTemplateIdFields(
       typeWithContext.packageId,
       typeWithContext.interface.metadata.map(_.name),
       typeWithContext.interface.languageVersion,

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -11,7 +11,6 @@ import Ref.ChoiceName
 import com.daml.ledger.javaapi.data.codegen.{Choice, Created, Exercised, Update}
 import com.daml.lf.codegen.NodeWithContext.AuxiliarySignatures
 import com.daml.lf.codegen.backend.java.inner.ToValueGenerator.generateToValueConverter
-import com.daml.lf.language.LanguageVersion
 import com.daml.lf.typesig
 import typesig._
 import com.squareup.javapoet._
@@ -21,7 +20,6 @@ import scalaz.syntax.std.option._
 
 import javax.lang.model.element.Modifier
 import scala.jdk.CollectionConverters._
-import scala.math.Ordering.Implicits.infixOrderingOps
 
 private[inner] object TemplateClass extends StrictLogging {
 
@@ -504,19 +502,14 @@ private[inner] object TemplateClass extends StrictLogging {
       )
     )
 
-  private def generateTemplateIdField(typeWithContext: TypeWithContext): FieldSpec = {
-    val lfVer = typeWithContext.interface.languageVersion
-    val packageRef = typeWithContext.interface.metadata match {
-      case Some(meta) if lfVer >= LanguageVersion.Features.packageUpgrades =>
-        Ref.PackageRef.Name(meta.name)
-      case _ => Ref.PackageRef.Id(typeWithContext.packageId)
-    }
+  private def generateTemplateIdField(typeWithContext: TypeWithContext): FieldSpec =
     ClassGenUtils.generateTemplateIdField(
-      packageRef,
+      typeWithContext.packageId,
+      typeWithContext.interface.metadata.map(_.name),
+      typeWithContext.interface.languageVersion,
       typeWithContext.modulesLineage.map(_._1).toImmArray.iterator.mkString("."),
       typeWithContext.name,
     )
-  }
 
   def generateChoicesMetadata(
       templateClassName: ClassName,

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -45,7 +45,7 @@ private[inner] object TemplateClass extends StrictLogging {
         .classBuilder(className)
         .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
         .superclass(classOf[javaapi.data.Template])
-        .addField(generateTemplateIdField(typeWithContext))
+        .addFields(generateTemplateIdField(typeWithContext).asJava)
         .addField(ClassGenUtils.generatePackageIdField(typeWithContext.packageId))
         .addMethod(generateCreateMethod(className))
         .addMethods(
@@ -502,7 +502,7 @@ private[inner] object TemplateClass extends StrictLogging {
       )
     )
 
-  private def generateTemplateIdField(typeWithContext: TypeWithContext): FieldSpec =
+  private def generateTemplateIdField(typeWithContext: TypeWithContext): Seq[FieldSpec] =
     ClassGenUtils.generateTemplateIdField(
       typeWithContext.packageId,
       typeWithContext.interface.metadata.map(_.name),

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/InterfaceSubscriptionsIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/InterfaceSubscriptionsIT.scala
@@ -532,7 +532,7 @@ abstract class InterfaceSubscriptionsITBase(prefix: String, useTemplateIdBasedLe
     allocate(SingleParty),
     enabled = _.templateFilters || useTemplateIdBasedLegacyFormat,
   )(implicit ec => { case Participants(Participant(ledger, party)) =>
-    val packageId = I.TEMPLATE_ID.getPackageId
+    val packageId = I.PACKAGE_ID
     val moduleName = I.TEMPLATE_ID.getModuleName
     val unknownTemplate = new javaapi.data.Identifier(packageId, moduleName, "TemplateDoesNotExist")
     val unknownInterface =

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/InterfaceSubscriptionsIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/InterfaceSubscriptionsIT.scala
@@ -118,7 +118,7 @@ abstract class InterfaceSubscriptionsITBase(prefix: String, useTemplateIdBasedLe
     assertEquals(
       "Create event 1 template ID",
       createdEvent1.templateId.get.toString,
-      T1.TEMPLATE_ID.toV1.toString,
+      T1.TEMPLATE_ID_WITH_PACKAGE_ID.toV1.toString,
     )
     assertEquals("Create event 1 contract ID", createdEvent1.contractId, c1)
     assertViewEquals(createdEvent1.interfaceViews, I.TEMPLATE_ID.toV1) { value =>
@@ -151,7 +151,7 @@ abstract class InterfaceSubscriptionsITBase(prefix: String, useTemplateIdBasedLe
     assertEquals(
       "Create event 2 template ID",
       createdEvent2.templateId.get.toString,
-      T2.TEMPLATE_ID.toV1.toString,
+      T2.TEMPLATE_ID_WITH_PACKAGE_ID.toV1.toString,
     )
     assertEquals("Create event 2 contract ID", createdEvent2.contractId, c2)
     assertViewEquals(createdEvent2.interfaceViews, I.TEMPLATE_ID.toV1) { value =>
@@ -176,7 +176,7 @@ abstract class InterfaceSubscriptionsITBase(prefix: String, useTemplateIdBasedLe
     assertEquals(
       "Create event 3 template ID",
       createdEvent3.templateId.get.toString,
-      T3.TEMPLATE_ID.toV1.toString,
+      T3.TEMPLATE_ID_WITH_PACKAGE_ID.toV1.toString,
     )
     assertEquals("Create event 3 contract ID", createdEvent3.contractId, c3)
     assertViewFailed(createdEvent3.interfaceViews, I.TEMPLATE_ID.toV1)
@@ -438,7 +438,7 @@ abstract class InterfaceSubscriptionsITBase(prefix: String, useTemplateIdBasedLe
       assertEquals(
         "Create event 1 template ID",
         createdEvent1.templateId.get.toString,
-        T1.TEMPLATE_ID.toV1.toString,
+        T1.TEMPLATE_ID_WITH_PACKAGE_ID.toV1.toString,
       )
       assertEquals("Create event 1 contract ID", createdEvent1.contractId, c1.contractId)
       assertEquals(
@@ -702,7 +702,7 @@ abstract class InterfaceSubscriptionsITBase(prefix: String, useTemplateIdBasedLe
 
     } yield assertSingleContractWithSimpleView(
       transactions = transactions,
-      contractIdentifier = carbonv2.carbonv2.T.TEMPLATE_ID.toV1,
+      contractIdentifier = carbonv2.carbonv2.T.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
       viewIdentifier = carbonv1.carbonv1.I.TEMPLATE_ID.toV1,
       contractId = contract.contractId,
       viewValue = 21,
@@ -744,7 +744,7 @@ abstract class InterfaceSubscriptionsITBase(prefix: String, useTemplateIdBasedLe
       )
     } yield assertSingleContractWithSimpleView(
       transactions = transactions,
-      contractIdentifier = carbonv2.carbonv2.T.TEMPLATE_ID.toV1,
+      contractIdentifier = carbonv2.carbonv2.T.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
       viewIdentifier = carbonv3.carbonv3.RetroI.TEMPLATE_ID.toV1,
       contractId = contract.contractId,
       viewValue = 77,

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/TransactionServiceFiltersIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/TransactionServiceFiltersIT.scala
@@ -221,7 +221,7 @@ class TransactionServiceFiltersIT extends LedgerTestSuite {
     assertEquals(
       "Create event 1 template ID",
       createdEvent1.templateId.get,
-      T5.TEMPLATE_ID.toV1,
+      T5.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
     )
     assertEquals("Create event 1 contract ID", createdEvent1.contractId, c1)
     assertLength("Create event 1 has a view", 1, createdEvent1.interfaceViews)
@@ -241,7 +241,7 @@ class TransactionServiceFiltersIT extends LedgerTestSuite {
     assertEquals(
       "Create event 2 template ID",
       createdEvent2.templateId.get,
-      T6.TEMPLATE_ID.toV1,
+      T6.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
     )
     assertEquals("Create event 2 contract ID", createdEvent2.contractId, c2)
     assertLength("Create event 2 has a view", 1, createdEvent2.interfaceViews)
@@ -262,7 +262,7 @@ class TransactionServiceFiltersIT extends LedgerTestSuite {
     assertEquals(
       "Create event 3 template ID",
       createdEvent3.templateId.get.toString,
-      T3.TEMPLATE_ID.toV1.toString,
+      T3.TEMPLATE_ID_WITH_PACKAGE_ID.toV1.toString,
     )
     assertEquals("Create event 3 contract ID", createdEvent3.contractId, c3)
     assertLength("Create event 3 has no view", 0, createdEvent3.interfaceViews)

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_16/UpgradingIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_16/UpgradingIT.scala
@@ -62,7 +62,7 @@ class UpgradingIT extends LedgerTestSuite {
     .withPackageId(PkgNameRef.toString)
 
   private val PkgRefId_UA_V1 =
-    PackageRef.Id(Ref.PackageId.assertFromString(UA_V1.TEMPLATE_ID.getPackageId))
+    PackageRef.Id(Ref.PackageId.assertFromString(UA_V1.PACKAGE_ID))
 
   test(
     "USubscriptionsUnknownPackageNames",

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_16/UpgradingIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_16/UpgradingIT.scala
@@ -234,7 +234,7 @@ class UpgradingIT extends LedgerTestSuite {
             create1,
             payloadUA_1,
             UA_V1.valueDecoder(),
-            UA_V1.TEMPLATE_ID,
+            UA_V1.TEMPLATE_ID_WITH_PACKAGE_ID,
             expectedCreatedEventBlob,
           )
           assertPayloadEquals(
@@ -242,7 +242,7 @@ class UpgradingIT extends LedgerTestSuite {
             create2,
             new UA_V1(party, party, 0L),
             UA_V1.valueDecoder(),
-            UA_V1.TEMPLATE_ID,
+            UA_V1.TEMPLATE_ID_WITH_PACKAGE_ID,
             expectedCreatedEventBlob,
           )
           assertPayloadEquals(
@@ -250,7 +250,7 @@ class UpgradingIT extends LedgerTestSuite {
             create3,
             new UA_V2(party, party, 0L, Optional.empty()),
             UA_V2.valueDecoder(),
-            UA_V2.TEMPLATE_ID,
+            UA_V2.TEMPLATE_ID_WITH_PACKAGE_ID,
             expectedCreatedEventBlob,
           )
           assertPayloadEquals(
@@ -258,15 +258,17 @@ class UpgradingIT extends LedgerTestSuite {
             create4,
             payloadUA_4,
             UA_V2.valueDecoder(),
-            UA_V2.TEMPLATE_ID,
+            UA_V2.TEMPLATE_ID_WITH_PACKAGE_ID,
             expectedCreatedEventBlob,
           )
           assertPayloadEquals(
             "UA create 5",
             create5,
             payloadUA_5,
-            UA_V1.valueDecoder(),
-            UA_V1.TEMPLATE_ID,
+            // The default is now to create the contract with a package name in the template id
+            // So the contract ends up being interpreted as the V2 version.
+            UA_V2.valueDecoder(),
+            UA_V2.TEMPLATE_ID_WITH_PACKAGE_ID,
             expectedCreatedEventBlob,
           )
         case other => fail(s"Expected five create events, got ${other.size}")
@@ -279,7 +281,7 @@ class UpgradingIT extends LedgerTestSuite {
             create1,
             payloadUB_1,
             UB_V2.valueDecoder(),
-            UB_V2.TEMPLATE_ID,
+            UB_V2.TEMPLATE_ID_WITH_PACKAGE_ID,
             expectedCreatedEventBlob,
           )
           assertPayloadEquals(
@@ -287,7 +289,7 @@ class UpgradingIT extends LedgerTestSuite {
             create2,
             payloadUB_2,
             UB_V3.valueDecoder(),
-            UB_V3.TEMPLATE_ID,
+            UB_V3.TEMPLATE_ID_WITH_PACKAGE_ID,
             expectedCreatedEventBlob,
           )
         case other => fail(s"Expected two create events, got ${other.size}")
@@ -340,22 +342,34 @@ class UpgradingIT extends LedgerTestSuite {
     }
   }
 
-  private def assertPayloadEquals[T](
+  private def haveSamePopulatedFields[A <: Template, B <: Template](a: A, b: B) = {
+    val aFields = a.toValue.getFields.asScala
+    val bFields = b.toValue.getFields.asScala
+    val count = aFields.size min bFields.size
+    def fieldIsNone(f: DamlRecord.Field) = f.getValue.equals(DamlOptional.EMPTY)
+    aFields.slice(0, count).equals(bFields.slice(0, count)) &&
+    aFields.slice(count, aFields.size).forall(fieldIsNone) &&
+    bFields.slice(count, bFields.size).forall(fieldIsNone)
+  }
+
+  private def assertPayloadEquals[I <: Template, O <: Template](
       context: String,
       createdEvent: CreatedEvent,
-      payload: T,
-      valueDecoder: ValueDecoder[T],
+      payload: I,
+      valueDecoder: ValueDecoder[O],
       templateId: Identifier,
       expectedCreatedEventBlob: Boolean,
   ): Unit = {
     assertEquals(context, toJavaProto(createdEvent.templateId.get), templateId.toProto)
 
-    assertEquals(
-      context,
-      valueDecoder.decode(
-        DamlRecord.fromProto(value.Record.toJavaProto(createdEvent.getCreateArguments))
+    assert(
+      haveSamePopulatedFields(
+        valueDecoder.decode(
+          DamlRecord.fromProto(value.Record.toJavaProto(createdEvent.getCreateArguments))
+        ),
+        payload,
       ),
-      payload,
+      context,
     )
 
     if (expectedCreatedEventBlob)

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
@@ -130,7 +130,9 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
       )
 
       assert(
-        activeContracts.head.getTemplateId == Identifier.fromJavaProto(Dummy.TEMPLATE_ID.toProto),
+        activeContracts.head.getTemplateId == Identifier.fromJavaProto(
+          Dummy.TEMPLATE_ID_WITH_PACKAGE_ID.toProto
+        ),
         s"Received contract is not of type Dummy, but ${activeContracts.head.templateId}.",
       )
       assert(
@@ -258,6 +260,9 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
     "The ActiveContractsService should return contracts for the requesting parties",
     allocate(TwoParties),
   )(implicit ec => { case Participants(Participant(ledger, alice, bob)) =>
+    val dummyTemplateId = Dummy.TEMPLATE_ID_WITH_PACKAGE_ID
+    val dummyWithParamTemplateId = DummyWithParam.TEMPLATE_ID_WITH_PACKAGE_ID
+    val dummyFactoryTemplateId = DummyFactory.TEMPLATE_ID_WITH_PACKAGE_ID
     for {
       _ <- createDummyContracts(alice, ledger)
       _ <- createDummyContracts(bob, ledger)
@@ -275,37 +280,37 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
         allContractsForAlice.size == 3,
         s"$alice expected 3 events, but received ${allContractsForAlice.size}.",
       )
-      assertTemplates(Seq(alice), allContractsForAlice, Dummy.TEMPLATE_ID, 1)
-      assertTemplates(Seq(alice), allContractsForAlice, DummyWithParam.TEMPLATE_ID, 1)
-      assertTemplates(Seq(alice), allContractsForAlice, DummyFactory.TEMPLATE_ID, 1)
+      assertTemplates(Seq(alice), allContractsForAlice, dummyTemplateId, 1)
+      assertTemplates(Seq(alice), allContractsForAlice, dummyWithParamTemplateId, 1)
+      assertTemplates(Seq(alice), allContractsForAlice, dummyFactoryTemplateId, 1)
 
       assert(
         allContractsForBob.size == 3,
         s"$bob expected 3 events, but received ${allContractsForBob.size}.",
       )
-      assertTemplates(Seq(bob), allContractsForBob, Dummy.TEMPLATE_ID, 1)
-      assertTemplates(Seq(bob), allContractsForBob, DummyWithParam.TEMPLATE_ID, 1)
-      assertTemplates(Seq(bob), allContractsForBob, DummyFactory.TEMPLATE_ID, 1)
+      assertTemplates(Seq(bob), allContractsForBob, dummyTemplateId, 1)
+      assertTemplates(Seq(bob), allContractsForBob, dummyWithParamTemplateId, 1)
+      assertTemplates(Seq(bob), allContractsForBob, dummyFactoryTemplateId, 1)
 
       assert(
         allContractsForAliceAndBob.size == 6,
         s"$alice and $bob expected 6 events, but received ${allContractsForAliceAndBob.size}.",
       )
-      assertTemplates(Seq(alice, bob), allContractsForAliceAndBob, Dummy.TEMPLATE_ID, 2)
-      assertTemplates(Seq(alice, bob), allContractsForAliceAndBob, DummyWithParam.TEMPLATE_ID, 2)
-      assertTemplates(Seq(alice, bob), allContractsForAliceAndBob, DummyFactory.TEMPLATE_ID, 2)
+      assertTemplates(Seq(alice, bob), allContractsForAliceAndBob, dummyTemplateId, 2)
+      assertTemplates(Seq(alice, bob), allContractsForAliceAndBob, dummyWithParamTemplateId, 2)
+      assertTemplates(Seq(alice, bob), allContractsForAliceAndBob, dummyFactoryTemplateId, 2)
 
       assert(
         dummyContractsForAlice.size == 1,
         s"$alice expected 1 event, but received ${dummyContractsForAlice.size}.",
       )
-      assertTemplates(Seq(alice), dummyContractsForAlice, Dummy.TEMPLATE_ID, 1)
+      assertTemplates(Seq(alice), dummyContractsForAlice, dummyTemplateId, 1)
 
       assert(
         dummyContractsForAliceAndBob.size == 2,
         s"$alice and $bob expected 2 events, but received ${dummyContractsForAliceAndBob.size}.",
       )
-      assertTemplates(Seq(alice, bob), dummyContractsForAliceAndBob, Dummy.TEMPLATE_ID, 2)
+      assertTemplates(Seq(alice, bob), dummyContractsForAliceAndBob, dummyTemplateId, 2)
     }
   })
 

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/CommandServiceIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/CommandServiceIT.scala
@@ -33,7 +33,7 @@ final class CommandServiceIT extends LedgerTestSuite {
     } yield {
       assert(active.size == 1)
       val dummyTemplateId = active.flatMap(_.templateId.toList).head
-      assert(dummyTemplateId == Dummy.TEMPLATE_ID.toV1)
+      assert(dummyTemplateId == Dummy.TEMPLATE_ID_WITH_PACKAGE_ID.toV1)
     }
   })
 
@@ -132,8 +132,8 @@ final class CommandServiceIT extends LedgerTestSuite {
       s"The returned transaction should contain a created-event, but was ${event.event}",
     )
     assert(
-      event.getCreated.getTemplateId == Dummy.TEMPLATE_ID.toV1,
-      s"The template ID of the created-event should by ${Dummy.TEMPLATE_ID.toV1}, but was ${event.getCreated.getTemplateId}",
+      event.getCreated.getTemplateId == Dummy.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
+      s"The template ID of the created-event should by ${Dummy.TEMPLATE_ID_WITH_PACKAGE_ID.toV1}, but was ${event.getCreated.getTemplateId}",
     )
   }
 
@@ -161,8 +161,8 @@ final class CommandServiceIT extends LedgerTestSuite {
         s"The returned transaction tree should contain a created-event, but was ${event.kind}",
       )
       assert(
-        event.getCreated.getTemplateId == Dummy.TEMPLATE_ID.toV1,
-        s"The template ID of the created-event should by ${Dummy.TEMPLATE_ID.toV1}, but was ${event.getCreated.getTemplateId}",
+        event.getCreated.getTemplateId == Dummy.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
+        s"The template ID of the created-event should by ${Dummy.TEMPLATE_ID_WITH_PACKAGE_ID.toV1}, but was ${event.getCreated.getTemplateId}",
       )
     }
   })
@@ -569,7 +569,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         assertEquals(
           "Unexpected template identifier in create event",
           trees.flatMap(createdEvents).map(_.getTemplateId),
-          Vector(Dummy.TEMPLATE_ID.toV1),
+          Vector(Dummy.TEMPLATE_ID_WITH_PACKAGE_ID.toV1),
         )
         val contractId = trees.flatMap(createdEvents).head.contractId
         assertEquals(

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/SemanticTests.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/SemanticTests.scala
@@ -190,13 +190,13 @@ final class SemanticTests extends LedgerTestSuite {
       } yield {
         val agreement = assertSingleton(
           "SemanticPaintOffer",
-          createdEvents(tree).filter(_.getTemplateId == PaintAgree.TEMPLATE_ID.toV1),
+          createdEvents(tree).filter(_.getTemplateId == PaintAgree.TEMPLATE_ID_WITH_PACKAGE_ID.toV1),
         )
         assertEquals(
           "Paint agreement parameters",
           agreement.getCreateArguments,
           Record(
-            recordId = Some(PaintAgree.TEMPLATE_ID.toV1),
+            recordId = Some(PaintAgree.TEMPLATE_ID_WITH_PACKAGE_ID.toV1),
             fields = Seq(
               RecordField("painter", Some(Value(Value.Sum.Party(painter)))),
               RecordField("houseOwner", Some(Value(Value.Sum.Party(houseOwner)))),
@@ -227,13 +227,13 @@ final class SemanticTests extends LedgerTestSuite {
       } yield {
         val agreement = assertSingleton(
           "SemanticPaintCounterOffer",
-          createdEvents(tree).filter(_.getTemplateId == PaintAgree.TEMPLATE_ID.toV1),
+          createdEvents(tree).filter(_.getTemplateId == PaintAgree.TEMPLATE_ID_WITH_PACKAGE_ID.toV1),
         )
         assertEquals(
           "Paint agreement parameters",
           agreement.getCreateArguments,
           Record(
-            recordId = Some(PaintAgree.TEMPLATE_ID.toV1),
+            recordId = Some(PaintAgree.TEMPLATE_ID_WITH_PACKAGE_ID.toV1),
             fields = Seq(
               RecordField("painter", Some(Value(Value.Sum.Party(painter)))),
               RecordField("houseOwner", Some(Value(Value.Sum.Party(houseOwner)))),
@@ -320,7 +320,7 @@ final class SemanticTests extends LedgerTestSuite {
 
         tree <- alpha.exercise(houseOwner, offer.exercisePaintOffer_Accept(iou))
         (newIouEvents, agreementEvents) = createdEvents(tree).partition(
-          _.getTemplateId == Iou.TEMPLATE_ID.toV1
+          _.getTemplateId == Iou.TEMPLATE_ID_WITH_PACKAGE_ID.toV1
         )
         newIouEvent <- Future(newIouEvents.head)
         agreementEvent <- Future(agreementEvents.head)

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceExerciseIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceExerciseIT.scala
@@ -49,13 +49,13 @@ class TransactionServiceExerciseIT extends LedgerTestSuite {
       assertEquals(
         "Create should be of DummyWithParam",
         create.getTemplateId,
-        DummyWithParam.TEMPLATE_ID.toV1,
+        DummyWithParam.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
       )
       val archive = assertSingleton("GetArchive", dummyFactory.flatMap(archivedEvents))
       assertEquals(
         "Archive should be of DummyFactory",
         archive.getTemplateId,
-        DummyFactory.TEMPLATE_ID.toV1,
+        DummyFactory.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
       )
       assertEquals(
         "Mismatching archived contract identifier",

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceStreamsIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceStreamsIT.scala
@@ -196,7 +196,6 @@ class TransactionServiceStreamsIT extends LedgerTestSuite {
     "The transaction service should correctly filter by template identifier",
     allocate(SingleParty),
   )(implicit ec => { case Participants(Participant(ledger, party)) =>
-    val filterBy = Dummy.TEMPLATE_ID
     val create = ledger.submitAndWaitRequest(
       party,
       (new Dummy(party).create.commands.asScala ++ new DummyFactory(
@@ -205,10 +204,14 @@ class TransactionServiceStreamsIT extends LedgerTestSuite {
     )
     for {
       _ <- ledger.submitAndWait(create)
-      transactions <- ledger.flatTransactionsByTemplateId(filterBy, party)
+      transactions <- ledger.flatTransactionsByTemplateId(Dummy.TEMPLATE_ID, party)
     } yield {
       val contract = assertSingleton("FilterByTemplate", transactions.flatMap(createdEvents))
-      assertEquals("FilterByTemplate", contract.getTemplateId, filterBy.toV1)
+      assertEquals(
+        "FilterByTemplate",
+        contract.getTemplateId,
+        Dummy.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
+      )
     }
   })
 }


### PR DESCRIPTION
- Populate package names into the package part of `TEMPLATE_ID`, if present and supported by LF version
- Interfaces will still always use a package id in their `TEMPLATE_ID`, until the ledger supports package names for interfaces
- Add `PACKAGE_ID` field to each class, so we always have a way to find it.
- Add `TEMPLATE_ID_WITH_PACKAGE_ID` field to each class, for cases where you need to preserve the behaviour where the template id is pinned to the package.