### PR TITLE
Remove double "server" prefix from grpc metrics

### DIFF
--- a/sdk/observability/metrics/src/main/scala/com/daml/metrics/grpc/DamlGrpcServerMetrics.scala
+++ b/sdk/observability/metrics/src/main/scala/com/daml/metrics/grpc/DamlGrpcServerMetrics.scala
@@ -26,13 +26,13 @@ class DamlGrpcServerHistograms(implicit
     qualification = MetricQualification.Latency,
   )
   val damlGrpcServerReceived: Item = Item(
-    prefix :+ "server" :+ "messages" :+ "received",
+    prefix :+ "messages" :+ "received",
     Histogram.Bytes,
     summary = "Distribution of payload sizes in gRPC messages received (both unary and streaming).",
     qualification = MetricQualification.Traffic,
   )
   val damlGrpcServerSent: Item = Item(
-    prefix :+ "server" :+ "messages" :+ "sent",
+    prefix :+ "messages" :+ "sent",
     Histogram.Bytes,
     summary = "Distribution of payload sizes in gRPC messages sent (both unary and streaming).",
     qualification = MetricQualification.Traffic,


### PR DESCRIPTION
server already covered in the prefix key

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
