### PR TITLE
Fix VSCode starting daml IDE

### DIFF
--- a/sdk/compiler/daml-extension/src/extension.ts
+++ b/sdk/compiler/daml-extension/src/extension.ts
@@ -352,7 +352,7 @@ export function createLanguageClient(
     {
       args: serverArgs,
       command: command,
-      options: { cwd: vscode.workspace.rootPath },
+      options: { cwd: vscode.workspace.rootPath, shell: true },
     },
     clientOptions,
     true,


### PR DESCRIPTION
Fixes #19721 
I've verified that adding this flag is okay, as the source for this field is already explicitly labelled as an executable, so users are aware that the given string argument will be run.

I've also spun up a windows machine, verified the issue exists, and verified that this fixes it