### PR TITLE
Clean-up: remove calls to the 3-arg overload of allocateParty

### DIFF
--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/GrpcLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/GrpcLedgerClient.scala
@@ -352,7 +352,7 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Option[R
       mat: Materializer,
   ) = {
     grpcClient.partyManagementClient
-      .allocateParty(Some(partyIdHint), None, None)
+      .allocateParty(hint = Some(partyIdHint), token = None)
       .map(_.party)
   }
 

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
@@ -354,7 +354,7 @@ class GrpcLedgerClient(
       mat: Materializer,
   ) = {
     grpcClient.partyManagementClient
-      .allocateParty(Some(partyIdHint), None, None)
+      .allocateParty(hint = Some(partyIdHint), token = None)
       .map(_.party)
   }
 

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/AuthIT.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/AuthIT.scala
@@ -33,7 +33,7 @@ class AuthIT(override val majorLanguageVersion: LanguageMajorVersion)
           adminClient <- defaultLedgerClient(config.adminToken)
           userId = Ref.UserId.assertFromString(CantonFixture.freshUserId())
           partyDetails <- Future.sequence(
-            List.fill(2)(adminClient.partyManagementClient.allocateParty(None, None, None))
+            List.fill(2)(adminClient.partyManagementClient.allocateParty(hint = None, token = None))
           )
           parties = partyDetails.map(_.party)
           user = domain.User(userId, None)

--- a/sdk/language-support/java/codegen/src/ledger-tests/scala/com/daml/TestUtil.scala
+++ b/sdk/language-support/java/codegen/src/ledger-tests/scala/com/daml/TestUtil.scala
@@ -48,7 +48,7 @@ trait TestLedger extends CantonFixture with SuiteResourceManagementAroundAll {
   protected def allocateParty: Future[String] = {
     implicit val ec: ExecutionContextExecutor = system.dispatcher
     client.partyManagementClient
-      .allocateParty(hint = None, deprecatedDisplayName = None, token = None)
+      .allocateParty(hint = None, token = None)
       .map(_.party)
   }
 


### PR DESCRIPTION
Part of https://github.com/DACH-NY/canton/issues/21344