### PR TITLE
JSON API: add test demonstrating issue with package id in exercise event in the presence of upgrades

### DIFF
--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -658,6 +658,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
     } yield succeed
   }
 
+  // TODO(i21459) Fix, and unignore
   "should recognise an archive against a newer version of the same contract" ignore withHttpService {
     fixture =>
       import AbstractHttpServiceIntegrationTestFuns.{fooV1Dar, fooV2Dar}


### PR DESCRIPTION
The problem is described more fully here

https://docs.google.com/document/d/1pvkq5E8cO9t6ryVQsXJwVcGAfNoR-BDR7Hk4ugze3NM/edit#heading=h.2308xr7hwu1w

and a tracking issue is here https://github.com/DACH-NY/canton/issues/21459