### PR TITLE
HOTFIX: add package name arg to ArchivedEvent in TransactionGenerator

### DIFF
--- a/sdk/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
+++ b/sdk/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
@@ -257,9 +257,10 @@ object TransactionGenerator {
     contractId <- nonEmptyId
     (scalaTemplateId, javaTemplateId) <- identifierGen
     parties <- Gen.listOf(nonEmptyId)
+    packageName <- Gen.option(nonEmptyId)
   } yield (
     Archived(ArchivedEvent(eventId, contractId, Some(scalaTemplateId), parties)),
-    new data.ArchivedEvent(parties.asJava, eventId, javaTemplateId, contractId),
+    new data.ArchivedEvent(parties.asJava, eventId, javaTemplateId, contractId, packageName.toJava),
   )
 
   val exercisedEventGen: Gen[(Exercised, data.ExercisedEvent)] = for {


### PR DESCRIPTION
Cherry-pick into the canton sync after https://github.com/DACH-NY/canton/pull/21919 is merged