### PR TITLE
Upgrades: shorter error message when upload dar with invalid upgrade

### DIFF
--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/PackageServiceErrors.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/PackageServiceErrors.scala
@@ -275,9 +275,9 @@ object PackageServiceErrors extends PackageServiceErrorGroup {
           val loggingContext: ContextualizedErrorLogger
       ) extends DamlError(cause = phase match {
             case TypecheckUpgrades.MaximalDarCheck =>
-              s"The uploaded DAR contains a package $newPackage, but upgrade checks indicate that new package $newPackage cannot be an upgrade of existing package $oldPackage. Reason: ${upgradeError.prettyInternal}"
+              s"Upgrade checks indicate that new package $newPackage cannot be an upgrade of existing package $oldPackage. Reason: ${upgradeError.prettyInternal}"
             case TypecheckUpgrades.MinimalDarCheck =>
-              s"The uploaded DAR contains a package $oldPackage, but upgrade checks indicate that existing package $newPackage cannot be an upgrade of new package $oldPackage. Reason: ${upgradeError.prettyInternal}"
+              s"Upgrade checks indicate that existing package $newPackage cannot be an upgrade of new package $oldPackage. Reason: ${upgradeError.prettyInternal}"
           })
     }
 

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesSpecBase.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesSpecBase.scala
@@ -903,7 +903,7 @@ abstract class UpgradesSpec(val suffix: String)
         s"Skipping upgrade validation for packages .*$testPackageSecondId".r
       )
       filterLog(cantonLogSrc, testPackageSecondId) should not include regex(
-        s"The uploaded DAR contains a package $testPackageSecondId \\(.*\\), but upgrade checks indicate that (existing package $testPackageFirstId|new package $testPackageSecondId) \\(.*\\) cannot be an upgrade of (existing package $testPackageFirstId|new package $testPackageSecondId)"
+        s"Upgrade checks indicate that (existing package $testPackageFirstId|new package $testPackageSecondId) \\(.*\\) cannot be an upgrade of (existing package $testPackageFirstId|new package $testPackageSecondId)"
       )
       cantonLogSrc should not include regex(
         s"Typechecking upgrades for $testPackageSecondId \\(.*\\) succeeded."
@@ -925,7 +925,7 @@ abstract class UpgradesSpec(val suffix: String)
         // If a failure message is expected, look for it in the canton logs
         case Some(additionalInfo) =>
           if (
-            s"The uploaded DAR contains a package $testPackageSecondId \\(.*\\), but upgrade checks indicate that (existing package $testPackageFirstId|new package $testPackageSecondId) \\(.*\\) cannot be an upgrade of (existing package $testPackageFirstId \\(.*\\)|new package $testPackageSecondId \\(.*\\)). Reason: $additionalInfo".r
+            s"Upgrade checks indicate that (existing package $testPackageFirstId|new package $testPackageSecondId) \\(.*\\) cannot be an upgrade of (existing package $testPackageFirstId \\(.*\\)|new package $testPackageSecondId \\(.*\\)). Reason: $additionalInfo".r
               .findFirstIn(cantonLogSrc)
               .isEmpty
           ) fail("did not find upgrade failure in canton log:\n")
@@ -937,7 +937,7 @@ abstract class UpgradesSpec(val suffix: String)
               val msg = err.toString
               msg should include("INVALID_ARGUMENT: DAR_NOT_VALID_UPGRADE")
               msg should include regex (
-                s"The uploaded DAR contains a package $testPackageSecondId \\(.*\\), but upgrade checks indicate that (existing package $testPackageFirstId|new package $testPackageSecondId) \\(.*\\) cannot be an upgrade of (existing package|new package)"
+                s"Upgrade checks indicate that (existing package $testPackageFirstId|new package $testPackageSecondId) \\(.*\\) cannot be an upgrade of (existing package|new package)"
               )
             }
           }


### PR DESCRIPTION
The message is currently truncated at 512 chars before being returned to the client, which for this error doesn't typically give enough space to actually see the upgrade failure reason at the end.
e.g. 
```
15:35:21.817 #1 D Fiber zio-fiber-4990 did not handle an errorException in thread "zio-fiber-4990" io.grpc.StatusException: INVALID_ARGUMENT: DAR_NOT_VALID_UPGRADE(8,6e4778e2): The uploaded DAR contains a package 8573fd1f5321f746a1707c059966b8340dd0a2e49009f4d990abfe8812c399f8 (com-digitalasset-scribe-features-upgrades-PackageNameSupportSpec-ping v0.0.1), but upgrade checks indicate that new package 8573fd1f5321f746a1707c059966b8340dd0a2e49009f4d990abfe8812c399f8 (com-digitalasset-scribe-features-upgrades-PackageNameSupportSpec-ping v0.0.1) cannot be an upgrade of existing package 0354dc017ec11c1dc7343b27f3e3e1867abd1b026ea459b00d46033f3754d531 (com-digitalasset-scribe-features-up...
```

The info about the uploaded package (here, `8573fd1f5321f746a1707c059966b8340dd0a2e49009f4d990abfe8812c399f8 (com-digitalasset-scribe-features-upgrades-PackageNameSupportSpec-ping v0.0.1)`) is provided twice and takes up a lot of space, so removing the duplication is a simple first step.