### PR TITLE
JSON API: remove constraint that decoded genmap has sorted unique keys

### DIFF
--- a/sdk/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
+++ b/sdk/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
@@ -13,8 +13,7 @@ import com.daml.lf.value.json.{NavigatorModelAliases => Model}
 import Model.{DamlLfIdentifier, DamlLfType, DamlLfTypeLookup}
 import ApiValueImplicits._
 import spray.json._
-import scalaz.{@@, Equal, Order, Tag}
-import scalaz.syntax.equal._
+import scalaz.{@@, Tag}
 import scalaz.syntax.std.string._
 
 import java.time.Instant
@@ -179,8 +178,6 @@ class ApiCodecCompressed(val encodeDecimalAsString: Boolean, val encodeInt64AsSt
       case Model.DamlLfPrimType.GenMap =>
         val Seq(kType, vType) = prim.typArgs;
         { case JsArray(entries) =>
-          implicit val keySort: Order[V @@ defs.type] = decodedOrder(defs)
-          implicit val keySSort: math.Ordering[V @@ defs.type] = keySort.toScalaOrdering
           type OK[K] = Vector[(K, V)]
           val decEntries: Vector[(V @@ defs.type, V)] = Tag
             .subst[V, OK, defs.type](entries.map {
@@ -190,8 +187,6 @@ class ApiCodecCompressed(val encodeDecimalAsString: Boolean, val encodeInt64AsSt
               case _ =>
                 deserializationError(s"Can't read ${value.prettyPrint} as key+value of $prim")
             })
-            .sortBy(_._1)
-          checkDups(decEntries)
           V.ValueGenMap(Tag.unsubst[V, OK, defs.type](decEntries).to(ImmArray))
         }
 
@@ -202,26 +197,6 @@ class ApiCodecCompressed(val encodeDecimalAsString: Boolean, val encodeInt64AsSt
     prim match {
       case typesig.TypePrim(_, Seq(typesig.TypePrim(typesig.PrimType.Optional, _))) => true
       case _ => false
-    }
-
-  private[this] def decodedOrder(defs: Model.DamlLfTypeLookup): Order[V @@ defs.type] = {
-    val scope: V.LookupVariantEnum = defs andThen (_ flatMap (_.dataType match {
-      case typesig.Variant(fields) => Some(fields.toImmArray map (_._1))
-      case typesig.Enum(ctors) => Some(ctors.toImmArray)
-      case typesig.Record(_) => None
-    }))
-    Tag subst (Tag unsubst V.orderInstance(scope))
-  }
-
-  @throws[DeserializationException]
-  private[this] def checkDups[K: Equal](decEntries: Seq[(K, _)]): Unit =
-    decEntries match {
-      case (h, _) +: t =>
-        val _ = t.foldLeft(h)((p, n) =>
-          if (p /== n._1) n._1 else deserializationError(s"duplicate key: $p")
-        )
-        ()
-      case _ => ()
     }
 
   private[this] def jsValueToApiDataType(

--- a/sdk/ledger-service/lf-value-json/src/test/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressedSpec.scala
+++ b/sdk/ledger-service/lf-value-json/src/test/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressedSpec.scala
@@ -24,7 +24,6 @@ import spray.json._
 import scalaz.syntax.show._
 
 import scala.util.{Success, Try}
-import scala.util.Random.shuffle
 
 class ApiCodecCompressedSpec
     extends AnyWordSpec
@@ -183,36 +182,6 @@ class ApiCodecCompressedSpec
         implicit val arbInj: Arbitrary[va.Inj] = va.injarb
         forAll(minSuccessful(1000)) { v: va.Inj =>
           roundtrip(va)(v) should ===(Some(v))
-        }
-      }
-
-      "ignore order in maps" in forAll(genAddend, minSuccessful(20)) { kva =>
-        val mapVa = VA.genMap(kva, VA.int64)
-        import mapVa.{injarb, injshrink}
-        forAll(minSuccessful(50)) { map: mapVa.Inj =>
-          val canonical = mapVa.inj(map)
-          val jsEnc = inside(apiValueToJsValue(canonical)) { case JsArray(elements) =>
-            elements
-          }
-          jsValueToApiValue(JsArray(shuffle(jsEnc)), mapVa.t, typeLookup) should ===(canonical)
-        }
-      }
-
-      "fail on map duplicate keys" in forAll(genAddend, minSuccessful(20)) { kva =>
-        val mapVa = VA.genMap(kva, VA.int64)
-        import kva.{injarb, injshrink}, mapVa.{injarb => maparb, injshrink => mapshrink}
-        forAll(minSuccessful(50)) { (k: kva.Inj, v: VA.int64.Inj, map: mapVa.Inj) =>
-          val canonical = mapVa.inj(map.updated(k, v))
-          val jsEnc = inside(apiValueToJsValue(canonical)) { case JsArray(elements) =>
-            elements
-          }
-          val broken = JsArray(
-            shuffle(jsEnc :+ JsArray(Seq(kva.inj(k), VA.int64.inj(v)) map apiValueToJsValue: _*))
-          )
-          val err = the[DeserializationException] thrownBy {
-            jsValueToApiValue(broken, mapVa.t, typeLookup)
-          }
-          err.msg should startWith("duplicate key: ")
         }
       }
 


### PR DESCRIPTION
This is the `daml:main-2.x` counterpart to https://github.com/DACH-NY/canton/pull/21658