### PR TITLE
fix the macos task condition

### DIFF
--- a/ci/macOS.yml
+++ b/ci/macOS.yml
@@ -19,7 +19,7 @@ jobs:
                  or(eq('${{parameters.name}}', 'macos'),
                     and(or(eq(variables['Build.SourceBranchName'], 'main'),
                            eq(variables['Build.SourceBranchName'], 'main-2.x')),
-                        not(dependencies.check_for_release.outputs['out.is_release']))))
+                        eq(dependencies.check_for_release.outputs['out.is_release'], 'false'))))
   variables:
     - name: release_sha
       value: $[ dependencies.check_for_release.outputs['out.release_sha'] ]


### PR DESCRIPTION
This should hopefully allow m1 to run post merge. This won't enable m1 for PRs but that was already the case before https://github.com/digital-asset/daml/pull/19865 so I think this was intended.