### PR TITLE
Addtional test multi package with different target

### DIFF
--- a/sdk/ledger-service/http-json-oracle/BUILD.bazel
+++ b/sdk/ledger-service/http-json-oracle/BUILD.bazel
@@ -70,6 +70,7 @@ da_scala_test_suite(
         "//ledger-service/http-json:Account.dar",
         "//ledger-service/http-json:CIou.dar",
         "//ledger-service/http-json:FooV1.dar",
+        "//ledger-service/http-json:FooV1OldTarget.dar",
         "//ledger-service/http-json:FooV2.dar",
         "//ledger-service/http-json:RIou.dar",
         "//ledger-service/http-json:User.dar",

--- a/sdk/ledger-service/http-json/BUILD.bazel
+++ b/sdk/ledger-service/http-json/BUILD.bazel
@@ -227,12 +227,22 @@ daml_compile(
     visibility = ["//ledger-service:__subpackages__"],
 )
 
-# Upgraded by FooV2
+# Upgraded by FooV2 with same target
 daml_compile(
     name = "FooV1",
     srcs = ["src/it/daml/upgrades/v1/Foo.daml"],
     project_name = "foo",
     target = "1.dev",
+    version = "0.0.1",
+    visibility = ["//ledger-service:__subpackages__"],
+)
+
+#Upgraded by FooV2 but different target
+daml_compile(
+    name = "FooV1OldTarget",
+    srcs = ["src/it/daml/upgrades/v1/Foo.daml"],
+    project_name = "foo",
+    target = "1.15",
     version = "0.0.1",
     visibility = ["//ledger-service:__subpackages__"],
 )

--- a/sdk/ledger-service/http-json/BUILD.bazel
+++ b/sdk/ledger-service/http-json/BUILD.bazel
@@ -492,6 +492,7 @@ alias(
             ":Account.dar",
             ":CIou.dar",
             ":FooV1.dar",
+            ":FooV1OldTarget.dar",
             ":FooV2.dar",
             ":RIou.dar",
             ":User.dar",

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -698,7 +698,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           hdrs,
         ) map { results =>
           results.map(_.contractId) should contain theSameElementsAs List(
-            cidV2PkgId,
+            cidV2PkgId
           )
         }
       } yield succeed

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -674,7 +674,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         (alice, hdrs) <- fixture.getUniquePartyAndAuthHeaders("Alice")
         // create v1 and v2 versions of contract, using the package name and package id.
         // v1 versions of contract, using the package id
-        cidV1PkgId <- postCreate(
+        _cidV1PkgId <- postCreate(
           fixture,
           jsObject(
             s"""{"templateId": "$pkgIdFooV1OldTarget:Foo:Bar", "payload": {"owner": "$alice"}}"""

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -681,20 +681,6 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           ),
           hdrs,
         )
-        cidV1PkgNm <- postCreate(
-          fixture,
-          // Payload per V1 but interpreted as V2, as the current highest version with this name.
-          jsObject(s"""{"templateId": "#foo:Foo:Bar", "payload": {"owner": "$alice"}}"""),
-          hdrs,
-        )
-        cidV1PkgNmWithV1Pref <- postCreate(
-          fixture,
-          // Payload per V1 and interpreted as V1, due to the explicit package id preference.
-          jsObject(
-            s"""{"templateId": "#foo:Foo:Bar", "payload": {"owner": "$alice"}, "meta":{"packageIdSelectionPreference":["$pkgIdFooV1OldTarget"]}}"""
-          ),
-          hdrs,
-        )
         // v2 versions of contract, using the package id, payload from V2
         cidV2PkgId <- postCreate(
           fixture,
@@ -703,42 +689,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           ),
           hdrs,
         )
-        // v2 versions of contract, using the package name, payload from V2
-        cidV2PkgNm <- postCreate(
-          fixture,
-          jsObject(
-            s"""{"templateId": "#foo:Foo:Bar", "payload": {"owner": "$alice", "extra":42}}"""
-          ),
-          hdrs,
-        )
-
-        // Queries using both package ids and package name.
-        // Query 1. via package id V1
-        _ <- searchExpectOk(
-          Nil,
-          jsObject(s"""{"templateIds": ["$pkgIdFooV1OldTarget:Foo:Bar"]}"""),
-          fixture,
-          hdrs,
-        ) map { results =>
-          results.map(_.contractId) should contain theSameElementsAs List(
-            cidV1PkgId,
-            cidV1PkgNmWithV1Pref,
-          )
-        }
-        // Query 2. via package id V2
-        _ <- searchExpectOk(
-          Nil,
-          jsObject(s"""{"templateIds": ["$pkgIdFooV2:Foo:Bar"]}"""),
-          fixture,
-          hdrs,
-        ) map { results =>
-          results.map(_.contractId) should contain theSameElementsAs List(
-            cidV1PkgNm,
-            cidV2PkgId,
-            cidV2PkgNm,
-          )
-        }
-        // Query 3. via package name
+        // Query via package name
         // When ask for the package name contracts with old target version should not appear
         _ <- searchExpectOk(
           Nil,
@@ -747,9 +698,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
           hdrs,
         ) map { results =>
           results.map(_.contractId) should contain theSameElementsAs List(
-            cidV1PkgNm,
             cidV2PkgId,
-            cidV2PkgNm,
           )
         }
       } yield succeed

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -658,91 +658,101 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
     } yield succeed
   }
 
-  "should handle multiple package ids with the same name but different target (supporting or not package name)" in withHttpService { fixture =>
-    import AbstractHttpServiceIntegrationTestFuns.{fooV1DarOldTarget, fooV2Dar, pkgIdFooV1OldTarget, pkgIdFooV2}
-
-    for {
-      _ <- uploadPackage(fixture)(fooV1DarOldTarget)
-      _ <- uploadPackage(fixture)(fooV2Dar)
-
-      (alice, hdrs) <- fixture.getUniquePartyAndAuthHeaders("Alice")
-      // create v1 and v2 versions of contract, using the package name and package id.
-      // v1 versions of contract, using the package id
-      cidV1PkgId <- postCreate(
-        fixture,
-        jsObject(s"""{"templateId": "$pkgIdFooV1OldTarget:Foo:Bar", "payload": {"owner": "$alice"}}"""),
-        hdrs,
-      )
-      cidV1PkgNm <- postCreate(
-        fixture,
-        // Payload per V1 but interpreted as V2, as the current highest version with this name.
-        jsObject(s"""{"templateId": "#foo:Foo:Bar", "payload": {"owner": "$alice"}}"""),
-        hdrs,
-      )
-      cidV1PkgNmWithV1Pref <- postCreate(
-        fixture,
-        // Payload per V1 and interpreted as V1, due to the explicit package id preference.
-        jsObject(
-          s"""{"templateId": "#foo:Foo:Bar", "payload": {"owner": "$alice"}, "meta":{"packageIdSelectionPreference":["$pkgIdFooV1OldTarget"]}}"""
-        ),
-        hdrs,
-      )
-      // v2 versions of contract, using the package id, payload from V2
-      cidV2PkgId <- postCreate(
-        fixture,
-        jsObject(
-          s"""{"templateId": "$pkgIdFooV2:Foo:Bar", "payload": {"owner": "$alice", "extra":42}}"""
-        ),
-        hdrs,
-      )
-      // v2 versions of contract, using the package name, payload from V2
-      cidV2PkgNm <- postCreate(
-        fixture,
-        jsObject(s"""{"templateId": "#foo:Foo:Bar", "payload": {"owner": "$alice", "extra":42}}"""),
-        hdrs,
-      )
-
-      // Queries using both package ids and package name.
-      // Query 1. via package id V1
-      _ <- searchExpectOk(
-        Nil,
-        jsObject(s"""{"templateIds": ["$pkgIdFooV1OldTarget:Foo:Bar"]}"""),
-        fixture,
-        hdrs,
-      ) map { results =>
-        results.map(_.contractId) should contain theSameElementsAs List(
-          cidV1PkgId,
-          cidV1PkgNmWithV1Pref,
-        )
+  "should handle multiple package ids with the same name but different target (supporting or not package name)" in withHttpService {
+    fixture =>
+      import AbstractHttpServiceIntegrationTestFuns.{
+        fooV1DarOldTarget,
+        fooV2Dar,
+        pkgIdFooV1OldTarget,
+        pkgIdFooV2,
       }
-      // Query 2. via package id V2
-      _ <- searchExpectOk(
-        Nil,
-        jsObject(s"""{"templateIds": ["$pkgIdFooV2:Foo:Bar"]}"""),
-        fixture,
-        hdrs,
-      ) map { results =>
-        results.map(_.contractId) should contain theSameElementsAs List(
-          cidV1PkgNm,
-          cidV2PkgId,
-          cidV2PkgNm,
+
+      for {
+        _ <- uploadPackage(fixture)(fooV1DarOldTarget)
+        _ <- uploadPackage(fixture)(fooV2Dar)
+
+        (alice, hdrs) <- fixture.getUniquePartyAndAuthHeaders("Alice")
+        // create v1 and v2 versions of contract, using the package name and package id.
+        // v1 versions of contract, using the package id
+        cidV1PkgId <- postCreate(
+          fixture,
+          jsObject(
+            s"""{"templateId": "$pkgIdFooV1OldTarget:Foo:Bar", "payload": {"owner": "$alice"}}"""
+          ),
+          hdrs,
         )
-      }
-      // Query 3. via package name
-      // When ask for the package name contracts with old target version should not appear
-      _ <- searchExpectOk(
-        Nil,
-        jsObject(s"""{"templateIds": ["#foo:Foo:Bar"]}"""),
-        fixture,
-        hdrs,
-      ) map { results =>
-        results.map(_.contractId) should contain theSameElementsAs List(
-          cidV1PkgNm,
-          cidV2PkgId,
-          cidV2PkgNm,
+        cidV1PkgNm <- postCreate(
+          fixture,
+          // Payload per V1 but interpreted as V2, as the current highest version with this name.
+          jsObject(s"""{"templateId": "#foo:Foo:Bar", "payload": {"owner": "$alice"}}"""),
+          hdrs,
         )
-      }
-    } yield succeed
+        cidV1PkgNmWithV1Pref <- postCreate(
+          fixture,
+          // Payload per V1 and interpreted as V1, due to the explicit package id preference.
+          jsObject(
+            s"""{"templateId": "#foo:Foo:Bar", "payload": {"owner": "$alice"}, "meta":{"packageIdSelectionPreference":["$pkgIdFooV1OldTarget"]}}"""
+          ),
+          hdrs,
+        )
+        // v2 versions of contract, using the package id, payload from V2
+        cidV2PkgId <- postCreate(
+          fixture,
+          jsObject(
+            s"""{"templateId": "$pkgIdFooV2:Foo:Bar", "payload": {"owner": "$alice", "extra":42}}"""
+          ),
+          hdrs,
+        )
+        // v2 versions of contract, using the package name, payload from V2
+        cidV2PkgNm <- postCreate(
+          fixture,
+          jsObject(
+            s"""{"templateId": "#foo:Foo:Bar", "payload": {"owner": "$alice", "extra":42}}"""
+          ),
+          hdrs,
+        )
+
+        // Queries using both package ids and package name.
+        // Query 1. via package id V1
+        _ <- searchExpectOk(
+          Nil,
+          jsObject(s"""{"templateIds": ["$pkgIdFooV1OldTarget:Foo:Bar"]}"""),
+          fixture,
+          hdrs,
+        ) map { results =>
+          results.map(_.contractId) should contain theSameElementsAs List(
+            cidV1PkgId,
+            cidV1PkgNmWithV1Pref,
+          )
+        }
+        // Query 2. via package id V2
+        _ <- searchExpectOk(
+          Nil,
+          jsObject(s"""{"templateIds": ["$pkgIdFooV2:Foo:Bar"]}"""),
+          fixture,
+          hdrs,
+        ) map { results =>
+          results.map(_.contractId) should contain theSameElementsAs List(
+            cidV1PkgNm,
+            cidV2PkgId,
+            cidV2PkgNm,
+          )
+        }
+        // Query 3. via package name
+        // When ask for the package name contracts with old target version should not appear
+        _ <- searchExpectOk(
+          Nil,
+          jsObject(s"""{"templateIds": ["#foo:Foo:Bar"]}"""),
+          fixture,
+          hdrs,
+        ) map { results =>
+          results.map(_.contractId) should contain theSameElementsAs List(
+            cidV1PkgNm,
+            cidV2PkgId,
+            cidV2PkgNm,
+          )
+        }
+      } yield succeed
   }
 
   "should support create and exerciseByKey with package names" in withHttpService { fixture =>

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -658,7 +658,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
     } yield succeed
   }
 
-  "should handle multiple package ids with the same name but different target (supporting or not package name)" in withHttpService {
+  "should not identify templates from old packages (<=LF 1.15) using a package name" in withHttpService {
     fixture =>
       import AbstractHttpServiceIntegrationTestFuns.{
         fooV1DarOldTarget,
@@ -672,7 +672,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         _ <- uploadPackage(fixture)(fooV2Dar)
 
         (alice, hdrs) <- fixture.getUniquePartyAndAuthHeaders("Alice")
-        // create v1 and v2 versions of contract, using the package name and package id.
+        // create v1 and v2 versions of contract, using the package id.
         // v1 versions of contract, using the package id
         _ <- postCreate(
           fixture,

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -658,6 +658,93 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
     } yield succeed
   }
 
+  "should handle multiple package ids with the same name but different target (supporting or not package name)" in withHttpService { fixture =>
+    import AbstractHttpServiceIntegrationTestFuns.{fooV1DarOldTarget, fooV2Dar, pkgIdFooV1OldTarget, pkgIdFooV2}
+
+    for {
+      _ <- uploadPackage(fixture)(fooV1DarOldTarget)
+      _ <- uploadPackage(fixture)(fooV2Dar)
+
+      (alice, hdrs) <- fixture.getUniquePartyAndAuthHeaders("Alice")
+      // create v1 and v2 versions of contract, using the package name and package id.
+      // v1 versions of contract, using the package id
+      cidV1PkgId <- postCreate(
+        fixture,
+        jsObject(s"""{"templateId": "$pkgIdFooV1OldTarget:Foo:Bar", "payload": {"owner": "$alice"}}"""),
+        hdrs,
+      )
+      cidV1PkgNm <- postCreate(
+        fixture,
+        // Payload per V1 but interpreted as V2, as the current highest version with this name.
+        jsObject(s"""{"templateId": "#foo:Foo:Bar", "payload": {"owner": "$alice"}}"""),
+        hdrs,
+      )
+      cidV1PkgNmWithV1Pref <- postCreate(
+        fixture,
+        // Payload per V1 and interpreted as V1, due to the explicit package id preference.
+        jsObject(
+          s"""{"templateId": "#foo:Foo:Bar", "payload": {"owner": "$alice"}, "meta":{"packageIdSelectionPreference":["$pkgIdFooV1OldTarget"]}}"""
+        ),
+        hdrs,
+      )
+      // v2 versions of contract, using the package id, payload from V2
+      cidV2PkgId <- postCreate(
+        fixture,
+        jsObject(
+          s"""{"templateId": "$pkgIdFooV2:Foo:Bar", "payload": {"owner": "$alice", "extra":42}}"""
+        ),
+        hdrs,
+      )
+      // v2 versions of contract, using the package name, payload from V2
+      cidV2PkgNm <- postCreate(
+        fixture,
+        jsObject(s"""{"templateId": "#foo:Foo:Bar", "payload": {"owner": "$alice", "extra":42}}"""),
+        hdrs,
+      )
+
+      // Queries using both package ids and package name.
+      // Query 1. via package id V1
+      _ <- searchExpectOk(
+        Nil,
+        jsObject(s"""{"templateIds": ["$pkgIdFooV1OldTarget:Foo:Bar"]}"""),
+        fixture,
+        hdrs,
+      ) map { results =>
+        results.map(_.contractId) should contain theSameElementsAs List(
+          cidV1PkgId,
+          cidV1PkgNmWithV1Pref,
+        )
+      }
+      // Query 2. via package id V2
+      _ <- searchExpectOk(
+        Nil,
+        jsObject(s"""{"templateIds": ["$pkgIdFooV2:Foo:Bar"]}"""),
+        fixture,
+        hdrs,
+      ) map { results =>
+        results.map(_.contractId) should contain theSameElementsAs List(
+          cidV1PkgNm,
+          cidV2PkgId,
+          cidV2PkgNm,
+        )
+      }
+      // Query 3. via package name
+      // When ask for the package name contracts with old target version should not appear
+      _ <- searchExpectOk(
+        Nil,
+        jsObject(s"""{"templateIds": ["#foo:Foo:Bar"]}"""),
+        fixture,
+        hdrs,
+      ) map { results =>
+        results.map(_.contractId) should contain theSameElementsAs List(
+          cidV1PkgNm,
+          cidV2PkgId,
+          cidV2PkgNm,
+        )
+      }
+    } yield succeed
+  }
+
   "should support create and exerciseByKey with package names" in withHttpService { fixture =>
     val tmplId = "#foo:Foo:Quux"
     for {

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -674,7 +674,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
         (alice, hdrs) <- fixture.getUniquePartyAndAuthHeaders("Alice")
         // create v1 and v2 versions of contract, using the package name and package id.
         // v1 versions of contract, using the package id
-        _cidV1PkgId <- postCreate(
+        _ <- postCreate(
           fixture,
           jsObject(
             s"""{"templateId": "$pkgIdFooV1OldTarget:Foo:Bar", "payload": {"owner": "$alice"}}"""

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
@@ -63,6 +63,7 @@ object AbstractHttpServiceIntegrationTestFuns {
   private[http] val riouDar = requiredResource("ledger-service/http-json/RIou.dar")
 
   private[http] val fooV1Dar = requiredResource("ledger-service/http-json/FooV1.dar")
+  private[http] val fooV1DarOldTarget = requiredResource("ledger-service/http-json/FooV1OldTarget.dar")
   private[http] val fooV2Dar = requiredResource("ledger-service/http-json/FooV2.dar")
 
   private[this] def packageIdOfDar(darFile: java.io.File): Ref.PackageId = {
@@ -77,6 +78,7 @@ object AbstractHttpServiceIntegrationTestFuns {
   lazy val pkgIdRiou = packageIdOfDar(riouDar)
   lazy val pkgIdUser = packageIdOfDar(userDar)
   lazy val pkgIdFooV1 = packageIdOfDar(fooV1Dar)
+  lazy val pkgIdFooV1OldTarget = packageIdOfDar(fooV1DarOldTarget)
   lazy val pkgIdFooV2 = packageIdOfDar(fooV2Dar)
   lazy val pkgIdAccount = packageIdOfDar(dar2)
 

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
@@ -63,7 +63,9 @@ object AbstractHttpServiceIntegrationTestFuns {
   private[http] val riouDar = requiredResource("ledger-service/http-json/RIou.dar")
 
   private[http] val fooV1Dar = requiredResource("ledger-service/http-json/FooV1.dar")
-  private[http] val fooV1DarOldTarget = requiredResource("ledger-service/http-json/FooV1OldTarget.dar")
+  private[http] val fooV1DarOldTarget = requiredResource(
+    "ledger-service/http-json/FooV1OldTarget.dar"
+  )
   private[http] val fooV2Dar = requiredResource("ledger-service/http-json/FooV2.dar")
 
   private[this] def packageIdOfDar(darFile: java.io.File): Ref.PackageId = {


### PR DESCRIPTION
added new test to the multi-package support, this one in particular to cover the situation of packages with different target lf... in particular when one of the targets is old enough that it does not support package name, thus when the json api request a query specifically with package name the results will only include the contracts with the newer and supported target (bigger than version 1.15)
