### PR TITLE
[fwd port] fix local contract upgrade + perform upgrade verification in softFetchInterface

### DIFF
--- a/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
@@ -815,7 +815,7 @@ class ExceptionTest(majorLanguageVersion: LanguageMajorVersion)
             };
 
             val mkParty : Text -> Party = \(t:Text) -> case TEXT_TO_PARTY t of None -> ERROR @Party "none" | Some x -> x;
-            val alice : Party = Mod:mkParty "alice";
+            val alice : Party = Mod:mkParty "Alice";
           }
       """ (parserParameters.copy(defaultPackageId = commonDefsPkgId))
 
@@ -826,11 +826,8 @@ class ExceptionTest(majorLanguageVersion: LanguageMajorVersion)
       */
     abstract class TemplateGenerator(val templateName: String) {
       def precondition = """True"""
-
       def signatories = s"""Cons @Party [Mod:${templateName} {p} this] (Nil @Party)"""
-
       def observers = """Nil @Party"""
-
       def key =
         s"""
            |  '$commonDefsPkgId':Mod:Key {
@@ -943,7 +940,7 @@ class ExceptionTest(majorLanguageVersion: LanguageMajorVersion)
       *   - When an instance of [[templateName]] is fetched/exercised by id/key/interface, exceptions thrown when
       *     evaluating its metadata cannot be caught.
       */
-    def tests(pkgId: Ref.PackageId, templateName: String): String = {
+    def globalContractTests(pkgId: Ref.PackageId, templateName: String): String = {
       val tplQualifiedName = s"'$pkgId':Mod:$templateName"
       s"""
          |  // Checks that the error thrown when creating a $templateName instance can be caught.
@@ -957,7 +954,7 @@ class ExceptionTest(majorLanguageVersion: LanguageMajorVersion)
          |
          |  // Tries to catch the error thrown by the contract info of $templateName when exercising a choice on
          |  // it, should fail to do so.
-         |  val exercise${templateName}AndCatchError: (ContractId $tplQualifiedName) -> Update Text =
+         |  val exercise${templateName}AndCatchErrorGlobal: (ContractId $tplQualifiedName) -> Update Text =
          |    \\(cid: ContractId $tplQualifiedName) ->
          |      try @Text
          |        exercise @$tplQualifiedName SomeChoice cid ()
@@ -966,7 +963,7 @@ class ExceptionTest(majorLanguageVersion: LanguageMajorVersion)
          |
          |  // Tries to catch the error thrown by the contract info of a $templateName contract when fetching it,
          |  // should fail to do so.
-         |  val fetch${templateName}AndCatchError: (ContractId $tplQualifiedName) -> Update Text =
+         |  val fetch${templateName}AndCatchErrorGlobal: (ContractId $tplQualifiedName) -> Update Text =
          |    \\(cid: ContractId $tplQualifiedName) ->
          |      try @Text
          |        ubind _:$tplQualifiedName <- fetch_template @$tplQualifiedName cid
@@ -976,7 +973,7 @@ class ExceptionTest(majorLanguageVersion: LanguageMajorVersion)
          |
          |  // Tries to catch the error thrown by the contract info of a $templateName contract when fetching it
          |  // by interface, should fail to do so.
-         |  val fetch${templateName}ByInterfaceAndCatchError: (ContractId $tplQualifiedName) -> Update Text =
+         |  val fetch${templateName}ByInterfaceAndCatchErrorGlobal: (ContractId $tplQualifiedName) -> Update Text =
          |    \\(cid: ContractId $tplQualifiedName) ->
          |      try @Text
          |        ubind _:'$commonDefsPkgId':Mod:Iface <-
@@ -988,7 +985,7 @@ class ExceptionTest(majorLanguageVersion: LanguageMajorVersion)
          |
          |  // Tries to catch the error thrown by the contract info of a $templateName contract when fetching it
          |  // by key, should fail to do so.
-         |  val fetch${templateName}ByKeyAndCatchError: '$commonDefsPkgId':Mod:Key -> Update Text =
+         |  val fetch${templateName}ByKeyAndCatchErrorGlobal: '$commonDefsPkgId':Mod:Key -> Update Text =
          |    \\(key: '$commonDefsPkgId':Mod:Key) ->
          |      try @Text
          |        ubind _:$tuple2TyCon (ContractId $tplQualifiedName) $tplQualifiedName <-
@@ -999,7 +996,7 @@ class ExceptionTest(majorLanguageVersion: LanguageMajorVersion)
          |
          |  // Tries to catch the error thrown by the contract info of a $templateName contract when looking it up
          |  // by key, should fail to do so.
-         |  val lookUp${templateName}ByKeyAndCatchError: '$commonDefsPkgId':Mod:Key -> Update Text =
+         |  val lookUp${templateName}ByKeyAndCatchErrorGlobal: '$commonDefsPkgId':Mod:Key -> Update Text =
          |    \\(key: '$commonDefsPkgId':Mod:Key) ->
          |      try @Text
          |        ubind _:Option (ContractId $tplQualifiedName) <-
@@ -1010,11 +1007,102 @@ class ExceptionTest(majorLanguageVersion: LanguageMajorVersion)
          |""".stripMargin
     }
 
-    def dynamicChoiceTests(templateName: String): String = {
+    /** Generates a series of expressions meant to test that when a locally created v1 instance of [[templateName]] is
+      * fetched/exercised by id/key/interface as a v2 exceptions thrown when evaluating its metadata cannot be caught.
+      */
+    def localContractTests(
+        v1PkgId: Ref.PackageId,
+        v2PkgId: Ref.PackageId,
+        templateName: String,
+    ): String = {
+      val v1TplQualifiedName = s"'$v1PkgId':Mod:$templateName"
+      val v2TplQualifiedName = s"'$v2PkgId':Mod:$templateName"
+      s"""
+         |  // Tries to catch the error thrown by the contract info of $templateName when exercising a choice on
+         |  // it, should fail to do so.
+         |  val exercise${templateName}AndCatchErrorLocal: Unit -> Update Text =
+         |    \\(_:Unit) ->
+         |      ubind cid: ContractId $v1TplQualifiedName <-
+         |         create @$v1TplQualifiedName ($v1TplQualifiedName { p = '$commonDefsPkgId':Mod:alice })
+         |      in try @Text
+         |        exercise
+         |            @$v2TplQualifiedName
+         |            SomeChoice
+         |            (COERCE_CONTRACT_ID @$v1TplQualifiedName @$v2TplQualifiedName cid)
+         |            ()
+         |      catch
+         |        e -> Some @(Update Text) (upure @Text "unexpected: some exception was caught");
+         |
+         |  // Tries to catch the error thrown by the contract info of a $templateName contract when fetching it,
+         |  // should fail to do so.
+         |  val fetch${templateName}AndCatchErrorLocal: Unit -> Update Text =
+         |    \\(_:Unit) ->
+         |      ubind cid: ContractId $v1TplQualifiedName <-
+         |          create @$v1TplQualifiedName ($v1TplQualifiedName { p = '$commonDefsPkgId':Mod:alice })
+         |      in try @Text
+         |        ubind _:$v2TplQualifiedName <-
+         |            fetch_template @$v2TplQualifiedName
+         |                (COERCE_CONTRACT_ID @$v1TplQualifiedName @$v2TplQualifiedName cid)
+         |        in upure @Text "unexpected: contract was fetched"
+         |      catch
+         |        e -> Some @(Update Text) (upure @Text "unexpected: some exception was caught");
+         |
+         |  // Tries to catch the error thrown by the contract info of a $templateName contract when fetching it
+         |  // by interface, should fail to do so.
+         |  val fetch${templateName}ByInterfaceAndCatchErrorLocal: Unit -> Update Text =
+         |    \\(_:Unit) ->
+         |      ubind cid: ContractId $v1TplQualifiedName <-
+         |          create @$v1TplQualifiedName ($v1TplQualifiedName { p = '$commonDefsPkgId':Mod:alice })
+         |      in try @Text
+         |        ubind _:'$commonDefsPkgId':Mod:Iface <-
+         |            fetch_interface @'$commonDefsPkgId':Mod:Iface
+         |                (COERCE_CONTRACT_ID @$v1TplQualifiedName @'$commonDefsPkgId':Mod:Iface cid)
+         |        in upure @Text "unexpected: contract was fetched by interface"
+         |      catch
+         |        e -> Some @(Update Text) (upure @Text "unexpected: some exception was caught");
+         |
+         |  // Tries to catch the error thrown by the contract info of a $templateName contract when fetching it
+         |  // by key, should fail to do so.
+         |  val fetch${templateName}ByKeyAndCatchErrorLocal: Unit -> Update Text =
+         |    \\(_:Unit) ->
+         |      ubind cid: ContractId $v1TplQualifiedName <-
+         |          create @$v1TplQualifiedName ($v1TplQualifiedName { p = '$commonDefsPkgId':Mod:alice })
+         |      in try @Text
+         |        ubind _:$tuple2TyCon (ContractId $v2TplQualifiedName) $v2TplQualifiedName <-
+         |            fetch_by_key
+         |                @$v2TplQualifiedName
+         |                ('$commonDefsPkgId':Mod:Key {
+         |                    label = "test-key",
+         |                    maintainers = (Cons @Party ['$commonDefsPkgId':Mod:alice] (Nil @Party)) })
+         |        in upure @Text "unexpected: contract was fetched by key"
+         |      catch
+         |        e -> Some @(Update Text) (upure @Text "unexpected: some exception was caught");
+         |
+         |  // Tries to catch the error thrown by the contract info of a $templateName contract when looking it up
+         |  // by key, should fail to do so.
+         |  val lookUp${templateName}ByKeyAndCatchErrorLocal: Unit -> Update Text =
+         |    \\(_:Unit) ->
+         |      ubind cid: ContractId $v1TplQualifiedName <-
+         |          create @$v1TplQualifiedName ($v1TplQualifiedName { p = '$commonDefsPkgId':Mod:alice })
+         |      in try @Text
+         |        ubind _:Option (ContractId $v2TplQualifiedName) <-
+         |            lookup_by_key
+         |                @$v2TplQualifiedName
+         |                ('$commonDefsPkgId':Mod:Key {
+         |                    label = "test-key",
+         |                    maintainers = (Cons @Party ['$commonDefsPkgId':Mod:alice] (Nil @Party)) })
+         |        in upure @Text "unexpected: contract was looked up by key"
+         |      catch
+         |        e -> Some @(Update Text) (upure @Text "unexpected: some exception was caught");
+         |""".stripMargin
+    }
+
+    def dynamicChoiceTestsGlobal(templateName: String): String = {
       s"""
          |  // Tries to catch the error thrown by the dynamic exercise of a $templateName choice when fetching it
          |  // by interface, should fail to do so.
-         |  val exercise${templateName}ByInterfaceAndCatchError: (ContractId '$commonDefsPkgId':Mod:Iface) -> Update Text =
+         |  val exercise${templateName}ByInterfaceAndCatchErrorGlobal:
+         |      (ContractId '$commonDefsPkgId':Mod:Iface) -> Update Text =
          |    \\(cid: ContractId '$commonDefsPkgId':Mod:Iface) ->
          |      try @Text
          |        exercise_interface @'$commonDefsPkgId':Mod:Iface MyChoice cid ()
@@ -1023,18 +1111,47 @@ class ExceptionTest(majorLanguageVersion: LanguageMajorVersion)
       """.stripMargin
     }
 
+    def dynamicChoiceTestsLocal(v1PkgId: Ref.PackageId, templateName: String): String = {
+      val v1TplQualifiedName = s"'$v1PkgId':Mod:$templateName"
+      s"""
+             |  // Tries to catch the error thrown by the dynamic exercise of a $templateName choice when fetching it
+             |  // by interface, should fail to do so.
+             |  val exercise${templateName}ByInterfaceAndCatchErrorLocal: Unit -> Update Text =
+             |    \\(_:Unit) ->
+             |      ubind cid: ContractId $v1TplQualifiedName <-
+             |          create @$v1TplQualifiedName ($v1TplQualifiedName { p = '$commonDefsPkgId':Mod:alice })
+             |      in try @Text
+             |        exercise_interface @'$commonDefsPkgId':Mod:Iface
+             |            MyChoice
+             |            (COERCE_CONTRACT_ID @$v1TplQualifiedName @'$commonDefsPkgId':Mod:Iface cid)
+             |            ()
+             |      catch
+             |        e -> Some @(Update Text) (upure @Text "unexpected: some exception was caught");
+      """.stripMargin
+    }
+
     val metadataTestsPkgId = Ref.PackageId.assertFromString("-metadata-tests-id-")
     val metadataTestsParserParams = parserParameters.copy(defaultPackageId = metadataTestsPkgId)
     val metadataTestsPkg =
       p"""metadata ( '-metadata-tests-' : '1.0.0' )
           module Mod {
-            ${tests(templateDefsV2PkgId, "Precondition")}
-            ${tests(templateDefsV2PkgId, "Signatories")}
-            ${tests(templateDefsV2PkgId, "Observers")}
-            ${tests(templateDefsV2PkgId, "Key")}
-            ${tests(templateDefsV2PkgId, "Maintainers")}
-            ${dynamicChoiceTests("ChoiceControllers")}
-            ${dynamicChoiceTests("ChoiceObservers")}
+            ${globalContractTests(templateDefsV2PkgId, "Precondition")}
+            ${globalContractTests(templateDefsV2PkgId, "Signatories")}
+            ${globalContractTests(templateDefsV2PkgId, "Observers")}
+            ${globalContractTests(templateDefsV2PkgId, "Key")}
+            ${globalContractTests(templateDefsV2PkgId, "Maintainers")}
+
+            ${localContractTests(templateDefsV1PkgId, templateDefsV2PkgId, "Precondition")}
+            ${localContractTests(templateDefsV1PkgId, templateDefsV2PkgId, "Signatories")}
+            ${localContractTests(templateDefsV1PkgId, templateDefsV2PkgId, "Observers")}
+            ${localContractTests(templateDefsV1PkgId, templateDefsV2PkgId, "Key")}
+            ${localContractTests(templateDefsV1PkgId, templateDefsV2PkgId, "Maintainers")}
+
+            ${dynamicChoiceTestsGlobal("ChoiceControllers")}
+            ${dynamicChoiceTestsGlobal("ChoiceObservers")}
+
+            ${dynamicChoiceTestsLocal(templateDefsV1PkgId, "ChoiceControllers")}
+            ${dynamicChoiceTestsLocal(templateDefsV1PkgId, "ChoiceObservers")}
           }
     """ (metadataTestsParserParams)
 
@@ -1071,7 +1188,8 @@ class ExceptionTest(majorLanguageVersion: LanguageMajorVersion)
 
       s"exceptions thrown by ${test.templateName} cannot be caught when fetched or exercised" in {
         val alice = Ref.Party.assertFromString("Alice")
-        val templateId = Ref.Identifier.assertFromString(s"-pkgId-:Mod:${test.templateName}")
+        val templateId =
+          Ref.Identifier.assertFromString(s"-template-defs-v1-id-:Mod:${test.templateName}")
         val cid = Value.ContractId.V1(crypto.Hash.hashPrivateKey("abc"))
         val key = SValue.SRecord(
           templateId,
@@ -1095,24 +1213,48 @@ class ExceptionTest(majorLanguageVersion: LanguageMajorVersion)
           Table[Expr, SValue](
             ("expression", "arg"),
             (
-              e"Mod:exercise${test.templateName}AndCatchError" (metadataTestsParserParams),
+              e"Mod:exercise${test.templateName}AndCatchErrorGlobal" (metadataTestsParserParams),
               SContractId(cid),
             ),
             (
-              e"Mod:fetch${test.templateName}AndCatchError" (metadataTestsParserParams),
+              e"Mod:exercise${test.templateName}AndCatchErrorLocal" (metadataTestsParserParams),
+              SUnit,
+            ),
+            (
+              e"Mod:fetch${test.templateName}AndCatchErrorGlobal" (metadataTestsParserParams),
               SContractId(cid),
             ),
             (
-              e"Mod:fetch${test.templateName}ByInterfaceAndCatchError" (metadataTestsParserParams),
+              e"Mod:fetch${test.templateName}AndCatchErrorLocal" (metadataTestsParserParams),
+              SUnit,
+            ),
+            (
+              e"Mod:fetch${test.templateName}ByInterfaceAndCatchErrorGlobal" (
+                metadataTestsParserParams
+              ),
               SContractId(cid),
             ),
             (
-              e"Mod:fetch${test.templateName}ByKeyAndCatchError" (metadataTestsParserParams),
+              e"Mod:fetch${test.templateName}ByInterfaceAndCatchErrorLocal" (
+                metadataTestsParserParams
+              ),
+              SUnit,
+            ),
+            (
+              e"Mod:fetch${test.templateName}ByKeyAndCatchErrorGlobal" (metadataTestsParserParams),
               key,
             ),
             (
-              e"Mod:lookUp${test.templateName}ByKeyAndCatchError" (metadataTestsParserParams),
+              e"Mod:fetch${test.templateName}ByKeyAndCatchErrorLocal" (metadataTestsParserParams),
+              SUnit,
+            ),
+            (
+              e"Mod:lookUp${test.templateName}ByKeyAndCatchErrorGlobal" (metadataTestsParserParams),
               key,
+            ),
+            (
+              e"Mod:lookUp${test.templateName}ByKeyAndCatchErrorLocal" (metadataTestsParserParams),
+              SUnit,
             ),
           )
         }
@@ -1168,38 +1310,58 @@ class ExceptionTest(majorLanguageVersion: LanguageMajorVersion)
         val alice = Ref.Party.assertFromString("Alice")
         val cid = Value.ContractId.V1(crypto.Hash.hashPrivateKey("abc"))
 
-        inside {
-          runUpdateApp(
-            compiledPackages,
-            packageResolution = Map(
-              templateDefsPkgName -> templateDefsV2PkgId
+        val testCases = {
+          Table[Expr, SValue](
+            ("expression", "arg"),
+            (
+              e"Mod:exercise${test.templateName}ByInterfaceAndCatchErrorGlobal" (
+                metadataTestsParserParams
+              ),
+              SContractId(cid),
             ),
-            e"Mod:exercise${test.templateName}ByInterfaceAndCatchError" (metadataTestsParserParams),
-            Array(SContractId(cid)),
-            getContract = Map(
-              cid -> Versioned(
-                version = TransactionVersion.StableVersions.max,
-                Value.ContractInstance(
-                  packageName = metadataTestsPkg.pkgName,
-                  template = t"Mod:${test.templateName}" (templateDefsV1ParserParams)
-                    .asInstanceOf[Ast.TTyCon]
-                    .tycon,
-                  arg = Value.ValueRecord(None, ImmArray(None -> Value.ValueParty(alice))),
-                ),
-              )
+            (
+              e"Mod:exercise${test.templateName}ByInterfaceAndCatchErrorLocal" (
+                metadataTestsParserParams
+              ),
+              SUnit,
             ),
-            getKey = PartialFunction.empty,
           )
-        } {
-          case Left(
-                SError.SErrorDamlException(
-                  IE.UnhandledException(
-                    _,
-                    Value.ValueRecord(_, ImmArray((_, Value.ValueText(msg)))),
-                  )
+        }
+
+        forEvery(testCases) { (expr, arg) =>
+          inside {
+            runUpdateApp(
+              compiledPackages,
+              packageResolution = Map(
+                templateDefsPkgName -> templateDefsV2PkgId
+              ),
+              expr,
+              Array(arg),
+              getContract = Map(
+                cid -> Versioned(
+                  version = TransactionVersion.StableVersions.max,
+                  Value.ContractInstance(
+                    packageName = metadataTestsPkg.pkgName,
+                    template = t"Mod:${test.templateName}" (templateDefsV1ParserParams)
+                      .asInstanceOf[Ast.TTyCon]
+                      .tycon,
+                    arg = Value.ValueRecord(None, ImmArray(None -> Value.ValueParty(alice))),
+                  ),
                 )
-              ) =>
-            msg shouldBe test.templateName
+              ),
+              getKey = PartialFunction.empty,
+            )
+          } {
+            case Left(
+                  SError.SErrorDamlException(
+                    IE.UnhandledException(
+                      _,
+                      Value.ValueRecord(_, ImmArray((_, Value.ValueText(msg)))),
+                    )
+                  )
+                ) =>
+              msg shouldBe test.templateName
+          }
         }
       }
     }

--- a/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
@@ -42,6 +42,26 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
   ): ParserParameters[this.type] =
     ParserParameters(pkgId, languageVersion = majorLanguageVersion.dev)
 
+  val ifacePkgId = Ref.PackageId.assertFromString("-iface-")
+  private lazy val ifacePkg = {
+    implicit def pkgId: Ref.PackageId = ifacePkgId
+    p""" metadata ( '-iface-' : '1.0.0' )
+    module M {
+
+      record @serializable MyUnit = {};
+      interface (this : Iface) = {
+        viewtype M:MyUnit;
+        method myChoice : Text;
+
+        choice @nonConsuming MyChoice (self) (ctl: Party): Text
+          , controllers (Cons @Party [ctl] Nil @Party)
+          , observers (Nil @Party)
+          to upure @Text (call_method @M:Iface myChoice this);
+      };
+    }
+    """
+  }
+
   val pkgId1 = Ref.PackageId.assertFromString("-pkg1-")
   private lazy val pkg1 = {
     implicit def pkgId: Ref.PackageId = pkgId1
@@ -53,8 +73,22 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
         precondition True;
         signatories M:mkList (M:T {sig} this) (None @Party);
         observers M:mkList (M:T {obs} this) (None @Party);
+        implements '-iface-':M:Iface {
+          view = '-iface-':M:MyUnit {};
+          method myChoice = "myChoice v1";
+        };
         key @Party (M:T {sig} this) (\ (p: Party) -> Cons @Party [p] Nil @Party);
       };
+
+      val mkParty : Text -> Party =
+        \(t:Text) ->
+          case TEXT_TO_PARTY t of
+            None -> ERROR @Party "none"
+          | Some x -> x;
+
+      val do_create: Text -> Text -> Int64 -> Update (ContractId M:T) =
+        \(sig: Text) -> \(obs: Text) -> \(n: Int64) ->
+          create @M:T M:T { sig = M:mkParty sig, obs = M:mkParty obs, aNumber = n };
 
       val do_fetch: ContractId M:T -> Update M:T =
         \(cId: ContractId M:T) ->
@@ -73,7 +107,7 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
   val pkgId2: Ref.PackageId = Ref.PackageId.assertFromString("-pkg2-")
 
   private lazy val pkg2 = {
-    // same signatures as pkg1
+    // adds a choice to T
     implicit def pkgId: Ref.PackageId = pkgId2
     p""" metadata ( '-upgrade-test-' : '2.0.0' )
       module M {
@@ -83,6 +117,14 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
         precondition True;
         signatories '-pkg1-':M:mkList (M:T {sig} this) (None @Party);
         observers '-pkg1-':M:mkList (M:T {obs} this) (None @Party);
+        choice NoOp (self) (arg: Unit) : Unit,
+          controllers Cons @Party [M:T {sig} this] Nil @Party,
+          observers Nil @Party
+          to upure @Unit ();
+        implements '-iface-':M:Iface {
+          view = '-iface-':M:MyUnit {};
+          method myChoice = "myChoice v2";
+        };
         key @Party (M:T {sig} this) (\ (p: Party) -> Cons @Party [p] Nil @Party);
       };
 
@@ -105,6 +147,10 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
         precondition True;
         signatories '-pkg1-':M:mkList (M:T {sig} this) (M:T {optSig} this);
         observers '-pkg1-':M:mkList (M:T {obs} this) (None @Party);
+        choice NoOp (self) (arg: Unit) : Unit,
+          controllers Cons @Party [M:T {sig} this] Nil @Party,
+          observers Nil @Party
+          to upure @Unit ();
         key @Party (M:T {sig} this) (\ (p: Party) -> Cons @Party [p] Nil @Party);
       };
 
@@ -128,6 +174,10 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
         precondition True;
         signatories '-pkg1-':M:mkList (M:T {obs} this) (None @Party);
         observers '-pkg1-':M:mkList (M:T {sig} this) (None @Party);
+        choice NoOp (self) (u: Unit) : Unit,
+          controllers '-pkg1-':M:mkList (M:T {sig} this) (None @Party),
+          observers Nil @Party
+          to upure @Unit ();
         key @Party (M:T {obs} this) (\ (p: Party) -> Cons @Party [p] Nil @Party);
       };
 
@@ -152,7 +202,13 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
 
   private lazy val pkgs =
     PureCompiledPackages.assertBuild(
-      Map(pkgId1 -> pkg1, pkgId2 -> pkg2, pkgId3 -> pkg3, pkgId4 -> pkg4),
+      Map(
+        ifacePkgId -> ifacePkg,
+        pkgId1 -> pkg1,
+        pkgId2 -> pkg2,
+        pkgId3 -> pkg3,
+        pkgId4 -> pkg4,
+      ),
       Compiler.Config.Dev(majorLanguageVersion),
     )
 
@@ -162,6 +218,31 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
   val theCid = ContractId.V1(crypto.Hash.hashPrivateKey(s"theCid"))
 
   type Success = (SValue, Value, List[UpgradeVerificationRequest])
+
+  def go(
+      e: Expr,
+      packageResolution: Map[Ref.PackageName, Ref.PackageId] = Map.empty,
+  ): Either[SError, Success] = {
+
+    val sexprToEval: SExpr = pkgs.compiler.unsafeCompile(e)
+
+    implicit def logContext: LoggingContext = LoggingContext.ForTesting
+    val seed = crypto.Hash.hashPrivateKey("seed")
+    val machine = Speedy.Machine.fromUpdateSExpr(
+      pkgs,
+      seed,
+      sexprToEval,
+      Set(alice, bob),
+      packageResolution = packageResolution,
+    )
+
+    SpeedyTestLib
+      .runCollectRequests(machine)
+      .map { case (sv, uvs) => // ignoring any AuthRequest
+        val v = sv.toNormalizedValue(VDev)
+        (sv, v, uvs)
+      }
+  }
 
   // The given contractValue is wrapped as a contract available for ledger-fetch
   def go(e: Expr, contract: ContractInstance): Either[SError, Success] = {
@@ -231,6 +312,9 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
 
   val v1_key =
     GlobalKeyWithMaintainers.assertBuild(i"'-pkg1-':M:T", ValueParty(alice), Set(alice), pkgName)
+
+  val v2_key =
+    GlobalKeyWithMaintainers.assertBuild(i"'-pkg2-':M:T", ValueParty(alice), Set(alice), pkgName)
 
   "upgrade attempted" - {
 
@@ -403,6 +487,92 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
       )
       res shouldBe a[Right[_, _]]
     }
+
+    "be able to fetch a locally created contract using different versions" in {
+      val res = go(
+        e"""ubind
+              cid: ContractId '-pkg1-':M:T <- '-pkg1-':M:do_create "alice" "bob" 100;
+              _: '-pkg2-':M:T <- fetch_template @'-pkg2-':M:T cid
+            in upure @(ContractId '-pkg1-':M:T) cid
+          """
+      )
+      inside(res) { case Right((_, ValueContractId(cid), verificationRequests)) =>
+        verificationRequests shouldBe List(
+          UpgradeVerificationRequest(cid, Set(alice), Set(bob), Some(v1_key))
+        )
+      }
+    }
+
+    "be able to fetch by key a locally created contract using different versions" in {
+      val res = go(
+        e"""let alice : Party = '-pkg1-':M:mkParty "alice"
+            in ubind
+              cid: ContractId '-pkg1-':M:T <- '-pkg1-':M:do_create "alice" "bob" 100;
+              _: '-pkg2-':M:T <- fetch_by_key @'-pkg2-':M:T alice
+            in upure @(ContractId '-pkg1-':M:T) cid
+          """
+      )
+      inside(res) { case Right((_, ValueContractId(cid), verificationRequests)) =>
+        verificationRequests shouldBe List(
+          UpgradeVerificationRequest(cid, Set(alice), Set(bob), Some(v2_key)),
+          UpgradeVerificationRequest(cid, Set(alice), Set(bob), Some(v2_key)),
+        )
+      }
+    }
+
+    "be able to exercise a locally created contract using different versions" in {
+      val res = go(
+        e"""ubind
+              cid: ContractId '-pkg1-':M:T <- '-pkg1-':M:do_create "alice" "bob" 100;
+              _: Unit <- exercise @'-pkg2-':M:T NoOp cid ()
+            in upure @(ContractId '-pkg1-':M:T) cid
+          """
+      )
+      inside(res) { case Right((_, ValueContractId(cid), verificationRequests)) =>
+        verificationRequests shouldBe List(
+          UpgradeVerificationRequest(cid, Set(alice), Set(bob), Some(v1_key))
+        )
+      }
+    }
+
+    "be able to exercise by key a locally created contract using different versions" in {
+      val res = go(
+        e"""let alice : Party = '-pkg1-':M:mkParty "alice"
+            in ubind
+                 cid: ContractId '-pkg1-':M:T <- '-pkg1-':M:do_create "alice" "bob" 100;
+                 _: Unit <- exercise_by_key @'-pkg2-':M:T NoOp alice ()
+               in upure @(ContractId '-pkg1-':M:T) cid
+          """
+      )
+      inside(res) { case Right((_, ValueContractId(cid), verificationRequests)) =>
+        verificationRequests shouldBe List(
+          UpgradeVerificationRequest(cid, Set(alice), Set(bob), Some(v2_key)),
+          UpgradeVerificationRequest(cid, Set(alice), Set(bob), Some(v2_key)),
+        )
+      }
+    }
+
+    // TODO(https://github.com/digital-asset/daml/issues/20099): re-enable this test once fixed
+    "be able to exercise by interface locally created contract using different versions" ignore {
+      val res = go(
+        e"""let alice : Party = '-pkg1-':M:mkParty "alice"
+            in ubind
+                 cid: ContractId '-pkg1-':M:T <- '-pkg1-':M:do_create "alice" "bob" 100;
+                 res: Text <- exercise_interface @'-iface-':M:Iface
+                                MyChoice
+                                (COERCE_CONTRACT_ID @'-pkg1-':M:T @'-iface-':M:Iface cid)
+                                alice
+               in upure @(ContractId '-pkg1-':M:T) cid
+          """,
+        packageResolution = Map(Ref.PackageName.assertFromString("-upgrade-test-") -> pkgId2),
+      )
+      inside(res) { case Right((_, ValueContractId(cid), verificationRequests)) =>
+        verificationRequests shouldBe List(
+          UpgradeVerificationRequest(cid, Set(alice), Set(bob), Some(v1_key))
+        )
+      }
+    }
+
     "do recompute and check immutability of meta data when using different versions" in {
       // The following code is not properly typed, but emulates two commands that fetch a same contract using different versions.
       val res: Either[SError, (SValue, Value, List[UpgradeVerificationRequest])] = go(

--- a/sdk/daml-script/test/daml/upgrades/ContractKeys.daml
+++ b/sdk/daml-script/test/daml/upgrades/ContractKeys.daml
@@ -13,10 +13,33 @@ import qualified V1.ChangedKeyExpr as V1
 import qualified V2.ChangedKeyExpr as V2
 import qualified V1.UpgradedContractKeys as V1
 import qualified V2.UpgradedContractKeys as V2
+import qualified V1.IfaceMod as Iface
+
+{- PACKAGE
+name: contract-key-upgrades-iface
+versions: 1
+-}
+
+{- MODULE
+package: contract-key-upgrades-iface
+contents: |
+  module IfaceMod where
+
+  data MyUnit = MyUnit {}
+    deriving (Eq, Show)
+
+  interface I where
+    viewtype MyUnit
+
+    nonconsuming choice NoOp : ()
+      controller signatory this
+      do pure ()
+-}
 
 {- PACKAGE
 name: contract-key-upgrades
 versions: 2
+depends: contract-key-upgrades-iface-1.0.0
 -}
 
 main : TestTree
@@ -33,8 +56,10 @@ main = tests
         [ ("queryContractId, src=v1 tgt=v2", queryKeyChangedExprSameValue)
         , ("queryContractKey, src=v1 tgt=v2", qckKeyChangedExprSameValue)
         , ("fetch, src=v1 tgt=v2", fetchKeyChangedExprSameValue)
+        , ("fetchByInterface, src=v1 tgt=i", fbiKeyChangedExprSameValue)
         , ("fetchByKey, src=v1 tgt=v2", fbkKeyChangedExprSameValue)
         , ("exercise, src=v1 tgt=v2", exerciseKeyChangedExprSameValue)
+        , ("exerciseByInterface, src=v1 tgt=i", ebiKeyChangedExprSameValue)
         , ("exerciseByKey, src=v1 tgt=v2", ebkKeyChangedExprSameValue)
         , ("exerciseCmd, src=v1 tgt=v2", exerciseCmdKeyChangedExprSameValue)
         , ("exerciseByKeyCmd, src=v1 tgt=v2", ebkCmdKeyChangedExprSameValue)
@@ -43,8 +68,10 @@ main = tests
         [ broken ("queryContractId, src=v1 tgt=v2", queryKeyChangedExprChangedValue)
         , broken ("queryContractKey, src=v1 tgt=v2", qckKeyChangedExprChangedValue)
         , ("fetch, src=v1 tgt=v2", fetchKeyChangedExprChangedValue)
+        , ("fetchByInterface, src=v1 tgt=i", fbiKeyChangedExprChangedValue)
         , ("fetchByKey, src=v1 tgt=v2", fbkKeyChangedExprChangedValue)
         , ("exercise, src=v1 tgt=v2", exerciseKeyChangedExprChangedValue)
+        , ("exerciseByInterface, src=v1 tgt=i", ebiKeyChangedExprChangedValue)
         , ("exerciseByKey, src=v1 tgt=v2", ebkKeyChangedExprChangedValue)
         , ("exerciseCmd, src=v1 tgt=v2", exerciseCmdKeyChangedExprChangedValue)
         , ("exerciseByKeyCmd, src=v1 tgt=v2", ebkCmdKeyChangedExprChangedValue)
@@ -138,6 +165,8 @@ package: contract-key-upgrades
 contents: |
   module ChangedKeyExpr where
 
+  import IfaceMod
+
   data ChangedKeyExprKey = ChangedKeyExprKey with
       p : Party
       b : Bool
@@ -152,6 +181,9 @@ contents: |
       key (ChangedKeyExprKey party False) : ChangedKeyExprKey -- @V 1
       key (ChangedKeyExprKey party b)     : ChangedKeyExprKey -- @V  2
       maintainer key.p
+
+      interface instance I for ChangedKeyExpr where
+        view = MyUnit {}
 
       choice ChangedKeyExprCall : Text
         controller party
@@ -169,6 +201,13 @@ contents: |
         controller party
         do fetch cid
 
+      choice ChangedKeyExprFetchByInterface : MyUnit with
+          cid : ContractId I
+        controller party
+        do
+          i <- fetch cid
+          pure (view i)
+
       choice ChangedKeyExprFetchByKey : (ContractId ChangedKeyExpr, ChangedKeyExpr) with
           k : ChangedKeyExprKey
         controller party
@@ -178,6 +217,11 @@ contents: |
           cid : ContractId ChangedKeyExpr
         controller party
         do exercise @ChangedKeyExpr cid ChangedKeyExprCall
+
+      choice ChangedKeyExprExerciseByInterface : () with
+          cid : ContractId I
+        controller party
+        do exercise @I cid NoOp
 
       choice ChangedKeyExprExerciseByKey : Text with
           k : ChangedKeyExprKey
@@ -233,6 +277,20 @@ fetchKeyChangedExprChangedValue = test $ do
   expectKeyChangedError =<<
     a `trySubmit` createAndExerciseCmd (V2.ChangedKeyExprHelper a) (V2.ChangedKeyExprFetch $ coerceContractId cid)
 
+fbiKeyChangedExprSameValue : Test
+fbiKeyChangedExprSameValue = test $ do
+  a <- allocateParty "alice"
+  cid <- a `submit` createExactCmd (V1.ChangedKeyExpr a False)
+  foundContract <- a `submit` createAndExerciseCmd (V2.ChangedKeyExprHelper a) (V2.ChangedKeyExprFetchByInterface $ coerceContractId cid)
+  foundContract === Iface.MyUnit {}
+
+fbiKeyChangedExprChangedValue : Test
+fbiKeyChangedExprChangedValue = test $ do
+  a <- allocateParty "alice"
+  cid <- a `submit` createExactCmd (V1.ChangedKeyExpr a True)
+  expectKeyChangedError =<<
+    a `trySubmit` createAndExerciseCmd (V2.ChangedKeyExprHelper a) (V2.ChangedKeyExprFetchByInterface $ coerceContractId cid)
+
 fbkKeyChangedExprSameValue : Test
 fbkKeyChangedExprSameValue = test $ do
   a <- allocateParty "alice"
@@ -245,7 +303,6 @@ fbkKeyChangedExprChangedValue : Test
 fbkKeyChangedExprChangedValue = test $ do
   a <- allocateParty "alice"
   cid <- a `submit` createExactCmd (V1.ChangedKeyExpr a True)
-  -- the fetch inside the following command works, even though the key value changed!
   expectKeyChangedError =<<
     a `trySubmit` createAndExerciseCmd (V2.ChangedKeyExprHelper a) (V2.ChangedKeyExprFetchByKey $ V2.ChangedKeyExprKey a False)
 
@@ -255,6 +312,13 @@ exerciseKeyChangedExprSameValue = test $ do
   cid <- a `submit` createExactCmd (V1.ChangedKeyExpr a False)
   res <- a `submit` createAndExerciseCmd (V2.ChangedKeyExprHelper a) (V2.ChangedKeyExprExercise $ coerceContractId cid)
   res === "V2"
+
+ebiKeyChangedExprSameValue : Test
+ebiKeyChangedExprSameValue = test $ do
+  a <- allocateParty "alice"
+  cid <- a `submit` createExactCmd (V1.ChangedKeyExpr a False)
+  res <- a `submit` createAndExerciseCmd (V2.ChangedKeyExprHelper a) (V2.ChangedKeyExprExerciseByInterface $ coerceContractId cid)
+  res === ()
 
 ebkKeyChangedExprSameValue : Test
 ebkKeyChangedExprSameValue = test $ do
@@ -283,6 +347,13 @@ exerciseKeyChangedExprChangedValue = test $ do
   cid <- a `submit` createExactCmd (V1.ChangedKeyExpr a True)
   expectKeyChangedError =<<
     a `trySubmit` createAndExerciseCmd (V2.ChangedKeyExprHelper a) (V2.ChangedKeyExprExercise $ coerceContractId cid)
+
+ebiKeyChangedExprChangedValue : Test
+ebiKeyChangedExprChangedValue = test $ do
+  a <- allocateParty "alice"
+  cid <- a `submit` createExactCmd (V1.ChangedKeyExpr a True)
+  expectKeyChangedError =<<
+    a `trySubmit` createAndExerciseCmd (V2.ChangedKeyExprHelper a) (V2.ChangedKeyExprExerciseByInterface $ coerceContractId cid)
 
 ebkKeyChangedExprChangedValue : Test
 ebkKeyChangedExprChangedValue = test $ do

--- a/sdk/daml-script/test/daml/upgrades/Ensure.daml
+++ b/sdk/daml-script/test/daml/upgrades/Ensure.daml
@@ -1,24 +1,46 @@
 -- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE AllowAmbiguousTypes #-}
-
 module Ensure (main) where
 
 import UpgradeTestLib
 import qualified V1.EnsureChanges as V1
 import qualified V2.EnsureChanges as V2
+import qualified V1.IfaceMod as Iface
 import DA.Exception
+
+{- PACKAGE
+name: ensure-changes-iface
+versions: 1
+-}
+
+{- MODULE
+package: ensure-changes-iface
+contents: |
+  module IfaceMod where
+
+  data MyUnit = MyUnit {}
+
+  interface I where
+    viewtype MyUnit
+
+    nonconsuming choice NoOp : ()
+      controller signatory this
+      do pure ()
+-}
 
 {- PACKAGE
 name: ensure-changes
 versions: 2
+depends: ensure-changes-iface-1.0.0
 -}
 
 {- MODULE
 package: ensure-changes
 contents: |
   module EnsureChanges where
+
+  import IfaceMod
 
   template EnsureChangesTemplate
     with
@@ -30,6 +52,9 @@ contents: |
       ensure v1Valid       -- @V 1
       ensure v2Valid       -- @V  2
 
+      interface instance I for EnsureChangesTemplate where
+        view = MyUnit {}
+
       choice EnsureChangesCall : Text
         controller party
         do pure "V1"       -- @V 1
@@ -39,29 +64,34 @@ contents: |
 main : TestTree
 main = tests
   [ ("Fails if the ensure clause changes such that V1 is not longer valid", ensureClauseBecomesInvalid)
+  , ("Fails if the ensure clause changes such that V1 is not longer valid, exercise by interface", ensureClauseBecomesInvalidDynamic)
   , ("Succeeds when implicitly creating a V1 contract such that the ensure clause only passes in V2", onlyV2EnsureClauseRequiredForImplicitUpgrade)
   , ("Fails when explicitly calling a V1 choice on a V2 contract that doesn't pass the ensure clause in V1", ensureClauseDowngradeToNoLongerValid)
   ]
 
 testForPreconditionFailed
-  : forall t2 t1 c2 r
-  . (Template t1, HasEnsure t1, Choice t2 c2 r, Show r)
+  :  (Template t1, HasEnsure t1, Show r)
   => (Party -> t1)
-  -> c2
-  -> Bool
+  -> (ContractId t1 -> Commands r)
   -> Test
-testForPreconditionFailed makeV1Contract v2Choice explicitPackageIds = test $ do
+testForPreconditionFailed makeV1Contract exerciseChoice = test $ do
   a <- allocatePartyOn "alice" participant0
   cid <- a `submit` createExactCmd (makeV1Contract a)
-  let cidV2 = coerceContractId @t1 @t2 cid
-  res <- a `trySubmit` (if explicitPackageIds then exerciseExactCmd else exerciseCmd) cidV2 v2Choice
+  res <-  a `trySubmit` exerciseChoice cid
   case res of
     Left (UnhandledException (Some (fromAnyException -> Some (PreconditionFailed _)))) -> pure ()
     res -> assertFail $ "Expected PreconditionFailed, got " <> show res
 
 ensureClauseBecomesInvalid : Test
 ensureClauseBecomesInvalid =
-  testForPreconditionFailed @V2.EnsureChangesTemplate (V1.EnsureChangesTemplate True False) V2.EnsureChangesCall False
+  testForPreconditionFailed (V1.EnsureChangesTemplate True False) $ \cidV1 ->
+     -- because the exercise is not exact, the contract should be upgraded to V2 before evaluating the ensure clause
+     exerciseCmd cidV1 V1.EnsureChangesCall
+
+ensureClauseBecomesInvalidDynamic : Test
+ensureClauseBecomesInvalidDynamic =
+  testForPreconditionFailed (V1.EnsureChangesTemplate True False) $ \cidV1 ->
+     exerciseExactCmd (coerceContractId @V1.EnsureChangesTemplate @Iface.I cidV1) Iface.NoOp
 
 onlyV2EnsureClauseRequiredForImplicitUpgrade : Test
 onlyV2EnsureClauseRequiredForImplicitUpgrade = test $ do
@@ -72,4 +102,5 @@ onlyV2EnsureClauseRequiredForImplicitUpgrade = test $ do
 
 ensureClauseDowngradeToNoLongerValid : Test
 ensureClauseDowngradeToNoLongerValid =
-  testForPreconditionFailed @V1.EnsureChangesTemplate (V2.EnsureChangesTemplate False True) V1.EnsureChangesCall True
+  testForPreconditionFailed (V2.EnsureChangesTemplate False True) $ \cidV2 ->
+    exerciseExactCmd (coerceContractId @V2.EnsureChangesTemplate @V1.EnsureChangesTemplate cidV2) V1.EnsureChangesCall

--- a/sdk/daml-script/test/daml/upgrades/SignatoryObserverChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/SignatoryObserverChanges.daml
@@ -6,17 +6,41 @@ module SignatoryObserverChanges (main) where
 import UpgradeTestLib
 import qualified V1.SignatoryObserverChanges as V1
 import qualified V2.SignatoryObserverChanges as V2
+import qualified V1.IfaceMod as Iface
 import DA.Text
+
+{- PACKAGE
+name: signatory-observer-changes-iface
+versions: 1
+-}
+
+{- MODULE
+package: signatory-observer-changes-iface
+contents: |
+  module IfaceMod where
+
+  data MyUnit = MyUnit {}
+
+  interface I where
+    viewtype MyUnit
+
+    nonconsuming choice NoOp : ()
+      controller signatory this
+      do pure ()
+-}
 
 {- PACKAGE
 name: signatory-observer-changes
 versions: 2
+depends: signatory-observer-changes-iface-1.0.0
 -}
 
 {- MODULE
 package: signatory-observer-changes
 contents: |
   module SignatoryObserverChanges where
+
+  import IfaceMod
 
   template SignatoryObserverChangesTemplate
     with
@@ -30,21 +54,42 @@ contents: |
       observer observers                              -- @V 1
       observer replacementObservers                   -- @V  2
 
+      interface instance I for SignatoryObserverChangesTemplate where
+        view = MyUnit {}
+
       choice InvalidUpgradeStakeholdersCall : () with -- @V  2
         controller signatory this                     -- @V  2
         do pure ()                                    -- @V  2
 -}
 
 main : TestTree
-main = tests
-  [ ("Succeeds if the signatories don't change", unchangedSignatoryUpgrade)
-  , ("Fails if the signatories set gets larger", largerSignatoryUpgrade)
-  , ("Fails if the signatories set gets smaller", smallerSignatoryUpgrade)
-  , ("Succeeds if the observers don't change", unchangeObserverUpgrade)
-  , ("Fails if the observers set gets larger", largerObserverUpgrade)
-  , ("Fails if the observers set gets smaller", smallerObserverUpgrade)
-  , ("Succeeds if the observer set loses parties that are already signatories", canRemoveObserversThatAreSignatories)
+main = tests $
+  [ subtree description
+      [ ("static exercise", testCase exerciseStaticChoice)
+      , ("dynamic exercise", testCase exerciseDynamicChoice)
+      ]
+  | (description, testCase) <-
+      [ ("Succeeds if the signatories don't change", unchangedSignatoryUpgrade)
+      , ("Fails if the signatories set gets larger", largerSignatoryUpgrade)
+      , ("Fails if the signatories set gets smaller", smallerSignatoryUpgrade)
+      , ("Succeeds if the observers don't change", unchangeObserverUpgrade)
+      , ("Fails if the observers set gets larger", largerObserverUpgrade)
+      , ("Fails if the observers set gets smaller", smallerObserverUpgrade)
+      , ("Succeeds if the observer set loses parties that are already signatories", canRemoveObserversThatAreSignatories)
+      ]
   ]
+
+type ChoiceExerciser = ContractId V1.SignatoryObserverChangesTemplate -> Commands ()
+
+exerciseStaticChoice : ChoiceExerciser
+exerciseStaticChoice cidV1 =
+  let cidV2 = coerceContractId @V1.SignatoryObserverChangesTemplate @V2.SignatoryObserverChangesTemplate cidV1
+  in exerciseCmd cidV2 V2.InvalidUpgradeStakeholdersCall
+
+exerciseDynamicChoice : ChoiceExerciser
+exerciseDynamicChoice cidV1 =
+  let cidI = coerceContractId @V1.SignatoryObserverChangesTemplate @Iface.I cidV1
+  in exerciseCmd cidI Iface.NoOp
 
 -- Given a function that maps a set of 3 parties to the pre-upgrade and post-upgrade signatory set
 -- and the same for observers
@@ -53,8 +98,9 @@ signatoryObserverUpgrade
   :  Bool
   -> ((Party, Party, Party) -> ([Party], [Party]))
   -> ((Party, Party, Party) -> ([Party], [Party]))
+  -> ChoiceExerciser
   -> Test
-signatoryObserverUpgrade shouldSucceed sigF obsF = test $ do
+signatoryObserverUpgrade shouldSucceed sigF obsF exerciseChoice = test $ do
   alice <- allocatePartyOn "alice" participant0
   bob <- allocatePartyOn "bob" participant0
   charlie <- allocatePartyOn "charlie" participant0
@@ -67,8 +113,7 @@ signatoryObserverUpgrade shouldSucceed sigF obsF = test $ do
     replacementSignatories = postSignatories
     replacementObservers = postObservers
 
-  let cidV2 = coerceContractId @V1.SignatoryObserverChangesTemplate @V2.SignatoryObserverChangesTemplate cid
-  res <- trySubmitMulti [alice, bob, charlie] [] $ exerciseCmd cidV2 V2.InvalidUpgradeStakeholdersCall
+  res <- trySubmitMulti [alice, bob, charlie] [] $ exerciseChoice cid
   case (res, shouldSucceed) of
     (Right _, True) -> pure ()
     (Left (DevError Upgrade msg), False)
@@ -79,31 +124,31 @@ signatoryObserverUpgrade shouldSucceed sigF obsF = test $ do
 unchanged : (Party, Party, Party) -> ([Party], [Party])
 unchanged (alice, bob, charlie) = ([alice], [alice])
 
-signatoryUpgrade : Bool -> ((Party, Party, Party) -> ([Party], [Party])) -> Test
+signatoryUpgrade : Bool -> ((Party, Party, Party) -> ([Party], [Party])) -> ChoiceExerciser ->Test
 signatoryUpgrade shouldSucceed f = signatoryObserverUpgrade shouldSucceed f unchanged
 
-observerUpgrade : Bool -> ((Party, Party, Party) -> ([Party], [Party])) -> Test
+observerUpgrade : Bool -> ((Party, Party, Party) -> ([Party], [Party])) -> ChoiceExerciser -> Test
 observerUpgrade shouldSucceed = signatoryObserverUpgrade shouldSucceed unchanged
 
-unchangedSignatoryUpgrade : Test
+unchangedSignatoryUpgrade : ChoiceExerciser -> Test
 unchangedSignatoryUpgrade = signatoryUpgrade True unchanged
 
-largerSignatoryUpgrade : Test
+largerSignatoryUpgrade : ChoiceExerciser -> Test
 largerSignatoryUpgrade = signatoryUpgrade False $ \(alice, bob, charlie) -> ([alice, bob], [alice, bob, charlie])
 
-smallerSignatoryUpgrade : Test
+smallerSignatoryUpgrade : ChoiceExerciser -> Test
 smallerSignatoryUpgrade = signatoryUpgrade False $ \(alice, bob, charlie) -> ([alice, bob, charlie], [alice, bob])
 
-unchangeObserverUpgrade : Test
+unchangeObserverUpgrade : ChoiceExerciser -> Test
 unchangeObserverUpgrade = observerUpgrade True unchanged
 
-largerObserverUpgrade : Test
+largerObserverUpgrade : ChoiceExerciser -> Test
 largerObserverUpgrade = observerUpgrade False $ \(alice, bob, charlie) -> ([alice, bob], [alice, bob, charlie])
 
-smallerObserverUpgrade : Test
+smallerObserverUpgrade : ChoiceExerciser -> Test
 smallerObserverUpgrade = observerUpgrade False $ \(alice, bob, charlie) -> ([alice, bob, charlie], [alice, bob])
 
-canRemoveObserversThatAreSignatories : Test
+canRemoveObserversThatAreSignatories : ChoiceExerciser -> Test
 canRemoveObserversThatAreSignatories =
   signatoryObserverUpgrade
     True


### PR DESCRIPTION
Fwd port of https://github.com/digital-asset/daml/pull/20035 and https://github.com/digital-asset/daml/pull/20110. The code of `SBuiltinFun` was quite different from that of 2.x so I ported this part quasi manually, worth a second look.

I accidentally merged https://github.com/digital-asset/daml/pull/20127 into this PR so it now contains two ports. Since https://github.com/digital-asset/daml/pull/20127 had been approved, I won't split again it in the interest of not running the CI too many times.