### PR TITLE
Allow passing in package id to `enrichChoiceResult`

### DIFF
--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
@@ -137,7 +137,7 @@ final class ValueEnricher(
     interfaceId,
     choiceName,
     value,
-  );
+  )
 
   def enrichContractKey(tyCon: Identifier, value: Value): Result[Value] =
     handleLookup(pkgInterface.lookupTemplateKey(tyCon))


### PR DESCRIPTION
In the participant, when we convert the LF choice result to verbose format we need to ensure we lookup the required type using the package id that the choice was executed at, even when returning a template id with the package id that the contract was created at. Using this signature where the package id is provided makes that decision point explicit.

My intention was to remove the existing overload that just takes a template id, after the uses of it have been replaced and sync-ed on the canton side.