### PR TITLE
Blinding partyPackageRequirements

### DIFF
--- a/sdk/daml-lf/engine/BUILD.bazel
+++ b/sdk/daml-lf/engine/BUILD.bazel
@@ -27,6 +27,8 @@ da_scala_library(
     srcs = glob(["src/main/**/*.scala"]),
     scala_deps = [
         "@maven//:org_scalaz_scalaz_core",
+        "@maven//:org_typelevel_cats_core",
+        "@maven//:org_typelevel_cats_kernel",
         "@maven//:org_typelevel_paiges_core",
     ],
     scalacopts = lf_scalacopts_stricter,

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -142,7 +142,7 @@ object Blinding {
       contractPackages: Map[ContractId, Ref.PackageId] = Map.empty,
   ): Relation[Party, PackageId] = {
     val (BlindingInfo(disclosure, _), contractVisibility) =
-      BlindingTransaction.calculateBlindingInfoWithContactVisibility(tx)
+      BlindingTransaction.calculateBlindingInfoWithContractVisibility(tx)
     partyPackages(tx, disclosure, contractVisibility, contractPackages)
   }
 
@@ -154,7 +154,7 @@ object Blinding {
   ): Map[Party, PackageRequirements] = {
     disclosedPartyPackageRequirements(tx, disclosure) ++
       contractPartyPackageRequirements(contractPackages, contractVisibility)
-  }.groupMapReduce(_._1)(_._2)(_ |+| _)
+  }.groupMapReduce(_._1)(_._2)(_ |+| _).view.mapValues(_.normalized).toMap
 
   // These are the package needed for reinterpretation
   private[engine] def disclosedPartyPackageRequirements(
@@ -201,7 +201,7 @@ object Blinding {
       contractPackages: Map[ContractId, Ref.PackageId] = Map.empty,
   ): Map[Party, PackageRequirements] = {
     val (BlindingInfo(disclosure, _), contractVisibility) =
-      BlindingTransaction.calculateBlindingInfoWithContactVisibility(tx)
+      BlindingTransaction.calculateBlindingInfoWithContractVisibility(tx)
     partyPackageRequirements(tx, disclosure, contractVisibility, contractPackages)
   }
 }

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala
@@ -5,32 +5,27 @@ package com.daml.lf
 package engine
 
 import com.daml.lf.data.{ImmArray, Ref}
-import com.daml.lf.engine.BlindingSpec.TxBuilder
+import com.daml.lf.engine.BlindingSpec._
 import com.daml.lf.ledger.BlindingTransaction
+import com.daml.lf.transaction.test.TestNodeBuilder.CreateKey
 import com.daml.lf.transaction.test.TreeTransactionBuilder.NodeOps
-import com.daml.lf.transaction.{BlindingInfo, Node}
 import com.daml.lf.transaction.test.{
   NodeIdTransactionBuilder,
   TestNodeBuilder,
   TransactionBuilder,
   TreeTransactionBuilder,
 }
+import com.daml.lf.transaction.{BlindingInfo, Node, VersionedTransaction}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ValueRecord, ValueTrue}
-import org.scalatest.matchers.should.Matchers
+import com.digitalasset.daml.lf.transaction.PackageRequirements
 import org.scalatest.freespec.AnyFreeSpec
-
-object BlindingSpec {
-  class TxBuilder extends NodeIdTransactionBuilder with TestNodeBuilder {
-    val defaultPackageName = Some(Ref.PackageName.assertFromString("-default-"))
-
-  }
-}
+import org.scalatest.matchers.should.Matchers
 
 class BlindingSpec extends AnyFreeSpec with Matchers {
 
-  import TransactionBuilder.Implicits._
   import TestNodeBuilder.CreateKey
+  import TransactionBuilder.Implicits._
 
   def create(builder: TxBuilder): (Value.ContractId, Node.Create) = {
     val cid = builder.newCid
@@ -287,67 +282,154 @@ class BlindingSpec extends AnyFreeSpec with Matchers {
       ),
     )
   }
+
   "contract visibility" in {
-
-    val builder = new TxBuilder()
-
-    val create1 = builder.create(
-      id = builder.newCid,
-      templateId = "M:T",
-      argument = ValueRecord(None, ImmArray.empty),
-      signatories = Seq("S1"),
-      observers = Seq(),
+    val (_, visibility) = BlindingTransaction.calculateBlindingInfoWithContractVisibility(
+      BlindingSpec.sampleTxForPartyPackagesVisibility
     )
 
-    val exercise1 = builder.exercise(
-      create1,
-      "C",
-      consuming = true,
-      actingParties = Set("A1"),
-      ValueRecord(None, ImmArray.empty),
-      byKey = false,
-    )
-
-    val create2 = builder.create(
-      id = builder.newCid,
-      templateId = "M:T",
-      argument = ValueRecord(None, ImmArray.empty),
-      signatories = Seq("S2"),
-      observers = Seq(),
-    )
-
-    val exercise2 = builder.exercise(
-      create2,
-      "C",
-      consuming = true,
-      actingParties = Set("A2"),
-      ValueRecord(None, ImmArray.empty),
-      byKey = false,
-    )
-
-    val create3 = builder.create(
-      id = builder.newCid,
-      templateId = "M:T",
-      argument = ValueRecord(None, ImmArray.empty),
-      signatories = Seq("S3", "M3"),
-      observers = Seq(),
-      key = CreateKey.KeyWithMaintainers(ValueTrue, Set("M3")),
-    )
-
-    val lbk = builder.lookupByKey(create3)
-
-    val tx = TreeTransactionBuilder.toVersionedTransaction(
-      exercise1.withChildren(
-        exercise2,
-        lbk,
-      )
-    )
-
-    val (_, visibility) = BlindingTransaction.calculateBlindingInfoWithContactVisibility(tx)
     visibility shouldBe Map(
-      create1.coid -> Set("S1", "A1"),
-      create2.coid -> Set("S1", "S2", "A1", "A2"),
-      create3.coid -> Set("S1", "A1", "M3"),
+      createC1.coid -> Set(sig1, act),
+      createC2.coid -> Set(sig1, sig2, act),
+      createC3.coid -> Set(sig1, sig3, sig4, act),
+      createC4.coid -> Set(sig1, sig4, act),
     )
   }
+
+  "party package requirements" in {
+    val inputContractsPackages =
+      Map(createC1.coid -> pkgIn1, createC2.coid -> pkgIn2, createC3.coid -> pkg3)
+    val packageRequirementsPerParty =
+      Blinding.partyPackageRequirements(
+        BlindingSpec.sampleTxForPartyPackagesVisibility,
+        inputContractsPackages,
+      )
+
+    packageRequirementsPerParty shouldBe Map(
+      sig1 -> PackageRequirements(
+        checkOnly = Set(pkgIn1, pkgIn2),
+        vetted = Set(pkgIface1, pkgIface2, pkg2, pkg3, pkg4),
+      ),
+      sig2 -> PackageRequirements(checkOnly = Set(pkgIn2), vetted = Set(pkg2)),
+      sig3 -> PackageRequirements(checkOnly = Set(pkg3), vetted = Set(pkgIface2, pkg2)),
+      sig4 -> PackageRequirements(
+        checkOnly = Set.empty,
+        vetted = Set(pkgIface1, pkgIface2, pkg1, pkg2, pkg3, pkg4),
+      ),
+      act -> PackageRequirements(
+        checkOnly = Set(pkgIn1, pkgIn2),
+        vetted = Set(pkgIface1, pkgIface2, pkg2, pkg3, pkg4),
+      ),
+    )
+  }
+}
+
+object BlindingSpec {
+  class TxBuilder extends NodeIdTransactionBuilder with TestNodeBuilder {
+    val defaultPackageName = Some(Ref.PackageName.assertFromString("-default-"))
+  }
+
+  import TransactionBuilder.Implicits.{toName, toParties}
+
+  implicit class PkgToTypeConName(pkg: Ref.PackageId) {
+    def |(shortTypeConName: String) =
+      Ref.TypeConName(pkg, Ref.QualifiedName.assertFromString(shortTypeConName))
+  }
+
+  // For the purpose of testing the partyPackageRequirements, we don't care about the qualified name of identifiers
+  // hence use the same default one for brevity
+  private val defaultQualifiedName = "M:T"
+
+  private def create(
+      pkgId: Ref.PackageId,
+      sigs: Seq[Ref.Party],
+      obs: Seq[Ref.Party] = Seq.empty,
+      key: CreateKey = CreateKey.NoKey,
+  ) =
+    builder.create(
+      id = builder.newCid,
+      templateId = pkgId | defaultQualifiedName,
+      argument = ValueRecord(None, ImmArray.empty),
+      signatories = sigs,
+      observers = obs,
+      key = key,
+    )
+
+  private def exercise(
+      create: Node.Create,
+      pkgId: Ref.PackageId,
+      acts: Seq[Ref.Party],
+      interfacePkgId: Option[Ref.PackageId] = None,
+  ): Node.Exercise =
+    builder
+      .exercise(
+        contract = create,
+        choice = "C",
+        consuming = true,
+        actingParties = acts,
+        argument = ValueRecord(None, ImmArray.empty),
+        byKey = false,
+      )
+      .copy(
+        templateId = pkgId | defaultQualifiedName,
+        interfaceId = interfacePkgId.map(_ | defaultQualifiedName),
+      )
+
+  private val builder = new TxBuilder()
+
+  private val Seq(sig1, sig2, sig3, sig4) =
+    (1 to 4).map(idx => Ref.Party.assertFromString(s"sig$idx"))
+  private val act = Ref.Party.assertFromString("act")
+
+  private val Seq(pkgIface1, pkgIface2) =
+    (1 to 2).map(idx => Ref.PackageId.assertFromString(s"iface$idx"))
+  private val Seq(pkgIn1, pkgIn2) =
+    (1 to 2).map(idx => Ref.PackageId.assertFromString(s"pkgIn$idx"))
+  private val Seq(pkg1, pkg2, pkg3, pkg4) =
+    (1 to 4).map(idx => Ref.PackageId.assertFromString(s"pkg$idx"))
+
+  private val createC1 = create(pkgIn1, Seq(sig1))
+  private val createC2 = create(pkgIn2, Seq(sig2))
+  private val createC3 =
+    create(pkg3, Seq(sig3, sig4), key = CreateKey.KeyWithMaintainers(ValueTrue, Set(sig4)))
+  private val createC4 = create(pkg1, Seq(sig4))
+
+  private val fetchC2 =
+    builder.fetch(createC2, byKey = false).copy(templateId = pkg2 | defaultQualifiedName)
+
+  private val exeC1 = exercise(createC1, pkg2, acts = Seq(act))
+
+  private val iExeC4 = exercise(createC4, pkg4, acts = Seq(sig4), interfacePkgId = Some(pkgIface1))
+
+  private val iFetchC3 = builder
+    .fetch(createC3, byKey = true)
+    .copy(templateId = pkg2 | "M:T", interfaceId = Some(pkgIface2 | defaultQualifiedName))
+
+  private val lbkC3 = builder.lookupByKey(createC3)
+
+  /*
+  Input contracts
+  =====
+  - contract C1 created with pkgIn1 by sig1
+  - contract C2 created with pkgIn2 by sig2
+  - contract C3 created with pkg3 by sig3
+
+  Transaction with two roots
+  ======================
+  Create C4       Exe C1
+   (pkg1)         (pkg2)
+     |              |
+                    ------------------------------------------------
+                    |            |              |                  |
+                 Fetch C2      LBK C3        IExe C4            IFetch C3
+                  (pkg2)       (pkg3)     (pkg4-pkgIface)    (pkg2-pkgIface2)
+
+   NOTE: Not well-authorized.
+         What matters here is the visibility of each node, contract and package
+   */
+  private val sampleTxForPartyPackagesVisibility: VersionedTransaction =
+    TreeTransactionBuilder.toVersionedTransaction(
+      createC4,
+      exeC1.withChildren(fetchC2, lbkC3, iExeC4, iFetchC3),
+    )
 }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
@@ -61,11 +61,11 @@ object BlindingTransaction {
 
   /** Calculate blinding information for a transaction. */
   def calculateBlindingInfo(tx: VersionedTransaction): BlindingInfo = {
-    val (info, _) = calculateBlindingInfoWithContactVisibility(tx)
+    val (info, _) = calculateBlindingInfoWithContractVisibility(tx)
     info
   }
 
-  def calculateBlindingInfoWithContactVisibility(
+  def calculateBlindingInfoWithContractVisibility(
       tx: VersionedTransaction
   ): (BlindingInfo, Relation[ContractId, Party]) = {
     val state = calculateBlindState(tx)

--- a/sdk/daml-lf/transaction/BUILD.bazel
+++ b/sdk/daml-lf/transaction/BUILD.bazel
@@ -46,6 +46,8 @@ da_scala_library(
     srcs = glob(["src/main/**/*.scala"]),
     scala_deps = [
         "@maven//:org_scalaz_scalaz_core",
+        "@maven//:org_typelevel_cats_core",
+        "@maven//:org_typelevel_cats_kernel",
     ],
     scalacopts = lf_scalacopts_stricter,
     tags = ["maven_coordinates=com.daml:daml-lf-transaction:__VERSION__"],

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/PackageRequirements.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/PackageRequirements.scala
@@ -6,24 +6,28 @@ package com.digitalasset.daml.lf.transaction
 import cats.Semigroup
 import com.daml.lf.data.Ref.PackageId
 
+/** Classifies the packages required for fully validating a Daml transaction into
+  *
+  * * check-only - Packages needed solely for replaying the creation of the input contracts for consistency checking reasons
+  *
+  * * vetted - Packages needed for evaluating the action nodes of the transaction
+  */
 case class PackageRequirements(checkOnly: Set[PackageId], vetted: Set[PackageId]) {
   lazy val isEmpty: Boolean = checkOnly.isEmpty && vetted.isEmpty
 
-  def subgroupOf(other: PackageRequirements): Boolean =
-    checkOnly.subsetOf(other.checkOnly) && vetted.subsetOf(other.vetted)
+  // Ensure the vetted and check-only sets are disjoint
+  // since a vetted package implies it can be used for consistency checking on replay create as well
+  def normalized: PackageRequirements = copy(vetted = vetted, checkOnly = checkOnly -- vetted)
 }
 
 object PackageRequirements {
-
   val empty: PackageRequirements = PackageRequirements(Set.empty, Set.empty)
 
   implicit val packagesUsedSemigroup: Semigroup[PackageRequirements] = Semigroup.instance {
     (x, y) =>
-      val vetted = x.vetted ++ y.vetted
-      val checkOnly = (x.checkOnly ++ y.checkOnly) -- vetted
       PackageRequirements(
-        checkOnly = checkOnly,
-        vetted = vetted,
+        checkOnly = x.checkOnly ++ y.checkOnly,
+        vetted = x.vetted ++ y.vetted,
       )
   }
 

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/PackageRequirements.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/PackageRequirements.scala
@@ -1,0 +1,32 @@
+package com.digitalasset.daml.lf.transaction
+
+import cats.Semigroup
+import com.daml.lf.data.Ref.PackageId
+
+case class PackageRequirements(checkOnly: Set[PackageId], vetted: Set[PackageId]) {
+  lazy val isEmpty: Boolean = checkOnly.isEmpty && vetted.isEmpty
+
+  def subgroupOf(other: PackageRequirements): Boolean =
+    checkOnly.subsetOf(other.checkOnly) && vetted.subsetOf(other.vetted)
+}
+
+object PackageRequirements {
+
+  val empty: PackageRequirements = PackageRequirements(Set.empty, Set.empty)
+
+  implicit val packagesUsedSemigroup: Semigroup[PackageRequirements] = Semigroup.instance {
+    (x, y) =>
+      val vetted = x.vetted ++ y.vetted
+      val checkOnly = (x.checkOnly ++ y.checkOnly) -- vetted
+      PackageRequirements(
+        checkOnly = checkOnly,
+        vetted = vetted,
+      )
+  }
+
+  def checkOnly(packageIds: PackageId*): PackageRequirements =
+    PackageRequirements(checkOnly = packageIds.toSet, vetted = Set.empty)
+
+  def vetted(packageIds: PackageId*): PackageRequirements =
+    PackageRequirements(checkOnly = Set.empty, vetted = packageIds.toSet)
+}

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/PackageRequirements.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/PackageRequirements.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.digitalasset.daml.lf.transaction
 
 import cats.Semigroup

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -25,14 +25,14 @@
 - Tail call optimization: Tail recursion does not blow the scala JVM stack.: [TailCallTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala#L19)
 
 ## Confidentiality:
-- ensure correct privacy for create node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L39)
-- ensure correct privacy for exercise node (consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L51)
-- ensure correct privacy for exercise node (non-consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L72)
-- ensure correct privacy for exercise subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L150)
-- ensure correct privacy for fetch node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L94)
-- ensure correct privacy for lookup-by-key node (found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L107)
-- ensure correct privacy for lookup-by-key node (not-found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L128)
-- ensure correct privacy for rollback subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L225)
+- ensure correct privacy for create node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L43)
+- ensure correct privacy for exercise node (consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L55)
+- ensure correct privacy for exercise node (non-consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L76)
+- ensure correct privacy for exercise subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L154)
+- ensure correct privacy for fetch node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L98)
+- ensure correct privacy for lookup-by-key node (found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L111)
+- ensure correct privacy for lookup-by-key node (not-found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L132)
+- ensure correct privacy for rollback subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L229)
 
 ## Integrity:
 - Evaluation order of create with authorization failure: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L589)

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -25,14 +25,14 @@
 - Tail call optimization: Tail recursion does not blow the scala JVM stack.: [TailCallTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala#L19)
 
 ## Confidentiality:
-- ensure correct privacy for create node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L48)
-- ensure correct privacy for exercise node (consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L60)
-- ensure correct privacy for exercise node (non-consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L81)
-- ensure correct privacy for exercise subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L159)
-- ensure correct privacy for fetch node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L103)
-- ensure correct privacy for lookup-by-key node (found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L116)
-- ensure correct privacy for lookup-by-key node (not-found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L137)
-- ensure correct privacy for rollback subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L234)
+- ensure correct privacy for create node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L39)
+- ensure correct privacy for exercise node (consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L51)
+- ensure correct privacy for exercise node (non-consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L72)
+- ensure correct privacy for exercise subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L150)
+- ensure correct privacy for fetch node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L94)
+- ensure correct privacy for lookup-by-key node (found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L107)
+- ensure correct privacy for lookup-by-key node (not-found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L128)
+- ensure correct privacy for rollback subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L225)
 
 ## Integrity:
 - Evaluation order of create with authorization failure: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L589)


### PR DESCRIPTION
Contributes to the tri-state vetting implementation (https://github.com/DACH-NY/canton/issues/21671)
This PR introduces the `PackageRequirements` and `Blinding.partyPackageRequirements` for distinguishing between packages used in a transaction and input contracts creation packages. Please refer to the Scaladoc of the added code for more details.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
