### PR TITLE
Make the comparison of LF version total

### DIFF
--- a/sdk/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/sdk/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -27,15 +27,17 @@ object LanguageVersion {
 
   def assertFromString(s: String): LanguageVersion = data.assertRight(fromString(s))
 
+  // TODO https://github.com/digital-asset/daml/issues/20101
+  //   Drop the ordering
   implicit val Ordering: scala.Ordering[LanguageVersion] = {
     case (LanguageVersion(Major.V1, leftMinor), LanguageVersion(Major.V1, rightMinor)) =>
       Major.V1.minorVersionOrdering.compare(leftMinor, rightMinor)
+    case (LanguageVersion(Major.V1, _), LanguageVersion(Major.V2, _)) =>
+      -1
+    case (LanguageVersion(Major.V2, _), LanguageVersion(Major.V1, _)) =>
+      1
     case (LanguageVersion(Major.V2, leftMinor), LanguageVersion(Major.V2, rightMinor)) =>
       Major.V2.minorVersionOrdering.compare(leftMinor, rightMinor)
-    case (v1, v2) =>
-      throw new IllegalArgumentException(
-        s"cannot compare version ${v1.pretty} with version ${v2.pretty}"
-      )
   }
 
   val AllV1 = Major.V1.supportedMinorVersions.map(LanguageVersion(Major.V1, _))


### PR DESCRIPTION
This quick fix addresses a crash issue when comparing V1 with V2 LF Versions unexpectedly. 
In the future, we should consider removing this ordering altogether. See issue #20101.



<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
