### PR TITLE
Fix fetch interface and fromInterface (Forward port #19676)

### DIFF
--- a/sdk/canton/community/base/src/main/scala/com/digitalasset/canton/data/ActionDescription.scala
+++ b/sdk/canton/community/base/src/main/scala/com/digitalasset/canton/data/ActionDescription.scala
@@ -162,6 +162,7 @@ object ActionDescription extends HasProtocolVersionedCompanion[ActionDescription
             _key,
             byKey,
             version,
+            _isInterfaceFetch,
           ) =>
         for {
           _ <- Either.cond(

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/submission/TransactionTreeFactoryImpl.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/submission/TransactionTreeFactoryImpl.scala
@@ -550,6 +550,8 @@ class TransactionTreeFactoryImpl(
     def nodePref(n: LfActionNode): Set[(LfPackageName, LfPackageId)] = n match {
       case ex: LfNodeExercises if ex.interfaceId.isDefined =>
         Set(ex.packageName -> ex.templateId.packageId)
+      case fn: LfNodeFetch if fn.isInterfaceFetch =>
+        Set(fn.packageName -> fn.templateId.packageId)
       case _ => Set.empty
     }
 

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -733,6 +733,7 @@ private[lf] final class Compiler(
     SBUInsertFetchNode(
       tmplId,
       byKey = mbKey.isDefined,
+      isInterfaceFetch = false,
     )(
       env.toSEVar(cidPos),
       mbKey.fold(s.SEValue.None: s.SExpr)(pos => SBSome(env.toSEVar(pos))),

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PartialTransaction.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PartialTransaction.scala
@@ -382,6 +382,7 @@ private[speedy] case class PartialTransaction(
       optLocation: Option[Location],
       byKey: Boolean,
       version: TxVersion,
+      isInterfaceFetch: Boolean,
   ): Either[TxErr.TransactionError, PartialTransaction] =
     mustBeActive(NameOf.qualifiedNameOfCurrentFunc, Some(coid)) {
       val contextActors = context.info.authorizers
@@ -398,6 +399,7 @@ private[speedy] case class PartialTransaction(
         keyOpt = contract.keyOpt.map(_.globalKeyWithMaintainers),
         byKey = normByKey(version, byKey),
         version = version,
+        isInterfaceFetch = isInterfaceFetch,
       )
 
       val newContractState = assertRightKey(

--- a/sdk/daml-lf/transaction-test-lib/src/main/scala/com/digitalasset/daml/lf/transaction/test/TestNodeBuilder.scala
+++ b/sdk/daml-lf/transaction-test-lib/src/main/scala/com/digitalasset/daml/lf/transaction/test/TestNodeBuilder.scala
@@ -134,6 +134,7 @@ trait TestNodeBuilder {
       keyOpt = contract.keyOpt,
       byKey = byKey,
       version = contractTransactionVersion(contract),
+      isInterfaceFetch = false,
     )
 
   def lookupByKey(contract: Node.Create, found: Boolean = true): Node.LookupByKey =

--- a/sdk/daml-lf/transaction-test-lib/src/main/scala/com/digitalasset/daml/lf/value/test/ValueGenerators.scala
+++ b/sdk/daml-lf/transaction-test-lib/src/main/scala/com/digitalasset/daml/lf/value/test/ValueGenerators.scala
@@ -359,6 +359,7 @@ object ValueGenerators {
       keyOpt = key,
       byKey = byKey,
       version = version,
+      isInterfaceFetch = false,
     )
 
   /** Makes rollback node with some random child IDs. */

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -158,6 +158,7 @@ object Node {
       override val byKey: Boolean,
       // For the sake of consistency between types with a version field, keep this field the last.
       override val version: TransactionVersion,
+      val isInterfaceFetch: Boolean,
   ) extends LeafOnlyAction {
     @deprecated("use keyOpt", since = "2.6.0")
     def key: Option[GlobalKeyWithMaintainers] = keyOpt

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -432,7 +432,7 @@ sealed abstract class HasTxNodes {
     fold(Set.empty[Cid2]) {
       case (acc, (_, Node.Exercise(coid, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _))) =>
         acc + coid
-      case (acc, (_, Node.Fetch(coid, _, _, _, _, _, _, _, _))) =>
+      case (acc, (_, Node.Fetch(coid, _, _, _, _, _, _, _, _, _))) =>
         acc + coid
       case (acc, (_, Node.LookupByKey(_, _, _, Some(coid), _))) =>
         acc + coid

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -288,6 +288,7 @@ object TransactionCoder {
       keyOpt = node.keyOpt,
       byKey = node.byKey,
       version = node.version,
+      isInterfaceFetch = false,
     )
     for {
       protoFetch <- encodeFetch(fetch)
@@ -498,6 +499,7 @@ object TransactionCoder {
       keyOpt = keyOpt,
       byKey = byKey,
       version = nodeVersion,
+      isInterfaceFetch = false,
     )
   }
 

--- a/sdk/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/ContractStateMachineSpec.scala
+++ b/sdk/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/ContractStateMachineSpec.scala
@@ -138,6 +138,7 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
       keyOpt = toOptKeyWithMaintainers(templateId, key),
       byKey = byKey,
       version = txVersion,
+      isInterfaceFetch = false,
     )
   }
 

--- a/sdk/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/ValidationSpec.scala
+++ b/sdk/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/ValidationSpec.scala
@@ -127,6 +127,7 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
       keyOpt = key,
       byKey = samBool1,
       version = version,
+      isInterfaceFetch = false,
     )
 
   private val someLookups: Seq[Node] =

--- a/sdk/daml-script/test/daml/upgrades/FromInterface.daml
+++ b/sdk/daml-script/test/daml/upgrades/FromInterface.daml
@@ -1,0 +1,151 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE ApplicativeDo #-}
+
+module FromInterface (main) where
+
+import qualified V1.InterfaceImplementer as V1
+import qualified V2.InterfaceImplementer as V2
+import qualified V3.InterfaceImplementer as V3
+import InvalidFromInterface
+import UpgradeTestLib
+import FixedInterface
+import PackageIds
+import DA.Optional
+import DA.Text
+
+-- Fixed package containing only the interface
+{- PACKAGE
+name: fixed-interface-fetch
+versions: 1
+-}
+
+{- MODULE
+package: fixed-interface-fetch
+contents: |
+  module FixedInterface where
+
+  data IV = IV with
+    owner : Party
+
+  interface I where
+    viewtype IV
+
+    getVersion : Text
+    nonconsuming choice GetVersion : Text
+      controller (view this).owner
+      do
+        pure $ getVersion this
+-}
+
+{- PACKAGE
+name: interface-implementer
+versions: 3
+depends: fixed-interface-fetch-1.0.0
+-}
+
+{- MODULE
+package: interface-implementer
+contents: |
+  module InterfaceImplementer where
+
+  import FixedInterface
+  import DA.Optional
+
+  template IITemplate with
+      party : Party
+      newField : Optional Text -- @V 2 3
+      newInvalidField : Int    -- @V   3
+    where
+    signatory party
+
+    interface instance I for IITemplate where
+      view = IV party
+      getVersion = "V1"    -- @V 1
+      getVersion = "V2"    -- @V  2
+      getVersion = "V3"    -- @V   3
+-}
+
+{- PACKAGE
+name: invalid-from-interface
+versions: 1
+depends: |
+  interface-implementer-1.0.0
+  interface-implementer-2.0.0
+  interface-implementer-3.0.0
+  fixed-interface-fetch-1.0.0
+-}
+
+{- MODULE
+package: invalid-from-interface
+contents: |
+  module InvalidFromInterface where
+
+  import qualified V1.InterfaceImplementer as V1
+  import qualified V2.InterfaceImplementer as V2
+  import qualified V3.InterfaceImplementer as V3
+  import FixedInterface
+
+  template TestHelper with
+      p : Party
+    where
+    signatory p
+
+    choice IllegalUpgrade : Optional V3.IITemplate
+      controller p
+      do
+        let v2Contract = V2.IITemplate p None
+            v2ContractInterface = toInterface @I v2Contract
+        pure $ fromInterface @V3.IITemplate v2ContractInterface
+
+    choice InvalidDowngrade : Optional V1.IITemplate
+      controller p
+      do
+        let v2Contract = V2.IITemplate p (Some "hello")
+            v2ContractInterface = toInterface @I v2Contract
+        pure $ fromInterface @V1.IITemplate v2ContractInterface
+-}
+
+main : TestTree
+main = tests
+  [ ("fromInterface performs upgrade", fromInterfaceUpgrade)
+  , ("fromInterface performs downgrade", fromInterfaceDowngrade)
+  , ("fromInterface fails invalid upgrade", fromInterfaceIllegalUpgrade)
+  , ("fromInterface fails invalid downgrade", fromInterfaceInvalidDowngrade)
+  ]
+
+fromInterfaceUpgrade : Test
+fromInterfaceUpgrade = test $ do
+  a <- allocateParty "alice"
+  let v1Contract = V1.IITemplate a
+      v1ContractInterface = toInterface @I v1Contract
+      v2Contract = fromInterface @V2.IITemplate v1ContractInterface
+  v2Contract === Some (V2.IITemplate a None)
+
+fromInterfaceDowngrade : Test
+fromInterfaceDowngrade = test $ do
+  a <- allocateParty "alice"
+  let v2Contract = V2.IITemplate a None
+      v2ContractInterface = toInterface @I v2Contract
+      v1Contract = fromInterface @V1.IITemplate v2ContractInterface
+  v1Contract === Some (V1.IITemplate a)
+
+fromInterfaceIllegalUpgrade : Test
+fromInterfaceIllegalUpgrade = test $ do
+  a <- allocateParty "alice"
+  res <- a `trySubmit` createAndExerciseCmd (TestHelper a) IllegalUpgrade
+  case res of
+    Right _ -> fail "Expected failure but got success"
+    -- The error is Unexpected non-optional extra template field type encountered during upgrading.
+    -- but its a crash, since it should be protected by the upload checks, therefore Canton doesn't send it back
+    Left _ -> pure ()
+
+fromInterfaceInvalidDowngrade : Test
+fromInterfaceInvalidDowngrade = test $ do
+  a <- allocateParty "alice"
+  res <- a `trySubmit` createAndExerciseCmd (TestHelper a) InvalidDowngrade
+  case res of
+    Right _ -> fail "Expected failure but got success"
+    Left (DevError Upgrade msg) | "field with a value of Some may not be dropped" `isInfixOf` msg -> pure ()
+    Left e -> fail $ "Expected Upgrade error but got " <> show e

--- a/sdk/daml-script/test/daml/upgrades/Interfaces.daml
+++ b/sdk/daml-script/test/daml/upgrades/Interfaces.daml
@@ -62,10 +62,10 @@ contents: |
     signatory party
 
     choice CallInterface : Text with
-        cid : ContractId I
+        icid : ContractId I
       controller party
       do
-        exercise cid GetVersion
+        exercise icid GetVersion
 -}
 
 -- The versioned/upgraded package
@@ -94,15 +94,22 @@ contents: |
       getVersion = "V1"    -- @V 1
       getVersion = "V2"    -- @V  2
 
-    -- This choice exists here for convenience. It could be in a separate package which depends on this,
+    -- Following two choices exist here for convenience. They could be in a separate package which depends on this,
     -- but additional unnecessary packages simply wastes time.
     choice FetchFromInterface : Text with
-        cid : ContractId I
+        icid : ContractId I
       controller party
       do
-        (_, res) <- fromSomeNote "Failed to fetch contract" <$> fetchFromInterface @FITemplate cid
+        (_, res) <- fromSomeNote "Failed to fetch contract" <$> fetchFromInterface @FITemplate icid
         let v = view $ toInterface @I res
         pure v.version
+
+    choice FetchInterface : () with
+        icid : ContractId I
+      controller party
+      do
+        fetch icid
+        pure ()
 -}
 
 -- Alt templates package to test multiple preference at once
@@ -153,7 +160,9 @@ main = tests
   , brokenOnIDELedger ("Multiple interface exercises use their respective package preference entries at command level", multipleInterfaceChoicePackagePreferenceCommand)
   , brokenOnIDELedger ("Multiple interface exercises use their respective package preference entries at choice body level", multipleInterfaceChoicePackagePreferenceUpdate)
   , broken ("queryInterfaceContractId uses highest version of view", queryInterfaceUpgrades)
-  , broken ("fetchFromInterface upgrades payload to match request", fetchFromInterfaceUpgrades)
+  , ("fetchFromInterface upgrades payload to match request", fetchFromInterfaceUpgrades)
+  -- IDE Ledger doesn't support unvetting
+  , broken ("Can fetch interface from V1 contract when V1 unvetted", fetchWithoutV1)
   ]
 
 setupAliceAndInterface : Script (Party, ContractId I)
@@ -171,7 +180,7 @@ defaultHighestVersionChoiceImplementationCommand = test $ do
 defaultHighestVersionChoiceImplementationUpdate : Test
 defaultHighestVersionChoiceImplementationUpdate = test $ do
   (alice, icid) <- setupAliceAndInterface
-  res <- alice `submit` createAndExerciseCmd (Caller with party = alice) (CallInterface with cid = icid)
+  res <- alice `submit` createAndExerciseCmd (Caller with party = alice) (CallInterface with icid = icid)
   res === "V2"
 
 interfaceChoicePackagePreferenceCommand : Test
@@ -189,7 +198,7 @@ interfaceChoicePackagePreferenceUpdate = test $ do
   res <-
     submitWithOptions
       (actAs alice <> packagePreference [interfacesV1])
-      (createAndExerciseCmd (Caller with party = alice) (CallInterface with cid = icid))
+      (createAndExerciseCmd (Caller with party = alice) (CallInterface with icid = icid))
   res === "V1"
 
 multipleInterfaceChoicePackagePreference : (Party -> ContractId I -> Commands Text) -> Test
@@ -223,7 +232,7 @@ multipleInterfaceChoicePackagePreferenceCommand =
 multipleInterfaceChoicePackagePreferenceUpdate : Test
 multipleInterfaceChoicePackagePreferenceUpdate =
   multipleInterfaceChoicePackagePreference $ \alice icid ->
-    createAndExerciseCmd (Caller with party = alice) (CallInterface with cid = icid)
+    createAndExerciseCmd (Caller with party = alice) (CallInterface with icid = icid)
 
 queryInterfaceUpgrades : Test
 queryInterfaceUpgrades = test $ do
@@ -234,5 +243,14 @@ queryInterfaceUpgrades = test $ do
 fetchFromInterfaceUpgrades : Test
 fetchFromInterfaceUpgrades = test $ do
   (alice, icid) <- setupAliceAndInterface
-  res <- alice `submit` createAndExerciseCmd (V2.FITemplate with party = alice) (V2.FetchFromInterface with cid = icid)
-  res === "V2"
+  resV1 <- alice `submit` createAndExerciseExactCmd (V1.FITemplate with party = alice) (V1.FetchFromInterface with icid = icid)
+  resV1 === "V1"
+  resV2 <- alice `submit` createAndExerciseExactCmd (V2.FITemplate with party = alice) (V2.FetchFromInterface with icid = icid)
+  resV2 === "V2"
+
+fetchWithoutV1 : Test
+fetchWithoutV1 = test $ do
+  (alice, icid) <- setupAliceAndInterface
+  withUnvettedDarOnParticipant "interfaces-1.0.0" participant0 $ do
+    alice `submit` createAndExerciseCmd (V2.FITemplate alice) (V2.FetchInterface icid)
+  pure ()


### PR DESCRIPTION
Currently the "Can fetch interface from V1 contract when V1 unvetted" test in "Interface.daml" is failing with the following error:
```
  com.digitalasset.daml.lf.engine.free.InterpretationError: Error: Unhandled Daml exception: Daml.Script.Internal.Questions.Testing:FailedCmd@d1c40430{ commandName = Daml.Script.Internal.Questions.Testing:CommandName@d1c40430{ getCommandName = "Submit" }, errorClassName = Daml.Script.Internal.Questions.Testing:ErrorClassName@d1c40430{ getErrorClassName = "StatusRuntimeException" }, errorMessage = Daml.Script.Internal.Questions.Testing:ErrorMessage@d1c40430{ getErrorMessage = "FAILED_PRECONDITION: INVALID_PRESCRIBED_DOMAIN_ID(9,5fae34f4): Cannot submit transaction to prescribed domain `mydomain::12207ce93435...` because: Some packages are not known to all informees on domain mydomain::12207ce93435...
```

The important part being `FAILED_PRECONDITION: INVALID_PRESCRIBED_DOMAIN_ID(9,5fae34f4): Cannot submit transaction to prescribed domain mydomain::12207ce93435... because: Some packages are not known to all informees on domain mydomain::12207ce93435.`