### PR TITLE
remove 'rotate release duty' PRs from sdk update slack message

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -314,7 +314,7 @@ jobs:
         export GH_REPO=digital-asset/daml
         pr_list=$(gh pr list --search "is:open author:app/azure-pipelines" --json title,url,createdAt --template \
         '{{range .}}{{slice .createdAt 0 10}} <{{.url}}|{{.title}}>
-        {{end}}')
+        {{end}}' | grep -v 'rotate release duty')
         message="Open daml repo PRs to address:
 
         $pr_list"


### PR DESCRIPTION
Tested locally:

```
$ gh pr list --search "is:open author:app/azure-pipelines" --json title,url,createdAt --template \
        '{{range .}}{{slice .createdAt 0 10}} <{{.url}}|{{.title}}>
        {{end}}' | grep -v 'rotate release duty'
2024-11-22 <https://github.com/digital-asset/daml/pull/20347|update canton to 20241121.14638.ve6ce9764>
        2024-11-22 <https://github.com/digital-asset/daml/pull/20346|update canton to 20241121.12347.0.v128eb969/2.10.0-snapshot.20241121.12347.0.v128eb969 in main-2.x>
        2024-11-21 <https://github.com/digital-asset/daml/pull/20338|update canton to 20241120.12346.0.va7aeb4ec/2.10.0-snapshot.20241120.12346.0.va7aeb4ec in main-2.x>

```

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
