### PR TITLE
Daml Engine: add overload of `enrichChoiceArgument` with separate packageId and qualifiedName args

### DIFF
--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
@@ -101,13 +101,35 @@ final class ValueEnricher(
   }
 
   def enrichChoiceArgument(
+      choicePackageId: PackageId,
+      qualifiedTemplateName: QualifiedName,
+      interfaceId: Option[Identifier],
+      choiceName: Name,
+      value: Value,
+  ): Result[Value] =
+    handleLookup(
+      pkgInterface.lookupChoice(
+        Identifier(choicePackageId, qualifiedTemplateName),
+        interfaceId,
+        choiceName,
+      )
+    )
+      .flatMap(choice => enrichValue(choice.argBinder._2, value))
+
+  // Deprecated
+  def enrichChoiceArgument(
       templateId: Identifier,
       interfaceId: Option[Identifier],
       choiceName: Name,
       value: Value,
   ): Result[Value] =
-    handleLookup(pkgInterface.lookupChoice(templateId, interfaceId, choiceName))
-      .flatMap(choice => enrichValue(choice.argBinder._2, value))
+    enrichChoiceArgument(
+      templateId.packageId,
+      templateId.qualifiedName,
+      interfaceId,
+      choiceName,
+      value,
+    )
 
   def enrichChoiceResult(
       choicePackageId: PackageId,
@@ -126,6 +148,7 @@ final class ValueEnricher(
       .flatMap(choice => enrichValue(choice.returnType, value))
   }
 
+  // Deprecated
   def enrichChoiceResult(
       templateId: Identifier,
       interfaceId: Option[Identifier],


### PR DESCRIPTION
And mark the ones which accept a single `templateId` as deprecated. 

The point is that these should generally be called with the package id that the choice was executed at, so this signature makes the package selection explicit.