### PR TITLE
default the assistant's sandbox to pv7

### DIFF
--- a/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -316,7 +316,7 @@ cantonConfig CantonOptions{..} =
                 , [ "clock" Aeson..= Aeson.object
                         [ "type" Aeson..= ("sim-clock" :: T.Text) ]
                   | StaticTime True <- [cantonStaticTime] ]
-                , [ "beta-version-support" Aeson..= True]
+                , [ "dev-version-support" Aeson..= True]
                 , [ "non-standard-config" Aeson..= True]
                 ] )
             , "participants" Aeson..= Aeson.object
@@ -329,7 +329,7 @@ cantonConfig CantonOptions{..} =
                          , "user-management-service" Aeson..= Aeson.object [ "enabled" Aeson..= True ]
                          -- Can be dropped once user mgmt is enabled by default
                          ]
-                     , "parameters" Aeson..= Aeson.object [ "beta-version-support" Aeson..= True ]
+                     , "parameters" Aeson..= Aeson.object [ "dev-version-support" Aeson..= True ]
                      ] <>
                      [ "testing-time" Aeson..= Aeson.object [ "type" Aeson..= ("monotonic-time" :: T.Text) ]
                      | StaticTime True <- [cantonStaticTime]
@@ -343,7 +343,7 @@ cantonConfig CantonOptions{..} =
                      , "admin-api" Aeson..= port cantonDomainAdminApi
                      , "init" Aeson..= Aeson.object
                            [ "domain-parameters" Aeson..= Aeson.object
-                               [ "protocol-version" Aeson..= ("5" :: T.Text) ]
+                               [ "protocol-version" Aeson..= ("7" :: T.Text) ]
                            ]
                      ]
                 ]


### PR DESCRIPTION
Tested manually with the sdk produced with `daml-sdk-head` that I can start the sandbox and run a 1.17 dar on it.