### PR TITLE
Java Codegen: qualify field names passed to `Package`

### DIFF
--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
@@ -126,10 +126,13 @@ object InterfaceClass extends StrictLogging {
           .constructorBuilder()
           // intentionally package-private
           .addStatement(
-            "super(new $T($N, $N, $N),$>$Z$S, $T.$N, $T::new, $T.$L(),$W$T::fromJson,$T.of($L))$<$Z",
+            "super(new $T($T.$N, $T.$N, $T.$N),$>$Z$S, $T.$N, $T::new, $T.$L(),$W$T::fromJson,$T.of($L))$<$Z",
             nestedClassName(ClassName.get(classOf[ContractTypeCompanion[_, _, _, _]]), "Package"),
+            interfaceName,
             ClassGenUtils.packageIdFieldName,
+            interfaceName,
             ClassGenUtils.packageNameFieldName,
+            interfaceName,
             ClassGenUtils.packageVersionFieldName,
             interfaceName,
             interfaceName,

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -616,12 +616,15 @@ private[inner] object TemplateClass extends StrictLogging {
           Modifier.PUBLIC,
         )
         .initializer(
-          "$Znew $T<>(new $T($N, $N, $N),$>$Z$S,$W$N,$W$T::new,$W$N -> $T.templateValueDecoder().decode($N),$W$T::fromJson,$W$T::new,$W$T.of($L)" + keyParams + "$<)",
+          "$Znew $T<>(new $T($T.$N, $T.$N, $T.$N),$>$Z$S,$W$N,$W$T::new,$W$N -> $T.templateValueDecoder().decode($N),$W$T::fromJson,$W$T::new,$W$T.of($L)" + keyParams + "$<)",
           Seq(
             fieldClass,
             nestedClassName(ClassName.get(classOf[ContractTypeCompanion[_, _, _, _]]), "Package"),
+            templateClassName,
             ClassGenUtils.packageIdFieldName,
+            templateClassName,
             ClassGenUtils.packageNameFieldName,
+            templateClassName,
             ClassGenUtils.packageVersionFieldName,
             templateClassName,
             templateIdFieldName,


### PR DESCRIPTION
This allows us to add those same field names to the Companion type without causing ambiguity for the compiler, such as those we see here

https://app.circleci.com/pipelines/github/DACH-NY/canton/82704/workflows/e788f2a3-3b90-4bda-bdc1-6ef0d0adf723/jobs/2267512?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary