### PR TITLE
check view consistency in fetch/exercise by interface

### DIFF
--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -590,66 +590,49 @@ private[lf] final class Compiler(
       cidPos: Position,
       choiceArgPos: Position,
       tokenPos: Position,
-  ): s.SExpr =
-    let(
-      env,
-      (if (soft) SBSoftFetchInterface else SBFetchAny(None))(
-        env.toSEVar(cidPos),
-        s.SEValue.None,
-      ),
-    ) { (payloadPos, env) =>
-      let(
-        env,
-        SBCastAnyInterface(ifaceId)(
-          env.toSEVar(cidPos),
+  ): s.SExpr = {
+    let(env, SBFetchInterface(soft, ifaceId)(env.toSEVar(cidPos))) { (payloadPos, _env) =>
+      val env =
+        _env.bindExprVar(param, payloadPos).bindExprVar(choice.argBinder._1, choiceArgPos)
+      let(env, SBExtractSAnyValue(env.toSEVar(payloadPos))) { (castPos, env) =>
+        // We use a chain of let bindings to make the evaluation order of SBResolveSBUBeginExercise's arguments
+        // is independent from the evaluation strategy imposed by the ANF transformation.
+        val applyChoiceGuardExpr = SBApplyChoiceGuard(choice.name, Some(ifaceId))(
+          env.toSEVar(guardPos),
           env.toSEVar(payloadPos),
-        ),
-      ) { (castPos, env) =>
-        let(
-          env,
-          s.SEPreventCatch(SBViewInterface(ifaceId)(env.toSEVar(payloadPos))),
-        ) { (_, _env) =>
-          val env =
-            _env.bindExprVar(param, payloadPos).bindExprVar(choice.argBinder._1, choiceArgPos)
-          // We use a chain of let bindings to make the evaluation order of SBResolveSBUBeginExercise's arguments
-          // is independent from the evaluation strategy imposed by the ANF transformation.
-          val applyChoiceGuardExpr = SBApplyChoiceGuard(choice.name, Some(ifaceId))(
-            env.toSEVar(guardPos),
-            env.toSEVar(payloadPos),
-            env.toSEVar(cidPos),
-          )
-          let(env, applyChoiceGuardExpr) { (_, env) =>
-            val controllersExpr = s.SEPreventCatch(translateExp(env, choice.controllers))
-            let(env, controllersExpr) { (controllersPos, env) =>
-              val observersExpr = choice.choiceObservers match {
-                case Some(observers) => s.SEPreventCatch(translateExp(env, observers))
+          env.toSEVar(cidPos),
+        )
+        let(env, applyChoiceGuardExpr) { (_, env) =>
+          val controllersExpr = s.SEPreventCatch(translateExp(env, choice.controllers))
+          let(env, controllersExpr) { (controllersPos, env) =>
+            val observersExpr = choice.choiceObservers match {
+              case Some(observers) => s.SEPreventCatch(translateExp(env, observers))
+              case None => s.SEValue.EmptyList
+            }
+            let(env, observersExpr) { (observersPos, env) =>
+              val authorizersExpr = choice.choiceAuthorizers match {
+                case Some(authorizers) => s.SEPreventCatch(translateExp(env, authorizers))
                 case None => s.SEValue.EmptyList
               }
-              let(env, observersExpr) { (observersPos, env) =>
-                val authorizersExpr = choice.choiceAuthorizers match {
-                  case Some(authorizers) => s.SEPreventCatch(translateExp(env, authorizers))
-                  case None => s.SEValue.EmptyList
-                }
-                let(env, authorizersExpr) { (authorizersPos, env) =>
-                  val exerciseExpr = SBResolveSBUBeginExercise(
-                    interfaceId = ifaceId,
-                    choiceName = choice.name,
-                    consuming = choice.consuming,
-                    byKey = false,
-                    explicitChoiceAuthority = choice.choiceAuthorizers.isDefined,
-                  )(
-                    env.toSEVar(payloadPos),
-                    env.toSEVar(choiceArgPos),
-                    env.toSEVar(cidPos),
-                    env.toSEVar(controllersPos),
-                    env.toSEVar(observersPos),
-                    env.toSEVar(authorizersPos),
-                    env.toSEVar(castPos),
-                  )
-                  let(env, exerciseExpr) { (_, _env) =>
-                    val env = _env.bindExprVar(choice.selfBinder, cidPos)
-                    s.SEScopeExercise(app(translateExp(env, choice.update), env.toSEVar(tokenPos)))
-                  }
+              let(env, authorizersExpr) { (authorizersPos, env) =>
+                val exerciseExpr = SBResolveSBUBeginExercise(
+                  interfaceId = ifaceId,
+                  choiceName = choice.name,
+                  consuming = choice.consuming,
+                  byKey = false,
+                  explicitChoiceAuthority = choice.choiceAuthorizers.isDefined,
+                )(
+                  env.toSEVar(payloadPos),
+                  env.toSEVar(choiceArgPos),
+                  env.toSEVar(cidPos),
+                  env.toSEVar(controllersPos),
+                  env.toSEVar(observersPos),
+                  env.toSEVar(authorizersPos),
+                  env.toSEVar(castPos),
+                )
+                let(env, exerciseExpr) { (_, _env) =>
+                  val env = _env.bindExprVar(choice.selfBinder, cidPos)
+                  s.SEScopeExercise(app(translateExp(env, choice.update), env.toSEVar(tokenPos)))
                 }
               }
             }
@@ -657,6 +640,7 @@ private[lf] final class Compiler(
         }
       }
     }
+  }
 
   private[this] def compileInterfaceChoice(
       ifaceId: TypeConName,
@@ -797,43 +781,22 @@ private[lf] final class Compiler(
   private[this] def compileFetchInterface(
       ifaceId: Identifier,
       soft: Boolean,
-  ): (t.SDefinitionRef, SDefinition) =
+  ): (t.SDefinitionRef, SDefinition) = {
     topLevelFunction2(t.FetchInterfaceDefRef(ifaceId)) { (cidPos, _, env) =>
-      if (soft) {
-        SBFetchInterface(ifaceId)(env.toSEVar(cidPos))
-      } else
+      let(env, SBFetchInterface(soft, ifaceId)(env.toSEVar(cidPos))) { (payloadPos, env) =>
         let(
           env,
-          SBFetchAny(None)(
+          SBResolveSBUInsertFetchNode(
+            env.toSEVar(payloadPos),
             env.toSEVar(cidPos),
             s.SEValue.None,
           ),
-        ) { (payloadPos, env) =>
-          let(
-            env,
-            SBCastAnyInterface(ifaceId)(
-              env.toSEVar(cidPos),
-              env.toSEVar(payloadPos),
-            ),
-          ) { (_, env) =>
-            let(
-              env,
-              s.SEPreventCatch(SBViewInterface(ifaceId)(env.toSEVar(payloadPos))),
-            ) { (_, env) =>
-              let(
-                env,
-                SBResolveSBUInsertFetchNode(
-                  env.toSEVar(payloadPos),
-                  env.toSEVar(cidPos),
-                  s.SEValue.None,
-                ),
-              ) { (_, env) =>
-                env.toSEVar(payloadPos)
-              }
-            }
-          }
+        ) { (_, env) =>
+          env.toSEVar(payloadPos)
         }
+      }
     }
+  }
 
   private[this] def compileAgreementText(
       tmplId: Identifier,

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -799,37 +799,40 @@ private[lf] final class Compiler(
       soft: Boolean,
   ): (t.SDefinitionRef, SDefinition) =
     topLevelFunction2(t.FetchInterfaceDefRef(ifaceId)) { (cidPos, _, env) =>
-      let(
-        env,
-        (if (soft) SBSoftFetchInterface else SBFetchAny(None))(
-          env.toSEVar(cidPos),
-          s.SEValue.None,
-        ),
-      ) { (payloadPos, env) =>
+      if (soft) {
+        SBFetchInterface(ifaceId)(env.toSEVar(cidPos))
+      } else
         let(
           env,
-          SBCastAnyInterface(ifaceId)(
+          SBFetchAny(None)(
             env.toSEVar(cidPos),
-            env.toSEVar(payloadPos),
+            s.SEValue.None,
           ),
-        ) { (_, env) =>
+        ) { (payloadPos, env) =>
           let(
             env,
-            s.SEPreventCatch(SBViewInterface(ifaceId)(env.toSEVar(payloadPos))),
+            SBCastAnyInterface(ifaceId)(
+              env.toSEVar(cidPos),
+              env.toSEVar(payloadPos),
+            ),
           ) { (_, env) =>
             let(
               env,
-              SBResolveSBUInsertFetchNode(
-                env.toSEVar(payloadPos),
-                env.toSEVar(cidPos),
-                s.SEValue.None,
-              ),
+              s.SEPreventCatch(SBViewInterface(ifaceId)(env.toSEVar(payloadPos))),
             ) { (_, env) =>
-              env.toSEVar(payloadPos)
+              let(
+                env,
+                SBResolveSBUInsertFetchNode(
+                  env.toSEVar(payloadPos),
+                  env.toSEVar(cidPos),
+                  s.SEValue.None,
+                ),
+              ) { (_, env) =>
+                env.toSEVar(payloadPos)
+              }
             }
           }
         }
-      }
     }
 
   private[this] def compileAgreementText(

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -252,6 +252,29 @@ private[lf] object Pretty {
                   "An optional contract field with a value of Some may not be dropped during downgrading"
                 )
 
+              case Dev.Upgrade.ViewMismatch(
+                    coid,
+                    iterfaceId,
+                    srcTemplateId,
+                    dstTemplateId,
+                    srcViewValue,
+                    dstViewValue,
+                  ) => {
+                text("View mismatch when trying to upgrade the contract") & prettyContractId(
+                  coid
+                ) & text("from") & prettyTypeConName(srcTemplateId) & text(
+                  "to"
+                ) & prettyTypeConName(
+                  dstTemplateId
+                ) & text("during a fetch or exercise by interface") /
+                  text("Verify that the views of the contract have not changed") /
+                  text("computed view for") & prettyTypeConName(iterfaceId) & text(
+                    "in the source contract is"
+                  ) & prettyValue(false)(srcViewValue) /
+                  text("computed view for") & prettyTypeConName(iterfaceId) & text(
+                    "in the destination contract is"
+                  ) & prettyValue(false)(dstViewValue)
+              }
             }
         }
     }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -644,7 +644,6 @@ private[lf] object Pretty {
               )
             case SBUCreate(id) => text(s"$$create($id)")
             case SBFetchAny(optTargetTemplateId) => text(s"$$fetchAny($optTargetTemplateId)")
-            case SBSoftFetchInterface => text(s"$$softFetchInterface")
             case SBUGetTime | SBSGetTime => text("$getTime")
             case _ => str(x)
           }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1587,8 +1587,7 @@ private[lf] object SBuiltin {
           s"template of type ${ifaceId}, but there's no matching interface instance."
       )
     )(iiRef => InterfaceInstanceViewDefRef(iiRef))
-    val e = SEApp(SEVal(ref), Array(record))
-    k(e)
+    k(SEApp(SEVal(ref), Array(record)))
   }
 
   /** $insertFetch[tid]

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1190,13 +1190,13 @@ private[lf] object SBuiltin {
                           ) // return wrongly typed
                         case Some(dstArg) =>
                           viewInterface(machine, interfaceId, dstTmplId, dstArg) { dstView =>
-                            executeExpression(machine, sourceView) { sourceViewValue =>
+                            executeExpression(machine, SEPreventCatch(sourceView)) { sourceViewValue =>
                               // If the destination and source templates are the same, we skip the computation
                               // of the destination template's view.
                               if (dstTmplId == sourceTplId)
                                 cacheContractAndInsertNode(machine, coid, dstTmplId, dstArg)
                               else
-                                executeExpression(machine, dstView) { dstViewValue =>
+                                executeExpression(machine, SEPreventCatch(dstView)) { dstViewValue =>
                                   if (sourceViewValue != dstViewValue) {
                                     crash(
                                       "view mismatch"

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1184,7 +1184,10 @@ private[lf] object SBuiltin {
                   ) { () =>
                     ensureTemplateImplementsInterface(machine, dstTmplId, interfaceId) { () =>
                       fromInterface(machine, sourceTplId, sourceArg, dstTmplId) {
-                        case None => crash(s"failed to convert contract $coid to type $dstTmplId")
+                        case None =>
+                          crash(
+                            s"failed to convert contract $coid to type $dstTmplId"
+                          ) // return wrongly typed
                         case Some(dstArg) =>
                           viewInterface(machine, interfaceId, dstTmplId, dstArg) { dstView =>
                             executeExpression(machine, sourceView) { sourceViewValue =>
@@ -1195,7 +1198,9 @@ private[lf] object SBuiltin {
                               else
                                 executeExpression(machine, dstView) { dstViewValue =>
                                   if (sourceViewValue != dstViewValue) {
-                                    crash("view mistmatch")
+                                    crash(
+                                      "view mismatch"
+                                    ) // introduce new error type, we can start with an interpretation.Error.Dev then add an error to ledger API (ask Tudor)
                                   } else
                                     cacheContractAndInsertNode(machine, coid, dstTmplId, dstArg)
                                 }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1200,7 +1200,7 @@ private[lf] object SBuiltin {
       castAnyInterface(machine, ifaceId, coid, tplId, arg) { _ =>
         viewInterface(machine, ifaceId, tplId, arg) { srcView =>
           executeExpression(machine, SEPreventCatch(srcView)) { _ =>
-            k(SAny(TTyCon(tplId), arg))
+            k(SAny(Ast.TTyCon(tplId), arg))
           }
         }
       }
@@ -1220,7 +1220,7 @@ private[lf] object SBuiltin {
     def cacheContractAndReturnAny(
         machine: UpdateMachine,
         coid: V.ContractId,
-        dstTplId: lf.data.Ref.ValueRef,
+        dstTplId: Ref.ValueRef,
         dstArg: SValue,
     )(k: SAny => Control[Question.Update]): Control[Question.Update] = {
       // ensure the contract and its metadata are cached

--- a/sdk/daml-lf/interpreter/src/test/scala/com/daml/SBuiltinInterfaceTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/daml/SBuiltinInterfaceTest.scala
@@ -395,7 +395,7 @@ final class SBuiltinInterfaceTestHelpers(
     val modifiedParserParameters: parser.ParserParameters[this.type] =
       parserParameters.copy(defaultPackageId = extraPkgId)
 
-    val pkg = p""" metadata ( 'extended-pkg' : '1.0.0' )
+    val pkg = p""" metadata ( '-extra-package-name-' : '1.0.0' )
         module Mod {
 
           record @serializable MyUnit = {};

--- a/sdk/daml-lf/interpreter/src/test/scala/com/daml/SBuiltinInterfaceTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/daml/SBuiltinInterfaceTest.scala
@@ -98,8 +98,8 @@ class SBuiltinInterfaceUpgradeTest extends AnyFreeSpec with Matchers with Inside
     Compiler.Config.Dev(LanguageMajorVersion.V1),
   )
 
-  // But we prefer version 2 of -implem-pkg-, which will force an upgrade of the contract and trigger a view
-  // consistency check, which is expected to fail.
+  // But we prefer version 2 of -implem-pkg-, which will force an upgrade of any version 1 contract when
+  // fetched/exercised by interface and trigger a view consistency check, which is expected to fail.
   val packagePreferences = Map(
     ifacePkgName -> ifacePkgId,
     implemPkgName -> implemPkgId(2),

--- a/sdk/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -6,9 +6,8 @@ package interpretation
 
 import com.daml.lf.crypto.Hash.KeyPackageName
 import com.daml.lf.data.Ref.{ChoiceName, Location, Party, TypeConName}
-import com.daml.lf.transaction.{GlobalKey, NodeId}
 import com.daml.lf.language.Ast
-import com.daml.lf.transaction.GlobalKeyWithMaintainers
+import com.daml.lf.transaction.{GlobalKey, GlobalKeyWithMaintainers, NodeId}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 
@@ -185,6 +184,14 @@ object Error {
       final case class DowngradeDropDefinedField(expectedType: Ast.Type, actualValue: Value)
           extends Error
 
+      final case class ViewMismatch(
+          coid: ContractId,
+          iterfaceId: TypeConName,
+          srcTemplateId: TypeConName,
+          dstTemplateId: TypeConName,
+          srcView: Value,
+          dstView: Value,
+      ) extends Error
     }
 
     /** A choice guard returned false, invalidating some expectation. */

--- a/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
+++ b/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
@@ -128,8 +128,7 @@ exerciseCommandShouldFail = test $ do
   (alice, icid) <- setupAliceAndInterface
   res <- alice `trySubmit` exerciseCmd icid GetVersion
   case res of
-      Left (UnknownError msg) | "An error occurred." `isInfixOf` msg -> pure ()
-      Left (UnknownError msg) | "SErrorCrash" `isInfixOf` msg -> pure ()
+      Left (DevError Upgrade msg) | "View mismatch" `isInfixOf` msg -> pure ()
       _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)
 
 exerciseInChoiceBodyShouldFail : Test
@@ -137,8 +136,7 @@ exerciseInChoiceBodyShouldFail = test $ do
   (alice, icid) <- setupAliceAndInterface
   res <- alice `trySubmit` createAndExerciseCmd (Caller with party = alice) (CallInterface with icid = icid)
   case res of
-    Left (UnknownError msg) | "An error occurred." `isInfixOf` msg -> pure ()
-    Left (UnknownError msg) | "SErrorCrash" `isInfixOf` msg -> pure ()
+    Left (DevError Upgrade msg) | "View mismatch" `isInfixOf` msg -> pure ()
     _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)
 
 fetchFromInterfaceShouldFail : Test
@@ -146,6 +144,5 @@ fetchFromInterfaceShouldFail = test $ do
   (alice, icid) <- setupAliceAndInterface
   res <- alice `trySubmit` createAndExerciseExactCmd (V2.FITemplate with party = alice) (V2.FetchFromInterface with icid = icid)
   case res of
-    Left (UnknownError msg) | "An error occurred." `isInfixOf` msg -> pure ()
-    Left (UnknownError msg) | "SErrorCrash" `isInfixOf` msg -> pure ()
+    Left (DevError Upgrade msg) | "View mismatch" `isInfixOf` msg -> pure ()
     _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)

--- a/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
+++ b/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
@@ -113,7 +113,7 @@ contents: |
 main : TestTree
 main = tests
   [ broken ("Calling an interface choice at command level fails as intended when the view is modified", exerciseCommandShouldFail)
-  , broken ("Calling an interface choice uses the highest version implementation at choice body level by default", exerciseInChoiceBodyShouldFail)
+  , broken ("Calling an interface choice in choice body fails as intended when the view is modified", exerciseInChoiceBodyShouldFail)
   , ("fetchFromInterface fails as intended when the view is modified", fetchFromInterfaceShouldFail)
   ]
 

--- a/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
+++ b/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
@@ -1,0 +1,151 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE ApplicativeDo #-}
+
+module InterfaceViews (main) where
+
+import UpgradeTestLib
+import FixedInterface
+import FixedInterfaceCaller
+import qualified V1.Interfaces as V1
+import qualified V2.Interfaces as V2
+import PackageIds
+import DA.Foldable
+import DA.Optional
+import DA.Text
+
+-- Fixed package containing only the interface
+{- PACKAGE
+name: fixed-interface-view
+versions: 1
+-}
+
+{- MODULE
+package: fixed-interface-view
+contents: |
+  module FixedInterface where
+
+  data IV = IV with
+    owner : Party
+    payload : Int
+
+  interface I where
+    viewtype IV
+
+    getVersion : Text
+    nonconsuming choice GetVersion : Text
+      controller (view this).owner
+      do
+        pure $ getVersion this
+-}
+
+-- Another fixed package containing a helper template for exercising the interface in a choice
+{- PACKAGE
+name: fixed-interface-view-caller
+versions: 1
+depends: fixed-interface-view-1.0.0
+-}
+
+{- MODULE
+package: fixed-interface-view-caller
+contents: |
+  module FixedInterfaceCaller where
+
+  import FixedInterface
+
+  template Caller with
+      party : Party
+    where
+    signatory party
+
+    choice CallInterface : Text with
+        icid : ContractId I
+      controller party
+      do
+        exercise icid GetVersion
+-}
+
+-- The versioned/upgraded package
+{- PACKAGE
+name: interface-views
+versions: 2
+depends: fixed-interface-view-1.0.0
+-}
+
+{- MODULE
+package: interface-views
+contents: |
+  module Interfaces where
+
+  import FixedInterface
+  import DA.Optional
+
+  template FITemplate with
+      party : Party
+    where
+    signatory party
+
+    interface instance I for FITemplate where
+      view = IV party 0   -- @V 1
+      view = IV party 1   -- @V  2
+      getVersion = "V1"   -- @V 1
+      getVersion = "V2"   -- @V  2
+
+    -- Following two choices exist here for convenience. They could be in a separate package which depends on this,
+    -- but additional unnecessary packages simply wastes time.
+    choice FetchFromInterface : Int with
+        icid : ContractId I
+      controller party
+      do
+        (_, res) <- fromSomeNote "Failed to fetch contract" <$> fetchFromInterface @FITemplate icid
+        let v = view $ toInterface @I res
+        pure v.payload
+
+    choice FetchInterface : () with
+        icid : ContractId I
+      controller party
+      do
+        fetch icid
+        pure ()
+-}
+
+main : TestTree
+main = tests
+  [ broken ("Calling an interface choice at command level fails as intended when the view is modified", exerciseCommandShouldFail)
+  , broken ("Calling an interface choice uses the highest version implementation at choice body level by default", exerciseInChoiceBodyShouldFail)
+  , ("fetchFromInterface fails as intended when the view is modified", fetchFromInterfaceShouldFail)
+  ]
+
+setupAliceAndInterface : Script (Party, ContractId I)
+setupAliceAndInterface = do
+  alice <- allocateParty "alice"
+  cid <- alice `submit` createExactCmd V1.FITemplate with party = alice
+  pure (alice, toInterfaceContractId @I cid)
+
+exerciseCommandShouldFail : Test
+exerciseCommandShouldFail = test $ do
+  (alice, icid) <- setupAliceAndInterface
+  res <- alice `trySubmit` exerciseCmd icid GetVersion
+  case res of
+      Left (UnknownError msg) | "An error occurred." `isInfixOf` msg -> pure ()
+      Left (UnknownError msg) | "SErrorCrash" `isInfixOf` msg -> pure ()
+      _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)
+
+exerciseInChoiceBodyShouldFail : Test
+exerciseInChoiceBodyShouldFail = test $ do
+  (alice, icid) <- setupAliceAndInterface
+  res <- alice `trySubmit` createAndExerciseCmd (Caller with party = alice) (CallInterface with icid = icid)
+  case res of
+    Left (UnknownError msg) | "An error occurred." `isInfixOf` msg -> pure ()
+    Left (UnknownError msg) | "SErrorCrash" `isInfixOf` msg -> pure ()
+    _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)
+
+fetchFromInterfaceShouldFail : Test
+fetchFromInterfaceShouldFail = test $ do
+  (alice, icid) <- setupAliceAndInterface
+  res <- alice `trySubmit` createAndExerciseExactCmd (V2.FITemplate with party = alice) (V2.FetchFromInterface with icid = icid)
+  case res of
+    Left (UnknownError msg) | "An error occurred." `isInfixOf` msg -> pure ()
+    Left (UnknownError msg) | "SErrorCrash" `isInfixOf` msg -> pure ()
+    _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)

--- a/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
+++ b/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
@@ -112,8 +112,8 @@ contents: |
 
 main : TestTree
 main = tests
-  [ broken ("Calling an interface choice at command level fails as intended when the view is modified", exerciseCommandShouldFail)
-  , broken ("Calling an interface choice in choice body fails as intended when the view is modified", exerciseInChoiceBodyShouldFail)
+  [ ("Calling an interface choice at command level fails as intended when the view is modified", exerciseCommandShouldFail)
+  , ("Calling an interface choice in choice body fails as intended when the view is modified", exerciseInChoiceBodyShouldFail)
   , ("fetchFromInterface fails as intended when the view is modified", fetchFromInterfaceShouldFail)
   ]
 

--- a/sdk/daml-script/test/daml/upgrades/Interfaces.daml
+++ b/sdk/daml-script/test/daml/upgrades/Interfaces.daml
@@ -30,7 +30,7 @@ contents: |
 
   data IV = IV with
     owner : Party
-    version : Text
+    payload : Optional Int
 
   interface I where
     viewtype IV
@@ -85,24 +85,25 @@ contents: |
 
   template FITemplate with
       party : Party
+      payload : Optional Int   -- @V  2
     where
     signatory party
 
     interface instance I for FITemplate where
-      view = IV party "V1" -- @V 1
-      view = IV party "V2" -- @V  2
-      getVersion = "V1"    -- @V 1
-      getVersion = "V2"    -- @V  2
+      view = IV party None     -- @V 1
+      view = IV party payload  -- @V  2
+      getVersion = "V1"        -- @V 1
+      getVersion = "V2"        -- @V  2
 
     -- Following two choices exist here for convenience. They could be in a separate package which depends on this,
     -- but additional unnecessary packages simply wastes time.
-    choice FetchFromInterface : Text with
+    choice FetchFromInterface : Optional Int with
         icid : ContractId I
       controller party
       do
         (_, res) <- fromSomeNote "Failed to fetch contract" <$> fetchFromInterface @FITemplate icid
         let v = view $ toInterface @I res
-        pure v.version
+        pure v.payload
 
     choice FetchInterface : () with
         icid : ContractId I
@@ -128,14 +129,15 @@ contents: |
 
   template FITemplateAlt with
       party : Party
+      payload : Optional Int   -- @V  2
     where
     signatory party
 
     interface instance I for FITemplateAlt where
-      view = IV party "V1" -- @V 1
-      view = IV party "V2" -- @V  2
-      getVersion = "V1"    -- @V 1
-      getVersion = "V2"    -- @V  2
+      view = IV party None     -- @V 1
+      view = IV party payload  -- @V  2
+      getVersion = "V1"        -- @V 1
+      getVersion = "V2"        -- @V  2
 -}
 
 interfacesV1 : PackageId
@@ -159,8 +161,8 @@ main = tests
   , ("Package map preference is used for interface implementation selection at choice body level", interfaceChoicePackagePreferenceUpdate)
   , ("Multiple interface exercises use their respective package preference entries at command level", multipleInterfaceChoicePackagePreferenceCommand)
   , ("Multiple interface exercises use their respective package preference entries at choice body level", multipleInterfaceChoicePackagePreferenceUpdate)
-  , broken ("queryInterfaceContractId uses highest version of view", queryInterfaceUpgrades)
-  , ("fetchFromInterface upgrades payload to match request", fetchFromInterfaceUpgrades)
+  , ("queryInterfaceContractId works as intended in the presence of upgraded packages", queryInterfaceUpgrades)
+  , ("fetchFromInterface works as intended in the presence of upgraded packages", fetchFromInterfaceUpgrades)
   -- IDE Ledger doesn't support unvetting
   , brokenOnIDELedger ("Can fetch interface from V1 contract when V1 unvetted", fetchWithoutV1)
   ]
@@ -209,7 +211,7 @@ multipleInterfaceChoicePackagePreference doExercise = test $ do
   let icid = toInterfaceContractId @I cid
       icidAlt = toInterfaceContractId @I cidAlt
       -- Tests all 4 combinations of 2 versions for 2 packages
-      cases = 
+      cases =
         [ (interfacesVersion, interfacesVersionStr, interfacesAltVersion, interfacesAltVersionStr)
         | (interfacesVersion, interfacesVersionStr) <- [(interfacesV1, "V1"), (interfacesV2, "V2")]
         , (interfacesAltVersion, interfacesAltVersionStr) <- [(interfacesAltV1, "V1"), (interfacesAltV2, "V2")]
@@ -238,19 +240,19 @@ queryInterfaceUpgrades : Test
 queryInterfaceUpgrades = test $ do
   (alice, icid) <- setupAliceAndInterface
   res <- fromSomeNote "Failed to find contract" <$> alice `queryInterfaceContractId` icid
-  res.version === "V2"
+  res.payload === None
 
 fetchFromInterfaceUpgrades : Test
 fetchFromInterfaceUpgrades = test $ do
   (alice, icid) <- setupAliceAndInterface
   resV1 <- alice `submit` createAndExerciseExactCmd (V1.FITemplate with party = alice) (V1.FetchFromInterface with icid = icid)
-  resV1 === "V1"
-  resV2 <- alice `submit` createAndExerciseExactCmd (V2.FITemplate with party = alice) (V2.FetchFromInterface with icid = icid)
-  resV2 === "V2"
+  resV1 === None
+  resV2 <- alice `submit` createAndExerciseExactCmd (V2.FITemplate with party = alice, payload = None) (V2.FetchFromInterface with icid = icid)
+  resV2 === None
 
 fetchWithoutV1 : Test
 fetchWithoutV1 = test $ do
   (alice, icid) <- setupAliceAndInterface
   withUnvettedDarOnParticipant "interfaces-1.0.0" participant0 $ do
-    alice `submit` createAndExerciseCmd (V2.FITemplate alice) (V2.FetchInterface icid)
+    alice `submit` createAndExerciseCmd (V2.FITemplate alice None) (V2.FetchInterface icid)
   pure ()

--- a/sdk/ledger-test-tool/tool/BUILD.bazel
+++ b/sdk/ledger-test-tool/tool/BUILD.bazel
@@ -261,6 +261,8 @@ conformance_test(
                 # the unexpected arg is now interpreted as a non-optional upgrade field
                 "CommandServiceIT:CSRefuseBadParameter",
                 "CommandServiceIT:CSBadCreateAndExercise",
+                # test failing now that we assume retroactive interface instances are not allowed
+                "InterfaceIT:ExerciseRetroactiveInterfaceInstanceSuccess",
             ]),
         ],
     )


### PR DESCRIPTION
Addresses the runtime part of UP-1 in [this doc](https://docs.google.com/spreadsheets/d/1_0ER--x-YJzoYSoy7VFs6emzn4ZYjBc0kte4MLosuxs/edit?gid=0#gid=0).

Make sure to "hide whitespace" if reviewing on github: quite a lot of code is untouched but indented at a different level.