### PR TITLE
Metrics, fix gauges: preserve the initial context

### DIFF
--- a/sdk/observability/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryMetricsFactory.scala
+++ b/sdk/observability/metrics/src/main/scala/com/daml/metrics/api/opentelemetry/OpenTelemetryMetricsFactory.scala
@@ -268,7 +268,8 @@ case class OpenTelemetryGauge[T](override val info: MetricInfo, initial: T, cont
   private val ref = new AtomicReference[(T, MetricsContext)](initial -> context)
   private[opentelemetry] val reference = new AtomicReference[Option[AutoCloseable]](None)
 
-  override def updateValue(newValue: T)(implicit mc: MetricsContext): Unit = ref.set(newValue -> mc)
+  override def updateValue(newValue: T)(implicit mc: MetricsContext): Unit =
+    ref.set(newValue -> context.merge(mc))
 
   override def getValue: T = ref.get()._1
 

--- a/sdk/observability/metrics/src/test/lib/scala/com/daml/metrics/api/testing/InMemoryMetricsFactory.scala
+++ b/sdk/observability/metrics/src/test/lib/scala/com/daml/metrics/api/testing/InMemoryMetricsFactory.scala
@@ -193,7 +193,7 @@ object InMemoryMetricsFactory extends InMemoryMetricsFactory {
 
     override def updateValue(newValue: T)(implicit mc: MetricsContext): Unit = {
       checkClosed()
-      value.set(newValue -> mc)
+      value.set(newValue -> context.merge(mc))
     }
 
     override def updateValue(f: T => T): Unit = {


### PR DESCRIPTION
The initial context should be preserved even when passing additional labels for data points b/c Canton relies on it.

Fixes #19688.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
