### PR TITLE
Unit tests for a large chunk of the upgrade test matrix

### DIFF
--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
@@ -51,16 +51,11 @@ sealed trait Result[+A] extends Product with Serializable {
   }
 
   private[lf] def consume(
-      pcs: PartialFunction[ContractId, VersionedContractInstance],
-      pkgs: PartialFunction[PackageId, Package],
-      keys: PartialFunction[GlobalKeyWithMaintainers, ContractId],
-      grantNeedAuthority: Boolean,
-      grantUpgradeVerification: (
-          ContractId,
-          Set[Party],
-          Set[Party],
-          Option[GlobalKeyWithMaintainers],
-      ) => Option[String],
+      pcs: PartialFunction[ContractId, VersionedContractInstance] = PartialFunction.empty,
+      pkgs: PartialFunction[PackageId, Package] = PartialFunction.empty,
+      keys: PartialFunction[GlobalKeyWithMaintainers, ContractId] = PartialFunction.empty,
+      grantNeedAuthority: Boolean = false,
+      grantUpgradeVerification: Option[String] = Some("not validated!"),
   ): Either[Error, A] = {
     @tailrec
     def go(res: Result[A]): Either[Error, A] =
@@ -72,20 +67,11 @@ sealed trait Result[+A] extends Product with Serializable {
         case ResultNeedPackage(pkgId, resume) => go(resume(pkgs.lift(pkgId)))
         case ResultNeedKey(key, resume) => go(resume(keys.lift(key)))
         case ResultNeedAuthority(_, _, resume) => go(resume(grantNeedAuthority))
-        case ResultNeedUpgradeVerification(coid, signatories, observers, keyOpt, resume) =>
-          go(resume(grantUpgradeVerification(coid, signatories, observers, keyOpt)))
+        case ResultNeedUpgradeVerification(_, _, _, _, resume) =>
+          go(resume(grantUpgradeVerification))
       }
     go(this)
   }
-
-  private[lf] def consume(
-      pcs: PartialFunction[ContractId, VersionedContractInstance] = PartialFunction.empty,
-      pkgs: PartialFunction[PackageId, Package] = PartialFunction.empty,
-      keys: PartialFunction[GlobalKeyWithMaintainers, ContractId] = PartialFunction.empty,
-      grantNeedAuthority: Boolean = false,
-      grantUpgradeVerification: Option[String] = Some("not validated!"),
-  ): Either[Error, A] =
-    consume(pcs, pkgs, keys, grantNeedAuthority, (_, _, _, _) => grantUpgradeVerification)
 }
 
 final case class ResultInterruption[A](continue: () => Result[A]) extends Result[A]

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/UpgradeTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/UpgradeTest.scala
@@ -1,0 +1,371 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package engine
+
+import com.daml.lf.command.{ApiCommand, ApiCommands}
+import com.daml.lf.data.Ref.{Identifier, Name, Party}
+import com.daml.lf.data.{Bytes, ImmArray, Ref, Time}
+import com.daml.lf.language.{Ast, LanguageMajorVersion, LanguageVersion}
+import com.daml.lf.speedy.SValue
+import com.daml.lf.testing.parser.Implicits._
+import com.daml.lf.testing.parser.ParserParameters
+import com.daml.lf.transaction.Node.Create
+import com.daml.lf.transaction.test.TransactionBuilder.assertAsVersionedContract
+import com.daml.lf.transaction.{GlobalKeyWithMaintainers, NodeId, VersionedTransaction}
+import com.daml.lf.value.Value._
+import com.daml.logging.LoggingContext
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.annotation.nowarn
+
+class UpgradeTest extends AnyFreeSpec with Matchers {
+
+  private[this] implicit def parserParameters(implicit
+      pkgId: Ref.PackageId
+  ): ParserParameters[this.type] =
+    ParserParameters(pkgId, languageVersion = LanguageVersion.Features.smartContractUpgrade)
+
+  // A package that defines an interface, a key type, an exception, and a party to be used by
+  // the packages defined below.
+  val commonDefsPkgId = Ref.PackageId.assertFromString("-common-defs-v1-id-")
+  val commonDefsPkg =
+    p"""metadata ( '-common-defs-' : '1.0.0' )
+          module Mod {
+            record @serializable MyUnit = {};
+            interface (this : Iface) = {
+              viewtype Mod:MyUnit;
+
+              method myChoiceControllers : List Party;
+              method myChoiceObservers : List Party;
+
+              choice @nonConsuming MyChoice (self) (u: Unit): Text
+                  , controllers (call_method @Mod:Iface myChoiceControllers this)
+                  , observers (call_method @Mod:Iface myChoiceObservers this)
+                  to upure @Text "MyChoice was called";
+            };
+
+            record @serializable Key = { label: Text, maintainers: List Party };
+
+            record @serializable Ex = { message: Text } ;
+            exception Ex = {
+              message \(e: Mod:Ex) -> Mod:Ex {message} e
+            };
+
+            val mkParty : Text -> Party = \(t:Text) -> case TEXT_TO_PARTY t of None -> ERROR @Party "none" | Some x -> x;
+            val alice : Party = Mod:mkParty "Alice";
+          }
+      """ (parserParameters(commonDefsPkgId))
+
+  /** An abstract class whose [[templateDefinition]] method generates LF code that defines a template named
+    * [[templateName]].
+    * The class is meant to be extended by concrete case objects which override one the metadata's expressions with an
+    * expression that throws an exception.
+    */
+  abstract class TemplateGenerator(val templateName: String) {
+    def v1Precondition: String = """True"""
+    def v1Signatories: String = s"""Cons @Party [Mod:${templateName} {p1} this] (Nil @Party)"""
+    def v1Observers: String = """Nil @Party"""
+    def v1Agreement: String = """"agreement""""
+    def v1Key: String =
+      s"""
+         |  '$commonDefsPkgId':Mod:Key {
+         |    label = "test-key",
+         |    maintainers = (Cons @Party [Mod:${templateName} {p1} this] (Nil @Party))
+         |  }""".stripMargin
+    def v1Maintainers: String =
+      s"""\\(key: '$commonDefsPkgId':Mod:Key) -> ('$commonDefsPkgId':Mod:Key {maintainers} key)"""
+    def v1ChoiceControllers: String =
+      s"""Cons @Party [Mod:${templateName} {p1} this] (Nil @Party)"""
+    def v1ChoiceObservers: String = """Nil @Party"""
+
+    def v2Precondition: String = v1Precondition
+    def v2Signatories: String = v1Signatories
+    def v2Observers: String = v1Observers
+    def v2Agreement: String = v1Agreement
+    def v2Key: String = v1Key
+    def v2ChoiceControllers: String = v1ChoiceControllers
+    def v2ChoiceObservers: String = v1ChoiceObservers
+    def v2Maintainers: String = v1Maintainers
+
+    private def templateDefinition(
+        precondition: String,
+        signatories: String,
+        observers: String,
+        agreement: String,
+        key: String,
+        maintainers: String,
+        choiceControllers: String,
+        choiceObservers: String,
+    ): String =
+      s"""
+         |  record @serializable $templateName = { p1: Party, p2: Party };
+         |  template (this: $templateName) = {
+         |    precondition $precondition;
+         |    signatories $signatories;
+         |    observers $observers;
+         |    agreement $agreement;
+         |
+         |    choice @nonConsuming SomeChoice (self) (u: Unit): Text
+         |      , controllers (Cons @Party [Mod:${templateName} {p1} this] (Nil @Party))
+         |      , observers (Nil @Party)
+         |      to upure @Text "SomeChoice was called";
+         |
+         |    implements '$commonDefsPkgId':Mod:Iface {
+         |      view = '$commonDefsPkgId':Mod:MyUnit {};
+         |      method myChoiceControllers = $choiceControllers;
+         |      method myChoiceObservers = $choiceObservers;
+         |    };
+         |
+         |    key @'$commonDefsPkgId':Mod:Key ($key) ($maintainers);
+         |  };""".stripMargin
+
+    def v1TemplateDefinition: String = templateDefinition(
+      v1Precondition,
+      v1Signatories,
+      v1Observers,
+      v1Agreement,
+      v1Key,
+      v1Maintainers,
+      v1ChoiceControllers,
+      v1ChoiceObservers,
+    )
+
+    def v2TemplateDefinition: String = templateDefinition(
+      v2Precondition,
+      v2Signatories,
+      v2Observers,
+      v2Agreement,
+      v2Key,
+      v2Maintainers,
+      v2ChoiceControllers,
+      v2ChoiceObservers,
+    )
+  }
+
+  case object ChangedPreconditionValid extends TemplateGenerator("ChangedPreconditionValid") {
+    override def v1Precondition = "True"
+    override def v2Precondition = "EQUAL @Int64 1 1"
+  }
+
+  case object ChangedPreconditionInvalid extends TemplateGenerator("ChangedPreconditionInvalid") {
+    override def v1Precondition = "True"
+    override def v2Precondition = "False"
+  }
+
+  case object ChangedObserversValid extends TemplateGenerator("ChangedObserversValid") {
+    override def v1Observers = "Nil @Party"
+    override def v2Observers = "case () of () -> Nil @Party"
+  }
+
+  case object ChangedObserversInvalid extends TemplateGenerator("ChangedObserversInvalid") {
+    override def v1Observers = "Nil @Party"
+    override def v2Observers = s"Cons @Party [Mod:${templateName} {p1} this] (Nil @Party)"
+  }
+
+  val templateGenerators: Seq[TemplateGenerator] = List(
+    ChangedPreconditionValid,
+    ChangedPreconditionInvalid,
+    ChangedObserversValid,
+    ChangedObserversInvalid,
+  )
+
+  val templateDefsPkgName = Ref.PackageName.assertFromString("-template-defs-")
+
+  /** A package that defines templates called Precondition, Signatories, ... whose metadata should evaluate without
+    * throwing exceptions.
+    */
+  val templateDefsV1PkgId = Ref.PackageId.assertFromString("-template-defs-v1-id-")
+  val templateDefsV1ParserParams = parserParameters(templateDefsV1PkgId)
+  val templateDefsV1Pkg =
+    p"""metadata ( '$templateDefsPkgName' : '1.0.0' )
+          module Mod {
+            ${templateGenerators.map(_.v1TemplateDefinition).mkString("\n")}
+          }
+      """ (templateDefsV1ParserParams)
+
+  /** Version 2 of the package above. It upgrades the previously defined templates such that:
+    *   - the precondition in the Precondition template is changed to throw an exception
+    *   - the signatories in the Signatories template is changed to throw an exception
+    *   - etc.
+    */
+  val templateDefsV2PkgId = Ref.PackageId.assertFromString("-template-defs-v2-id-")
+  val templateDefsV2ParserParams = parserParameters(templateDefsV2PkgId)
+  val templateDefsV2Pkg =
+    p"""metadata ( '$templateDefsPkgName' : '2.0.0' )
+          module Mod {
+            ${templateGenerators.map(_.v2TemplateDefinition).mkString("\n")}
+          }
+      """ (templateDefsV2ParserParams)
+
+//  val compiledPackages: PureCompiledPackages =
+//    PureCompiledPackages.assertBuild(
+//      Map(
+//        commonDefsPkgId -> commonDefsPkg,
+//        templateDefsV1PkgId -> templateDefsV1Pkg,
+//        templateDefsV2PkgId -> templateDefsV2Pkg,
+//      ),
+//      // TODO: revert to the default compiler config once it supports upgrades
+//      Compiler.Config.Dev(LanguageMajorVersion.V1),
+//    )
+//
+//  println(compiledPackages)
+
+  val lookupPackage: Map[Ref.PackageId, Ast.Package] = Map(
+    commonDefsPkgId -> commonDefsPkg,
+    templateDefsV1PkgId -> templateDefsV1Pkg,
+    templateDefsV2PkgId -> templateDefsV2Pkg,
+  )
+
+  val packageMap =
+    lookupPackage.view.mapValues(pkg => (pkg.name.get, pkg.metadata.get.version)).toMap
+
+  // println(lookupPackage)
+
+  def newEngine() =
+    new Engine(
+      EngineConfig(
+        allowedLanguageVersions = language.LanguageVersion.AllVersions(LanguageMajorVersion.V1)
+      )
+    )
+
+  def toContractId(s: String): ContractId =
+    ContractId.V1.assertBuild(crypto.Hash.hashPrivateKey(s), Bytes.assertFromString("00"))
+
+  "test" in {
+
+    implicit val logContext: LoggingContext = LoggingContext.ForTesting
+
+    val participant = Ref.ParticipantId.assertFromString("participant")
+    val engine = newEngine()
+    val alice: Party = Party.assertFromString("Alice")
+    val bob: Party = Party.assertFromString("Bob")
+
+    val tplQualifiedName =
+      Ref.QualifiedName.assertFromString(s"Mod:${ChangedObserversInvalid.templateName}")
+    val tplId = Identifier(templateDefsV1PkgId, tplQualifiedName)
+    val let = Time.Timestamp.Epoch
+
+    val submissionSeed = crypto.Hash.hashPrivateKey("command")
+    val submitters = Set(alice)
+    val readAs = Set.empty[Party]
+
+    case class ContractInfo(
+        instance: VersionedContractInstance,
+        signatories: Set[Party],
+        observers: Set[Party],
+        keyOpt: Option[GlobalKeyWithMaintainers],
+    )
+
+    // create global contracts
+    val contractInfo = {
+      val createCommand =
+        ApiCommand.Create(
+          tplId,
+          ValueRecord(
+            Some(tplId),
+            ImmArray(
+              Some(Name.assertFromString("p1")) -> ValueParty(alice),
+              Some(Name.assertFromString("p2")) -> ValueParty(bob),
+            ),
+          ),
+        )
+      val interpretResult = engine
+        .submit(
+          packageMap = packageMap,
+          packagePreference = Set(commonDefsPkgId, templateDefsV1PkgId),
+          submitters = submitters,
+          readAs = readAs,
+          cmds = ApiCommands(ImmArray(createCommand), let, "test"),
+          disclosures = ImmArray.empty,
+          participantId = participant,
+          submissionSeed = submissionSeed,
+        )
+        .consume(
+          pcs = Map.empty,
+          pkgs = lookupPackage,
+          keys = Map.empty,
+          grantNeedAuthority = false,
+          grantUpgradeVerification = (_, _, _, _) => None,
+        )
+      interpretResult match {
+        case Right((VersionedTransaction(_, nodes, _), _)) =>
+          nodes.toList match {
+            case List(
+                  NodeId(0) -> Create(
+                    _,
+                    packageName,
+                    templateId,
+                    arg,
+                    _,
+                    signatories,
+                    stakeholders,
+                    keyOpt,
+                    _,
+                  )
+                ) =>
+              ContractInfo(
+                assertAsVersionedContract(ContractInstance(packageName, templateId, arg)),
+                signatories,
+                stakeholders -- signatories,
+                keyOpt,
+              )
+            case _ => fail("Unexpected transaction nodes")
+          }
+        case _ => fail("Unexpected transaction result")
+      }
+    }
+
+    val lookupContract =
+      Map(toContractId("1") -> contractInfo.instance)
+
+    @nowarn
+    val fetchCmd = speedy.Command.FetchTemplate(
+      Identifier(templateDefsV1PkgId, tplQualifiedName),
+      SValue.SContractId(toContractId("1")),
+    )
+
+    // @nowarn
+    val exerciseCmd = ApiCommand.Exercise(
+      Identifier(templateDefsV2PkgId, tplQualifiedName),
+      toContractId("1"),
+      Ref.ChoiceName.assertFromString("SomeChoice"),
+      ValueUnit,
+    )
+
+    val interpretResult = engine
+      .submit(
+        packageMap = packageMap,
+        packagePreference = Set(commonDefsPkgId, templateDefsV2PkgId),
+        submitters = submitters,
+        readAs = readAs,
+        cmds = ApiCommands(ImmArray(exerciseCmd), let, "test"),
+        disclosures = ImmArray.empty,
+        participantId = participant,
+        submissionSeed = submissionSeed,
+      )
+      .consume(
+        pcs = lookupContract,
+        pkgs = lookupPackage,
+        keys = Map.empty,
+        grantNeedAuthority = false,
+        grantUpgradeVerification = (coid, signatories, observers, keyOpt) => {
+          println(s"grantUpgradeVerification: $coid, $signatories, $observers, $keyOpt")
+          println(s"contractInfo: ${contractInfo}")
+          if (
+            coid == toContractId(
+              "1"
+            ) && signatories == contractInfo.signatories && observers == contractInfo.observers && keyOpt == contractInfo.keyOpt
+          ) {
+            None
+          } else {
+            Some("Upgrade verification failed")
+          }
+        },
+      )
+    interpretResult shouldBe a[Right[_, _]]
+  }
+
+}

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/UpgradeTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/UpgradeTest.scala
@@ -797,21 +797,14 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
   case object Command extends EntryPoint("Command")
   case object ChoiceBody extends EntryPoint("ChoiceBody")
 
-  val entryPoints: List[EntryPoint] = List(
-    Command,
-    ChoiceBody,
-  )
+  val entryPoints: List[EntryPoint] = List(Command, ChoiceBody)
 
   sealed abstract class ContractOrigin(val name: String)
   case object Global extends ContractOrigin("Global")
   case object Disclosed extends ContractOrigin("Disclosed")
   case object Local extends ContractOrigin("Local")
 
-  val contractOrigins: List[ContractOrigin] = List(
-    Global,
-    Disclosed,
-    Local,
-  )
+  val contractOrigins: List[ContractOrigin] = List(Global, Disclosed, Local)
 
   /** A class that defines all the "global" variables shared by tests for a given template name: the template ID of the
     * v1 template, the template ID of the v2 template, the ID of the v1 contract, etc. It exposes two methods:

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/UpgradeTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/UpgradeTest.scala
@@ -997,7 +997,9 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
         case _ => Map(clientContractId -> clientContract)
       }
       val lookupContractByKey = contractOrigin match {
-        case Global => Map(globalContractKey -> globalContractId)
+        case Global =>
+          val keyMap = Map(globalContractKey.globalKey -> globalContractId)
+          ((kwm: GlobalKeyWithMaintainers) => keyMap.get(kwm.globalKey)).unlift
         case _ => PartialFunction.empty
       }
 

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/UpgradeTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/UpgradeTest.scala
@@ -7,19 +7,17 @@ package engine
 import com.daml.lf.command.{ApiCommand, ApiCommands, DisclosedContract}
 import com.daml.lf.crypto.Hash.KeyPackageName
 import com.daml.lf.data.Ref._
-import com.daml.lf.data.{Bytes, FrontStack, ImmArray, Ref, Time}
+import com.daml.lf.data._
 import com.daml.lf.language.{Ast, LanguageMajorVersion, LanguageVersion}
 import com.daml.lf.speedy.{ArrayList, SValue}
 import com.daml.lf.testing.parser.Implicits._
 import com.daml.lf.testing.parser.ParserParameters
-import com.daml.lf.transaction.GlobalKeyWithMaintainers
 import com.daml.lf.transaction.test.TransactionBuilder.assertAsVersionedContract
+import com.daml.lf.transaction.{GlobalKeyWithMaintainers, SubmittedTransaction, Transaction}
 import com.daml.lf.value.Value._
 import com.daml.logging.LoggingContext
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
-
-import scala.annotation.nowarn
 
 class UpgradeTest extends AnyFreeSpec with Matchers {
 
@@ -47,7 +45,11 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
                   to upure @Text "InterfaceChoice was called";
             };
 
-            record @serializable Key = { label: Text, maintainers: List Party };
+            record @serializable Key =
+              { label: Text
+              , maintainers1: List Party
+              , maintainers2: List Party
+              };
 
             record @serializable Ex = { message: Text } ;
             exception Ex = {
@@ -60,12 +62,16 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
           }
       """ (parserParameters(commonDefsPkgId))
 
+  sealed trait ExpectedOutcome
+  case object ExpectSuccess extends ExpectedOutcome
+  case object ExpectUpgradeError extends ExpectedOutcome
+
   /** An abstract class whose [[templateDefinition]] method generates LF code that defines a template named
     * [[templateName]].
     * The class is meant to be extended by concrete case objects which override one the metadata's expressions with an
     * expression that throws an exception.
     */
-  abstract class TemplateGenerator(val templateName: String) {
+  abstract class TemplateGenerator(val templateName: String, val expectedOutcome: ExpectedOutcome) {
     def v1Precondition: String = """True"""
     def v1Signatories: String = s"""Cons @Party [Mod:${templateName} {p1} this] (Nil @Party)"""
     def v1Observers: String = """Nil @Party"""
@@ -74,10 +80,11 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
       s"""
          |  '$commonDefsPkgId':Mod:Key {
          |    label = "test-key",
-         |    maintainers = (Cons @Party [Mod:${templateName} {p1} this] (Nil @Party))
+         |    maintainers1 = (Cons @Party [Mod:${templateName} {p1} this] (Nil @Party)),
+         |    maintainers2 = (Cons @Party [Mod:${templateName} {p2} this] (Nil @Party))
          |  }""".stripMargin
     def v1Maintainers: String =
-      s"""\\(key: '$commonDefsPkgId':Mod:Key) -> ('$commonDefsPkgId':Mod:Key {maintainers} key)"""
+      s"""\\(key: '$commonDefsPkgId':Mod:Key) -> ('$commonDefsPkgId':Mod:Key {maintainers1} key)"""
     def v1ChoiceControllers: String =
       s"""Cons @Party [Mod:${templateName} {p1} this] (Nil @Party)"""
     def v1ChoiceObservers: String = """Nil @Party"""
@@ -221,7 +228,8 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
         |            TemplateChoice
         |            ('$commonDefsPkgId':Mod:Key {
         |                 label = "test-key",
-        |                 maintainers = (Cons @Party ['$commonDefsPkgId':Mod:alice] (Nil @Party)) })
+        |                 maintainers1 = (Cons @Party ['$commonDefsPkgId':Mod:alice] (Nil @Party)),
+        |                 maintainers2 = (Cons @Party ['$commonDefsPkgId':Mod:bob] (Nil @Party)) })
         |            ();
         |
         |  choice @nonConsuming ExerciseByKeyGlobal${templateName} (self) (key: '$commonDefsPkgId':Mod:Key): Text
@@ -269,7 +277,8 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
         |                @$v2TplQualifiedName
         |                ('$commonDefsPkgId':Mod:Key {
         |                     label = "test-key",
-        |                     maintainers = (Cons @Party ['$commonDefsPkgId':Mod:alice] (Nil @Party)) })
+        |                     maintainers1 = (Cons @Party ['$commonDefsPkgId':Mod:alice] (Nil @Party)),
+        |                     maintainers2 = (Cons @Party ['$commonDefsPkgId':Mod:bob] (Nil @Party)) })
         |          in upure @$v2TplQualifiedName (pair).contract;
         |
         |  choice @nonConsuming FetchByKeyGlobal${templateName} (self) (key: '$commonDefsPkgId':Mod:Key): $v2TplQualifiedName
@@ -319,7 +328,8 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
         |            @$v2TplQualifiedName
         |            ('$commonDefsPkgId':Mod:Key {
         |                 label = "test-key",
-        |                 maintainers = (Cons @Party ['$commonDefsPkgId':Mod:alice] (Nil @Party)) });
+        |                 maintainers1 = (Cons @Party ['$commonDefsPkgId':Mod:alice] (Nil @Party)),
+        |                 maintainers2 = (Cons @Party ['$commonDefsPkgId':Mod:bob] (Nil @Party)) });
         |
         |  choice @nonConsuming LookupByKeyGlobal${templateName} (self) (key: '$commonDefsPkgId':Mod:Key): Option (ContractId $v2TplQualifiedName)
         |    , controllers (Cons @Party [Mod:Client {p} this] (Nil @Party))
@@ -331,31 +341,111 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
     }
   }
 
-  case object ChangedPreconditionValid extends TemplateGenerator("ChangedPreconditionValid") {
+  case object UnchangedPrecondition
+      extends TemplateGenerator("UnchangedPrecondition", ExpectSuccess) {
     override def v1Precondition = "True"
-    override def v2Precondition = "EQUAL @Int64 1 1"
+    override def v2Precondition = "case () of () -> True"
   }
 
-  case object ChangedPreconditionInvalid extends TemplateGenerator("ChangedPreconditionInvalid") {
+  case object ChangedPrecondition
+      extends TemplateGenerator("ChangedPrecondition", ExpectUpgradeError) {
     override def v1Precondition = "True"
     override def v2Precondition = "False"
   }
 
-  case object ChangedObserversValid extends TemplateGenerator("ChangedObserversValid") {
+  case object UnchangedSignatories
+      extends TemplateGenerator("UnchangedSignatories", ExpectSuccess) {
+    override def v1Signatories = s"Cons @Party [Mod:${templateName} {p1} this] (Nil @Party)"
+    override def v2Signatories =
+      s"case () of () -> Cons @Party [Mod:${templateName} {p1} this] (Nil @Party)"
+  }
+
+  case object ChangedSignatories
+      extends TemplateGenerator("ChangedSignatories", ExpectUpgradeError) {
+    override def v1Signatories = s"Cons @Party [Mod:${templateName} {p1} this] (Nil @Party)"
+    override def v2Signatories =
+      s"Cons @Party [Mod:${templateName} {p1} this, Mod:${templateName} {p2} this] (Nil @Party)"
+  }
+
+  case object UnchangedObservers extends TemplateGenerator("UnchangedObservers", ExpectSuccess) {
     override def v1Observers = "Nil @Party"
     override def v2Observers = "case () of () -> Nil @Party"
   }
 
-  case object ChangedObserversInvalid extends TemplateGenerator("ChangedObserversInvalid") {
+  case object ChangedObservers extends TemplateGenerator("ChangedObservers", ExpectUpgradeError) {
     override def v1Observers = "Nil @Party"
     override def v2Observers = s"Cons @Party [Mod:${templateName} {p2} this] (Nil @Party)"
   }
 
-  val templateGenerators: Seq[TemplateGenerator] = List(
-    ChangedPreconditionValid,
-    ChangedPreconditionInvalid,
-    ChangedObserversValid,
-    ChangedObserversInvalid,
+  case object UnchangedAgreement extends TemplateGenerator("UnchangedAgreement", ExpectSuccess) {
+    override def v1Agreement = """ "agreement" """
+    override def v2Agreement = """ case () of () -> "agreement" """
+  }
+
+  case object ChangedAgreement extends TemplateGenerator("ChangedAgreement", ExpectSuccess) {
+    override def v1Agreement = """ "agreement" """
+    override def v2Agreement = """ "text changed, but we don't care" """
+  }
+
+  case object UnchangedKey extends TemplateGenerator("UnchangedKey", ExpectSuccess) {
+    override def v1Key = s"""
+                            |  '$commonDefsPkgId':Mod:Key {
+                            |    label = "test-key",
+                            |    maintainers1 = (Cons @Party [Mod:${templateName} {p1} this] (Nil @Party)),
+                            |    maintainers2 = (Cons @Party [Mod:${templateName} {p2} this] (Nil @Party))
+                            |  }""".stripMargin
+    override def v2Key = s""" case () of () ->
+                            |    '$commonDefsPkgId':Mod:Key {
+                            |      label = "test-key",
+                            |      maintainers1 = (Cons @Party [Mod:${templateName} {p1} this] (Nil @Party)),
+                            |      maintainers2 = (Cons @Party [Mod:${templateName} {p2} this] (Nil @Party))
+                            |    }""".stripMargin
+  }
+
+  case object ChangedKey extends TemplateGenerator("ChangedKey", ExpectUpgradeError) {
+    override def v1Key = s"""
+                            |  '$commonDefsPkgId':Mod:Key {
+                            |    label = "test-key",
+                            |    maintainers1 = (Cons @Party [Mod:${templateName} {p1} this] (Nil @Party)),
+                            |    maintainers2 = (Cons @Party [Mod:${templateName} {p2} this] (Nil @Party))
+                            |  }""".stripMargin
+    override def v2Key = s""" case () of () ->
+                            |    '$commonDefsPkgId':Mod:Key {
+                            |      label = "test-key-2",
+                            |      maintainers1 = (Cons @Party [Mod:${templateName} {p1} this] (Nil @Party)),
+                            |      maintainers2 = (Cons @Party [Mod:${templateName} {p2} this] (Nil @Party))
+                            |    }""".stripMargin
+  }
+
+  case object UnchangedMaintainers
+      extends TemplateGenerator("UnchangedMaintainers", ExpectSuccess) {
+    override def v1Maintainers =
+      s"\\(key: '$commonDefsPkgId':Mod:Key) -> ('$commonDefsPkgId':Mod:Key {maintainers1} key)"
+    override def v2Maintainers =
+      s"\\(key: '$commonDefsPkgId':Mod:Key) -> case () of () -> ('$commonDefsPkgId':Mod:Key {maintainers1} key)"
+  }
+
+  case object ChangedMaintainers
+      extends TemplateGenerator("ChangedMaintainers", ExpectUpgradeError) {
+    override def v1Maintainers =
+      s"\\(key: '$commonDefsPkgId':Mod:Key) -> ('$commonDefsPkgId':Mod:Key {maintainers1} key)"
+    override def v2Maintainers =
+      s"\\(key: '$commonDefsPkgId':Mod:Key) -> ('$commonDefsPkgId':Mod:Key {maintainers2} key)"
+  }
+
+  val testCases: Seq[TemplateGenerator] = List(
+    UnchangedPrecondition,
+    ChangedPrecondition,
+    UnchangedSignatories,
+    ChangedSignatories,
+    UnchangedObservers,
+    ChangedObservers,
+    UnchangedAgreement,
+    ChangedAgreement,
+    ChangedKey,
+    UnchangedKey,
+    ChangedMaintainers,
+    UnchangedMaintainers,
   )
 
   val templateDefsPkgName = Ref.PackageName.assertFromString("-template-defs-")
@@ -368,7 +458,7 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
   val templateDefsV1Pkg =
     p"""metadata ( '$templateDefsPkgName' : '1.0.0' )
           module Mod {
-            ${templateGenerators.map(_.v1TemplateDefinition).mkString("\n")}
+            ${testCases.map(_.v1TemplateDefinition).mkString("\n")}
           }
       """ (templateDefsV1ParserParams)
 
@@ -382,14 +472,14 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
   val templateDefsV2Pkg =
     p"""metadata ( '$templateDefsPkgName' : '2.0.0' )
           module Mod {
-            ${templateGenerators.map(_.v2TemplateDefinition).mkString("\n")}
+            ${testCases.map(_.v2TemplateDefinition).mkString("\n")}
           }
       """ (templateDefsV2ParserParams)
 
   val clientPkgId = Ref.PackageId.assertFromString("-client-id-")
   val clientParserParams = parserParameters(clientPkgId)
   val clientPkg = {
-    val choices = templateGenerators
+    val choices = testCases
       .map(_.clientChoices(templateDefsV1PkgId, templateDefsV2PkgId))
     p"""metadata ( '-client-' : '1.0.0' )
             module Mod {
@@ -406,19 +496,6 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
         """ (clientParserParams)
   }
 
-  //  val compiledPackages: PureCompiledPackages =
-//    PureCompiledPackages.assertBuild(
-//      Map(
-//        commonDefsPkgId -> commonDefsPkg,
-//        templateDefsV1PkgId -> templateDefsV1Pkg,
-//        templateDefsV2PkgId -> templateDefsV2Pkg,
-//      ),
-//      // TODO: revert to the default compiler config once it supports upgrades
-//      Compiler.Config.Dev(LanguageMajorVersion.V1),
-//    )
-//
-//  println(compiledPackages)
-
   val lookupPackage: Map[Ref.PackageId, Ast.Package] = Map(
     commonDefsPkgId -> commonDefsPkg,
     templateDefsV1PkgId -> templateDefsV1Pkg,
@@ -429,83 +506,70 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
   val packageMap: Map[PackageId, (PackageName, Ref.PackageVersion)] =
     lookupPackage.view.mapValues(pkg => (pkg.name.get, pkg.metadata.get.version)).toMap
 
-  // println(lookupPackage)
-
-  def newEngine() =
-    new Engine(
-      EngineConfig(
-        allowedLanguageVersions = language.LanguageVersion.AllVersions(LanguageMajorVersion.V1)
-      )
-    )
-
-  def toContractId(s: String): ContractId =
-    ContractId.V1.assertBuild(crypto.Hash.hashPrivateKey(s), Bytes.assertFromString("00"))
-
   sealed abstract class Operation(val name: String)
-  case object Exercise extends Operation("exercise")
-  case object ExerciseByKey extends Operation("exerciseByKey")
-  case object ExerciseInterface extends Operation("exerciseInterface")
-  case object Fetch extends Operation("fetch")
-  case object FetchByKey extends Operation("fetch")
-  case object FetchInterface extends Operation("fetchInterface")
-  case object LookupByKey extends Operation("lookupByKey")
+  case object Exercise extends Operation("Exercise")
+  case object ExerciseByKey extends Operation("ExerciseByKey")
+  case object ExerciseInterface extends Operation("ExerciseInterface")
+  case object Fetch extends Operation("Fetch")
+  case object FetchByKey extends Operation("FetchByKey")
+  case object FetchInterface extends Operation("FetchInterface")
+  case object LookupByKey extends Operation("LookupByKey")
+
+  val operations: List[Operation] =
+    List(Exercise, ExerciseByKey, ExerciseInterface, Fetch, FetchByKey, FetchInterface, LookupByKey)
 
   sealed abstract class EntryPoint(val name: String)
-  case object Command extends EntryPoint("command")
-  case object ChoiceBody extends EntryPoint("choiceBody")
+  case object Command extends EntryPoint("Command")
+  case object ChoiceBody extends EntryPoint("ChoiceBody")
+
+  val entryPoints: List[EntryPoint] = List(
+    Command,
+    ChoiceBody,
+  )
 
   sealed abstract class ContractOrigin(val name: String)
-  case object Global extends ContractOrigin("global")
-  case object Disclosed extends ContractOrigin("disclosed")
-  case object Local extends ContractOrigin("local")
+  case object Global extends ContractOrigin("Global")
+  case object Disclosed extends ContractOrigin("Disclosed")
+  case object Local extends ContractOrigin("Local")
 
-  for (templateGenerator <- templateGenerators) {
-    templateGenerator.templateName - {}
-  }
+  val contractOrigins: List[ContractOrigin] = List(
+    Global,
+    Disclosed,
+    Local,
+  )
 
-  "test" in {
+  class TestHelper(templateName: String) {
 
     implicit val logContext: LoggingContext = LoggingContext.ForTesting
 
-    val template = ChangedObserversInvalid
-
-    val participant = Ref.ParticipantId.assertFromString("participant")
-    val engine = newEngine()
     val alice: Party = Party.assertFromString("Alice")
     val bob: Party = Party.assertFromString("Bob")
 
-    val tplQualifiedName =
-      Ref.QualifiedName.assertFromString(s"Mod:${template.templateName}")
-    val v1TplId = Identifier(templateDefsV1PkgId, tplQualifiedName)
-    val v2TplId = Identifier(templateDefsV2PkgId, tplQualifiedName)
+    val clientTplId: Identifier =
+      Identifier(clientPkgId, Ref.QualifiedName.assertFromString("Mod:Client"))
+    val ifaceId: Identifier =
+      Identifier(commonDefsPkgId, Ref.QualifiedName.assertFromString("Mod:Iface"))
+    val tplQualifiedName: QualifiedName = Ref.QualifiedName.assertFromString(s"Mod:$templateName")
+    val v1TplId: Identifier = Identifier(templateDefsV1PkgId, tplQualifiedName)
+    val v2TplId: Identifier = Identifier(templateDefsV2PkgId, tplQualifiedName)
 
-    val let = Time.Timestamp.Epoch
+    val clientContractId: ContractId = toContractId("client")
+    val globalContractId: ContractId = toContractId("1")
 
-    val submissionSeed = crypto.Hash.hashPrivateKey("command")
-    val submitters = Set(alice)
-    val readAs = Set.empty[Party]
+    val clientContract: VersionedContractInstance = assertAsVersionedContract(
+      ContractInstance(
+        clientPkg.name,
+        clientTplId,
+        ValueRecord(
+          Some(clientTplId),
+          ImmArray(
+            Some(Name.assertFromString("p")) -> ValueParty(alice)
+          ),
+        ),
+      )
+    )
 
-    val clientTplId = Identifier(clientPkgId, Ref.QualifiedName.assertFromString("Mod:Client"))
-
-    val ifaceId = Identifier(commonDefsPkgId, Ref.QualifiedName.assertFromString("Mod:Iface"))
-
-//    @nowarn
-//    val createCommand =
-//      ApiCommand.Create(
-//        v1TplId,
-//        ValueRecord(
-//          Some(v1TplId),
-//          ImmArray(
-//            Some(Name.assertFromString("p1")) -> ValueParty(alice),
-//            Some(Name.assertFromString("p2")) -> ValueParty(bob),
-//          ),
-//        ),
-//      )
-
-    val clientContractId = toContractId("client")
-
-    val globalContractId = toContractId("1")
-    val globalContractArg = ValueRecord(
+    val globalContractArg: ValueRecord = ValueRecord(
       Some(v1TplId),
       ImmArray(
         Some(Name.assertFromString("p1")) -> ValueParty(alice),
@@ -513,230 +577,192 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
       ),
     )
 
-    val lookupContract =
-      Map(
-        clientContractId ->
-          assertAsVersionedContract(
-            ContractInstance(
-              clientPkg.name,
-              clientTplId,
-              ValueRecord(
-                Some(clientTplId),
-                ImmArray(
-                  Some(Name.assertFromString("p")) -> ValueParty(alice)
-                ),
-              ),
-            )
-          ),
-        globalContractId ->
-          assertAsVersionedContract(
-            ContractInstance(
-              templateDefsV1Pkg.name,
-              v1TplId,
-              globalContractArg,
-            )
-          ),
+    val globalContract: VersionedContractInstance = assertAsVersionedContract(
+      ContractInstance(
+        templateDefsV1Pkg.name,
+        v1TplId,
+        globalContractArg,
       )
+    )
 
-    val key = SValue.SRecord(
+    val globalContractSKey: SValue = SValue.SRecord(
       Ref.Identifier.assertFromString(s"$commonDefsPkgId:Mod:Key"),
       ImmArray(
         Ref.Name.assertFromString("label"),
-        Ref.Name.assertFromString("maintainers"),
+        Ref.Name.assertFromString("maintainers1"),
+        Ref.Name.assertFromString("maintainers2"),
       ),
       ArrayList(
         SValue.SText("test-key"),
         SValue.SList(FrontStack(SValue.SParty(alice))),
+        SValue.SList(FrontStack(SValue.SParty(bob))),
       ),
     )
 
-    val globalKey = GlobalKeyWithMaintainers.assertBuild(
+    val globalContractKey: GlobalKeyWithMaintainers = GlobalKeyWithMaintainers.assertBuild(
       v1TplId,
-      key.toUnnormalizedValue,
+      globalContractSKey.toUnnormalizedValue,
       Set(alice),
       KeyPackageName(Some(templateDefsPkgName), templateDefsV1Pkg.languageVersion),
     )
 
-    @nowarn
-    val globalContractDisclosure = DisclosedContract(
+    val globalContractDisclosure: DisclosedContract = DisclosedContract(
       templateId = v1TplId,
       contractId = globalContractId,
       argument = globalContractArg,
       keyHash = Some(
         crypto.Hash.assertHashContractKey(
           v1TplId,
-          key.toUnnormalizedValue.asInstanceOf[ValueRecord],
+          globalContractSKey.toUnnormalizedValue.asInstanceOf[ValueRecord],
           KeyPackageName(Some(templateDefsPkgName), templateDefsV1Pkg.languageVersion),
         )
       ),
     )
 
-    // @nowarn
-    val exerciseCmdGlobal = ApiCommand.Exercise(
-      v2TplId,
-      globalContractId,
-      Ref.ChoiceName.assertFromString("TemplateChoice"),
-      ValueUnit,
-    )
+    def toContractId(s: String): ContractId =
+      ContractId.V1.assertBuild(crypto.Hash.hashPrivateKey(s), Bytes.assertFromString("00"))
 
-    @nowarn
-    val exerciseCmdLocal = ApiCommand.CreateAndExercise(
-      v2TplId,
-      ValueRecord(
-        Some(v2TplId),
-        ImmArray(
-          Some(Name.assertFromString("p1")) -> ValueParty(alice),
-          Some(Name.assertFromString("p2")) -> ValueParty(bob),
-        ),
-      ),
-      Ref.ChoiceName.assertFromString("TemplateChoice"),
-      ValueUnit,
-    )
+    def makeApiCommand(
+        operation: Operation,
+        entryPoint: EntryPoint,
+        contractOrigin: ContractOrigin,
+    ): Option[ApiCommand] = {
 
-    @nowarn
-    val exerciseInterfaceCmdGlobal = ApiCommand.Exercise(
-      ifaceId,
-      globalContractId,
-      Ref.ChoiceName.assertFromString("InterfaceChoice"),
-      ValueUnit,
-    )
+      (operation, entryPoint, contractOrigin) match {
+        case (_, Command, Local) =>
+          None // Local contracts cannot be exercised by commands
+        case (Fetch | FetchInterface | FetchByKey | LookupByKey, Command, _) =>
+          None // There are no fetch* or lookupByKey commands
+        case (Exercise, Command, Global | Disclosed) =>
+          Some(
+            ApiCommand.Exercise(
+              v2TplId,
+              globalContractId,
+              Ref.ChoiceName.assertFromString("TemplateChoice"),
+              ValueUnit,
+            )
+          )
+        case (ExerciseInterface, Command, Global | Disclosed) =>
+          Some(
+            ApiCommand.Exercise(
+              ifaceId,
+              globalContractId,
+              Ref.ChoiceName.assertFromString("InterfaceChoice"),
+              ValueUnit,
+            )
+          )
+        case (ExerciseByKey, Command, Global | Disclosed) =>
+          Some(
+            ApiCommand.ExerciseByKey(
+              v2TplId,
+              globalContractSKey.toUnnormalizedValue,
+              Ref.ChoiceName.assertFromString("TemplateChoice"),
+              ValueUnit,
+            )
+          )
+        case (_, ChoiceBody, Global | Disclosed) =>
+          Some(
+            ApiCommand.Exercise(
+              clientTplId,
+              clientContractId,
+              Ref.ChoiceName.assertFromString(
+                s"${operation.name}Global${templateName}"
+              ),
+              operation match {
+                case Fetch | FetchInterface | Exercise | ExerciseInterface =>
+                  ValueContractId(globalContractId)
+                case FetchByKey | LookupByKey | ExerciseByKey =>
+                  globalContractSKey.toUnnormalizedValue
+              },
+            )
+          )
+        case (_, ChoiceBody, Local) =>
+          Some(
+            ApiCommand.Exercise(
+              clientTplId,
+              clientContractId,
+              Ref.ChoiceName.assertFromString(s"${operation.name}Local${templateName}"),
+              ValueUnit,
+            )
+          )
+      }
+    }
 
-    @nowarn
-    val exerciseByKeyCmdGlobal = ApiCommand.ExerciseByKey(
-      v2TplId,
-      key.toUnnormalizedValue,
-      Ref.ChoiceName.assertFromString("TemplateChoice"),
-      ValueUnit,
-    )
-
-    @nowarn
-    val fetchChoiceBodyGlobal = ApiCommand.Exercise(
-      clientTplId,
-      clientContractId,
-      Ref.ChoiceName.assertFromString(s"FetchGlobal${template.templateName}"),
-      ValueContractId(globalContractId),
-    )
-
-    @nowarn
-    val fetchChoiceBodyLocal = ApiCommand.Exercise(
-      clientTplId,
-      clientContractId,
-      Ref.ChoiceName.assertFromString(s"FetchLocal${template.templateName}"),
-      ValueUnit,
-    )
-
-    @nowarn
-    val fetchInterfaceChoiceBodyGlobal = ApiCommand.Exercise(
-      clientTplId,
-      clientContractId,
-      Ref.ChoiceName.assertFromString(s"FetchInterfaceGlobal${template.templateName}"),
-      ValueContractId(globalContractId),
-    )
-
-    @nowarn
-    val fetchInterfaceChoiceBodyLocal = ApiCommand.Exercise(
-      clientTplId,
-      clientContractId,
-      Ref.ChoiceName.assertFromString(s"FetchInterfaceLocal${template.templateName}"),
-      ValueUnit,
-    )
-
-    @nowarn
-    val fetchByKeyChoiceBodyGlobal = ApiCommand.Exercise(
-      clientTplId,
-      clientContractId,
-      Ref.ChoiceName.assertFromString(s"FetchByKeyGlobal${template.templateName}"),
-      key.toUnnormalizedValue,
-    )
-
-    @nowarn
-    val fetchByKeyChoiceBodyLocal = ApiCommand.Exercise(
-      clientTplId,
-      clientContractId,
-      Ref.ChoiceName.assertFromString(s"FetchByKeyLocal${template.templateName}"),
-      ValueUnit,
-    )
-
-    @nowarn
-    val lookupByKeyChoiceBodyGlobal = ApiCommand.Exercise(
-      clientTplId,
-      clientContractId,
-      Ref.ChoiceName.assertFromString(s"LookupByKeyGlobal${template.templateName}"),
-      key.toUnnormalizedValue,
-    )
-
-    @nowarn
-    val lookupByKeyChoiceBodyLocal = ApiCommand.Exercise(
-      clientTplId,
-      clientContractId,
-      Ref.ChoiceName.assertFromString(s"LookupByKeyLocal${template.templateName}"),
-      ValueUnit,
-    )
-
-    @nowarn
-    val exerciseChoiceBodyGlobal = ApiCommand.Exercise(
-      clientTplId,
-      clientContractId,
-      Ref.ChoiceName.assertFromString(s"ExerciseGlobal${template.templateName}"),
-      ValueContractId(globalContractId),
-    )
-
-    @nowarn
-    val exerciseChoiceBodyLocal = ApiCommand.Exercise(
-      clientTplId,
-      clientContractId,
-      Ref.ChoiceName.assertFromString(s"ExerciseLocal${template.templateName}"),
-      ValueUnit,
-    )
-
-    @nowarn
-    val exerciseByKeyChoiceBodyGlobal = ApiCommand.Exercise(
-      clientTplId,
-      clientContractId,
-      Ref.ChoiceName.assertFromString(s"ExerciseByKeyGlobal${template.templateName}"),
-      key.toUnnormalizedValue,
-    )
-
-    @nowarn
-    val exerciseByKeyChoiceBodyLocal = ApiCommand.Exercise(
-      clientTplId,
-      clientContractId,
-      Ref.ChoiceName.assertFromString(s"ExerciseByKeyLocal${template.templateName}"),
-      ValueUnit,
-    )
-
-    @nowarn
-    val exerciseInterfaceChoiceBodyGlobal = ApiCommand.Exercise(
-      clientTplId,
-      clientContractId,
-      Ref.ChoiceName.assertFromString(s"ExerciseInterfaceGlobal${template.templateName}"),
-      ValueContractId(globalContractId),
-    )
-
-    @nowarn
-    val exerciseInterfaceChoiceBodyLocal = ApiCommand.Exercise(
-      clientTplId,
-      clientContractId,
-      Ref.ChoiceName.assertFromString(s"ExerciseInterfaceLocal${template.templateName}"),
-      ValueUnit,
-    )
-
-    val interpretResult = engine
-      .submit(
-        packageMap = packageMap,
-        packagePreference = Set(commonDefsPkgId, templateDefsV2PkgId, clientPkgId),
-        submitters = submitters,
-        readAs = readAs,
-        cmds = ApiCommands(ImmArray(exerciseCmdGlobal), let, "test"),
-        disclosures = ImmArray.empty, // ImmArray(globalContractDisclosure),
-        participantId = participant,
-        submissionSeed = submissionSeed,
+    def newEngine() = new Engine(
+      EngineConfig(allowedLanguageVersions =
+        language.LanguageVersion.AllVersions(LanguageMajorVersion.V1)
       )
-      .consume(
-        pcs = lookupContract,
-        pkgs = lookupPackage,
-        keys = Map(globalKey -> globalContractId),
-      )
-    interpretResult shouldBe a[Right[_, _]]
+    )
+
+    def execute(
+        apiCommand: ApiCommand,
+        contractOrigin: ContractOrigin,
+    ): Either[Error, (SubmittedTransaction, Transaction.Metadata)] = {
+
+      val participant = Ref.ParticipantId.assertFromString("participant")
+      val submissionSeed = crypto.Hash.hashPrivateKey("command")
+      val submitters = Set(alice)
+      val readAs = Set.empty[Party]
+
+      val disclosures = contractOrigin match {
+        case Disclosed => ImmArray(globalContractDisclosure)
+        case _ => ImmArray.empty
+      }
+      val lookupContractById = contractOrigin match {
+        case Global => Map(clientContractId -> clientContract, globalContractId -> globalContract)
+        case _ => Map(clientContractId -> clientContract)
+      }
+      val lookupContractByKey = contractOrigin match {
+        case Global => Map(globalContractKey -> globalContractId)
+        case _ => PartialFunction.empty
+      }
+
+      newEngine()
+        .submit(
+          packageMap = packageMap,
+          packagePreference = Set(commonDefsPkgId, templateDefsV2PkgId, clientPkgId),
+          submitters = submitters,
+          readAs = readAs,
+          cmds = ApiCommands(ImmArray(apiCommand), Time.Timestamp.Epoch, "test"),
+          disclosures = disclosures,
+          participantId = participant,
+          submissionSeed = submissionSeed,
+        )
+        .consume(
+          pcs = lookupContractById,
+          pkgs = lookupPackage,
+          keys = lookupContractByKey,
+        )
+    }
   }
+
+  for (template <- testCases)
+    template.templateName - {
+      val testHelper = new TestHelper(template.templateName)
+      for (operation <- operations) {
+        operation.name - {
+          for (entryPoint <- entryPoints) {
+            entryPoint.name - {
+              for (contractOrigin <- contractOrigins) {
+                contractOrigin.name - {
+                  testHelper.makeApiCommand(operation, entryPoint, contractOrigin).foreach {
+                    apiCommand =>
+                      template.expectedOutcome match {
+                        case ExpectSuccess =>
+                          s"should succeed" in {
+                            testHelper.execute(apiCommand, contractOrigin) shouldBe a[Right[_, _]]
+                          }
+                        case ExpectUpgradeError =>
+                          "should fail" in {
+                            testHelper.execute(apiCommand, contractOrigin) shouldBe a[Left[_, _]]
+                          }
+                      }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
 }

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/UpgradeTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/UpgradeTest.scala
@@ -4,11 +4,12 @@
 package com.daml.lf
 package engine
 
-import com.daml.lf.command.{ApiCommand, ApiCommands}
-import com.daml.lf.data.Ref.{Identifier, Name, Party}
-import com.daml.lf.data.{Bytes, ImmArray, Ref, Time}
+import com.daml.lf.command.{ApiCommand, ApiCommands, DisclosedContract}
+import com.daml.lf.crypto.Hash.KeyPackageName
+import com.daml.lf.data.Ref._
+import com.daml.lf.data.{Bytes, FrontStack, ImmArray, Ref, Time}
 import com.daml.lf.language.{Ast, LanguageMajorVersion, LanguageVersion}
-import com.daml.lf.speedy.SValue
+import com.daml.lf.speedy.{ArrayList, SValue}
 import com.daml.lf.testing.parser.Implicits._
 import com.daml.lf.testing.parser.ParserParameters
 import com.daml.lf.transaction.GlobalKeyWithMaintainers
@@ -33,9 +34,9 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
   val commonDefsPkg =
     p"""metadata ( '-common-defs-' : '1.0.0' )
           module Mod {
-            record @serializable MyUnit = {};
+            record @serializable MyView = { value : Int64 };
             interface (this : Iface) = {
-              viewtype Mod:MyUnit;
+              viewtype Mod:MyView;
 
               method interfaceChoiceControllers : List Party;
               method interfaceChoiceObservers : List Party;
@@ -55,6 +56,7 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
 
             val mkParty : Text -> Party = \(t:Text) -> case TEXT_TO_PARTY t of None -> ERROR @Party "none" | Some x -> x;
             val alice : Party = Mod:mkParty "Alice";
+            val bob : Party = Mod:mkParty "Bob";
           }
       """ (parserParameters(commonDefsPkgId))
 
@@ -79,6 +81,7 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
     def v1ChoiceControllers: String =
       s"""Cons @Party [Mod:${templateName} {p1} this] (Nil @Party)"""
     def v1ChoiceObservers: String = """Nil @Party"""
+    def v1View: String = s"'$commonDefsPkgId':Mod:MyView { value = 0 }"
 
     def v2Precondition: String = v1Precondition
     def v2Signatories: String = v1Signatories
@@ -88,6 +91,7 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
     def v2ChoiceControllers: String = v1ChoiceControllers
     def v2ChoiceObservers: String = v1ChoiceObservers
     def v2Maintainers: String = v1Maintainers
+    def v2View: String = v1View
 
     private def templateDefinition(
         precondition: String,
@@ -98,6 +102,7 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
         maintainers: String,
         choiceControllers: String,
         choiceObservers: String,
+        view: String,
     ): String =
       s"""
          |  record @serializable $templateName = { p1: Party, p2: Party };
@@ -107,13 +112,13 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
          |    observers $observers;
          |    agreement $agreement;
          |
-         |    choice @nonConsuming SomeChoice (self) (u: Unit): Text
+         |    choice @nonConsuming TemplateChoice (self) (u: Unit): Text
          |      , controllers (Cons @Party [Mod:${templateName} {p1} this] (Nil @Party))
          |      , observers (Nil @Party)
-         |      to upure @Text "SomeChoice was called";
+         |      to upure @Text "TemplateChoice was called";
          |
          |    implements '$commonDefsPkgId':Mod:Iface {
-         |      view = '$commonDefsPkgId':Mod:MyUnit {};
+         |      view = $view;
          |      method interfaceChoiceControllers = $choiceControllers;
          |      method interfaceChoiceObservers = $choiceObservers;
          |    };
@@ -130,6 +135,7 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
       v1Maintainers,
       v1ChoiceControllers,
       v1ChoiceObservers,
+      v1View,
     )
 
     def v2TemplateDefinition: String = templateDefinition(
@@ -141,22 +147,186 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
       v2Maintainers,
       v2ChoiceControllers,
       v2ChoiceObservers,
+      v2View,
     )
 
     def clientChoices(v1PkgId: Ref.PackageId, v2PkgId: Ref.PackageId): String = {
       val v1TplQualifiedName = s"'$v1PkgId':Mod:$templateName"
       val v2TplQualifiedName = s"'$v2PkgId':Mod:$templateName"
+      val ifaceQualifiedName = s"'$commonDefsPkgId':Mod:Iface"
+      val viewQualifiedName = s"'$commonDefsPkgId':Mod:MyView"
       s"""
         |  choice @nonConsuming ExerciseLocal${templateName} (self) (u: Unit): Text
         |    , controllers (Cons @Party [Mod:Client {p} this] (Nil @Party))
         |    , observers (Nil @Party)
         |    to ubind cid: ContractId $v1TplQualifiedName <-
-        |         create @$v1TplQualifiedName ($v1TplQualifiedName { p = '$commonDefsPkgId':Mod:alice })
+        |         create
+        |           @$v1TplQualifiedName
+        |           ($v1TplQualifiedName
+        |               { p1 = '$commonDefsPkgId':Mod:alice
+        |               , p2 = '$commonDefsPkgId':Mod:bob
+        |               })
         |       in exercise
         |            @$v2TplQualifiedName
-        |            SomeChoice
+        |            TemplateChoice
         |            (COERCE_CONTRACT_ID @$v1TplQualifiedName @$v2TplQualifiedName cid)
         |            ();
+        |
+        |  choice @nonConsuming ExerciseGlobal${templateName} (self) (cid: ContractId $v1TplQualifiedName): Text
+        |    , controllers (Cons @Party [Mod:Client {p} this] (Nil @Party))
+        |    , observers (Nil @Party)
+        |    to exercise
+        |         @$v2TplQualifiedName
+        |         TemplateChoice
+        |         (COERCE_CONTRACT_ID @$v1TplQualifiedName @$v2TplQualifiedName cid)
+        |         ();
+        |
+        |  choice @nonConsuming ExerciseInterfaceLocal${templateName} (self) (u: Unit): Text
+        |    , controllers (Cons @Party [Mod:Client {p} this] (Nil @Party))
+        |    , observers (Nil @Party)
+        |    to ubind cid: ContractId $v1TplQualifiedName <-
+        |         create
+        |           @$v1TplQualifiedName
+        |           ($v1TplQualifiedName
+        |               { p1 = '$commonDefsPkgId':Mod:alice
+        |               , p2 = '$commonDefsPkgId':Mod:bob
+        |               })
+        |       in exercise_interface
+        |            @$ifaceQualifiedName
+        |            InterfaceChoice
+        |            (COERCE_CONTRACT_ID @$v1TplQualifiedName @$ifaceQualifiedName cid)
+        |            ();
+        |
+        |  choice @nonConsuming ExerciseInterfaceGlobal${templateName} (self) (cid: ContractId $v1TplQualifiedName): Text
+        |    , controllers (Cons @Party [Mod:Client {p} this] (Nil @Party))
+        |    , observers (Nil @Party)
+        |    to exercise_interface
+        |         @$ifaceQualifiedName
+        |         InterfaceChoice
+        |         (COERCE_CONTRACT_ID @$v1TplQualifiedName @$ifaceQualifiedName cid)
+        |         ();
+        |
+        |  choice @nonConsuming ExerciseByKeyLocal${templateName} (self) (u: Unit): Text
+        |    , controllers (Cons @Party [Mod:Client {p} this] (Nil @Party))
+        |    , observers (Nil @Party)
+        |    to ubind cid: ContractId $v1TplQualifiedName <-
+        |         create
+        |           @$v1TplQualifiedName
+        |           ($v1TplQualifiedName
+        |               { p1 = '$commonDefsPkgId':Mod:alice
+        |               , p2 = '$commonDefsPkgId':Mod:bob
+        |               })
+        |       in exercise_by_key
+        |            @$v2TplQualifiedName
+        |            TemplateChoice
+        |            ('$commonDefsPkgId':Mod:Key {
+        |                 label = "test-key",
+        |                 maintainers = (Cons @Party ['$commonDefsPkgId':Mod:alice] (Nil @Party)) })
+        |            ();
+        |
+        |  choice @nonConsuming ExerciseByKeyGlobal${templateName} (self) (key: '$commonDefsPkgId':Mod:Key): Text
+        |    , controllers (Cons @Party [Mod:Client {p} this] (Nil @Party))
+        |    , observers (Nil @Party)
+        |    to exercise_by_key
+        |         @$v2TplQualifiedName
+        |         TemplateChoice
+        |         key
+        |         ();
+        |
+        |  choice @nonConsuming FetchLocal${templateName} (self) (u: Unit): $v2TplQualifiedName
+        |    , controllers (Cons @Party [Mod:Client {p} this] (Nil @Party))
+        |    , observers (Nil @Party)
+        |    to ubind cid: ContractId $v1TplQualifiedName <-
+        |         create
+        |           @$v1TplQualifiedName
+        |           ($v1TplQualifiedName
+        |               { p1 = '$commonDefsPkgId':Mod:alice
+        |               , p2 = '$commonDefsPkgId':Mod:bob
+        |               })
+        |       in fetch_template
+        |            @$v2TplQualifiedName
+        |            (COERCE_CONTRACT_ID @$v1TplQualifiedName @$v2TplQualifiedName cid);
+        |
+        |  choice @nonConsuming FetchGlobal${templateName} (self) (cid: ContractId $v1TplQualifiedName): $v2TplQualifiedName
+        |    , controllers (Cons @Party [Mod:Client {p} this] (Nil @Party))
+        |    , observers (Nil @Party)
+        |    to fetch_template
+        |         @$v2TplQualifiedName
+        |         (COERCE_CONTRACT_ID @$v1TplQualifiedName @$v2TplQualifiedName cid);
+        |
+        |  choice @nonConsuming FetchByKeyLocal${templateName} (self) (u: Unit): $v2TplQualifiedName
+        |    , controllers (Cons @Party [Mod:Client {p} this] (Nil @Party))
+        |    , observers (Nil @Party)
+        |    to ubind cid: ContractId $v1TplQualifiedName <-
+        |         create
+        |           @$v1TplQualifiedName
+        |           ($v1TplQualifiedName
+        |               { p1 = '$commonDefsPkgId':Mod:alice
+        |               , p2 = '$commonDefsPkgId':Mod:bob
+        |               })
+        |       in ubind pair:<contract: $v2TplQualifiedName, contractId: ContractId $v2TplQualifiedName> <-
+        |              fetch_by_key
+        |                @$v2TplQualifiedName
+        |                ('$commonDefsPkgId':Mod:Key {
+        |                     label = "test-key",
+        |                     maintainers = (Cons @Party ['$commonDefsPkgId':Mod:alice] (Nil @Party)) })
+        |          in upure @$v2TplQualifiedName (pair).contract;
+        |
+        |  choice @nonConsuming FetchByKeyGlobal${templateName} (self) (key: '$commonDefsPkgId':Mod:Key): $v2TplQualifiedName
+        |    , controllers (Cons @Party [Mod:Client {p} this] (Nil @Party))
+        |    , observers (Nil @Party)
+        |    to ubind pair:<contract: $v2TplQualifiedName, contractId: ContractId $v2TplQualifiedName> <-
+        |          fetch_by_key
+        |            @$v2TplQualifiedName
+        |            key
+        |       in upure @$v2TplQualifiedName (pair).contract;
+        |
+        |  choice @nonConsuming FetchInterfaceLocal${templateName} (self) (u: Unit): $viewQualifiedName
+        |    , controllers (Cons @Party [Mod:Client {p} this] (Nil @Party))
+        |    , observers (Nil @Party)
+        |    to ubind
+        |         cid: ContractId $v1TplQualifiedName <-
+        |           create
+        |             @$v1TplQualifiedName
+        |             ($v1TplQualifiedName
+        |                 { p1 = '$commonDefsPkgId':Mod:alice
+        |                 , p2 = '$commonDefsPkgId':Mod:bob
+        |                 });
+        |         iface: $ifaceQualifiedName <- fetch_interface
+        |            @$ifaceQualifiedName
+        |            (COERCE_CONTRACT_ID @$v1TplQualifiedName @$ifaceQualifiedName cid)
+        |         in upure @$viewQualifiedName (view_interface @$ifaceQualifiedName iface);
+        |
+        |  choice @nonConsuming FetchInterfaceGlobal${templateName} (self) (cid: ContractId $v1TplQualifiedName): $viewQualifiedName
+        |    , controllers (Cons @Party [Mod:Client {p} this] (Nil @Party))
+        |    , observers (Nil @Party)
+        |    to ubind iface: $ifaceQualifiedName <- fetch_interface
+        |         @$ifaceQualifiedName
+        |         (COERCE_CONTRACT_ID @$v1TplQualifiedName @$ifaceQualifiedName cid)
+        |       in upure @$viewQualifiedName (view_interface @$ifaceQualifiedName iface);
+        |
+        |  choice @nonConsuming LookupByKeyLocal${templateName} (self) (u: Unit): Option (ContractId $v2TplQualifiedName)
+        |    , controllers (Cons @Party [Mod:Client {p} this] (Nil @Party))
+        |    , observers (Nil @Party)
+        |    to ubind cid: ContractId $v1TplQualifiedName <-
+        |         create
+        |           @$v1TplQualifiedName
+        |           ($v1TplQualifiedName
+        |               { p1 = '$commonDefsPkgId':Mod:alice
+        |               , p2 = '$commonDefsPkgId':Mod:bob
+        |               })
+        |       in lookup_by_key
+        |            @$v2TplQualifiedName
+        |            ('$commonDefsPkgId':Mod:Key {
+        |                 label = "test-key",
+        |                 maintainers = (Cons @Party ['$commonDefsPkgId':Mod:alice] (Nil @Party)) });
+        |
+        |  choice @nonConsuming LookupByKeyGlobal${templateName} (self) (key: '$commonDefsPkgId':Mod:Key): Option (ContractId $v2TplQualifiedName)
+        |    , controllers (Cons @Party [Mod:Client {p} this] (Nil @Party))
+        |    , observers (Nil @Party)
+        |    to lookup_by_key
+        |         @$v2TplQualifiedName
+        |         key;
         |""".stripMargin
     }
   }
@@ -178,7 +348,7 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
 
   case object ChangedObserversInvalid extends TemplateGenerator("ChangedObserversInvalid") {
     override def v1Observers = "Nil @Party"
-    override def v2Observers = s"Cons @Party [Mod:${templateName} {p1} this] (Nil @Party)"
+    override def v2Observers = s"Cons @Party [Mod:${templateName} {p2} this] (Nil @Party)"
   }
 
   val templateGenerators: Seq[TemplateGenerator] = List(
@@ -256,7 +426,7 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
     clientPkgId -> clientPkg,
   )
 
-  val packageMap =
+  val packageMap: Map[PackageId, (PackageName, Ref.PackageVersion)] =
     lookupPackage.view.mapValues(pkg => (pkg.name.get, pkg.metadata.get.version)).toMap
 
   // println(lookupPackage)
@@ -271,9 +441,33 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
   def toContractId(s: String): ContractId =
     ContractId.V1.assertBuild(crypto.Hash.hashPrivateKey(s), Bytes.assertFromString("00"))
 
+  sealed abstract class Operation(val name: String)
+  case object Exercise extends Operation("exercise")
+  case object ExerciseByKey extends Operation("exerciseByKey")
+  case object ExerciseInterface extends Operation("exerciseInterface")
+  case object Fetch extends Operation("fetch")
+  case object FetchByKey extends Operation("fetch")
+  case object FetchInterface extends Operation("fetchInterface")
+  case object LookupByKey extends Operation("lookupByKey")
+
+  sealed abstract class EntryPoint(val name: String)
+  case object Command extends EntryPoint("command")
+  case object ChoiceBody extends EntryPoint("choiceBody")
+
+  sealed abstract class ContractOrigin(val name: String)
+  case object Global extends ContractOrigin("global")
+  case object Disclosed extends ContractOrigin("disclosed")
+  case object Local extends ContractOrigin("local")
+
+  for (templateGenerator <- templateGenerators) {
+    templateGenerator.templateName - {}
+  }
+
   "test" in {
 
     implicit val logContext: LoggingContext = LoggingContext.ForTesting
+
+    val template = ChangedObserversInvalid
 
     val participant = Ref.ParticipantId.assertFromString("participant")
     val engine = newEngine()
@@ -281,63 +475,249 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
     val bob: Party = Party.assertFromString("Bob")
 
     val tplQualifiedName =
-      Ref.QualifiedName.assertFromString(s"Mod:${ChangedObserversValid.templateName}")
-    val tplId = Identifier(templateDefsV1PkgId, tplQualifiedName)
+      Ref.QualifiedName.assertFromString(s"Mod:${template.templateName}")
+    val v1TplId = Identifier(templateDefsV1PkgId, tplQualifiedName)
+    val v2TplId = Identifier(templateDefsV2PkgId, tplQualifiedName)
+
     val let = Time.Timestamp.Epoch
 
     val submissionSeed = crypto.Hash.hashPrivateKey("command")
     val submitters = Set(alice)
     val readAs = Set.empty[Party]
 
-    case class ContractInfo(
-        instance: VersionedContractInstance,
-        signatories: Set[Party],
-        observers: Set[Party],
-        keyOpt: Option[GlobalKeyWithMaintainers],
-    )
+    val clientTplId = Identifier(clientPkgId, Ref.QualifiedName.assertFromString("Mod:Client"))
 
-    @nowarn
-    val createCommand =
-      ApiCommand.Create(
-        tplId,
-        ValueRecord(
-          Some(tplId),
-          ImmArray(
-            Some(Name.assertFromString("p1")) -> ValueParty(alice),
-            Some(Name.assertFromString("p2")) -> ValueParty(bob),
-          ),
-        ),
-      )
+    val ifaceId = Identifier(commonDefsPkgId, Ref.QualifiedName.assertFromString("Mod:Iface"))
+
+//    @nowarn
+//    val createCommand =
+//      ApiCommand.Create(
+//        v1TplId,
+//        ValueRecord(
+//          Some(v1TplId),
+//          ImmArray(
+//            Some(Name.assertFromString("p1")) -> ValueParty(alice),
+//            Some(Name.assertFromString("p2")) -> ValueParty(bob),
+//          ),
+//        ),
+//      )
+
+    val clientContractId = toContractId("client")
+
+    val globalContractId = toContractId("1")
+    val globalContractArg = ValueRecord(
+      Some(v1TplId),
+      ImmArray(
+        Some(Name.assertFromString("p1")) -> ValueParty(alice),
+        Some(Name.assertFromString("p2")) -> ValueParty(bob),
+      ),
+    )
 
     val lookupContract =
       Map(
-        toContractId("1") ->
+        clientContractId ->
           assertAsVersionedContract(
             ContractInstance(
-              templateDefsV1Pkg.name,
-              Identifier(templateDefsV1PkgId, tplQualifiedName),
+              clientPkg.name,
+              clientTplId,
               ValueRecord(
-                Some(Identifier(templateDefsV1PkgId, tplQualifiedName)),
+                Some(clientTplId),
                 ImmArray(
-                  Some(Name.assertFromString("p1")) -> ValueParty(alice),
-                  Some(Name.assertFromString("p2")) -> ValueParty(bob),
+                  Some(Name.assertFromString("p")) -> ValueParty(alice)
                 ),
               ),
             )
-          )
+          ),
+        globalContractId ->
+          assertAsVersionedContract(
+            ContractInstance(
+              templateDefsV1Pkg.name,
+              v1TplId,
+              globalContractArg,
+            )
+          ),
       )
 
+    val key = SValue.SRecord(
+      Ref.Identifier.assertFromString(s"$commonDefsPkgId:Mod:Key"),
+      ImmArray(
+        Ref.Name.assertFromString("label"),
+        Ref.Name.assertFromString("maintainers"),
+      ),
+      ArrayList(
+        SValue.SText("test-key"),
+        SValue.SList(FrontStack(SValue.SParty(alice))),
+      ),
+    )
+
+    val globalKey = GlobalKeyWithMaintainers.assertBuild(
+      v1TplId,
+      key.toUnnormalizedValue,
+      Set(alice),
+      KeyPackageName(Some(templateDefsPkgName), templateDefsV1Pkg.languageVersion),
+    )
+
     @nowarn
-    val fetchCmd = speedy.Command.FetchTemplate(
-      Identifier(templateDefsV1PkgId, tplQualifiedName),
-      SValue.SContractId(toContractId("1")),
+    val globalContractDisclosure = DisclosedContract(
+      templateId = v1TplId,
+      contractId = globalContractId,
+      argument = globalContractArg,
+      keyHash = Some(
+        crypto.Hash.assertHashContractKey(
+          v1TplId,
+          key.toUnnormalizedValue.asInstanceOf[ValueRecord],
+          KeyPackageName(Some(templateDefsPkgName), templateDefsV1Pkg.languageVersion),
+        )
+      ),
     )
 
     // @nowarn
-    val exerciseCmd = ApiCommand.Exercise(
-      Identifier(templateDefsV2PkgId, tplQualifiedName),
-      toContractId("1"),
-      Ref.ChoiceName.assertFromString("SomeChoice"),
+    val exerciseCmdGlobal = ApiCommand.Exercise(
+      v2TplId,
+      globalContractId,
+      Ref.ChoiceName.assertFromString("TemplateChoice"),
+      ValueUnit,
+    )
+
+    @nowarn
+    val exerciseCmdLocal = ApiCommand.CreateAndExercise(
+      v2TplId,
+      ValueRecord(
+        Some(v2TplId),
+        ImmArray(
+          Some(Name.assertFromString("p1")) -> ValueParty(alice),
+          Some(Name.assertFromString("p2")) -> ValueParty(bob),
+        ),
+      ),
+      Ref.ChoiceName.assertFromString("TemplateChoice"),
+      ValueUnit,
+    )
+
+    @nowarn
+    val exerciseInterfaceCmdGlobal = ApiCommand.Exercise(
+      ifaceId,
+      globalContractId,
+      Ref.ChoiceName.assertFromString("InterfaceChoice"),
+      ValueUnit,
+    )
+
+    @nowarn
+    val exerciseByKeyCmdGlobal = ApiCommand.ExerciseByKey(
+      v2TplId,
+      key.toUnnormalizedValue,
+      Ref.ChoiceName.assertFromString("TemplateChoice"),
+      ValueUnit,
+    )
+
+    @nowarn
+    val fetchChoiceBodyGlobal = ApiCommand.Exercise(
+      clientTplId,
+      clientContractId,
+      Ref.ChoiceName.assertFromString(s"FetchGlobal${template.templateName}"),
+      ValueContractId(globalContractId),
+    )
+
+    @nowarn
+    val fetchChoiceBodyLocal = ApiCommand.Exercise(
+      clientTplId,
+      clientContractId,
+      Ref.ChoiceName.assertFromString(s"FetchLocal${template.templateName}"),
+      ValueUnit,
+    )
+
+    @nowarn
+    val fetchInterfaceChoiceBodyGlobal = ApiCommand.Exercise(
+      clientTplId,
+      clientContractId,
+      Ref.ChoiceName.assertFromString(s"FetchInterfaceGlobal${template.templateName}"),
+      ValueContractId(globalContractId),
+    )
+
+    @nowarn
+    val fetchInterfaceChoiceBodyLocal = ApiCommand.Exercise(
+      clientTplId,
+      clientContractId,
+      Ref.ChoiceName.assertFromString(s"FetchInterfaceLocal${template.templateName}"),
+      ValueUnit,
+    )
+
+    @nowarn
+    val fetchByKeyChoiceBodyGlobal = ApiCommand.Exercise(
+      clientTplId,
+      clientContractId,
+      Ref.ChoiceName.assertFromString(s"FetchByKeyGlobal${template.templateName}"),
+      key.toUnnormalizedValue,
+    )
+
+    @nowarn
+    val fetchByKeyChoiceBodyLocal = ApiCommand.Exercise(
+      clientTplId,
+      clientContractId,
+      Ref.ChoiceName.assertFromString(s"FetchByKeyLocal${template.templateName}"),
+      ValueUnit,
+    )
+
+    @nowarn
+    val lookupByKeyChoiceBodyGlobal = ApiCommand.Exercise(
+      clientTplId,
+      clientContractId,
+      Ref.ChoiceName.assertFromString(s"LookupByKeyGlobal${template.templateName}"),
+      key.toUnnormalizedValue,
+    )
+
+    @nowarn
+    val lookupByKeyChoiceBodyLocal = ApiCommand.Exercise(
+      clientTplId,
+      clientContractId,
+      Ref.ChoiceName.assertFromString(s"LookupByKeyLocal${template.templateName}"),
+      ValueUnit,
+    )
+
+    @nowarn
+    val exerciseChoiceBodyGlobal = ApiCommand.Exercise(
+      clientTplId,
+      clientContractId,
+      Ref.ChoiceName.assertFromString(s"ExerciseGlobal${template.templateName}"),
+      ValueContractId(globalContractId),
+    )
+
+    @nowarn
+    val exerciseChoiceBodyLocal = ApiCommand.Exercise(
+      clientTplId,
+      clientContractId,
+      Ref.ChoiceName.assertFromString(s"ExerciseLocal${template.templateName}"),
+      ValueUnit,
+    )
+
+    @nowarn
+    val exerciseByKeyChoiceBodyGlobal = ApiCommand.Exercise(
+      clientTplId,
+      clientContractId,
+      Ref.ChoiceName.assertFromString(s"ExerciseByKeyGlobal${template.templateName}"),
+      key.toUnnormalizedValue,
+    )
+
+    @nowarn
+    val exerciseByKeyChoiceBodyLocal = ApiCommand.Exercise(
+      clientTplId,
+      clientContractId,
+      Ref.ChoiceName.assertFromString(s"ExerciseByKeyLocal${template.templateName}"),
+      ValueUnit,
+    )
+
+    @nowarn
+    val exerciseInterfaceChoiceBodyGlobal = ApiCommand.Exercise(
+      clientTplId,
+      clientContractId,
+      Ref.ChoiceName.assertFromString(s"ExerciseInterfaceGlobal${template.templateName}"),
+      ValueContractId(globalContractId),
+    )
+
+    @nowarn
+    val exerciseInterfaceChoiceBodyLocal = ApiCommand.Exercise(
+      clientTplId,
+      clientContractId,
+      Ref.ChoiceName.assertFromString(s"ExerciseInterfaceLocal${template.templateName}"),
       ValueUnit,
     )
 
@@ -347,17 +727,16 @@ class UpgradeTest extends AnyFreeSpec with Matchers {
         packagePreference = Set(commonDefsPkgId, templateDefsV2PkgId, clientPkgId),
         submitters = submitters,
         readAs = readAs,
-        cmds = ApiCommands(ImmArray(exerciseCmd), let, "test"),
-        disclosures = ImmArray.empty,
+        cmds = ApiCommands(ImmArray(exerciseCmdGlobal), let, "test"),
+        disclosures = ImmArray.empty, // ImmArray(globalContractDisclosure),
         participantId = participant,
         submissionSeed = submissionSeed,
       )
       .consume(
         pcs = lookupContract,
         pkgs = lookupPackage,
-        keys = Map.empty,
+        keys = Map(globalKey -> globalContractId),
       )
     interpretResult shouldBe a[Right[_, _]]
   }
-
 }

--- a/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -42,6 +42,7 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
       eFromAnyException |
       eToTextTypeConName |
       eThrow |
+      eViewInterface |
       eCallInterface |
       eToInterface |
       eFromInterface |
@@ -229,6 +230,11 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
   private lazy val eThrow: Parser[EThrow] =
     `throw` ~>! argTyp ~ argTyp ~ expr0 ^^ { case retType ~ excepType ~ exception =>
       EThrow(retType, excepType, exception)
+    }
+
+  private lazy val eViewInterface: Parser[EViewInterface] =
+    `view_interface` ~! `@` ~> fullIdentifier ~ expr0 ^^ { case ifaceId ~ expr0 =>
+      EViewInterface(ifaceId, expr0)
     }
 
   private lazy val eToTextTypeConName: Parser[Expr] =

--- a/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
+++ b/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
@@ -42,6 +42,7 @@ private[parser] object Lexer extends RegexParsers {
     "to_any_exception" -> `to_any_exception`,
     "from_any_exception" -> `from_any_exception`,
     "throw" -> `throw`,
+    "view_interface" -> `view_interface`,
     "catch" -> `catch`,
     "to_interface" -> `to_interface`,
     "to_required_interface" -> `to_required_interface`,

--- a/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
+++ b/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
@@ -51,6 +51,7 @@ private[parser] object Token {
   case object `to_any_exception` extends Token
   case object `from_any_exception` extends Token
   case object `throw` extends Token
+  case object `view_interface` extends Token
   case object `catch` extends Token
   case object `to_interface` extends Token
   case object `from_interface` extends Token


### PR DESCRIPTION
Adds one large unit test which tests the runtime semantics of upgrades in a large number of scenarios. The scenarios are enumerated systematically. The inner workings of the tests are detailed in [this scaladoc comment](https://github.com/digital-asset/daml/pull/20329/files#diff-a9b0ccb254f474fb2f6237104c7a6bdac59824d7b0c38d1eed05568ca8c418ffR26-R57) and other scaladoc comments inside the class.

We don't test yet all the rows of the test matrix, and we may never be able to cover all of them with this one test, but it is large enough already that it warrants a review. I'll add more cases in further PRs. The currently tested rows are:

```
    UnchangedPrecondition,
    ChangedPrecondition,
    ThrowingPrecondition,
    UnchangedSignatories,
    ChangedSignatories,
    ThrowingSignatories,
    UnchangedObservers,
    ChangedObservers,
    ThrowingObservers,
    UnchangedAgreement,
    ChangedAgreement,
    ThrowingAgreement,
    ChangedKey,
    UnchangedKey,
    ThrowingKey,
    ChangedMaintainers,
    UnchangedMaintainers,
    ThrowingMaintainers,
    ThrowingMaintainersBody,
    AdditionalTemplateArg
```