### PR TITLE
Add standardized flags for downgrading/upgrading warnings from/to errors

### DIFF
--- a/sdk/compiler/daml-lf-tools/BUILD.bazel
+++ b/sdk/compiler/daml-lf-tools/BUILD.bazel
@@ -29,7 +29,6 @@ da_haskell_library(
     deps = [
         "//compiler/daml-lf-ast",
         "//compiler/damlc/daml-lf-util",
-        "//compiler/damlc/daml-opts:daml-opts-types",
         "//compiler/damlc/daml-package-config",
         "//libs-haskell/da-hs-base",
     ],

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
@@ -43,8 +43,6 @@ import           Data.HashMap.Strict (HashMap)
 
 import           DA.Daml.LF.Ast
 import           DA.Daml.LF.TypeChecker.Error
-import           DA.Daml.Options.Types (DamlWarningFlagStatus(..), DamlWarningFlag)
-import           DA.Cli.Options (getWarningStatus)
 
 -- | The environment for the Daml-LF type checker.
 data Gamma = Gamma

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
@@ -31,8 +31,8 @@ module DA.Daml.LF.TypeChecker.Env(
     Gamma(..),
     emptyGamma,
     SomeErrorOrWarning(..),
-    addDiagnosticSwapIndicator,
-    withDiagnosticSwapIndicatorF,
+    getWarningStatusF,
+    damlWarningFlags,
     ) where
 
 import           Control.Lens hiding (Context)
@@ -43,6 +43,8 @@ import           Data.HashMap.Strict (HashMap)
 
 import           DA.Daml.LF.Ast
 import           DA.Daml.LF.TypeChecker.Error
+import           DA.Daml.Options.Types (DamlWarningFlagStatus(..), DamlWarningFlag)
+import           DA.Cli.Options (getWarningStatus)
 
 -- | The environment for the Daml-LF type checker.
 data Gamma = Gamma
@@ -56,7 +58,7 @@ data Gamma = Gamma
     -- ^ The packages in scope.
   , _lfVersion :: Version
     -- ^ The Daml-LF version of the package being type checked.
-  , _diagnosticSwapIndicator :: Either WarnableError Warning -> Bool
+  , _damlWarningFlags :: [DamlWarningFlag]
     -- ^ Function for relaxing errors into warnings and strictifying warnings into errors
   }
 
@@ -68,23 +70,10 @@ class SomeErrorOrWarning d where
 getLfVersion :: MonadGamma m => m Version
 getLfVersion = view lfVersion
 
-getDiagnosticSwapIndicatorF :: forall m gamma. MonadGammaF gamma m => Getter gamma Gamma -> m (Either WarnableError Warning -> Bool)
-getDiagnosticSwapIndicatorF getter = view (getter . diagnosticSwapIndicator)
-
-addDiagnosticSwapIndicator
-  :: (Either WarnableError Warning -> Maybe Bool)
-  -> Gamma -> Gamma
-addDiagnosticSwapIndicator newIndicator =
-  diagnosticSwapIndicator %~ \oldIndicator err ->
-    case newIndicator err of
-      Nothing -> oldIndicator err
-      Just verdict -> verdict
-
-withDiagnosticSwapIndicatorF
-  :: MonadGammaF gamma m
-  => Setter' gamma Gamma -> (Either WarnableError Warning -> Maybe Bool) -> m () -> m ()
-withDiagnosticSwapIndicatorF setter newIndicator =
-  locally setter (addDiagnosticSwapIndicator newIndicator)
+getWarningStatusF :: forall m gamma. MonadGammaF gamma m => Getter gamma Gamma -> WarnableError -> m DamlWarningFlagStatus
+getWarningStatusF getter warnableError = do
+  flags <- view (getter . damlWarningFlags)
+  pure (getWarningStatus flags warnableError)
 
 getWorld :: MonadGamma m => m World
 getWorld = view world
@@ -117,7 +106,7 @@ match p e x = either (const (throwWithContext e)) pure (matching p x)
 -- | Environment containing only the packages in scope but no type or term
 -- variables.
 emptyGamma :: World -> Version -> Gamma
-emptyGamma world version = Gamma ContextNone mempty mempty world version (const False)
+emptyGamma world version = Gamma ContextNone mempty mempty world version []
 
 -- | Run a computation in the current environment extended by a new type
 -- variable/kind binding. Does not fail on shadowing.
@@ -158,7 +147,7 @@ diagnosticWithContext = diagnosticWithContextF id
 throwWithContext :: MonadGamma m => UnwarnableError -> m a
 throwWithContext = throwWithContextF id
 
-warnWithContext :: MonadGamma m => Warning -> m ()
+warnWithContext :: MonadGamma m => StandaloneWarning -> m ()
 warnWithContext = warnWithContextF id
 
 withContext :: MonadGamma m => Context -> m b -> m b
@@ -175,8 +164,13 @@ throwWithContextFRaw getter err = do
   ctx <- view $ getter . locCtx
   throwError $ EContext ctx err
 
-warnWithContextF :: forall m gamma. MonadGammaF gamma m => Getter gamma Gamma -> Warning -> m ()
-warnWithContextF = diagnosticWithContextF
+warnWithContextF :: forall m gamma. MonadGammaF gamma m => Getter gamma Gamma -> StandaloneWarning -> m ()
+warnWithContextF getter warning = warnWithContextFRaw getter (WStandaloneWarning warning)
+
+warnWithContextFRaw :: forall m gamma. MonadGammaF gamma m => Getter gamma Gamma -> Warning -> m ()
+warnWithContextFRaw getter warning = do
+  ctx <- view $ getter . locCtx
+  modify' (WContext ctx warning :)
 
 withContextF :: MonadGammaF gamma m => Setter' gamma Gamma -> Context -> m b -> m b
 withContextF setter newCtx = local (over (setter . locCtx) setCtx)
@@ -193,20 +187,11 @@ instance SomeErrorOrWarning UnwarnableError where
 
 instance SomeErrorOrWarning WarnableError where
   diagnosticWithContextF getter err = do
-    shouldSwap <- getDiagnosticSwapIndicatorF getter
-    if shouldSwap (Left err)
-       then do
-        ctx <- view $ getter . locCtx
-        modify' (WContext ctx (WErrorToWarning err) :)
-       else do
-        throwWithContextFRaw getter (EWarnableError err)
+    status <- getWarningStatusF getter err
+    case status of
+      AsError -> throwWithContextFRaw getter (EWarnableError err)
+      AsWarning -> warnWithContextFRaw getter (WErrorToWarning err)
+      Hidden -> pure ()
 
-instance SomeErrorOrWarning Warning where
-  diagnosticWithContextF getter warning = do
-    shouldSwap <- getDiagnosticSwapIndicatorF getter
-    if shouldSwap (Right warning)
-       then do
-        throwWithContextFRaw getter (EWarningToError warning)
-       else do
-        ctx <- view $ getter . locCtx
-        modify' (WContext ctx warning :)
+instance SomeErrorOrWarning StandaloneWarning where
+  diagnosticWithContextF = warnWithContextF

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -23,6 +23,7 @@ module DA.Daml.LF.TypeChecker.Error(
     DamlWarningFlagStatus(..),
     parseDamlWarningFlag,
     getWarningStatus,
+    upgradeInterfacesName, upgradeInterfacesFilter,
     ) where
 
 import Control.Applicative
@@ -272,7 +273,7 @@ data DamlWarningFlag
     , rfStatus :: DamlWarningFlagStatus
     , rfFilter :: WarnableError -> Bool
     }
-  | WarnBadInterfaceInstances Bool -- When true, same as warn-bad-interface-instances
+  | WarnBadInterfaceInstances Bool -- When true, same as -Wupgrade-interfaces
 
 parseDamlWarningFlag :: String -> Either String DamlWarningFlag
 parseDamlWarningFlag = \case

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -19,7 +19,6 @@ import qualified DA.Daml.LF.Ast.Alpha as Alpha
 import           DA.Daml.LF.TypeChecker.Check (expandTypeSynonyms)
 import           DA.Daml.LF.TypeChecker.Env
 import           DA.Daml.LF.TypeChecker.Error
-import           DA.Daml.Options.Types (UpgradeInfo (..))
 import           Data.Either (partitionEithers)
 import           Data.Hashable
 import qualified Data.HashMap.Strict as HMS
@@ -33,7 +32,6 @@ import Data.Function (on)
 import Module (UnitId)
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
-import           DA.Daml.Options.Types (DamlWarningFlag(..))
 
 -- Allows us to split the world into upgraded and non-upgraded
 type TcUpgradeM = TcMF UpgradingEnv
@@ -42,6 +40,11 @@ data PreUpgradingEnv = PreUpgradingEnv
   { pueVersion :: Version
   , pueUpgradeInfo :: UpgradeInfo
   , pueWarningFlags :: [DamlWarningFlag]
+  }
+
+data UpgradeInfo = UpgradeInfo
+  { uiUpgradedPackagePath :: Maybe FilePath
+  , uiTypecheckUpgrades :: Bool
   }
 
 type DepsMap = HMS.HashMap LF.PackageId UpgradingDep
@@ -78,7 +81,7 @@ shouldTypecheckM :: TcPreUpgradeM Bool
 shouldTypecheckM = asks $ uiTypecheckUpgrades . pueUpgradeInfo
 
 mkGamma :: PreUpgradingEnv -> World -> Gamma
-mkGamma PreUpgradingEnv { pueVersion, pueUpgradeInfo, pueWarningFlags } world =
+mkGamma PreUpgradingEnv { pueVersion, pueWarningFlags } world =
     set damlWarningFlags pueWarningFlags (emptyGamma world pueVersion)
 
 gammaM :: World -> TcPreUpgradeM Gamma

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -33,10 +33,16 @@ import Data.Function (on)
 import Module (UnitId)
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
+import           DA.Daml.Options.Types (DamlWarningFlag(..))
 
 -- Allows us to split the world into upgraded and non-upgraded
 type TcUpgradeM = TcMF UpgradingEnv
-type TcPreUpgradeM = TcMF (Version, UpgradeInfo)
+type TcPreUpgradeM = TcMF PreUpgradingEnv
+data PreUpgradingEnv = PreUpgradingEnv
+  { pueVersion :: Version
+  , pueUpgradeInfo :: UpgradeInfo
+  , pueWarningFlags :: [DamlWarningFlag]
+  }
 
 type DepsMap = HMS.HashMap LF.PackageId UpgradingDep
 
@@ -68,34 +74,20 @@ runGammaUnderUpgrades Upgrading{ _past = pastAction, _present = presentAction } 
     presentResult <- withReaderT (_present . _upgradingGamma) presentAction
     pure Upgrading { _past = pastResult, _present = presentResult }
 
-shouldTypecheck :: Version -> UpgradeInfo -> Bool
-shouldTypecheck _ upgradeInfo = uiTypecheckUpgrades upgradeInfo
-
 shouldTypecheckM :: TcPreUpgradeM Bool
-shouldTypecheckM = asks (uncurry shouldTypecheck)
+shouldTypecheckM = asks $ uiTypecheckUpgrades . pueUpgradeInfo
 
-mkGamma :: Version -> UpgradeInfo -> World -> Gamma
-mkGamma version upgradeInfo world =
-    let addBadIfaceSwapIndicator :: Gamma -> Gamma
-        addBadIfaceSwapIndicator =
-            if uiWarnBadInterfaceInstances upgradeInfo
-            then
-                addDiagnosticSwapIndicator (\case
-                    Left WEUpgradeShouldDefineIfaceWithoutImplementation {} -> Just True
-                    Left WEUpgradeShouldDefineTplInSeparatePackage {} -> Just True
-                    Left WEUpgradeShouldDefineIfacesAndTemplatesSeparately {} -> Just True
-                    _ -> Nothing)
-            else id
-    in
-    addBadIfaceSwapIndicator $ emptyGamma world version
+mkGamma :: PreUpgradingEnv -> World -> Gamma
+mkGamma PreUpgradingEnv { pueVersion, pueUpgradeInfo, pueWarningFlags } world =
+    set damlWarningFlags pueWarningFlags (emptyGamma world pueVersion)
 
 gammaM :: World -> TcPreUpgradeM Gamma
-gammaM world = asks (flip (uncurry mkGamma) world)
+gammaM world = asks (flip mkGamma world)
 
 {- HLINT ignore "Use nubOrd" -}
-extractDiagnostics :: Version -> UpgradeInfo -> TcPreUpgradeM () -> [Diagnostic]
-extractDiagnostics version upgradeInfo action =
-  case runGammaF (version, upgradeInfo) action of
+extractDiagnostics :: Version -> UpgradeInfo -> [DamlWarningFlag] -> TcPreUpgradeM () -> [Diagnostic]
+extractDiagnostics version upgradeInfo warningFlags action =
+  case runGammaF (PreUpgradingEnv version upgradeInfo warningFlags) action of
     Left err -> [toDiagnostic err]
     Right ((), warnings) -> map toDiagnostic (nub warnings)
 
@@ -109,18 +101,18 @@ unitIdDalfPackageToUpgradedPkg (unitId, dalfPkg) =
 
 checkPackage
   :: LF.Package
-  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo
+  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo -> [DamlWarningFlag]
   -> Maybe (UpgradedPkgWithNameAndVersion, [UpgradedPkgWithNameAndVersion])
   -> [Diagnostic]
 checkPackage = checkPackageToDepth CheckOnlyMissingModules
 
 checkPackageToDepth
   :: CheckDepth -> LF.Package
-  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo
+  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo -> [DamlWarningFlag]
   -> Maybe (UpgradedPkgWithNameAndVersion, [UpgradedPkgWithNameAndVersion])
   -> [Diagnostic]
-checkPackageToDepth checkDepth pkg deps version upgradeInfo mbUpgradedPkg =
-  extractDiagnostics version upgradeInfo $ do
+checkPackageToDepth checkDepth pkg deps version upgradeInfo warningFlags mbUpgradedPkg =
+  extractDiagnostics version upgradeInfo warningFlags $ do
     shouldTypecheck <- shouldTypecheckM
     when shouldTypecheck $ do
       case mbUpgradedPkg of
@@ -140,7 +132,7 @@ checkPackageBoth checkDepth mbContext pkg ((upgradedPkgId, upgradedPkg), depsMap
           Nothing -> id
           Just context -> withContextF present' context
   in
-  withReaderT (\(version, upgradeInfo) -> UpgradingEnv (mkGamma version upgradeInfo <$> upgradingWorld) depsMap) $
+  withReaderT (\preEnv -> UpgradingEnv (mkGamma preEnv <$> upgradingWorld) depsMap) $
     withMbContext $
       checkPackageM checkDepth (UpgradedPackageId upgradedPkgId) (Upgrading upgradedPkg pkg)
 
@@ -153,21 +145,22 @@ checkPackageSingle mbContext pkg =
       withMbContext :: TcM () -> TcM ()
       withMbContext = maybe id withContext mbContext
   in
-  withReaderT (\(version, upgradeInfo) -> mkGamma version upgradeInfo presentWorld) $
+  withReaderT (\preEnv -> mkGamma preEnv presentWorld) $
     withMbContext $ do
       checkNewInterfacesAreUnused pkg
       checkNewInterfacesHaveNoTemplates
 
 checkModule
   :: LF.World -> LF.Module
-  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo
+  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo -> [DamlWarningFlag]
   -> Maybe (UpgradedPkgWithNameAndVersion, [UpgradedPkgWithNameAndVersion])
   -> [Diagnostic]
-checkModule world0 module_ deps version upgradeInfo mbUpgradedPkg =
-  extractDiagnostics version upgradeInfo $
-    when (shouldTypecheck version upgradeInfo) $ do
+checkModule world0 module_ deps version upgradeInfo warningFlags mbUpgradedPkg =
+  extractDiagnostics version upgradeInfo warningFlags $ do
+    shouldTypecheck <- shouldTypecheckM
+    when shouldTypecheck $ do
       let world = extendWorldSelf module_ world0
-      withReaderT (\(version, upgradeInfo) -> mkGamma version upgradeInfo world) $ do
+      withReaderT (\preEnv -> mkGamma preEnv world) $ do
         checkNewInterfacesAreUnused module_
         checkNewInterfacesHaveNoTemplates
       case mbUpgradedPkg of
@@ -177,7 +170,7 @@ checkModule world0 module_ deps version upgradeInfo mbUpgradedPkg =
             -- TODO: https://github.com/digital-asset/daml/issues/19859
             depsMap <- checkUpgradeDependenciesM deps (upgradedPkgWithId : upgradingDeps)
             let upgradingWorld = Upgrading { _past = initWorldSelf [] (upwnavPkg upgradedPkgWithId), _present = world }
-            withReaderT (\(version, upgradeInfo) -> UpgradingEnv (mkGamma version upgradeInfo <$> upgradingWorld) depsMap) $
+            withReaderT (\preEnv -> UpgradingEnv (mkGamma preEnv <$> upgradingWorld) depsMap) $
               case NM.lookup (NM.name module_) (LF.packageModules (upwnavPkg upgradedPkgWithId)) of
                 Nothing -> pure ()
                 Just pastModule -> do
@@ -201,7 +194,7 @@ checkUpgradeDependenciesM presentDeps pastDeps = do
               Just packageVersion -> do
                 case splitPackageVersion id packageVersion of
                   Left version -> do
-                    diagnosticWithContext $ WErrorToWarning $ WEDependencyHasUnparseableVersion upwnavName version UpgradedPackage
+                    diagnosticWithContext $ WEDependencyHasUnparseableVersion upwnavName version UpgradedPackage
                     pure Nothing
                   Right rawVersion ->
                     pure $ Just (upwnavName, [(Just rawVersion, upwnavPkgId, upwnavPkg)])
@@ -225,7 +218,7 @@ checkUpgradeDependenciesM presentDeps pastDeps = do
     where
     withPkgAsGamma :: Package -> TcM a -> TcPreUpgradeM a
     withPkgAsGamma pkg action =
-      withReaderT (\(version, _) -> emptyGamma (initWorldSelf [] pkg) version) action
+      withReaderT (\pue -> emptyGamma (initWorldSelf [] pkg) (pueVersion pue)) action
 
     upgradeablePackageMapToDeps :: UpgradeablePackageMap -> DepsMap
     upgradeablePackageMapToDeps upgradeablePackageMap =
@@ -284,7 +277,7 @@ checkUpgradeDependenciesM presentDeps pastDeps = do
             Just packageVersion ->
               case splitPackageVersion id packageVersion of
                 Left version -> do
-                  diagnosticWithContext $ WErrorToWarning $ WEDependencyHasUnparseableVersion packageName version UpgradedPackage
+                  diagnosticWithContext $ WEDependencyHasUnparseableVersion packageName version UpgradedPackage
                   pure Nothing
                 Right presentVersion -> do
                   let result = (packageName, (Just presentVersion, presentPkgId, presentPkg))

--- a/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -109,8 +109,9 @@ buildDar ::
     -> NormalizedFilePath
     -> FromDalf
     -> UpgradeInfo
+    -> [DamlWarningFlag]
     -> IO (Maybe (Zip.ZipArchive (), Maybe LF.PackageId))
-buildDar service PackageConfigFields {..} ifDir dalfInput upgradeInfo = do
+buildDar service PackageConfigFields {..} ifDir dalfInput upgradeInfo warningFlags = do
     liftIO $
         IdeLogger.logDebug (ideLogger service) $
         "Creating dar: " <> T.pack pSrc
@@ -160,7 +161,7 @@ buildDar service PackageConfigFields {..} ifDir dalfInput upgradeInfo = do
                  dalfDependencies0 <- getDalfDependencies files
                  MaybeT $
                      runDiagnosticCheck $ diagsToIdeResult (toNormalizedFilePath' pSrc) $
-                         Upgrade.checkPackage pkg (map Upgrade.unitIdDalfPackageToUpgradedPkg (Map.toList dalfDependencies0)) lfVersion upgradeInfo mbUpgradedPackage
+                         Upgrade.checkPackage pkg (map Upgrade.unitIdDalfPackageToUpgradedPkg (Map.toList dalfDependencies0)) lfVersion upgradeInfo warningFlags mbUpgradedPackage
                  let dalfDependencies =
                          [ (T.pack $ unitIdString unitId, LF.dalfPackageBytes pkg, LF.dalfPackageId pkg)
                          | (unitId, pkg) <- Map.toList dalfDependencies0

--- a/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -24,6 +24,7 @@ import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Resource (ResourceT)
 import qualified DA.Daml.LF.Ast as LF
 import DA.Daml.LF.Proto3.Archive (encodeArchiveAndHash)
+import DA.Daml.LF.TypeChecker.Error (DamlWarningFlag)
 import DA.Daml.LF.TypeChecker.Upgrade as Upgrade
 import DA.Daml.Options (expandSdkPackages)
 import DA.Daml.Options.Types

--- a/sdk/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/sdk/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -308,7 +308,7 @@ generateDalfRule opts =
         upgradedPackage <- join <$> useNoFile ExtractUpgradedPackage
         setPriority priorityGenerateDalf
         let lfDiags = LF.checkModule world lfVersion rawDalf
-            upgradeDiags = Upgrade.checkModule world rawDalf (map Upgrade.unitIdDalfPackageToUpgradedPkg (foldMap Map.toList mbDalfDependencies)) lfVersion (optUpgradeInfo opts) upgradedPackage
+            upgradeDiags = Upgrade.checkModule world rawDalf (map Upgrade.unitIdDalfPackageToUpgradedPkg (foldMap Map.toList mbDalfDependencies)) lfVersion (optUpgradeInfo opts) (optDamlWarningFlags opts) upgradedPackage
         pure $! second (rawDalf <$) (diagsToIdeResult file (lfDiags ++ upgradeDiags))
 
 -- TODO Share code with typecheckModule in ghcide. The environment needs to be setup

--- a/sdk/compiler/damlc/daml-opts/BUILD.bazel
+++ b/sdk/compiler/damlc/daml-opts/BUILD.bazel
@@ -25,6 +25,7 @@ da_haskell_library(
     src_strip_prefix = "daml-opts-types",
     visibility = ["//visibility:public"],
     deps = [
+        "//compiler/daml-lf-tools",
         "//compiler/daml-lf-ast",
         "//compiler/damlc/daml-package-config",
         "//daml-assistant:daml-project-config",

--- a/sdk/compiler/damlc/daml-opts/BUILD.bazel
+++ b/sdk/compiler/damlc/daml-opts/BUILD.bazel
@@ -25,8 +25,8 @@ da_haskell_library(
     src_strip_prefix = "daml-opts-types",
     visibility = ["//visibility:public"],
     deps = [
-        "//compiler/daml-lf-tools",
         "//compiler/daml-lf-ast",
+        "//compiler/daml-lf-tools",
         "//compiler/damlc/daml-package-config",
         "//daml-assistant:daml-project-config",
         "//libs-haskell/bazel-runfiles",

--- a/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -36,8 +36,6 @@ module DA.Daml.Options.Types
     , optUnitId
     , getLogger
     , UpgradeInfo (..)
-    , DamlWarningFlag(..)
-    , DamlWarningFlagStatus(..)
     , defaultUiTypecheckUpgrades
     , defaultUiWarnBadInterfaceInstances
     , defaultUpgradeInfo
@@ -59,6 +57,7 @@ import Module (UnitId, stringToUnitId)
 import qualified System.Directory as Dir
 import System.FilePath
 import DA.Daml.LF.TypeChecker.Error
+import DA.Daml.LF.TypeChecker.Upgrade (UpgradeInfo(..))
 
 -- | Orphan instances for debugging
 instance Show PackageFlag where
@@ -143,24 +142,6 @@ data Options = Options
   , optUpgradeInfo :: UpgradeInfo
   , optDamlWarningFlags :: [DamlWarningFlag]
   }
-
-data UpgradeInfo = UpgradeInfo
-  { uiUpgradedPackagePath :: Maybe FilePath
-  , uiTypecheckUpgrades :: Bool
-  }
-
-data DamlWarningFlagStatus
-  = AsError -- -Werror=<name>
-  | AsWarning -- -W<name>
-  | Hidden -- -Wno-<name>
-
-data DamlWarningFlag
-  = RawDamlWarningFlag
-    { rfName :: String
-    , rfStatus :: DamlWarningFlagStatus
-    , rfFilter :: WarnableError -> Bool
-    }
-  | WarnBadInterfaceInstances Bool -- When true, same as -Wupgrade-interfaces
 
 newtype IncrementalBuild = IncrementalBuild { getIncrementalBuild :: Bool }
   deriving Show

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -142,6 +142,7 @@ import DA.Daml.Options.Types (EnableScenarioService(..),
                               optSkipScenarioValidation,
                               optThreads,
                               optUpgradeInfo,
+                              optDamlWarningFlags,
                               pkgNameVersion,
                               projectPackageDatabase)
 import DA.Daml.Package.Config (MultiPackageConfigFields(..),
@@ -1028,6 +1029,7 @@ buildEffect relativize pkgPath pkgConfig opts mbOutFile incrementalBuild initPkg
               (toNormalizedFilePath' $ fromMaybe ifaceDir $ optIfaceDir opts)
               (FromDalf False)
               (optUpgradeInfo opts)
+              (optDamlWarningFlags opts)
       (dar, mPkgId) <- mbErr "ERROR: Creation of DAR file failed." mbDar
       createDarFile loggerH fp dar
       pure mPkgId
@@ -1422,6 +1424,7 @@ execPackage projectOpts filePath opts mbOutFile dalfInput =
                             (toNormalizedFilePath' $ fromMaybe ifaceDir $ optIfaceDir opts)
                             dalfInput
                             (optUpgradeInfo opts)
+                            (optDamlWarningFlags opts)
           case mbDar of
             Nothing -> do
                 hPutStrLn stderr "ERROR: Creation of DAR file failed."

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/UpgradeCheck.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/UpgradeCheck.hs
@@ -165,7 +165,8 @@ checkPackageAgainstPastPackages ((path, main, deps), pastPackages) = do
                   Upgrade.CheckAll
                   (upwnavPkg main) deps
                   LFV.version2_dev
-                  (UpgradeInfo (Just (fromNormalizedFilePath path)) True True)
+                  (UpgradeInfo (Just (fromNormalizedFilePath path)) True)
+                  []
                   (Just (closestPastPackageWithLowerVersion, closestPastPackageWithLowerVersionDeps))
           when (not (null errs)) (throwE [CEDiagnostic path errs])
       case minimumByMay ordFst $ pastPackageFilterVersion (\v -> v > rawVersion) of
@@ -176,7 +177,8 @@ checkPackageAgainstPastPackages ((path, main, deps), pastPackages) = do
                   Upgrade.CheckAll
                   (upwnavPkg closestPastPackageWithHigherVersion) closestPastPackageWithHigherVersionDeps
                   LFV.version2_dev
-                  (UpgradeInfo (Just (fromNormalizedFilePath path)) True True)
+                  (UpgradeInfo (Just (fromNormalizedFilePath path)) True)
+                  []
                   (Just (main, deps))
           when (not (null errs)) (throwE [CEDiagnostic path errs])
 

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -601,62 +601,14 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
 
     optDamlWarningFlag :: Parser DamlWarningFlag
     optDamlWarningFlag =
-      Options.Applicative.option parseDamlWarningFlag (short 'W' <> long "warn")
-      <|> 
-      fmap WarnBadInterfaceInstances optWarnBadInterfaceInstances
+      Options.Applicative.option (eitherReader parseDamlWarningFlag) (short 'W' <> long "warn")
+      <|> fmap WarnBadInterfaceInstances optWarnBadInterfaceInstances
 
     optUpgradeInfo :: Parser UpgradeInfo
     optUpgradeInfo = do
       uiTypecheckUpgrades <- optTypecheckUpgrades
       uiUpgradedPackagePath <- optUpgradeDar
       pure UpgradeInfo {..}
-
-parseDamlWarningFlag :: ReadM DamlWarningFlag
-parseDamlWarningFlag = eitherReader parseDamlWarningFlagE
-  where
-  names =
-    [ ( "upgrade-interfaces"
-      , upgradeInterfacesFilter
-      )
-    ]
-
-  parseNameE name = case lookup name names of
-    Nothing -> Left $ "Warning flag is not valid - warning flags must be of the form `error=<name>`, `no-<name>`, or `<name>`. The list of available names is: " <> intercalate ", " (map fst names)
-    Just filter -> Right filter
-
-  parseDamlWarningFlagE ('e':'r':'r':'o':'r':'=':name) = RawDamlWarningFlag name AsError <$> parseNameE name
-  parseDamlWarningFlagE ('n':'o':'-':name) = RawDamlWarningFlag name Hidden <$> parseNameE name
-  parseDamlWarningFlagE name = RawDamlWarningFlag name AsWarning <$> parseNameE name
-
-upgradeInterfacesFilter :: WarnableError -> Bool
-upgradeInterfacesFilter =
-    \case
-        WEUpgradeShouldDefineIfacesAndTemplatesSeparately {} -> True
-        WEUpgradeShouldDefineIfaceWithoutImplementation {} -> True
-        WEUpgradeShouldDefineTplInSeparatePackage {} -> True
-        _ -> False
-
-dwfFilter :: DamlWarningFlag -> WarnableError -> Bool
-dwfFilter RawDamlWarningFlag { rfFilter } = rfFilter
-dwfFilter WarnBadInterfaceInstances {} = upgradeInterfacesFilter
-
-dwfStatus :: DamlWarningFlag -> DamlWarningFlagStatus
-dwfStatus RawDamlWarningFlag { rfStatus } = rfStatus
-dwfStatus (WarnBadInterfaceInstances shouldWarn) = if shouldWarn then AsWarning else AsError
-
-dwfStatusDefault :: WarnableError -> DamlWarningFlagStatus
-dwfStatusDefault = \case
-  WEUpgradeShouldDefineIfacesAndTemplatesSeparately {} -> AsError
-  WEUpgradeShouldDefineIfaceWithoutImplementation {} -> AsError
-  WEUpgradeShouldDefineTplInSeparatePackage {} -> AsError
-  WEDependencyHasUnparseableVersion {} -> AsWarning
-  WEDependencyHasNoMetadataDespiteUpgradeability {} -> AsWarning
-
-getWarningStatus :: [DamlWarningFlag] -> WarnableError -> DamlWarningFlagStatus
-getWarningStatus flags err =
-  case filter (\flag -> dwfFilter flag err) flags of
-    [] -> dwfStatusDefault err
-    xs -> dwfStatus (last xs)
 
 optGhcCustomOptions :: Parser [String]
 optGhcCustomOptions =

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -595,7 +595,7 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
     optWarnBadInterfaceInstances =
       determineAuto defaultUiWarnBadInterfaceInstances <$>
         flagYesNoAuto''
-          "warn-bad-interface-instances"
+          "-Wupgrade-interfaces"
           "Convert errors about bad, non-upgradeable interface instances into warnings."
           idm
 

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -593,11 +593,11 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
 
     optWarnBadInterfaceInstances :: Parser Bool
     optWarnBadInterfaceInstances =
-      flagYesNoAuto
-        "warn-bad-interface-instances"
-        defaultUiWarnBadInterfaceInstances
-        "Convert errors about bad, non-upgradeable interface instances into warnings."
-        idm
+      determineAuto defaultUiWarnBadInterfaceInstances <$>
+        flagYesNoAuto''
+          "warn-bad-interface-instances"
+          "Convert errors about bad, non-upgradeable interface instances into warnings."
+          idm
 
     optDamlWarningFlag :: Parser DamlWarningFlag
     optDamlWarningFlag =

--- a/sdk/compiler/damlc/tests/BUILD.bazel
+++ b/sdk/compiler/damlc/tests/BUILD.bazel
@@ -152,6 +152,7 @@ da_haskell_library(
     visibility = ["//visibility:public"],
     deps = [
         "//compiler/daml-lf-ast",
+        "//compiler/daml-lf-tools",
         "//compiler/daml-lf-proto-encode",
         "//compiler/damlc:damlc-lib",
         "//compiler/damlc/daml-compiler",

--- a/sdk/compiler/damlc/tests/BUILD.bazel
+++ b/sdk/compiler/damlc/tests/BUILD.bazel
@@ -152,8 +152,8 @@ da_haskell_library(
     visibility = ["//visibility:public"],
     deps = [
         "//compiler/daml-lf-ast",
-        "//compiler/daml-lf-tools",
         "//compiler/daml-lf-proto-encode",
+        "//compiler/daml-lf-tools",
         "//compiler/damlc:damlc-lib",
         "//compiler/damlc/daml-compiler",
         "//compiler/damlc/daml-ide-core",

--- a/sdk/compiler/damlc/tests/daml-test-files/ChoiceFunctions.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/ChoiceFunctions.daml
@@ -2,8 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_CHOICE_FUNCS
--- @WARN warn-bad-interface-instances
--- @WARN warn-bad-interface-instances
+-- @WARN -Werror=upgrade-interfaces
+-- @WARN -Werror=upgrade-interfaces
 
 module ChoiceFunctions where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/Daml3ScriptTrySubmit.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/Daml3ScriptTrySubmit.daml
@@ -3,8 +3,8 @@
 
 -- @ SCRIPT-V2
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 -- @ WARN range=15:1-15:28; Import of internal module Daml.Script.Internal of package daml3-script is discouraged, as this module will change without warning.
 
 {-# LANGUAGE ApplicativeDo #-}

--- a/sdk/compiler/damlc/tests/daml-test-files/DamlDocHoogle.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/DamlDocHoogle.daml
@@ -1,6 +1,6 @@
 module DamlDocHoogle where
 
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
 
 -- | T docs
 template T with

--- a/sdk/compiler/damlc/tests/daml-test-files/Interface.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/Interface.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 {-# LANGUAGE ApplicativeDo #-}
 
 module Interface where

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceArchive.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceArchive.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 module InterfaceArchive where
 
 import Daml.Script

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision.daml
@@ -1,9 +1,9 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 
 -- This checks collisions check for Interface choice
 -- This also covers regression test for interface instance, view and method markers.

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailed.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailed.daml
@@ -6,8 +6,8 @@ module InterfaceChoiceGuardFailed where
 import Daml.Script
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE_EXTENDED
--- @WARN warn-bad-interface-instances
--- @WARN warn-bad-interface-instances
+-- @WARN -Werror=upgrade-interfaces
+-- @WARN -Werror=upgrade-interfaces
 data EmptyInterfaceView = EmptyInterfaceView {}
 
 interface I where

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceContractDoesNotImplementInterface.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceContractDoesNotImplementInterface.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2022, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 module InterfaceContractDoesNotImplementInterface where
 import Daml.Script
 

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceConversions.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceConversions.daml
@@ -1,9 +1,9 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 -- | Test interface conversion functions specifically.
 module InterfaceConversions where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceDoubleSpend.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceDoubleSpend.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 {-# LANGUAGE ApplicativeDo #-}
 
 module InterfaceDoubleSpend where

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceEmpty.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceEmpty.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 -- | Test that empty interfaces are fine.
 module InterfaceEmpty (I, EmptyInterfaceView(..)) where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceEmptyIndirect.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceEmptyIndirect.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 
 -- | Test that empty interfaces work fine across modules.
 module InterfaceEmptyIndirect where

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceEq.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceEq.daml
@@ -1,9 +1,9 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 module InterfaceEq where
 
 import Daml.Script

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceErrors.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceErrors.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
 module InterfaceErrors where
 
 import Daml.Script

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceFunctions.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceFunctions.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 -- | Check that `create`, `signatory`, `observer`, `interfaceTypeRep` work as expected on interface payloads.
 module InterfaceFunctions where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceGuarded.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceGuarded.daml
@@ -2,10 +2,10 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE_EXTENDED
--- @WARN warn-bad-interface-instances
--- @WARN warn-bad-interface-instances
--- @WARN warn-bad-interface-instances
--- @WARN warn-bad-interface-instances
+-- @WARN -Werror=upgrade-interfaces
+-- @WARN -Werror=upgrade-interfaces
+-- @WARN -Werror=upgrade-interfaces
+-- @WARN -Werror=upgrade-interfaces
 
 module InterfaceGuarded where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceMethodInMethod.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceMethodInMethod.daml
@@ -1,10 +1,10 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 -- regression test for https://github.com/digital-asset/daml/issues/15459
 
 module InterfaceMethodInMethod where

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceMissingMethod.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceMissingMethod.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 -- @ERROR range=21:5-22:32;error type checking template InterfaceMissingMethod.T interface instance InterfaceMissingMethod:I for InterfaceMissingMethod:T: Interface instance lacks an implementation for method 'm'
 
 module InterfaceMissingMethod where

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceRequiresError.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceRequiresError.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 -- @ERROR range=26:5-27:32;error type checking template InterfaceRequiresError.T interface instance InterfaceRequiresError:B for InterfaceRequiresError:T: Missing required 'interface instance InterfaceRequiresError:A for InterfaceRequiresError:T', required by interface 'InterfaceRequiresError:B'
 
 -- | Check that interface hierarchy is enforced. So if interface B requires

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceSyntax.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceSyntax.daml
@@ -1,9 +1,9 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 
 module InterfaceSyntax where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceTypeRepCheck.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceTypeRepCheck.daml
@@ -1,9 +1,9 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 -- @ERROR Attempt to fetch or exercise a wrongly typed contract
 
 -- | Verify that you can't accidentally exercise a T1 template

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.daml
@@ -1,10 +1,10 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 
 -- | Try out some upcasts and downcasts, checking that everything works.
 module InterfaceUpcastDowncast where

--- a/sdk/compiler/damlc/tests/daml-test-files/LfInterfaces.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/LfInterfaces.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 
 module LfInterfaces where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/QualifiedInterface.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/QualifiedInterface.daml
@@ -3,8 +3,8 @@
 
 {-# LANGUAGE ApplicativeDo #-}
 
--- @ WARN warn-bad-interface-instances
--- @ WARN warn-bad-interface-instances
+-- @ WARN -Werror=upgrade-interfaces
+-- @ WARN -Werror=upgrade-interfaces
 
 module QualifiedInterface where
 

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -82,6 +82,7 @@ import Options.Applicative (execParser, forwardOptions, info, many, strArgument)
 import Outputable (ppr, showSDoc)
 import qualified Proto3.Suite.JSONPB as JSONPB
 import DA.Daml.Project.Types (unsafeResolveReleaseVersion, parseUnresolvedVersion)
+import DA.Daml.LF.TypeChecker.Error (DamlWarningFlag(..), DamlWarningFlagStatus(..), upgradeInterfacesName, upgradeInterfacesFilter)
 
 import Test.Tasty
 import Test.Tasty.Golden (goldenVsStringDiff)
@@ -331,7 +332,7 @@ getIntegrationTests registerTODO scenarioService (packageDbPath, packageFlags) =
                 , optPackageImports = packageFlags
                 , optDetailLevel = PrettyLevel (-1)
                 , optEnableInterfaces = EnableInterfaces True
-                , optUpgradeInfo = (optUpgradeInfo opts0) { uiWarnBadInterfaceInstances = True }
+                , optDamlWarningFlags = [RawDamlWarningFlag upgradeInterfacesName AsWarning upgradeInterfacesFilter]
                 }
 
               mkIde options = do

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -857,7 +857,7 @@ tests damlc =
           , "  - --enable-interfaces=yes"
           ]
             ++ ["  - --typecheck-upgrades=no" | not doTypecheck]
-            ++ ["  - --warn-bad-interface-instances=yes" | warnBadInterfaceInstances ]
+            ++ ["  - -Wupgrade-interfaces" | warnBadInterfaceInstances ]
             ++ ["upgrades: '" <> path <> "'" | Just path <- pure upgradedFile]
             ++ renderDataDeps deps
         )

--- a/sdk/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -2707,7 +2707,7 @@ tests TestArgs{..} =
         { buildOptions =
             [ "--target=" <> LF.renderVersion targetDevVersion
             , "--enable-interfaces=yes"
-            , "--warn-bad-interface-instances=yes"
+            , "-Wupgrade-interfaces"
             ]
         , extraDeps = []
         }

--- a/sdk/compiler/damlc/tests/src/DamlcTest.hs
+++ b/sdk/compiler/damlc/tests/src/DamlcTest.hs
@@ -105,7 +105,7 @@ testsForDamlcValidate damlc = testGroup "damlc validate-dar"
         , "dependencies: [daml-prim, daml-stdlib]"
         , "build-options:"
         , "- --enable-interfaces=yes"
-        , "- --warn-bad-interface-instances=yes"
+        , "- -Wupgrade-interfaces"
         ]
       writeFileUTF8 (projDir </> "Good.daml") $ unlines
         [ "module Good where"
@@ -133,7 +133,7 @@ testsForDamlcValidate damlc = testGroup "damlc validate-dar"
         , "dependencies: [daml-prim, daml-stdlib]"
         , "build-options:"
         , "- --enable-interfaces=yes"
-        , "- --warn-bad-interface-instances=yes"
+        , "- -Wupgrade-interfaces"
         ]
       writeFileUTF8 (projDir </> "Interface.daml") $ unlines
         [ "module Interface where"

--- a/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -126,7 +126,7 @@ damlStart tmpDir disableUpgradeValidation = do
             , "    output-directory: ui/java"
             , "build-options:"
             , "- --target=2.1"
-            ] ++ [ "- --warn-bad-interface-instances=yes" |  disableUpgradeValidation ]
+            ] ++ [ "- -Wupgrade-interfaces" |  disableUpgradeValidation ]
     writeFileUTF8 (projDir </> "daml/Main.daml") $
         unlines
             [ "module Main where"

--- a/sdk/docs/BUILD.bazel
+++ b/sdk/docs/BUILD.bazel
@@ -389,7 +389,7 @@ java_binary(
 daml_test(
     name = "ledger-api-daml-test",
     srcs = glob(["source/app-dev/code-snippets/**/*.daml"]),
-    additional_compiler_flags = ["--warn-bad-interface-instances=yes"],
+    additional_compiler_flags = ["-Wupgrade-interfaces"],
     # TODO(https://github.com/digital-asset/daml/issues/18457): remove contract
     #   keys from the docs, delete the explicit target, and revert the
     #   daml-script.dar to the non-dev version.
@@ -400,7 +400,7 @@ daml_test(
 daml_test(
     name = "bindings-java-daml-test",
     srcs = glob(["source/app-dev/bindings-java/code-snippets/**/*.daml"]),
-    additional_compiler_flags = ["--warn-bad-interface-instances=yes"],
+    additional_compiler_flags = ["-Wupgrade-interfaces"],
     enable_interfaces = True,
     # TODO(https://github.com/digital-asset/daml/issues/18457): remove contract
     #   keys from the docs and delete the explicit target.
@@ -430,7 +430,7 @@ daml_test(
     name = "daml-ref-daml-test",
     timeout = "long",
     srcs = glob(["source/daml/code-snippets/**/*.daml"]),
-    additional_compiler_flags = ["--warn-bad-interface-instances=yes"],
+    additional_compiler_flags = ["-Wupgrade-interfaces"],
     # TODO(https://github.com/digital-asset/daml/issues/18457): remove contract keys from the
     #  docs, delete the explicit target, and revert the daml-script.dar to the non-dev version.
     target = "2.dev",
@@ -442,7 +442,7 @@ daml_test(
         name = "daml-ref-daml-test-{}".format(version),
         timeout = "long",
         srcs = glob(["source/daml/code-snippets-dev/**/*.daml"]),
-        additional_compiler_flags = ["--warn-bad-interface-instances=yes"],
+        additional_compiler_flags = ["-Wupgrade-interfaces"],
         enable_interfaces = True,
         target = version,
     )
@@ -497,7 +497,7 @@ daml_test(
     srcs = glob(
         ["source/daml/intro/daml/daml-intro-13/**/*.daml"],
     ),
-    additional_compiler_flags = ["--warn-bad-interface-instances=yes"],
+    additional_compiler_flags = ["-Wupgrade-interfaces"],
     enable_interfaces = True,
     target = "2.1",
     deps = ["//daml-script/daml:daml-script-2.1.dar"],
@@ -508,7 +508,7 @@ daml_test(
     srcs = glob(
         ["source/daml/intro/daml/daml-intro-12-part1/**/*.daml"],
     ),
-    additional_compiler_flags = ["--warn-bad-interface-instances=yes"],
+    additional_compiler_flags = ["-Wupgrade-interfaces"],
     enable_interfaces = True,
     target = "2.1",
     deps = ["//daml-script/daml:daml-script-2.1.dar"],
@@ -529,7 +529,7 @@ daml_test(
     srcs = glob(
         ["source/daml/intro/daml/daml-intro-12-part2/**/*.daml"],
     ),
-    additional_compiler_flags = ["--warn-bad-interface-instances=yes"],
+    additional_compiler_flags = ["-Wupgrade-interfaces"],
     data_deps = ["daml-intro12-part1.dar"],
     enable_interfaces = True,
     target = "2.1",

--- a/sdk/docs/source/daml-script/template-root/daml.yaml.template
+++ b/sdk/docs/source/daml-script/template-root/daml.yaml.template
@@ -6,7 +6,7 @@ version: 0.0.1
 build-options:
   - --target=2.1
   - --enable-interfaces=yes
-  - --warn-bad-interface-instances=yes
+  - -Wupgrade-interfaces
 # script-build-options-end
 # script-dependencies-begin
 dependencies:

--- a/sdk/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
+++ b/sdk/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
@@ -5,6 +5,7 @@ module Options.Applicative.Extended
     ( YesNoAuto (..)
     , flagYesNoAuto
     , flagYesNoAuto'
+    , flagYesNoAuto''
     , determineAuto
     , determineAutoM
     , optionOnce
@@ -45,7 +46,13 @@ determineAutoM m = \case
 -- This maps yes to "Just true", no to "Just False" and auto to "Nothing"
 flagYesNoAuto' :: String -> String -> Mod OptionFields YesNoAuto -> Parser YesNoAuto
 flagYesNoAuto' flagName helpText mods =
-    optionOnce reader (long flagName <> value Auto <> help helpText <> completeWith ["true", "false", "yes", "no", "auto"] <> mods)
+    flagYesNoAuto'' flagName helpText (value Auto <> mods)
+
+-- | This constructs flags that can be set to yes, no, or auto, with no default
+-- This maps yes to "Just true", no to "Just False" and auto to "Nothing"
+flagYesNoAuto'' :: String -> String -> Mod OptionFields YesNoAuto -> Parser YesNoAuto
+flagYesNoAuto'' flagName helpText mods =
+    optionOnce reader (long flagName <> help helpText <> completeWith ["true", "false", "yes", "no", "auto"] <> mods)
   where reader = eitherReader $ \case
             "yes" -> Right Yes
             "true" -> Right Yes


### PR DESCRIPTION
Originally requested by Sam to make the output of Daml Finance less noisy

Modelled after GCC's method:

- `-W<name>` turns any error of class `name` into a warning
- `-Werror=<name>` turns any warning of class `name` into an error
- `-Wno-<name>` disables the `name` warning/error completely, so it is omitted from the output

Currently, on 3.x we only support -Wupgrade-interfaces

TODO: Support --disable-warn-large-tuples