### PR TITLE
Fecth ReplayCommand should not accept interface ID.

### DIFF
--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
@@ -260,14 +260,10 @@ private[lf] final class CommandPreprocessor(
             argument,
           ) =>
         unsafePreprocessExerciseByKey(templateId, contractKey, choiceId, argument, strict = true)
-      case command.ReplayCommand.Fetch(typeId, coid) =>
+      case command.ReplayCommand.Fetch(tmplId, coid) =>
         val cid = valueTranslator.unsafeTranslateCid(coid)
-        handleLookup(pkgInterface.lookupTemplateOrInterface(typeId)) match {
-          case TemplateOrInterface.Template(_) =>
-            speedy.Command.FetchTemplate(typeId, cid)
-          case TemplateOrInterface.Interface(_) =>
-            speedy.Command.FetchInterface(typeId, cid)
-        }
+        discard(handleLookup(pkgInterface.lookupTemplate(tmplId)))
+        speedy.Command.FetchTemplate(tmplId, cid)
       case command.ReplayCommand.FetchByKey(templateId, key) =>
         val ckTtype = handleLookup(pkgInterface.lookupTemplateKey(templateId)).typ
         val sKey = translateNonUpgradableArg(ckTtype, key, strict = true)


### PR DESCRIPTION
This minor bug was introduce as part of the refactoring #13804.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
