### PR TITLE
Drop MaxCauseLogLength back to 512 (2.x)

### DIFF
--- a/sdk/canton/daml-common-staging/daml-errors/src/main/scala/com/daml/error/SerializableErrorComponents.scala
+++ b/sdk/canton/daml-common-staging/daml-errors/src/main/scala/com/daml/error/SerializableErrorComponents.scala
@@ -212,7 +212,7 @@ private[error] final case class NonSecuritySensitiveErrorCodeComponents(
 private[error] object NonSecuritySensitiveErrorCodeComponents {
 
   /** The maximum size (in characters) of the self-service error description, truncated for transport as part of a Status */
-  val MaxCauseLogLength = 1024
+  val MaxCauseLogLength = 512
 
   private[error] def truncateDetails(
       context: Map[String, String],

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesSpecBase.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesSpecBase.scala
@@ -980,7 +980,7 @@ abstract class UpgradesSpec(val suffix: String)
         // If a failure message is expected, look for it in the canton logs
         case Some(additionalInfo) =>
           if (
-            s"The uploaded DAR contains a package $testPackageSecondId \\(.*\\), but upgrade checks indicate that (existing package $testPackageFirstId|new package $testPackageSecondId) \\(.*\\) cannot be an upgrade of (existing package $testPackageFirstId|new package $testPackageSecondId)".r
+            s"The uploaded DAR contains a package $testPackageSecondId \\(.*\\), but upgrade checks indicate that (existing package $testPackageFirstId|new package $testPackageSecondId) \\(.*\\) cannot be an upgrade of (existing package $testPackageFirstId \\(.*\\)|new package $testPackageSecondId \\(.*\\)). Reason: $additionalInfo".r
               .findFirstIn(cantonLogSrc)
               .isEmpty
           ) fail("did not find upgrade failure in canton log:\n")
@@ -992,7 +992,7 @@ abstract class UpgradesSpec(val suffix: String)
               val msg = err.toString
               msg should include("INVALID_ARGUMENT: DAR_NOT_VALID_UPGRADE")
               msg should include regex (
-                s"The uploaded DAR contains a package $testPackageSecondId \\(.*\\), but upgrade checks indicate that (existing package $testPackageFirstId|new package $testPackageSecondId) \\(.*\\) cannot be an upgrade of (existing package $testPackageFirstId|new package $testPackageSecondId).*Reason: $additionalInfo"
+                s"The uploaded DAR contains a package $testPackageSecondId \\(.*\\), but upgrade checks indicate that (existing package $testPackageFirstId|new package $testPackageSecondId) \\(.*\\) cannot be an upgrade of (existing package|new package)"
               )
             }
           }


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
