### PR TITLE
Ensure engine only gives interface id on fetch nodes when upgrades su…

### DIFF
--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -783,7 +783,7 @@ private[lf] final class Compiler(
       let(env, SBFetchInterface(soft, ifaceId)(env.toSEVar(cidPos))) { (payloadPos, env) =>
         let(
           env,
-          SBResolveSBUInsertFetchNode(ifaceId)(
+          SBResolveSBUInsertFetchNode(Option.when(soft)(ifaceId))(
             env.toSEVar(payloadPos),
             env.toSEVar(cidPos),
           ),

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1394,7 +1394,7 @@ private[lf] object SBuiltin {
 
   // Only for interface fetches
   final case class SBResolveSBUInsertFetchNode(
-      interfaceId: TypeConName
+      oInterfaceId: Option[TypeConName] // Only provided if Upgrades are enabled
   ) extends SBuiltin(1) {
     override private[speedy] def execute[Q](
         args: util.ArrayList[SValue],
@@ -1406,7 +1406,7 @@ private[lf] object SBuiltin {
           templateId,
           Some(templateId),
           byKey = false,
-          interfaceId = Some(interfaceId),
+          interfaceId = oInterfaceId,
         )
       )
       Control.Expression(e)


### PR DESCRIPTION
…pported

Ensures the engine doesn't give interface ids for fetches that don't need it, to ensure compatibility with older versions of canton.
Related to #20196
