### PR TITLE
disable m1 for snapshots

### DIFF
--- a/ci/macOS.yml
+++ b/ci/macOS.yml
@@ -17,8 +17,9 @@ jobs:
     demands: assignment -equals ${{parameters.assignment}}
   condition: and(succeeded(),
                  or(eq('${{parameters.name}}', 'macos'),
-                    or(eq(variables['Build.SourceBranchName'], 'main'),
-                       eq(variables['Build.SourceBranchName'], 'main-2.x'))))
+                    and(or(eq(variables['Build.SourceBranchName'], 'main'),
+                           eq(variables['Build.SourceBranchName'], 'main-2.x')),
+                        not(dependencies.check_for_release.outputs['out.is_release']))))
   variables:
     - name: release_sha
       value: $[ dependencies.check_for_release.outputs['out.release_sha'] ]


### PR DESCRIPTION
Temporarily disable m1 build in the snapshot pipeline because of https://github.com/digital-asset/daml/issues/19866.