### PR TITLE
Fix LF 1.17 interface fetches in v1+v2 of daml-script

### DIFF
--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/IdeLedgerClient.scala
@@ -308,10 +308,6 @@ class IdeLedgerClient(
       // A default package map for when using LF1.17 with old daml-script
       // Needed for interface exercises, which will perform a soft fetch, and ask for package resolution
       // Assumes single package per name and gives this package. If multiple, throws recommending daml-script-beta
-
-      // TODO: This doesn't work as daml-prim and such are added multiple times
-      // We could try to omit them by LF and serializability and utility and all that
-      // Note that v2 does not omit utility packages, so may also error - try with daml3-script
       val packageMap: Map[PackageName, PackageId] =
         compiledPackages.packageIds
           .collect(

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -193,12 +193,12 @@ class IdeLedgerClient(
 
     val valueTranslator = new ValueTranslator(
       pkgInterface = compiledPackages.pkgInterface,
-      checkV1ContractIdSuffixes = true,
+      checkV1ContractIdSuffixes = false,
     )
 
     valueTranslator.translateValue(TTyCon(templateId), arg) match {
-      case Left(_) =>
-        sys.error("computeView: translateValue failed")
+      case Left(e) =>
+        sys.error(s"computeView: translateValue failed: $e")
 
       case Right(argument) =>
         val compiler: speedy.Compiler = compiledPackages.compiler

--- a/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
+++ b/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
@@ -7,6 +7,7 @@ module InterfaceViews (main) where
 
 import UpgradeTestLib
 import FixedInterface
+import FixedInterfaceViewTemplate
 import FixedInterfaceCaller
 import qualified V1.Interfaces as V1
 import qualified V2.Interfaces as V2
@@ -15,20 +16,41 @@ import DA.Foldable
 import DA.Optional
 import DA.Text
 
+-- Fixed template so interface view can contain a contract ID
+{- PACKAGE
+name: fixed-interface-view-template
+versions: 1
+-}
+
+{- MODULE
+package: fixed-interface-view-template
+contents: |
+  module FixedInterfaceViewTemplate where
+
+  template FIVT with
+      fivtOwner : Party
+    where
+    signatory fivtOwner
+-}
+
 -- Fixed package containing only the interface
 {- PACKAGE
 name: fixed-interface-view
 versions: 1
+depends: fixed-interface-view-template-1.0.0
 -}
 
 {- MODULE
 package: fixed-interface-view
 contents: |
   module FixedInterface where
+  import FixedInterfaceViewTemplate
 
   data IV = IV with
-    owner : Party
-    payload : Int
+      owner : Party
+      payload : Int
+      oContractId : Optional (ContractId FIVT)
+    deriving (Eq, Show)
 
   interface I where
     viewtype IV
@@ -70,7 +92,9 @@ contents: |
 {- PACKAGE
 name: interface-views
 versions: 2
-depends: fixed-interface-view-1.0.0
+depends: |
+  fixed-interface-view-1.0.0
+  fixed-interface-view-template-1.0.0
 -}
 
 {- MODULE
@@ -79,6 +103,7 @@ contents: |
   module Interfaces where
 
   import FixedInterface
+  import FixedInterfaceViewTemplate
   import DA.Optional
 
   template FITemplate with
@@ -87,10 +112,10 @@ contents: |
     signatory party
 
     interface instance I for FITemplate where
-      view = IV party 0   -- @V 1
-      view = IV party 1   -- @V  2
-      getVersion = "V1"   -- @V 1
-      getVersion = "V2"   -- @V  2
+      view = IV party 0 None -- @V 1
+      view = IV party 1 None -- @V  2
+      getVersion = "V1"      -- @V 1
+      getVersion = "V2"      -- @V  2
 
     -- Following two choices exist here for convenience. They could be in a separate package which depends on this,
     -- but additional unnecessary packages simply wastes time.
@@ -108,6 +133,16 @@ contents: |
       do
         fetch icid
         pure ()
+
+  template FITemplateWithContractId with
+      party : Party
+      cid : ContractId FIVT
+    where
+    signatory party
+
+    interface instance I for FITemplateWithContractId where
+      view = IV party 0 (Some cid)
+      getVersion = "V1"
 -}
 
 main : TestTree
@@ -115,6 +150,7 @@ main = tests
   [ ("Calling an interface choice at command level fails as intended when the view is modified", exerciseCommandShouldFail)
   , ("Calling an interface choice in choice body fails as intended when the view is modified", exerciseInChoiceBodyShouldFail)
   , ("fetchFromInterface fails as intended when the view is modified", fetchFromInterfaceShouldFail)
+  , ("queryInterfactContractId can query interfaces with contract ID in the view", queryInterfaceContractIdInView)
   ]
 
 setupAliceAndInterface : Script (Party, ContractId I)
@@ -146,3 +182,12 @@ fetchFromInterfaceShouldFail = test $ do
   case res of
     Left (DevError Upgrade msg) | "View mismatch" `isInfixOf` msg -> pure ()
     _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)
+
+queryInterfaceContractIdInView : Test
+queryInterfaceContractIdInView = test $ do
+  alice <- allocateParty "alice"
+  fivtCid <- alice `submit` createExactCmd FIVT with fivtOwner = alice
+  cid <- alice `submit` createExactCmd V1.FITemplateWithContractId with party = alice, cid = fivtCid
+  let icid = toInterfaceContractId @I cid
+  res <- queryInterfaceContractId alice icid
+  res === Some (IV with owner = alice, payload = 0, oContractId = Some fivtCid)


### PR DESCRIPTION
Moving daml-finance to LF1.17 revealed some issues with the IDELedger in both daml2-script and daml3-script

For daml3-script, interface views were checking for contract id suffixes, which the IDE doesn't provide. This was a mistaken change from 2 weeks ago.

For daml2-script, no package preference is passed to submit, but fetching an interface requires the package be looked up.
As such, we provide a simple preference mapping name to package id, and failing if there are multiple upgradable packages with the same name, recommending daml3-script.