### PR TITLE
fix full compat on 2.9

### DIFF
--- a/ci/prs.yml
+++ b/ci/prs.yml
@@ -131,6 +131,7 @@ jobs:
       var_name: bash-lib
   - bash: |
       set -euo pipefail
+      cd sdk
       eval "$(./dev-env/bin/dade-assist)"
       source $(bash-lib)
       COMMIT=$(git rev-parse HEAD^2)


### PR DESCRIPTION
This PR proves that revision 71f67ec07dc9e83ffcea2e1a63a9e7e8ca6827a9, which we made a snapshot from, passes the main-only and full-compat tests.

It also fixes the full-compat run on 2.9, that's why I'd like to merge it.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
