### PR TITLE
Add validation to release.sh snapshot command, improve check command

### DIFF
--- a/sdk/release.sh
+++ b/sdk/release.sh
@@ -178,7 +178,7 @@ commit_belongs_to_branch() {
     commit=$1
     branch=$2
     git branch --all --format='%(refname:short)' --contains="$commit" \
-      | grep -F -x "$branch" >/dev/null 2>/dev/null # grep -q flag quits early and causes a SIGPIPE signal in git branch
+      | grep -F -x "$branch" &>/dev/null # grep -q flag quits early and causes a SIGPIPE signal in git branch
 }
 
 # Takes a version x.y.z as its first argument, a commit reference as its second argument

--- a/sdk/release.sh
+++ b/sdk/release.sh
@@ -161,18 +161,19 @@ available_release_lines() {
 release_branch_for_version() {
     version="$1"
     version_arr=(${version//./ })
-    available_release_lines "${version_arr[0]}" | jq -r """
+    available_release_lines "${version_arr[0]}" | \
+    jq -r --argjson major "${version_arr[0]}" --argjson minor "${version_arr[1]}" '''
       max |
-      if .[1] < ${version_arr[1]} then
-          if ${version_arr[0]} == 2 then
-              \"origin/main-2.x\"
+      if .[1] < $minor then
+          if $major == 2 then
+              "origin/main-2.x"
           else
-              \"origin/main\"
+              "origin/main"
           end
       else
-          \"origin/release/${version_arr[0]}.${version_arr[1]}.x\"
+          "origin/release/\($major).\($minor).x"
       end
-    """
+    '''
 }
 
 # Takes a commit reference as its first argument.

--- a/sdk/release.sh
+++ b/sdk/release.sh
@@ -14,7 +14,7 @@ uhoh() {
     of the LATEST file and consider running this script again."
 }
 
-#trap uhoh EXIT
+trap uhoh EXIT
 
 STABLE_REGEX="\d+\.\d+\.\d+"
 SNAPSHOT_REGEX="^${STABLE_REGEX}-snapshot\.\d{8}\.\d+(\.\d+)?\.v[0-9a-f]{8}$"

--- a/sdk/release.sh
+++ b/sdk/release.sh
@@ -114,6 +114,10 @@ is_snapshot() (
     echo "$1" | grep -q -P "($SNAPSHOT_REGEX)"
 )
 
+is_adhoc() (
+    echo "$1" | grep -q -P "($ADHOC_REGEX)"
+)
+
 make_snapshot() {
     local sha prefix commit_date number_of_commits commit_sha_8
     t=$1

--- a/sdk/release.sh
+++ b/sdk/release.sh
@@ -148,8 +148,16 @@ available_release_lines() {
       | jq -sR 'split("\n") | map(select(length > 0)) | map(split("/")[2] | split(".")[0:2] | map(tonumber))'
 }
 
-# Takes a version x.y.z as its first argument, prints the expected branch for
+# Takes a version a.b.c as its first argument, prints the expected branch for
 # producing those release lines.
+# If the version's minor is greater than the highest existing release line, then
+# we use main/main-2.x.
+# Otherwise, we use the release line release/a.b.x. For example, 3.2.5 would
+# have expected branch release/3.2.x.
+# Example 1: If the highest release line for Daml 3 is release/3.2.x, then version 3.3.0 has expected branch main.
+# Example 2: If the highest release line for Daml 2 is release/2.9.x, then 2.10.0 has expected branch main-2.x.
+# Example 3: If there is a branch release/3.2.x, then version 3.2.0 has expected branch release/3.2.x.
+# Example 4: If there is a branch release/3.2.x, but no branch release/3.1.x then version 3.1.0 still has expected branch release/3.1.x.
 release_branch_for_version() {
     version="$1"
     version_arr=(${version//./ })


### PR DESCRIPTION
- Stable versions or RCs must always be made from the correct release line.
- New snapshots must be made from either the correct release line if one exists or origin/main{-2.x} if one doesn't. For example:
  - a 3.2.0 snapshot must be made from release/3.2.x
  - a 3.3.0 snapshot must be made from main because no release/3.3.x exists as of yet.
  - a 2.9.7 snapshot must be made from release/2.9.x
  - a 2.10.0 snapshot must be made from main-2.x because no release/2.10.x exists as of yet.
- A commit originating from any other branch must be adhoc.