### PR TITLE
test downgrade of choice return values for disclosed and local contracts

### DIFF
--- a/sdk/daml-script/test/daml/upgrades/LedgerApiChoiceUpgrade.daml
+++ b/sdk/daml-script/test/daml/upgrades/LedgerApiChoiceUpgrade.daml
@@ -8,6 +8,9 @@ module LedgerApiChoiceUpgrade (main) where
 import UpgradeTestLib
 import qualified V1.UpgradedChoice as V1
 import qualified V2.UpgradedChoice as V2
+import qualified V1.UpgradedChoiceClient as V1
+import qualified V2.UpgradedChoiceClient as V2
+import DA.Optional (fromSome)
 
 {- PACKAGE
 name: ledger-api-choice-upgrades
@@ -42,11 +45,47 @@ contents: |
             secondArg                                   -- @V  2
 -}
 
+{- PACKAGE
+name: ledger-api-choice-upgrades-client
+versions: 2
+depends: |
+  ledger-api-choice-upgrades-1.0.0
+  ledger-api-choice-upgrades-2.0.0
+-}
+
+{- MODULE
+package: ledger-api-choice-upgrades-client
+contents: |
+  module UpgradedChoiceClient where
+
+  import qualified V1.UpgradedChoice as V1
+  import qualified V2.UpgradedChoice as V2
+
+  template UpgradedChoiceClientTemplate
+    with
+      party : Party
+    where
+      signatory party
+
+      choice CreateAndExercise : V1.UpgradedChoiceReturn with -- @V 1
+      choice CreateAndExercise : V2.UpgradedChoiceReturn with -- @V 2
+        controller party
+        do 
+          cid <- create (V1.UpgradedChoiceTemplate party)
+          exercise cid (V1.UpgradedChoice "v1 to v1")                                                                               -- @V 1
+          exercise (coerceContractId @V1.UpgradedChoiceTemplate @V2.UpgradedChoiceTemplate cid) (V2.UpgradedChoice "v1 to v1" None) -- @V 2
+-}
+
+
 main : TestTree
 main = tests
   [ ("Explicitly call a V1 choice on a V1 contract over the ledger-api, expect V1 implementation used.", explicitV1ChoiceV1Contract)
   , ("Explicitly call a V2 choice on a V1 contract over the ledger-api, expect V2 implementation used, and contract upgraded.", explicitV2ChoiceV1Contract)
-  , ("Call a V1 choice without package ID on a V1 contract over the ledger-api, expect V2 implementation used, contract + argument upgraded, daml-script downgrades return type.", inferredV1ChoiceV1Contract)
+  , subtree "Call a V1 choice without package ID on a V1 contract over the ledger-api, expect V2 implementation used, contract + argument upgraded, daml-script downgrades return type." 
+     [ ("global contract", inferredV1ChoiceV1GlobalContract)
+     , ("disclosed contract", inferredV1ChoiceV1DisclosedContract)
+     , ("local contract", inferredV1ChoiceV1LocalContract)
+     ]
   , ("Call a V2 choice without package ID on a V1 contract over the ledger-api, expect V2 implementation used, and contract upgraded.", inferredV2ChoiceV1Contract)
   , broken ("Call a V2 choice without package ID on a V1 contract over the ledger-api, with V2 unvetted, expect V1 implementation used, argument downgraded, daml-script upgrades return type.", inferredV1ChoiceV1ContractWithoutV2)
   , ("Explicitly call a V1 choice on a V2 contract over the ledger-api, expect V1 implementation used, and contract downgraded.", explicitV1ChoiceV2Contract)
@@ -81,9 +120,26 @@ explicitV2ChoiceV1Contract =
 -- When inferring, the V1 contract and choice argument is upgraded, and the return type is downgraded directly by daml script.
 -- As such, we get the v2 implementation called, with the additional field set to None (as shown in the choice return)
 -- and since the extra data in the return will also be none, the downgrade can succeed.
-inferredV1ChoiceV1Contract : Test
-inferredV1ChoiceV1Contract =
+inferredV1ChoiceV1GlobalContract : Test
+inferredV1ChoiceV1GlobalContract =
   choiceTest @V1.UpgradedChoiceTemplate V1.UpgradedChoiceTemplate (V1.UpgradedChoice "v1 to v1") False (V1.UpgradedChoiceReturn "v1 to v1:V2:None")
+
+inferredV1ChoiceV1DisclosedContract = test $ do
+  a <- allocatePartyOn "alice" participant0
+  cid <- a `submit` createExactCmd (V1.UpgradedChoiceTemplate a)
+  disclosure <- fromSome <$> queryDisclosure a cid
+  res <- (actAs a <> disclose disclosure) `trySubmit` exerciseCmd cid (V1.UpgradedChoice "v1 to v1")
+  case res of
+    Right returnValue -> returnValue === (V1.UpgradedChoiceReturn "v1 to v1:V2:None")
+    Left err -> assertFail $ "Expected 'v1 to v1:V2:None' but got " <> show err
+
+inferredV1ChoiceV1LocalContract = test $ do
+  a <- allocatePartyOn "alice" participant0
+  cid <- a `submit` createExactCmd (V1.UpgradedChoiceClientTemplate a)
+  res <- a `trySubmit` exerciseCmd cid V1.CreateAndExercise
+  case res of
+    Right returnValue -> returnValue === (V1.UpgradedChoiceReturn "v1 to v1:V2:None")
+    Left err -> assertFail $ "Expected 'v1 to v1:V2:None' but got " <> show err
 
 inferredV2ChoiceV1Contract : Test
 inferredV2ChoiceV1Contract =


### PR DESCRIPTION
Upgrades can't be tested because the ledger API still considers unvetted packages in package selection.