### PR TITLE
Backport 'use safe pruning in pruning offset tests'

### DIFF
--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ParticipantPruningIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ParticipantPruningIT.scala
@@ -951,12 +951,12 @@ class ParticipantPruningIT extends LedgerTestSuite {
   test(
     "PRTServePruningOffsets",
     "Pruning offsets should be served when requested",
-    allocate(SingleParty),
+    allocate(TwoParties),
     enabled = _.prunedOffsets,
     disabledReason = "Ledger does not support pruned offset streaming",
     runConcurrently = false,
   )(implicit ec => {
-    case Participants(Participant(ledger, party)) => {
+    case Participants(Participant(ledger, party, party2)) => {
       val expectedMsgs = 11
 
       def validate[Response](
@@ -986,7 +986,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
         _ <- Future.sequence(
           Vector.fill((expectedMsgs - 1) / 2)(ledger.create(party, new Dummy(party)))
         )
-        _ <- ledger.prune(offsetToPruneUpTo)
+        _ <- pruneCantonSafe(ledger, offsetToPruneUpTo, party2)
         _ <- Future.sequence(
           Vector.fill((expectedMsgs - 1) / 2)(ledger.create(party, new Dummy(party)))
         )
@@ -1003,12 +1003,12 @@ class ParticipantPruningIT extends LedgerTestSuite {
   test(
     "PRTDontServePruningOffsets",
     "Pruning offsets should not be served when not requested",
-    allocate(SingleParty),
+    allocate(TwoParties),
     enabled = _.prunedOffsets,
     disabledReason = "Ledger does not support pruned offset streaming",
     runConcurrently = false,
   )(implicit ec => {
-    case Participants(Participant(ledger, party)) => {
+    case Participants(Participant(ledger, party, party2)) => {
       val expectedMsgs = 10
 
       def validate[Response](
@@ -1036,7 +1036,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
         _ <- Future.sequence(
           Vector.fill(expectedMsgs / 2)(ledger.create(party, new Dummy(party)))
         )
-        _ <- ledger.prune(offsetToPruneUpTo)
+        _ <- pruneCantonSafe(ledger, offsetToPruneUpTo, party2)
         _ <- Future.sequence(
           Vector.fill(expectedMsgs / 2)(ledger.create(party, new Dummy(party)))
         )


### PR DESCRIPTION
Backport https://github.com/digital-asset/daml/pull/19571 to 2.9

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
