### PR TITLE
Multi-ide sdk install improvements

### DIFF
--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/OpenFiles.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/OpenFiles.hs
@@ -7,6 +7,8 @@ module DA.Cli.Damlc.Command.MultiIde.OpenFiles (
   handleRemovedPackageOpenFiles,
   handleCreatedPackageOpenFiles,
   sendPackageDiagnostic,
+  setDamlYamlOpen,
+  isIdeDataOpen,
 ) where
 
 import Control.Monad
@@ -49,6 +51,13 @@ removeOpenFile :: MultiIdeState -> PackageHome -> DamlFile -> STM ()
 removeOpenFile miState home file = do
   unsafeIOToSTM $ logInfo miState $ "Removed open file " <> unDamlFile file <> " from " <> unPackageHome home
   onOpenFiles miState home $ Set.delete file
+
+setDamlYamlOpen :: MultiIdeState -> PackageHome -> Bool -> STM ()
+setDamlYamlOpen miState home isOpen =
+  modifyTMVar (misSubIdesVar miState) $ Map.adjust (\ideData -> ideData {ideDataOpenDamlYaml = isOpen}) home
+
+isIdeDataOpen :: SubIdeData -> Bool
+isIdeDataOpen SubIdeData {..} = not (Set.null ideDataOpenFiles) || ideDataOpenDamlYaml
 
 -- Logic for moving open files between subIdes when packages are created/destroyed
 

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/SubIdeManagement.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/SubIdeManagement.hs
@@ -238,7 +238,9 @@ runSubProc miState home = do
 rebootIdeByHome :: MultiIdeState -> PackageHome -> IO ()
 rebootIdeByHome miState home = withIDEs_ miState $ \ides -> do
   ides' <- unsafeShutdownIdeByHome miState ides home
-  unsafeAddNewSubIdeAndSend miState ides' home Nothing
+  if isIdeDataOpen $ lookupSubIde home ides'
+    then unsafeAddNewSubIdeAndSend miState ides' home Nothing
+    else pure ides'
 
 -- Version of rebootIdeByHome that only spins up IDEs that were either active, or disabled.
 -- Does not spin up IDEs that were naturally shutdown/never started

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/Types.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/Types.hs
@@ -133,12 +133,13 @@ data SubIdeData = SubIdeData
   , ideDataMain :: Maybe SubIdeInstance
   , ideDataClosing :: Set.Set SubIdeInstance
   , ideDataOpenFiles :: Set.Set DamlFile
+  , ideDataOpenDamlYaml :: Bool
   , ideDataFailures :: [(UTCTime, T.Text)]
   , ideDataDisabled :: IdeDataDisabled
   }
 
 defaultSubIdeData :: PackageHome -> SubIdeData
-defaultSubIdeData home = SubIdeData home Nothing Set.empty Set.empty [] IdeDataNotDisabled
+defaultSubIdeData home = SubIdeData home Nothing Set.empty Set.empty False [] IdeDataNotDisabled
 
 lookupSubIde :: PackageHome -> SubIdes -> SubIdeData
 lookupSubIde home ides = fromMaybe (defaultSubIdeData home) $ Map.lookup home ides
@@ -231,7 +232,7 @@ data SdkInstallStatus
   | SISAsking
   | SISInstalling (Async ())
   | SISDenied
-  | SISFailed T.Text SomeException
+  | SISFailed T.Text (Maybe SomeException)
 
 instance Eq SdkInstallStatus where
   SISCanAsk == SISCanAsk = True


### PR DESCRIPTION
Updates Multi-ide to only try to start IDEs for open projects (i.e. projects with either a daml or daml.yaml file open in the editor), ignoring background file changes. This resolves the issue of changing your branch causing many `daml.yaml` files to update, and spinning up IDEs/requesting sdk installs.

We also prevent asking for 0.0.0, since this popup would never work.


