### PR TITLE
Add standardized flags for downgrading/upgrading warnings from/to errors

### DIFF
--- a/sdk/compiler/daml-lf-tools/BUILD.bazel
+++ b/sdk/compiler/daml-lf-tools/BUILD.bazel
@@ -29,7 +29,6 @@ da_haskell_library(
     deps = [
         "//compiler/daml-lf-ast",
         "//compiler/damlc/daml-lf-util",
-        "//compiler/damlc/daml-opts:daml-opts-types",
         "//compiler/damlc/daml-package-config",
         "//libs-haskell/da-hs-base",
     ],

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
@@ -31,8 +31,8 @@ module DA.Daml.LF.TypeChecker.Env(
     Gamma(..),
     emptyGamma,
     SomeErrorOrWarning(..),
-    addDiagnosticSwapIndicator,
-    withDiagnosticSwapIndicatorF,
+    getWarningStatusF,
+    damlWarningFlags,
     ) where
 
 import           Control.Lens hiding (Context)
@@ -56,7 +56,7 @@ data Gamma = Gamma
     -- ^ The packages in scope.
   , _lfVersion :: Version
     -- ^ The Daml-LF version of the package being type checked.
-  , _diagnosticSwapIndicator :: Either WarnableError Warning -> Bool
+  , _damlWarningFlags :: [DamlWarningFlag]
     -- ^ Function for relaxing errors into warnings and strictifying warnings into errors
   }
 
@@ -68,23 +68,10 @@ class SomeErrorOrWarning d where
 getLfVersion :: MonadGamma m => m Version
 getLfVersion = view lfVersion
 
-getDiagnosticSwapIndicatorF :: forall m gamma. MonadGammaF gamma m => Getter gamma Gamma -> m (Either WarnableError Warning -> Bool)
-getDiagnosticSwapIndicatorF getter = view (getter . diagnosticSwapIndicator)
-
-addDiagnosticSwapIndicator
-  :: (Either WarnableError Warning -> Maybe Bool)
-  -> Gamma -> Gamma
-addDiagnosticSwapIndicator newIndicator =
-  diagnosticSwapIndicator %~ \oldIndicator err ->
-    case newIndicator err of
-      Nothing -> oldIndicator err
-      Just verdict -> verdict
-
-withDiagnosticSwapIndicatorF
-  :: MonadGammaF gamma m
-  => Setter' gamma Gamma -> (Either WarnableError Warning -> Maybe Bool) -> m () -> m ()
-withDiagnosticSwapIndicatorF setter newIndicator =
-  locally setter (addDiagnosticSwapIndicator newIndicator)
+getWarningStatusF :: forall m gamma. MonadGammaF gamma m => Getter gamma Gamma -> WarnableError -> m DamlWarningFlagStatus
+getWarningStatusF getter warnableError = do
+  flags <- view (getter . damlWarningFlags)
+  pure (getWarningStatus flags warnableError)
 
 getWorld :: MonadGamma m => m World
 getWorld = view world
@@ -117,7 +104,7 @@ match p e x = either (const (throwWithContext e)) pure (matching p x)
 -- | Environment containing only the packages in scope but no type or term
 -- variables.
 emptyGamma :: World -> Version -> Gamma
-emptyGamma world version = Gamma ContextNone mempty mempty world version (const False)
+emptyGamma world version = Gamma ContextNone mempty mempty world version []
 
 -- | Run a computation in the current environment extended by a new type
 -- variable/kind binding. Does not fail on shadowing.
@@ -158,7 +145,7 @@ diagnosticWithContext = diagnosticWithContextF id
 throwWithContext :: MonadGamma m => UnwarnableError -> m a
 throwWithContext = throwWithContextF id
 
-warnWithContext :: MonadGamma m => Warning -> m ()
+warnWithContext :: MonadGamma m => StandaloneWarning -> m ()
 warnWithContext = warnWithContextF id
 
 withContext :: MonadGamma m => Context -> m b -> m b
@@ -175,8 +162,13 @@ throwWithContextFRaw getter err = do
   ctx <- view $ getter . locCtx
   throwError $ EContext ctx err
 
-warnWithContextF :: forall m gamma. MonadGammaF gamma m => Getter gamma Gamma -> Warning -> m ()
-warnWithContextF = diagnosticWithContextF
+warnWithContextF :: forall m gamma. MonadGammaF gamma m => Getter gamma Gamma -> StandaloneWarning -> m ()
+warnWithContextF getter warning = warnWithContextFRaw getter (WStandaloneWarning warning)
+
+warnWithContextFRaw :: forall m gamma. MonadGammaF gamma m => Getter gamma Gamma -> Warning -> m ()
+warnWithContextFRaw getter warning = do
+  ctx <- view $ getter . locCtx
+  modify' (WContext ctx warning :)
 
 withContextF :: MonadGammaF gamma m => Setter' gamma Gamma -> Context -> m b -> m b
 withContextF setter newCtx = local (over (setter . locCtx) setCtx)
@@ -193,20 +185,11 @@ instance SomeErrorOrWarning UnwarnableError where
 
 instance SomeErrorOrWarning WarnableError where
   diagnosticWithContextF getter err = do
-    shouldSwap <- getDiagnosticSwapIndicatorF getter
-    if shouldSwap (Left err)
-       then do
-        ctx <- view $ getter . locCtx
-        modify' (WContext ctx (WErrorToWarning err) :)
-       else do
-        throwWithContextFRaw getter (EWarnableError err)
+    status <- getWarningStatusF getter err
+    case status of
+      AsError -> throwWithContextFRaw getter (EWarnableError err)
+      AsWarning -> warnWithContextFRaw getter (WErrorToWarning err)
+      Hidden -> pure ()
 
-instance SomeErrorOrWarning Warning where
-  diagnosticWithContextF getter warning = do
-    shouldSwap <- getDiagnosticSwapIndicatorF getter
-    if shouldSwap (Right warning)
-       then do
-        throwWithContextFRaw getter (EWarningToError warning)
-       else do
-        ctx <- view $ getter . locCtx
-        modify' (WContext ctx warning :)
+instance SomeErrorOrWarning StandaloneWarning where
+  diagnosticWithContextF = warnWithContextF

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -275,7 +275,7 @@ instance Pretty ErrorOrWarning where
 
 data DamlWarningFlagStatus
   = AsError -- -Werror=<name>
-  | AsWarning -- -W<name>
+  | AsWarning -- -W<name> or -Wwarn=<name> or -Wno-error=<name>
   | Hidden -- -Wno-<name>
 
 data DamlWarningFlag
@@ -284,8 +284,12 @@ data DamlWarningFlag
     , rfStatus :: DamlWarningFlagStatus
     , rfFilter :: ErrorOrWarning -> Bool
     }
-  | WarnBadInterfaceInstances Bool -- When true, same as -Wupgrade-interfaces
+  | WarnBadInterfaceInstances Bool
+  -- ^ For legacy --warn-bad-interface-instance flag.
+  -- Interpreted identically to -Wupgrade-interfaces
   | WarnBadExceptions Bool
+  -- ^ For legacy --warn-bad-exceptions flag.
+  -- Interpreted identically to -Wupgrade-exceptions
 
 parseRawDamlWarningFlag :: String -> Either String DamlWarningFlag
 parseRawDamlWarningFlag = \case

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -297,7 +297,7 @@ parseRawDamlWarningFlag = \case
   name -> RawDamlWarningFlag name AsWarning <$> parseNameE name
   where
   parseNameE name = case lookup name namesToFilters of
-    Nothing -> Left $ "Warning flag is not valid - warning flags must be of the form `error=<name>`, `no-<name>`, or `<name>`. Available names are: " <> L.intercalate ", " (map fst namesToFilters)
+    Nothing -> Left $ "Warning flag is not valid - warning flags must be of the form `-Werror=<name>`, `-Wno-<name>`, or `-W<name>`. Available names are: " <> L.intercalate ", " (map fst namesToFilters)
     Just filter -> Right filter
 
 namesToFilters :: [(String, WarnableError -> Bool)]

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -298,7 +298,7 @@ parseRawDamlWarningFlag = \case
   where
   parseNameE name = case lookup name namesToFilters of
     Nothing -> Left $ "Warning flag is not valid - warning flags must be of the form `-Werror=<name>`, `-Wno-<name>`, or `-W<name>`. Available names are: " <> L.intercalate ", " (map fst namesToFilters)
-    Just filter -> Right filter
+    Just rfFilter -> Right rfFilter
 
 namesToFilters :: [(String, WarnableError -> Bool)]
 namesToFilters =

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -291,7 +291,9 @@ data DamlWarningFlag
 parseRawDamlWarningFlag :: String -> Either String DamlWarningFlag
 parseRawDamlWarningFlag = \case
   ('e':'r':'r':'o':'r':'=':name) -> RawDamlWarningFlag name AsError <$> parseNameE name
+  ('n':'o':'-':'e':'r':'r':'o':'r':'=':name) -> RawDamlWarningFlag name AsWarning <$> parseNameE name
   ('n':'o':'-':name) -> RawDamlWarningFlag name Hidden <$> parseNameE name
+  ('w':'a':'r':'n':'=':name) -> RawDamlWarningFlag name AsWarning <$> parseNameE name
   name -> RawDamlWarningFlag name AsWarning <$> parseNameE name
   where
   parseNameE name = case lookup name namesToFilters of

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -19,7 +19,6 @@ import qualified DA.Daml.LF.Ast.Alpha as Alpha
 import           DA.Daml.LF.TypeChecker.Check (expandTypeSynonyms)
 import           DA.Daml.LF.TypeChecker.Env
 import           DA.Daml.LF.TypeChecker.Error
-import           DA.Daml.Options.Types (UpgradeInfo (..))
 import           Data.Either (partitionEithers)
 import           Data.Hashable
 import qualified Data.HashMap.Strict as HMS
@@ -36,7 +35,17 @@ import Control.DeepSeq (NFData)
 
 -- Allows us to split the world into upgraded and non-upgraded
 type TcUpgradeM = TcMF UpgradingEnv
-type TcPreUpgradeM = TcMF (Version, UpgradeInfo)
+type TcPreUpgradeM = TcMF PreUpgradingEnv
+data PreUpgradingEnv = PreUpgradingEnv
+  { pueVersion :: Version
+  , pueUpgradeInfo :: UpgradeInfo
+  , pueWarningFlags :: [DamlWarningFlag]
+  }
+
+data UpgradeInfo = UpgradeInfo
+  { uiUpgradedPackagePath :: Maybe FilePath
+  , uiTypecheckUpgrades :: Bool
+  }
 
 type DepsMap = HMS.HashMap LF.PackageId UpgradingDep
 
@@ -68,41 +77,23 @@ runGammaUnderUpgrades Upgrading{ _past = pastAction, _present = presentAction } 
     presentResult <- withReaderT (_present . _upgradingGamma) presentAction
     pure Upgrading { _past = pastResult, _present = presentResult }
 
-shouldTypecheck :: Version -> UpgradeInfo -> Bool
-shouldTypecheck version upgradeInfo = version `LF.supports` LF.featurePackageUpgrades && uiTypecheckUpgrades upgradeInfo
+shouldTypecheck :: PreUpgradingEnv -> Bool
+shouldTypecheck PreUpgradingEnv { pueVersion, pueUpgradeInfo } = pueVersion `LF.supports` LF.featurePackageUpgrades && uiTypecheckUpgrades pueUpgradeInfo
 
 shouldTypecheckM :: TcPreUpgradeM Bool
-shouldTypecheckM = asks (uncurry shouldTypecheck)
+shouldTypecheckM = asks shouldTypecheck
 
-mkGamma :: Version -> UpgradeInfo -> World -> Gamma
-mkGamma version upgradeInfo world =
-    let addBadIfaceSwapIndicator, addBadExceptionSwapIndicator :: Gamma -> Gamma
-        addBadIfaceSwapIndicator =
-            if uiWarnBadInterfaceInstances upgradeInfo
-            then
-                addDiagnosticSwapIndicator (\case
-                    Left WEUpgradeShouldDefineIfaceWithoutImplementation {} -> Just True
-                    Left WEUpgradeShouldDefineTplInSeparatePackage {} -> Just True
-                    Left WEUpgradeShouldDefineIfacesAndTemplatesSeparately {} -> Just True
-                    _ -> Nothing)
-            else id
-        addBadExceptionSwapIndicator =
-            if uiWarnBadExceptions upgradeInfo
-            then
-                addDiagnosticSwapIndicator (\case
-                    Left WEUpgradeShouldDefineExceptionsAndTemplatesSeparately {} -> Just True
-                    _ -> Nothing)
-            else id
-    in
-    addBadExceptionSwapIndicator $ addBadIfaceSwapIndicator $ emptyGamma world version
+mkGamma :: PreUpgradingEnv -> World -> Gamma
+mkGamma PreUpgradingEnv { pueVersion, pueWarningFlags } world =
+    set damlWarningFlags pueWarningFlags (emptyGamma world pueVersion)
 
 gammaM :: World -> TcPreUpgradeM Gamma
-gammaM world = asks (flip (uncurry mkGamma) world)
+gammaM world = asks (flip mkGamma world)
 
 {- HLINT ignore "Use nubOrd" -}
-extractDiagnostics :: Version -> UpgradeInfo -> TcPreUpgradeM () -> [Diagnostic]
-extractDiagnostics version upgradeInfo action =
-  case runGammaF (version, upgradeInfo) action of
+extractDiagnostics :: Version -> UpgradeInfo -> [DamlWarningFlag] -> TcPreUpgradeM () -> [Diagnostic]
+extractDiagnostics version upgradeInfo warningFlags action =
+  case runGammaF (PreUpgradingEnv version upgradeInfo warningFlags) action of
     Left err -> [toDiagnostic err]
     Right ((), warnings) -> map toDiagnostic (nub warnings)
 
@@ -116,18 +107,18 @@ unitIdDalfPackageToUpgradedPkg (unitId, dalfPkg) =
 
 checkPackage
   :: LF.Package
-  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo
+  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo -> [DamlWarningFlag]
   -> Maybe (UpgradedPkgWithNameAndVersion, [UpgradedPkgWithNameAndVersion])
   -> [Diagnostic]
 checkPackage = checkPackageToDepth CheckOnlyMissingModules
 
 checkPackageToDepth
   :: CheckDepth -> LF.Package
-  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo
+  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo -> [DamlWarningFlag]
   -> Maybe (UpgradedPkgWithNameAndVersion, [UpgradedPkgWithNameAndVersion])
   -> [Diagnostic]
-checkPackageToDepth checkDepth pkg deps version upgradeInfo mbUpgradedPkg =
-  extractDiagnostics version upgradeInfo $ do
+checkPackageToDepth checkDepth pkg deps version upgradeInfo warningFlags mbUpgradedPkg =
+  extractDiagnostics version upgradeInfo warningFlags $ do
     shouldTypecheck <- shouldTypecheckM
     when shouldTypecheck $ do
       case mbUpgradedPkg of
@@ -147,7 +138,7 @@ checkPackageBoth checkDepth mbContext pkg ((upgradedPkgId, upgradedPkg), depsMap
           Nothing -> id
           Just context -> withContextF present' context
   in
-  withReaderT (\(version, upgradeInfo) -> UpgradingEnv (mkGamma version upgradeInfo <$> upgradingWorld) depsMap) $
+  withReaderT (\preEnv -> UpgradingEnv (mkGamma preEnv <$> upgradingWorld) depsMap) $
     withMbContext $
       checkPackageM checkDepth (UpgradedPackageId upgradedPkgId) (Upgrading upgradedPkg pkg)
 
@@ -160,21 +151,22 @@ checkPackageSingle mbContext pkg =
       withMbContext :: TcM () -> TcM ()
       withMbContext = maybe id withContext mbContext
   in
-  withReaderT (\(version, upgradeInfo) -> mkGamma version upgradeInfo presentWorld) $
+  withReaderT (\preEnv -> mkGamma preEnv presentWorld) $
     withMbContext $ do
       checkNewInterfacesAreUnused pkg
       checkInterfacesAndExceptionsHaveNoTemplates
 
 checkModule
   :: LF.World -> LF.Module
-  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo
+  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo -> [DamlWarningFlag]
   -> Maybe (UpgradedPkgWithNameAndVersion, [UpgradedPkgWithNameAndVersion])
   -> [Diagnostic]
-checkModule world0 module_ deps version upgradeInfo mbUpgradedPkg =
-  extractDiagnostics version upgradeInfo $
-    when (shouldTypecheck version upgradeInfo) $ do
+checkModule world0 module_ deps version upgradeInfo warningFlags mbUpgradedPkg =
+  extractDiagnostics version upgradeInfo warningFlags $ do
+    shouldTypecheck <- shouldTypecheckM
+    when shouldTypecheck $ do
       let world = extendWorldSelf module_ world0
-      withReaderT (\(version, upgradeInfo) -> mkGamma version upgradeInfo world) $ do
+      withReaderT (\preEnv -> mkGamma preEnv world) $ do
         checkNewInterfacesAreUnused module_
         checkInterfacesAndExceptionsHaveNoTemplates
       case mbUpgradedPkg of
@@ -184,7 +176,7 @@ checkModule world0 module_ deps version upgradeInfo mbUpgradedPkg =
             -- TODO: https://github.com/digital-asset/daml/issues/19859
             depsMap <- checkUpgradeDependenciesM deps (upgradedPkgWithId : upgradingDeps)
             let upgradingWorld = Upgrading { _past = initWorldSelf [] (upwnavPkg upgradedPkgWithId), _present = world }
-            withReaderT (\(version, upgradeInfo) -> UpgradingEnv (mkGamma version upgradeInfo <$> upgradingWorld) depsMap) $
+            withReaderT (\preEnv -> UpgradingEnv (mkGamma preEnv <$> upgradingWorld) depsMap) $
               case NM.lookup (NM.name module_) (LF.packageModules (upwnavPkg upgradedPkgWithId)) of
                 Nothing -> pure ()
                 Just pastModule -> do
@@ -202,12 +194,12 @@ checkUpgradeDependenciesM presentDeps pastDeps = do
             case upwnavVersion of
               Nothing -> do
                 when (pkgSupportsUpgrades upwnavPkg && PackageName "daml-prim" /= upwnavName) $
-                  diagnosticWithContext $ WErrorToWarning $ WEDependencyHasNoMetadataDespiteUpgradeability upwnavPkgId UpgradedPackage
+                  diagnosticWithContext $ WEDependencyHasNoMetadataDespiteUpgradeability upwnavPkgId UpgradedPackage
                 pure $ Just (upwnavName, [(Nothing, upwnavPkgId, upwnavPkg)])
               Just packageVersion -> do
                 case splitPackageVersion id packageVersion of
                   Left version -> do
-                    diagnosticWithContext $ WErrorToWarning $ WEDependencyHasUnparseableVersion upwnavName version UpgradedPackage
+                    diagnosticWithContext $ WEDependencyHasUnparseableVersion upwnavName version UpgradedPackage
                     pure Nothing
                   Right rawVersion ->
                     pure $ Just (upwnavName, [(Just rawVersion, upwnavPkgId, upwnavPkg)])
@@ -231,7 +223,7 @@ checkUpgradeDependenciesM presentDeps pastDeps = do
     where
     withPkgAsGamma :: Package -> TcM a -> TcPreUpgradeM a
     withPkgAsGamma pkg action =
-      withReaderT (\(version, _) -> emptyGamma (initWorldSelf [] pkg) version) action
+      withReaderT (\pue -> emptyGamma (initWorldSelf [] pkg) (pueVersion pue)) action
 
     upgradeablePackageMapToDeps :: UpgradeablePackageMap -> DepsMap
     upgradeablePackageMapToDeps upgradeablePackageMap =
@@ -284,12 +276,12 @@ checkUpgradeDependenciesM presentDeps pastDeps = do
         case mbPkgVersion of
             Nothing -> do
               when (pkgSupportsUpgrades presentPkg && PackageName "daml-prim" /= packageName) $
-                diagnosticWithContext $ WErrorToWarning $ WEDependencyHasNoMetadataDespiteUpgradeability presentPkgId UpgradedPackage
+                diagnosticWithContext $ WEDependencyHasNoMetadataDespiteUpgradeability presentPkgId UpgradedPackage
               pure $ Just (packageName, (Nothing, presentPkgId, presentPkg))
             Just packageVersion ->
               case splitPackageVersion id packageVersion of
                 Left version -> do
-                  diagnosticWithContext $ WErrorToWarning $ WEDependencyHasUnparseableVersion packageName version UpgradedPackage
+                  diagnosticWithContext $ WEDependencyHasUnparseableVersion packageName version UpgradedPackage
                   pure Nothing
                 Right presentVersion -> do
                   let result = (packageName, (Just presentVersion, presentPkgId, presentPkg))

--- a/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -26,6 +26,7 @@ import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Resource (ResourceT)
 import qualified DA.Daml.LF.Ast as LF
 import DA.Daml.LF.Proto3.Archive (encodeArchiveAndHash)
+import DA.Daml.LF.TypeChecker.Error (DamlWarningFlag)
 import DA.Daml.LF.TypeChecker.Upgrade as Upgrade
 import DA.Daml.Options (expandSdkPackages)
 import DA.Daml.Options.Types
@@ -111,8 +112,9 @@ buildDar ::
     -> NormalizedFilePath
     -> FromDalf
     -> UpgradeInfo
+    -> [DamlWarningFlag]
     -> IO (Maybe (Zip.ZipArchive (), Maybe LF.PackageId))
-buildDar service PackageConfigFields {..} ifDir dalfInput upgradeInfo = do
+buildDar service PackageConfigFields {..} ifDir dalfInput upgradeInfo warningFlags = do
     liftIO $
         IdeLogger.logDebug (ideLogger service) $
         "Creating dar: " <> T.pack pSrc
@@ -162,7 +164,7 @@ buildDar service PackageConfigFields {..} ifDir dalfInput upgradeInfo = do
                  dalfDependencies0 <- getDalfDependencies files
                  MaybeT $
                      runDiagnosticCheck $ diagsToIdeResult (toNormalizedFilePath' pSrc) $
-                         Upgrade.checkPackage pkg (map Upgrade.unitIdDalfPackageToUpgradedPkg (Map.toList dalfDependencies0)) lfVersion upgradeInfo mbUpgradedPackage
+                         Upgrade.checkPackage pkg (map Upgrade.unitIdDalfPackageToUpgradedPkg (Map.toList dalfDependencies0)) lfVersion upgradeInfo warningFlags mbUpgradedPackage
                  let dalfDependencies =
                          [ (T.pack $ unitIdString unitId, LF.dalfPackageBytes pkg, LF.dalfPackageId pkg)
                          | (unitId, pkg) <- Map.toList dalfDependencies0

--- a/sdk/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/sdk/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -311,7 +311,7 @@ generateDalfRule opts =
             Left err -> ([ideErrorPretty file err], Nothing)
             Right dalf ->
                 let lfDiags = LF.checkModule world lfVersion dalf
-                    upgradeDiags = Upgrade.checkModule world dalf (map Upgrade.unitIdDalfPackageToUpgradedPkg (foldMap Map.toList mbDalfDependencies)) lfVersion (optUpgradeInfo opts) upgradedPackage
+                    upgradeDiags = Upgrade.checkModule world dalf (map Upgrade.unitIdDalfPackageToUpgradedPkg (foldMap Map.toList mbDalfDependencies)) lfVersion (optUpgradeInfo opts) (optDamlWarningFlags opts) upgradedPackage
                 in second (dalf <$) (diagsToIdeResult file (lfDiags ++ upgradeDiags))
 
 -- TODO Share code with typecheckModule in ghcide. The environment needs to be setup

--- a/sdk/compiler/damlc/daml-opts/BUILD.bazel
+++ b/sdk/compiler/damlc/daml-opts/BUILD.bazel
@@ -25,6 +25,7 @@ da_haskell_library(
     src_strip_prefix = "daml-opts-types",
     visibility = ["//visibility:public"],
     deps = [
+        "//compiler/daml-lf-tools",
         "//compiler/daml-lf-ast",
         "//compiler/damlc/daml-package-config",
         "//daml-assistant:daml-project-config",

--- a/sdk/compiler/damlc/daml-opts/BUILD.bazel
+++ b/sdk/compiler/damlc/daml-opts/BUILD.bazel
@@ -25,8 +25,8 @@ da_haskell_library(
     src_strip_prefix = "daml-opts-types",
     visibility = ["//visibility:public"],
     deps = [
-        "//compiler/daml-lf-tools",
         "//compiler/daml-lf-ast",
+        "//compiler/daml-lf-tools",
         "//compiler/damlc/daml-package-config",
         "//daml-assistant:daml-project-config",
         "//libs-haskell/bazel-runfiles",

--- a/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -56,6 +56,8 @@ import DynFlags (ModRenaming(..), PackageFlag(..), PackageArg(..))
 import Module (UnitId, stringToUnitId)
 import qualified System.Directory as Dir
 import System.FilePath
+import DA.Daml.LF.TypeChecker.Error
+import DA.Daml.LF.TypeChecker.Upgrade (UpgradeInfo(..))
 
 -- | Orphan instances for debugging
 instance Show PackageFlag where
@@ -136,14 +138,8 @@ data Options = Options
   -- ^ When running in IDE, some rules need access to the package name and version, but we don't want to use own
   -- unit-id, as script + scenario service assume it will be "main"
   , optUpgradeInfo :: UpgradeInfo
+  , optDamlWarningFlags :: [DamlWarningFlag]
   }
-
-data UpgradeInfo = UpgradeInfo
-    { uiUpgradedPackagePath :: Maybe FilePath
-    , uiTypecheckUpgrades :: Bool
-    , uiWarnBadInterfaceInstances :: Bool
-    , uiWarnBadExceptions :: Bool
-    }
 
 newtype IncrementalBuild = IncrementalBuild { getIncrementalBuild :: Bool }
   deriving Show
@@ -286,14 +282,13 @@ defaultOptions mbVersion =
         , optAllowLargeTuples = AllowLargeTuples False
         , optHideUnitId = False
         , optUpgradeInfo = defaultUpgradeInfo
+        , optDamlWarningFlags = []
         }
 
 defaultUpgradeInfo :: UpgradeInfo
 defaultUpgradeInfo = UpgradeInfo
     { uiUpgradedPackagePath = Nothing
     , uiTypecheckUpgrades = defaultUiTypecheckUpgrades
-    , uiWarnBadInterfaceInstances = defaultUiWarnBadInterfaceInstances
-    , uiWarnBadExceptions = defaultUiWarnBadExceptions
     }
 
 defaultUiTypecheckUpgrades, defaultUiWarnBadInterfaceInstances, defaultUiWarnBadExceptions :: Bool

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -150,6 +150,7 @@ import DA.Daml.Options.Types (EnableScenarioService(..),
                               optSkipScenarioValidation,
                               optThreads,
                               optUpgradeInfo,
+                              optDamlWarningFlags,
                               pkgNameVersion,
                               projectPackageDatabase)
 import DA.Daml.Package.Config (MultiPackageConfigFields(..),
@@ -1143,6 +1144,7 @@ buildEffect relativize pkgPath pkgConfig opts mbOutFile incrementalBuild initPkg
               (toNormalizedFilePath' $ fromMaybe ifaceDir $ optIfaceDir opts)
               (FromDalf False)
               (optUpgradeInfo opts)
+              (optDamlWarningFlags opts)
       (dar, mPkgId) <- mbErr "ERROR: Creation of DAR file failed." mbDar
       createDarFile loggerH fp dar
       pure mPkgId
@@ -1605,6 +1607,7 @@ execPackage projectOpts filePath opts mbOutFile dalfInput =
                             (toNormalizedFilePath' $ fromMaybe ifaceDir $ optIfaceDir opts)
                             dalfInput
                             (optUpgradeInfo opts)
+                            (optDamlWarningFlags opts)
           case mbDar of
             Nothing -> do
                 hPutStrLn stderr "ERROR: Creation of DAR file failed."

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/UpgradeCheck.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/UpgradeCheck.hs
@@ -165,7 +165,8 @@ checkPackageAgainstPastPackages ((path, main, deps), pastPackages) = do
                   Upgrade.CheckAll
                   (upwnavPkg main) deps
                   LFV.version2_dev
-                  (UpgradeInfo (Just (fromNormalizedFilePath path)) True True True)
+                  (UpgradeInfo (Just (fromNormalizedFilePath path)) True)
+                  []
                   (Just (closestPastPackageWithLowerVersion, closestPastPackageWithLowerVersionDeps))
           when (not (null errs)) (throwE [CEDiagnostic path errs])
       case minimumByMay ordFst $ pastPackageFilterVersion (\v -> v > rawVersion) of
@@ -176,7 +177,8 @@ checkPackageAgainstPastPackages ((path, main, deps), pastPackages) = do
                   Upgrade.CheckAll
                   (upwnavPkg closestPastPackageWithHigherVersion) closestPastPackageWithHigherVersionDeps
                   LFV.version2_dev
-                  (UpgradeInfo (Just (fromNormalizedFilePath path)) True True True)
+                  (UpgradeInfo (Just (fromNormalizedFilePath path)) True)
+                  []
                   (Just (main, deps))
           when (not (null errs)) (throwE [CEDiagnostic path errs])
 

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -587,9 +587,9 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
     optWarnBadInterfaceInstances =
       determineAuto defaultUiWarnBadInterfaceInstances <$>
         flagYesNoAuto''
-          "-Wupgrade-interfaces"
-          "Convert errors about bad, non-upgradeable interface instances into warnings."
-          idm
+          "warn-bad-interface-instances"
+          "(Deprecated) Convert errors about bad, non-upgradeable interface instances into warnings."
+          hidden
 
     optDamlWarningFlag :: Parser DamlWarningFlag
     optDamlWarningFlag =
@@ -605,9 +605,9 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
       where
       helpStr =
         PAL.vcat
-          [ "Downgrade errors to warnings with -W<name>"
-          , "upgrade warnings to errors with -Werror=<name>"
-          , "disable warnings and errors with -Wno-<name>"
+          [ "Turn an error into a warning with -W<name>"
+          , "Turn a warning into an error with -Werror=<name>"
+          , "Disable warnings and errors with -Wno-<name>"
           , "Available names are: " <> PAL.string (intercalate ", " (map fst namesToFilters))
           ]
 
@@ -616,8 +616,8 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
       determineAuto defaultUiWarnBadInterfaceInstances <$>
         flagYesNoAuto''
           "warn-bad-exceptions"
-          "Convert errors about bad, non-upgradeable exceptions into warnings."
-          idm
+          "(Deprecated) Convert errors about bad, non-upgradeable exceptions into warnings."
+          hidden
 
     optUpgradeInfo :: Parser UpgradeInfo
     optUpgradeInfo = do

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -21,6 +21,7 @@ import qualified DA.Service.Logger as Logger
 import qualified Module as GHC
 import qualified Text.ParserCombinators.ReadP as R
 import qualified Data.Text as T
+import DA.Daml.LF.TypeChecker.Error
 
 -- | Pretty-printing documents with syntax-highlighting annotations.
 type Document = Pretty.Doc Pretty.SyntaxClass
@@ -439,6 +440,7 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
     optTestFilter <- compilePatternExpr <$> optTestPattern
     let optHideUnitId = False
     optUpgradeInfo <- optUpgradeInfo
+    optDamlWarningFlags <- many optDamlWarningFlag
 
     return Options{..}
   where
@@ -581,26 +583,30 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
 
     optWarnBadInterfaceInstances :: Parser Bool
     optWarnBadInterfaceInstances =
-      flagYesNoAuto
-        "warn-bad-interface-instances"
-        defaultUiWarnBadInterfaceInstances
-        "Convert errors about bad, non-upgradeable interface instances into warnings."
-        idm
+      determineAuto defaultUiWarnBadInterfaceInstances <$>
+        flagYesNoAuto''
+          "-Wupgrade-interfaces"
+          "Convert errors about bad, non-upgradeable interface instances into warnings."
+          idm
+
+    optDamlWarningFlag :: Parser DamlWarningFlag
+    optDamlWarningFlag =
+      Options.Applicative.option (eitherReader parseDamlWarningFlag) (short 'W' <> long "warn")
+      <|> fmap WarnBadInterfaceInstances optWarnBadInterfaceInstances
+      <|> fmap WarnBadExceptions optWarnBadExceptions
 
     optWarnBadExceptions :: Parser Bool
     optWarnBadExceptions =
-      flagYesNoAuto
-        "warn-bad-exceptions"
-        defaultUiWarnBadExceptions
-        "Convert errors about bad, non-upgradeable exceptions into warnings."
-        idm
+      determineAuto defaultUiWarnBadInterfaceInstances <$>
+        flagYesNoAuto''
+          "warn-bad-exceptions"
+          "Convert errors about bad, non-upgradeable exceptions into warnings."
+          idm
 
     optUpgradeInfo :: Parser UpgradeInfo
     optUpgradeInfo = do
       uiTypecheckUpgrades <- optTypecheckUpgrades
       uiUpgradedPackagePath <- optUpgradeDar
-      uiWarnBadInterfaceInstances <- optWarnBadInterfaceInstances
-      uiWarnBadExceptions <- optWarnBadExceptions
       pure UpgradeInfo {..}
 
 optGhcCustomOptions :: Parser [String]

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -608,7 +608,7 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
           [ "Turn an error into a warning with -W<name> or -Wwarn=<name> or -Wno-error=<name>"
           , "Turn a warning into an error with -Werror=<name>"
           , "Disable warnings and errors with -Wno-<name>"
-          , "Available names are: " <> PAL.string (intercalate ", " (map fst namesToFilters))
+          , "Available names are: " <> PAL.string (intercalate ", " (map fst namesToFlags))
           ]
 
     optWarnBadExceptions :: Parser Bool

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -23,6 +23,8 @@ import qualified Text.ParserCombinators.ReadP as R
 import qualified Data.Text as T
 import DA.Daml.LF.TypeChecker.Error
 
+import qualified Text.PrettyPrint.ANSI.Leijen as PAL
+
 -- | Pretty-printing documents with syntax-highlighting annotations.
 type Document = Pretty.Doc Pretty.SyntaxClass
 
@@ -591,9 +593,23 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
 
     optDamlWarningFlag :: Parser DamlWarningFlag
     optDamlWarningFlag =
-      Options.Applicative.option (eitherReader parseDamlWarningFlag) (short 'W' <> long "warn")
+      optRawDamlWarningFlag
       <|> fmap WarnBadInterfaceInstances optWarnBadInterfaceInstances
       <|> fmap WarnBadExceptions optWarnBadExceptions
+
+    optRawDamlWarningFlag :: Parser DamlWarningFlag
+    optRawDamlWarningFlag =
+      Options.Applicative.option
+        (eitherReader parseRawDamlWarningFlag)
+        (short 'W' <> long "warn" <> helpDoc (Just helpStr))
+      where
+      helpStr =
+        PAL.vcat
+          [ "Downgrade errors to warnings with -W<name>"
+          , "upgrade warnings to errors with -Werror=<name>"
+          , "disable warnings and errors with -Wno-<name>"
+          , "Available names are: " <> PAL.string (intercalate ", " (map fst namesToFilters))
+          ]
 
     optWarnBadExceptions :: Parser Bool
     optWarnBadExceptions =

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -601,11 +601,11 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
     optRawDamlWarningFlag =
       Options.Applicative.option
         (eitherReader parseRawDamlWarningFlag)
-        (short 'W' <> long "warn" <> helpDoc (Just helpStr))
+        (short 'W' <> helpDoc (Just helpStr))
       where
       helpStr =
         PAL.vcat
-          [ "Turn an error into a warning with -W<name>"
+          [ "Turn an error into a warning with -W<name> or -Wwarn=<name> or -Wno-error=<name>"
           , "Turn a warning into an error with -Werror=<name>"
           , "Disable warnings and errors with -Wno-<name>"
           , "Available names are: " <> PAL.string (intercalate ", " (map fst namesToFilters))

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -586,7 +586,7 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
     optWarnBadInterfaceInstances :: Parser Bool
     optWarnBadInterfaceInstances =
       determineAuto defaultUiWarnBadInterfaceInstances <$>
-        flagYesNoAuto''
+        flagYesNoAutoNoDefault
           "warn-bad-interface-instances"
           "(Deprecated) Convert errors about bad, non-upgradeable interface instances into warnings."
           hidden
@@ -614,7 +614,7 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
     optWarnBadExceptions :: Parser Bool
     optWarnBadExceptions =
       determineAuto defaultUiWarnBadInterfaceInstances <$>
-        flagYesNoAuto''
+        flagYesNoAutoNoDefault
           "warn-bad-exceptions"
           "(Deprecated) Convert errors about bad, non-upgradeable exceptions into warnings."
           hidden

--- a/sdk/compiler/damlc/tests/BUILD.bazel
+++ b/sdk/compiler/damlc/tests/BUILD.bazel
@@ -152,6 +152,7 @@ da_haskell_library(
     visibility = ["//visibility:public"],
     deps = [
         "//compiler/daml-lf-ast",
+        "//compiler/daml-lf-tools",
         "//compiler/daml-lf-proto-encode",
         "//compiler/damlc:damlc-lib",
         "//compiler/damlc/daml-compiler",

--- a/sdk/compiler/damlc/tests/BUILD.bazel
+++ b/sdk/compiler/damlc/tests/BUILD.bazel
@@ -152,8 +152,8 @@ da_haskell_library(
     visibility = ["//visibility:public"],
     deps = [
         "//compiler/daml-lf-ast",
-        "//compiler/daml-lf-tools",
         "//compiler/daml-lf-proto-encode",
+        "//compiler/daml-lf-tools",
         "//compiler/damlc:damlc-lib",
         "//compiler/damlc/daml-compiler",
         "//compiler/damlc/daml-ide-core",

--- a/sdk/compiler/damlc/tests/BUILD.bazel
+++ b/sdk/compiler/damlc/tests/BUILD.bazel
@@ -1195,6 +1195,7 @@ da_haskell_test(
     main_function = "DA.Test.ScriptService.main",
     deps = [
         "//compiler/daml-lf-ast",
+        "//compiler/daml-lf-tools",
         "//compiler/damlc:damlc-lib",
         "//compiler/damlc/daml-ide-core",
         "//compiler/damlc/daml-opts:daml-opts-types",

--- a/sdk/compiler/damlc/tests/daml-test-files/ChoiceFunctions.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/ChoiceFunctions.daml
@@ -2,8 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_CHOICE_FUNCS
--- @WARN since-lf=1.17 2.0; warn-bad-interface-instances
--- @WARN since-lf=1.17 2.0; warn-bad-interface-instances
+-- @WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
+-- @WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
 
 module ChoiceFunctions where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/Daml3ScriptTrySubmit.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/Daml3ScriptTrySubmit.daml
@@ -3,8 +3,8 @@
 
 -- @ SCRIPT-V2
 
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
 -- @ WARN range=15:1-15:28; Import of internal module Daml.Script.Internal of package daml3-script is discouraged, as this module will change without warning.
 
 {-# LANGUAGE ApplicativeDo #-}

--- a/sdk/compiler/damlc/tests/daml-test-files/Daml3ScriptTrySubmitConcurrently.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/Daml3ScriptTrySubmitConcurrently.daml
@@ -4,7 +4,7 @@
 -- @ SCRIPT-V2
 
 -- @ WARN range=20:1-20:52; Import of internal module Daml.Script.Internal of package daml3-script is discouraged, as this module will change without warning.
--- @ WARN version=1.17 2.0; -Wupgrade-exceptions
+-- @ WARN -Wupgrade-exceptions
 
 {-# LANGUAGE ApplicativeDo #-}
 

--- a/sdk/compiler/damlc/tests/daml-test-files/Daml3ScriptTrySubmitConcurrently.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/Daml3ScriptTrySubmitConcurrently.daml
@@ -4,7 +4,7 @@
 -- @ SCRIPT-V2
 
 -- @ WARN range=20:1-20:52; Import of internal module Daml.Script.Internal of package daml3-script is discouraged, as this module will change without warning.
--- @ WARN warn-bad-exceptions
+-- @ WARN version=1.17 2.0; -Wupgrade-exceptions
 
 {-# LANGUAGE ApplicativeDo #-}
 

--- a/sdk/compiler/damlc/tests/daml-test-files/DamlDocHoogle.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/DamlDocHoogle.daml
@@ -1,7 +1,7 @@
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
 module DamlDocHoogle where
 
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
 
 -- | T docs
 template T with

--- a/sdk/compiler/damlc/tests/daml-test-files/ExceptionSemantics.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/ExceptionSemantics.daml
@@ -6,7 +6,7 @@
 -- @ERROR range=148:1-148:25; Unhandled exception: DA.Exception.ArithmeticError:ArithmeticError@XXXXXX with message = "ArithmeticError while evaluating (DIV_INT64 1 0)."
 -- @WARN range=182:3-182:12; Use of divulged contracts is deprecated
 -- @ERROR range=185:1-185:11; Attempt to exercise a consumed contract
--- @WARN since-lf=1.17 2.0; warn-bad-exceptions
+-- @WARN since-lf=1.17 2.0; -Wupgrade-exceptions
 module ExceptionSemantics where
 
 import Daml.Script

--- a/sdk/compiler/damlc/tests/daml-test-files/ExceptionSyntax.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/ExceptionSyntax.daml
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_EXCEPTIONS
--- @WARN since-lf=1.17 2.0; warn-bad-exceptions
+-- @WARN since-lf=1.17 2.0; -Wupgrade-exceptions
 -- @QUERY-LF [ $pkg.modules[].exceptions[] ] | length == 1
 
 -- | Test that exception syntax is correctly handled.

--- a/sdk/compiler/damlc/tests/daml-test-files/Interface.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/Interface.daml
@@ -2,8 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
 {-# LANGUAGE ApplicativeDo #-}
 
 module Interface where

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceArchive.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceArchive.daml
@@ -3,8 +3,8 @@
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
 
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
 module InterfaceArchive where
 
 import Daml.Script

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision.daml
@@ -2,9 +2,9 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
 
 -- This checks collisions check for Interface choice
 -- This also covers regression test for interface instance, view and method markers.

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailed.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceChoiceGuardFailed.daml
@@ -6,8 +6,8 @@ module InterfaceChoiceGuardFailed where
 import Daml.Script
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE_EXTENDED
--- @WARN since-lf=1.17 2.0; warn-bad-interface-instances
--- @WARN since-lf=1.17 2.0; warn-bad-interface-instances
+-- @WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
+-- @WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
 data EmptyInterfaceView = EmptyInterfaceView {}
 
 interface I where

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceContractDoesNotImplementInterface.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceContractDoesNotImplementInterface.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2022, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
 module InterfaceContractDoesNotImplementInterface where
 import Daml.Script
 

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceConversions.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceConversions.daml
@@ -3,9 +3,9 @@
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
 
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
 -- | Test interface conversion functions specifically.
 module InterfaceConversions where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceDoubleSpend.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceDoubleSpend.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
 {-# LANGUAGE ApplicativeDo #-}
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceEmpty.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceEmpty.daml
@@ -3,8 +3,8 @@
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
 
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
 -- | Test that empty interfaces are fine.
 module InterfaceEmpty (I, EmptyInterfaceView(..)) where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceEmptyIndirect.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceEmptyIndirect.daml
@@ -2,8 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
 
 -- | Test that empty interfaces work fine across modules.
 module InterfaceEmptyIndirect where

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceEq.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceEq.daml
@@ -2,9 +2,9 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
 module InterfaceEq where
 
 import Daml.Script

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceErrors.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceErrors.daml
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
 module InterfaceErrors where
 
 import Daml.Script

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceFunctions.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceFunctions.daml
@@ -2,8 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
 -- | Check that `create`, `signatory`, `observer`, `interfaceTypeRep` work as expected on interface payloads.
 module InterfaceFunctions where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceGuarded.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceGuarded.daml
@@ -2,11 +2,11 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE_EXTENDED
--- @WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @WARN since-lf=1.16 2.0; warn-bad-exceptions
+-- @WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @WARN since-lf=1.16 2.0; -Wupgrade-exceptions
 
 module InterfaceGuarded where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceMethodInMethod.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceMethodInMethod.daml
@@ -1,10 +1,10 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
 -- regression test for https://github.com/digital-asset/daml/issues/15459
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceMissingMethod.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceMissingMethod.daml
@@ -2,8 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
 -- @ERROR range=22:5-23:32;error type checking template InterfaceMissingMethod.T interface instance InterfaceMissingMethod:I for InterfaceMissingMethod:T: Interface instance lacks an implementation for method 'm'
 
 module InterfaceMissingMethod where

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceRequiresError.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceRequiresError.daml
@@ -2,8 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
 -- @ERROR range=27:5-28:32;error type checking template InterfaceRequiresError.T interface instance InterfaceRequiresError:B for InterfaceRequiresError:T: Missing required 'interface instance InterfaceRequiresError:A for InterfaceRequiresError:T', required by interface 'InterfaceRequiresError:B'
 
 -- | Check that interface hierarchy is enforced. So if interface B requires

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceSyntax.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceSyntax.daml
@@ -2,9 +2,9 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
 
 module InterfaceSyntax where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceTypeRepCheck.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceTypeRepCheck.daml
@@ -2,9 +2,9 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
 -- @ERROR Attempt to fetch or exercise a wrongly typed contract
 
 -- | Verify that you can't accidentally exercise a T1 template

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.daml
@@ -2,10 +2,10 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
 
 -- | Try out some upcasts and downcasts, checking that everything works.
 module InterfaceUpcastDowncast where

--- a/sdk/compiler/damlc/tests/daml-test-files/LfInterfaces.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/LfInterfaces.daml
@@ -2,8 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.17 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
 
 module LfInterfaces where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/QualifiedInterface.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/QualifiedInterface.daml
@@ -4,8 +4,8 @@
 {-# LANGUAGE ApplicativeDo #-}
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
 
 module QualifiedInterface where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.daml
@@ -8,7 +8,7 @@
 -- this test will no longer make sense.
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
 module QualifiedRetroactiveInterfaceInstance where
 
 import Daml.Script

--- a/sdk/compiler/damlc/tests/daml-test-files/RestrictedNameWarnings.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/RestrictedNameWarnings.daml
@@ -2,7 +2,7 @@
 -- @WARN range=15:5-15:8; `arg' is an unsupported field name, and may break without warning in future versions. Please use something else.
 -- @WARN range=20:5-20:9; `self' is an unsupported field name, and may break without warning in future versions. Please use something else.
 -- @WARN range=25:5-25:8; `arg' is an unsupported field name, and may break without warning in future versions. Please use something else.
--- @WARN since-lf=1.17 2.0; warn-bad-exceptions
+-- @WARN since-lf=1.17 2.0; -Wupgrade-exceptions
 
 module RestrictedNameWarnings where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.daml
@@ -8,7 +8,7 @@
 -- this test will no longer make sense.
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
--- @ WARN since-lf=1.16 2.0; warn-bad-interface-instances
+-- @ WARN since-lf=1.16 2.0; -Werror=upgrade-interfaces
 module RetroactiveInterfaceInstance where
 
 import Daml.Script

--- a/sdk/compiler/damlc/tests/daml-test-files/WarnRetroactiveInterfaceInstance.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/WarnRetroactiveInterfaceInstance.daml
@@ -6,7 +6,7 @@
 
 -- @SUPPORTS-LF-FEATURE DAML_INTERFACE
 -- @SUPPORTS-LF-FEATURE DAML_PACKAGE_UPGRADES
--- @WARN since-lf=1.17 2.0; warn-bad-interface-instances
+-- @WARN since-lf=1.17 2.0; -Werror=upgrade-interfaces
 -- @WARN range=24:3-25:16; Found interface instance in the body of an interface
 -- TODO(https://github.com/digital-asset/daml/issues/18049):
 -- Retroactive interface instances will be removed in LF 2.x, after which

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -82,7 +82,7 @@ import Options.Applicative (execParser, forwardOptions, info, many, strArgument)
 import Outputable (ppr, showSDoc)
 import qualified Proto3.Suite.JSONPB as JSONPB
 import DA.Daml.Project.Types (unsafeResolveReleaseVersion, parseUnresolvedVersion)
-import DA.Daml.LF.TypeChecker.Error (DamlWarningFlag(..), DamlWarningFlagStatus(..), upgradeInterfacesName, upgradeInterfacesFilter, upgradeExceptionsName, upgradeExceptionsFilter)
+import DA.Daml.LF.TypeChecker.Error (DamlWarningFlag(..), DamlWarningFlagStatus(..), upgradeInterfacesFlag, upgradeExceptionsFlag)
 
 import Test.Tasty
 import Test.Tasty.Golden (goldenVsStringDiff)
@@ -331,8 +331,8 @@ getIntegrationTests registerTODO scenarioService (packageDbPath, packageFlags) =
                     }
                 , optPackageImports = packageFlags
                 , optDamlWarningFlags =
-                    [ RawDamlWarningFlag upgradeInterfacesName AsWarning upgradeInterfacesFilter
-                    , RawDamlWarningFlag upgradeExceptionsName AsWarning upgradeExceptionsFilter
+                    [ upgradeInterfacesFlag AsWarning
+                    , upgradeExceptionsFlag AsWarning
                     ]
                 }
 

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -82,6 +82,7 @@ import Options.Applicative (execParser, forwardOptions, info, many, strArgument)
 import Outputable (ppr, showSDoc)
 import qualified Proto3.Suite.JSONPB as JSONPB
 import DA.Daml.Project.Types (unsafeResolveReleaseVersion, parseUnresolvedVersion)
+import DA.Daml.LF.TypeChecker.Error (DamlWarningFlag(..), DamlWarningFlagStatus(..), upgradeInterfacesName, upgradeInterfacesFilter, upgradeExceptionsName, upgradeExceptionsFilter)
 
 import Test.Tasty
 import Test.Tasty.Golden (goldenVsStringDiff)
@@ -329,7 +330,10 @@ getIntegrationTests registerTODO scenarioService (packageDbPath, packageFlags) =
                     , dlintHintFiles = NoDlintHintFiles
                     }
                 , optPackageImports = packageFlags
-                , optUpgradeInfo = (optUpgradeInfo opts0) { uiWarnBadInterfaceInstances = True, uiWarnBadExceptions = True }
+                , optDamlWarningFlags =
+                    [ RawDamlWarningFlag upgradeInterfacesName AsWarning upgradeInterfacesFilter
+                    , RawDamlWarningFlag upgradeExceptionsName AsWarning upgradeExceptionsFilter
+                    ]
                 }
 
               mkIde options = do

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -82,7 +82,7 @@ import Options.Applicative (execParser, forwardOptions, info, many, strArgument)
 import Outputable (ppr, showSDoc)
 import qualified Proto3.Suite.JSONPB as JSONPB
 import DA.Daml.Project.Types (unsafeResolveReleaseVersion, parseUnresolvedVersion)
-import DA.Daml.LF.TypeChecker.Error (DamlWarningFlag(..), DamlWarningFlagStatus(..), upgradeInterfacesFlag, upgradeExceptionsFlag)
+import DA.Daml.LF.TypeChecker.Error (DamlWarningFlagStatus(..), upgradeInterfacesFlag, upgradeExceptionsFlag)
 
 import Test.Tasty
 import Test.Tasty.Golden (goldenVsStringDiff)

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -891,7 +891,7 @@ tests damlc =
           , "  - --target=" <> LF.renderVersion lfVersion
           ]
             ++ ["  - --typecheck-upgrades=no" | not doTypecheck]
-            ++ ["  - --warn-bad-interface-instances=yes" | warnBadInterfaceInstances ]
+            ++ ["  - -Wupgrade-interfaces" | warnBadInterfaceInstances ]
             ++ ["upgrades: '" <> path <> "'" | Just path <- pure upgradedFile]
             ++ renderDataDeps deps
         )

--- a/sdk/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -2765,7 +2765,7 @@ tests TestArgs{..} =
 
     optionsDevScript :: DataDependenciesTestOptions
     optionsDevScript = defTestOptions
-        { buildOptions = ["--target=" <> LF.renderVersion targetDevVersion, "--warn-bad-interface-instances=yes"]
+        { buildOptions = ["--target=" <> LF.renderVersion targetDevVersion, "-Wupgrade-interfaces"]
         , extraDeps = [scriptDevDar]
         }
 

--- a/sdk/compiler/damlc/tests/src/DA/Test/ScriptService_1_17.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/ScriptService_1_17.hs
@@ -42,6 +42,7 @@ import System.IO.Extra
 import Test.Tasty
 import Test.Tasty.HUnit
 import Text.Regex.TDFA
+import DA.Daml.LF.TypeChecker.Error
 
 lfVersion :: LF.Version
 lfVersion = LF.version1_17
@@ -237,7 +238,7 @@ options :: Options
 options =
   let opts0 = defaultOptions (Just lfVersion)
   in
-  opts0 { optUpgradeInfo = (optUpgradeInfo opts0) { uiWarnBadInterfaceInstances = True } }
+  opts0 { optDamlWarningFlags = optDamlWarningFlags opts0 ++ [RawDamlWarningFlag upgradeInterfacesName AsWarning upgradeInterfacesFilter] }
 
 
 runScripts :: SdkVersioned => SS.Handle -> [T.Text] -> IO [(VirtualResource, Either T.Text T.Text)]

--- a/sdk/compiler/damlc/tests/src/DA/Test/ScriptService_1_17.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/ScriptService_1_17.hs
@@ -238,7 +238,7 @@ options :: Options
 options =
   let opts0 = defaultOptions (Just lfVersion)
   in
-  opts0 { optDamlWarningFlags = optDamlWarningFlags opts0 ++ [RawDamlWarningFlag upgradeInterfacesName AsWarning upgradeInterfacesFilter] }
+  opts0 { optDamlWarningFlags = optDamlWarningFlags opts0 ++ [upgradeInterfacesFlag AsWarning] }
 
 
 runScripts :: SdkVersioned => SS.Handle -> [T.Text] -> IO [(VirtualResource, Either T.Text T.Text)]

--- a/sdk/compiler/damlc/tests/src/DamlcTest.hs
+++ b/sdk/compiler/damlc/tests/src/DamlcTest.hs
@@ -112,7 +112,7 @@ testsForDamlcValidate damlc = testGroup "damlc validate-dar"
         , "source: ."
         , "dependencies: [daml-prim, daml-stdlib]"
         , "build-options:"
-        , "- --warn-bad-interface-instances=yes"
+        , "- -Wupgrade-interfaces"
         ]
       writeFileUTF8 (projDir </> "Good.daml") $ unlines
         [ "module Good where"
@@ -140,7 +140,7 @@ testsForDamlcValidate damlc = testGroup "damlc validate-dar"
         , "source: ."
         , "dependencies: [daml-prim, daml-stdlib]"
         , "build-options:"
-        , "- --warn-bad-interface-instances=yes"
+        , "- -Wupgrade-interfaces"
         ]
       writeFileUTF8 (projDir </> "Interface.daml") $ unlines
         [ "module Interface where"

--- a/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -123,7 +123,7 @@ damlStart tmpDir disableUpgradeValidation = do
             , "    npm-scope: daml.js"
             , "  java:"
             , "    output-directory: ui/java"
-            ] ++ [ "build-options:\n- -Wupgrade-interfaces\n- -Wupgrade-exceptions" | disableUpgradeValidation ]
+            ] ++ [ "build-options:\n- -Wno-upgrade-interfaces\n- -Wno-upgrade-exceptions" | disableUpgradeValidation ]
     writeFileUTF8 (projDir </> "daml/Main.daml") $
         unlines
             [ "module Main where"

--- a/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -123,7 +123,7 @@ damlStart tmpDir disableUpgradeValidation = do
             , "    npm-scope: daml.js"
             , "  java:"
             , "    output-directory: ui/java"
-            ] ++ [ "build-options:\n- --warn-bad-interface-instances=yes\n- --warn-bad-exceptions=yes" | disableUpgradeValidation ]
+            ] ++ [ "build-options:\n- -Wupgrade-interfaces\n- -Wupgrade-exceptions" | disableUpgradeValidation ]
     writeFileUTF8 (projDir </> "daml/Main.daml") $
         unlines
             [ "module Main where"

--- a/sdk/docs/BUILD.bazel
+++ b/sdk/docs/BUILD.bazel
@@ -423,8 +423,8 @@ daml_test(
     name = "ledger-api-daml-test",
     srcs = glob(["source/app-dev/code-snippets/**/*.daml"]),
     additional_compiler_flags = [
-        "--warn-bad-interface-instances=yes",
-        "--warn-bad-exceptions=yes",
+        "-Wupgrade-interfaces",
+        "-Wupgrade-exceptions",
     ],
     deps = ["//daml-script/daml:daml-script.dar"],
 )
@@ -433,8 +433,8 @@ daml_test(
     name = "bindings-java-daml-test",
     srcs = glob(["source/app-dev/bindings-java/code-snippets/**/*.daml"]),
     additional_compiler_flags = [
-        "--warn-bad-interface-instances=yes",
-        "--warn-bad-exceptions=yes",
+        "-Wupgrade-interfaces",
+        "-Wupgrade-exceptions",
     ],
     # FIXME: https://github.com/digital-asset/daml/issues/12051
     #  remove target, once interfaces are stable.
@@ -465,8 +465,8 @@ daml_test(
     timeout = "long",
     srcs = glob(["source/daml/code-snippets/**/*.daml"]),
     additional_compiler_flags = [
-        "--warn-bad-interface-instances=yes",
-        "--warn-bad-exceptions=yes",
+        "-Wupgrade-interfaces",
+        "-Wupgrade-exceptions",
     ],
     deps = ["//daml-script/daml:daml-script.dar"],
 )
@@ -477,8 +477,8 @@ daml_test(
         timeout = "long",
         srcs = glob(["source/daml/code-snippets-dev/**/*.daml"]),
         additional_compiler_flags = [
-            "--warn-bad-interface-instances=yes",
-            "--warn-bad-exceptions=yes",
+            "-Wupgrade-interfaces",
+            "-Wupgrade-exceptions",
         ],
         target = version,
     )
@@ -540,8 +540,8 @@ daml_test(
         ["source/daml/intro/daml/daml-intro-12-part1/**/*.daml"],
     ),
     additional_compiler_flags = [
-        "--warn-bad-interface-instances=yes",
-        "--warn-bad-exceptions=yes",
+        "-Wupgrade-interfaces",
+        "-Wupgrade-exceptions",
     ],
     target = "1.15",
     deps = ["//daml-script/daml:daml-script-1.15.dar"],
@@ -562,8 +562,8 @@ daml_test(
         ["source/daml/intro/daml/daml-intro-12-part2/**/*.daml"],
     ),
     additional_compiler_flags = [
-        "--warn-bad-interface-instances=yes",
-        "--warn-bad-exceptions=yes",
+        "-Wupgrade-interfaces",
+        "-Wupgrade-exceptions",
     ],
     data_deps = ["daml-intro12-part1.dar"],
     target = "1.15",
@@ -590,7 +590,7 @@ daml_test(
     daml_test(
         name = "daml-intro-8-daml-test-{}".format(version),
         srcs = glob(["source/daml/intro/daml/daml-intro-8/**/*.daml"]),
-        additional_compiler_flags = ["--warn-bad-exceptions=yes"],
+        additional_compiler_flags = ["-Wupgrade-exceptions"],
         target = version,
         deps = ["//daml-script/daml:daml-script-{}.dar".format(version)],
     )

--- a/sdk/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
+++ b/sdk/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
@@ -5,6 +5,7 @@ module Options.Applicative.Extended
     ( YesNoAuto (..)
     , flagYesNoAuto
     , flagYesNoAuto'
+    , flagYesNoAuto''
     , determineAuto
     , determineAutoM
     , optionOnce
@@ -45,7 +46,13 @@ determineAutoM m = \case
 -- This maps yes to "Just true", no to "Just False" and auto to "Nothing"
 flagYesNoAuto' :: String -> String -> Mod OptionFields YesNoAuto -> Parser YesNoAuto
 flagYesNoAuto' flagName helpText mods =
-    optionOnce reader (long flagName <> value Auto <> help helpText <> completeWith ["true", "false", "yes", "no", "auto"] <> mods)
+    flagYesNoAuto'' flagName helpText (value Auto <> mods)
+
+-- | This constructs flags that can be set to yes, no, or auto, with no default
+-- This maps yes to "Just true", no to "Just False" and auto to "Nothing"
+flagYesNoAuto'' :: String -> String -> Mod OptionFields YesNoAuto -> Parser YesNoAuto
+flagYesNoAuto'' flagName helpText mods =
+    optionOnce reader (long flagName <> help helpText <> completeWith ["true", "false", "yes", "no", "auto"] <> mods)
   where reader = eitherReader $ \case
             "yes" -> Right Yes
             "true" -> Right Yes

--- a/sdk/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
+++ b/sdk/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
@@ -5,7 +5,7 @@ module Options.Applicative.Extended
     ( YesNoAuto (..)
     , flagYesNoAuto
     , flagYesNoAuto'
-    , flagYesNoAuto''
+    , flagYesNoAutoNoDefault
     , determineAuto
     , determineAutoM
     , optionOnce
@@ -46,12 +46,13 @@ determineAutoM m = \case
 -- This maps yes to "Just true", no to "Just False" and auto to "Nothing"
 flagYesNoAuto' :: String -> String -> Mod OptionFields YesNoAuto -> Parser YesNoAuto
 flagYesNoAuto' flagName helpText mods =
-    flagYesNoAuto'' flagName helpText (value Auto <> mods)
+    flagYesNoAutoNoDefault flagName helpText (value Auto <> mods)
 
 -- | This constructs flags that can be set to yes, no, or auto, with no default
 -- This maps yes to "Just true", no to "Just False" and auto to "Nothing"
-flagYesNoAuto'' :: String -> String -> Mod OptionFields YesNoAuto -> Parser YesNoAuto
-flagYesNoAuto'' flagName helpText mods =
+-- Use this when putting this flag behind a combinator like `many`
+flagYesNoAutoNoDefault :: String -> String -> Mod OptionFields YesNoAuto -> Parser YesNoAuto
+flagYesNoAutoNoDefault flagName helpText mods =
     optionOnce reader (long flagName <> help helpText <> completeWith ["true", "false", "yes", "no", "auto"] <> mods)
   where reader = eitherReader $ \case
             "yes" -> Right Yes

--- a/sdk/triggers/tests/BUILD.bazel
+++ b/sdk/triggers/tests/BUILD.bazel
@@ -100,7 +100,7 @@ dependencies:
   - daml-prim
   - daml-trigger.dar
   - daml-script.dar
-build-options: [--target={lf_version}, --warn-bad-interface-instances=yes]
+build-options: [--target={lf_version}, -Wupgrade-interfaces]
 EOF
       $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location acs-{major}.dar)
       rm -rf $$TMP_DIR


### PR DESCRIPTION
Originally requested by Sam to make the output of Daml Finance less noisy

Modelled after GCC's method:

- `-W<name>` turns any error of class `name` into a warning
- `-Werror=<name>` turns any warning of class `name` into an error
- `-Wno-<name>` disables the `name` warning/error completely, so it is omitted from the output

Currently, on 2.x we only support -Wupgrade-interfaces and -Wupgrade-exceptions

TODO: Support --disable-warn-large-tuples