### PR TITLE
Fix IDE show results issue with path normalization 3.x

### DIFF
--- a/sdk/compiler/daml-extension/src/extension.ts
+++ b/sdk/compiler/daml-extension/src/extension.ts
@@ -73,7 +73,8 @@ export async function activate(context: vscode.ExtensionContext) {
       // Need to normalize paths so that prefix comparison works on Windows,
       // where path separators can differ.
       vrPath = path.normalize(vrPath);
-      let isPrefixOfVrPath = candidate => vrPath.startsWith(path.normalize(candidate) + path.sep);
+      let isPrefixOfVrPath = candidate =>
+        vrPath.startsWith(path.normalize(candidate) + path.sep);
 
       // Try to find a client for the virtual resource- if we can't, log to DevTools
       let foundAClient = false;
@@ -89,8 +90,12 @@ export async function activate(context: vscode.ExtensionContext) {
       }
 
       if (!foundAClient) {
-        console.log(`daml.showResource: Could not find a language client for ${vrPath}`);
-        vscode.window.showWarningMessage(`Could not show script results - could not find a language client for ${vrPath}`);
+        console.log(
+          `daml.showResource: Could not find a language client for ${vrPath}`,
+        );
+        vscode.window.showWarningMessage(
+          `Could not show script results - could not find a language client for ${vrPath}`,
+        );
       }
     },
   );

--- a/sdk/compiler/daml-extension/src/extension.ts
+++ b/sdk/compiler/daml-extension/src/extension.ts
@@ -67,13 +67,13 @@ export async function activate(context: vscode.ExtensionContext) {
   let d1 = vscode.commands.registerCommand(
     "daml.showResource",
     (title, uri) => {
-      let vrPath = getVRFilePath(uri);
-      if (!vrPath) return;
+      let vrPathMb = getVRFilePath(uri);
+      if (!vrPathMb) return;
 
       // Need to normalize paths so that prefix comparison works on Windows,
       // where path separators can differ.
-      vrPath = path.normalize(vrPath);
-      let isPrefixOfVrPath = candidate =>
+      let vrPath: string = path.normalize(vrPathMb);
+      let isPrefixOfVrPath = (candidate: string) =>
         vrPath.startsWith(path.normalize(candidate) + path.sep);
 
       // Try to find a client for the virtual resource- if we can't, log to DevTools


### PR DESCRIPTION
As of https://github.com/digital-asset/daml/pull/19773 (ported to 3.x in https://github.com/digital-asset/daml/pull/20023), given a virtual resource path, we would find a valid language server using the following code:
```
if (path.startsWith(projectPath))
  damlLanguageClients[projectPath].virtualResourceManager.createOrShow(
    title,
    uri,
  );
```
This would break on Windows because the `path` for a virtual resource would use `/` separators. We now normalize both paths, and add a path separator to the end of the projectPath to make sure we only match the full path when using `startsWith`