### PR TITLE
Backport iface compiler checks 2.x

### DIFF
--- a/sdk/.pre-commit-config.yaml
+++ b/sdk/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       description: Idempotently add DA copyright headers to source files.
       language: system
       pass_filenames: false
-      entry: "dade-copyright-headers update"
+      entry: "bash -c 'unset GIT_DIR; dade-copyright-headers update'"
       types: [text]
     - id: platform-independence-check
       name: platform-independence-check

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -17,9 +17,12 @@ import           DA.Daml.LF.Ast.Alpha (alphaExpr, alphaType)
 import           DA.Daml.LF.TypeChecker.Check (expandTypeSynonyms)
 import           DA.Daml.LF.TypeChecker.Env
 import           DA.Daml.LF.TypeChecker.Error
+import           Data.Bifunctor (first)
 import           Data.Data
+import           Data.Either (partitionEithers)
 import           Data.Hashable
 import qualified Data.HashMap.Strict as HMS
+import           Data.List (foldl')
 import qualified Data.NameMap as NM
 import qualified Data.Text as T
 import           Development.IDE.Types.Diagnostics
@@ -58,22 +61,40 @@ runGammaUnderUpgrades Upgrading{ _past = pastAction, _present = presentAction } 
     presentResult <- withReaderT _present presentAction
     pure Upgrading { _past = pastResult, _present = presentResult }
 
-checkUpgrade :: Version -> Upgrading LF.Package -> [Diagnostic]
-checkUpgrade version package =
-    let upgradingWorld = fmap (\package -> emptyGamma (initWorldSelf [] package) version) package
-        result =
-            runGammaF
-                upgradingWorld
-                (checkUpgradeM package)
+checkUpgrade :: Version -> Bool -> LF.Package -> Maybe (LF.PackageId, LF.Package) -> [Diagnostic]
+checkUpgrade version shouldTypecheckUpgrades presentPkg mbUpgradedPackage =
+    let bothPkgDiagnostics :: Either Error ((), [Warning])
+        bothPkgDiagnostics =
+            case mbUpgradedPackage of
+                Nothing ->
+                    Right ((), [])
+                Just (_, pastPkg) ->
+                    let package = Upgrading { _past = pastPkg, _present = presentPkg }
+                        upgradingWorld = fmap (\package -> emptyGamma (initWorldSelf [] package) version) package
+                    in
+                    runGammaF upgradingWorld $ do
+                        when shouldTypecheckUpgrades (checkUpgradeM package)
+
+        singlePkgDiagnostics :: Either Error ((), [Warning])
+        singlePkgDiagnostics =
+            let world = initWorldSelf [] presentPkg
+            in
+            runGamma world version $ do
+                 checkNewInterfacesHaveNoTemplates presentPkg
+                 checkNewInterfacesAreUnused presentPkg
+
+        extractDiagnostics :: Either Error ((), [Warning]) -> [Diagnostic]
+        extractDiagnostics result =
+            case result of
+              Left err -> [toDiagnostic err]
+              Right ((), warnings) -> map toDiagnostic warnings
     in
-    case result of
-      Left err -> [toDiagnostic err]
-      Right ((), warnings) -> map toDiagnostic warnings
+    extractDiagnostics bothPkgDiagnostics ++ extractDiagnostics singlePkgDiagnostics
 
 checkUpgradeM :: Upgrading LF.Package -> TcUpgradeM ()
 checkUpgradeM package = do
     (upgradedModules, _new) <- checkDeleted (EUpgradeError . MissingModule . NM.name) $ NM.toHashMap . packageModules <$> package
-    forM_ upgradedModules checkModule
+    forM_ upgradedModules $ \module_ -> checkModule package module_
 
 extractDelExistNew
     :: (Eq k, Hashable k)
@@ -90,32 +111,52 @@ checkDeleted
     => (a -> Error)
     -> Upgrading (HMS.HashMap k a)
     -> TcUpgradeM (HMS.HashMap k (Upgrading a), HMS.HashMap k a)
-checkDeleted handleError upgrade = do
+checkDeleted handleError upgrade =
+    checkDeletedG ((Nothing,) . handleError) upgrade
+
+checkDeletedWithContext
+    :: (Eq k, Hashable k)
+    => (a -> (Context, Error))
+    -> Upgrading (HMS.HashMap k a)
+    -> TcUpgradeM (HMS.HashMap k (Upgrading a), HMS.HashMap k a)
+checkDeletedWithContext handleError upgrade =
+    checkDeletedG (first Just . handleError) upgrade
+
+checkDeletedG
+    :: (Eq k, Hashable k)
+    => (a -> (Maybe Context, Error))
+    -> Upgrading (HMS.HashMap k a)
+    -> TcUpgradeM (HMS.HashMap k (Upgrading a), HMS.HashMap k a)
+checkDeletedG handleError upgrade = do
     let (deleted, existing, new) = extractDelExistNew upgrade
     throwIfNonEmpty handleError deleted
     pure (existing, new)
 
 throwIfNonEmpty
     :: (Eq k, Hashable k)
-    => (a -> Error)
+    => (a -> (Maybe Context, Error))
     -> HMS.HashMap k a
     -> TcUpgradeM ()
 throwIfNonEmpty handleError hm =
     case HMS.toList hm of
-      ((_, first):_) -> throwWithContextF present $ handleError first
+      ((_, first):_) ->
+          let (ctx, err) = handleError first
+              ctxHandler =
+                  case ctx of
+                    Nothing -> id
+                    Just ctx -> withContextF present ctx
+          in
+          ctxHandler $ throwWithContextF present err
       _ -> pure ()
 
-checkModule :: Upgrading LF.Module -> TcUpgradeM ()
-checkModule module_ = do
+checkModule :: Upgrading LF.Package -> Upgrading LF.Module -> TcUpgradeM ()
+checkModule package module_ = do
     (existingTemplates, _new) <- checkDeleted (EUpgradeError . MissingTemplate . NM.name) $ NM.toHashMap . moduleTemplates <$> module_
     forM_ existingTemplates $ \template ->
         withContextF
             present
             (ContextTemplate (_present module_) (_present template) TPWhole)
             (checkTemplate module_ template)
-
-    -- checkDeleted should only trigger on datatypes not belonging to templates or choices, which we checked above
-    (dtExisting, _dtNew) <- checkDeleted (EUpgradeError . MissingDataCon . NM.name) $ NM.toHashMap . moduleDataTypes <$> module_
 
     -- For a datatype, derive its context
     let deriveChoiceInfo :: LF.Module -> HMS.HashMap LF.TypeConName (LF.Template, LF.TemplateChoice)
@@ -151,6 +192,65 @@ checkModule module_ = do
                 , ContextDefDataType module_ dt
                 )
 
+    let ifaceDts :: Upgrading (HMS.HashMap LF.TypeConName (DefDataType, DefInterface))
+        unownedDts :: Upgrading (HMS.HashMap LF.TypeConName DefDataType)
+        (ifaceDts, unownedDts) =
+            let Upgrading
+                    { _past = (pastIfaceDts, pastUnownedDts)
+                    , _present = (presentIfaceDts, presentUnownedDts)
+                    } = fmap splitModuleDts module_
+            in
+            ( Upgrading pastIfaceDts presentIfaceDts
+            , Upgrading pastUnownedDts presentUnownedDts
+            )
+
+        splitModuleDts
+            :: Module
+            -> ( HMS.HashMap LF.TypeConName (DefDataType, DefInterface)
+               , HMS.HashMap LF.TypeConName DefDataType)
+        splitModuleDts module_ =
+            let (ifaceDtsList, unownedDtsList) =
+                    partitionEithers
+                        $ map (\(tcon, def) -> lookupInterface module_ tcon def)
+                        $ HMS.toList $ NM.toHashMap $ moduleDataTypes module_
+            in
+            (HMS.fromList ifaceDtsList, HMS.fromList unownedDtsList)
+
+        lookupInterface
+            :: Module -> LF.TypeConName -> DefDataType
+            -> Either (LF.TypeConName, (DefDataType, DefInterface)) (LF.TypeConName, DefDataType)
+        lookupInterface module_ tcon datatype =
+            case NM.name datatype `NM.lookup` moduleInterfaces module_ of
+              Nothing -> Right (tcon, datatype)
+              Just iface -> Left (tcon, (datatype, iface))
+
+    -- Check that no interfaces have been deleted, nor propagated
+    -- New interface checks are handled by `checkNewInterfacesHaveNoTemplates`,
+    -- invoked in `singlePkgDiagnostics` above
+    -- Interface deletion is the correct behaviour so we ignore that
+    let (_ifaceDel, ifaceExisting, _ifaceNew) = extractDelExistNew ifaceDts
+    checkContinuedIfaces module_ ifaceExisting
+
+    let flattenInstances
+            :: Module
+            -> HMS.HashMap (TypeConName, Qualified TypeConName) (Template, TemplateImplements)
+        flattenInstances module_ = HMS.fromList
+            [ ((NM.name template, NM.name implementation), (template, implementation))
+            | template <- NM.elems (moduleTemplates module_)
+            , implementation <- NM.elems (tplImplements template)
+            ]
+    (_instanceExisting, instanceNew) <-
+        checkDeletedWithContext
+            (\(tpl, impl) ->
+                ( ContextTemplate (_present module_) tpl TPWhole
+                , EUpgradeError (MissingImplementation (NM.name tpl) (LF.qualObject (NM.name impl)))
+                ))
+            (flattenInstances <$> module_)
+    checkUpgradedInterfacesAreUnused (_present package) (_present module_) instanceNew
+
+    -- checkDeleted should only trigger on datatypes not belonging to templates or choices or interfaces, which we checked above
+    (dtExisting, _dtNew) <- checkDeleted (EUpgradeError . MissingDataCon . NM.name) unownedDts
+
     forM_ dtExisting $ \dt ->
         -- Get origin/context for each datatype in both _past and _present
         let origin = dataTypeOrigin <$> dt <*> module_
@@ -162,6 +262,79 @@ checkModule module_ = do
         else do
             let (presentOrigin, context) = _present origin
             withContextF present context $ checkDefDataType presentOrigin dt
+
+-- It is always invalid to keep an interface in an upgrade
+checkContinuedIfaces
+    :: Upgrading Module
+    -> HMS.HashMap LF.TypeConName (Upgrading (DefDataType, DefInterface))
+    -> TcUpgradeM ()
+checkContinuedIfaces module_ ifaces =
+    forM_ ifaces $ \upgradedDtIface ->
+        let (_dt, iface) = _present upgradedDtIface
+        in
+        withContextF present (ContextDefInterface (_present module_) iface IPWhole) $
+            throwWithContextF present $ EUpgradeError $ TriedToUpgradeIface (NM.name iface)
+
+-- This warning should run even when no upgrade target is set
+checkNewInterfacesHaveNoTemplates :: LF.Package -> TcM ()
+checkNewInterfacesHaveNoTemplates presentPkg =
+    let modules = NM.toHashMap $ packageModules presentPkg
+        templateDefined = HMS.filter (not . NM.null . moduleTemplates) modules
+        interfaceDefined = HMS.filter (not . NM.null . moduleInterfaces) modules
+        templateAndInterfaceDefined =
+            HMS.intersectionWith (,) templateDefined interfaceDefined
+    in
+    forM_ (HMS.toList templateAndInterfaceDefined) $ \(_, (module_, _)) ->
+        withContext (ContextDefModule module_) $
+            warnWithContext WShouldDefineIfacesAndTemplatesSeparately
+
+-- This warning should run even when no upgrade target is set
+checkNewInterfacesAreUnused :: LF.Package -> TcM ()
+checkNewInterfacesAreUnused presentPkg =
+    forM_ definedAndInstantiated $ \((module_, iface), implementations) ->
+        withContext (ContextDefInterface module_ iface IPWhole) $
+            warnWithContext $ WShouldDefineIfaceWithoutImplementation (NM.name iface) ((\(_,a,_) -> NM.name a) <$> implementations)
+    where
+    definedIfaces :: HMS.HashMap (LF.Qualified LF.TypeConName) (Module, DefInterface)
+    definedIfaces = HMS.unions
+        [ HMS.mapKeys qualify $ HMS.map (module_,) $ NM.toHashMap (moduleInterfaces module_)
+        | module_ <- NM.elems (packageModules presentPkg)
+        , let qualify :: LF.TypeConName -> LF.Qualified LF.TypeConName
+              qualify tcn = Qualified PRSelf (NM.name module_) tcn
+        ]
+
+    definedAndInstantiated
+        :: HMS.HashMap
+            (LF.Qualified LF.TypeConName)
+            ((Module, DefInterface), [(Module, Template, TemplateImplements)])
+    definedAndInstantiated = HMS.intersectionWith (,) definedIfaces (instantiatedIfaces presentPkg)
+
+checkUpgradedInterfacesAreUnused
+    :: Package
+    -> Module
+    -> HMS.HashMap (TypeConName, Qualified TypeConName) (Template, TemplateImplements)
+    -> TcUpgradeM ()
+checkUpgradedInterfacesAreUnused package module_ newInstances = do
+    forM_ (HMS.toList newInstances) $ \((tplName, ifaceName), (tpl, implementation)) ->
+        when (fromUpgradedPackage ifaceName) $
+            let qualifiedTplName = Qualified PRSelf (moduleName module_) tplName
+                ifaceInstanceHead = InterfaceInstanceHead ifaceName qualifiedTplName
+            in
+            withContextF present (ContextTemplate module_ tpl (TPInterfaceInstance ifaceInstanceHead Nothing)) $
+                warnWithContextF present $ WShouldDefineTplInSeparatePackage (NM.name tpl) (LF.qualObject (NM.name implementation))
+    where
+    fromUpgradedPackage :: forall a. LF.Qualified a -> Bool
+    fromUpgradedPackage identifier =
+        case (upgradedPackageId =<< packageMetadata package, qualPackage identifier) of
+          (Just upgradedId, PRImport identifierOrigin) -> upgradedId == identifierOrigin
+          _ -> False
+
+instantiatedIfaces :: LF.Package -> HMS.HashMap (LF.Qualified LF.TypeConName) [(Module, Template, TemplateImplements)]
+instantiatedIfaces pkg = foldl' (HMS.unionWith (<>)) HMS.empty $ (map . fmap) pure
+    [ HMS.map (module_,template,) $ NM.toHashMap $ tplImplements template
+    | module_ <- NM.elems (packageModules pkg)
+    , template <- NM.elems (moduleTemplates module_)
+    ]
 
 checkTemplate :: Upgrading Module -> Upgrading LF.Template -> TcUpgradeM ()
 checkTemplate module_ template = do

--- a/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -161,13 +161,9 @@ buildDar service PackageConfigFields {..} ifDir dalfInput = do
                      Nothing -> mergePkgs pMeta lfVersion . map fst <$> usesE GeneratePackage files
                      Just _ -> generateSerializedPackage pName pVersion pMeta files
 
-                 when pTypecheckUpgrades $
-                     case mbUpgradedPackage of
-                        Just (_, upgradedPackage) ->
-                          MaybeT $ do
-                            let upgradePair = Upgrading { _past = upgradedPackage, _present = pkg }
-                            runDiagnosticCheck $ diagsToIdeResult (toNormalizedFilePath' pSrc) $ TypeChecker.Upgrade.checkUpgrade lfVersion upgradePair
-                        _ -> pure ()
+                 MaybeT $
+                     runDiagnosticCheck $ diagsToIdeResult (toNormalizedFilePath' pSrc) $
+                         TypeChecker.Upgrade.checkUpgrade lfVersion pTypecheckUpgrades pkg mbUpgradedPackage
                  MaybeT $ finalPackageCheck (toNormalizedFilePath' pSrc) pkg
 
                  let pkgModuleNames = map (Ghc.mkModuleName . T.unpack) $ LF.packageModuleNames pkg

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -32,6 +32,7 @@ tests damlc =
         [ test
               "Warns when template changes signatories"
               (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A signatories:\n  The upgraded template A has changed the definition of its signatories.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -55,6 +56,7 @@ tests damlc =
         , test
               "Warns when template changes observers"
               (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A observers:\n  The upgraded template A has changed the definition of its observers.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -82,6 +84,7 @@ tests damlc =
         , test
               "Warns when template changes ensure"
               (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A precondition:\n  The upgraded template A has changed the definition of its precondition.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -109,6 +112,7 @@ tests damlc =
         , test
               "Warns when template changes agreement"
               (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A agreement:\n  The upgraded template A has changed the definition of agreement.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "{-# OPTIONS -Wno-template-agreement #-}"
@@ -138,6 +142,7 @@ tests damlc =
         , test
               "Warns when template changes key expression"
               (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A key:\n  The upgraded template A has changed the expression for computing its key.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -167,6 +172,7 @@ tests damlc =
         , test
               "Warns when template changes key maintainers"
               (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A key:\n  The upgraded template A has changed the maintainers for its key.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -196,6 +202,7 @@ tests damlc =
         , test
               "Fails when template changes key type"
               (FailWithError "\ESC\\[0;91merror type checking template MyLib.A key:\n  The upgraded template A cannot change its key type.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -225,6 +232,7 @@ tests damlc =
         , test
               "Fails when template removes key type"
               (FailWithError "\ESC\\[0;91merror type checking template MyLib.A key:\n  The upgraded template A cannot remove its key.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -252,6 +260,7 @@ tests damlc =
         , test
               "Fails when template adds key type"
               (FailWithError "\ESC\\[0;91merror type checking template MyLib.A key:\n  The upgraded template A cannot add a key where it didn't have one previously.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -279,6 +288,7 @@ tests damlc =
         , test
               "Fails when new field is added to template without Optional type"
               (FailWithError "\ESC\\[0;91merror type checking template MyLib.A :\n  The upgraded template A has added new fields, but those fields are not Optional.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -305,6 +315,7 @@ tests damlc =
         , test
               "Fails when old field is deleted from template"
               (FailWithError "\ESC\\[0;91merror type checking template MyLib.A :\n  The upgraded template A is missing some of its original fields.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -329,6 +340,7 @@ tests damlc =
         , test
               "Fails when existing field in template is changed"
               (FailWithError "\ESC\\[0;91merror type checking template MyLib.A :\n  The upgraded template A has changed the types of some of its original fields.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -354,6 +366,7 @@ tests damlc =
         , test
               "Succeeds when new field with optional type is added to template"
               Succeed
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -380,6 +393,7 @@ tests damlc =
         , test
               "Fails when new field is added to template choice without Optional type"
               (FailWithError "\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded input type of choice C on template A has added new fields, but those fields are not Optional.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -416,6 +430,7 @@ tests damlc =
         , test
               "Fails when old field is deleted from template choice"
               (FailWithError "\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded input type of choice C on template A is missing some of its original fields.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -450,6 +465,7 @@ tests damlc =
         , test
               "Fails when existing field in template choice is changed"
               (FailWithError "\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded input type of choice C on template A has changed the types of some of its original fields.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -485,6 +501,7 @@ tests damlc =
         , test
               "Warns when controllers of template choice are changed"
               (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A choice C:\n  The upgraded choice C has changed the definition of controllers.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -516,6 +533,7 @@ tests damlc =
         , test
               "Warns when observers of template choice are changed"
               (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.A choice C:\n  The upgraded choice C has changed the definition of observers.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -549,6 +567,7 @@ tests damlc =
         , test
               "Fails when template choice changes its return type"
               (FailWithError "\ESC\\[0;91merror type checking template MyLib.A choice C:\n  The upgraded choice C cannot change its return type.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -584,6 +603,7 @@ tests damlc =
         , test
               "Succeeds when template choice returns a template which has changed"
               Succeed
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -614,6 +634,7 @@ tests damlc =
         , test
               "Succeeds when template choice input argument has changed"
               Succeed
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -648,6 +669,7 @@ tests damlc =
         , test
               "Succeeds when new field with optional type is added to template choice"
               Succeed
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -684,6 +706,7 @@ tests damlc =
         , test
               "Fails when a top-level record adds a non-optional field"
               (FailWithError "\ESC\\[0;91merror type checking data type MyLib.A:\n  The upgraded data type A has added new fields, but those fields are not Optional.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -701,6 +724,7 @@ tests damlc =
         , test
               "Succeeds when a top-level record adds an optional field at the end"
               Succeed
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -718,6 +742,7 @@ tests damlc =
         , test
               "Fails when a top-level record adds an optional field before the end"
               (FailWithError "\ESC\\[0;91merror type checking data type MyLib.A:\n  The upgraded data type A has changed the order of its fields - any new fields must be added at the end of the record.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -735,6 +760,7 @@ tests damlc =
         , test
               "Succeeds when a top-level variant adds a variant"
               Succeed
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -752,6 +778,7 @@ tests damlc =
         , test
               "Fails when a top-level variant removes a variant"
               (FailWithError "\ESC\\[0;91merror type checking <none>:\n  Data type A.Z appears in package that is being upgraded, but does not appear in this package.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -769,6 +796,7 @@ tests damlc =
         , test
               "Fail when a top-level variant changes changes the order of its variants"
               (FailWithError "\ESC\\[0;91merror type checking data type MyLib.A:\n  The upgraded data type A has changed the order of its variants - any new variant must be added at the end of the variant.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -786,6 +814,7 @@ tests damlc =
         , test
               "Fails when a top-level variant adds a field to a variant's type"
               (FailWithError "\ESC\\[0;91merror type checking data type MyLib.A:\n  The upgraded variant constructor Y from variant A has added a field.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -803,6 +832,7 @@ tests damlc =
         , test
               "Succeeds when a top-level variant adds an optional field to a variant's type"
               Succeed
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -820,6 +850,7 @@ tests damlc =
         , test
               "Succeed when a top-level enum adds a field"
               Succeed
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -837,6 +868,7 @@ tests damlc =
         , test
               "Fail when a top-level enum changes changes the order of its variants"
               (FailWithError "\ESC\\[0;91merror type checking data type MyLib.A:\n  The upgraded data type A has changed the order of its variants - any new variant must be added at the end of the enum.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -854,6 +886,7 @@ tests damlc =
         , test
               "Succeeds when a top-level type synonym changes"
               Succeed
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -875,6 +908,7 @@ tests damlc =
         , test
               "Succeeds when two deeply nested type synonyms resolve to the same datatypes"
               Succeed
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -903,6 +937,7 @@ tests damlc =
         , test
               "Fails when two deeply nested type synonyms resolve to different datatypes"
               (FailWithError "\ESC\\[0;91merror type checking template MyLib.A :\n  The upgraded template A has changed the types of some of its original fields.")
+              NoDependencies
               [ ( "daml/MyLib.daml"
                 , unlines
                       [ "module MyLib where"
@@ -929,35 +964,325 @@ tests damlc =
                       ]
                 )
               ]
+        , test
+              "Succeeds when an interface is only defined in the initial package."
+              Succeed
+              NoDependencies
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "data IView = IView { i : Text }"
+                      , "interface I where"
+                      , "  viewtype IView"
+                      , "  method1 : Int"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "data IView = IView { i : Text }" -- TODO: Do we also want to ignore dropped viewtypes?
+                      ]
+                )
+              ]
+        , test
+              "Fails when an interface is defined in an upgrading package when it was already in the prior package."
+              (FailWithError "\ESC\\[0;91merror type checking interface MyLib.I :\n  Tried to upgrade interface I, but interfaces cannot be upgraded. They should be removed in any upgrading package.")
+              NoDependencies
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "data IView = IView { i : Text }"
+                      , "interface I where"
+                      , "  viewtype IView"
+                      , "  method1 : Int"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "data IView = IView { i : Text }"
+                      , "interface I where"
+                      , "  viewtype IView"
+                      , "  method1 : Int"
+                      ]
+                )
+              ]
+        , test
+              "Warns when an interface and a template are defined in the same package."
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking module MyLib:\n  This package defines both interfaces and templates.\n  \n  This is not recommended - templates are upgradeable, but interfaces are not, which means that this version of the package and its templates can never be uninstalled.\n  \n  It is recommended that interfaces are defined in their own package separate from their implementations.")
+              NoDependencies
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "data IView = IView { i : Text }"
+                      , "interface I where"
+                      , "  viewtype IView"
+                      , "  method1 : Int"
+                      , "template T with"
+                      , "    p: Party"
+                      , "  where"
+                      , "    signatory p"
+                      ]
+                )
+              ]
+        , test
+              "Warns when an interface is used in the package that it's defined in."
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking interface MyLib.I :\n  The interface I was defined in this package and implemented in this package by the following templates:\n  \n  'T'\n  \n  However, it is recommended that interfaces are defined in their own package separate from their implementations.")
+              NoDependencies
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "data IView = IView { i : Text }"
+                      , "interface I where"
+                      , "  viewtype IView"
+                      , "  method1 : Int"
+                      , "template T with"
+                      , "    p: Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    interface instance I for T where"
+                      , "      view = IView \"hi\""
+                      , "      method1 = 2"
+                      ]
+                )
+              ]
+        , test
+              "Warns when an interface is defined and then used in a package that upgrades it."
+              (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template MyLib.T interface instance [0-9a-f]+:MyLib:I for MyLib:T:\n  The template T has implemented interface I, which is defined in a previous version of this package.")
+              DependOnV1
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "data IView = IView { i : Text }"
+                      , "interface I where"
+                      , "  viewtype IView"
+                      , "  method1 : Int"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "import qualified \"mylib-v1\" MyLib as V1"
+                      , "data IView = IView { i : Text }"
+                      , "template T with"
+                      , "    p: Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    interface instance V1.I for T where"
+                      , "      view = V1.IView \"hi\""
+                      , "      method1 = 2"
+                      ]
+                )
+              ]
+        , test
+              "Fails when an instance is dropped."
+              (FailWithError "\ESC\\[0;91merror type checking template MyLib.T :\n  Implementation of interface I by template T appears in package that is being upgraded, but does not appear in this package.")
+              (SeparateDep [
+                ( "daml/Dep.daml"
+                , unlines
+                      [ "module Dep where"
+                      , "data IView = IView { i : Text }"
+                      , "interface I where"
+                      , "  viewtype IView"
+                      , "  method1 : Int"
+                      ]
+                )
+              ])
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "import Dep"
+                      , "template T with"
+                      , "    p: Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    interface instance I for T where"
+                      , "      view = IView \"hi\""
+                      , "      method1 = 2"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "import Dep"
+                      , "template T with"
+                      , "    p: Party"
+                      , "  where"
+                      , "    signatory p"
+                      ]
+                )
+              ]
+        , test
+              "Succeeds when an instance is added (separate dep)."
+              Succeed
+              (SeparateDep [
+                ( "daml/Dep.daml"
+                , unlines
+                      [ "module Dep where"
+                      , "data IView = IView { i : Text }"
+                      , "interface I where"
+                      , "  viewtype IView"
+                      , "  method1 : Int"
+                      ]
+                )
+              ])
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "import Dep"
+                      , "template T with"
+                      , "    p: Party"
+                      , "  where"
+                      , "    signatory p"
+                      ]
+                )
+              ]
+              [ ("daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "import Dep"
+                      , "template T with"
+                      , "    p: Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    interface instance I for T where"
+                      , "      view = IView \"hi\""
+                      , "      method1 = 2"
+                      ]
+                )
+              ]
+        , test
+              "Succeeds when an instance is added (upgraded package)."
+              Succeed
+              DependOnV1
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template T with"
+                      , "    p: Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "data IView = IView { i : Text }"
+                      , "interface I where"
+                      , "  viewtype IView"
+                      , "  method1 : Int"
+                      ]
+                )
+              ]
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "import qualified \"mylib-v1\" MyLib as V1"
+                      , "template T with"
+                      , "    p: Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    interface instance V1.I for T where"
+                      , "      view = V1.IView \"hi\""
+                      , "      method1 = 2"
+                      , "data IView = IView { i : Text }"
+                      ]
+                )
+              ]
+        , test
+              "Cannot upgrade view"
+              (FailWithError ".*Tried to implement a view of type (‘|\915\199\255)IView(’|\915\199\214) on interface (‘|\915\199\255)V1.I(’|\915\199\214), but the definition of interface (‘|\915\199\255)V1.I(’|\915\199\214) requires a view of type (‘|\915\199\255)V1.IView(’|\915\199\214)")
+              DependOnV1
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "template T with"
+                      , "    p: Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "data IView = IView { i : Text }"
+                      , "interface I where"
+                      , "  viewtype IView"
+                      , "  method1 : Int"
+                      ]
+                )
+              ]
+              [ ( "daml/MyLib.daml"
+                , unlines
+                      [ "module MyLib where"
+                      , "import qualified \"mylib-v1\" MyLib as V1"
+                      , "template T with"
+                      , "    p: Party"
+                      , "  where"
+                      , "    signatory p"
+                      , "    interface instance V1.I for T where"
+                      , "      view = IView \"hi\" None"
+                      , "      method1 = 2"
+                      , "data IView = IView { i : Text, other : Optional Text }"
+                      ]
+                )
+              ]
         ]
   where
     test ::
            String
         -> Expectation
+        -> Dependency
         -> [(FilePath, String)]
         -> [(FilePath, String)]
         -> TestTree
-    test name expectation oldVersion newVersion =
+    test name expectation sharedDep oldVersion newVersion =
         testCase name $
         withTempDir $ \dir -> do
-            let depDir = dir </> "oldVersion"
-            let dar = dir </> "out.dar"
-            let depDar = dir </> "oldVersion" </> "dep.dar"
-            writeFiles dir (projectFile "mylib-v2" (Just depDar) : newVersion)
-            writeFiles depDir (projectFile "mylib-v1" Nothing : oldVersion)
-            callProcessSilent damlc ["build", "--project-root", depDir, "-o", depDar]
+            let newDir = dir </> "newVersion"
+            let oldDir = dir </> "oldVersion"
+            let newDar = newDir </> "out.dar"
+            let oldDar = oldDir </> "old.dar"
+
+            (depV1Dar, depV2Dar) <- case sharedDep of
+              SeparateDep sharedDep -> do
+                let sharedDir = dir </> "shared"
+                let sharedDar = sharedDir </> "out.dar"
+                writeFiles sharedDir (projectFile "mylib-shared" Nothing Nothing : sharedDep)
+                callProcessSilent damlc ["build", "--project-root", sharedDir, "-o", sharedDar]
+                pure (Just sharedDar, Just sharedDar)
+              DependOnV1 ->
+                pure (Nothing, Just oldDar)
+              _ ->
+                pure (Nothing, Nothing)
+
+            writeFiles oldDir (projectFile "mylib-v1" Nothing depV1Dar : oldVersion)
+            callProcessSilent damlc ["build", "--project-root", oldDir, "-o", oldDar]
+
+            writeFiles newDir (projectFile "mylib-v2" (Just oldDar) depV2Dar : newVersion)
+
             case expectation of
               Succeed ->
-                  callProcessSilent damlc ["build", "--project-root", dir, "-o", dar]
+                  callProcessSilent damlc ["build", "--project-root", newDir, "-o", newDar]
               FailWithError regex -> do
-                  stderr <- callProcessForStderr damlc ["build", "--project-root", dir, "-o", dar]
+                  stderr <- callProcessForStderr damlc ["build", "--project-root", newDir, "-o", newDar]
                   let regexWithSeverity = "Severity: DsError\nMessage: \n" <> regex
-                  unless (matchTest (makeRegex regexWithSeverity :: Regex) stderr) $
+                  let compiledRegex :: Regex
+                      compiledRegex = makeRegexOpts defaultCompOpt { multiline = False } defaultExecOpt regexWithSeverity
+                  unless (matchTest compiledRegex stderr) $
                       assertFailure ("`daml build` failed as expected, but did not give an error matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
               SucceedWithWarning regex -> do
-                  stderr <- callProcessForSuccessfulStderr damlc ["build", "--project-root", dir, "-o", dar]
+                  stderr <- callProcessForSuccessfulStderr damlc ["build", "--project-root", newDir, "-o", newDar]
                   let regexWithSeverity = "Severity: DsWarning\nMessage: \n" <> regex
-                  unless (matchTest (makeRegex regexWithSeverity :: Regex) stderr) $
+                  let compiledRegex :: Regex
+                      compiledRegex = makeRegexOpts defaultCompOpt { multiline = False } defaultExecOpt regexWithSeverity
+                  unless (matchTest compiledRegex stderr) $
                       assertFailure ("`daml build` succeeded, but did not give a warning matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
 
     writeFiles dir fs =
@@ -965,7 +1290,7 @@ tests damlc =
             createDirectoryIfMissing True (takeDirectory $ dir </> file)
             writeFileUTF8 (dir </> file) content
 
-    projectFile name upgradedFile =
+    projectFile name upgradedFile mbDep =
         ( "daml.yaml"
         , unlines $
           [ "sdk-version: " <> sdkVersion
@@ -983,10 +1308,17 @@ tests damlc =
                     (error "DamlcUpgrades: featureMinVersion should be defined over featurePackageUpgrades")
                     (featureMinVersion featurePackageUpgrades V1))
           ] ++ ["upgrades: '" <> path <> "'" | Just path <- pure upgradedFile]
+            ++ ["data-dependencies:\n -  '" <> path <> "'" | Just path <- pure mbDep]
         )
 
 data Expectation
   = Succeed
   | FailWithError T.Text
   | SucceedWithWarning T.Text
+  deriving (Show, Eq, Ord)
+
+data Dependency
+  = NoDependencies
+  | DependOnV1
+  | SeparateDep [(FilePath, String)]
   deriving (Show, Eq, Ord)

--- a/sdk/libs-haskell/da-hs-base/src/Data/NameMap.hs
+++ b/sdk/libs-haskell/da-hs-base/src/Data/NameMap.hs
@@ -38,6 +38,7 @@ module Data.NameMap
   , insertMany
   , insertManyEither
   , union
+  , unions
 
   -- * Transformations
   , map
@@ -173,6 +174,9 @@ union :: Named a => NameMap a -> NameMap a -> NameMap a
 union (NameMap _ nm1) (NameMap _ nm2) =
     let m = nm1 `HMS.union` nm2
      in NameMap (HMS.toList m) m
+
+unions :: Named a => [NameMap a] -> NameMap a
+unions = foldl' union empty
 
 (!) :: (HasCallStack, Named a) => NameMap a -> Name a -> a
 (!) nm n = case lookup n nm of


### PR DESCRIPTION
Backport changes from https://github.com/digital-asset/daml/pull/19054 that weren't merged in https://github.com/digital-asset/daml/pull/19380. Had to make some changes because cf2b387c3bd72e9c342acf9ba1b3169463cd3a1c is not on main-2.x