### PR TITLE
Include originating contract packages when calculating party packages

### DIFF
--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -93,17 +93,14 @@ object Blinding {
   }
 
   // These are the packages needed for model conformance
-  private[engine] def divulgedPartyPackages(
+  private def divulgedPartyPackages(
       contractPackages: Map[ContractId, Ref.PackageId],
       divulgence: Relation[ContractId, Party],
-  ): Seq[(Party, PackageId)] = {
-    divulgence.view.flatMap { case (contractId, parties) =>
-      val packageId = contractPackages.getOrElse(
-        contractId,
-        throw new IllegalArgumentException(s"Could not find package for $contractId"),
-      )
-      parties.view.map(_ -> packageId)
-    }.toSeq
+  ): Iterable[(Party, PackageId)] = {
+    for {
+      (contractId, packageId) <- contractPackages
+      party <- divulgence.getOrElse(contractId, Set.empty)
+    } yield party -> packageId
   }
 
   // These are the package needed for reinterpretation

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -6,9 +6,10 @@ package com.daml.lf.engine
 import com.daml.lf.data._
 import com.daml.lf.data.Ref.{PackageId, Party}
 import com.daml.lf.transaction.Node
-import com.daml.lf.transaction.{BlindingInfo, Transaction, NodeId, VersionedTransaction}
+import com.daml.lf.transaction.{BlindingInfo, NodeId, Transaction, VersionedTransaction}
 import com.daml.lf.ledger._
 import com.daml.lf.data.Relation
+import com.daml.lf.value.Value.ContractId
 
 import scala.annotation.tailrec
 
@@ -83,8 +84,34 @@ object Blinding {
   private[engine] def partyPackages(
       tx: VersionedTransaction,
       blindingInfo: BlindingInfo,
+      contractPackages: Map[ContractId, Ref.PackageId],
   ): Relation[Party, Ref.PackageId] = {
-    val entries = blindingInfo.disclosure.view.flatMap { case (nodeId, parties) =>
+    Relation.from(
+      disclosedPartyPackages(tx, blindingInfo.disclosure) ++
+        divulgedPartyPackages(contractPackages, blindingInfo.divulgence)
+    )
+  }
+
+  // These are the packages needed for model conformance
+  private[engine] def divulgedPartyPackages(
+      contractPackages: Map[ContractId, Ref.PackageId],
+      divulgence: Relation[ContractId, Party],
+  ): Seq[(Party, PackageId)] = {
+    divulgence.view.flatMap { case (contractId, parties) =>
+      val packageId = contractPackages.getOrElse(
+        contractId,
+        throw new IllegalArgumentException(s"Could not find package for $contractId"),
+      )
+      parties.view.map(_ -> packageId)
+    }.toSeq
+  }
+
+  // These are the package needed for reinterpretation
+  private[engine] def disclosedPartyPackages(
+      tx: VersionedTransaction,
+      disclosure: Relation[NodeId, Party],
+  ): Seq[(Party, PackageId)] = {
+    disclosure.view.flatMap { case (nodeId, parties) =>
       def toEntries(tyCon: Ref.TypeConName) = parties.view.map(_ -> tyCon.packageId)
       tx.nodes(nodeId) match {
         case action: Node.LeafOnlyAction =>
@@ -94,12 +121,14 @@ object Blinding {
         case _: Node.Rollback =>
           Iterable.empty
       }
-    }
-    Relation.from(entries)
+    }.toSeq
   }
 
   /* Calculate the packages needed by a party to interpret the projection   */
-  def partyPackages(tx: VersionedTransaction): Relation[Party, PackageId] =
-    partyPackages(tx, blind(tx))
+  def partyPackages(
+      tx: VersionedTransaction,
+      contractPackages: Map[ContractId, Ref.PackageId] = Map.empty,
+  ): Relation[Party, PackageId] =
+    partyPackages(tx, blind(tx), contractPackages)
 
 }

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -425,7 +425,14 @@ class Engine(val config: EngineConfig = Engine.StableConfig, allowLF2: Boolean =
     def finish: Result[(SubmittedTransaction, Tx.Metadata)] =
       machine.finish match {
         case Right(
-              UpdateMachine.Result(tx, _, nodeSeeds, globalKeyMapping, disclosedCreateEvents)
+              UpdateMachine.Result(
+                tx,
+                _,
+                nodeSeeds,
+                globalKeyMapping,
+                disclosedCreateEvents,
+                contractPackages,
+              )
             ) =>
           deps(tx).flatMap { deps =>
             val meta = Tx.Metadata(
@@ -436,6 +443,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig, allowLF2: Boolean =
               nodeSeeds = nodeSeeds,
               globalKeyMapping = globalKeyMapping,
               disclosedEvents = disclosedCreateEvents,
+              contractPackages = contractPackages,
             )
             config.profileDir.foreach { dir =>
               val desc = Engine.profileDesc(tx)

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -443,7 +443,9 @@ class Engine(val config: EngineConfig = Engine.StableConfig, allowLF2: Boolean =
               nodeSeeds = nodeSeeds,
               globalKeyMapping = globalKeyMapping,
               disclosedEvents = disclosedCreateEvents,
-              contractPackages = contractPackages,
+              contractPackages = contractPackages ++ disclosedCreateEvents
+                .map(c => c.coid -> c.templateId.packageId)
+                .iterator,
             )
             config.profileDir.foreach { dir =>
               val desc = Engine.profileDesc(tx)

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -2696,6 +2696,7 @@ class EngineTestHelpers(majorLanguageVersion: LanguageMajorVersion) {
       inside(result) { case Right((transaction, metadata)) =>
         transaction should haveDisclosedInputContracts(usedDisclosedContract)
         metadata should haveDisclosedEvents(expectedDisclosedEvent)
+        metadata should haveDisclosedContractIdPackages(expectedDisclosedEvent)
       }
     }
 
@@ -2722,6 +2723,26 @@ class EngineTestHelpers(majorLanguageVersion: LanguageMajorVersion) {
           expectedResult == actualResult,
           s"Failed with unexpected disclosed contracts: $expectedResult != $actualResult $debugMessage",
           s"Failed with unexpected disclosed contracts: $expectedResult == $actualResult",
+        )
+      }
+
+    def haveDisclosedContractIdPackages(
+        expectedProcessedDisclosedContracts: Node.Create*
+    ): Matcher[Tx.Metadata] =
+      Matcher { metadata =>
+        val expectedResult = Seq(expectedProcessedDisclosedContracts: _*)
+          .map(c => c.coid -> c.templateId.packageId)
+          .toMap
+        val actualResult = metadata.contractPackages
+
+        val missing = expectedResult -- actualResult.keySet
+
+        val debugMessage = s"Missing contractIds package mappings: $missing"
+
+        MatchResult(
+          missing.isEmpty,
+          s"Failed with missing disclosed contracts: $expectedResult != $actualResult $debugMessage",
+          s"Failed with missing disclosed contracts: $expectedResult == $actualResult",
         )
       }
 

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -363,6 +363,10 @@ class EngineTest(majorLanguageVersion: LanguageMajorVersion)
         case Right(()) => ()
       }
     }
+
+    "return contract id package in metadata" in {
+      txMeta.contractPackages shouldBe Map(cid -> templateId.packageId)
+    }
   }
 
   "exercise-by-key command with missing key" should {
@@ -2663,6 +2667,7 @@ class EngineTestHelpers(majorLanguageVersion: LanguageMajorVersion) {
           nodeSeeds = state.nodeSeeds.toImmArray,
           globalKeyMapping = Map.empty,
           disclosedEvents = ImmArray.empty,
+          contractPackages = Map.empty,
         ),
       )
     )

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -31,7 +31,7 @@ import com.daml.lf.transaction.{
   IncompleteTransaction => IncompleteTx,
   TransactionVersion => TxVersion,
 }
-import com.daml.lf.value.Value.ValueArithmeticError
+import com.daml.lf.value.Value.{ContractId, ValueArithmeticError}
 import com.daml.lf.value.{Value => V}
 import com.daml.nameof.NameOf
 import com.daml.scalautil.Statement.discard
@@ -663,6 +663,7 @@ private[lf] object Speedy {
         zipSameLength(seeds, ptx.actionNodeSeeds.toImmArray),
         ptx.contractState.globalKeyInputs.transform((_, v) => v.toKeyMapping),
         disclosedCreateEvents,
+        contractsCache.view.mapValues(_.template.packageId).toMap,
       )
     }
 
@@ -771,6 +772,7 @@ private[lf] object Speedy {
         seeds: NodeSeeds,
         globalKeyMapping: Map[GlobalKey, KeyMapping],
         disclosedCreateEvent: ImmArray[Node.Create],
+        contractPackages: Map[ContractId, PackageId],
     )
   }
 

--- a/sdk/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/sdk/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -508,7 +508,7 @@ private[lf] object ScenarioRunner {
           Interruption(continue)
         case SResult.SResultFinal(resultValue) =>
           ledgerMachine.finish match {
-            case Right(Speedy.UpdateMachine.Result(tx, locationInfo, _, _, _)) =>
+            case Right(Speedy.UpdateMachine.Result(tx, locationInfo, _, _, _, _)) =>
               ledger.commit(committers, readAs, location, enrich(tx), locationInfo) match {
                 case Left(err) =>
                   SubmissionError(err, enrich(ledgerMachine.incompleteTransaction))

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -680,7 +680,8 @@ object Transaction {
     * @param nodeSeeds        : An association list that maps to each ID of create and exercise
     *                         nodes its seeds.
     * @param globalKeyMapping : input key mapping inferred by interpretation
-    * @param disclosedEvents    : disclosed create events that have been used in this transaction
+    * @param disclosedEvents  : disclosed create events that have been used in this transaction
+    * @param contractPackages : The originating package associated with each contract id
     */
   final case class Metadata(
       submissionSeed: Option[crypto.Hash],
@@ -690,6 +691,7 @@ object Transaction {
       nodeSeeds: ImmArray[(NodeId, crypto.Hash)],
       globalKeyMapping: Map[GlobalKey, Option[Value.ContractId]],
       disclosedEvents: ImmArray[Node.Create],
+      contractPackages: Map[ContractId, PackageId],
   )
 
   def commitTransaction(submittedTransaction: SubmittedTransaction): CommittedTransaction =

--- a/sdk/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/LedgerTest.scala
+++ b/sdk/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/LedgerTest.scala
@@ -31,6 +31,10 @@ trait LedgerTest
 
   import TestUtil._
 
+  override lazy val devMode: Boolean = true
+  override protected val cantonFixtureDebugMode: CantonFixtureDebugMode =
+    CantonFixtureDebugKeepTmpFiles
+
   def withUniqueParty(
       testCode: (String, Wolpertinger, Wolpertinger, Channel) => Assertion
   ): Future[Assertion] = for {

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -149,7 +149,7 @@
 - Evaluation order of successful lookup_by_key of a local contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3098)
 - Evaluation order of successful lookup_by_key of a non-cached global contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L2940)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L30)
-- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2115)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2119)
 - This checks that type checking in exercise_interface is done after checking activeness.: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L1988)
 - This checks that type checking is done after checking activeness.: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L1876)
 - This checks that type checking is done after checking activeness.: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L2884)


### PR DESCRIPTION
We decided that originating contract packages must be available in 2.x (for submission and conformance).

At domain selection time a call is made to `Blinding.partyPackages` to establish all the packages that need to be available. This PR:
- Extends Tx.Metadata to include a `contractPackages: Map[ContractId, PackageId]` 
- Extends `Blinding.partyPackages` to take this map and combine it is divulged contracts to extend the party packages relation

**Canton Issue**
Change package vetting rules for 2.x to include creating packages of input contracts
See https://github.com/DACH-NY/canton/issues/20727