### PR TITLE
[Engine] Add transaction trace

### DIFF
--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -295,7 +295,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
               )
             }
 
-        case ResultInterruption(continue) =>
+        case ResultInterruption(continue, abort) =>
           // We want to prevent the interpretation to run indefinitely and use all the resources.
           // For this purpose, we check the following condition:
           //
@@ -333,6 +333,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
                   .InterpretationTimeExceeded(
                     ledgerEffectiveTime,
                     ledgerTimeRecordTimeTolerance,
+                    abort(),
                   )
                 Future.successful(Left(error))
               } else resume()

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
@@ -25,6 +25,7 @@ object ErrorCause {
   final case class InterpretationTimeExceeded(
       ledgerEffectiveTime: Time.Timestamp, // the Ledger Effective Time of the submitted command
       tolerance: NonNegativeFiniteDuration,
+      transactionTrace: Option[String],
   ) extends ErrorCause
 }
 
@@ -65,7 +66,7 @@ object RejectionGenerators {
     def processDamlException(
         err: com.daml.lf.interpretation.Error,
         renderedMessage: String,
-        detailMessage: Option[String],
+        transactionTrace: Option[String],
     ): DamlError =
       // detailMessage is only suitable for server side debugging but not for the user, so don't pass except on internal errors
 
@@ -100,7 +101,7 @@ object RejectionGenerators {
             .RejectWithContractKeyArg(renderedMessage, key)
         case e: LfInterpretationError.UnhandledException =>
           CommandExecutionErrors.Interpreter.UnhandledException.Reject(
-            renderedMessage + detailMessage.fold("")(x => ". Details: " + x),
+            renderedMessage + transactionTrace.fold("")("\n" + _) + ".",
             e,
           )
         case e: LfInterpretationError.UserError =>
@@ -176,9 +177,9 @@ object RejectionGenerators {
       case ErrorCause.LedgerTime(retries) =>
         CommandExecutionErrors.FailedToDetermineLedgerTime
           .Reject(s"Could not find a suitable ledger time after $retries retries")
-      case ErrorCause.InterpretationTimeExceeded(let, tolerance) =>
+      case ErrorCause.InterpretationTimeExceeded(let, tolerance, transactionTrace) =>
         CommandExecutionErrors.TimeExceeded.Reject(
-          s"Interpretation time exceeds limit of Ledger Effective Time ($let) + tolerance ($tolerance)"
+          s"Time exceeds limit of Ledger Effective Time ($let) + tolerance ($tolerance). Interpretation aborted" + transactionTrace.fold("")("\n" + _) + "."
         )
     }
   }

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/LfValueTranslation.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/LfValueTranslation.scala
@@ -652,7 +652,7 @@ final class LfValueTranslation(
               .map(resume)
               .flatMap(goAsync)
 
-          case LfEngine.ResultInterruption(continue) =>
+          case LfEngine.ResultInterruption(continue, _) =>
             goAsync(continue())
 
           case LfEngine.ResultNeedAuthority(_, _, _) =>

--- a/sdk/canton/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandExecutorSpec.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandExecutorSpec.scala
@@ -215,7 +215,7 @@ class StoreBackedCommandExecutorSpec
           LoggingContextWithTrace(loggerFactory)
         )
         .map {
-          case Left(InterpretationTimeExceeded(`let`, `tolerance`)) => succeed
+          case Left(InterpretationTimeExceeded(`let`, `tolerance`, _)) => succeed
           case _ => fail()
         }
     }

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/util/DAMLe.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/util/DAMLe.scala
@@ -169,7 +169,7 @@ class DAMLe(
           Left(
             Error.Interpretation(
               Error.Interpretation.Internal("engine.reinterpret", msg, None),
-              detailMessage = None,
+              transactionTrace = None,
             )
           )
 
@@ -317,7 +317,7 @@ class DAMLe(
     @tailrec
     def iterateOverInterrupts(continue: () => Result[A]): Result[A] =
       continue() match {
-        case ResultInterruption(continue) => iterateOverInterrupts(continue)
+        case ResultInterruption(continue, _) => iterateOverInterrupts(continue)
         case otherResult => otherResult
       }
 
@@ -349,7 +349,7 @@ class DAMLe(
           .value
           .flatMap(optInst => handleResult(contracts, resume(optInst)))
       case ResultError(err) => Future.successful(Left(err))
-      case ResultInterruption(continue) =>
+      case ResultInterruption(continue, _) =>
         // Using a `Future` as a trampoline to make the recursive call to `handleResult` stack safe.
         Future {
           iterateOverInterrupts(continue)

--- a/sdk/compatibility/bazel_tools/testing.bzl
+++ b/sdk/compatibility/bazel_tools/testing.bzl
@@ -759,6 +759,18 @@ excluded_test_tool_tests = [
             },
         ],
     },
+    {
+        "end": "2.10.0-snapshot.20240821.12933.0",
+        "platform_ranges": [
+            {
+                "start": "2.10.0-snapshot.20240821.12933.1",
+                "exclusions": [
+                   "MultiPartySubmissionIT:MPSLookupOtherByKeyInvisible",
+                   "CommandServiceIT:CSReturnStackTrace",
+                ],
+            },
+        ],
+    },
 ]
 
 def in_range(version, range):

--- a/sdk/compatibility/bazel_tools/testing.bzl
+++ b/sdk/compatibility/bazel_tools/testing.bzl
@@ -765,8 +765,8 @@ excluded_test_tool_tests = [
             {
                 "start": "2.10.0-snapshot.20240821.12933.1",
                 "exclusions": [
-                   "MultiPartySubmissionIT:MPSLookupOtherByKeyInvisible",
-                   "CommandServiceIT:CSReturnStackTrace",
+                    "MultiPartySubmissionIT:MPSLookupOtherByKeyInvisible",
+                    "CommandServiceIT:CSReturnStackTrace",
                 ],
             },
         ],

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -8,7 +8,7 @@ import com.daml.lf.command._
 import com.daml.lf.data._
 import com.daml.lf.data.Ref.{Identifier, PackageId, ParticipantId, Party}
 import com.daml.lf.language.Ast._
-import com.daml.lf.speedy.{InitialSeeding, Pretty, Question, SError, SResult, SValue, TraceLog}
+import com.daml.lf.speedy.{InitialSeeding, Question, SError, SResult, SValue, TraceLog}
 import com.daml.lf.speedy.SExpr.{SEApp, SExpr}
 import com.daml.lf.speedy.Speedy.{Machine, PureMachine, UpdateMachine}
 import com.daml.lf.speedy.SResult._
@@ -405,7 +405,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig, allowLF2: Boolean =
     ResultDone(deps)
   }
 
-  private def handleError(err: SError.SError, detailMsg: Option[String] = None): ResultError = {
+  private def handleError(err: SError.SError, detailMsg: Option[String]): ResultError = {
     err match {
       case SError.SErrorDamlException(error) =>
         ResultError(Error.Interpretation.DamlException(error), detailMsg)
@@ -418,9 +418,10 @@ class Engine(val config: EngineConfig = Engine.StableConfig, allowLF2: Boolean =
       machine: UpdateMachine,
       time: Time.Timestamp,
   ): Result[(SubmittedTransaction, Tx.Metadata)] = {
-    def detailMsg = Some(
-      s"Last location: ${Pretty.prettyLoc(machine.getLastLocation).render(80)}, partial transaction: ${machine.nodesToString}"
-    )
+    val abort = () => {
+      machine.abort()
+      Some(machine.transactionTrace)
+    }
 
     def finish: Result[(SubmittedTransaction, Tx.Metadata)] =
       machine.finish match {
@@ -456,7 +457,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig, allowLF2: Boolean =
             ResultDone((tx, meta))
           }
         case Left(err) =>
-          handleError(err)
+          handleError(err, None)
       }
 
     @scala.annotation.tailrec
@@ -544,13 +545,13 @@ class Engine(val config: EngineConfig = Engine.StableConfig, allowLF2: Boolean =
           }
 
         case SResultInterruption =>
-          ResultInterruption(() => interpretLoop(machine, time))
+          ResultInterruption(() => interpretLoop(machine, time), abort)
 
         case _: SResultFinal =>
           finish
 
         case SResultError(err) =>
-          handleError(err, detailMsg)
+          handleError(err, Some(machine.transactionTrace))
       }
     }
 
@@ -626,11 +627,12 @@ class Engine(val config: EngineConfig = Engine.StableConfig, allowLF2: Boolean =
       interfaceId: Identifier,
   )(implicit loggingContext: LoggingContext): Result[Versioned[Value]] = {
     @scala.annotation.nowarn("msg=dead code following this construct")
-    def interpret(machine: PureMachine): Result[SValue] =
+    def interpret(machine: PureMachine, abort: () => Option[String]): Result[SValue] =
       machine.run() match {
         case SResultFinal(v) => ResultDone(v)
         case SResultError(err) => handleError(err, None)
-        case SResult.SResultInterruption => ResultInterruption(() => interpret(machine))
+        case SResult.SResultInterruption =>
+          ResultInterruption(() => interpret(machine, abort), abort)
         case SResultQuestion(nothing) => nothing: Nothing
       }
     for {
@@ -644,7 +646,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig, allowLF2: Boolean =
         sexpr,
         config.iterationsBetweenInterruptions,
       )
-      r <- interpret(machine)
+      r <- interpret(machine, () => { machine.abort(); None })
       version = machine.tmplId2TxVersion(interfaceId)
     } yield Versioned(version, r.toNormalizedValue(version))
   }

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -420,7 +420,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig, allowLF2: Boolean =
   ): Result[(SubmittedTransaction, Tx.Metadata)] = {
     val abort = () => {
       machine.abort()
-      Some(machine.transactionTrace)
+      Some(machine.transactionTrace(config.transactionTraceMaxLength))
     }
 
     def finish: Result[(SubmittedTransaction, Tx.Metadata)] =
@@ -551,7 +551,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig, allowLF2: Boolean =
           finish
 
         case SResultError(err) =>
-          handleError(err, Some(machine.transactionTrace))
+          handleError(err, Some(machine.transactionTrace(config.transactionTraceMaxLength)))
       }
     }
 

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -22,6 +22,8 @@ import com.daml.lf.transaction.ContractKeyUniquenessMode
   * @param allowedLanguageVersions The range of language versions the
   *     engine is allowed to load.  The engine will crash if it asked
   *     to load a language version that is not included in this range.
+  * @param transactionTraceMaxLenght Specified the maximum length of
+  *     the stack trace reported in case of interpretation error.
   * @param stackTraceMode The flag enables the runtime support for
   *     stack trace.
   * @param profileDir The optional specifies the directory where to
@@ -41,6 +43,7 @@ import com.daml.lf.transaction.ContractKeyUniquenessMode
 final case class EngineConfig(
     allowedLanguageVersions: VersionRange[language.LanguageVersion],
     packageValidation: Boolean = true,
+    transactionTraceMaxLength: Int = 10,
     stackTraceMode: Boolean = false,
     profileDir: Option[Path] = None,
     contractKeyUniqueness: ContractKeyUniquenessMode = ContractKeyUniquenessMode.Strict,

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
@@ -166,8 +166,7 @@ object Error {
   // Error happening during interpretation
   final case class Interpretation(
       interpretationError: Interpretation.Error,
-      // detailMessage describes the state of the machine when the error occurs
-      detailMessage: Option[String],
+      transactionTrace: Option[String],
   ) extends Error {
     def message: String = interpretationError.message
   }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -1044,35 +1044,38 @@ private[lf] final class Compiler(
       }
     }
 
-  private[this] def translateCommand(env: Env, cmd: Command): s.SExpr = cmd match {
-    case Command.Create(templateId, argument) =>
-      t.CreateDefRef(templateId)(s.SEValue(argument))
-    case Command.ExerciseTemplate(templateId, contractId, choiceId, argument) =>
-      t.TemplateChoiceDefRef(templateId, choiceId)(s.SEValue(contractId), s.SEValue(argument))
-    case Command.ExerciseInterface(interfaceId, contractId, choiceId, argument) =>
-      t.InterfaceChoiceDefRef(interfaceId, choiceId)(
-        s.SEBuiltin(SBGuardConstTrue),
-        s.SEValue(contractId),
-        s.SEValue(argument),
-      )
-    case Command.ExerciseByKey(templateId, contractKey, choiceId, argument) =>
-      t.ChoiceByKeyDefRef(templateId, choiceId)(s.SEValue(contractKey), s.SEValue(argument))
-    case Command.FetchTemplate(templateId, coid) =>
-      t.FetchTemplateDefRef(templateId)(s.SEValue(coid))
-    case Command.FetchInterface(interfaceId, coid) =>
-      t.FetchInterfaceDefRef(interfaceId)(s.SEValue(coid))
-    case Command.FetchByKey(templateId, key) =>
-      t.FetchByKeyDefRef(templateId)(s.SEValue(key))
-    case Command.CreateAndExercise(templateId, createArg, choice, choiceArg) =>
-      translateCreateAndExercise(
-        env,
-        templateId,
-        createArg,
-        choice,
-        choiceArg,
-      )
-    case Command.LookupByKey(templateId, contractKey) =>
-      t.LookupByKeyDefRef(templateId)(s.SEValue(contractKey))
+  private[this] def translateCommand(env: Env, cmd: Command): s.SExpr = {
+    val body = cmd match {
+      case Command.Create(templateId, argument) =>
+        t.CreateDefRef(templateId)(s.SEValue(argument))
+      case Command.ExerciseTemplate(templateId, contractId, choiceId, argument) =>
+        t.TemplateChoiceDefRef(templateId, choiceId)(s.SEValue(contractId), s.SEValue(argument))
+      case Command.ExerciseInterface(interfaceId, contractId, choiceId, argument) =>
+        t.InterfaceChoiceDefRef(interfaceId, choiceId)(
+          s.SEBuiltin(SBGuardConstTrue),
+          s.SEValue(contractId),
+          s.SEValue(argument),
+        )
+      case Command.ExerciseByKey(templateId, contractKey, choiceId, argument) =>
+        t.ChoiceByKeyDefRef(templateId, choiceId)(s.SEValue(contractKey), s.SEValue(argument))
+      case Command.FetchTemplate(templateId, coid) =>
+        t.FetchTemplateDefRef(templateId)(s.SEValue(coid))
+      case Command.FetchInterface(interfaceId, coid) =>
+        t.FetchInterfaceDefRef(interfaceId)(s.SEValue(coid))
+      case Command.FetchByKey(templateId, key) =>
+        t.FetchByKeyDefRef(templateId)(s.SEValue(key))
+      case Command.CreateAndExercise(templateId, createArg, choice, choiceArg) =>
+        translateCreateAndExercise(
+          env,
+          templateId,
+          createArg,
+          choice,
+          choiceArg,
+        )
+      case Command.LookupByKey(templateId, contractKey) =>
+        t.LookupByKeyDefRef(templateId)(s.SEValue(contractKey))
+    }
+    SBUSetLastCommand(cmd)(body)
   }
 
   private val SEUpdatePureUnit = unaryFunction(Env.Empty)((_, _) => s.SEValue.Unit)

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -2201,6 +2201,16 @@ private[lf] object SBuiltin {
     }
   }
 
+  final case class SBUSetLastCommand(cmd: Command) extends UpdateBuiltin(1) {
+    override protected def executeUpdate(
+        args: util.ArrayList[SValue],
+        machine: UpdateMachine,
+    ): Control[Question.Update] = {
+      machine.lastCommand = Some(cmd)
+      Control.Value(args.get(0))
+    }
+  }
+
   /** $dynamicExercise[T, C, R] :: HasDynamicExercise T C R => ContractId T ->  C -> Update R */
   final case class SBUDynamicExercise(
       templateId: TypeConName,

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -685,4 +685,17 @@ private[speedy] case class PartialTransaction(
     go(this)
   }
 
+  def transactionTrace: List[(NodeId, Node.Exercise)] = {
+    def go(context: Context): List[(NodeId, Node.Exercise)] =
+      context.info match {
+        case exeC: PartialTransaction.ExercisesContextInfo =>
+          (exeC.nodeId, makeExNode(exeC)) :: go(exeC.parent)
+        case tryC: PartialTransaction.TryContextInfo =>
+          go(tryC.parent)
+        case _: PartialTransaction.RootContextInfo =>
+          Nil
+      }
+    go(context)
+  }
+
 }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -685,17 +685,18 @@ private[speedy] case class PartialTransaction(
     go(this)
   }
 
-  def transactionTrace: List[(NodeId, Node.Exercise)] = {
-    def go(context: Context): List[(NodeId, Node.Exercise)] =
+  def transactionTrace: Iterator[(NodeId, Node.Exercise)] = {
+    @tailrec
+    def go(context: Context): Option[((NodeId, Node.Exercise), Context)] =
       context.info match {
         case exeC: PartialTransaction.ExercisesContextInfo =>
-          (exeC.nodeId, makeExNode(exeC)) :: go(exeC.parent)
+          Some((exeC.nodeId, makeExNode(exeC)) -> exeC.parent)
         case tryC: PartialTransaction.TryContextInfo =>
           go(tryC.parent)
         case _: PartialTransaction.RootContextInfo =>
-          Nil
+          None
       }
-    go(context)
+    Iterator.unfold(context)(go)
   }
 
 }

--- a/sdk/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/Daml2ScriptTestRunner.scala
+++ b/sdk/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/Daml2ScriptTestRunner.scala
@@ -19,7 +19,9 @@ class Daml2ScriptTestRunner extends DamlScriptTestRunner {
         darPath,
         """MultiTest:disclosuresByKeyTest SUCCESS
           |MultiTest:disclosuresTest SUCCESS
-          |MultiTest:inactiveDisclosureDoesNotFailDuringSubmission FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.GeneralError:GeneralError@XXXXXXXX{ message = "Here" }. Details: Last location: [GHC.Err:25], partial transaction: ...
+          |MultiTest:inactiveDisclosureDoesNotFailDuringSubmission FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.GeneralError:GeneralError@XXXXXXXX{ message = "Here" }
+          |    in choice XXXXXXXX:Template:Helper:FailWith on contract 00XXXXXXXX (#1)
+          |    in exercise command XXXXXXXX:Template:Helper:FailWith on contract 00XXXXXXXX.
           |MultiTest:listKnownPartiesTest SUCCESS
           |MultiTest:multiTest SUCCESS
           |MultiTest:partyIdHintTest SUCCESS
@@ -29,12 +31,16 @@ class Daml2ScriptTestRunner extends DamlScriptTestRunner {
           |ScriptExample:initializeUser SUCCESS
           |ScriptExample:test SUCCESS
           |ScriptTest:clearUsers SUCCESS
-          |ScriptTest:failingTest FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.AssertionFailed:AssertionFailed@XXXXXXXX{ message = "Assertion failed" }. Details: Last location: [DA.Internal.Exception:169], partial transaction: ...
+          |ScriptTest:failingTest FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.AssertionFailed:AssertionFailed@XXXXXXXX{ message = "Assertion failed" }
+          |    in choice XXXXXXXX:ScriptTest:C:ShouldFail on contract 00XXXXXXXX (#0)
+          |    in exercise command XXXXXXXX:ScriptTest:C:ShouldFail on contract 00XXXXXXXX.
           |ScriptTest:listKnownPartiesTest SUCCESS
           |ScriptTest:multiPartySubmission SUCCESS
           |ScriptTest:partyIdHintTest SUCCESS
           |ScriptTest:sleepTest SUCCESS
-          |ScriptTest:stackTrace FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.AssertionFailed:AssertionFailed@XXXXXXXX{ message = "Assertion failed" }. Details: Last location: [DA.Internal.Exception:169], partial transaction: ...
+          |ScriptTest:stackTrace FAILURE (com.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.AssertionFailed:AssertionFailed@XXXXXXXX{ message = "Assertion failed" }
+          |    in choice XXXXXXXX:ScriptTest:C:ShouldFail on contract 00XXXXXXXX (#1)
+          |    in create-and-exercise command 1ef98323:ScriptTest:C:ShouldFail.
           |ScriptTest:test0 SUCCESS
           |ScriptTest:test1 SUCCESS
           |ScriptTest:test3 SUCCESS

--- a/sdk/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/sdk/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -415,7 +415,7 @@ final class JsonApiIt extends AsyncWordSpec with JsonApiFixture with Matchers wi
         )
       } yield {
         exception.cause.getMessage should include(
-          "Interpretation error: Error: Unhandled Daml exception: DA.Exception.AssertionFailed:AssertionFailed@3f4deaf1{ message = \"Assertion failed\" }."
+          "Interpretation error: Error: Unhandled Daml exception: DA.Exception.AssertionFailed:AssertionFailed@3f4deaf1{ message = \"Assertion failed\" }"
         )
       }
     }

--- a/sdk/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/DamlScriptTestRunner.scala
+++ b/sdk/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/DamlScriptTestRunner.scala
@@ -48,16 +48,23 @@ trait DamlScriptTestRunner extends AnyWordSpec with CantonFixture with Matchers 
     val actual = builder
       .toString()
       .linesIterator
-      .filter(s => List("SUCCESS", "FAILURE").exists(s.contains))
+      .filter(s => List("SUCCESS", "FAILURE", "    in ").exists(s.contains))
       .mkString("", f"%n", f"%n")
       // ignore partial transactions as parties, cids, and package Ids are pretty unpredictable
-      .replaceAll("partial transaction: .*", "partial transaction: ...")
       .replaceAll(
-        """UNHANDLED_EXCEPTION\((\d+),\w{8}\)""",
+        raw"in choice [0-9a-f]{8}:([\w_\.:]+)+ on contract 00[0-9a-f]{8}",
+        "in choice XXXXXXXX:$1 on contract 00XXXXXXXX",
+      )
+      .replaceAll(
+        raw"in ([\w\-]+) command [0-9a-f]{8}:([\w_\.:]+)+ on contract 00[0-9a-f]{8}",
+        "in $1 command XXXXXXXX:$2 on contract 00XXXXXXXX",
+      )
+      .replaceAll(
+        raw"UNHANDLED_EXCEPTION\((\d+),\w{8}\)",
         "UNHANDLED_EXCEPTION($1,XXXXXXXX)",
       )
       .replaceAll(
-        """DA.Exception.(\w+):(\w+)@\w{8}""",
+        raw"DA.Exception.(\w+):(\w+)@\w{8}",
         "DA.Exception.$1:$2@XXXXXXXX",
       )
 

--- a/sdk/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/DamlScriptTestRunner.scala
+++ b/sdk/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/DamlScriptTestRunner.scala
@@ -48,7 +48,7 @@ trait DamlScriptTestRunner extends AnyWordSpec with CantonFixture with Matchers 
     val actual = builder
       .toString()
       .linesIterator
-      .filter(s => List("SUCCESS", "FAILURE", "    in ").exists(s.contains))
+      .filter(s => s.endsWith("SUCCESS") || s.contains("FAILURE") || s.startsWith("    in "))
       .mkString("", f"%n", f"%n")
       // ignore partial transactions as parties, cids, and package Ids are pretty unpredictable
       .replaceAll(

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/CommandServiceIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/CommandServiceIT.scala
@@ -359,6 +359,11 @@ final class CommandServiceIT extends LedgerTestSuite {
     "A submission resulting in an interpretation error should return the stack trace",
     allocate(SingleParty),
   )(implicit ec => { case Participants(Participant(ledger, party)) =>
+    val trace =
+      """
+        |    in choice [0-9a-f]{8}:Test:Dummy:FailingChoice on contract 00[0-9a-f]{8} \(#3\)
+        |    in choice [0-9a-f]{8}:Test:Dummy:FailingClone on contract 00[0-9a-f]{8} \(#0\)
+        |    in exercise command [0-9a-f]{8}:Test:Dummy:FailingClone on contract 00[0-9a-f]{8}""".stripMargin
     for {
       dummy: Dummy.ContractId <- ledger.create(party, new Dummy(party))
       failure <- ledger
@@ -370,7 +375,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         LedgerApiErrors.CommandExecution.Interpreter.UnhandledException,
         Some(
           Pattern.compile(
-            "Interpretation error: Error: (User abort: Assertion failed.?|Unhandled (Daml )?exception: [0-9a-zA-Z\\.:]*@[0-9a-f]*\\{ message = \"Assertion failed\" \\}\\. [Dd]etails(: |=)Last location: \\[[^\\]]*\\], partial transaction: root node)"
+            s"Interpretation error: Error: (User abort: Assertion failed.?|Unhandled (Daml )?exception: [0-9a-zA-Z\\.:]*@[0-9a-f]*\\{ message = \"Assertion failed\" \\}(\\. [Dd]etails(: |=)Last location: \\[[^\\]]*\\], partial transaction: root node|$trace))"
           )
         ),
         checkDefiniteAnswerMetadata = true,

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/MultiPartySubmissionIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/MultiPartySubmissionIT.scala
@@ -397,6 +397,10 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
             ),
         )
         .mustFail("exercising a choice without authorization to look up another contract by key")
+      trace =
+        """
+          |    in choice [0-9a-f]{8}:Test:MultiPartyContract:MPLookupOtherByKey on contract [0-9a-f]{10} (#0)
+          |    in exercise command [0-9a-f]{8}:MultiPartyContract:MPLookupOtherByKey on contract [0-9a-f]{10}.""".stripMargin
     } yield {
       assertGrpcErrorRegex(
         failure,
@@ -406,8 +410,8 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
             "Interpretation error: Error: (" +
               "User abort: Assertion failed." +
               "|User abort: LookupOtherByKey value matches" +
-              "|Unhandled (Daml )?exception: [0-9a-zA-Z\\.:]*@[0-9a-f]*\\{ message = \"LookupOtherByKey value matches\" \\}\\." +
-              ")( [Dd]etails(: |=)Last location: \\[[^\\]]*\\], partial transaction: root node)?"
+              "|Unhandled (Daml )?exception: [0-9a-zA-Z\\.:]*@[0-9a-f]*\\{ message = \"LookupOtherByKey value matches\" \\}" +
+              s")(\\n. [Dd]etails(: |=)Last location: \\[[^\\]]*\\], partial transaction: root node|$trace)?"
           )
         ),
         checkDefiniteAnswerMetadata = true,


### PR DESCRIPTION
Transaction trace are similar to classical stack trace but track only exercise call.

The transaction is of the form

```
    in choice XXXXXXXX:ScriptTest:C:ShouldFail on contract 00XXXXXXXX (#1)
    in create-and-exercise command 1ef98323:ScriptTest:C:ShouldFail.
```
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
