### PR TITLE
ignore timeFinalized fields when comparing checked-releases records

### DIFF
--- a/ci/cron/check-releases.sh
+++ b/ci/cron/check-releases.sh
@@ -193,7 +193,9 @@ matches_record() (
   release=$2
   remote=$(mktemp)
   gcloud storage cat $(remote_record_location $release) > $remote
-  diff $remote $listing
+  diff \
+    <(cat $remote | jq 'del(.gcloud[].metadata.timeFinalized)') \
+    <(cat $listing | jq 'del(.gcloud[].metadata.timeFinalized)')
 )
 
 record_success() (


### PR DESCRIPTION
This script checks that the releases on github and gcs contain the same data. Once it has checked a new release, it creates a file on gcs that lists records containing metadata about the releases that have already been checked, so that they don't have to be checked again. In order to decide it doesn't need to check a release, the script creates the expected records and compares them against the records stored on gcs. The records are created via a gcp api call, which started recently adding more info to its responses. Hence old records don't match with new records.

This PR normalizes the records before comparing them.