### PR TITLE
test reminder

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -311,6 +311,17 @@ jobs:
           tell_slack "Daily tests failed ($(Build.SourceBranchName)): $COMMIT_LINK." "$(Slack.ci-failures-daml)"
         fi
 
+        export GH_REPO=digital-asset/daml
+        pr_list=$(gh pr list --search "is:open author:app/azure-pipelines" --json title,url,createdAt --template \
+        '{{range .}}{{slice .createdAt 0 10}} <{{.url}}|{{.title}}>
+        {{end}}')
+        message="Open daml repo PRs to address:
+
+        $pr_list"
+        tell_slack "$message" "$(Slack.team-sdk-updates)"
+      env:
+        GITHUB_TOKEN: $(CANTON_READONLY_TOKEN)
+
   - job: snapshots
     timeoutInMinutes: 60
     condition: eq(variables['Build.SourceBranchName'], 'main')

--- a/sdk/dev-env/bin/gh
+++ b/sdk/dev-env/bin/gh
@@ -1,0 +1,1 @@
+../lib/dade-exec-nix-tool

--- a/sdk/nix/default.nix
+++ b/sdk/nix/default.nix
@@ -165,6 +165,8 @@ in rec {
     wget = pkgs.wget;
     grpcurl = pkgs.grpcurl;
 
+    gh = pkgs.gitAndTools.gh;
+
     # String mangling tooling.
     base64 = pkgs.coreutils;
     bc = pkgs.bc;


### PR DESCRIPTION
Sends a message to the sdk update channel every morning after having created the daily-compat PRs. The message contains the list of open PRs to address, with links to the PRs. This was requested by @mlachkar-da who wanted a daily reminded to address the code drop PRs, and @remyhaemmerle-da and @rgugliel-da who wanted to batch the reminders to limit the noise.

Tested successfully (with a fake list of PRs, closed ones) in [this message](https://daholdings.slack.com/archives/C03UB7YM9J4/p1726762588727139).