### PR TITLE
Forward port of [Engine] Add transaction traces (#20337)

### DIFF
--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -293,7 +293,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
               )
             }
 
-        case ResultInterruption(continue) =>
+        case ResultInterruption(continue, abort) =>
           // We want to prevent the interpretation to run indefinitely and use all the resources.
           // For this purpose, we check the following condition:
           //
@@ -331,6 +331,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
                   .InterpretationTimeExceeded(
                     ledgerEffectiveTime,
                     ledgerTimeRecordTimeTolerance,
+                    abort(),
                   )
                 Future.successful(Left(error))
               } else resume()

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/LfValueTranslation.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/LfValueTranslation.scala
@@ -567,7 +567,7 @@ final class LfValueTranslation(
               .map(resume)
               .flatMap(goAsync)
 
-          case LfEngine.ResultInterruption(continue) =>
+          case LfEngine.ResultInterruption(continue, _) =>
             goAsync(continue())
 
           case LfEngine.ResultNeedUpgradeVerification(_, _, _, _, _) =>

--- a/sdk/canton/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandExecutorSpec.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandExecutorSpec.scala
@@ -245,7 +245,7 @@ class StoreBackedCommandExecutorSpec
           LoggingContextWithTrace(loggerFactory)
         )
         .map {
-          case Left(InterpretationTimeExceeded(`let`, `tolerance`)) => succeed
+          case Left(InterpretationTimeExceeded(`let`, `tolerance`, _)) => succeed
           case _ => fail()
         }
     }

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/util/DAMLe.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/util/DAMLe.scala
@@ -214,7 +214,7 @@ class DAMLe(
           Left(
             Error.Interpretation(
               Error.Interpretation.Internal("engine.reinterpret", msg, None),
-              detailMessage = None,
+              transactionTrace = None,
             )
           )
 
@@ -385,7 +385,7 @@ class DAMLe(
           continue: () => Result[A]
       ): Either[EngineAborted, Result[A]] =
         continue() match {
-          case ResultInterruption(continue) =>
+          case ResultInterruption(continue, _) =>
             getEngineAbortStatus().reasonO match {
               case Some(reason) =>
                 logger.warn(s"Aborting engine computation, reason = $reason")
@@ -426,7 +426,7 @@ class DAMLe(
             .value
             .flatMap(optInst => handleResultInternal(contracts, resume(optInst)))
         case ResultError(err) => Future.successful(Left(EngineError(err)))
-        case ResultInterruption(continue) =>
+        case ResultInterruption(continue, _) =>
           // Run the interruption loop asynchronously to avoid blocking the calling thread.
           // Using a `Future` as a trampoline also makes the recursive call to `handleResult` stack safe.
           Future(iterateOverInterrupts(continue)).flatMap {

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -22,6 +22,8 @@ import com.digitalasset.daml.lf.transaction.ContractKeyUniquenessMode
   * @param allowedLanguageVersions The range of language versions the
   *     engine is allowed to load.  The engine will crash if it asked
   *     to load a language version that is not included in this range.
+  * @param transactionTraceMaxLenght Specified the maximum length of
+  *     the stack trace reported in case of interpretation error.
   * @param stackTraceMode The flag enables the runtime support for
   *     stack trace.
   * @param profileDir The optional specifies the directory where to
@@ -39,6 +41,7 @@ import com.digitalasset.daml.lf.transaction.ContractKeyUniquenessMode
 final case class EngineConfig(
     allowedLanguageVersions: VersionRange[language.LanguageVersion],
     packageValidation: Boolean = true,
+    transactionTraceMaxLength: Int = 10,
     stackTraceMode: Boolean = false,
     profileDir: Option[Path] = None,
     contractKeyUniqueness: ContractKeyUniquenessMode = ContractKeyUniquenessMode.Strict,

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
@@ -154,8 +154,7 @@ object Error {
   // Error happening during interpretation
   final case class Interpretation(
       interpretationError: Interpretation.Error,
-      // detailMessage describes the state of the machine when the error occurs
-      detailMessage: Option[String],
+      transactionTrace: Option[String],
   ) extends Error {
     def message: String = interpretationError.message
   }

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
@@ -19,7 +19,8 @@ import scala.annotation.tailrec
   */
 sealed trait Result[+A] extends Product with Serializable {
   def map[B](f: A => B): Result[B] = this match {
-    case ResultInterruption(continue) => ResultInterruption(() => continue().map(f))
+    case ResultInterruption(continue, abort) =>
+      ResultInterruption(() => continue().map(f), abort)
     case ResultDone(x) => ResultDone(f(x))
     case ResultError(err) => ResultError(err)
     case ResultNeedContract(acoid, resume) =>
@@ -33,7 +34,8 @@ sealed trait Result[+A] extends Product with Serializable {
   }
 
   def flatMap[B](f: A => Result[B]): Result[B] = this match {
-    case ResultInterruption(continue) => ResultInterruption(() => continue().flatMap(f))
+    case ResultInterruption(continue, abort) =>
+      ResultInterruption(() => continue().flatMap(f), abort)
     case ResultDone(x) => f(x)
     case ResultError(err) => ResultError(err)
     case ResultNeedContract(acoid, resume) =>
@@ -56,7 +58,7 @@ sealed trait Result[+A] extends Product with Serializable {
     def go(res: Result[A]): Either[Error, A] =
       res match {
         case ResultDone(x) => Right(x)
-        case ResultInterruption(continue) => go(continue())
+        case ResultInterruption(continue, _) => go(continue())
         case ResultError(err) => Left(err)
         case ResultNeedContract(acoid, resume) => go(resume(pcs.lift(acoid)))
         case ResultNeedPackage(pkgId, resume) => go(resume(pkgs.lift(pkgId)))
@@ -68,7 +70,8 @@ sealed trait Result[+A] extends Product with Serializable {
   }
 }
 
-final case class ResultInterruption[A](continue: () => Result[A]) extends Result[A]
+final case class ResultInterruption[A](continue: () => Result[A], abort: () => Option[String])
+    extends Result[A]
 
 /** Indicates that the command (re)interpretation was successful.
   */
@@ -253,13 +256,15 @@ object Result {
                       .map(otherResults => (okResults :+ x) :++ otherResults)
                   ),
               )
-            case ResultInterruption(continue) =>
-              ResultInterruption(() =>
-                continue().flatMap(x =>
-                  Result
-                    .sequence(results_)
-                    .map(otherResults => (okResults :+ x) :++ otherResults)
-                )
+            case ResultInterruption(continue, abort) =>
+              ResultInterruption(
+                () =>
+                  continue().flatMap(x =>
+                    Result
+                      .sequence(results_)
+                      .map(otherResults => (okResults :+ x) :++ otherResults)
+                  ),
+                abort,
               )
           }
       }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -984,35 +984,38 @@ private[lf] final class Compiler(
       }
     }
 
-  private[this] def translateCommand(env: Env, cmd: Command): s.SExpr = cmd match {
-    case Command.Create(templateId, argument) =>
-      t.CreateDefRef(templateId)(s.SEValue(argument))
-    case Command.ExerciseTemplate(templateId, contractId, choiceId, argument) =>
-      t.TemplateChoiceDefRef(templateId, choiceId)(s.SEValue(contractId), s.SEValue(argument))
-    case Command.ExerciseInterface(interfaceId, contractId, choiceId, argument) =>
-      t.InterfaceChoiceDefRef(interfaceId, choiceId)(
-        s.SEBuiltin(SBGuardConstTrue),
-        s.SEValue(contractId),
-        s.SEValue(argument),
-      )
-    case Command.ExerciseByKey(templateId, contractKey, choiceId, argument) =>
-      t.ChoiceByKeyDefRef(templateId, choiceId)(s.SEValue(contractKey), s.SEValue(argument))
-    case Command.FetchTemplate(templateId, coid) =>
-      t.FetchTemplateDefRef(templateId)(s.SEValue(coid))
-    case Command.FetchInterface(interfaceId, coid) =>
-      t.FetchInterfaceDefRef(interfaceId)(s.SEValue(coid))
-    case Command.FetchByKey(templateId, key) =>
-      t.FetchByKeyDefRef(templateId)(s.SEValue(key))
-    case Command.CreateAndExercise(templateId, createArg, choice, choiceArg) =>
-      translateCreateAndExercise(
-        env,
-        templateId,
-        createArg,
-        choice,
-        choiceArg,
-      )
-    case Command.LookupByKey(templateId, contractKey) =>
-      t.LookupByKeyDefRef(templateId)(s.SEValue(contractKey))
+  private[this] def translateCommand(env: Env, cmd: Command): s.SExpr = {
+    val body = cmd match {
+      case Command.Create(templateId, argument) =>
+        t.CreateDefRef(templateId)(s.SEValue(argument))
+      case Command.ExerciseTemplate(templateId, contractId, choiceId, argument) =>
+        t.TemplateChoiceDefRef(templateId, choiceId)(s.SEValue(contractId), s.SEValue(argument))
+      case Command.ExerciseInterface(interfaceId, contractId, choiceId, argument) =>
+        t.InterfaceChoiceDefRef(interfaceId, choiceId)(
+          s.SEBuiltin(SBGuardConstTrue),
+          s.SEValue(contractId),
+          s.SEValue(argument),
+        )
+      case Command.ExerciseByKey(templateId, contractKey, choiceId, argument) =>
+        t.ChoiceByKeyDefRef(templateId, choiceId)(s.SEValue(contractKey), s.SEValue(argument))
+      case Command.FetchTemplate(templateId, coid) =>
+        t.FetchTemplateDefRef(templateId)(s.SEValue(coid))
+      case Command.FetchInterface(interfaceId, coid) =>
+        t.FetchInterfaceDefRef(interfaceId)(s.SEValue(coid))
+      case Command.FetchByKey(templateId, key) =>
+        t.FetchByKeyDefRef(templateId)(s.SEValue(key))
+      case Command.CreateAndExercise(templateId, createArg, choice, choiceArg) =>
+        translateCreateAndExercise(
+          env,
+          templateId,
+          createArg,
+          choice,
+          choiceArg,
+        )
+      case Command.LookupByKey(templateId, contractKey) =>
+        t.LookupByKeyDefRef(templateId)(s.SEValue(contractKey))
+    }
+    SBUSetLastCommand(cmd)(body)
   }
 
   private val SEUpdatePureUnit = unaryFunction(Env.Empty)((_, _) => s.SEValue.Unit)

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PartialTransaction.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PartialTransaction.scala
@@ -688,4 +688,18 @@ private[speedy] case class PartialTransaction(
     go(this)
   }
 
+  def transactionTrace: Iterator[(NodeId, Node.Exercise)] = {
+    @tailrec
+    def go(context: Context): Option[((NodeId, Node.Exercise), Context)] =
+      context.info match {
+        case exeC: PartialTransaction.ExercisesContextInfo =>
+          Some((exeC.nodeId, makeExNode(exeC)) -> exeC.parent)
+        case tryC: PartialTransaction.TryContextInfo =>
+          go(tryC.parent)
+        case _: PartialTransaction.RootContextInfo =>
+          None
+      }
+    Iterator.unfold(context)(go)
+  }
+
 }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -2124,6 +2124,16 @@ private[lf] object SBuiltinFun {
     }
   }
 
+  final case class SBUSetLastCommand(cmd: Command) extends UpdateBuiltin(1) {
+    override protected def executeUpdate(
+        args: util.ArrayList[SValue],
+        machine: UpdateMachine,
+    ): Control[Question.Update] = {
+      machine.lastCommand = Some(cmd)
+      Control.Value(args.get(0))
+    }
+  }
+
   /** $dynamicExercise[T, C, R] :: HasDynamicExercise T C R => ContractId T ->  C -> Update R */
   final case class SBUDynamicExercise(
       templateId: TypeConName,

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -379,32 +379,35 @@ private[lf] object Speedy {
       * producing a text message.
       */
     private[speedy] override def handleException(excep: SValue.SAny): Control[Nothing] = {
-      @tailrec def unwind(): Option[KTryCatchHandler] =
+      @tailrec
+      def unwind(ptx: PartialTransaction): Option[KTryCatchHandler] =
         if (kontDepth() == 0) {
           None
         } else {
           popKont() match {
             case handler: KTryCatchHandler =>
-              ptx = ptx.rollbackTry()
+              // The machine's ptx is updated even if the handler does not catch the exception.
+              // This may cause the transaction trace to report the error from the handler's location.
+              // Ideally we should embed the trace into the exception directly.
+              this.ptx = ptx.rollbackTry()
               Some(handler)
             case _: KCloseExercise =>
-              ptx = ptx.abortExercises
-              unwind()
+              unwind(ptx.abortExercises)
             case k: KCheckChoiceGuard =>
               // We must abort, because the transaction has failed in a way that is
               // unrecoverable (it depends on the state of an input contract that
               // we may not have the authority to fetch).
-              clearKontStack()
-              clearEnv()
+              abort()
               k.abort()
             case KPreventException() =>
+              abort()
               None
             case _ =>
-              unwind()
+              unwind(ptx)
           }
         }
 
-      unwind() match {
+      unwind(ptx) match {
         case Some(kh) =>
           kh.restore()
           popTempStackToBase()
@@ -671,6 +674,56 @@ private[lf] object Speedy {
       }
     }
 
+    private[speedy] var lastCommand: Option[Command] = None
+
+    def transactionTrace(maxLength: Int): String = {
+      def prettyTypeId(typeId: TypeConName): String =
+        s"${typeId.packageId.take(8)}:${typeId.qualifiedName}"
+      def prettyCoid(coid: V.ContractId): String = coid.coid.take(10)
+      def prettyValue(v: SValue) = Pretty.prettyValue(false)(v.toUnnormalizedValue)
+      val stringBuilder = new StringBuilder()
+      def addLine(s: String) = {
+        val _ = stringBuilder.addAll("    ").addAll(s).addAll("\n")
+      }
+
+      val traceIterator = ptx.transactionTrace
+
+      traceIterator
+        .take(maxLength)
+        .map { case (NodeId(nid), exe) =>
+          val typeId = prettyTypeId(exe.interfaceId.getOrElse(exe.templateId))
+          s"in choice $typeId:${exe.choiceId} on contract ${exe.targetCoid.coid.take(10)} (#$nid)"
+        }
+        .foreach(addLine)
+
+      if (traceIterator.hasNext) {
+        addLine("...")
+      }
+
+      lastCommand
+        .map {
+          case Command.Create(tmplId, _) =>
+            s"in create command ${prettyTypeId(tmplId)}."
+          case Command.ExerciseTemplate(tmplId, coid, choiceId, _) =>
+            s"in exercise command ${prettyTypeId(tmplId)}:$choiceId on contract ${prettyCoid(coid.value)}."
+          case Command.ExerciseInterface(ifaceId, coid, choiceId, _) =>
+            s"in exercise command ${prettyTypeId(ifaceId)}:$choiceId on contract ${prettyCoid(coid.value)}."
+          case Command.ExerciseByKey(tmplId, key, choiceId, _) =>
+            s"in exercise-by-key command ${prettyTypeId(tmplId)}:$choiceId on key ${prettyValue(key)}."
+          case Command.FetchTemplate(tmplId, coid) =>
+            s"in fetch command ${prettyTypeId(tmplId)} on contract ${prettyCoid(coid.value)}."
+          case Command.FetchInterface(ifaceId, coid) =>
+            s"in fecth-by-interface command ${prettyTypeId(ifaceId)} on contract ${prettyCoid(coid.value)}."
+          case Command.FetchByKey(tmplId, key) =>
+            s"in fetch-by-key command ${prettyTypeId(tmplId)} on key ${prettyValue(key)}."
+          case Command.CreateAndExercise(tmplId, _, choiceId, _) =>
+            s"in create-and-exercise command ${prettyTypeId(tmplId)}:$choiceId."
+          case Command.LookupByKey(tmplId, key) =>
+            s"in lookup-by-key command ${prettyTypeId(tmplId)} on key ${prettyValue(key)}."
+        }
+        .foreach(addLine)
+      stringBuilder.result()
+    }
   }
 
   object UpdateMachine {
@@ -828,8 +881,7 @@ private[lf] object Speedy {
     private[speedy] def handleException(excep: SValue.SAny): Control[Nothing]
 
     protected final def unhandledException(excep: SValue.SAny): Control.Error = {
-      clearKontStack()
-      clearEnv()
+      abort()
       Control.Error(IError.UnhandledException(excep.ty, excep.value.toUnnormalizedValue))
     }
 
@@ -884,6 +936,14 @@ private[lf] object Speedy {
         tmplId: TypeConName
     ): (PackageName, Option[PackageVersion]) =
       compiledPackages.pkgInterface.signatures(tmplId.packageId).pkgNameVersion
+
+    private[lf] def abort(): Unit = {
+      // We make sure the interpretation cannot be resumed
+      // For update machine, this preserves the partial transaction
+      clearKontStack()
+      clearEnv()
+      setControl(Control.WeAreUnset)
+    }
 
     /* kont manipulation... */
 
@@ -1059,6 +1119,7 @@ private[lf] object Speedy {
                 if (enableInstrumentation) track.print()
                 SResultFinal(value)
               case Control.Error(ie) =>
+                abort()
                 SResultError(SErrorDamlException(ie))
               case Control.WeAreUnset =>
                 sys.error("**attempt to run a machine with unset control")

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/Daml2ScriptTestRunner.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/Daml2ScriptTestRunner.scala
@@ -42,14 +42,20 @@ class Daml2ScriptTestRunner extends DamlScriptTestRunner {
           |ExceptionSemantics:tryContext FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submit failed: NOT_FOUND: CONTRACT_NOT_FOUND(11,XXXXXXXX): Contract could not be found with id XXXXXXXX
           |ExceptionSemantics:uncaughtArithmeticError SUCCESS
           |ExceptionSemantics:uncaughtUserException SUCCESS
-          |ExceptionSemantics:unhandledArithmeticError FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.ArithmeticError:ArithmeticError@XXXXXXXX{ message = "ArithmeticError while evaluating (DIV_INT64 1 0)." }. Details: Last location: [DA.Internal.Template.Functions:265], partial transaction: ...
-          |ExceptionSemantics:unhandledUserException FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: ExceptionSemantics:E@XXXXXXXX{  }. Details: Last location: [DA.Internal.Exception:176], partial transaction: ...
+          |ExceptionSemantics:unhandledArithmeticError FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.ArithmeticError:ArithmeticError@XXXXXXXX{ message = "ArithmeticError while evaluating (DIV_INT64 1 0)." }
+          |    in choice XXXXXXXX:ExceptionSemantics:T:ThrowArithmeticError on contract XXXXXXXXXX (#1)
+          |    in create-and-exercise command XXXXXXXX:ExceptionSemantics:T:ThrowArithmeticError.
+          |ExceptionSemantics:unhandledUserException FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: ExceptionSemantics:E@XXXXXXXX{  }
+          |    in choice XXXXXXXX:ExceptionSemantics:T:Throw on contract XXXXXXXXXX (#1)
+          |    in create-and-exercise command XXXXXXXX:ExceptionSemantics:T:Throw.
           |ExceptionSemanticsWithKeys:duplicateKey FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submitMustFail failed: SErrorDamlException(UserError(Expected submit to fail but it succeeded)
           |LFContractKeys:lookupTest FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submitMustFail failed: SErrorDamlException(UserError(Expected submit to fail but it succeeded)
           |MoreChoiceObserverDivulgence:test FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submit failed: NOT_FOUND: CONTRACT_NOT_FOUND(11,XXXXXXXX): Contract could not be found with id XXXXXXXX
           |MultiTest:disclosuresByKeyTest SUCCESS
           |MultiTest:disclosuresTest SUCCESS
-          |MultiTest:inactiveDisclosureDoesNotFailDuringSubmission FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.GeneralError:GeneralError@XXXXXXXX{ message = "Here" }. Details: Last location: [GHC.Err:25], partial transaction: ...
+          |MultiTest:inactiveDisclosureDoesNotFailDuringSubmission FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.GeneralError:GeneralError@XXXXXXXX{ message = "Here" }
+          |    in choice XXXXXXXX:MultiTest:Helper:FailWith on contract XXXXXXXXXX (#1)
+          |    in exercise command XXXXXXXX:MultiTest:Helper:FailWith on contract XXXXXXXXXX.
           |MultiTest:listKnownPartiesTest SUCCESS
           |MultiTest:multiTest SUCCESS
           |MultiTest:partyIdHintTest SUCCESS
@@ -58,12 +64,16 @@ class Daml2ScriptTestRunner extends DamlScriptTestRunner {
           |ScriptExample:initializeUser SUCCESS
           |ScriptExample:test SUCCESS
           |ScriptTest:clearUsers SUCCESS
-          |ScriptTest:failingTest FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.AssertionFailed:AssertionFailed@XXXXXXXX{ message = "Assertion failed" }. Details: Last location: [DA.Internal.Exception:176], partial transaction: ...
+          |ScriptTest:failingTest FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.AssertionFailed:AssertionFailed@XXXXXXXX{ message = "Assertion failed" }
+          |    in choice XXXXXXXX:ScriptTest:C:ShouldFail on contract XXXXXXXXXX (#0)
+          |    in exercise command XXXXXXXX:ScriptTest:C:ShouldFail on contract XXXXXXXXXX.
           |ScriptTest:listKnownPartiesTest SUCCESS
           |ScriptTest:multiPartySubmission SUCCESS
           |ScriptTest:partyIdHintTest SUCCESS
           |ScriptTest:sleepTest SUCCESS
-          |ScriptTest:stackTrace FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.AssertionFailed:AssertionFailed@XXXXXXXX{ message = "Assertion failed" }. Details: Last location: [DA.Internal.Exception:176], partial transaction: ...
+          |ScriptTest:stackTrace FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.AssertionFailed:AssertionFailed@XXXXXXXX{ message = "Assertion failed" }
+          |    in choice XXXXXXXX:ScriptTest:C:ShouldFail on contract XXXXXXXXXX (#1)
+          |    in create-and-exercise command XXXXXXXX:ScriptTest:C:ShouldFail.
           |ScriptTest:test0 SUCCESS
           |ScriptTest:test1 SUCCESS
           |ScriptTest:test3 SUCCESS

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/Daml3ScriptTestRunner.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/Daml3ScriptTestRunner.scala
@@ -42,14 +42,20 @@ class Daml3ScriptTestRunner extends DamlScriptTestRunner {
           |ExceptionSemantics:tryContext FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: NOT_FOUND: CONTRACT_NOT_FOUND(11,XXXXXXXX): Contract could not be found with id XXXXXXXX
           |ExceptionSemantics:uncaughtArithmeticError SUCCESS
           |ExceptionSemantics:uncaughtUserException SUCCESS
-          |ExceptionSemantics:unhandledArithmeticError FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.ArithmeticError:ArithmeticError@XXXXXXXX{ message = "ArithmeticError while evaluating (DIV_INT64 1 0)." }. Details: Last location: [DA.Internal.Template.Functions:265], partial transaction: ...
-          |ExceptionSemantics:unhandledUserException FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: ExceptionSemantics:E@XXXXXXXX{  }. Details: Last location: [DA.Internal.Exception:176], partial transaction: ...
+          |ExceptionSemantics:unhandledArithmeticError FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.ArithmeticError:ArithmeticError@XXXXXXXX{ message = "ArithmeticError while evaluating (DIV_INT64 1 0)." }
+          |    in choice XXXXXXXX:ExceptionSemantics:T:ThrowArithmeticError on contract XXXXXXXXXX (#1)
+          |    in create-and-exercise command XXXXXXXX:ExceptionSemantics:T:ThrowArithmeticError.
+          |ExceptionSemantics:unhandledUserException FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: ExceptionSemantics:E@XXXXXXXX{  }
+          |    in choice XXXXXXXX:ExceptionSemantics:T:Throw on contract XXXXXXXXXX (#1)
+          |    in create-and-exercise command XXXXXXXX:ExceptionSemantics:T:Throw.
           |ExceptionSemanticsWithKeys:duplicateKey FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: SErrorDamlException(UserError(Expected submit to fail but it succeeded)
           |LFContractKeys:lookupTest FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: SErrorDamlException(UserError(Expected submit to fail but it succeeded)
           |MoreChoiceObserverDivulgence:test FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: NOT_FOUND: CONTRACT_NOT_FOUND(11,XXXXXXXX): Contract could not be found with id XXXXXXXX
           |MultiTest:disclosuresByKeyTest SUCCESS
           |MultiTest:disclosuresTest SUCCESS
-          |MultiTest:inactiveDisclosureDoesNotFailDuringSubmission FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.GeneralError:GeneralError@XXXXXXXX{ message = "Here" }. Details: Last location: [GHC.Err:25], partial transaction: ...
+          |MultiTest:inactiveDisclosureDoesNotFailDuringSubmission FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.GeneralError:GeneralError@XXXXXXXX{ message = "Here" }
+          |    in choice XXXXXXXX:MultiTest:Helper:FailWith on contract XXXXXXXXXX (#1)
+          |    in exercise command XXXXXXXX:MultiTest:Helper:FailWith on contract XXXXXXXXXX.
           |MultiTest:listKnownPartiesTest SUCCESS
           |MultiTest:multiTest SUCCESS
           |MultiTest:partyIdHintTest SUCCESS
@@ -58,12 +64,16 @@ class Daml3ScriptTestRunner extends DamlScriptTestRunner {
           |ScriptExample:initializeUser SUCCESS
           |ScriptExample:test SUCCESS
           |ScriptTest:clearUsers SUCCESS
-          |ScriptTest:failingTest FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.AssertionFailed:AssertionFailed@XXXXXXXX{ message = "Assertion failed" }. Details: Last location: [DA.Internal.Exception:176], partial transaction: ...
+          |ScriptTest:failingTest FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.AssertionFailed:AssertionFailed@XXXXXXXX{ message = "Assertion failed" }
+          |    in choice XXXXXXXX:ScriptTest:C:ShouldFail on contract XXXXXXXXXX (#0)
+          |    in exercise command XXXXXXXX:ScriptTest:C:ShouldFail on contract XXXXXXXXXX.
           |ScriptTest:listKnownPartiesTest SUCCESS
           |ScriptTest:multiPartySubmission SUCCESS
           |ScriptTest:partyIdHintTest SUCCESS
           |ScriptTest:sleepTest SUCCESS
-          |ScriptTest:stackTrace FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.AssertionFailed:AssertionFailed@XXXXXXXX{ message = "Assertion failed" }. Details: Last location: [DA.Internal.Exception:176], partial transaction: ...
+          |ScriptTest:stackTrace FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: UNHANDLED_EXCEPTION(9,XXXXXXXX): Interpretation error: Error: Unhandled Daml exception: DA.Exception.AssertionFailed:AssertionFailed@XXXXXXXX{ message = "Assertion failed" }
+          |    in choice XXXXXXXX:ScriptTest:C:ShouldFail on contract XXXXXXXXXX (#1)
+          |    in create-and-exercise command XXXXXXXX:ScriptTest:C:ShouldFail.
           |ScriptTest:test0 SUCCESS
           |ScriptTest:test1 SUCCESS
           |ScriptTest:test3 SUCCESS


### PR DESCRIPTION
Transaction trace are similar to classical stack trace but track only exercise call.

The transaction is of the form

```
    in choice XXXXXXXX:ScriptTest:C:ShouldFail on contract 00XXXXXXXX (#1)
    in create-and-exercise command 1ef98323:ScriptTest:C:ShouldFail.
```

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
