### PR TITLE
Fix GetUser in daml script to populate the party participant map (2.8)

### DIFF
--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ScriptF.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ScriptF.scala
@@ -545,10 +545,17 @@ object ScriptF {
       for {
         client <- Converter.toFuture(env.clients.getParticipant(participant))
         user <- client.getUser(userId)
-        user <- Converter.toFuture(
+        userValue <- Converter.toFuture(
           Converter.fromOptional(user, Converter.fromUser(env.scriptIds, _))
         )
-      } yield SEAppAtomic(SEValue(continue), Array(SEValue(user)))
+      } yield {
+        (participant, user.flatMap(_.primaryParty)) match {
+          case (Some(participant), Some(party)) =>
+            env.addPartyParticipantMapping(party, participant)
+          case _ =>
+        }
+        SEAppAtomic(SEValue(continue), Array(SEValue(userValue)))
+      }
   }
 
   final case class DeleteUser(

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
@@ -626,10 +626,17 @@ object ScriptF {
       for {
         client <- Converter.toFuture(env.clients.getParticipant(participant))
         user <- client.getUser(userId)
-        user <- Converter.toFuture(
+        userValue <- Converter.toFuture(
           Converter.fromOptional(user, Converter.fromUser(env.scriptIds, _))
         )
-      } yield SEValue(user)
+      } yield {
+        (participant, user.flatMap(_.primaryParty)) match {
+          case (Some(participant), Some(party)) =>
+            env.addPartyParticipantMapping(party, participant)
+          case _ =>
+        }
+        SEValue(userValue)
+      }
   }
 
   final case class DeleteUser(


### PR DESCRIPTION
Fixes #19781

Proven with a local setup involving 2 nodes, the following participant config (`conf.conf`):
```
{
    "default_participant": {"host": "localhost", "port": 3005},
    "participants": {
        "one": {"host": "localhost", "port": 3005},
        "two": {"host": "localhost", "port": 3006}
    },
    "party_participants": {}
}
```

and by running the following script twice:
```haskell
module Main where

import Daml.Script
import DA.Foldable

template Name
  with
    party : Party
  where
    signatory party

userExists : UserId -> Script Bool
userExists u = do try do _ <- getUserOn u (ParticipantName "two"); pure True catch UserNotFound _ -> pure False

script : Script ()
script = do
  name <- validateUserId "my_user"
  exists <- userExists name
  u <-
    if exists
      then do
        debug "exists"
        getUserOn name (ParticipantName "two")
      else do
        debug "creating"
        p <- allocatePartyOn "my_user" (ParticipantName "two")
        let u = User name (Some p)
        createUserOn u [CanActAs p, CanReadAs p] (ParticipantName "two")
        pure u
  
  debug u
  let p = primaryParty u
  forA_ p $ \party -> do
    cid <- party `submit` createCmd Name with party = party
    debug cid
```
First time should print "creating", second should print "exists", both should give a (different) contract id at the end, proving the user submission works.
Ran using `daml script --dar ./.daml/dist/test-0.0.1.dar --participant-config ./conf.conf --script-name Main:script`



Second run with the fix gives:
```
Slf4jLogger started
[DA.Internal.Prelude:557]: \"exists\"
[DA.Internal.Prelude:557]: User {userId = 'my_user', primaryParty = Some 'party-6575a589-e5a1-493a-b106-3e9bbd0f3994::1220bbb6a33e33bc5d7a457ee4d1a42e17a0b8d85f4ed8bbdc108435a268f3506952'}
[DA.Internal.Prelude:557]: 002d08deb62ba3f3659bb9e4204c55c5820ea968aad5391672890db587f7c50436ca03122027c3fd4cf79c97818faa22bde8c4317fc8d04437a9ed793054f8f7320939dfcc
Running CoordinatedShutdown with reason [ActorSystemTerminateReason]
```

Second run without the fix (i.e. on 2.8.9) gives
```
Slf4jLogger started
[DA.Internal.Prelude:557]: \"exists\"
[DA.Internal.Prelude:557]: User {userId = 'my_user', primaryParty = Some 'party-17652a21-7103-4331-8a30-cce245f69034::12203ad88e943dbadd3aff6f1394e222d45aacd990a002a8292bad206838ba344e0b'}
Exception in thread "main" com.daml.lf.engine.script.Script$FailedCmd: Command submit failed: NOT_FOUND: UNKNOWN_SUBMITTERS(11,03789b4d): The participant is not connected to any domain where the given submitters are known.
```