### PR TITLE
Fix dependencies in IDE following #19978

### DIFF
--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -377,6 +377,9 @@ generateAndInstallIfaceFiles GenerateAndInstallIfaceFilesArgs {..} = do
             , optDflagCheck = False
             , optMbPackageName = Just pkgName
             , optMbPackageVersion = mbPkgVersion
+            -- This is essentially a new package options, cannot inherit optHideUnitId = True from IDE
+            -- or the dependency will be installed as "main"
+            , optHideUnitId = False
             , optGhcCustomOpts = []
             , optPackageImports =
                   baseImports ++


### PR DESCRIPTION
Following #19978, the options passed to the IDE guard the unit id of those options to always be `Nothing`
Unfortunately, the implementation of install dependencies reuses the same options, but changes the package name and version.
This did not used to reset the hideUnitId flag, so deps were being installed under "main" in the IDE, and giving an error.