### PR TITLE
add flag and instructions for attaching a java debugger to the canton fixture

### DIFF
--- a/sdk/test-common/canton/it-lib/src/main/com/daml/CantonConfig.scala
+++ b/sdk/test-common/canton/it-lib/src/main/com/daml/CantonConfig.scala
@@ -53,6 +53,7 @@ final case class CantonConfig(
     targetScope: Option[String] = None,
     disableUpgradeValidation: Boolean = false,
     maxPartiesPageSize: Option[Int] = None,
+    enableRemoteJavaDebugging: Boolean = false,
 ) {
 
   lazy val tlsConfig =

--- a/sdk/test-common/canton/it-lib/src/main/com/daml/CantonFixture.scala
+++ b/sdk/test-common/canton/it-lib/src/main/com/daml/CantonFixture.scala
@@ -89,6 +89,14 @@ trait CantonFixtureWithResource[A]
   // temporary files after a test is done running
   protected val cantonFixtureDebugModeRemoveTmpFilesRegardless = false
 
+  // When true, the canton process is started with the necessary flags to enable remote debugging and is suspended until
+  // a debugger is attached. In order to use this feature, launch the test making use of the fixture from IntelliJ
+  // *in debug mode* and look for "Listening for transport dt_socket at address: 5005" in the console output. IntelliJ
+  // should display a clickable chip labelled "Attach debugger" next to this line. Clicking on this chip will attach the
+  // debugger to the canton process and resume execution. Breakpoints in the canton code under canton/* will then be
+  // taken into account by IntelliJ.
+  protected val remoteJavaDebugging: Boolean = false
+
   final protected val logger = org.slf4j.LoggerFactory.getLogger(getClass)
 
   if (cantonFixtureDebugModeIsDebug) {
@@ -129,6 +137,7 @@ trait CantonFixtureWithResource[A]
     targetScope = targetScope,
     disableUpgradeValidation = disableUpgradeValidation,
     maxPartiesPageSize = maxPartiesPageSize,
+    enableRemoteJavaDebugging = remoteJavaDebugging,
   )
 
   protected def info(msg: String): Unit =

--- a/sdk/test-common/canton/it-lib/src/main/com/daml/CantonRunner.scala
+++ b/sdk/test-common/canton/it-lib/src/main/com/daml/CantonRunner.scala
@@ -166,15 +166,18 @@ object CantonRunner {
     )
     var outputBuffer = ""
     val cmd = java ::
-      "-jar" ::
-      config.jarPath.toString ::
-      "daemon" ::
-      "--auto-connect-local" ::
-      "-c" ::
-      files.configFile.toString ::
-      "--bootstrap" ::
-      files.bootstrapFile.toString ::
-      debugOptions
+      (if (config.enableRemoteJavaDebugging)
+         List("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005")
+       else List.empty) ++
+      ("-jar" ::
+        config.jarPath.toString ::
+        "daemon" ::
+        "--auto-connect-local" ::
+        "-c" ::
+        files.configFile.toString ::
+        "--bootstrap" ::
+        files.bootstrapFile.toString ::
+        debugOptions)
     info(cmd.mkString("\\\n    "))
     for {
       proc <- Future(


### PR DESCRIPTION
backport of https://github.com/digital-asset/daml/pull/19763