### PR TITLE
Add metadata checks to upgraded dar (#19978)

### DIFF
--- a/sdk/bazel-haskell-deps.bzl
+++ b/sdk/bazel-haskell-deps.bzl
@@ -18,8 +18,8 @@ load("@dadew//:dadew.bzl", "dadew_tool_home")
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 load("//bazel_tools/ghc-lib:repositories.bzl", "ghc_lib_and_dependencies")
 
-GHCIDE_REV = "eff0d9141f5825f4765fb0899f65f5174cb29261"
-GHCIDE_SHA256 = "a43aa87c1b8e4ff4b861c0ab728df8ac125ab4c4c01420eaa86d60c1e32f5c87"
+GHCIDE_REV = "1ec6a3457f8f3700376be6b6ee4fe6591fc129ee"
+GHCIDE_SHA256 = "6ed371ebf9597aab21675fc4c54dbc59bc4b7648ab7513482620c996b650ea29"
 GHCIDE_LOCAL_PATH = None
 JS_JQUERY_VERSION = "3.3.1"
 JS_DGTABLE_VERSION = "0.5.2"

--- a/sdk/compiler/damlc/daml-ide-core/BUILD.bazel
+++ b/sdk/compiler/damlc/daml-ide-core/BUILD.bazel
@@ -66,6 +66,7 @@ da_haskell_library(
         "//compiler/damlc/daml-package-config",
         "//compiler/damlc/daml-rule-types",
         "//compiler/scenario-service/client",
+        "//daml-assistant:daml-project-config",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
         "//sdk-version/hs:sdk-version-class-lib",

--- a/sdk/compiler/damlc/daml-opts/BUILD.bazel
+++ b/sdk/compiler/damlc/daml-opts/BUILD.bazel
@@ -27,6 +27,7 @@ da_haskell_library(
     deps = [
         "//compiler/daml-lf-ast",
         "//compiler/damlc/daml-package-config",
+        "//daml-assistant:daml-project-config",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
     ],

--- a/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -44,6 +44,7 @@ module DA.Daml.Options.Types
 import Control.Monad.Reader
 import DA.Bazel.Runfiles
 import qualified DA.Daml.LF.Ast as LF
+import DA.Daml.Project.Types (ProjectPath)
 import DA.Pretty
 import qualified DA.Service.Logger as Logger
 import qualified DA.Service.Logger.Impl.IO as Logger.IO
@@ -73,6 +74,8 @@ data Options = Options
     -- ^ Name of the package (version not included, so this is not the unit id)
   , optMbPackageVersion :: Maybe LF.PackageVersion
     -- ^ Version of the package
+  , optMbPackageConfigPath :: Maybe ProjectPath
+    -- ^ Path to the daml.yaml
   , optIfaceDir :: Maybe FilePath
     -- ^ directory to write interface files to. If set to `Nothing` we default to <current working dir>.daml/interfaces.
   , optPackageImports :: [PackageFlag]
@@ -131,6 +134,9 @@ data Options = Options
   -- packages from remote ledgers.
   , optAllowLargeTuples :: AllowLargeTuples
   -- ^ Do not warn when tuples of size > 5 are used
+  , optHideUnitId :: Bool
+  -- ^ When running in IDE, some rules need access to the package name and version, but we don't want to use own
+  -- unit-id, as script + scenario service assume it will be "main"
   , optUpgradeInfo :: UpgradeInfo
   }
 
@@ -258,6 +264,7 @@ defaultOptions mbVersion =
         , optStablePackages = Nothing
         , optMbPackageName = Nothing
         , optMbPackageVersion = Nothing
+        , optMbPackageConfigPath = Nothing
         , optIfaceDir = Nothing
         , optPackageImports = []
         , optShakeProfiling = Nothing
@@ -282,6 +289,7 @@ defaultOptions mbVersion =
         , optEnableOfInterestRule = False
         , optAccessTokenPath = Nothing
         , optAllowLargeTuples = AllowLargeTuples False
+        , optHideUnitId = False
         , optUpgradeInfo = defaultUpgradeInfo
         }
 
@@ -309,7 +317,7 @@ fullPkgName (LF.PackageName n) mbV (LF.PackageId h) =
         Just (LF.PackageVersion v) -> n <> "-" <> v <> "-" <> h
 
 optUnitId :: Options -> Maybe UnitId
-optUnitId Options{..} = fmap (\name -> pkgNameVersion name optMbPackageVersion) optMbPackageName
+optUnitId Options{..} = guard (not optHideUnitId) >> fmap (\name -> pkgNameVersion name optMbPackageVersion) optMbPackageName
 
 getLogger :: Options -> T.Text -> IO (Logger.Handle IO)
 getLogger Options {optLogLevel} name = Logger.IO.newStderrLogger optLogLevel name

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -128,9 +128,11 @@ import DA.Daml.Options.Types (EnableScenarioService(..),
                               optEnableOfInterestRule,
                               optEnableScenarios,
                               optHaddock,
+                              optHideUnitId,
                               optIfaceDir,
                               optImportPath,
                               optIncrementalBuild,
+                              optMbPackageConfigPath,
                               optMbPackageName,
                               optMbPackageVersion,
                               optPackageDbs,
@@ -698,9 +700,10 @@ execIde telemetry (Debug debug) enableScenarioService autorunAllScenarios option
                       whenJust gcpStateM $ \gcpState -> Logger.GCP.logIgnored gcpState
                       f loggerH
                   TelemetryDisabled -> f loggerH
-          mPkgConfig <- withMaybeConfig (withPackageConfig defaultProjectPath) pure
+          pkgPath <- getCanonDefaultProjectPath
+          mPkgConfig <- withMaybeConfig (withPackageConfig pkgPath) pure
           let pkgConfUpgradeDar = pUpgradeDar =<< mPkgConfig
-          options <- updateUpgradePath "ide" options pkgConfUpgradeDar
+          options <- updateUpgradePath "ide" pkgPath options pkgConfUpgradeDar
           options <- pure options
               { optScenarioService = enableScenarioService
               , optEnableOfInterestRule = True
@@ -709,6 +712,13 @@ execIde telemetry (Debug debug) enableScenarioService autorunAllScenarios option
               -- individual options. As a stopgap we ignore the argument to
               -- --jobs.
               , optThreads = 0
+              , optMbPackageName = pName <$> mPkgConfig
+              , optMbPackageVersion = mPkgConfig >>= pVersion
+              , optMbPackageConfigPath = Just pkgPath
+              -- IDE was built around not passing the package name and version, assuming the unit-id is "main" everywhere
+              -- For upgrade metadata checking, the IDE now needs the package name and version
+              -- This flag allows us to still hide the unit-id from ghc, so our assumption that the unit-id is "main" holds.
+              , optHideUnitId = True
               }
           installDepsAndInitPackageDb options (InitPkgDb True)
           scenarioServiceConfig <- readScenarioServiceConfig
@@ -819,6 +829,9 @@ execLint inputFiles opts =
 defaultProjectPath :: ProjectPath
 defaultProjectPath = ProjectPath "."
 
+getCanonDefaultProjectPath :: IO ProjectPath
+getCanonDefaultProjectPath = fmap ProjectPath $ canonicalizePath $ unwrapProjectPath defaultProjectPath
+
 -- | If we're in a daml project, read the daml.yaml field, install the dependencies and create the
 -- project local package database. Otherwise do nothing.
 execInit :: SdkVersion.Class.SdkVersioned => Options -> ProjectOpts -> Command
@@ -883,16 +896,17 @@ execBuild projectOpts opts mbOutFile incrementalBuild initPkgDb enableMultiPacka
   Command Build (Just projectOpts) $ evalContT $ do
     relativize <- ContT $ withProjectRoot' (projectOpts {projectCheck = ProjectCheck "" False})
 
-    let buildSingle :: PackageConfigFields -> IO ()
-        buildSingle pkgConfig = void $ buildEffect relativize pkgConfig opts mbOutFile incrementalBuild initPkgDb
-        buildMulti :: Maybe PackageConfigFields -> ProjectPath -> IO ()
-        buildMulti mPkgConfig multiPackageConfigPath = do
+    let buildSingle :: ProjectPath -> PackageConfigFields -> IO ()
+        buildSingle pkgPath pkgConfig = void $ buildEffect relativize pkgPath pkgConfig opts mbOutFile incrementalBuild initPkgDb
+        buildMulti :: ProjectPath -> Maybe PackageConfigFields -> ProjectPath -> IO ()
+        buildMulti pkgPath mPkgConfig multiPackageConfigPath = do
           hPutStrLn stderr $ "Running multi-package build of "
             <> maybe ("all packages in " <> unwrapProjectPath multiPackageConfigPath) (T.unpack . LF.unPackageName . pName) mPkgConfig <> "."
           withMultiPackageConfig multiPackageConfigPath $ \multiPackageConfig ->
-            multiPackageBuildEffect relativize mPkgConfig multiPackageConfig projectOpts opts mbOutFile incrementalBuild initPkgDb noCache
+            multiPackageBuildEffect relativize pkgPath mPkgConfig multiPackageConfig opts mbOutFile incrementalBuild initPkgDb noCache
 
-    mPkgConfig <- ContT $ withMaybeConfig $ withPackageConfig defaultProjectPath
+    pkgPath <- liftIO getCanonDefaultProjectPath
+    mPkgConfig <- ContT $ withMaybeConfig $ withPackageConfig pkgPath
     liftIO $ if getEnableMultiPackage enableMultiPackage then do
       mMultiPackagePath <- getMultiPackagePath multiPackageLocation
       -- At this point, if mMultiPackagePath is Just, we know it points to a multi-package.yaml
@@ -902,7 +916,7 @@ execBuild projectOpts opts mbOutFile incrementalBuild initPkgDb enableMultiPacka
         (True, _, Just multiPackagePath) ->
           -- TODO[SW]: Ideally we would error here if any of the flags that change `opts` has been set, as it won't be propagated
           -- Its unclear how to implement this.
-          buildMulti Nothing multiPackagePath
+          buildMulti pkgPath Nothing multiPackagePath
 
         -- We're attempting to multi-package build --all but we don't have a multi-package.yaml
         (True, _, Nothing) -> do
@@ -911,12 +925,12 @@ execBuild projectOpts opts mbOutFile incrementalBuild initPkgDb enableMultiPacka
           exitFailure
 
         -- We know the package we want and we have a multi-package.yaml
-        (False, Just pkgConfig, Just multiPackagePath) -> buildMulti (Just pkgConfig) multiPackagePath
+        (False, Just pkgConfig, Just multiPackagePath) -> buildMulti pkgPath (Just pkgConfig) multiPackagePath
 
         -- We know the package we want but we do not have a multi-package. The user has provided no reason they would want a multi-package build.
         (False, Just pkgConfig, Nothing) -> do
           hPutStrLn stderr $ "Running single package build of " <> T.unpack (LF.unPackageName $ pName pkgConfig) <> " as no multi-package.yaml was found."
-          buildSingle pkgConfig
+          buildSingle pkgPath pkgConfig
 
         -- We have no package context, but we have found a multi package at the current directory
         (False, Nothing, Just _) -> do
@@ -942,7 +956,7 @@ execBuild projectOpts opts mbOutFile incrementalBuild initPkgDb enableMultiPacka
             then do
               hPutStrLn stderr "Multi-package build option used with multi-package disabled - re-enable it by setting the --enable-multi-package=yes flag."
               exitFailure
-            else buildSingle pkgConfig
+            else buildSingle pkgPath pkgConfig
 
 -- Takes the withPackageConfig style functions and changes the continuation
 -- to give a Maybe, where Nothing signifies a missing file. Parse errors are still thrown
@@ -963,9 +977,18 @@ withMaybeConfig withConfig handler = do
     ) (withConfig $ pure . Just)
   handler mConfig
 
-buildEffect :: SdkVersion.Class.SdkVersioned => (FilePath -> IO FilePath) -> PackageConfigFields -> Options -> Maybe FilePath -> IncrementalBuild -> InitPkgDb -> IO (Maybe LF.PackageId)
-buildEffect relativize pkgConfig opts mbOutFile incrementalBuild initPkgDb = do
-  (pkgConfig, opts) <- syncUpgradesField pkgConfig opts
+buildEffect
+  :: SdkVersion.Class.SdkVersioned
+  => (FilePath -> IO FilePath)
+  -> ProjectPath
+  -> PackageConfigFields
+  -> Options
+  -> Maybe FilePath
+  -> IncrementalBuild
+  -> InitPkgDb
+  -> IO (Maybe LF.PackageId)
+buildEffect relativize pkgPath pkgConfig opts mbOutFile incrementalBuild initPkgDb = do
+  (pkgConfig, opts) <- syncUpgradesField pkgPath pkgConfig opts
   let PackageConfigFields{..} = pkgConfig
   installDepsAndInitPackageDb opts initPkgDb
   loggerH <- getLogger opts "build"
@@ -978,6 +1001,7 @@ buildEffect relativize pkgConfig opts mbOutFile incrementalBuild initPkgDb = do
       opts
         { optMbPackageName = Just pName
         , optMbPackageVersion = pVersion
+        , optMbPackageConfigPath = Just pkgPath
         , optIncrementalBuild = incrementalBuild
         }
       loggerH
@@ -999,20 +1023,25 @@ buildEffect relativize pkgConfig opts mbOutFile incrementalBuild initPkgDb = do
             Nothing -> pure $ distDir </> name <.> "dar"
             Just out -> rel out
 
-        syncUpgradesField :: PackageConfigFields -> Options -> IO (PackageConfigFields, Options)
-        syncUpgradesField pkgConf opts = do
-          opts <- updateUpgradePath "build" opts (pUpgradeDar pkgConf)
+        syncUpgradesField :: ProjectPath -> PackageConfigFields -> Options -> IO (PackageConfigFields, Options)
+        syncUpgradesField pkgPath pkgConf opts = do
+          opts <- updateUpgradePath "build" pkgPath opts (pUpgradeDar pkgConf)
           pure (pkgConf { pUpgradeDar = uiUpgradedPackagePath (optUpgradeInfo opts) }, opts)
 
-updateUpgradePath :: T.Text -> Options -> Maybe FilePath -> IO Options
-updateUpgradePath context opts@Options{optUpgradeInfo} newPkgPath = do
-  uiUpgradedPackagePath <- case (newPkgPath, uiUpgradedPackagePath optUpgradeInfo) of
+updateUpgradePath :: T.Text -> ProjectPath -> Options -> Maybe FilePath -> IO Options
+updateUpgradePath context projectPath opts@Options{optUpgradeInfo} newPkgPath = do
+  let projectFilePath = unwrapProjectPath projectPath
+  optCanonPath <- traverse canonicalizePath $ uiUpgradedPackagePath optUpgradeInfo
+  pkgCanonPath <- withCurrentDirectory projectFilePath $ traverse canonicalizePath newPkgPath
+  -- optUpgradeInfo is normalised to current directory
+  -- newPkgPath is normalised to daml.yaml location (or currentDirectory)
+  uiUpgradedPackagePath <- case (pkgCanonPath, optCanonPath) of
     (Just damlYamlOption, Just buildFlagsOption) | damlYamlOption /= buildFlagsOption -> do
       loggerH <- getLogger opts context
       Logger.logError loggerH $ T.unlines
         [ "ERROR: Specified two different DARs to run upgrade checks against:"
-        , "  Path specified in daml.yaml `upgrades:` field is '" <> T.pack damlYamlOption <> "'"
-        , "  Path specified in `--upgrades` build option is '" <> T.pack buildFlagsOption <> "'"
+        , "  Path specified in daml.yaml `upgrades:` field is '" <> T.pack (makeRelative projectFilePath damlYamlOption) <> "'"
+        , "  Path specified in `--upgrades` build option is '" <> T.pack (makeRelative projectFilePath buildFlagsOption) <> "'"
         ]
       exitFailure
     (a, b) ->
@@ -1054,19 +1083,18 @@ updateUpgradePath context opts@Options{optUpgradeInfo} newPkgPath = do
 multiPackageBuildEffect
   :: SdkVersion.Class.SdkVersioned
   => (FilePath -> IO FilePath)
+  -> ProjectPath
   -> Maybe PackageConfigFields -- Nothing signifies build all
   -> MultiPackageConfigFields
-  -> ProjectOpts
   -> Options
   -> Maybe FilePath
   -> IncrementalBuild
   -> InitPkgDb
   -> MultiPackageNoCache
   -> IO ()
-multiPackageBuildEffect relativize mPkgConfig multiPackageConfig projectOpts opts mbOutFile incrementalBuild initPkgDb noCache = do
+multiPackageBuildEffect relativize pkgPath mPkgConfig multiPackageConfig opts mbOutFile incrementalBuild initPkgDb noCache = do
   vfs <- makeVFSHandle
   loggerH <- getLogger opts "multi-package build"
-  cDir <- getCurrentDirectory
   assistantPath <- getEnv "DAML_ASSISTANT"
   -- Must drop DAML_PROJECT from env var so it can be repopulated based on `cwd`
   assistantEnv <- filter (flip notElem ["DAML_PROJECT", "DAML_SDK_VERSION", "DAML_SDK"] . fst) <$> getEnvironment
@@ -1082,11 +1110,11 @@ multiPackageBuildEffect relativize mPkgConfig multiPackageConfig projectOpts opt
 
       buildableDataDeps = BuildableDataDeps $ flip Map.lookup buildableDataDepsMapping
       mRootPkgBuilder = flip fmap mPkgConfig $ \pkgConfig -> do
-        mPkgId <- buildEffect relativize pkgConfig opts mbOutFile incrementalBuild initPkgDb
+        mPkgId <- buildEffect relativize pkgPath pkgConfig opts mbOutFile incrementalBuild initPkgDb
         pure $ fromMaybe
           (error "Internal error: root package was built from dalf, giving no package-id. This is incompatible with multi-package")
           mPkgId
-      mRootPkgData = (toNormalizedFilePath' $ maybe cDir unwrapProjectPath $ projectRoot projectOpts,) <$> mRootPkgBuilder
+      mRootPkgData = (toNormalizedFilePath' $ unwrapProjectPath pkgPath,) <$> mRootPkgBuilder
       rule = buildMultiRule assistantRunner buildableDataDeps noCache mRootPkgData
 
   -- Set up a near empty shake environment, with just the buildMulti rule

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -419,6 +419,7 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
     ~(optMbPackageName, optMbPackageVersion) <-
         fmap parseUnitId parsePkgName
 
+    let optMbPackageConfigPath = Nothing
     optImportPath <- optImportPath
     optPackageDbs <- optPackageDir
     optAccessTokenPath <- optAccessTokenPath
@@ -446,6 +447,7 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
     optEnableInterfaces <- enableInterfacesOpt
     optAllowLargeTuples <- allowLargeTuplesOpt
     optTestFilter <- compilePatternExpr <$> optTestPattern
+    let optHideUnitId = False
     optUpgradeInfo <- optUpgradeInfo
 
     return Options{..}

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -267,76 +267,6 @@ tests damlc =
                       False
                       setUpgradeField
                 , test
-                      "SucceedsWhenATopLevelTypeSynonymChanges"
-                      Succeed
-                      versionDefault
-                      NoDependencies
-                      False
-                      setUpgradeField
-                , test
-                      "SucceedsWhenTwoDeeplyNestedTypeSynonymsResolveToTheSameDatatypes"
-                      Succeed
-                      versionDefault
-                      NoDependencies
-                      False
-                      setUpgradeField
-                , test
-                      "FailsWhenTwoDeeplyNestedTypeSynonymsResolveToDifferentDatatypes"
-                      (FailWithError "\ESC\\[0;91merror type checking template Main.A :\n  The upgraded template A has changed the types of some of its original fields.")
-                      versionDefault
-                      NoDependencies
-                      False
-                      setUpgradeField
-                , test
-                      "SucceedsWhenAnInterfaceIsOnlyDefinedInTheInitialPackage"
-                      Succeed
-                      versionDefault
-                      NoDependencies
-                      False
-                      setUpgradeField
-                , test
-                      "FailsWhenAnInterfaceIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage"
-                      (FailWithError "\ESC\\[0;91merror type checking interface Main.I :\n  Tried to upgrade interface I, but interfaces cannot be upgraded. They should be removed in any upgrading package.")
-                      versionDefault
-                      NoDependencies
-                      False
-                      setUpgradeField
-                , test
-                      "FailsWhenAnInstanceIsDropped"
-                      (FailWithError "\ESC\\[0;91merror type checking template Main.T :\n  Implementation of interface I by template T appears in package that is being upgraded, but does not appear in this package.")
-                      versionDefault
-                      SharedDep
-                      False
-                      setUpgradeField
-                , test
-                      "FailsWhenAnInstanceIsAddedSeparateDep"
-                      (FailWithError "\ESC\\[0;91merror type checking template Main.T :\n  Implementation of interface I by template T appears in this package, but does not appear in package that is being upgraded.")
-                      versionDefault
-                      SharedDep
-                      False
-                      setUpgradeField
-                , test
-                      "FailsWhenAnInstanceIsAddedUpgradedPackage"
-                      (FailWithError "\ESC\\[0;91merror type checking template Main.T :\n  Implementation of interface I by template T appears in this package, but does not appear in package that is being upgraded.")
-                      versionDefault
-                      DependOnV1
-                      True
-                      setUpgradeField
-                , test
-                      "SucceedsWhenAnInstanceIsAddedToNewTemplateSeparateDep"
-                      Succeed
-                      versionDefault
-                      SharedDep
-                      False
-                      setUpgradeField
-                , test
-                      "SucceedsWhenAnInstanceIsAddedToNewTemplateUpgradedPackage"
-                      Succeed
-                      versionDefault
-                      DependOnV1
-                      True
-                      setUpgradeField
-                , test
                       "ValidUpgrade"
                       Succeed
                       contractKeysMinVersion
@@ -427,88 +357,6 @@ tests damlc =
                       NoDependencies
                       False
                       setUpgradeField
-                , test
-                      "FailsWhenDepsDowngradeVersionsWhileUsingDatatypes"
-                      (FailWithError "\ESC\\[0;91merror type checking data type Main.Main:\n  The upgraded data type Main has changed the types of some of its original fields.")
-                      versionDefault
-                      (SeparateDeps True)
-                      False
-                      setUpgradeField
-                , test
-                      "SucceedsWhenDepsDowngradeVersionsWithoutUsingDatatypes"
-                      Succeed
-                      versionDefault
-                      (SeparateDeps True)
-                      False
-                      setUpgradeField
-                , test
-                      "FailsWhenDependencyIsNotAValidUpgrade"
-                      (FailWithError "\ESC\\[0;91merror while validating that dependency upgrades-example-FailsWhenDependencyIsNotAValidUpgrade-dep version 0.0.2 is a valid upgrade of version 0.0.1\n  error type checking data type Dep.Dep:\n    The upgraded data type Dep has added new fields, but those fields are not Optional.")
-                      versionDefault
-                      (SeparateDeps False)
-                      False
-                      setUpgradeField
-                , testWithAdditionalDars
-                      "FailsWhenUpgradedFieldPackagesAreNotUpgradable"
-                      (FailWithError "\ESC\\[0;91merror type checking data type ProjectMain.T:\n  The upgraded data type T has changed the types of some of its original fields.")
-                      versionDefault
-                      NoDependencies
-                      False
-                      setUpgradeField
-                      ["upgrades-SucceedsWhenATopLevelRecordAddsAnOptionalFieldAtTheEnd-v2.dar"] -- Note that dependencies are in different order
-                      ["upgrades-SucceedsWhenATopLevelRecordAddsAnOptionalFieldAtTheEnd-v1.dar"]
-                , testWithAdditionalDars
-                      "FailsWhenUpgradedFieldFromDifferentPackageName"
-                      (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded data type A has changed the types of some of its original fields.")
-                      versionDefault
-                      NoDependencies
-                      False
-                      setUpgradeField
-                      ["upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-dep-name1.dar"]
-                      ["upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-dep-name2.dar"]
-                , test
-                      "SucceedsWhenUpgradingLFVersionWithoutExpressionWarning"
-                      (SucceedWithoutWarning "\ESC\\[0;93mwarning while type checking data type Main.T:\n  The upgraded template T has changed the definition of its signatories.")
-                      (LF.version2_1, versionDefault)
-                      NoDependencies
-                      False
-                      setUpgradeField
-                , testWithAdditionalDars
-                      "WarnsWhenExpressionChangesPackageId"
-                      (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.T signatories:\n  The upgraded template T has changed the definition of its signatories..*Name came from package .* and now comes from differently-named package .*")
-                      versionDefault
-                      NoDependencies
-                      False
-                      setUpgradeField
-                      ["upgrades-WarnsWhenExpressionChangesPackageId-dep-name1.dar"]
-                      ["upgrades-WarnsWhenExpressionChangesPackageId-dep-name2.dar"]
-                , test
-                      "WarnsWhenExpressionChangesUtilityToSchemaPackage"
-                      (SucceedWithWarning ".*the previous package was a utility package and the current one is not.")
-                      versionDefault
-                      (SeparateDeps False)
-                      False
-                      setUpgradeField
-                , test
-                      "WarnsWhenExpressionDowngradesVersion"
-                      (SucceedWithWarning ".*Both packages support upgrades, but the previous package had a higher version than the current one.")
-                      versionDefault
-                      (SeparateDeps True)
-                      False
-                      setUpgradeField
-                -- TODO https://github.com/digital-asset/daml/issues/19980
-                -- Currently there is no good way to test BindingMismatch errors
-                -- in upgrades, because LF turns lambdas into their own
-                -- top-level definitions, which are not expanded by the
-                -- expression equality checker. We're disabling the following
-                -- test in the meantime.
-                --, test
-                --      "WarnsWhenExpressionChangesBindingOrder"
-                --      (SucceedWithWarning ".*refer to different bindings in the environment")
-                --      versionDefault
-                --      (SeparateDeps False)
-                --      False
-                --      setUpgradeField
                 ]
             | setUpgradeField <- [True, False]
             ] ++
@@ -543,6 +391,208 @@ tests damlc =
                          then SucceedWithWarning ("\ESC\\[0;93mwarning while " <> msg)
                          else FailWithError ("\ESC\\[0;91merror " <> msg)
             , doTypecheck <- [True, False]
+            ] ++
+            [ test
+                  "SucceedsWhenATopLevelTypeSynonymChanges"
+                  Succeed
+                  versionDefault
+                  NoDependencies
+                  False
+                  True
+            , test
+                  "SucceedsWhenTwoDeeplyNestedTypeSynonymsResolveToTheSameDatatypes"
+                  Succeed
+                  versionDefault
+                  NoDependencies
+                  False
+                  True
+            , test
+                  "FailsWhenTwoDeeplyNestedTypeSynonymsResolveToDifferentDatatypes"
+                  (FailWithError "\ESC\\[0;91merror type checking template Main.A :\n  The upgraded template A has changed the types of some of its original fields.")
+                  versionDefault
+                  NoDependencies
+                  False
+                  True
+            , test
+                  "SucceedsWhenAnInterfaceIsOnlyDefinedInTheInitialPackage"
+                  Succeed
+                  versionDefault
+                  NoDependencies
+                  False
+                  True
+            , test
+                  "FailsWhenAnInterfaceIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage"
+                  (FailWithError "\ESC\\[0;91merror type checking interface Main.I :\n  Tried to upgrade interface I, but interfaces cannot be upgraded. They should be removed in any upgrading package.")
+                  versionDefault
+                  NoDependencies
+                  False
+                  True
+            , test
+                  "FailsWhenAnInstanceIsDropped"
+                  (FailWithError "\ESC\\[0;91merror type checking template Main.T :\n  Implementation of interface I by template T appears in package that is being upgraded, but does not appear in this package.")
+                  versionDefault
+                  SharedDep
+                  False
+                  True
+            , test
+                  "FailsWhenAnInstanceIsAddedSeparateDep"
+                  (FailWithError "\ESC\\[0;91merror type checking template Main.T :\n  Implementation of interface I by template T appears in this package, but does not appear in package that is being upgraded.")
+                  versionDefault
+                  SharedDep
+                  False
+                  True
+            , test
+                  "FailsWhenAnInstanceIsAddedUpgradedPackage"
+                  (FailWithError "\ESC\\[0;91merror type checking template Main.T :\n  Implementation of interface I by template T appears in this package, but does not appear in package that is being upgraded.")
+                  versionDefault
+                  DependOnV1
+                  True
+                  True
+            , test
+                  "SucceedsWhenAnInstanceIsAddedToNewTemplateSeparateDep"
+                  Succeed
+                  versionDefault
+                  SharedDep
+                  False
+                  True
+            , test
+                  "SucceedsWhenAnInstanceIsAddedToNewTemplateUpgradedPackage"
+                  Succeed
+                  versionDefault
+                  DependOnV1
+                  True
+                  True
+            , test
+                  "FailsWhenDepsDowngradeVersionsWhileUsingDatatypes"
+                  (FailWithError "\ESC\\[0;91merror type checking data type Main.Main:\n  The upgraded data type Main has changed the types of some of its original fields.")
+                  versionDefault
+                  (SeparateDeps True)
+                  False
+                  True
+            , test
+                  "SucceedsWhenDepsDowngradeVersionsWithoutUsingDatatypes"
+                  Succeed
+                  versionDefault
+                  (SeparateDeps True)
+                  False
+                  True
+            , test
+                  "FailsWhenDependencyIsNotAValidUpgrade"
+                  (FailWithError "\ESC\\[0;91merror while validating that dependency upgrades-example-FailsWhenDependencyIsNotAValidUpgrade-dep version 0.0.2 is a valid upgrade of version 0.0.1\n  error type checking data type Dep.Dep:\n    The upgraded data type Dep has added new fields, but those fields are not Optional.")
+                  versionDefault
+                  (SeparateDeps False)
+                  False
+                  True
+            , testWithAdditionalDars
+                  "FailsWhenUpgradedFieldPackagesAreNotUpgradable"
+                  (FailWithError "\ESC\\[0;91merror type checking data type ProjectMain.T:\n  The upgraded data type T has changed the types of some of its original fields.")
+                  versionDefault
+                  NoDependencies
+                  False
+                  True
+                  ["upgrades-SucceedsWhenATopLevelRecordAddsAnOptionalFieldAtTheEnd-v2.dar"] -- Note that dependencies are in different order
+                  ["upgrades-SucceedsWhenATopLevelRecordAddsAnOptionalFieldAtTheEnd-v1.dar"]
+            , testWithAdditionalDars
+                  "FailsWhenUpgradedFieldFromDifferentPackageName"
+                  (FailWithError "\ESC\\[0;91merror type checking data type Main.A:\n  The upgraded data type A has changed the types of some of its original fields.")
+                  versionDefault
+                  NoDependencies
+                  False
+                  True
+                  ["upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-dep-name1.dar"]
+                  ["upgrades-FailsWhenUpgradedFieldFromDifferentPackageName-dep-name2.dar"]
+            , test
+                  "SucceedsWhenUpgradingLFVersionWithoutExpressionWarning"
+                  (SucceedWithoutWarning "\ESC\\[0;93mwarning while type checking data type Main.T:\n  The upgraded template T has changed the definition of its signatories.")
+                  (LF.version2_1, versionDefault)
+                  NoDependencies
+                  False
+                  True
+            , testWithAdditionalDars
+                  "WarnsWhenExpressionChangesPackageId"
+                  (SucceedWithWarning "\ESC\\[0;93mwarning while type checking template Main.T signatories:\n  The upgraded template T has changed the definition of its signatories..*Name came from package .* and now comes from differently-named package .*")
+                  versionDefault
+                  NoDependencies
+                  False
+                  True
+                  ["upgrades-WarnsWhenExpressionChangesPackageId-dep-name1.dar"]
+                  ["upgrades-WarnsWhenExpressionChangesPackageId-dep-name2.dar"]
+            , test
+                  "WarnsWhenExpressionChangesUtilityToSchemaPackage"
+                  (SucceedWithWarning ".*the previous package was a utility package and the current one is not.")
+                  versionDefault
+                  (SeparateDeps False)
+                  False
+                  True
+            , test
+                  "WarnsWhenExpressionDowngradesVersion"
+                  (SucceedWithWarning ".*Both packages support upgrades, but the previous package had a higher version than the current one.")
+                  versionDefault
+                  (SeparateDeps True)
+                  False
+                  True
+            -- TODO https://github.com/digital-asset/daml/issues/19980
+            -- Currently there is no good way to test BindingMismatch errors
+            -- in upgrades, because LF turns lambdas into their own
+            -- top-level definitions, which are not expanded by the
+            -- expression equality checker. We're disabling the following
+            -- test in the meantime.
+            --, test
+            --      "WarnsWhenExpressionChangesBindingOrder"
+            --      (SucceedWithWarning ".*refer to different bindings in the environment")
+            --      versionDefault
+            --      (SeparateDeps False)
+            --      False
+            --      True
+            , testMetadata
+                  "FailsWhenUpgradesPackageHasDifferentPackageName"
+                  (FailWithError $ 
+                    "\ESC\\[0;91mMain package must have the same package name as upgraded package.\n"
+                      <> "Main package \\(v0.0.2\\) name: my-package2\n"
+                      <> "Upgraded package \\(v0.0.1\\) name: my-package"
+                  )
+                  "my-package"
+                  "0.0.1"
+                  versionDefault
+                  "my-package2"
+                  "0.0.2"
+                  versionDefault
+            , testMetadata
+                  "FailsWhenUpgradesPackageHasEqualVersion"
+                  (FailWithError "\ESC\\[0;91mMain package \\(v0.0.1\\) cannot have the same package version as Upgraded package \\(v0.0.1\\)")
+                  "my-package"
+                  "0.0.1"
+                  versionDefault
+                  "my-package"
+                  "0.0.1"
+                  versionDefault
+            , testMetadata
+                  "FailsWhenUpgradesPackageHasHigherVersion"
+                  (FailWithError "\ESC\\[0;91mUpgraded package \\(v0.0.2\\) cannot have a higher package version than Main package \\(v0.0.1\\)")
+                  "my-package"
+                  "0.0.2"
+                  versionDefault
+                  "my-package"
+                  "0.0.1"
+                  versionDefault
+            , testMetadata
+                  "FailsWhenUpgradesPackageHasHigherLFVersion"
+                  (FailWithError "\ESC\\[0;91mMain package \\(v0.0.2\\) LF Version \\(2.1\\) cannot be lower than the Upgraded package \\(v0.0.1\\) LF Version \\(2.dev\\)")
+                  "my-package"
+                  "0.0.1"
+                  LF.version2_dev
+                  "my-package"
+                  "0.0.2"
+                  LF.version2_1
+            , testMetadata
+                  "SucceedsWhenUpgradesPackageHasLowerLFVersion"
+                  Succeed
+                  "my-package"
+                  "0.0.1"
+                  LF.version2_1
+                  "my-package"
+                  "0.0.2"
+                  LF.version2_dev
             ]
        )
   where
@@ -672,65 +722,96 @@ tests damlc =
             v2AdditionalDarsRunFiles <- traverse testAdditionaDarRunfile additionalDarsV2
             writeFiles newDir (projectFile "0.0.2" newLfVersion ("upgrades-example-" <> location) (if setUpgradeField then Just oldDar else Nothing) depV2Dar v2AdditionalDarsRunFiles : newVersion)
 
-            case expectation of
-              Succeed ->
-                  callProcessSilent damlc ["build", "--project-root", newDir, "-o", newDar]
-              SucceedWithoutWarning regex -> do
-                  stderr <- callProcessForSuccessfulStderr damlc ["build", "--project-root", newDir, "-o", newDar]
-                  let regexWithSeverity = "Severity: DsWarning\nMessage: \n" <> regex
-                  let compiledRegex :: Regex
-                      compiledRegex = makeRegexOpts defaultCompOpt { multiline = False } defaultExecOpt regexWithSeverity
-                  when (matchTest compiledRegex stderr) $
-                    if setUpgradeField && doTypecheck
-                      then assertFailure ("`daml build` succeeded, but should not give a warning matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
-                      else assertFailure ("`daml build` succeeded, did not `upgrade:` field set, should not give a warning matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
-              FailWithError _ | not (doTypecheck && setUpgradeField) ->
-                  callProcessSilent damlc ["build", "--project-root", newDir, "-o", newDar]
-              FailWithError regex -> do
-                  stderr <- callProcessForStderr damlc ["build", "--project-root", newDir, "-o", newDar]
-                  let regexWithSeverity = "Severity: DsError\nMessage: \n" <> regex
-                  let compiledRegex :: Regex
-                      compiledRegex = makeRegexOpts defaultCompOpt { multiline = False } defaultExecOpt regexWithSeverity
-                  unless (matchTest compiledRegex stderr) $
-                      assertFailure ("`daml build` failed as expected, but did not give an error matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
-              SucceedWithWarning regex -> do
-                  stderr <- callProcessForSuccessfulStderr damlc ["build", "--project-root", newDir, "-o", newDar]
-                  let regexWithSeverity = "Severity: DsWarning\nMessage: \n" <> regex
-                  let compiledRegex :: Regex
-                      compiledRegex = makeRegexOpts defaultCompOpt { multiline = False } defaultExecOpt regexWithSeverity
-                  if setUpgradeField && doTypecheck
-                      then case matchCount compiledRegex stderr of
-                            0 -> assertFailure ("`daml build` succeeded, but did not give a warning matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
-                            1 -> pure ()
-                            _ -> assertFailure ("`daml build` succeeded, but gave a warning matching '" <> show regexWithSeverity <> "' more than once:\n" <> show stderr)
-                      else when (matchTest compiledRegex stderr) $
-                            assertFailure ("`daml build` succeeded, did not `upgrade:` field set, should NOT give a warning matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
-          where
-          projectFile version lfVersion name upgradedFile mbDep darDeps =
-              ( "daml.yaml"
-              , pure $ unlines $
-                [ "sdk-version: " <> sdkVersion
-                , "name: " <> name
-                , "source: daml"
-                , "version: " <> version
-                , "dependencies:"
-                , "  - daml-prim"
-                , "  - daml-stdlib"
-                , "build-options:"
-                , "  - --target=" <> LF.renderVersion lfVersion
-                , "  - --enable-interfaces=yes"
-                ]
-                  ++ ["  - --typecheck-upgrades=no" | not doTypecheck]
-                  ++ ["  - --warn-bad-interface-instances=yes" | warnBadInterfaceInstances ]
-                  ++ ["upgrades: '" <> path <> "'" | Just path <- pure upgradedFile]
-                  ++ renderDataDeps (maybeToList mbDep ++ darDeps)
-              )
+            handleExpectation expectation newDir newDar (doTypecheck && setUpgradeField) Nothing
+      where
+        projectFile version lfVersion name upgradedFile mbDep darDeps =
+          makeProjectFile name version lfVersion upgradedFile (maybeToList mbDep ++ darDeps) doTypecheck warnBadInterfaceInstances
 
-          renderDataDeps :: [String] -> [String]
-          renderDataDeps [] = []
-          renderDataDeps paths =
-            ["data-dependencies:"] ++ [" -  '" <> path <> "'" | path <- paths]
+    handleExpectation :: Expectation -> FilePath -> FilePath -> Bool -> Maybe FilePath -> IO ()
+    handleExpectation expectation dir dar shouldRunChecks expectedDiagFile =
+      case expectation of
+        Succeed ->
+            callProcessSilent damlc ["build", "--project-root", dir, "-o", dar]
+        SucceedWithoutWarning regex -> do
+            stderr <- callProcessForSuccessfulStderr damlc ["build", "--project-root", dir, "-o", dar]
+            let regexWithSeverity = "Severity: DsWarning\nMessage: \n" <> regex
+            let compiledRegex :: Regex
+                compiledRegex = makeRegexOpts defaultCompOpt { multiline = False } defaultExecOpt regexWithSeverity
+            when (matchTest compiledRegex stderr) $
+              if shouldRunChecks
+                then assertFailure ("`daml build` succeeded, but should not give a warning matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
+                else assertFailure ("`daml build` succeeded, did not `upgrade:` field set, should not give a warning matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
+        FailWithError _ | not shouldRunChecks ->
+            callProcessSilent damlc ["build", "--project-root", dir, "-o", dar]
+        FailWithError regex -> do
+            stderr <- callProcessForStderr damlc ["build", "--project-root", dir, "-o", dar]
+            let regexWithSeverity = regexPrefix <> "Severity: DsError\nMessage: \n" <> regex
+            let compiledRegex :: Regex
+                compiledRegex = makeRegexOpts defaultCompOpt { multiline = False } defaultExecOpt regexWithSeverity
+            unless (matchTest compiledRegex stderr) $
+                assertFailure ("`daml build` failed as expected, but did not give an error matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
+        SucceedWithWarning regex -> do
+            stderr <- callProcessForSuccessfulStderr damlc ["build", "--project-root", dir, "-o", dar]
+            let regexWithSeverity = regexPrefix <> "Severity: DsWarning\nMessage: \n" <> regex
+            let compiledRegex :: Regex
+                compiledRegex = makeRegexOpts defaultCompOpt { multiline = False } defaultExecOpt regexWithSeverity
+            if shouldRunChecks
+                then case matchCount compiledRegex stderr of
+                      0 -> assertFailure ("`daml build` succeeded, but did not give a warning matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
+                      1 -> pure ()
+                      _ -> assertFailure ("`daml build` succeeded, but gave a warning matching '" <> show regexWithSeverity <> "' more than once:\n" <> show stderr)
+                else when (matchTest compiledRegex stderr) $
+                      assertFailure ("`daml build` succeeded, did not have `upgrade:` field set, should NOT give a warning matching '" <> show regexWithSeverity <> "':\n" <> show stderr)
+      where
+        -- Note ".*" after "File:", as CI prefixes the path with `private/`, which we need to match
+        regexPrefix = maybe "" (\filePat -> "File:.*" <> T.pack filePat <> ".+") expectedDiagFile
 
+    testMetadata :: String -> Expectation -> String -> String -> LF.Version -> String -> String -> LF.Version -> TestTree
+    testMetadata name expectation v1Name v1Version v1LfVersion v2Name v2Version v2LfVersion =
+        testCase name $ do
+        withTempDir $ \dir -> do
+            let newDir = dir </> "newVersion"
+            let oldDir = dir </> "oldVersion"
+            let newDar = newDir </> "out.dar"
+            let oldDar = oldDir </> "old.dar"
+            writeFiles oldDir [makeProjectFile v1Name v1Version v1LfVersion Nothing [] True False, ("daml/Main.daml", pure "module Main where")]
+            callProcessSilent damlc ["build", "--project-root", oldDir, "-o", oldDar]
+            writeFiles newDir [makeProjectFile v2Name v2Version v2LfVersion (Just oldDar) [] True False, ("daml/Main.daml", pure "module Main where")]
+            -- Metadata errors are reported on the daml.yaml file
+            handleExpectation expectation newDir newDar True (Just $ toUnixPath $ newDir </> "daml.yaml")
+
+    toUnixPath :: FilePath -> FilePath
+    toUnixPath = fmap $ \case
+      '\\' -> '/'
+      c -> c
+
+    makeProjectFile :: String -> String -> LF.Version -> Maybe FilePath -> [FilePath] -> Bool -> Bool -> (FilePath, IO String)
+    makeProjectFile name version lfVersion upgradedFile deps doTypecheck warnBadInterfaceInstances =
+        ( "daml.yaml"
+        , pure $ unlines $
+          [ "sdk-version: " <> sdkVersion
+          , "name: " <> name
+          , "source: daml"
+          , "version: " <> version
+          , "dependencies:"
+          , "  - daml-prim"
+          , "  - daml-stdlib"
+          , "build-options:"
+          , "  - --target=" <> LF.renderVersion lfVersion
+          , "  - --enable-interfaces=yes"
+          ]
+            ++ ["  - --typecheck-upgrades=no" | not doTypecheck]
+            ++ ["  - --warn-bad-interface-instances=yes" | warnBadInterfaceInstances ]
+            ++ ["upgrades: '" <> path <> "'" | Just path <- pure upgradedFile]
+            ++ renderDataDeps deps
+        )
+      where
+        renderDataDeps :: [String] -> [String]
+        renderDataDeps [] = []
+        renderDataDeps paths =
+          ["data-dependencies:"] ++ [" -  '" <> path <> "'" | path <- paths]
+
+    writeFiles :: FilePath -> [(FilePath, IO String)] -> IO ()
     writeFiles dir fs =
         for_ fs $ \(file, ioContent) -> do
             content <- ioContent


### PR DESCRIPTION
Forward port of #19978
Removed the checks for LF versions that don't support upgrades, as LF1 + the packageUpgradesFeature are removed in 3x.