### PR TITLE
JSON API: downgrade crash to log.debug when (start > end)

### DIFF
--- a/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/LedgerClientJwt.scala
+++ b/sdk/ledger-service/http-json/src/main/scala/com/digitalasset/http/LedgerClientJwt.scala
@@ -228,13 +228,15 @@ object LedgerClientJwt {
       import com.daml.http.util.LedgerOffsetUtil.AbsoluteOffsetOrdering.gt
       (offset.value, terminates.toOffset.map(_.value)) match {
         case (start: LedgerOffset.Value.Absolute, Some(end: LedgerOffset.Value.Absolute))
-            if gt(start, end) => // Something fishy.
-          logger.warn(
+            if gt(start, end) => {
+          logger.debug(
             s"""When looking up $filter, the lastOffset in the cache was $start which was greater than the ledger end of $end.
                |This can occur due to concurrent queries updating the cache (which is harmless), or may indicate that the server
                |is using a cache which was populated against an entirely different ledger.
                |In the latter case, please restart with a start-mode of 'create-and-start'.""".stripMargin
           )
+          Source.empty[Transaction]
+        }
         case (start, Some(end)) if start == end => // Noop, we're already up-to-date
           Source.empty[Transaction]
         case _ => // Normal case, fetch the changes


### PR DESCRIPTION
I think we can't crash when the cached offset is greater than the fetched ledger end, because it could occur when interleaving queries for the same templates cause concurrent updates to the cache, while some ledger activity is also going on. For example.

* Some query has happened in the past which update the cache to offset O1
* Later Query A and Query B are issued concurrently
* Query A asks the participant for the ledger end and gets back offset O2 (> O1)
* more movement on the ledger
* Query B asks the participant for the ledger end and gets back offset O3 (> O2)
* Query B checks the cache to see the last offset for this template id and gets back O1
* Query B requests the transactions between O1 and O3, stores the results into the cache and updates the last offset in the cache to O3
* Query A continues where it left off, and checks the cache for the last offset for this template id, and gets back O3
* Query A sees that O3 (i.e. it's start offset) is greater than O2 (the ledger end it requested from the participant earlier) and :boom: 

```
Cache    Query A    Query B   Participant
  |         |          |             | 
  |         |--end?----^------------>| 
  |         |          |             | 
  |         |<-end=2---^-------------| 
  |         |          |             | 
  |         |          |--end?------>| 
  |         |          |             | 
  |         |          |<-end=3------| 
  |         |          |             | 
  |<--------^---last?--|             | 
  |         |          |             | 
  |---------^--last=1->|             | 
  |         |          |             | 
  |         |          |-data(1,3]?->| 
  |         |          |             | 
  |         |          |<-data=...---| 
  |         |          |             | 
  |<--------^--last=3--|             | 
  |         |          |             | 
  |<--last?-|          |             | 
  |         |          |             | 
  |-last=3->|          |             | 
  |         |          |             | 
  |      (3>2!)        |             | 
```

This downgrades the behaviour just introduced in https://github.com/digital-asset/daml/pull/20026/ so we can still get clues from the logs in the case of an incorrect cache, but it doesn't turn harmless contention into a fatal condition.