### PR TITLE
Make hs binding test independent of the ledger state

### DIFF
--- a/sdk/language-support/hs/bindings/BUILD.bazel
+++ b/sdk/language-support/hs/bindings/BUILD.bazel
@@ -51,10 +51,16 @@ daml_compile(
     srcs = ["test/daml/for-upload/ExtraModule.daml"],
 )
 
+daml_compile(
+    name = "dummy",
+    srcs = ["test/daml/dummy/Main.daml"],
+)
+
 da_haskell_test(
     name = "test",
     srcs = glob(["test/**/*.hs"]),
     data = [
+        "dummy.dar",
         ":for-tests.dar",
         ":for-upload.dar",
     ] + (["@sysctl_nix//:bin/sysctl"] if is_darwin else []),

--- a/sdk/language-support/hs/bindings/BUILD.bazel
+++ b/sdk/language-support/hs/bindings/BUILD.bazel
@@ -61,8 +61,8 @@ da_haskell_test(
     srcs = glob(["test/**/*.hs"]),
     data = [
         "dummy.dar",
-        ":for-tests.dar",
-        ":for-upload.dar",
+        "for-tests.dar",
+        "for-upload.dar",
     ] + (["@sysctl_nix//:bin/sysctl"] if is_darwin else []),
     # The tests throw flaky timeout errors. It looks like this comes
     # from a fundamental issue in the Haskell bindings: they eagerly pull

--- a/sdk/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/sdk/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -131,7 +131,7 @@ tGetPackageStatusUnspecify withSandbox = testCase "getPackageStatus/Unspecify" $
     let pid = PackageId "xxxxxxxxxxxxxxxxxxxxxx"
     status <- getPackageStatus pid
     liftIO $ assertBool "status" (status == PackageStatusPACKAGE_STATUS_UNSPECIFIED)
-    
+
 tUploadDarFileBad :: SandboxTest
 tUploadDarFileBad withSandbox = testCase "tUploadDarFileBad" $ run withSandbox $ \_darMetadata _testId -> do
     Right _ <- uploadDummy -- force uploading the stdlib

--- a/sdk/language-support/hs/bindings/test/daml/dummy/Main.daml
+++ b/sdk/language-support/hs/bindings/test/daml/dummy/Main.daml
@@ -1,0 +1,4 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where


### PR DESCRIPTION
This fix is a forward port of part of #20307

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
