### PR TITLE
Participant: unignore and uncomment tests for i21459

### DIFF
--- a/sdk/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
+++ b/sdk/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
@@ -191,6 +191,7 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
       timeProviderType = TimeProviderType.WallClock,
       debug = false,
       bootstrapScript = None,
+      synchronizeVettingOnUpload = false,
     )
     val logger = org.slf4j.LoggerFactory.getLogger(getClass)
     val portsResource = CantonRunner

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -658,8 +658,7 @@ abstract class QueryStoreAndAuthDependentIntegrationTest
     } yield succeed
   }
 
-  // TODO(i21459) Fix, and unignore
-  "should recognise an archive against a newer version of the same contract" ignore withHttpService {
+  "should recognise an archive against a newer version of the same contract" in withHttpService {
     fixture =>
       import AbstractHttpServiceIntegrationTestFuns.{fooV1Dar, fooV2Dar}
 

--- a/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/sdk/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -68,6 +68,7 @@ trait AbstractHttpServiceIntegrationTestFunsCustomToken
   import json.JsonProtocol._
 
   override protected lazy val maxPartiesPageSize = Some(100)
+  override protected lazy val synchronizeVettingOnUpload = true
 
   protected def jwt(uri: Uri)(implicit ec: ExecutionContext): Future[Jwt] =
     jwtForParties(uri)(domain.Party subst List("Alice"), List(), config.ledgerIds.headOption.value)

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_17/UpgradingIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_17/UpgradingIT.scala
@@ -344,8 +344,7 @@ class UpgradingIT extends LedgerTestSuite {
 
       // Both exercise events's template-id should match the create template-id (i.e. v1)
       assertEquals(toJavaProto(exercised1.templateId.get), v1TmplId.toProto)
-      // TODO(i21823): Uncomment
-      // assertEquals(toJavaProto(exercised2.templateId.get), v1TmplId.toProto)
+      assertEquals(toJavaProto(exercised2.templateId.get), v1TmplId.toProto)
 
       // The first exercise has a result shape per v1, and the second per v2
       assertExerciseResult(exercised1.exerciseResult.get, v1TmplId, new FetcherV1(party))
@@ -356,9 +355,8 @@ class UpgradingIT extends LedgerTestSuite {
       )
 
       // The first exercise has a choicePackageId of v1 and the second of v2
-      // TODO(i21913): Uncomment
-      // assertEquals(toJavaProto(ex1.choicePackageId.get), FetcherV1.PACKAGE_ID.toProto)
-      // assertEquals(toJavaProto(ex2.choicePackageId.get), FetcherV2.PACKAGE_ID.toProto)
+      assertEquals(exercised1.choicePackageId, Some(FetcherV1.PACKAGE_ID))
+      assertEquals(exercised2.choicePackageId, Some(FetcherV2.PACKAGE_ID))
     }
   })
 

--- a/sdk/test-common/canton/it-lib/src/main/com/daml/CantonConfig.scala
+++ b/sdk/test-common/canton/it-lib/src/main/com/daml/CantonConfig.scala
@@ -54,6 +54,7 @@ final case class CantonConfig(
     disableUpgradeValidation: Boolean = false,
     maxPartiesPageSize: Option[Int] = None,
     enableRemoteJavaDebugging: Boolean = false,
+    synchronizeVettingOnUpload: Boolean = false,
 ) {
 
   lazy val tlsConfig =

--- a/sdk/test-common/canton/it-lib/src/main/com/daml/CantonFixture.scala
+++ b/sdk/test-common/canton/it-lib/src/main/com/daml/CantonFixture.scala
@@ -63,6 +63,7 @@ trait CantonFixtureWithResource[A]
   protected lazy val cantonJar: Path = CantonRunner.cantonPath
   protected lazy val targetScope: Option[String] = Option.empty
   protected lazy val maxPartiesPageSize: Option[Int] = None
+  protected lazy val synchronizeVettingOnUpload: Boolean = false
 
   // This flag setup some behavior to ease debugging tests.
   //  If `CantonFixtureDebugKeepTmpFiles` or `CantonFixtureDebugRemoveTmpFiles`
@@ -138,6 +139,7 @@ trait CantonFixtureWithResource[A]
     disableUpgradeValidation = disableUpgradeValidation,
     maxPartiesPageSize = maxPartiesPageSize,
     enableRemoteJavaDebugging = remoteJavaDebugging,
+    synchronizeVettingOnUpload = synchronizeVettingOnUpload,
   )
 
   protected def info(msg: String): Unit =

--- a/sdk/test-common/canton/it-lib/src/main/com/daml/CantonRunner.scala
+++ b/sdk/test-common/canton/it-lib/src/main/com/daml/CantonRunner.scala
@@ -96,6 +96,7 @@ object CantonRunner {
          |        ${authConfig}
          |        ${tls}
          |        ${partiesPageSize}
+         |        synchronize-vetting-on-upload = ${config.synchronizeVettingOnUpload}
          |      }
          |      storage.type = memory
          |      parameters = {


### PR DESCRIPTION
And enable `synchronize-vetting-on-upload` so the test can be reliably executed.

Fixes https://github.com/DACH-NY/canton/issues/21459

Fixes UP80 and UP85