### PR TITLE
add view_interface to the LF test notation parser

### DIFF
--- a/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -52,6 +52,7 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
       eInterfaceTemplateTypeRep |
       eSignatoryInterface |
       eObserverInterface |
+      eViewInterface |
       eChoiceController |
       eChoiceObserver |
       (id ^? builtinFunctions) ^^ EBuiltinFun |
@@ -283,6 +284,11 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
   private lazy val eObserverInterface: Parser[Expr] =
     `observer_interface` ~! `@` ~> fullIdentifier ~ expr0 ^^ { case ifaceId ~ e =>
       EObserverInterface(ifaceId, e)
+    }
+
+  private lazy val eViewInterface: Parser[Expr] =
+    `view_interface` ~! `@` ~> fullIdentifier ~ expr0 ^^ { case ifaceId ~ e =>
+      EViewInterface(ifaceId, e)
     }
 
   private lazy val eChoiceController: Parser[Expr] =

--- a/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
+++ b/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
@@ -53,6 +53,7 @@ private[parser] object Lexer extends RegexParsers {
     "interface_template_type_rep" -> `interface_template_type_rep`,
     "signatory_interface" -> `signatory_interface`,
     "observer_interface" -> `observer_interface`,
+    "view_interface" -> `view_interface`,
     "choice_controller" -> `choice_controller`,
     "choice_observer" -> `choice_observer`,
   )

--- a/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
+++ b/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
@@ -61,6 +61,7 @@ private[parser] object Token {
   case object `interface_template_type_rep` extends Token
   case object `signatory_interface` extends Token
   case object `observer_interface` extends Token
+  case object `view_interface` extends Token
   case object `choice_controller` extends Token
   case object `choice_observer` extends Token
 

--- a/sdk/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/sdk/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -386,6 +386,10 @@ class ParsersSpec(majorLanguageVersion: LanguageMajorVersion)
           EObserverInterface(I.tycon, e"body"),
         "observer_interface @'-pkgId-':Mod:I body" ->
           EObserverInterface(I.tycon, e"body"),
+        "view_interface @Mod:I body" ->
+          EViewInterface(I.tycon, e"body"),
+        "view_interface @'-pkgId-':Mod:I body" ->
+          EViewInterface(I.tycon, e"body"),
         "choice_controller @Mod:T ChoiceName contract choiceArg" ->
           EChoiceController(T.tycon, n"ChoiceName", e"contract", e"choiceArg"),
         "choice_controller @'-pkgId-':Mod:T ChoiceName contract choiceArg" ->
@@ -990,6 +994,7 @@ class ParsersSpec(majorLanguageVersion: LanguageMajorVersion)
     "interface_template_type_rep",
     "signatory_interface",
     "observer_interface",
+    "view_interface",
   )
 
   private val modName = DottedName.assertFromString("Mod")


### PR DESCRIPTION
As discussed with @remyhaemmerle-da, this is an oversight. We also discussed adding it to the spec but this is non-trivial: the spec doesn't currently specify view functions for interfaces. So this will have to be done in a separate PR.