### PR TITLE
Add ContractNotUpgradable Error

### DIFF
--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
@@ -148,6 +148,9 @@ object RejectionGenerators {
         case LfInterpretationError.Upgrade(error: LfInterpretationError.Upgrade.ViewMismatch) =>
           CommandExecutionErrors.Interpreter.UpgradeError.ViewMismatch
             .Reject(renderedMessage, error)
+        case LfInterpretationError.Upgrade(error: LfInterpretationError.Upgrade.ContractNotUpgradable) =>
+          CommandExecutionErrors.Interpreter.UpgradeError.ContractNotUpgradable
+            .Reject(renderedMessage, error)
         case LfInterpretationError.Dev(_, err) =>
           CommandExecutionErrors.Interpreter.InterpretationDevError
             .Reject(renderedMessage, err)

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
@@ -738,8 +738,33 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
             )
         }
       }
-    }
 
+      @Explanation("ContractNotUpgradable explanation")
+      @Resolution("ContractNotUpgradable resolution")
+      object ContractNotUpgradable
+        extends ErrorCode(
+          id = "CONTRACT_NOT_UPGRADABLE",
+          ErrorCategory.InvalidGivenCurrentSystemStateOther,
+        ) {
+
+        final case class Reject(
+                                 override val cause: String,
+                                 err: LfInterpretationError.Upgrade.ContractNotUpgradable,
+                               )(implicit
+                                 loggingContext: ContextualizedErrorLogger
+                               ) extends DamlErrorWithDefiniteAnswer(
+          cause = cause
+        ) {
+
+          override def resources: Seq[(ErrorResource, String)] =
+            Seq(
+              (ErrorResource.ContractId, err.coid.coid),
+              (ErrorResource.TemplateId, err.target.toString),
+              (ErrorResource.TemplateId, err.actual.toString),
+            )
+        }
+      }
+    }
     @Explanation(
       """This error is a catch-all for errors thrown by in-development features, and should never be thrown in production."""
     )

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -101,13 +101,6 @@ private[lf] object Pretty {
           ) & prettyTypeConName(
             actual
           )
-      case ContractNotUpgradable(coid, target, actual) =>
-        text("Attempt to upgrade non-upgradable contract id") & prettyContractId(coid) /
-          text("to target package") & prettyTypeConName(target) & text(
-            "from"
-          ) & prettyTypeConName(
-            actual
-          )
       case ContractDoesNotImplementInterface(interfaceId, coid, templateId) =>
         text("Update failed due to contract") & prettyContractId(coid) & text(
           "not implementing an interface"
@@ -204,6 +197,14 @@ private[lf] object Pretty {
               text("computed view for") & prettyTypeConName(iterfaceId) & text(
                 "in the destination contract is"
               ) & prettyValue(false)(dstViewValue)
+          }
+          case Upgrade.ContractNotUpgradable(coid, target, actual) => {
+            text("Attempt to upgrade non-upgradable contract id") & prettyContractId(coid) /
+              text("to target package") & prettyTypeConName(target) & text(
+                "from"
+              ) & prettyTypeConName(
+                actual
+              )
           }
         }
       case Dev(_, error) =>

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -101,6 +101,13 @@ private[lf] object Pretty {
           ) & prettyTypeConName(
             actual
           )
+      case ContractNotUpgradable(coid, target, actual) =>
+        text("Attempt to upgrade non-upgradable contract id") & prettyContractId(coid) /
+          text("to target package") & prettyTypeConName(target) & text(
+            "from"
+          ) & prettyTypeConName(
+            actual
+          )
       case ContractDoesNotImplementInterface(interfaceId, coid, templateId) =>
         text("Update failed due to contract") & prettyContractId(coid) & text(
           "not implementing an interface"

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -2463,7 +2463,7 @@ private[lf] object SBuiltin {
 
       if (unsupportedUpgrade) {
         Control.Error(
-          IE.ContractNotUpgradable(coid, dstTmplId, srcTmplId)
+          IE.Upgrade(IE.Upgrade.ContractNotUpgradable(coid, dstTmplId, srcTmplId))
         )
       } else if (srcTmplId.qualifiedName != dstTmplId.qualifiedName) {
         Control.Error(

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -2455,7 +2455,7 @@ private[lf] object SBuiltin {
       val (upgradingIsEnabled, dstTmplId, unsupportedUpgrade) = optTargetTemplateId match {
         case Some(tycon) if coinst.upgradable =>
           (true, tycon, false)
-        case Some(tycon) =>
+        case Some(tycon) if tycon != srcTmplId =>
           (true, tycon, true)
         case _ =>
           (false, srcTmplId, false) // upgrading not enabled; import at source type

--- a/sdk/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -111,13 +111,6 @@ object Error {
       actual: TypeConName,
   ) extends Error
 
-  /** An attempt was made to upgrade a contract from a LF version that does not support upgrading */
-  final case class ContractNotUpgradable(
-      coid: ContractId,
-      target: TypeConName,
-      actual: TypeConName,
-  ) extends Error
-
   /** We tried to fetch / exercise a contract by interface, but
     * the contract does not implement this interface.
     */
@@ -189,6 +182,14 @@ object Error {
         srcView: Value,
         dstView: Value,
     ) extends Error
+
+    /** An attempt was made to upgrade a contract from a LF version that does not support upgrading */
+    final case class ContractNotUpgradable(
+        coid: ContractId,
+        target: TypeConName,
+        actual: TypeConName,
+    ) extends Error
+
   }
 
   // Error that can be thrown by dev or PoC feature only

--- a/sdk/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -111,6 +111,13 @@ object Error {
       actual: TypeConName,
   ) extends Error
 
+  /** An attempt was made to upgrade a contract from a LF version that does not support upgrading */
+  final case class ContractNotUpgradable(
+      coid: ContractId,
+      target: TypeConName,
+      actual: TypeConName,
+  ) extends Error
+
   /** We tried to fetch / exercise a contract by interface, but
     * the contract does not implement this interface.
     */

--- a/sdk/daml-script/daml3/Daml/Script/Internal/Questions/Submit/Error.daml
+++ b/sdk/daml-script/daml3/Daml/Script/Internal/Questions/Submit/Error.daml
@@ -19,6 +19,7 @@ data UpgradeErrorType
   = ValidationFailed
   | DowngradeDropDefinedField
   | ViewMismatch
+  | ContractNotUpgradable
   deriving Show
 
 -- | Errors that will be promoted to SubmitError once stable - code needs to be kept in sync with SubmitError.scala

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -384,6 +384,13 @@ class IdeLedgerClient(
           innerError.dstTemplateId,
           Pretty.prettyDamlException(e).renderWideStream.mkString,
         )
+      case e @ Upgrade(innerError: Upgrade.ContractNotUpgradable) =>
+        submitErrors.UpgradeError.ContractNotUpgradable(
+          innerError.coid,
+          innerError.target,
+          innerError.actual,
+          Pretty.prettyDamlException(e).renderWideStream.mkString,
+        )
       case e @ Dev(_, innerError) =>
         submitErrors.DevError(
           innerError.getClass.getSimpleName,

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
@@ -469,6 +469,25 @@ class SubmitErrors(majorLanguageVersion: LanguageMajorVersion) {
         )
       }
     }
+
+    sealed case class ContractNotUpgradable(
+        contractId: ContractId,
+        targetTemplateId: Identifier,
+        actualTemplateId: Identifier,
+        message: String,
+    ) extends SubmitError {
+      override def toDamlSubmitError(env: Env): SValue = {
+        val upgradeErrorType =
+          SEnum(upgradeErrorTypeIdentifier(env), Name.assertFromString("ContractNotUpgradable"), 3)
+        SubmitErrorConverters(env).damlScriptError(
+          "UpgradeError",
+          20,
+          ("errorType", upgradeErrorType),
+          ("errorMessage", SText(message)),
+        )
+      }
+    }
+
   }
 
   sealed case class DevError(errorType: String, message: String) extends SubmitError {

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcErrorParser.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcErrorParser.scala
@@ -376,6 +376,22 @@ class GrpcErrorParser(majorVersion: LanguageMajorVersion) {
               message,
             )
         }
+
+      case "CONTRACT_NOT_UPGRADABLE" =>
+        caseErr {
+          case Seq(
+                (ErrorResource.ContractId, coid),
+                (ErrorResource.TemplateId, srcTemplateId),
+                (ErrorResource.TemplateId, targetTemplateId),
+              ) =>
+            submitErrors.UpgradeError.ContractNotUpgradable(
+              ContractId.assertFromString(coid),
+              Identifier.assertFromString(srcTemplateId),
+              Identifier.assertFromString(targetTemplateId),
+              message,
+            )
+        }
+
       case "INTERPRETATION_DEV_ERROR" =>
         caseErr { case Seq((ErrorResource.DevErrorType, errorType)) =>
           submitErrors.DevError(errorType, message)

--- a/sdk/daml-script/test/daml/upgrades/LfVersions.daml
+++ b/sdk/daml-script/test/daml/upgrades/LfVersions.daml
@@ -73,9 +73,14 @@ main = tests
   , ("Call a LF < 1.15 choice on a LF >= 1.15 contract, expect LF 1.15 implementation to attempt to be used, but fail upgrade", exerciseNonUpgradingLfFail)
   ]
 
+assertIsUpgradeError : Either SubmitError a -> Script ()
+assertIsUpgradeError (Left (UpgradeError ContractNotUpgradable _)) = pure ()
+assertIsUpgradeError (Left e) = fail $ "Expected upgrade error but got " <> show e
+assertIsUpgradeError _ = fail "Expected upgrade error but got success"
+
 mustBeWronglyTypedContract : Either SubmitError r -> Script ()
 mustBeWronglyTypedContract (Left (WronglyTypedContract {})) = pure ()
-mustBeWronglyTypedContract (Left e) = assertFail $ "Incorrect error: " <> show e
+mustBeWronglyTypedContract (Left e) = assertFail $ "Expected WronglyTypedContract but got: " <> show e
 mustBeWronglyTypedContract _ = assertFail $ "Expected failure and got success"
 
 fetchNonUpgradableLfFail : Test
@@ -83,16 +88,14 @@ fetchNonUpgradableLfFail = test $ do
   alice <- allocateParty "alice"
   v1Cid <- alice `submit` createExactCmd V1.LfTemplate with party = alice
   let v2Cid = coerceContractId @V1.LfTemplate @V2.LfTemplate v1Cid
-
   res <- alice `trySubmit` createAndExerciseCmd (LfTemplateHelper with party = alice) (FetchV2 with cid = v2Cid)
-  mustBeWronglyTypedContract res
+  assertIsUpgradeError res
 
 fetchNonUpgradingLfFail : Test
 fetchNonUpgradingLfFail = test $ do
   alice <- allocateParty "alice"
   v2Cid <- alice `submit` createExactCmd V2.LfTemplate with party = alice
   let v1Cid = coerceContractId @V2.LfTemplate @V1.LfTemplate v2Cid
-
   res <- alice `trySubmit` createAndExerciseCmd (LfTemplateHelper with party = alice) (FetchV1 with cid = v1Cid)
   mustBeWronglyTypedContract res
 
@@ -102,7 +105,7 @@ exerciseNonUpgradableLfFail = test $ do
     v1Cid <- alice `submit` createExactCmd V1.LfTemplate with party = alice
     let v2Cid = coerceContractId @V1.LfTemplate @V2.LfTemplate v1Cid
     res <- alice `trySubmit` exerciseExactCmd @V2.LfTemplate v2Cid V2.Noop
-    mustBeWronglyTypedContract res
+    assertIsUpgradeError res
 
 exerciseNonUpgradingLfFail: Test
 exerciseNonUpgradingLfFail = test $ do


### PR DESCRIPTION
Adds a `ContractNotUpgradable` error that is returned when an attempt is made to upgrade a non-upgradable contract. Previously reported `WronglyTypedContract`