### PR TITLE
[Forward-port] Implement interface upgrades and package preference support for IDE Ledger (#19660) (#19669)

### DIFF
--- a/sdk/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/sdk/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -273,7 +273,7 @@ class Context(
         e.cause match {
           case e: Error => handleFailure(e)
           case e: speedy.SError.SError => handleFailure(Error.RunnerException(e))
-          case e =>
+          case _ =>
             // We can't send _everything_ over without changing internal, we log and wrap the error in t.
             logger.warn("Script.FailedCmd unexpected cause: " + e.getMessage)
             logger.debug(e.getStackTrace.mkString("\n"))

--- a/sdk/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioRunner.scala
+++ b/sdk/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioRunner.scala
@@ -425,16 +425,13 @@ private[lf] object ScenarioRunner {
       commands: SExpr,
       location: Option[Location],
       seed: crypto.Hash,
+      packageResolution: Map[PackageName, PackageId] = Map.empty,
       traceLog: TraceLog = Speedy.Machine.newTraceLog,
       warningLog: WarningLog = Speedy.Machine.newWarningLog,
       doEnrichment: Boolean = true,
   )(implicit loggingContext: LoggingContext): SubmissionResult[R] = {
     val ledgerMachine = Speedy.UpdateMachine(
-      packageResolution = Map(
-        PackageName.assertFromString("-dummy-package-name-") -> PackageId.assertFromString(
-          "-homePackageId-"
-        )
-      ),
+      packageResolution = packageResolution,
       compiledPackages = compiledPackages,
       submissionTime = Time.Timestamp.MinValue,
       initialSeeding = InitialSeeding.TransactionSeed(seed),

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -221,7 +221,7 @@ object Script {
 
   final case class FailedCmd(description: String, stackTrace: StackTrace, cause: Throwable)
       extends RuntimeException(
-        s"""Command ${description} failed: ${cause.getMessage}
+        s"""Command ${description} failed: ${Option(cause.getMessage).getOrElse(cause)}
           |Daml stacktrace:
           |${stackTrace.pretty()}""".stripMargin,
         cause,

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/IdeLedgerClient.scala
@@ -314,6 +314,11 @@ class IdeLedgerClient(
           translated,
           optLocation,
           nextSeed(),
+          packageResolution = Map(
+            PackageName.assertFromString("-dummy-package-name-") -> PackageId.assertFromString(
+              "-homePackageId-"
+            )
+          ),
           traceLog = traceLog,
           warningLog = warningLog,
         )(Script.DummyLoggingContext)

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/IdeLedgerClient.scala
@@ -314,8 +314,8 @@ class IdeLedgerClient(
           translated,
           optLocation,
           nextSeed(),
-          traceLog,
-          warningLog,
+          traceLog = traceLog,
+          warningLog = warningLog,
         )(Script.DummyLoggingContext)
 
       @tailrec

--- a/sdk/daml-script/test/daml/upgrades/Interfaces.daml
+++ b/sdk/daml-script/test/daml/upgrades/Interfaces.daml
@@ -146,12 +146,12 @@ interfacesAltV2 = getPackageId "interfaces-alt-2.0.0"
 -- cant upgrade contracts in interface choice argument - i dont think this is possible in daml-script
 main : TestTree
 main = tests
-  [ brokenOnIDELedger ("Calling an interface choice uses the highest version implementation at command level by default", defaultHighestVersionChoiceImplementationCommand)
-  , brokenOnIDELedger ("Calling an interface choice uses the highest version implementation at choice body level by default", defaultHighestVersionChoiceImplementationUpdate)
-  , brokenOnIDELedger ("Package map preference is used for interface implementation selection at command level", interfaceChoicePackagePreferenceCommand)
-  , brokenOnIDELedger ("Package map preference is used for interface implementation selection at choice body level", interfaceChoicePackagePreferenceUpdate)
-  , brokenOnIDELedger ("Multiple interface exercises use their respective package preference entries at command level", multipleInterfaceChoicePackagePreferenceCommand)
-  , brokenOnIDELedger ("Multiple interface exercises use their respective package preference entries at choice body level", multipleInterfaceChoicePackagePreferenceUpdate)
+  [ ("Calling an interface choice uses the highest version implementation at command level by default", defaultHighestVersionChoiceImplementationCommand)
+  , ("Calling an interface choice uses the highest version implementation at choice body level by default", defaultHighestVersionChoiceImplementationUpdate)
+  , ("Package map preference is used for interface implementation selection at command level", interfaceChoicePackagePreferenceCommand)
+  , ("Package map preference is used for interface implementation selection at choice body level", interfaceChoicePackagePreferenceUpdate)
+  , ("Multiple interface exercises use their respective package preference entries at command level", multipleInterfaceChoicePackagePreferenceCommand)
+  , ("Multiple interface exercises use their respective package preference entries at choice body level", multipleInterfaceChoicePackagePreferenceUpdate)
   , broken ("queryInterfaceContractId uses highest version of view", queryInterfaceUpgrades)
   , broken ("fetchFromInterface upgrades payload to match request", fetchFromInterfaceUpgrades)
   ]

--- a/sdk/daml-script/test/daml/upgrades/PackagePreference.daml
+++ b/sdk/daml-script/test/daml/upgrades/PackagePreference.daml
@@ -37,9 +37,9 @@ v1PackageId = getPackageId "package-preference-1.0.0"
 main : TestTree
 main = tests
   [ ("No package preference uses the default 'highest version' logic for exercise", noPackagePreference)
-  , brokenOnIDELedger ("Explicit package preference is used over highest version for exercise", explicitPackagePreference)
-  , brokenOnIDELedger ("Explicit package preference is not used for exact exercises", explicitPackagePreferenceWithExact)
-  , brokenOnIDELedger ("Explicit package preference is not used for exact exercises in transactions that do use preference", explicitPackagePreferenceWithExactAndNon)
+  , ("Explicit package preference is used over highest version for exercise", explicitPackagePreference)
+  , ("Explicit package preference is not used for exact exercises", explicitPackagePreferenceWithExact)
+  , ("Explicit package preference is not used for exact exercises in transactions that do use preference", explicitPackagePreferenceWithExactAndNon)
   ]
 
 noPackagePreference : Test

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/Daml2ScriptTestRunner.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/Daml2ScriptTestRunner.scala
@@ -43,8 +43,8 @@ class Daml2ScriptTestRunner extends DamlScriptTestRunner {
           |ExceptionSemantics:uncaughtUserException SUCCESS
           |ExceptionSemantics:unhandledArithmeticError FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.ArithmeticError:ArithmeticError@XXXXXXXX{ message = "ArithmeticError while evaluating (DIV_INT64 1 0)." }. Details: Last location: [DA.Internal.Template.Functions:265], partial transaction: ...
           |ExceptionSemantics:unhandledUserException FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: ExceptionSemantics:E@XXXXXXXX{  }. Details: Last location: [DA.Internal.Exception:176], partial transaction: ...
-          |ExceptionSemanticsWithKeys:duplicateKey FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submitMustFail failed: null
-          |LFContractKeys:lookupTest FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submitMustFail failed: null
+          |ExceptionSemanticsWithKeys:duplicateKey FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submitMustFail failed: SErrorDamlException(UserError(Expected submit to fail but it succeeded)
+          |LFContractKeys:lookupTest FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submitMustFail failed: SErrorDamlException(UserError(Expected submit to fail but it succeeded)
           |MoreChoiceObserverDivulgence:test FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submit failed: NOT_FOUND: CONTRACT_NOT_FOUND(11,XXXXXXXX): Contract could not be found with id XXXXXXXX
           |MultiTest:disclosuresByKeyTest SUCCESS
           |MultiTest:disclosuresTest SUCCESS

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/Daml3ScriptTestRunner.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/Daml3ScriptTestRunner.scala
@@ -43,8 +43,8 @@ class Daml3ScriptTestRunner extends DamlScriptTestRunner {
           |ExceptionSemantics:uncaughtUserException SUCCESS
           |ExceptionSemantics:unhandledArithmeticError FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.ArithmeticError:ArithmeticError@XXXXXXXX{ message = "ArithmeticError while evaluating (DIV_INT64 1 0)." }. Details: Last location: [DA.Internal.Template.Functions:265], partial transaction: ...
           |ExceptionSemantics:unhandledUserException FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: ExceptionSemantics:E@XXXXXXXX{  }. Details: Last location: [DA.Internal.Exception:176], partial transaction: ...
-          |ExceptionSemanticsWithKeys:duplicateKey FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: null
-          |LFContractKeys:lookupTest FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: null
+          |ExceptionSemanticsWithKeys:duplicateKey FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: SErrorDamlException(UserError(Expected submit to fail but it succeeded)
+          |LFContractKeys:lookupTest FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: SErrorDamlException(UserError(Expected submit to fail but it succeeded)
           |MoreChoiceObserverDivulgence:test FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: NOT_FOUND: CONTRACT_NOT_FOUND(11,XXXXXXXX): Contract could not be found with id XXXXXXXX
           |MultiTest:disclosuresByKeyTest SUCCESS
           |MultiTest:disclosuresTest SUCCESS


### PR DESCRIPTION
This ports https://github.com/digital-asset/daml/pull/19660 to the `main` (3.x) branch

* Implement interface upgrades and package preference support for IDE Ledger

* Add upgrades filters to by name conversion Defer package lookup errors to Update machine
Improve FailedCmd errors

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
