### PR TITLE
Add support for regenerate-stackage trailer

### DIFF
--- a/sdk/BAZEL-haskell.md
+++ b/sdk/BAZEL-haskell.md
@@ -149,11 +149,20 @@ custom snapshot and will be built using the `Cabal` library. Additionally, we
 can provide custom Bazel build definitions for packages using the
 `vendored_packages` attribute.
 
+### Updating the Stackage Snapshot
+
 The packages are pinned by the Stackage snapshot, in this case a
 `local_snapshot` and in the lock-file defined by `stack_snapshot_json`. If you
 wish to update packages, then you need to change the `packages` and
-`local_snapshot` attributes accordingly and afterwards execute the following
-command on Unix and Windows to update the lock-files:
+`local_snapshot` attributes accordingly.
+
+Commit your changes - add the trailer `regenerate-stackage: true` to your commit
+message, and CI will regenerate the lockfiles, print them out, and fail without
+running any tests. Copy the printed out files for Unix and Windows from CI logs
+into `stackage_snapshot.json` and `stackage_snapshot_windows.json` respectively.
+
+Alternatively, if you do not have access to CI, you may also execute the
+following command locally on Unix and Windows to update the lock-files manually:
 ```
 bazel run @stackage-unpinned//:pin
 ```

--- a/sdk/Upgrading.md
+++ b/sdk/Upgrading.md
@@ -11,13 +11,10 @@ A few Stackage packages require custom patches or custom build rules. These are
 defined in the `WORKSPACE` file and referenced in the `vendored_packages`
 attribute to `stack_snapshot` in the same file.
 
-After changing any of this entries you need to execute the following command to
-update the lock-file:
+After changing any of this entries you will need to execute the following
+command to update the lock-file - [see here](update-stackage-snapshot)
 
-```
-bazel run @stackage-unpinned//:pin
-```
-
+[update-stackage-snapshot]: ./BAZEL-haskell.md#updating-the-stackage-snapshot
 
 ## Nixpkgs
 

--- a/sdk/bazel-haskell-deps.bzl
+++ b/sdk/bazel-haskell-deps.bzl
@@ -532,6 +532,7 @@ exports_files(["stack.exe"], visibility = ["//visibility:public"])
             "parser-combinators",
             "path",
             "path-io",
+            "pcre-utils",
             "pretty",
             "prettyprinter",
             "pretty-show",

--- a/sdk/bazel-haskell-deps.bzl
+++ b/sdk/bazel-haskell-deps.bzl
@@ -532,7 +532,6 @@ exports_files(["stack.exe"], visibility = ["//visibility:public"])
             "parser-combinators",
             "path",
             "path-io",
-            "pcre-utils",
             "pretty",
             "prettyprinter",
             "pretty-show",

--- a/sdk/build.ps1
+++ b/sdk/build.ps1
@@ -71,6 +71,13 @@ function Has-Regenerate-Stackage-Trailer {
 }
 
 if (Has-Regenerate-Stackage-Trailer) {
+  # https://stackoverflow.com/questions/32654493/stack-haskell-throws-tlsexception-in-windows
+  $tls_urls = @("https://github.com", "https://www.hackage.org", "https://stackage.haskell.org", "https://s3.amazonaws.com")
+  $tls_urls |`
+    ForEach-Object {
+        Invoke-WebRequest -Uri $_ -UseBasicParsing | out-null
+    }
+
   Write-Output "Running @stackage-unpinned//:pin due to 'regenerate-stackage' trailer"
   bazel run @stackage-unpinned//:pin
   Get-Content .\stackage_snapshot_windows.json

--- a/sdk/build.ps1
+++ b/sdk/build.ps1
@@ -72,12 +72,10 @@ function Has-Regenerate-Stackage-Trailer {
 
 if (Has-Regenerate-Stackage-Trailer) {
   # https://stackoverflow.com/questions/32654493/stack-haskell-throws-tlsexception-in-windows
-  [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
-  $tls_urls = @("https://github.com", "https://www.hackage.org", "https://stackage.haskell.org", "https://s3.amazonaws.com")
-  $tls_urls |`
-    ForEach-Object {
-        Invoke-WebRequest -Uri $_ -UseBasicParsing | out-null
-    }
+  Invoke-WebRequest -Uri "https://github.com" -UseBasicParsing | out-null
+  Invoke-WebRequest -Uri "https://www.hackage.org" -UseBasicParsing | out-null
+  Invoke-WebRequest -Uri "https://stackage.haskell.org" -UseBasicParsing | out-null
+  Invoke-WebRequest -Uri "https://s3.amazonaws.com" -UseBasicParsing | out-null
 
   Write-Output "Running @stackage-unpinned//:pin due to 'regenerate-stackage' trailer"
   bazel run @stackage-unpinned//:pin

--- a/sdk/build.ps1
+++ b/sdk/build.ps1
@@ -72,10 +72,18 @@ function Has-Regenerate-Stackage-Trailer {
 
 if (Has-Regenerate-Stackage-Trailer) {
   # https://stackoverflow.com/questions/32654493/stack-haskell-throws-tlsexception-in-windows
-  Invoke-WebRequest -Uri "https://github.com" -UseBasicParsing | out-null
-  Invoke-WebRequest -Uri "https://www.hackage.org" -UseBasicParsing | out-null
-  Invoke-WebRequest -Uri "https://stackage.haskell.org" -UseBasicParsing | out-null
-  Invoke-WebRequest -Uri "https://s3.amazonaws.com" -UseBasicParsing | out-null
+  try {
+    Invoke-WebRequest -Uri "https://github.com" -UseBasicParsing | out-null
+  } catch {}
+  try {
+    Invoke-WebRequest -Uri "https://www.hackage.org" -UseBasicParsing | out-null
+  } catch {}
+  try {
+    Invoke-WebRequest -Uri "https://stackage.haskell.org" -UseBasicParsing | out-null
+  } catch {}
+  try {
+    Invoke-WebRequest -Uri "https://s3.amazonaws.com" -UseBasicParsing | out-null
+  } catch {}
 
   Write-Output "Running @stackage-unpinned//:pin due to 'regenerate-stackage' trailer"
   bazel run @stackage-unpinned//:pin

--- a/sdk/build.ps1
+++ b/sdk/build.ps1
@@ -72,18 +72,10 @@ function Has-Regenerate-Stackage-Trailer {
 
 if (Has-Regenerate-Stackage-Trailer) {
   # https://stackoverflow.com/questions/32654493/stack-haskell-throws-tlsexception-in-windows
-  try {
-    Invoke-WebRequest -Uri "https://github.com" -UseBasicParsing | out-null
-  } catch {}
-  try {
-    Invoke-WebRequest -Uri "https://www.hackage.org" -UseBasicParsing | out-null
-  } catch {}
-  try {
-    Invoke-WebRequest -Uri "https://stackage.haskell.org" -UseBasicParsing | out-null
-  } catch {}
-  try {
-    Invoke-WebRequest -Uri "https://s3.amazonaws.com" -UseBasicParsing | out-null
-  } catch {}
+  try { Invoke-WebRequest -Uri "https://github.com"           -UseBasicParsing | out-null } catch {}
+  try { Invoke-WebRequest -Uri "https://www.hackage.org"      -UseBasicParsing | out-null } catch {}
+  try { Invoke-WebRequest -Uri "https://stackage.haskell.org" -UseBasicParsing | out-null } catch {}
+  try { Invoke-WebRequest -Uri "https://s3.amazonaws.com"     -UseBasicParsing | out-null } catch {}
 
   Write-Output "Running @stackage-unpinned//:pin due to 'regenerate-stackage' trailer"
   bazel run @stackage-unpinned//:pin

--- a/sdk/build.ps1
+++ b/sdk/build.ps1
@@ -72,10 +72,11 @@ function Has-Regenerate-Stackage-Trailer {
 
 if (Has-Regenerate-Stackage-Trailer) {
   # https://stackoverflow.com/questions/32654493/stack-haskell-throws-tlsexception-in-windows
+  [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
   $tls_urls = @("https://github.com", "https://www.hackage.org", "https://stackage.haskell.org", "https://s3.amazonaws.com")
   $tls_urls |`
     ForEach-Object {
-        Invoke-WebRequest -Uri $_ -UseBasicParsing -SslProtocol Tls12 | out-null
+        Invoke-WebRequest -Uri $_ -UseBasicParsing | out-null
     }
 
   Write-Output "Running @stackage-unpinned//:pin due to 'regenerate-stackage' trailer"

--- a/sdk/build.ps1
+++ b/sdk/build.ps1
@@ -75,7 +75,7 @@ if (Has-Regenerate-Stackage-Trailer) {
   $tls_urls = @("https://github.com", "https://www.hackage.org", "https://stackage.haskell.org", "https://s3.amazonaws.com")
   $tls_urls |`
     ForEach-Object {
-        Invoke-WebRequest -Uri $_ -UseBasicParsing | out-null
+        Invoke-WebRequest -Uri $_ -UseBasicParsing -SslProtocol Tls12 | out-null
     }
 
   Write-Output "Running @stackage-unpinned//:pin due to 'regenerate-stackage' trailer"

--- a/sdk/build.sh
+++ b/sdk/build.sh
@@ -88,21 +88,21 @@ else
 fi
 
 if has_regenerate_stackage_trailer; then
-  echo "Running @stackage-unpinned//:pin"
-  bazel run @stackage-unpinned//:pin
+  echo "Running @stackage-unpinned//:pin due to 'regenerate-stackage' trailer"
+  $bazel run @stackage-unpinned//:pin
   cat stackage_snapshot.json
   exit 1
-else
-  echo "Running bazel build due to no 'regenerate-stackage' trailer"
-  # Bazel test only builds targets that are dependencies of a test suite so do a full build first.
-  $bazel build //... \
-    --build_tag_filters "${tag_filter}" \
-    --profile build-profile.json \
-    --experimental_profile_include_target_label \
-    --build_event_json_file build-events.json \
-    --build_event_publish_all_actions \
-    --execution_log_json_file "$ARTIFACT_DIRS/logs/build_execution${execution_log_postfix}.json.gz"
 fi
+
+echo "Running 'bazel build //...'"
+# Bazel test only builds targets that are dependencies of a test suite so do a full build first.
+$bazel build //... \
+  --build_tag_filters "${tag_filter}" \
+  --profile build-profile.json \
+  --experimental_profile_include_target_label \
+  --build_event_json_file build-events.json \
+  --build_event_publish_all_actions \
+  --execution_log_json_file "$ARTIFACT_DIRS/logs/build_execution${execution_log_postfix}.json.gz"
 
 # Set up a shared PostgreSQL instance.
 export POSTGRESQL_ROOT_DIR="${POSTGRESQL_TMP_ROOT_DIR:-$DIR/.tmp-pg}/daml/postgresql"


### PR DESCRIPTION
Setting `regenerate-stackage: true` trailer on a commit makes all machine regenerate stackage-snapshot, print it out, and immediately fail.