### PR TITLE
prevent ValueTranslation usage on non serializable data

### DIFF
--- a/sdk/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/sdk/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -280,7 +280,7 @@ generateRawDalfRule =
                             let world = LF.initWorldSelf pkgs pkg
                                 simplified = LF.simplifyModule world lfVersion v
                             pure $! case Serializability.inferModule world simplified of
-                              Left err -> (ideErrorPretty file err : conversionWarnings, Nothing)
+                              Left err -> ([ideErrorPretty file err], Nothing)
                               Right dalf -> (conversionWarnings, Just dalf)
 
 getExternalPackages :: NormalizedFilePath -> Action [LF.ExternalPackage]

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
@@ -64,7 +64,7 @@ private[lf] final class ValueTranslator(
       ty: Type,
       value: Value,
   ): SValue = {
-    import TypeDestructor.TypeF._
+    import TypeDestructor.SerializableTypeF._
     val Destructor = TypeDestructor(pkgInterface)
 
     // TODO: https://github.com/digital-asset/daml/issues/17082

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValueEnricherSpec.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValueEnricherSpec.scala
@@ -52,7 +52,7 @@ class ValueEnricherSpec(majorLanguageVersion: LanguageMajorVersion)
           record @serializable MyUnit = {};
           record @serializable Record = { field : Int64, optField: Option Int64 };
           variant @serializable Variant = variant1 : Text | variant2 : Int64 ;
-          enum Enum = value1 | value2;
+          enum @serializable Enum = value1 | value2;
 
           record @serializable Key = {
              party: Party,

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslatorSpec.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslatorSpec.scala
@@ -55,12 +55,10 @@ class ValueTranslatorSpec(majorLanguageVersion: LanguageMajorVersion)
           record @serializable Tuple (a: *) (b: *) = { x: a, y: b };
           record @serializable Record = { field : Int64 };
           variant @serializable Either (a: *) (b: *) = Left : a | Right : b;
-          enum Color = red | green | blue;
+          enum @serializable Color = red | green | blue;
 
-          record Tricky (b: * -> *) = { x : b Unit };
-
-          record MyCons = { head : Int64, tail: Mod:MyList };
-          variant MyList = MyNil : Unit | MyCons: Mod:MyCons ;
+          record @serializable MyCons = { head : Int64, tail: Mod:MyList };
+          variant @serializable  MyList = MyNil : Unit | MyCons: Mod:MyCons ;
 
           record @serializable Template = { field : Int64 };
           record @serializable TemplateRef = { owner: Party, cid: (ContractId Mod:Template) };
@@ -136,11 +134,6 @@ class ValueTranslatorSpec(majorLanguageVersion: LanguageMajorVersion)
         SVariant("Mod:Either", "Right", 1, SText("some test")),
       ),
       (Ast.TTyCon("Mod:Color"), ValueEnum("", "blue"), SEnum("Mod:Color", "blue", 2)),
-      (
-        Ast.TApp(Ast.TTyCon("Mod:Tricky"), Ast.TBuiltin(Ast.BTList)),
-        ValueRecord("", ImmArray("" -> ValueNil)),
-        SRecord("Mod:Tricky", ImmArray("x"), ArrayList(SValue.EmptyList)),
-      ),
     )
 
     val emptyTestCase = Table[Ast.Type, Value, speedy.SValue](

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -1186,7 +1186,7 @@ private[lf] object Speedy {
     // Raises an exception if missing a package.
     private[speedy] final def importValue(typ0: Type, value0: V): Control.Value = {
 
-      import TypeDestructor.TypeF._
+      import TypeDestructor.SerializableTypeF._
       val Destructor = TypeDestructor(compiledPackages.pkgInterface)
 
       def assertRight[X](x: Either[LookupError, X]): X =

--- a/sdk/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/TypeDestructor.scala
+++ b/sdk/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/TypeDestructor.scala
@@ -11,49 +11,49 @@ import scala.collection.immutable.ArraySeq
 
 object TypeDestructor {
 
-  sealed abstract class TypeF[+Type] extends Product with Serializable
+  sealed abstract class SerializableTypeF[+Type] extends Product with Serializable
 
-  object TypeF {
+  object SerializableTypeF {
 
-    case object UnitF extends TypeF[Nothing]
+    case object UnitF extends SerializableTypeF[Nothing]
 
-    case object BoolF extends TypeF[Nothing]
+    case object BoolF extends SerializableTypeF[Nothing]
 
-    case object Int64F extends TypeF[Nothing]
+    case object Int64F extends SerializableTypeF[Nothing]
 
-    case object DateF extends TypeF[Nothing]
+    case object DateF extends SerializableTypeF[Nothing]
 
-    case object TimestampF extends TypeF[Nothing]
+    case object TimestampF extends SerializableTypeF[Nothing]
 
-    final case class NumericF(scale: Numeric.Scale) extends TypeF[Nothing]
+    final case class NumericF(scale: Numeric.Scale) extends SerializableTypeF[Nothing]
 
-    case object PartyF extends TypeF[Nothing]
+    case object PartyF extends SerializableTypeF[Nothing]
 
-    case object TextF extends TypeF[Nothing]
+    case object TextF extends SerializableTypeF[Nothing]
 
-    final case class ContractIdF[Type](a: Type) extends TypeF[Type]
+    final case class ContractIdF[Type](a: Type) extends SerializableTypeF[Type]
 
-    final case class OptionalF[Type](a: Type) extends TypeF[Type]
+    final case class OptionalF[Type](a: Type) extends SerializableTypeF[Type]
 
-    final case class ListF[Type](a: Type) extends TypeF[Type]
+    final case class ListF[Type](a: Type) extends SerializableTypeF[Type]
 
-    final case class MapF[Type](a: Type, b: Type) extends TypeF[Type]
+    final case class MapF[Type](a: Type, b: Type) extends SerializableTypeF[Type]
 
-    final case class TextMapF[Type](a: Type) extends TypeF[Type]
+    final case class TextMapF[Type](a: Type) extends SerializableTypeF[Type]
 
     final case class RecordF[Type](
         tyCon: Ref.TypeConName,
         pkgName: Ref.PackageName,
         fieldNames: ArraySeq[Ref.Name],
         fieldTypes: ArraySeq[Type],
-    ) extends TypeF[Type]
+    ) extends SerializableTypeF[Type]
 
     final case class VariantF[Type](
         tyCon: Ref.TypeConName,
         pkgName: Ref.PackageName,
         cons: ArraySeq[Ref.Name],
         consTypes: ArraySeq[Type],
-    ) extends TypeF[Type] {
+    ) extends SerializableTypeF[Type] {
       private[this] lazy val consRankMap = cons.view.zipWithIndex.toMap
 
       def consRank(cons: Ref.Name): Either[LookupError, Int] = {
@@ -67,7 +67,7 @@ object TypeDestructor {
         tyCon: Ref.TypeConName,
         pkgName: Ref.PackageName,
         cons: ArraySeq[Ref.Name],
-    ) extends TypeF[Nothing] {
+    ) extends SerializableTypeF[Nothing] {
       private[this] lazy val consRankMap = cons.view.zipWithIndex.toMap
 
       def consRank(cons: Ref.Name): Either[LookupError, Int] = {
@@ -94,16 +94,16 @@ object TypeDestructor {
 final class TypeDestructor(pkgInterface: PackageInterface) {
   self =>
 
-  import TypeDestructor.TypeF
-  import TypeF._
+  import TypeDestructor.SerializableTypeF
+  import SerializableTypeF._
 
-  def destruct(state: Ast.Type): Either[TypeDestructor.Error, TypeF[Ast.Type]] =
+  def destruct(state: Ast.Type): Either[TypeDestructor.Error, SerializableTypeF[Ast.Type]] =
     go(state, List.empty)
 
   private def go(
       typ0: Ast.Type,
       args: List[Ast.Type],
-  ): Either[TypeDestructor.Error, TypeF[Ast.Type]] = {
+  ): Either[TypeDestructor.Error, SerializableTypeF[Ast.Type]] = {
     def prettyType = args.foldLeft(typ0)(Ast.TApp).pretty
 
     def unserializableType = TypeDestructor.Error.TypeError(s"unserializableType type $prettyType")


### PR DESCRIPTION
This is not absolutely necessary. However taking into account several test were actually using non serializable data, I think this sanity check can be useful to prevent misusing the translator. 

Note we discovered a small bug in the compiler that was not running the Serializability inference when type-checking was disable. (Thanks for @samuel-williams-da to quickly fine and propose the fix included in this PR)

We also rename `TypeF` in `SerializableTypeF` to make it clear the `TypeDesctructor` handles only serializable types. 

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
