### PR TITLE
add an upload test for two incompatible deps

### DIFF
--- a/sdk/daml-lf/validation/BUILD.bazel
+++ b/sdk/daml-lf/validation/BUILD.bazel
@@ -221,6 +221,9 @@ da_scala_test_suite(
             "//test-common:upgrades-EmptyProject-v1dev.dar",
             "//test-common:upgrades-FailsWhenDepIsInvalidPreviousVersionOfSelf-v1.dar",
             "//test-common:upgrades-FailsWhenDepIsInvalidPreviousVersionOfSelf-v2.dar",
+            "//test-common:upgrades-FailsWhenDepsAreIncompatible-v1.dar",
+            "//test-common:upgrades-FailsWhenDepsAreIncompatible-dep-v1.dar",
+            "//test-common:upgrades-FailsWhenDepsAreIncompatible-dep-v2.dar",
             "//test-common:upgrades-SucceedsWhenDepIsValidPreviousVersionOfSelf-v1.dar",
             "//test-common:upgrades-SucceedsWhenDepIsValidPreviousVersionOfSelf-v2.dar",
 

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesCheckSpec.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesCheckSpec.scala
@@ -192,6 +192,21 @@ final class UpgradesCheckSpec extends AsyncWordSpec with Matchers with Inside {
       )
     }
 
+    "Fails when a package embeds two versions of a package that are not in an upgrade relationship" in {
+      testPackages(
+        Seq("test-common/upgrades-FailsWhenDepsAreIncompatible-v1.dar"),
+        Seq(
+          (
+            "test-common/upgrades-FailsWhenDepsAreIncompatible-dep-v1.dar",
+            "test-common/upgrades-FailsWhenDepsAreIncompatible-dep-v2.dar",
+            Some(
+              "The upgraded data type Dep has added new fields, but those fields are not Optional"
+            ),
+          )
+        ),
+      )
+    }
+
     "Succeeds when a package embeds a previous version of itself it is a valid upgrade of" in {
       testPackages(
         Seq("test-common/upgrades-SucceedsWhenDepIsValidPreviousVersionOfSelf-v2.dar"),

--- a/sdk/test-common/BUILD.bazel
+++ b/sdk/test-common/BUILD.bazel
@@ -653,6 +653,60 @@ da_scala_dar_resources_library(
     ]
 ]
 
+# test cases where there's only one v1 of a package depending on both v1 and v2 of a dep
+[
+    [
+        filegroup(
+            name = "upgrades-{}-files".format(identifier),
+            srcs = glob(["src/main/daml/upgrades/{}/*/*.daml".format(identifier)]),
+            visibility = ["//visibility:public"],
+        ),
+        daml_compile(
+            name = "upgrades-{}-dep-v1".format(identifier),
+            srcs = glob(["src/main/daml/upgrades/{}/dep-v1/*.daml".format(identifier)]),
+            dependencies = ["//daml-script/daml:daml-script-1.dev.dar"],
+            project_name = "upgrades-example-{}-dep".format(identifier),
+            target = "1.dev",
+            version = "1.0.0",
+            visibility = ["//visibility:public"],
+        ),
+        daml_compile(
+            name = "upgrades-{}-dep-v2".format(identifier),
+            srcs = glob(["src/main/daml/upgrades/{}/dep-v2/*.daml".format(identifier)]),
+            dependencies = ["//daml-script/daml:daml-script-1.dev.dar"],
+            project_name = "upgrades-example-{}-dep".format(identifier),
+            target = "1.dev",
+            # We want to check the validity of this upgrade on the ledger
+            # client, not during compilation
+            typecheck_upgrades = False,
+            upgrades = "//test-common:upgrades-{}-dep-v1.dar".format(identifier),
+            version = "2.0.0",
+            visibility = ["//visibility:public"],
+        ),
+        daml_compile(
+            name = "upgrades-{}-v1".format(identifier),
+            srcs = glob(["src/main/daml/upgrades/{}/v1/*.daml".format(identifier)]),
+            data_dependencies = [
+                "//test-common:upgrades-{}-dep-v1.dar".format(identifier),
+                "//test-common:upgrades-{}-dep-v2.dar".format(identifier),
+            ],
+            dependencies = ["//daml-script/daml:daml-script-1.dev.dar"],
+            ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
+            module_prefixes = {
+                "upgrades-example-{}-dep-1.0.0".format(identifier): "V1",
+                "upgrades-example-{}-dep-2.0.0".format(identifier): "V2",
+            },
+            project_name = "upgrades-example-{}".format(identifier),
+            target = "1.dev",
+            version = "1.0.0",
+            visibility = ["//visibility:public"],
+        ),
+    ]
+    for identifier in [
+        "FailsWhenDepsAreIncompatible",
+    ]
+]
+
 [
     [
         [

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsAreIncompatible/dep-v1/Dep.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsAreIncompatible/dep-v1/Dep.daml
@@ -1,0 +1,6 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Dep where
+
+data Dep = Dep { dep : Text }

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsAreIncompatible/dep-v2/Dep.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsAreIncompatible/dep-v2/Dep.daml
@@ -1,0 +1,6 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Dep where
+
+data Dep = Dep { dep : Text, nonOptionalField : Text }

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsAreIncompatible/v1/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenDepsAreIncompatible/v1/Main.daml
@@ -1,0 +1,8 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+-- We import the deps so they get included in the dar
+import qualified V1.Dep as V1
+import qualified V2.Dep as V2


### PR DESCRIPTION
Addresses the following line in the test matrix:

> Test that a dar cannot be uploaded if it contains two mutually incompatible packages.