### PR TITLE
reorganize script tests

### DIFF
--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/Daml2ScriptTestRunner.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/Daml2ScriptTestRunner.scala
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package com.digitalasset.daml.lf.engine.script
+package test
 
 import com.daml.bazeltools.BazelRunfiles
 import org.scalatest.Suite

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/Daml3ScriptTestRunner.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/Daml3ScriptTestRunner.scala
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package com.digitalasset.daml.lf.engine.script
+package test
 
 import com.daml.bazeltools.BazelRunfiles
 import org.scalatest.Suite

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/Daml3ScriptTestRunnerDev.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/Daml3ScriptTestRunnerDev.scala
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package com.digitalasset.daml.lf.engine.script
+package test
 
 import com.daml.bazeltools.BazelRunfiles
 import org.scalatest.Suite

--- a/sdk/daml-script/test/src/test-utils/scala/com/digitalasset/daml/lf/engine/script/test/DamlScriptTestRunner.scala
+++ b/sdk/daml-script/test/src/test-utils/scala/com/digitalasset/daml/lf/engine/script/test/DamlScriptTestRunner.scala
@@ -1,18 +1,18 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.daml.lf.engine.script
+package com.digitalasset.daml.lf
+package engine.script.test
 
 import com.daml.bazeltools.BazelRunfiles
 import com.daml.integrationtest.CantonConfig.TimeProviderType
 import com.daml.integrationtest.CantonFixture
 import com.daml.scalautil.Statement.discard
-import org.scalatest.{Assertion, Suite}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{Assertion, Suite}
 
-import java.nio.file.Files
-import java.nio.file.Path
+import java.nio.file.{Files, Path}
 
 trait DamlScriptTestRunner extends AnyWordSpec with CantonFixture with Matchers {
   self: Suite =>


### PR DESCRIPTION
Moves all the test classes under the same directory. Moves all the test util classes under the same directory