### PR TITLE
Upgrade checks - Disallow key upgrades

### DIFF
--- a/sdk/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
+++ b/sdk/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
@@ -5,6 +5,11 @@
 module DA.Daml.LF.Ast.Alpha
     ( alphaType
     , alphaExpr
+    , alphaType'
+    , initialAlphaEnv
+    , alphaTypeCon
+    , bindTypeVar
+    , AlphaEnv(..)
     ) where
 
 import qualified Data.Map.Strict as Map
@@ -27,6 +32,7 @@ data AlphaEnv = AlphaEnv
   , boundExprVarsRhs :: !(Map.Map ExprVarName Int)
     -- ^ Maps bound expr variables from the right-hand-side to
     -- the depth of the binder which introduced them.
+  , tconEquivalence :: !(Qualified TypeConName -> Qualified TypeConName -> Bool)
   }
 
 onList :: (a -> a -> Bool) -> [a] -> [a] -> Bool
@@ -77,7 +83,7 @@ alphaType' env = \case
         TVar x2 -> alphaTypeVar env x1 x2
         _ -> False
     TCon c1 -> \case
-        TCon c2 -> alphaTypeCon c1 c2
+        TCon c2 -> tconEquivalence env c1 c2
         _ -> False
     TApp t1a t1b -> \case
         TApp t2a t2b -> alphaType' env t1a t2a && alphaType' env t1b t2b
@@ -461,6 +467,7 @@ initialAlphaEnv = AlphaEnv
     , boundTypeVarsRhs = Map.empty
     , boundExprVarsLhs = Map.empty
     , boundExprVarsRhs = Map.empty
+    , tconEquivalence = alphaTypeCon
     }
 
 alphaType :: Type -> Type -> Bool

--- a/sdk/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/sdk/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -16,6 +16,7 @@ import Data.List.Extra (nubSort, stripInfixEnd)
 import qualified Data.NameMap as NM
 import Module (UnitId, unitIdString, stringToUnitId)
 import System.FilePath
+import Text.Read (readMaybe)
 
 import DA.Daml.LF.Ast.Base
 import DA.Daml.LF.Ast.TypeLevelNat
@@ -335,3 +336,30 @@ splitUnitId (unitIdString -> unitId) = fromMaybe (PackageName (T.pack unitId), N
     (name, ver) <- stripInfixEnd "-" unitId
     guard $ all (`elem` '.' : ['0' .. '9']) ver
     pure (PackageName (T.pack name), Just (PackageVersion (T.pack ver)))
+
+-- | Take a package version of regex "(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*" into
+-- a list of integers [Integer]
+splitPackageVersion
+  :: (PackageVersion -> a) -> PackageVersion
+  -> Either a [Integer]
+splitPackageVersion mkError version@(PackageVersion raw) =
+  let pieces = T.split (== '.') raw
+  in
+  case traverse (readMaybe . T.unpack) pieces of
+    Nothing -> Left (mkError version)
+    Just versions -> Right versions
+
+data ComparePackageVersionError
+  = FirstVersionUnparseable PackageVersion
+  | SecondVersionUnparseable PackageVersion
+  deriving (Show, Eq, Ord)
+
+comparePackageVersion :: PackageVersion -> PackageVersion -> Either ComparePackageVersionError Ordering
+comparePackageVersion v1 v2 = do
+  v1Pieces <- splitPackageVersion FirstVersionUnparseable v1
+  v2Pieces <- splitPackageVersion SecondVersionUnparseable v2
+  let pad xs target =
+        take
+          (length target `max` length xs)
+          (xs ++ repeat 0)
+  pure $ compare (pad v1Pieces v2Pieces) (pad v2Pieces v1Pieces)

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -202,12 +202,15 @@ data UnwarnableError
   | EUpgradeTemplateAddedKey !TypeConName !TemplateKey
   | EUpgradeTriedToUpgradeIface !TypeConName
   | EUpgradeMissingImplementation !TypeConName !TypeConName
+  | EUpgradeDependencyHasLowerVersionDespiteUpgrade !PackageName !PackageVersion !PackageVersion
   deriving (Show)
 
 data WarnableError
   = WEUpgradeShouldDefineIfacesAndTemplatesSeparately
   | WEUpgradeShouldDefineIfaceWithoutImplementation !TypeConName ![TypeConName]
   | WEUpgradeShouldDefineTplInSeparatePackage !TypeConName !TypeConName
+  | WEPastDependencyHasUnparseableVersion !PackageName !PackageVersion
+  | WEPresentDependencyHasUnparseableVersion !PackageName !PackageVersion
   deriving (Show)
 
 instance Pretty WarnableError where
@@ -233,6 +236,10 @@ instance Pretty WarnableError where
         , "It is recommended that interfaces are defined in their own package separate from their implementations."
         , "Ignore this error message with the --warn-bad-interface-instances=yes flag."
         ]
+    WEPastDependencyHasUnparseableVersion pkgName version ->
+      "Dependency " <> pPrint pkgName <> " of upgrading package has a version which cannot be parsed: '" <> pPrint version <> "'"
+    WEPresentDependencyHasUnparseableVersion pkgName version ->
+      "Dependency " <> pPrint pkgName <> " of upgraded package has a version which cannot be parsed: '" <> pPrint version <> "'"
 
 data UpgradedRecordOrigin
   = TemplateBody TypeConName
@@ -644,6 +651,12 @@ instance Pretty UnwarnableError where
     EUpgradeTemplateAddedKey template _key -> "The upgraded template " <> pPrint template <> " cannot add a key where it didn't have one previously."
     EUpgradeTriedToUpgradeIface iface -> "Tried to upgrade interface " <> pPrint iface <> ", but interfaces cannot be upgraded. They should be removed in any upgrading package."
     EUpgradeMissingImplementation tpl iface -> "Implementation of interface " <> pPrint iface <> " by template " <> pPrint tpl <> " appears in package that is being upgraded, but does not appear in this package."
+    EUpgradeDependencyHasLowerVersionDespiteUpgrade pkgName presentVersion pastVersion ->
+      vcat
+        [ "Dependency " <> pPrint pkgName <> " has version " <> pPrint presentVersion <> " on the upgrading package, which is older than version " <> pPrint pastVersion <> " on the upgraded package."
+        , "Dependency versions of upgrading packages must always be greater or equal to the dependency versions on upgraded packages."
+        ]
+
 
 instance Pretty UpgradedRecordOrigin where
   pPrint = \case

--- a/sdk/compiler/damlc/daml-rule-types/src/Development/IDE/Core/RuleTypes/Daml.hs
+++ b/sdk/compiler/damlc/daml-rule-types/src/Development/IDE/Core/RuleTypes/Daml.hs
@@ -318,7 +318,7 @@ instance Binary ExtractUpgradedPackage
 instance Hashable ExtractUpgradedPackage
 instance NFData ExtractUpgradedPackage
 
-type instance RuleResult ExtractUpgradedPackage = Maybe (LF.PackageId, LF.Package)
+type instance RuleResult ExtractUpgradedPackage = Maybe ((LF.PackageId, LF.Package), [(LF.PackageId, LF.Package)])
 
 data ExtractUpgradedPackageFile = ExtractUpgradedPackageFile
    deriving (Eq, Show, Typeable, Generic)
@@ -326,4 +326,4 @@ instance Binary ExtractUpgradedPackageFile
 instance Hashable ExtractUpgradedPackageFile
 instance NFData ExtractUpgradedPackageFile
 
-type instance RuleResult ExtractUpgradedPackageFile = (LF.PackageId, LF.Package)
+type instance RuleResult ExtractUpgradedPackageFile = ((LF.PackageId, LF.Package), [(LF.PackageId, LF.Package)])

--- a/sdk/compiler/damlc/tests/BUILD.bazel
+++ b/sdk/compiler/damlc/tests/BUILD.bazel
@@ -497,6 +497,7 @@ da_haskell_test(
         "//test-common:upgrades-SucceedsWhenTwoDeeplyNestedTypeSynonymsResolveToTheSameDatatypes-files",
         "//test-common:upgrades-SucceedsWhenUpgradingADependency-files",
         "//test-common:upgrades-TemplateChangedKeyType-files",
+        "//test-common:upgrades-TemplateChangedKeyType2-files",
         "//test-common:upgrades-ValidUpgrade-files",
         "//test-common:upgrades-WarnsWhenAnInterfaceAndATemplateAreDefinedInTheSamePackage-files",
         "//test-common:upgrades-WarnsWhenAnInterfaceIsDefinedAndThenUsedInAPackageThatUpgradesIt-files",

--- a/sdk/compiler/damlc/tests/BUILD.bazel
+++ b/sdk/compiler/damlc/tests/BUILD.bazel
@@ -446,7 +446,6 @@ da_haskell_test(
 da_haskell_test(
     name = "upgrades",
     srcs = ["src/DA/Test/DamlcUpgrades.hs"],
-    compiler_flags = ["-Wno-unused-local-binds"],
     data = [
         "//compiler/damlc",
         "//daml-script/daml:daml-script.dar",
@@ -463,6 +462,7 @@ da_haskell_test(
         "//test-common:upgrades-FailsWhenAnInstanceIsDropped-files",
         "//test-common:upgrades-FailsWhenAnInterfaceIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-files",
         "//test-common:upgrades-FailsWhenDatatypeChangesVariety-files",
+        "//test-common:upgrades-FailsWhenDepsDowngradeVersions-files",
         "//test-common:upgrades-FailsWhenExistingFieldInTemplateChoiceIsChanged-files",
         "//test-common:upgrades-FailsWhenExistingFieldInTemplateIsChanged-files",
         "//test-common:upgrades-FailsWhenNewFieldIsAddedToTemplateChoiceWithoutOptionalType-files",

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -367,6 +367,13 @@ tests damlc =
                       False
                       setUpgradeField
                 , test
+                      "TemplateChangedKeyType2"
+                      (FailWithError "\ESC\\[0;91merror type checking template Main.T key:\n  The upgraded template T cannot change its key type.")
+                      contractKeysMinVersion
+                      NoDependencies
+                      False
+                      setUpgradeField
+                , test
                       "RecordFieldsNewNonOptional"
                       (FailWithError "\ESC\\[0;91merror type checking data type Main.Struct:\n  The upgraded data type Struct has added new fields, but those fields are not Optional.")
                       LF.versionDefault

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -384,14 +384,14 @@ tests damlc =
                       "FailsWithSynonymReturnTypeChangeInSeparatePackage"
                       (FailWithError "\ESC\\[0;91merror type checking template Main.T choice C:\n  The upgraded choice C cannot change its return type.")
                       LF.versionDefault
-                      SeparateDeps
+                      (SeparateDeps False)
                       False
                       setUpgradeField
                 , test
                       "SucceedsWhenUpgradingADependency"
                       Succeed
                       LF.versionDefault
-                      SeparateDeps
+                      (SeparateDeps False)
                       False
                       setUpgradeField
                 , test
@@ -406,6 +406,13 @@ tests damlc =
                       (FailWithError "\ESC\\[0;91merror type checking data type Main.RecordToEnum:\n  The upgraded data type RecordToEnum has changed from a record to a enum.")
                       LF.versionDefault
                       NoDependencies
+                      False
+                      setUpgradeField
+                , test
+                      "FailsWhenDepsDowngradeVersions"
+                      (FailWithError "\ESC\\[0;91merror type checking <none>:\n  Dependency upgrades-example-FailsWhenDepsDowngradeVersions-dep has version 0.0.1 on the upgrading package, which is older than version 0.0.2 on the upgraded package.\n  Dependency versions of upgrading packages must always be greater or equal to the dependency versions on upgraded packages.")
+                      LF.versionDefault
+                      (SeparateDeps True)
                       False
                       setUpgradeField
                 ]
@@ -510,10 +517,10 @@ tests damlc =
                       )
                 let sharedDir = dir </> "shared"
                 let sharedDar = sharedDir </> "out.dar"
-                writeFiles sharedDir (projectFile ("upgrades-example-" <> location <> "-dep") Nothing Nothing : sharedDepFiles)
+                writeFiles sharedDir (projectFile "0.0.1" ("upgrades-example-" <> location <> "-dep") Nothing Nothing : sharedDepFiles)
                 callProcessSilent damlc ["build", "--project-root", sharedDir, "-o", sharedDar]
                 pure (Just sharedDar, Just sharedDar)
-              SeparateDeps -> do
+              SeparateDeps { shouldSwap } -> do
                 depV1FilePaths <- listDirectory =<< testRunfile (location </> "dep-v1")
                 let depV1Files = flip map depV1FilePaths $ \path ->
                       ( "daml" </> path
@@ -521,7 +528,7 @@ tests damlc =
                       )
                 let depV1Dir = dir </> "shared-v1"
                 let depV1Dar = depV1Dir </> "out.dar"
-                writeFiles depV1Dir (projectFile ("upgrades-example-" <> location <> "-dep-v1") Nothing Nothing : depV1Files)
+                writeFiles depV1Dir (projectFile "0.0.1" ("upgrades-example-" <> location <> "-dep") Nothing Nothing : depV1Files)
                 callProcessSilent damlc ["build", "--project-root", depV1Dir, "-o", depV1Dar]
 
                 depV2FilePaths <- listDirectory =<< testRunfile (location </> "dep-v2")
@@ -531,19 +538,21 @@ tests damlc =
                       )
                 let depV2Dir = dir </> "shared-v2"
                 let depV2Dar = depV2Dir </> "out.dar"
-                writeFiles depV2Dir (projectFile ("upgrades-example-" <> location <> "-dep-v2") Nothing Nothing : depV2Files)
+                writeFiles depV2Dir (projectFile "0.0.2" ("upgrades-example-" <> location <> "-dep") Nothing Nothing : depV2Files)
                 callProcessSilent damlc ["build", "--project-root", depV2Dir, "-o", depV2Dar]
 
-                pure (Just depV1Dar, Just depV2Dar)
+                if shouldSwap
+                   then pure (Just depV2Dar, Just depV1Dar)
+                   else pure (Just depV1Dar, Just depV2Dar)
               DependOnV1 ->
                 pure (Nothing, Just oldDar)
               _ ->
                 pure (Nothing, Nothing)
 
-            writeFiles oldDir (projectFile ("upgrades-example-" <> location) Nothing depV1Dar : oldVersion)
+            writeFiles oldDir (projectFile "0.0.1" ("upgrades-example-" <> location) Nothing depV1Dar : oldVersion)
             callProcessSilent damlc ["build", "--project-root", oldDir, "-o", oldDar]
 
-            writeFiles newDir (projectFile ("upgrades-example-" <> location <> "-v2") (if setUpgradeField then Just oldDar else Nothing) depV2Dar : newVersion)
+            writeFiles newDir (projectFile "0.0.2" ("upgrades-example-" <> location) (if setUpgradeField then Just oldDar else Nothing) depV2Dar : newVersion)
 
             case expectation of
               Succeed ->
@@ -568,13 +577,13 @@ tests damlc =
                       else when (matchTest compiledRegex stderr) $
                             assertFailure ("`daml build` succeeded, did not `upgrade:` field set, should NOT give a warning matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
           where
-          projectFile name upgradedFile mbDep =
+          projectFile version name upgradedFile mbDep =
               ( "daml.yaml"
               , unlines $
                 [ "sdk-version: " <> sdkVersion
                 , "name: " <> name
                 , "source: daml"
-                , "version: 0.0.1"
+                , "version: " <> version
                 , "dependencies:"
                 , "  - daml-prim"
                 , "  - daml-stdlib"
@@ -604,4 +613,4 @@ data Dependency
   = NoDependencies
   | DependOnV1
   | SeparateDep
-  | SeparateDeps
+  | SeparateDeps { shouldSwap :: Bool }

--- a/sdk/daml-lf/validation/BUILD.bazel
+++ b/sdk/daml-lf/validation/BUILD.bazel
@@ -235,6 +235,12 @@ da_scala_test_suite(
             "//test-common:upgrades-SucceedsWhenATopLevelVariantAddsAVariant-v2.dar",
             "//test-common:upgrades-FailsWhenDatatypeChangesVariety-v1.dar",
             "//test-common:upgrades-FailsWhenDatatypeChangesVariety-v2.dar",
+
+            # Test for dependency upgrades
+            "//test-common:upgrades-FailsWhenDepsDowngradeVersions-dep-v1.dar",
+            "//test-common:upgrades-FailsWhenDepsDowngradeVersions-dep-v2.dar",
+            "//test-common:upgrades-FailsWhenDepsDowngradeVersions-v1.dar",
+            "//test-common:upgrades-FailsWhenDepsDowngradeVersions-v2.dar",
         ],
         flaky = True,
         scala_deps = [

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesSpecBase.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesSpecBase.scala
@@ -567,22 +567,6 @@ trait LongTests { this: UpgradesSpec =>
       )
     }
 
-    "Fails when adding deps downgrade versions." in {
-      for {
-        _ <- uploadPackage("test-common/upgrades-FailsWhenDepsDowngradeVersions-dep-v1.dar")
-        _ <- uploadPackage("test-common/upgrades-FailsWhenDepsDowngradeVersions-dep-v2.dar")
-        result <- testPackagePair(
-          "test-common/upgrades-FailsWhenDepsDowngradeVersions-v1.dar",
-          "test-common/upgrades-FailsWhenDepsDowngradeVersions-v2.dar",
-          assertPackageUpgradeCheck(
-            Some(
-              "Dependency upgrades-example-FailsWhenDepsDowngradeVersions-dep has version 1.0.0 on the upgrading package, which is older than version 2.0.0 on the upgraded package."
-            )
-          ),
-        )
-      } yield result
-    }
-
     def mkTrivialPkg(pkgName: String, pkgVersion: String, lfVersion: LanguageVersion) = {
       import com.digitalasset.daml.lf.testing.parser._
       import com.digitalasset.daml.lf.testing.parser.Implicits._

--- a/sdk/test-common/BUILD.bazel
+++ b/sdk/test-common/BUILD.bazel
@@ -108,6 +108,7 @@ da_scala_dar_resources_library(
         "MissingChoice",
         "RecordFieldsNewNonOptional",
         "TemplateChangedKeyType",
+        "TemplateChangedKeyType2",
         "ValidUpgrade",
 
         # Ported from DamlcUpgrades.hs

--- a/sdk/test-common/BUILD.bazel
+++ b/sdk/test-common/BUILD.bazel
@@ -295,6 +295,73 @@ da_scala_dar_resources_library(
             visibility = ["//visibility:public"],
         ),
         daml_compile(
+            name = "upgrades-{}-dep-v1".format(identifier),
+            srcs = glob(["src/main/daml/upgrades/{}/dep-v1/*.daml".format(identifier)]),
+            dependencies = ["//daml-script/daml:daml-script-2.dev.dar"],
+            enable_interfaces = True,
+            ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
+            project_name = "upgrades-example-{}-dep".format(identifier),
+            target = "2.dev",
+            version = "1.0.0",
+            visibility = ["//visibility:public"],
+        ),
+        daml_compile(
+            name = "upgrades-{}-dep-v2".format(identifier),
+            srcs = glob(["src/main/daml/upgrades/{}/dep-v2/*.daml".format(identifier)]),
+            dependencies = ["//daml-script/daml:daml-script-2.dev.dar"],
+            enable_interfaces = True,
+            ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
+            project_name = "upgrades-example-{}-dep".format(identifier),
+            target = "2.dev",
+            # We want to check the validity of this upgrade on the ledger
+            # client, not during compilation
+            typecheck_upgrades = False,
+            upgrades = "//test-common:upgrades-{}-dep-v1.dar".format(identifier),
+            version = "2.0.0",
+            visibility = ["//visibility:public"],
+        ),
+        daml_compile(
+            name = "upgrades-{}-v1".format(identifier),
+            srcs = glob(["src/main/daml/upgrades/{}/v1/*.daml".format(identifier)]),
+            data_dependencies = ["//test-common:upgrades-{}-dep-v2.dar".format(identifier)],
+            dependencies = ["//daml-script/daml:daml-script-2.dev.dar"],
+            enable_interfaces = True,
+            ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
+            project_name = "upgrades-example-{}".format(identifier),
+            target = "2.dev",
+            version = "1.0.0",
+            visibility = ["//visibility:public"],
+        ),
+        daml_compile(
+            name = "upgrades-{}-v2".format(identifier),
+            srcs = glob(["src/main/daml/upgrades/{}/v2/*.daml".format(identifier)]),
+            data_dependencies = ["//test-common:upgrades-{}-dep-v1.dar".format(identifier)],
+            dependencies = ["//daml-script/daml:daml-script-2.dev.dar"],
+            enable_interfaces = True,
+            ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
+            project_name = "upgrades-example-{}".format(identifier),
+            target = "2.dev",
+            # We want to check the validity of this upgrade on the ledger
+            # client, not during compilation
+            typecheck_upgrades = False,
+            upgrades = "//test-common:upgrades-{}-v1.dar".format(identifier),
+            version = "2.0.0",
+            visibility = ["//visibility:public"],
+        ),
+    ]
+    for identifier in [
+        "FailsWhenDepsDowngradeVersions",
+    ]
+]
+
+[
+    [
+        filegroup(
+            name = "upgrades-{}-files".format(identifier),
+            srcs = glob(["src/main/daml/upgrades/{}/*/*.daml".format(identifier)]),
+            visibility = ["//visibility:public"],
+        ),
+        daml_compile(
             name = "upgrades-{}-dep".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/dep/*.daml".format(identifier)]),
             dependencies = ["//daml-script/daml:daml-script-2.dev.dar"],

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/dep-v1/Dep.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/dep-v1/Dep.daml
@@ -1,0 +1,7 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Dep where
+
+dep : Text
+dep = "dep-v1"

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/dep-v2/Dep.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/dep-v2/Dep.daml
@@ -1,0 +1,7 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Dep where
+
+dep : Text
+dep = "dep-v2"

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/v1/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/v1/Main.daml
@@ -1,0 +1,9 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+import Dep
+
+self : Text
+self = "v1 with " <> dep

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/v2/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsDowngradeVersions/v2/Main.daml
@@ -1,0 +1,9 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+import Dep
+
+self : Text
+self = "v2 with " <> dep

--- a/sdk/test-common/src/main/daml/upgrades/TemplateChangedKeyType2/v1/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/TemplateChangedKeyType2/v1/Main.daml
@@ -1,0 +1,15 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+data TKey
+  = TKey1 with p : Party
+  | TKey2 with p : Party
+
+template T with
+    p: Party
+  where
+  signatory p
+  key (TKey1 p) : TKey
+  maintainer key.p

--- a/sdk/test-common/src/main/daml/upgrades/TemplateChangedKeyType2/v2/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/TemplateChangedKeyType2/v2/Main.daml
@@ -1,0 +1,16 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+data TKey
+  = TKey1 with p : Party
+  | TKey2 with p : Party
+  | TKey3 with p : Party
+
+template T with
+    p: Party
+  where
+  signatory p
+  key (TKey1 p) : TKey
+  maintainer key.p


### PR DESCRIPTION
Builds on work from https://github.com/digital-asset/daml/pull/19184 and https://github.com/digital-asset/daml/pull/19509

This needs backporting to 2.9.x and 2.x, simultaneously participant-side checks from 2.9.x/2.x for key types and structural equality needs to be forward-ported to 3.x - other PR incoming