### PR TITLE
Mark unintentially fixed tests as working

### DIFF
--- a/sdk/daml-script/test/daml/upgrades/ContractKeys.daml
+++ b/sdk/daml-script/test/daml/upgrades/ContractKeys.daml
@@ -61,8 +61,8 @@ main = tests
       -- https://github.com/digital-asset/daml/pull/19792,
       -- however, the latter is considered a hack, see
       -- https://github.com/digital-asset/daml/issues/19782
-      [ broken ("queryContractKey, src=v1 tgt=v2", queryKeyUpgraded)
-      , broken ("exerciseByKeyCmd, src=v1 tgt=v2", exerciseCmdKeyUpgraded)
+      [ ("queryContractKey, src=v1 tgt=v2", queryKeyUpgraded)
+      , ("exerciseByKeyCmd, src=v1 tgt=v2", exerciseCmdKeyUpgraded)
       , ("fetch, src=v1 tgt=v2", fetchKeyUpgraded)
       , ("exerciseByKey, src=v1 tgt=v2", exerciseUpdateKeyUpgraded)
       ]


### PR DESCRIPTION
It appears that https://github.com/digital-asset/daml/pull/19912 fixed some upgrade tests that were marked broken, but they weren't run by CI
As such, CI on main is now broken