### PR TITLE
Default to CantonFixtureDontDebug in CantonFixtures

### DIFF
--- a/sdk/test-common/canton/it-lib/src/main/com/daml/CantonFixture.scala
+++ b/sdk/test-common/canton/it-lib/src/main/com/daml/CantonFixture.scala
@@ -77,7 +77,7 @@ trait CantonFixtureWithResource[A]
   final case object CantonFixtureDebugRemoveTmpFiles extends CantonFixtureDebugMode
   final case object CantonFixtureDontDebug extends CantonFixtureDebugMode
 
-  protected val cantonFixtureDebugMode: CantonFixtureDebugMode = CantonFixtureDebugKeepTmpFiles
+  protected val cantonFixtureDebugMode: CantonFixtureDebugMode = CantonFixtureDontDebug
   def cantonFixtureDebugModeIsDebug: Boolean = cantonFixtureDebugMode match {
     case CantonFixtureDebugKeepTmpFiles | CantonFixtureDebugRemoveTmpFiles => true
     case _ => false


### PR DESCRIPTION
The default value had accidentally been flipped to CantonFixtureDebugKeepTmpFiles