### PR TITLE
Implement interface upgrades and package preference support for IDE Ledger

### DIFF
--- a/sdk/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/sdk/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -273,7 +273,7 @@ class Context(
         e.cause match {
           case e: Error => handleFailure(e)
           case e: speedy.SError.SError => handleFailure(Error.RunnerException(e))
-          case e =>
+          case _ =>
             // We can't send _everything_ over without changing internal, we log and wrap the error in t.
             logger.warn("Script.FailedCmd unexpected cause: " + e.getMessage)
             logger.debug(e.getStackTrace.mkString("\n"))

--- a/sdk/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/sdk/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -431,12 +431,13 @@ private[lf] object ScenarioRunner {
       commands: SExpr,
       location: Option[Location],
       seed: crypto.Hash,
+      packageResolution: Map[PackageName, PackageId] = Map.empty,
       traceLog: TraceLog = Speedy.Machine.newTraceLog,
       warningLog: WarningLog = Speedy.Machine.newWarningLog,
       doEnrichment: Boolean = true,
   )(implicit loggingContext: LoggingContext): SubmissionResult[R] = {
     val ledgerMachine = Speedy.UpdateMachine(
-      packageResolution = Map.empty,
+      packageResolution = packageResolution,
       compiledPackages = compiledPackages,
       submissionTime = Time.Timestamp.MinValue,
       initialSeeding = InitialSeeding.TransactionSeed(seed),

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -224,7 +224,7 @@ object Script {
 
   final case class FailedCmd(description: String, stackTrace: StackTrace, cause: Throwable)
       extends RuntimeException(
-        s"""Command ${description} failed: ${cause.getMessage}
+        s"""Command ${description} failed: ${Option(cause.getMessage).getOrElse(cause)}
           |Daml stacktrace:
           |${stackTrace.pretty()}""".stripMargin,
         cause,

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/IdeLedgerClient.scala
@@ -314,8 +314,8 @@ class IdeLedgerClient(
           translated,
           optLocation,
           nextSeed(),
-          traceLog,
-          warningLog,
+          traceLog = traceLog,
+          warningLog = warningLog,
         )(Script.DummyLoggingContext)
 
       @tailrec

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -36,6 +36,7 @@ import scalaz.syntax.foldable._
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
+import scala.math.Ordered.orderingToOrdered
 
 // Client for the script service.
 class IdeLedgerClient(
@@ -100,6 +101,13 @@ class IdeLedgerClient(
       else originalCompiledPackages
     preprocessor = makePreprocessor
   }
+
+  // Throws if the packageId isn't known
+  def packageSupportsUpgrades(packageId: PackageId): Boolean =
+    compiledPackages.pkgInterface
+      .lookupPackage(packageId)
+      .getOrElse(throw new IllegalArgumentException("Unknown PackageId"))
+      .languageVersion >= LanguageVersion.Features.packageUpgrades
 
   private var _ledger: ScenarioLedger = ScenarioLedger.initialLedger(Time.Timestamp.Epoch)
   def ledger: ScenarioLedger = _ledger
@@ -483,28 +491,21 @@ class IdeLedgerClient(
     makeEmptySubmissionError(scenario.Error.PartiesNotAllocated(unallocatedSubmitters))
 
   /* Given a daml-script CommandWithMeta, returns the corresponding IDE Ledger
-   * ApiCommand. If the CommandWithMeta has an explicit package id,
+   * ApiCommand. If the CommandWithMeta has an explicit package id, or is <LF1.16,
    * the ApiCommand will have the same PackageRef, otherwise it will be
-   * replaced with the PackageId of the most recent (newest version) package
-   * of the same name in the original compiled packages.
+   * replaced with PackageRef.Name, such that the preprocess will replace it
+   * according to package resolution
    */
   private def toCommand(
-      cmdWithMeta: ScriptLedgerClient.CommandWithMeta
+      cmdWithMeta: ScriptLedgerClient.CommandWithMeta,
+      // This map only contains packageIds >=LF1.16
+      packageIdMap: Map[PackageId, ScriptLedgerClient.ReadablePackageId],
   ): ApiCommand = {
-    def adjustPackageRef(old: PackageRef): PackageRef =
-      old match {
-        case PackageRef.Id(id) =>
-          PackageRef.Id(newestPackageId(id))
-        case PackageRef.Name(_) =>
-          // TODO: https://github.com/digital-asset/daml/issues/17995
-          //  add support for package name
-          throw new IllegalArgumentException("package name not supported")
-      }
-
     def adjustTypeConRef(old: TypeConRef): TypeConRef =
       old match {
-        case TypeConRef(pkgRef, qName) =>
-          TypeConRef(adjustPackageRef(pkgRef), qName)
+        case TypeConRef(PackageRef.Id(packageIdMap(nameVersion)), qName) =>
+          TypeConRef(PackageRef.Name(nameVersion.name), qName)
+        case ref => ref
       }
 
     val ScriptLedgerClient.CommandWithMeta(cmd, explicitPackageId) = cmdWithMeta
@@ -545,6 +546,7 @@ class IdeLedgerClient(
       actAs: OneAnd[Set, Ref.Party],
       readAs: Set[Ref.Party],
       disclosures: List[Disclosure],
+      packagePreference: List[PackageId],
       commands: List[ScriptLedgerClient.CommandWithMeta],
       optLocation: Option[Location],
   ): Either[
@@ -556,6 +558,8 @@ class IdeLedgerClient(
     if (unallocatedSubmitters.nonEmpty) {
       Left(makePartiesNotAllocatedError(unallocatedSubmitters))
     } else {
+      val reversePackageIdMap = getPackageIdReverseMap()
+      val packageMap = calculatePackageMap(packagePreference, reversePackageIdMap)
       @tailrec
       def loop(
           result: ScenarioRunner.SubmissionResult[ScenarioLedger.CommitResult]
@@ -603,8 +607,8 @@ class IdeLedgerClient(
         try {
           Right(
             preprocessor.unsafePreprocessApiCommands(
-              Map.empty,
-              commands.map(toCommand(_)).to(ImmArray),
+              packageMap,
+              commands.map(toCommand(_, reversePackageIdMap)).to(ImmArray),
             )
           )
         } catch {
@@ -656,6 +660,7 @@ class IdeLedgerClient(
             translated,
             optLocation,
             nextSeed(),
+            packageMap,
             traceLog,
             warningLog,
           )(Script.DummyLoggingContext)
@@ -681,11 +686,15 @@ class IdeLedgerClient(
     ScriptLedgerClient.SubmitFailure,
     (Seq[ScriptLedgerClient.CommandResult], ScriptLedgerClient.TransactionTree),
   ]] = Future {
-    optPackagePreference.foreach(_ =>
-      throw new IllegalArgumentException("IDE Ledger does not support Package Preference")
-    )
     synchronized {
-      unsafeSubmit(actAs, readAs, disclosures, commands, optLocation) match {
+      unsafeSubmit(
+        actAs,
+        readAs,
+        disclosures,
+        optPackagePreference.getOrElse(List()),
+        commands,
+        optLocation,
+      ) match {
         case Right(ScenarioRunner.Commit(result, _, tx)) =>
           _ledger = result.newLedger
           val transaction = result.richTransaction.transaction
@@ -874,21 +883,38 @@ class IdeLedgerClient(
       .listUserRights(id, IdentityProviderId.Default)(LoggingContext.empty)
       .map(_.toOption.map(_.toList))
 
-  /* Given a PackageId, returns the PackageId with the same name and
-   * greatest version found in the original compiled packages.
-   * If the impossible happens and there's no package with that name in the
-   * original compiled packages, returns the argument unchanged.
+  /* Generate a package name map based on package preference then highest version
    */
-  def newestPackageId(old: PackageId): PackageId = {
-    for {
-      oldReadable <- getPackageIdReverseMap().get(old)
-      oldName = oldReadable.name
-      newest <- getPackageIdMap().maxByOption {
-        case (k, _) if k.name == oldName => Some(k.version);
-        case _ => None;
-      }
-    } yield newest._2
-  }.getOrElse(old)
+  def calculatePackageMap(
+      packagePreference: List[PackageId],
+      reverseMap: Map[PackageId, ScriptLedgerClient.ReadablePackageId],
+  ): Map[PackageName, PackageId] = {
+    // Map containing only elements of the package preference
+    val pkgPrefMap: Map[PackageName, PackageId] = packagePreference
+      .map(pkgId =>
+        (
+          reverseMap
+            .getOrElse(pkgId, throw new IllegalArgumentException(s"No such PackageId $pkgId"))
+            .name,
+          if (packageSupportsUpgrades(pkgId)) pkgId
+          else throw new IllegalArgumentException(s"Package $pkgId does not support Upgrades."),
+        )
+      )
+      .toMap
+    val ordering: Ordering[(PackageVersion, PackageId)] = Ordering[PackageVersion].on(_._1)
+    // Map containing only highest versions of upgrades compatible packages, could be cached
+    val highestVersionMap: Map[PackageName, PackageId] = getPackageIdMap()
+      .filter { case (_, pkgId) => packageSupportsUpgrades(pkgId) }
+      .groupMapReduce(_._1.name) { case (nameVersion, packageId) =>
+        (nameVersion.version, packageId)
+      }(ordering.max)
+      .view
+      .mapValues(_._2)
+      .toMap
+
+    // Preference overrides highest version
+    highestVersionMap ++ pkgPrefMap
+  }
 
   def getPackageIdMap(): Map[ScriptLedgerClient.ReadablePackageId, PackageId] =
     getPackageIdPairs().toMap

--- a/sdk/daml-script/test/daml/upgrades/Interfaces.daml
+++ b/sdk/daml-script/test/daml/upgrades/Interfaces.daml
@@ -146,12 +146,12 @@ interfacesAltV2 = getPackageId "interfaces-alt-2.0.0"
 -- cant upgrade contracts in interface choice argument - i dont think this is possible in daml-script
 main : TestTree
 main = tests
-  [ brokenOnIDELedger ("Calling an interface choice uses the highest version implementation at command level by default", defaultHighestVersionChoiceImplementationCommand)
-  , brokenOnIDELedger ("Calling an interface choice uses the highest version implementation at choice body level by default", defaultHighestVersionChoiceImplementationUpdate)
-  , brokenOnIDELedger ("Package map preference is used for interface implementation selection at command level", interfaceChoicePackagePreferenceCommand)
-  , brokenOnIDELedger ("Package map preference is used for interface implementation selection at choice body level", interfaceChoicePackagePreferenceUpdate)
-  , brokenOnIDELedger ("Multiple interface exercises use their respective package preference entries at command level", multipleInterfaceChoicePackagePreferenceCommand)
-  , brokenOnIDELedger ("Multiple interface exercises use their respective package preference entries at choice body level", multipleInterfaceChoicePackagePreferenceUpdate)
+  [ ("Calling an interface choice uses the highest version implementation at command level by default", defaultHighestVersionChoiceImplementationCommand)
+  , ("Calling an interface choice uses the highest version implementation at choice body level by default", defaultHighestVersionChoiceImplementationUpdate)
+  , ("Package map preference is used for interface implementation selection at command level", interfaceChoicePackagePreferenceCommand)
+  , ("Package map preference is used for interface implementation selection at choice body level", interfaceChoicePackagePreferenceUpdate)
+  , ("Multiple interface exercises use their respective package preference entries at command level", multipleInterfaceChoicePackagePreferenceCommand)
+  , ("Multiple interface exercises use their respective package preference entries at choice body level", multipleInterfaceChoicePackagePreferenceUpdate)
   , broken ("queryInterfaceContractId uses highest version of view", queryInterfaceUpgrades)
   , broken ("fetchFromInterface upgrades payload to match request", fetchFromInterfaceUpgrades)
   ]

--- a/sdk/daml-script/test/daml/upgrades/LfVersions.daml
+++ b/sdk/daml-script/test/daml/upgrades/LfVersions.daml
@@ -73,7 +73,6 @@ main = tests
   , ("Call a LF < 1.15 choice on a LF >= 1.15 contract, expect LF 1.15 implementation to attempt to be used, but fail upgrade", exerciseNonUpgradingLfFail)
   ]
 
-
 mustBeWronglyTypedContract : Either SubmitError r -> Script ()
 mustBeWronglyTypedContract (Left (WronglyTypedContract {})) = pure ()
 mustBeWronglyTypedContract (Left e) = assertFail $ "Incorrect error: " <> show e

--- a/sdk/daml-script/test/daml/upgrades/PackagePreference.daml
+++ b/sdk/daml-script/test/daml/upgrades/PackagePreference.daml
@@ -37,9 +37,9 @@ v1PackageId = getPackageId "package-preference-1.0.0"
 main : TestTree
 main = tests
   [ ("No package preference uses the default 'highest version' logic for exercise", noPackagePreference)
-  , brokenOnIDELedger ("Explicit package preference is used over highest version for exercise", explicitPackagePreference)
-  , brokenOnIDELedger ("Explicit package preference is not used for exact exercises", explicitPackagePreferenceWithExact)
-  , brokenOnIDELedger ("Explicit package preference is not used for exact exercises in transactions that do use preference", explicitPackagePreferenceWithExactAndNon)
+  , ("Explicit package preference is used over highest version for exercise", explicitPackagePreference)
+  , ("Explicit package preference is not used for exact exercises", explicitPackagePreferenceWithExact)
+  , ("Explicit package preference is not used for exact exercises in transactions that do use preference", explicitPackagePreferenceWithExactAndNon)
   ]
 
 noPackagePreference : Test


### PR DESCRIPTION
IDELedger now builds a package resolution map by taking the package preference packageids, ensuring they're all known and LF1.16+, then taking highest version of all LF1.16 packages and using it as backup.
We pass this to the Update machine and command preprocessor

We also iterate commands and replace PackageRef.Id with `Name` for any packages that support upgrades and aren't explicit.
