### PR TITLE
Backport java codegen support for upgrade from main-2.x

### DIFF
--- a/sdk/canton/community/bindings-java/src/test/scala/com/daml/ledger/javaapi/data/PackageVersionSpec.scala
+++ b/sdk/canton/community/bindings-java/src/test/scala/com/daml/ledger/javaapi/data/PackageVersionSpec.scala
@@ -1,0 +1,40 @@
+package com.daml.ledger.javaapi.data
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Random
+
+class PackageVersionSpec extends AnyFlatSpec with Matchers {
+
+  "PackageVersion" should "be parsed correctly from String" in {
+    val packageVersion = PackageVersion.unsafeFromString("1.22.333")
+    packageVersion.toString shouldBe "1.22.333"
+    packageVersion shouldBe new PackageVersion(Array(1, 22, 333))
+  }
+
+  "PackageVersion" should "not allow negative or non-integers" in {
+    an[IllegalArgumentException] should be thrownBy PackageVersion.unsafeFromString("0.-1")
+    an[IllegalArgumentException] should be thrownBy PackageVersion.unsafeFromString("0.beef")
+  }
+
+  "PackageVersion" should "be ordered correctly" in {
+
+    val expectedOrderedPackageVersions = Seq(
+      // Lowest possible package version
+      PackageVersion.unsafeFromString("0"),
+      PackageVersion.unsafeFromString("0.1"),
+      PackageVersion.unsafeFromString("0.11"),
+      PackageVersion.unsafeFromString("1.0"),
+      PackageVersion.unsafeFromString("2"),
+      PackageVersion.unsafeFromString("10"),
+      PackageVersion.unsafeFromString(s"${Int.MaxValue}"),
+      PackageVersion.unsafeFromString(s"${Int.MaxValue}.3"),
+      PackageVersion.unsafeFromString(s"${Int.MaxValue}." * 23 + "99"),
+    )
+
+    Random
+      .shuffle(expectedOrderedPackageVersions)
+      .sorted should contain theSameElementsInOrderAs expectedOrderedPackageVersions
+  }
+}

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/admin/PingService.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/admin/PingService.scala
@@ -144,7 +144,7 @@ class PingService(
       .unlessShutdown(
         performUnlessClosingF("wait-for-admin-workflows-to-appear-on-ledger-api")(
           connection
-            .getPackageStatus(M.Ping.TEMPLATE_ID.getPackageId)
+            .getPackageStatus(M.Ping.PACKAGE_ID)
             .map(_.packageStatus.isRegistered)
         ),
         AllExnRetryable,

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/admin/workflows/PackageID.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/admin/workflows/PackageID.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.canton.participant.admin.workflows.java
 
 object PackageID {
-  val PingPong: String = pingpong.Ping.TEMPLATE_ID.getPackageId
-  val PingPongVacuum: String = pingpongvacuum.PingCleanup.TEMPLATE_ID.getPackageId
-  val DarDistribution: String = dardistribution.AcceptedDar.TEMPLATE_ID.getPackageId
+  val PingPong: String = pingpong.Ping.PACKAGE_ID
+  val PingPongVacuum: String = pingpongvacuum.PingCleanup.PACKAGE_ID
+  val DarDistribution: String = dardistribution.AcceptedDar.PACKAGE_ID
 }

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/sync/EventTranslationStrategy.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/sync/EventTranslationStrategy.scala
@@ -55,9 +55,9 @@ final class EventTranslationStrategy(
   private val excludedPackageIds: Set[LfPackageId] =
     if (excludeInfrastructureTransactions) {
       Set(
-        LfPackageId.assertFromString(pingpong.Ping.TEMPLATE_ID.getPackageId),
-        LfPackageId.assertFromString(dardistribution.AcceptedDar.TEMPLATE_ID.getPackageId),
-        LfPackageId.assertFromString(pingpongvacuum.PingCleanup.TEMPLATE_ID.getPackageId),
+        LfPackageId.assertFromString(pingpong.Ping.PACKAGE_ID),
+        LfPackageId.assertFromString(dardistribution.AcceptedDar.PACKAGE_ID),
+        LfPackageId.assertFromString(pingpongvacuum.PingCleanup.PACKAGE_ID),
       )
     } else {
       Set.empty[LfPackageId]

--- a/sdk/language-support/java/codegen/BUILD.bazel
+++ b/sdk/language-support/java/codegen/BUILD.bazel
@@ -243,6 +243,7 @@ scala_source_jar(
         ),
         project_name = "integration-tests-model",
         target = ver,
+        version = "1.2.3",
     )
     for ver in LF_VERSIONS
 ]

--- a/sdk/language-support/java/codegen/src/it/java/com/daml/AllGenericTests.java
+++ b/sdk/language-support/java/codegen/src/it/java/com/daml/AllGenericTests.java
@@ -15,6 +15,7 @@ import org.junit.runners.Suite;
   ContractKeysTest.class,
   DecoderTest.class,
   ListTest.class,
+  PackageNameAndVersionTest.class,
   OptionalTest.class,
   ParametrizedContractIdTest.class,
   RecordTest.class,

--- a/sdk/language-support/java/codegen/src/it/java/com/daml/PackageNameAndVersionTest.java
+++ b/sdk/language-support/java/codegen/src/it/java/com/daml/PackageNameAndVersionTest.java
@@ -1,0 +1,25 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml;
+
+import static org.junit.Assert.assertEquals;
+
+import com.daml.ledger.javaapi.data.PackageVersion;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import tests.template1.SimpleTemplate;
+
+@RunWith(JUnitPlatform.class)
+public class PackageNameAndVersionTest {
+  @Test
+  void packageName() {
+    assertEquals(SimpleTemplate.PACKAGE_NAME, "integration-tests-model");
+  }
+
+  @Test
+  void packageVersion() {
+    assertEquals(SimpleTemplate.PACKAGE_VERSION, PackageVersion.unsafeFromString("1.2.3"));
+  }
+}

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
@@ -66,6 +66,7 @@ object ClassForType extends StrictLogging {
             typeWithContext.auxiliarySignatures,
             typeWithContext.interface.packageId,
             interfaceName,
+            typeWithContext.interface.languageVersion,
             typeWithContext.interface.metadata,
           )
     } yield javaFile(packageName, interfaceClass)

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
@@ -66,6 +66,7 @@ object ClassForType extends StrictLogging {
             typeWithContext.auxiliarySignatures,
             typeWithContext.interface.packageId,
             interfaceName,
+            typeWithContext.interface.metadata,
           )
     } yield javaFile(packageName, interfaceClass)
 

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -4,7 +4,7 @@
 package com.daml.lf.codegen.backend.java.inner
 
 import com.daml.ledger.javaapi
-import ClassGenUtils.{companionFieldName, templateIdFieldName, generateGetCompanion}
+import ClassGenUtils.{companionFieldName, generateGetCompanion, templateIdFieldName}
 import com.daml.lf.codegen.TypeWithContext
 import com.daml.lf.data.Ref
 import Ref.ChoiceName
@@ -105,6 +105,11 @@ private[inner] object TemplateClass extends StrictLogging {
           .addType(
             generateByKeyClass(className, \/-(template.implementedInterfaces))
           )
+      }
+      typeWithContext.interface.metadata foreach { meta =>
+        templateType
+          .addField(ClassGenUtils.generatePackageNameField(meta.name))
+          .addField(ClassGenUtils.generatePackageVersionField(meta.version))
       }
       logger.debug("End")
       (templateType.build(), staticImports)

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -45,7 +45,8 @@ private[inner] object TemplateClass extends StrictLogging {
         .classBuilder(className)
         .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
         .superclass(classOf[javaapi.data.Template])
-        .addField(generateTemplateIdField(typeWithContext))
+        .addFields(generateTemplateIdFields(typeWithContext).asJava)
+        .addField(ClassGenUtils.generatePackageIdField(typeWithContext.packageId))
         .addMethod(generateCreateMethod(className))
         .addMethods(
           generateDeprecatedStaticExerciseByKeyMethods(
@@ -501,9 +502,11 @@ private[inner] object TemplateClass extends StrictLogging {
       )
     )
 
-  private def generateTemplateIdField(typeWithContext: TypeWithContext): FieldSpec =
-    ClassGenUtils.generateTemplateIdField(
+  private def generateTemplateIdFields(typeWithContext: TypeWithContext): Seq[FieldSpec] =
+    ClassGenUtils.generateTemplateIdFields(
       typeWithContext.packageId,
+      typeWithContext.interface.metadata.map(_.name),
+      typeWithContext.interface.languageVersion,
       typeWithContext.modulesLineage.map(_._1).toImmArray.iterator.mkString("."),
       typeWithContext.name,
     )

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/EventQueryServiceIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/EventQueryServiceIT.scala
@@ -148,7 +148,7 @@ class EventQueryServiceIT extends LedgerTestSuite {
       events <- ledger.getEventsByContractKey(
         GetEventsByContractKeyRequest(
           contractKey = Some(key),
-          templateId = Some(TextKey.TEMPLATE_ID.toV1),
+          templateId = Some(TextKey.TEMPLATE_ID_WITH_PACKAGE_ID.toV1),
           requestingParties = Seq(party),
         )
       )
@@ -178,7 +178,7 @@ class EventQueryServiceIT extends LedgerTestSuite {
       events <- ledger.getEventsByContractKey(
         GetEventsByContractKeyRequest(
           contractKey = Some(key),
-          templateId = Some(TextKey.TEMPLATE_ID.toV1),
+          templateId = Some(TextKey.TEMPLATE_ID_WITH_PACKAGE_ID.toV1),
           requestingParties = Seq(party),
         )
       )
@@ -200,7 +200,7 @@ class EventQueryServiceIT extends LedgerTestSuite {
       events <- ledger.getEventsByContractKey(
         GetEventsByContractKeyRequest(
           contractKey = Some(key),
-          templateId = Some(TextKey.TEMPLATE_ID.toV1),
+          templateId = Some(TextKey.TEMPLATE_ID_WITH_PACKAGE_ID.toV1),
           requestingParties = Seq(party),
         )
       )
@@ -228,7 +228,7 @@ class EventQueryServiceIT extends LedgerTestSuite {
       events <- ledger.getEventsByContractKey(
         GetEventsByContractKeyRequest(
           contractKey = Some(key),
-          templateId = Some(TextKey.TEMPLATE_ID.toV1),
+          templateId = Some(TextKey.TEMPLATE_ID_WITH_PACKAGE_ID.toV1),
           requestingParties = Seq(notTheSubmittingParty),
         )
       )
@@ -250,7 +250,7 @@ class EventQueryServiceIT extends LedgerTestSuite {
         .getEventsByContractKey(
           GetEventsByContractKeyRequest(
             contractKey = Some(key),
-            templateId = Some(TextKey.TEMPLATE_ID.toV1),
+            templateId = Some(TextKey.TEMPLATE_ID_WITH_PACKAGE_ID.toV1),
             requestingParties = Seq(party),
             continuationToken = continuationToken.getOrElse(
               GetEventsByContractKeyRequest.defaultInstance.continuationToken
@@ -299,7 +299,7 @@ class EventQueryServiceIT extends LedgerTestSuite {
         .getEventsByContractKey(
           GetEventsByContractKeyRequest(
             contractKey = Some(key),
-            templateId = Some(TextKey.TEMPLATE_ID.toV1),
+            templateId = Some(TextKey.TEMPLATE_ID_WITH_PACKAGE_ID.toV1),
             requestingParties = Seq(party),
             continuationToken = continuationToken.getOrElse(
               GetEventsByContractKeyRequest.defaultInstance.continuationToken

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/InterfaceSubscriptionsIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/InterfaceSubscriptionsIT.scala
@@ -118,7 +118,7 @@ abstract class InterfaceSubscriptionsITBase(prefix: String, useTemplateIdBasedLe
     assertEquals(
       "Create event 1 template ID",
       createdEvent1.templateId.get.toString,
-      T1.TEMPLATE_ID.toV1.toString,
+      T1.TEMPLATE_ID_WITH_PACKAGE_ID.toV1.toString,
     )
     assertEquals("Create event 1 contract ID", createdEvent1.contractId, c1)
     assertViewEquals(createdEvent1.interfaceViews, I.TEMPLATE_ID.toV1) { value =>
@@ -151,7 +151,7 @@ abstract class InterfaceSubscriptionsITBase(prefix: String, useTemplateIdBasedLe
     assertEquals(
       "Create event 2 template ID",
       createdEvent2.templateId.get.toString,
-      T2.TEMPLATE_ID.toV1.toString,
+      T2.TEMPLATE_ID_WITH_PACKAGE_ID.toV1.toString,
     )
     assertEquals("Create event 2 contract ID", createdEvent2.contractId, c2)
     assertViewEquals(createdEvent2.interfaceViews, I.TEMPLATE_ID.toV1) { value =>
@@ -176,7 +176,7 @@ abstract class InterfaceSubscriptionsITBase(prefix: String, useTemplateIdBasedLe
     assertEquals(
       "Create event 3 template ID",
       createdEvent3.templateId.get.toString,
-      T3.TEMPLATE_ID.toV1.toString,
+      T3.TEMPLATE_ID_WITH_PACKAGE_ID.toV1.toString,
     )
     assertEquals("Create event 3 contract ID", createdEvent3.contractId, c3)
     assertViewFailed(createdEvent3.interfaceViews, I.TEMPLATE_ID.toV1)
@@ -438,7 +438,7 @@ abstract class InterfaceSubscriptionsITBase(prefix: String, useTemplateIdBasedLe
       assertEquals(
         "Create event 1 template ID",
         createdEvent1.templateId.get.toString,
-        T1.TEMPLATE_ID.toV1.toString,
+        T1.TEMPLATE_ID_WITH_PACKAGE_ID.toV1.toString,
       )
       assertEquals("Create event 1 contract ID", createdEvent1.contractId, c1.contractId)
       assertEquals(
@@ -532,7 +532,7 @@ abstract class InterfaceSubscriptionsITBase(prefix: String, useTemplateIdBasedLe
     allocate(SingleParty),
     enabled = _.templateFilters || useTemplateIdBasedLegacyFormat,
   )(implicit ec => { case Participants(Participant(ledger, party)) =>
-    val packageId = I.TEMPLATE_ID.getPackageId
+    val packageId = I.PACKAGE_ID
     val moduleName = I.TEMPLATE_ID.getModuleName
     val unknownTemplate = new javaapi.data.Identifier(packageId, moduleName, "TemplateDoesNotExist")
     val unknownInterface =
@@ -702,7 +702,7 @@ abstract class InterfaceSubscriptionsITBase(prefix: String, useTemplateIdBasedLe
 
     } yield assertSingleContractWithSimpleView(
       transactions = transactions,
-      contractIdentifier = carbonv2.carbonv2.T.TEMPLATE_ID.toV1,
+      contractIdentifier = carbonv2.carbonv2.T.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
       viewIdentifier = carbonv1.carbonv1.I.TEMPLATE_ID.toV1,
       contractId = contract.contractId,
       viewValue = 21,
@@ -744,7 +744,7 @@ abstract class InterfaceSubscriptionsITBase(prefix: String, useTemplateIdBasedLe
       )
     } yield assertSingleContractWithSimpleView(
       transactions = transactions,
-      contractIdentifier = carbonv2.carbonv2.T.TEMPLATE_ID.toV1,
+      contractIdentifier = carbonv2.carbonv2.T.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
       viewIdentifier = carbonv3.carbonv3.RetroI.TEMPLATE_ID.toV1,
       contractId = contract.contractId,
       viewValue = 77,

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/TransactionServiceFiltersIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/TransactionServiceFiltersIT.scala
@@ -221,7 +221,7 @@ class TransactionServiceFiltersIT extends LedgerTestSuite {
     assertEquals(
       "Create event 1 template ID",
       createdEvent1.templateId.get,
-      T5.TEMPLATE_ID.toV1,
+      T5.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
     )
     assertEquals("Create event 1 contract ID", createdEvent1.contractId, c1)
     assertLength("Create event 1 has a view", 1, createdEvent1.interfaceViews)
@@ -241,7 +241,7 @@ class TransactionServiceFiltersIT extends LedgerTestSuite {
     assertEquals(
       "Create event 2 template ID",
       createdEvent2.templateId.get,
-      T6.TEMPLATE_ID.toV1,
+      T6.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
     )
     assertEquals("Create event 2 contract ID", createdEvent2.contractId, c2)
     assertLength("Create event 2 has a view", 1, createdEvent2.interfaceViews)
@@ -262,7 +262,7 @@ class TransactionServiceFiltersIT extends LedgerTestSuite {
     assertEquals(
       "Create event 3 template ID",
       createdEvent3.templateId.get.toString,
-      T3.TEMPLATE_ID.toV1.toString,
+      T3.TEMPLATE_ID_WITH_PACKAGE_ID.toV1.toString,
     )
     assertEquals("Create event 3 contract ID", createdEvent3.contractId, c3)
     assertLength("Create event 3 has no view", 0, createdEvent3.interfaceViews)

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ActiveContractsServiceIT.scala
@@ -130,7 +130,9 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
       )
 
       assert(
-        activeContracts.head.getTemplateId == Identifier.fromJavaProto(Dummy.TEMPLATE_ID.toProto),
+        activeContracts.head.getTemplateId == Identifier.fromJavaProto(
+          Dummy.TEMPLATE_ID_WITH_PACKAGE_ID.toProto
+        ),
         s"Received contract is not of type Dummy, but ${activeContracts.head.templateId}.",
       )
       assert(
@@ -258,6 +260,9 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
     "The ActiveContractsService should return contracts for the requesting parties",
     allocate(TwoParties),
   )(implicit ec => { case Participants(Participant(ledger, alice, bob)) =>
+    val dummyTemplateId = Dummy.TEMPLATE_ID_WITH_PACKAGE_ID
+    val dummyWithParamTemplateId = DummyWithParam.TEMPLATE_ID_WITH_PACKAGE_ID
+    val dummyFactoryTemplateId = DummyFactory.TEMPLATE_ID_WITH_PACKAGE_ID
     for {
       _ <- createDummyContracts(alice, ledger)
       _ <- createDummyContracts(bob, ledger)
@@ -275,37 +280,37 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
         allContractsForAlice.size == 3,
         s"$alice expected 3 events, but received ${allContractsForAlice.size}.",
       )
-      assertTemplates(Seq(alice), allContractsForAlice, Dummy.TEMPLATE_ID, 1)
-      assertTemplates(Seq(alice), allContractsForAlice, DummyWithParam.TEMPLATE_ID, 1)
-      assertTemplates(Seq(alice), allContractsForAlice, DummyFactory.TEMPLATE_ID, 1)
+      assertTemplates(Seq(alice), allContractsForAlice, dummyTemplateId, 1)
+      assertTemplates(Seq(alice), allContractsForAlice, dummyWithParamTemplateId, 1)
+      assertTemplates(Seq(alice), allContractsForAlice, dummyFactoryTemplateId, 1)
 
       assert(
         allContractsForBob.size == 3,
         s"$bob expected 3 events, but received ${allContractsForBob.size}.",
       )
-      assertTemplates(Seq(bob), allContractsForBob, Dummy.TEMPLATE_ID, 1)
-      assertTemplates(Seq(bob), allContractsForBob, DummyWithParam.TEMPLATE_ID, 1)
-      assertTemplates(Seq(bob), allContractsForBob, DummyFactory.TEMPLATE_ID, 1)
+      assertTemplates(Seq(bob), allContractsForBob, dummyTemplateId, 1)
+      assertTemplates(Seq(bob), allContractsForBob, dummyWithParamTemplateId, 1)
+      assertTemplates(Seq(bob), allContractsForBob, dummyFactoryTemplateId, 1)
 
       assert(
         allContractsForAliceAndBob.size == 6,
         s"$alice and $bob expected 6 events, but received ${allContractsForAliceAndBob.size}.",
       )
-      assertTemplates(Seq(alice, bob), allContractsForAliceAndBob, Dummy.TEMPLATE_ID, 2)
-      assertTemplates(Seq(alice, bob), allContractsForAliceAndBob, DummyWithParam.TEMPLATE_ID, 2)
-      assertTemplates(Seq(alice, bob), allContractsForAliceAndBob, DummyFactory.TEMPLATE_ID, 2)
+      assertTemplates(Seq(alice, bob), allContractsForAliceAndBob, dummyTemplateId, 2)
+      assertTemplates(Seq(alice, bob), allContractsForAliceAndBob, dummyWithParamTemplateId, 2)
+      assertTemplates(Seq(alice, bob), allContractsForAliceAndBob, dummyFactoryTemplateId, 2)
 
       assert(
         dummyContractsForAlice.size == 1,
         s"$alice expected 1 event, but received ${dummyContractsForAlice.size}.",
       )
-      assertTemplates(Seq(alice), dummyContractsForAlice, Dummy.TEMPLATE_ID, 1)
+      assertTemplates(Seq(alice), dummyContractsForAlice, dummyTemplateId, 1)
 
       assert(
         dummyContractsForAliceAndBob.size == 2,
         s"$alice and $bob expected 2 events, but received ${dummyContractsForAliceAndBob.size}.",
       )
-      assertTemplates(Seq(alice, bob), dummyContractsForAliceAndBob, Dummy.TEMPLATE_ID, 2)
+      assertTemplates(Seq(alice, bob), dummyContractsForAliceAndBob, dummyTemplateId, 2)
     }
   })
 

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/CommandServiceIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/CommandServiceIT.scala
@@ -33,7 +33,7 @@ final class CommandServiceIT extends LedgerTestSuite {
     } yield {
       assert(active.size == 1)
       val dummyTemplateId = active.flatMap(_.templateId.toList).head
-      assert(dummyTemplateId == Dummy.TEMPLATE_ID.toV1)
+      assert(dummyTemplateId == Dummy.TEMPLATE_ID_WITH_PACKAGE_ID.toV1)
     }
   })
 
@@ -132,8 +132,8 @@ final class CommandServiceIT extends LedgerTestSuite {
       s"The returned transaction should contain a created-event, but was ${event.event}",
     )
     assert(
-      event.getCreated.getTemplateId == Dummy.TEMPLATE_ID.toV1,
-      s"The template ID of the created-event should by ${Dummy.TEMPLATE_ID.toV1}, but was ${event.getCreated.getTemplateId}",
+      event.getCreated.getTemplateId == Dummy.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
+      s"The template ID of the created-event should by ${Dummy.TEMPLATE_ID_WITH_PACKAGE_ID.toV1}, but was ${event.getCreated.getTemplateId}",
     )
   }
 
@@ -161,8 +161,8 @@ final class CommandServiceIT extends LedgerTestSuite {
         s"The returned transaction tree should contain a created-event, but was ${event.kind}",
       )
       assert(
-        event.getCreated.getTemplateId == Dummy.TEMPLATE_ID.toV1,
-        s"The template ID of the created-event should by ${Dummy.TEMPLATE_ID.toV1}, but was ${event.getCreated.getTemplateId}",
+        event.getCreated.getTemplateId == Dummy.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
+        s"The template ID of the created-event should by ${Dummy.TEMPLATE_ID_WITH_PACKAGE_ID.toV1}, but was ${event.getCreated.getTemplateId}",
       )
     }
   })
@@ -569,7 +569,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         assertEquals(
           "Unexpected template identifier in create event",
           trees.flatMap(createdEvents).map(_.getTemplateId),
-          Vector(Dummy.TEMPLATE_ID.toV1),
+          Vector(Dummy.TEMPLATE_ID_WITH_PACKAGE_ID.toV1),
         )
         val contractId = trees.flatMap(createdEvents).head.contractId
         assertEquals(

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/SemanticTests.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/SemanticTests.scala
@@ -190,13 +190,13 @@ final class SemanticTests extends LedgerTestSuite {
       } yield {
         val agreement = assertSingleton(
           "SemanticPaintOffer",
-          createdEvents(tree).filter(_.getTemplateId == PaintAgree.TEMPLATE_ID.toV1),
+          createdEvents(tree).filter(_.getTemplateId == PaintAgree.TEMPLATE_ID_WITH_PACKAGE_ID.toV1),
         )
         assertEquals(
           "Paint agreement parameters",
           agreement.getCreateArguments,
           Record(
-            recordId = Some(PaintAgree.TEMPLATE_ID.toV1),
+            recordId = Some(PaintAgree.TEMPLATE_ID_WITH_PACKAGE_ID.toV1),
             fields = Seq(
               RecordField("painter", Some(Value(Value.Sum.Party(painter)))),
               RecordField("houseOwner", Some(Value(Value.Sum.Party(houseOwner)))),
@@ -227,13 +227,13 @@ final class SemanticTests extends LedgerTestSuite {
       } yield {
         val agreement = assertSingleton(
           "SemanticPaintCounterOffer",
-          createdEvents(tree).filter(_.getTemplateId == PaintAgree.TEMPLATE_ID.toV1),
+          createdEvents(tree).filter(_.getTemplateId == PaintAgree.TEMPLATE_ID_WITH_PACKAGE_ID.toV1),
         )
         assertEquals(
           "Paint agreement parameters",
           agreement.getCreateArguments,
           Record(
-            recordId = Some(PaintAgree.TEMPLATE_ID.toV1),
+            recordId = Some(PaintAgree.TEMPLATE_ID_WITH_PACKAGE_ID.toV1),
             fields = Seq(
               RecordField("painter", Some(Value(Value.Sum.Party(painter)))),
               RecordField("houseOwner", Some(Value(Value.Sum.Party(houseOwner)))),
@@ -320,7 +320,7 @@ final class SemanticTests extends LedgerTestSuite {
 
         tree <- alpha.exercise(houseOwner, offer.exercisePaintOffer_Accept(iou))
         (newIouEvents, agreementEvents) = createdEvents(tree).partition(
-          _.getTemplateId == Iou.TEMPLATE_ID.toV1
+          _.getTemplateId == Iou.TEMPLATE_ID_WITH_PACKAGE_ID.toV1
         )
         newIouEvent <- Future(newIouEvents.head)
         agreementEvent <- Future(agreementEvents.head)

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceExerciseIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceExerciseIT.scala
@@ -49,13 +49,13 @@ class TransactionServiceExerciseIT extends LedgerTestSuite {
       assertEquals(
         "Create should be of DummyWithParam",
         create.getTemplateId,
-        DummyWithParam.TEMPLATE_ID.toV1,
+        DummyWithParam.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
       )
       val archive = assertSingleton("GetArchive", dummyFactory.flatMap(archivedEvents))
       assertEquals(
         "Archive should be of DummyFactory",
         archive.getTemplateId,
-        DummyFactory.TEMPLATE_ID.toV1,
+        DummyFactory.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
       )
       assertEquals(
         "Mismatching archived contract identifier",

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceStreamsIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceStreamsIT.scala
@@ -196,7 +196,6 @@ class TransactionServiceStreamsIT extends LedgerTestSuite {
     "The transaction service should correctly filter by template identifier",
     allocate(SingleParty),
   )(implicit ec => { case Participants(Participant(ledger, party)) =>
-    val filterBy = Dummy.TEMPLATE_ID
     val create = ledger.submitAndWaitRequest(
       party,
       (new Dummy(party).create.commands.asScala ++ new DummyFactory(
@@ -205,10 +204,14 @@ class TransactionServiceStreamsIT extends LedgerTestSuite {
     )
     for {
       _ <- ledger.submitAndWait(create)
-      transactions <- ledger.flatTransactionsByTemplateId(filterBy, party)
+      transactions <- ledger.flatTransactionsByTemplateId(Dummy.TEMPLATE_ID, party)
     } yield {
       val contract = assertSingleton("FilterByTemplate", transactions.flatMap(createdEvents))
-      assertEquals("FilterByTemplate", contract.getTemplateId, filterBy.toV1)
+      assertEquals(
+        "FilterByTemplate",
+        contract.getTemplateId,
+        Dummy.TEMPLATE_ID_WITH_PACKAGE_ID.toV1,
+      )
     }
   })
 }


### PR DESCRIPTION
This back-ports from main-2.x: 

- 924a1f35b427a6287758bedd1e8afa8b0dae2114 Java Codegen - JSON decoding: backport #19499 to main-2.x (#19507) 
- 4fa4f3b74bf918a03a0893d7461f6c6cf2afa4dc  Java Codegen: ETX-534 support package names (#19485)


<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
