### PR TITLE
Many Unvetted package multi-participant tests

### DIFF
--- a/sdk/daml-script/test/daml/upgrades/UnvettedPackages.daml
+++ b/sdk/daml-script/test/daml/upgrades/UnvettedPackages.daml
@@ -1,0 +1,349 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module UnvettedPackages (main) where
+
+import UpgradeTestLib
+import qualified V1.UnvettedPackagesTestPackage as V1
+import qualified V2.UnvettedPackagesTestPackage as V2
+import UnvettedPackagesHelper
+import UnvettedPackagesInterface
+import DA.Optional
+import DA.Text
+
+-- These tests rely on unvetting, none of them will work on IDE
+main : TestTree
+main = tests $ brokenOnIDELedger <$>
+  [ ("Exercise a choice against a V1 contract with V1 unvetted on submitter via Command", v1UnvettedOnSubmitterCommand)
+  , ("Exercise a choice against a V1 contract with V1 unvetted on submitter via Command Interface", v1UnvettedOnSubmitterCommandInterface)
+  , ("Exercise a choice against a V1 contract with V1 unvetted on submitter via Choice Body", v1UnvettedOnSubmitterChoiceBody)
+  , ("Exercise a choice against a V1 contract with V1 unvetted on submitter via Choice Body Interface", v1UnvettedOnSubmitterChoiceBodyInterface)
+
+  , -- Didn't get the usual missing package error, we get No valid domain for submission found
+    -- It's unclear if this is a problem, since the submission is still rejected
+    -- This applies to next 4 tests
+    brokenOnCanton ("Exercise a choice against a V1 disclosed contract with V1 unvetted on submitter via Command", v1UnvettedOnSubmitterDisclosedCommand)
+  , brokenOnCanton ("Exercise a choice against a V1 disclosed contract with V1 unvetted on submitter via Command Interface", v1UnvettedOnSubmitterDisclosedCommandInterface)
+  , brokenOnCanton ("Exercise a choice against a V1 disclosed contract with V1 unvetted on submitter via Choice Body", v1UnvettedOnSubmitterDisclosedChoiceBody)
+  , brokenOnCanton ("Exercise a choice against a V1 disclosed contract with V1 unvetted on submitter via Choice Body Interface", v1UnvettedOnSubmitterDisclosedChoiceBodyInterface)
+
+  , ("Exercise a choice against a V1 contract with V1 unvetted on a non-confirming informee via Command", v1UnvettedOnNonConfirmingInformeeCommand)
+  , -- Unexpected behaviour, non-confirming informee (bob) not having V1 vetted should cause transaction to fail, but it succeeds
+    brokenOnCanton ("Exercise a choice against a V1 contract with V1 unvetted on a non-confirming informee via Command Interface", v1UnvettedOnNonConfirmingInformeeCommandInterface)
+  , ("Exercise a choice against a V1 contract with V1 unvetted on a non-confirming informee via Choice Body", v1UnvettedOnNonConfirmingInformeeChoiceBody)
+  , -- Unexpected behaviour, non-confirming informee (bob) not having V1 vetted should cause transaction to fail, but it succeeds
+    brokenOnCanton ("Exercise a choice against a V1 contract with V1 unvetted on a non-confirming informee via Choice Body Interface", v1UnvettedOnNonConfirmingInformeeChoiceBodyInterface)
+
+  , ("Exercise a choice against a V1 contract with V1 unvetted on a confirming informee via Command", v1UnvettedOnConfirmingInformeeCommand)
+  , ("Exercise a choice against a V1 contract with V1 unvetted on a confirming informee via Command Interface", v1UnvettedOnConfirmingInformeeCommandInterface)
+  , ("Exercise a choice against a V1 contract with V1 unvetted on a confirming informee via Choice Body", v1UnvettedOnConfirmingInformeeChoiceBody)
+  , ("Exercise a choice against a V1 contract with V1 unvetted on a confirming informee via Choice Body Interface", v1UnvettedOnConfirmingInformeeChoiceBodyInterface)
+  ]
+
+-- Interface required for some tests
+
+{- PACKAGE
+name: unvetted-packages-interface
+versions: 1
+-}
+
+{- MODULE
+package: unvetted-packages-interface
+contents: |
+  module UnvettedPackagesInterface where
+
+  data TestTemplateInterfaceView = TestTemplateInterfaceView with owner: Party
+
+  interface TestTemplateInterface where
+    viewtype TestTemplateInterfaceView
+
+    getVersion : Text
+    nonconsuming choice GetVersion : Text
+      controller (view this).owner
+      do
+        pure $ getVersion this
+
+    nonconsuming choice GetVersionDisclosed : Text with
+        c : Party
+      controller c
+      do
+        pure $ getVersion this
+-}
+
+{- PACKAGE
+name: unvetted-packages-test-template
+versions: 2
+depends: unvetted-packages-interface-1.0.0
+-}
+
+{- MODULE
+package: unvetted-packages-test-template
+contents: |
+  module UnvettedPackagesTestPackage where
+
+  import UnvettedPackagesInterface
+
+  template TestTemplate with
+      p : Party
+      sigs : [Party]
+      obs : [Party]
+    where
+    signatory p, sigs
+    observer obs
+
+    choice TestTemplateChoice : Text
+      controller p
+      do
+        pure "V1" -- @V 1
+        pure "V2" -- @V  2
+
+    choice TestTemplateChoiceDisclosed : Text with
+        c : Party
+      controller c
+      do
+        pure "V1" -- @V 1
+        pure "V2" -- @V  2
+
+    choice SetInformees : ContractId TestTemplate with
+        newSigs : [Party]
+        newObs : [Party]
+      controller newSigs, newObs
+      do
+        create this with sigs = newSigs, obs = newObs
+
+    interface instance TestTemplateInterface for TestTemplate where
+      view = TestTemplateInterfaceView p
+      getVersion = "V1"        -- @V 1
+      getVersion = "V2"        -- @V  2
+-}
+
+-- Helper template for ChoiceBody tests
+
+{- PACKAGE
+name: unvetted-packages-helper
+versions: 1
+depends: |
+  unvetted-packages-test-template-2.0.0
+  unvetted-packages-interface-1.0.0
+-}
+
+{- MODULE
+package: unvetted-packages-helper
+contents: |
+  module UnvettedPackagesHelper where
+
+  import UnvettedPackagesTestPackage
+  import UnvettedPackagesInterface
+  
+  template TestTemplateHelper with
+      p : Party
+    where
+    signatory p
+
+    choice HelperChoice : Text with
+        cid : ContractId TestTemplate
+      controller p
+      do
+        exercise cid TestTemplateChoice
+
+    choice HelperChoiceDisclosed : Text with
+        cid : ContractId TestTemplate
+      controller p
+      do
+        exercise cid TestTemplateChoiceDisclosed with c = p
+
+    choice HelperInterfaceChoice : Text with
+        iid : ContractId TestTemplateInterface
+      controller p
+      do
+        exercise iid GetVersion
+
+    choice HelperInterfaceChoiceDisclosed : Text with
+        iid : ContractId TestTemplateInterface
+      controller p
+      do
+        exercise iid GetVersionDisclosed with c = p
+-}
+
+expectPackageMissingFailure : Show a => Either SubmitError a -> Script ()
+expectPackageMissingFailure (Right res) = fail $ "Expected failure, got success: " <> show res
+expectPackageMissingFailure (Left (UnknownError (isInfixOf "Some packages are not known to all informees" -> True))) = pure ()
+expectPackageMissingFailure (Left e) = fail $ "Expected package missing error, got " <> show e
+
+v1UnvettedOnSubmitterCommand : Test
+v1UnvettedOnSubmitterCommand = test $ do
+  alice <- allocateParty "alice"
+  cidV1 <- alice `submit` createExactCmd V1.TestTemplate with p = alice, sigs = [], obs = []
+  let cidV2 = coerceContractId @V1.TestTemplate @V2.TestTemplate cidV1
+  withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant0 $ do
+    res <- alice `trySubmit` exerciseCmd cidV2 V2.TestTemplateChoice
+    expectPackageMissingFailure res
+
+v1UnvettedOnSubmitterCommandInterface : Test
+v1UnvettedOnSubmitterCommandInterface = test $ do
+  alice <- allocateParty "alice"
+  cidV1 <- alice `submit` createExactCmd V1.TestTemplate with p = alice, sigs = [], obs = []
+  let iid = toInterfaceContractId @TestTemplateInterface cidV1
+  withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant0 $ do
+    res <- alice `trySubmit` exerciseCmd iid GetVersion
+    expectPackageMissingFailure res
+
+v1UnvettedOnSubmitterChoiceBody : Test
+v1UnvettedOnSubmitterChoiceBody = test $ do
+  alice <- allocateParty "alice"
+  cidV1 <- alice `submit` createExactCmd V1.TestTemplate with p = alice, sigs = [], obs = []
+  let cidV2 = coerceContractId @V1.TestTemplate @V2.TestTemplate cidV1
+  withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant0 $ do
+    res <- alice `trySubmit` createAndExerciseCmd (TestTemplateHelper with p = alice) (HelperChoice with cid = cidV2)
+    expectPackageMissingFailure res
+
+v1UnvettedOnSubmitterChoiceBodyInterface : Test
+v1UnvettedOnSubmitterChoiceBodyInterface = test $ do
+  alice <- allocateParty "alice"
+  cidV1 <- alice `submit` createExactCmd V1.TestTemplate with p = alice, sigs = [], obs = []
+  let iid = toInterfaceContractId @TestTemplateInterface cidV1
+  withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant0 $ do
+    res <- alice `trySubmit` createAndExerciseCmd (TestTemplateHelper with p = alice) (HelperInterfaceChoice with iid = iid)
+    expectPackageMissingFailure res
+
+v1UnvettedOnSubmitterDisclosedCommand : Test
+v1UnvettedOnSubmitterDisclosedCommand = test $ do
+  alice <- allocatePartyOn "alice" participant0
+  bob <- allocatePartyOn "bob" participant1
+  cidV1 <- alice `submit` createExactCmd V1.TestTemplate with p = alice, sigs = [], obs = []
+  let cidV2 = coerceContractId @V1.TestTemplate @V2.TestTemplate cidV1
+  disclosure <- fromSome <$> queryDisclosure alice cidV2
+
+  withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant1 $ do
+    res <- (actAs bob <> disclose disclosure) `trySubmit` exerciseCmd cidV2 V2.TestTemplateChoiceDisclosed with c = bob
+    expectPackageMissingFailure res
+
+v1UnvettedOnSubmitterDisclosedCommandInterface : Test
+v1UnvettedOnSubmitterDisclosedCommandInterface = test $ do
+  alice <- allocatePartyOn "alice" participant0
+  bob <- allocatePartyOn "bob" participant1
+  cidV1 <- alice `submit` createExactCmd V1.TestTemplate with p = alice, sigs = [], obs = []
+  let cidV2 = coerceContractId @V1.TestTemplate @V2.TestTemplate cidV1
+  disclosure <- fromSome <$> queryDisclosure alice cidV2
+  let iid = toInterfaceContractId @TestTemplateInterface cidV1
+
+  withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant1 $ do
+    res <- (actAs bob <> disclose disclosure) `trySubmit` exerciseCmd iid GetVersionDisclosed with c = bob
+    expectPackageMissingFailure res
+
+v1UnvettedOnSubmitterDisclosedChoiceBody : Test
+v1UnvettedOnSubmitterDisclosedChoiceBody = test $ do
+  alice <- allocatePartyOn "alice" participant0
+  bob <- allocatePartyOn "bob" participant1
+  cidV1 <- alice `submit` createExactCmd V1.TestTemplate with p = alice, sigs = [], obs = []
+  let cidV2 = coerceContractId @V1.TestTemplate @V2.TestTemplate cidV1
+  disclosure <- fromSome <$> queryDisclosure alice cidV2
+
+  withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant1 $ do
+    res <- (actAs bob <> disclose disclosure) `trySubmit` createAndExerciseCmd (TestTemplateHelper with p = bob) (HelperChoiceDisclosed with cid = cidV2)
+    expectPackageMissingFailure res
+
+v1UnvettedOnSubmitterDisclosedChoiceBodyInterface : Test
+v1UnvettedOnSubmitterDisclosedChoiceBodyInterface = test $ do
+  alice <- allocatePartyOn "alice" participant0
+  bob <- allocatePartyOn "bob" participant1
+  cidV1 <- alice `submit` createExactCmd V1.TestTemplate with p = alice, sigs = [], obs = []
+  let cidV2 = coerceContractId @V1.TestTemplate @V2.TestTemplate cidV1
+  disclosure <- fromSome <$> queryDisclosure alice cidV2
+  let iid = toInterfaceContractId @TestTemplateInterface cidV1
+
+  withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant1 $ do
+    res <- (actAs bob <> disclose disclosure) `trySubmit` createAndExerciseCmd (TestTemplateHelper with p = bob) (HelperInterfaceChoiceDisclosed with iid = iid)
+    expectPackageMissingFailure res
+
+v1UnvettedOnNonConfirmingInformeeCommand : Test
+v1UnvettedOnNonConfirmingInformeeCommand = test $ do
+  alice <- allocatePartyOn "alice" participant0
+  bob <- allocatePartyOn "bob" participant1
+  cidV1 <- alice `submit` createExactCmd V1.TestTemplate with p = alice, sigs = [], obs = [bob]
+  let cidV2 = coerceContractId @V1.TestTemplate @V2.TestTemplate cidV1
+
+  withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant1 $ do
+    res <- alice `trySubmit` exerciseCmd cidV2 V2.TestTemplateChoice
+    expectPackageMissingFailure res
+
+v1UnvettedOnNonConfirmingInformeeCommandInterface : Test
+v1UnvettedOnNonConfirmingInformeeCommandInterface = test $ do
+  alice <- allocatePartyOn "alice" participant0
+  bob <- allocatePartyOn "bob" participant1
+  cidV1 <- alice `submit` createExactCmd V1.TestTemplate with p = alice, sigs = [], obs = [bob]
+  let iid = toInterfaceContractId @TestTemplateInterface cidV1
+
+  withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant1 $ do
+    res <- alice `trySubmit` exerciseCmd iid GetVersion
+    expectPackageMissingFailure res
+
+v1UnvettedOnNonConfirmingInformeeChoiceBody : Test
+v1UnvettedOnNonConfirmingInformeeChoiceBody = test $ do
+  alice <- allocatePartyOn "alice" participant0
+  bob <- allocatePartyOn "bob" participant1
+  cidV1 <- alice `submit` createExactCmd V1.TestTemplate with p = alice, sigs = [], obs = [bob]
+  let cidV2 = coerceContractId @V1.TestTemplate @V2.TestTemplate cidV1
+
+  withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant1 $ do
+    res <- alice `trySubmit` createAndExerciseCmd (TestTemplateHelper with p = alice) (HelperChoice with cid = cidV2)
+    expectPackageMissingFailure res
+
+v1UnvettedOnNonConfirmingInformeeChoiceBodyInterface : Test
+v1UnvettedOnNonConfirmingInformeeChoiceBodyInterface = test $ do
+  alice <- allocatePartyOn "alice" participant0
+  bob <- allocatePartyOn "bob" participant1
+  cidV1 <- alice `submit` createExactCmd V1.TestTemplate with p = alice, sigs = [], obs = [bob]
+  let iid = toInterfaceContractId @TestTemplateInterface cidV1
+
+  withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant1 $ do
+    res <- alice `trySubmit` createAndExerciseCmd (TestTemplateHelper with p = alice) (HelperInterfaceChoice with iid = iid)
+    expectPackageMissingFailure res
+
+v1UnvettedOnConfirmingInformeeCommand : Test
+v1UnvettedOnConfirmingInformeeCommand = test $ do
+  alice <- allocatePartyOn "alice" participant0
+  bob <- allocatePartyOn "bob" participant1
+  cidWithoutSigs <- alice `submit` createExactCmd V1.TestTemplate with p = alice, sigs = [], obs = [bob]
+  cidV1 <- bob `submit` exerciseExactCmd cidWithoutSigs V1.SetInformees with newSigs = [bob], newObs = []
+  let cidV2 = coerceContractId @V1.TestTemplate @V2.TestTemplate cidV1
+
+  withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant1 $ do
+    res <- alice `trySubmit` exerciseCmd cidV2 V2.TestTemplateChoice
+    expectPackageMissingFailure res
+
+v1UnvettedOnConfirmingInformeeCommandInterface : Test
+v1UnvettedOnConfirmingInformeeCommandInterface = test $ do
+  alice <- allocatePartyOn "alice" participant0
+  bob <- allocatePartyOn "bob" participant1
+  cidWithoutSigs <- alice `submit` createExactCmd V1.TestTemplate with p = alice, sigs = [], obs = [bob]
+  cidV1 <- bob `submit` exerciseExactCmd cidWithoutSigs V1.SetInformees with newSigs = [bob], newObs = []
+  let iid = toInterfaceContractId @TestTemplateInterface cidV1
+
+  withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant1 $ do
+    res <- alice `trySubmit` exerciseCmd iid GetVersion
+    expectPackageMissingFailure res
+
+v1UnvettedOnConfirmingInformeeChoiceBody : Test
+v1UnvettedOnConfirmingInformeeChoiceBody = test $ do
+  alice <- allocatePartyOn "alice" participant0
+  bob <- allocatePartyOn "bob" participant1
+  cidWithoutSigs <- alice `submit` createExactCmd V1.TestTemplate with p = alice, sigs = [], obs = [bob]
+  cidV1 <- bob `submit` exerciseExactCmd cidWithoutSigs V1.SetInformees with newSigs = [bob], newObs = []
+  let cidV2 = coerceContractId @V1.TestTemplate @V2.TestTemplate cidV1
+
+  withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant1 $ do
+    res <- alice `trySubmit` createAndExerciseCmd (TestTemplateHelper with p = alice) (HelperChoice with cid = cidV2)
+    expectPackageMissingFailure res
+
+v1UnvettedOnConfirmingInformeeChoiceBodyInterface : Test
+v1UnvettedOnConfirmingInformeeChoiceBodyInterface = test $ do
+  alice <- allocatePartyOn "alice" participant0
+  bob <- allocatePartyOn "bob" participant1
+  cidWithoutSigs <- alice `submit` createExactCmd V1.TestTemplate with p = alice, sigs = [], obs = [bob]
+  cidV1 <- bob `submit` exerciseExactCmd cidWithoutSigs V1.SetInformees with newSigs = [bob], newObs = []
+  let iid = toInterfaceContractId @TestTemplateInterface cidV1
+
+  withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant1 $ do
+    res <- alice `trySubmit` createAndExerciseCmd (TestTemplateHelper with p = alice) (HelperInterfaceChoice with iid = iid)
+    expectPackageMissingFailure res

--- a/sdk/daml-script/test/daml/upgrades/UnvettedPackages.daml
+++ b/sdk/daml-script/test/daml/upgrades/UnvettedPackages.daml
@@ -19,13 +19,10 @@ main = tests $ brokenOnIDELedger <$>
   , ("Exercise a choice against a V1 contract with V1 unvetted on submitter via Choice Body", v1UnvettedOnSubmitterChoiceBody)
   , ("Exercise a choice against a V1 contract with V1 unvetted on submitter via Choice Body Interface", v1UnvettedOnSubmitterChoiceBodyInterface)
 
-  , -- Didn't get the usual missing package error, we get No valid domain for submission found
-    -- It's unclear if this is a problem, since the submission is still rejected
-    -- This applies to next 4 tests
-    brokenOnCanton ("Exercise a choice against a V1 disclosed contract with V1 unvetted on submitter via Command", v1UnvettedOnSubmitterDisclosedCommand)
-  , brokenOnCanton ("Exercise a choice against a V1 disclosed contract with V1 unvetted on submitter via Command Interface", v1UnvettedOnSubmitterDisclosedCommandInterface)
-  , brokenOnCanton ("Exercise a choice against a V1 disclosed contract with V1 unvetted on submitter via Choice Body", v1UnvettedOnSubmitterDisclosedChoiceBody)
-  , brokenOnCanton ("Exercise a choice against a V1 disclosed contract with V1 unvetted on submitter via Choice Body Interface", v1UnvettedOnSubmitterDisclosedChoiceBodyInterface)
+  , ("Exercise a choice against a V1 disclosed contract with V1 unvetted on submitter via Command", v1UnvettedOnSubmitterDisclosedCommand)
+  , ("Exercise a choice against a V1 disclosed contract with V1 unvetted on submitter via Command Interface", v1UnvettedOnSubmitterDisclosedCommandInterface)
+  , ("Exercise a choice against a V1 disclosed contract with V1 unvetted on submitter via Choice Body", v1UnvettedOnSubmitterDisclosedChoiceBody)
+  , ("Exercise a choice against a V1 disclosed contract with V1 unvetted on submitter via Choice Body Interface", v1UnvettedOnSubmitterDisclosedChoiceBodyInterface)
 
   , ("Exercise a choice against a V1 contract with V1 unvetted on a non-confirming informee via Command", v1UnvettedOnNonConfirmingInformeeCommand)
   , ("Exercise a choice against a V1 contract with V1 unvetted on a non-confirming informee via Command Interface", v1UnvettedOnNonConfirmingInformeeCommandInterface)
@@ -168,6 +165,11 @@ expectPackageMissingFailure (Right res) = fail $ "Expected failure, got success:
 expectPackageMissingFailure (Left (UnknownError (isInfixOf "Some packages are not known to all informees" -> True))) = pure ()
 expectPackageMissingFailure (Left e) = fail $ "Expected package missing error, got " <> show e
 
+expectNoDomainFailure : Show a => Either SubmitError a -> Script ()
+expectNoDomainFailure (Right res) = fail $ "Expected failure, got success: " <> show res
+expectNoDomainFailure (Left (UnknownError (isInfixOf "No valid domain for submission found" -> True))) = pure ()
+expectNoDomainFailure (Left e) = fail $ "Expected No Domain error, got " <> show e
+
 v1UnvettedOnSubmitterCommand : Test
 v1UnvettedOnSubmitterCommand = test $ do
   alice <- allocateParty "alice"
@@ -204,6 +206,9 @@ v1UnvettedOnSubmitterChoiceBodyInterface = test $ do
     res <- alice `trySubmit` createAndExerciseCmd (TestTemplateHelper with p = alice) (HelperInterfaceChoice with iid = iid)
     expectPackageMissingFailure res
 
+-- Following 4 tests use `expectNoDomainFailure`, over expectPackageMissingFailure
+-- This is incorrect, and implies an issue with the domain selector, but under the hood is giving the correct error
+-- So we will likely not fix this for 2.x
 v1UnvettedOnSubmitterDisclosedCommand : Test
 v1UnvettedOnSubmitterDisclosedCommand = test $ do
   alice <- allocatePartyOn "alice" participant0
@@ -214,7 +219,7 @@ v1UnvettedOnSubmitterDisclosedCommand = test $ do
 
   withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant1 $ do
     res <- (actAs bob <> disclose disclosure) `trySubmit` exerciseCmd cidV2 V2.TestTemplateChoiceDisclosed with c = bob
-    expectPackageMissingFailure res
+    expectNoDomainFailure res
 
 v1UnvettedOnSubmitterDisclosedCommandInterface : Test
 v1UnvettedOnSubmitterDisclosedCommandInterface = test $ do
@@ -227,7 +232,7 @@ v1UnvettedOnSubmitterDisclosedCommandInterface = test $ do
 
   withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant1 $ do
     res <- (actAs bob <> disclose disclosure) `trySubmit` exerciseCmd iid GetVersionDisclosed with c = bob
-    expectPackageMissingFailure res
+    expectNoDomainFailure res
 
 v1UnvettedOnSubmitterDisclosedChoiceBody : Test
 v1UnvettedOnSubmitterDisclosedChoiceBody = test $ do
@@ -239,7 +244,7 @@ v1UnvettedOnSubmitterDisclosedChoiceBody = test $ do
 
   withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant1 $ do
     res <- (actAs bob <> disclose disclosure) `trySubmit` createAndExerciseCmd (TestTemplateHelper with p = bob) (HelperChoiceDisclosed with cid = cidV2)
-    expectPackageMissingFailure res
+    expectNoDomainFailure res
 
 v1UnvettedOnSubmitterDisclosedChoiceBodyInterface : Test
 v1UnvettedOnSubmitterDisclosedChoiceBodyInterface = test $ do
@@ -252,7 +257,7 @@ v1UnvettedOnSubmitterDisclosedChoiceBodyInterface = test $ do
 
   withUnvettedDarOnParticipant "unvetted-packages-test-template-1.0.0" participant1 $ do
     res <- (actAs bob <> disclose disclosure) `trySubmit` createAndExerciseCmd (TestTemplateHelper with p = bob) (HelperInterfaceChoiceDisclosed with iid = iid)
-    expectPackageMissingFailure res
+    expectNoDomainFailure res
 
 v1UnvettedOnNonConfirmingInformeeCommand : Test
 v1UnvettedOnNonConfirmingInformeeCommand = test $ do

--- a/sdk/daml-script/test/daml/upgrades/UnvettedPackages.daml
+++ b/sdk/daml-script/test/daml/upgrades/UnvettedPackages.daml
@@ -28,11 +28,9 @@ main = tests $ brokenOnIDELedger <$>
   , brokenOnCanton ("Exercise a choice against a V1 disclosed contract with V1 unvetted on submitter via Choice Body Interface", v1UnvettedOnSubmitterDisclosedChoiceBodyInterface)
 
   , ("Exercise a choice against a V1 contract with V1 unvetted on a non-confirming informee via Command", v1UnvettedOnNonConfirmingInformeeCommand)
-  , -- Unexpected behaviour, non-confirming informee (bob) not having V1 vetted should cause transaction to fail, but it succeeds
-    brokenOnCanton ("Exercise a choice against a V1 contract with V1 unvetted on a non-confirming informee via Command Interface", v1UnvettedOnNonConfirmingInformeeCommandInterface)
+  , ("Exercise a choice against a V1 contract with V1 unvetted on a non-confirming informee via Command Interface", v1UnvettedOnNonConfirmingInformeeCommandInterface)
   , ("Exercise a choice against a V1 contract with V1 unvetted on a non-confirming informee via Choice Body", v1UnvettedOnNonConfirmingInformeeChoiceBody)
-  , -- Unexpected behaviour, non-confirming informee (bob) not having V1 vetted should cause transaction to fail, but it succeeds
-    brokenOnCanton ("Exercise a choice against a V1 contract with V1 unvetted on a non-confirming informee via Choice Body Interface", v1UnvettedOnNonConfirmingInformeeChoiceBodyInterface)
+  , ("Exercise a choice against a V1 contract with V1 unvetted on a non-confirming informee via Choice Body Interface", v1UnvettedOnNonConfirmingInformeeChoiceBodyInterface)
 
   , ("Exercise a choice against a V1 contract with V1 unvetted on a confirming informee via Command", v1UnvettedOnConfirmingInformeeCommand)
   , ("Exercise a choice against a V1 contract with V1 unvetted on a confirming informee via Command Interface", v1UnvettedOnConfirmingInformeeCommandInterface)
@@ -58,12 +56,12 @@ contents: |
     viewtype TestTemplateInterfaceView
 
     getVersion : Text
-    nonconsuming choice GetVersion : Text
+    choice GetVersion : Text
       controller (view this).owner
       do
         pure $ getVersion this
 
-    nonconsuming choice GetVersionDisclosed : Text with
+    choice GetVersionDisclosed : Text with
         c : Party
       controller c
       do


### PR DESCRIPTION
Discoveries:
- When submitting transactions with disclosures and unvetted source packages, we get a "No Valid domain" error, instead of the usual "Some participants don't have this package vetted". Under the hood, the No Valid Domain error is triggered by the one we expect, its just odd that it's being masked in this case. The test has been updated to expect this, since it's low priority