### PR TITLE
Fix various issues with multi-build + multi-ide

### DIFF
--- a/sdk/compiler/daml-extension/package.json
+++ b/sdk/compiler/daml-extension/package.json
@@ -117,7 +117,7 @@
                 "daml.multiPackageIdeSupport": {
                   "type": "boolean",
                   "default": false,
-                  "description": "EXPERIMENTAL: Enables the incomplete and experimental multi-ide feature."
+                  "description": "Enables the Initial Access support for multi-package compatibility in the IDE."
                 }
             }
         },

--- a/sdk/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/SplitGotoDefinition.hs
+++ b/sdk/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/SplitGotoDefinition.hs
@@ -47,7 +47,7 @@ import Language.LSP.Types
 import qualified Language.LSP.Types as LSP
 import qualified Language.LSP.Types.Lens as LSP
 import qualified Language.LSP.Types.Utils as LSP
-import System.FilePath ((</>))
+import System.FilePath (normalise, (</>))
 import "ghc-lib" GhcPlugins (
   Module,
   isGoodSrcSpan,
@@ -206,7 +206,7 @@ gotoDefinitionByName ideState params = do
     projectConfig <- liftIO $ readProjectConfig (ProjectPath root)
     config <- except $ first (Just . show) $ parseProjectConfig projectConfig
 
-    srcFiles <- maybeTToExceptT "Failed to get source files" $ getDamlFiles $ root </> pSrc config
+    srcFiles <- maybeTToExceptT "Failed to get source files" $ getDamlFiles $ normalise $ root </> pSrc config
     -- Must be sorted shorted to longest, since we always want the shortest path that matches our suffix
     -- to avoid accidentally picking Main.A.B.C if we're just looking for A.B.C
     -- We also prefix all paths with "/" and search for our suffix starting with "/"

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -1209,7 +1209,7 @@ data BuildMultiPackageConfig = BuildMultiPackageConfig
   , bmName :: LF.PackageName
   , bmVersion :: LF.PackageVersion
   , bmDarDeps :: [FilePath]
-      -- ^ not canonicalized
+      -- ^ not canonicalized, all dars that the package requires to build, including "upgrades"
   , bmSourceDaml :: FilePath
       -- ^ not canonicalized
   , bmOutput :: Maybe FilePath
@@ -1360,7 +1360,6 @@ buildMultiRule assistantRunner buildableDataDeps (MultiPackageNoCache noCache) m
             IDELogger.logInfo logger $ T.pack $ "Building " <> filePath
 
             -- Call build via daml assistant so it selects the correct SDK version.
-            -- TODO[SW]: Update this check to compare version to most recent snapshot, once a snapshot is released that won't error with --enable-multi-package.
             runAssistant assistantRunner filePath $
               ["build"] <> (["--enable-multi-package=no" | bmSdkVersion >= damlMultiBuildVersion || isHeadVersion bmSdkVersion])
 
@@ -1860,7 +1859,7 @@ darPathFromDamlYaml path = do
   where
     mbProjectOpts = Just $ ProjectOpts (Just $ ProjectPath path) (ProjectCheck "" False)
 
--- | Subset of parseProjectConfig to get only what we need for differring to the correct build call with multi-package build
+-- | Subset of parseProjectConfig to get only what we need for deferring to the correct build call with multi-package build
 buildMultiPackageConfigFromDamlYaml :: FilePath -> IO BuildMultiPackageConfig
 buildMultiPackageConfigFromDamlYaml path =
   onDamlYaml
@@ -1872,7 +1871,8 @@ buildMultiPackageConfigFromDamlYaml path =
       bmSourceDaml <- queryProjectConfigRequired ["source"] project
       dataDeps <- fromMaybe [] <$> queryProjectConfig ["data-dependencies"] project
       deps <- fromMaybe [] <$> queryProjectConfig ["dependencies"] project
-      let bmDarDeps = dataDeps <> filter (\dep -> takeExtension dep == ".dar") deps
+      upgradesDar <- maybe [] pure <$> queryProjectConfig ["upgrades"] project
+      let bmDarDeps = dataDeps <> filter (\dep -> takeExtension dep == ".dar") deps <> upgradesDar
       bmOutput <- queryProjectConfigBuildOutput project
       pure $ BuildMultiPackageConfig {..}
     )

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/Forwarding.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/Forwarding.hs
@@ -31,7 +31,6 @@ import Development.IDE.Core.RuleTypes.Daml (VirtualResource (..))
 import qualified Language.LSP.Types as LSP
 import qualified Language.LSP.Types.Lens as LSP
 import qualified Network.URI as URI
-import System.FilePath (joinPath, splitPath)
 import DA.Cli.Damlc.Command.MultiIde.Types
 
 {-# ANN module ("HLint: ignore Avoid restricted flags" :: String) #-}
@@ -188,7 +187,4 @@ filePathFromURI miState uri =
           pure $ LSP.fromNormalizedFilePath $ vrScenarioFile vr
         "untitled:" ->
           pure $ unPackageHome $ misDefaultPackagePath miState
-        -- For the GitHub Pull Request extension, which gives paths of the form `review:commit~<hash>/path/to/the/file`
-        "review:" ->
-          pure $ joinPath $ drop 1 $ splitPath $ URI.uriPath parsedUri
         _ -> Nothing

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/Types.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/Types.hs
@@ -385,6 +385,10 @@ data ForwardingBehaviour (m :: LSP.Method 'LSP.FromClient t) where
     -> ForwardingBehaviour m
   AllNotification
     :: ForwardingBehaviour (m :: LSP.Method 'LSP.FromClient 'LSP.Notification)
+  -- For the case where a File Path cannot be deduced because it is unrecognised (i.e. unknown schema)
+  CannotForwardRequest
+    :: forall t (m :: LSP.Method 'LSP.FromClient t)
+    .  ForwardingBehaviour m
 
 -- Akin to ClientNotOrReq tagged with ForwardingBehaviour, and CustomMethod realised to req/not
 data Forwarding (m :: LSP.Method 'LSP.FromClient t) where

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -160,7 +160,7 @@ enableMultiPackageOpt = EnableMultiPackage <$> flagYesNoAuto "enable-multi-packa
 
 newtype MultiPackageBuildAll = MultiPackageBuildAll {getMultiPackageBuildAll :: Bool}
 multiPackageBuildAllOpt :: Parser MultiPackageBuildAll
-multiPackageBuildAllOpt = MultiPackageBuildAll <$> switch (long "all" <> help "Build all packages in multi-package.daml")
+multiPackageBuildAllOpt = MultiPackageBuildAll <$> switch (long "all" <> help "Build all packages in multi-package.yaml")
 
 newtype MultiPackageNoCache = MultiPackageNoCache {getMultiPackageNoCache :: Bool}
 multiPackageNoCacheOpt :: Parser MultiPackageNoCache
@@ -184,7 +184,7 @@ multiPackageLocationOpt =
 
 newtype MultiPackageCleanAll = MultiPackageCleanAll {getMultiPackageCleanAll :: Bool}
 multiPackageCleanAllOpt :: Parser MultiPackageCleanAll
-multiPackageCleanAllOpt = MultiPackageCleanAll <$> switch (long "all" <> help "Clean all packages in multi-package.daml")
+multiPackageCleanAllOpt = MultiPackageCleanAll <$> switch (long "all" <> help "Clean all packages in multi-package.yaml")
 
 data Telemetry
     = TelemetryOptedIn -- ^ User has explicitly opted in


### PR DESCRIPTION
Fixes for
- #19459 by normalising path in SplitGotoDefinition, note that I couldn't seem to recreate the build issue.
- #19481 by including the "upgrades" dar in the list of dar deps that multi-build builds
- changing the forwarding logic to not error when a schema is unrecognised, instead return empty replies, to fix an error from GitHub Pull Request
- Backport #19050 small typo
- Update multi-ide VSCode option to be less scary ([see here](https://docs.google.com/document/d/1FaBFuYweYt0hx6fVg9rhufCtDNPiATXu5zwN2NWp2s4/edit#heading=h.araj0ebzh0v3))