### PR TITLE
move readme, add symlink to license at root

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+sdk/LICENSE

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+
+See full README at [sdk/README.md](sdk/README.md)

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -27,7 +27,7 @@ asking on StackOverflow, please use [the `daml` tag].
 
 ## Contributing to Daml
 
-We warmly welcome [contributions](./CONTRIBUTING.md). If you are looking for ideas on how to contribute, please browse our
+We warmly welcome [contributions](../CONTRIBUTING.md). If you are looking for ideas on how to contribute, please browse our
 [issues](https://github.com/digital-asset/daml/issues). To build and test Daml:
 
 ### 1. Clone this repository


### PR DESCRIPTION
- Correct link to contributing md in readme
- Add README at root pointing to readme in sdk/readme.md
- Add symlink for license at root so github will detect license