### PR TITLE
JSON API: fail loudly if cache is newer than ledger

### DIFF
--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/LedgerClientJwt.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/LedgerClientJwt.scala
@@ -225,11 +225,18 @@ object LedgerClientJwt {
 
   def getCreatesAndArchivesSince(client: DamlLedgerClient): GetCreatesAndArchivesSince =
     (jwt, ledgerId, filter, offset, terminates) => { implicit lc =>
-      {
-        val end = terminates.toOffset
-        if (skipRequest(offset, end))
+      import com.daml.http.util.LedgerOffsetUtil.AbsoluteOffsetOrdering.gt
+      (offset.value, terminates.toOffset.map(_.value)) match {
+        case (start: LedgerOffset.Value.Absolute, Some(end: LedgerOffset.Value.Absolute))
+            if gt(start, end) => // Something has gone very wrong!
+          throw new IllegalStateException(
+            s"""When looking up $filter the lastOffset in the cache was $start which is greater than the ledger end of $end.
+               |This indicates that the server may be using a cache which was populated against a different ledger.
+               |If so, please restart with a start-mode of 'create-and-start'.""".stripMargin
+          )
+        case (start, Some(end)) if start == end => // Noop, we're already up-to-date
           Source.empty[Transaction]
-        else {
+        case _ => // Normal case, fetch the changes
           LedgerClientRequestTimeLogger.log(GetTransactionsLog) {
             client.transactionClient
               .getTransactions(
@@ -241,18 +248,8 @@ object LedgerClientJwt {
                 token = bearer(jwt),
               )
           }
-        }
       }
     }
-
-  private def skipRequest(start: LedgerOffset, end: Option[LedgerOffset]): Boolean = {
-    import com.daml.http.util.LedgerOffsetUtil.AbsoluteOffsetOrdering
-    (start.value, end.map(_.value)) match {
-      case (s: LedgerOffset.Value.Absolute, Some(e: LedgerOffset.Value.Absolute)) =>
-        AbsoluteOffsetOrdering.gteq(s, e)
-      case _ => false
-    }
-  }
 
   def listKnownParties(client: DamlLedgerClient)(implicit
       ec: EC


### PR DESCRIPTION
Intended to make it more obvious when an existing cache database is re-used with a new ledger.

Previously we used `start >= end` to decide that our cache is up-to-date and we silently fetched nothing. This is a valid decision for the `start == end` case, but we should not expect `start > end` under normal use. This is something we can see if they have started json api with a cache that was populated against a different ledger history, in which case we have no recourse other than :boom: 

Inspired by
https://support.digitalasset.com/s/case/500Pq00000LS2dwIAD/inconsistence-querying-jsonapi