### PR TITLE
Template for upgrades-example

### DIFF
--- a/sdk/templates/BUILD.bazel
+++ b/sdk/templates/BUILD.bazel
@@ -51,6 +51,7 @@ genrule(
             "skeleton/**",
             "empty-skeleton/**",
             "create-daml-app/**",
+            "upgrades-example/**",
             "quickstart-java/**",
             "copy-trigger/**",
             "gsg-trigger.patch",
@@ -84,6 +85,7 @@ genrule(
         for d in skeleton \
                  empty-skeleton \
                  create-daml-app \
+                 upgrades-example \
                  quickstart-java \
                  copy-trigger \
                  gsg-trigger; do

--- a/sdk/templates/upgrades-example/interfaces/daml.yaml.template
+++ b/sdk/templates/upgrades-example/interfaces/daml.yaml.template
@@ -2,15 +2,12 @@
 # https://docs.daml.com/tools/assistant.html#project-config-file-daml-yaml
 
 sdk-version: __VERSION__
-name: __PROJECT_NAME__-main
+name: __PROJECT_NAME__-interfaces
 source: daml
-version: 2.0.0
+version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml3-script
-data-dependencies:
-  - ../interfaces/.daml/dist/__PROJECT_NAME__-interfaces-1.0.0.dar
-upgrades: ../main-v1/.daml/dist/__PROJECT_NAME__-main-1.0.0.dar
 build-options:
 - --target=1.17

--- a/sdk/templates/upgrades-example/interfaces/daml/Asset.daml
+++ b/sdk/templates/upgrades-example/interfaces/daml/Asset.daml
@@ -1,0 +1,16 @@
+module Asset where
+
+data View = View
+  { assetOwner : Party
+  , description : Text
+  }
+  deriving (Show, Eq)
+
+interface Asset where
+  viewtype View
+  getOwner : Party
+
+  nonconsuming choice GetView : View
+    controller (getOwner this)
+    do
+      pure (view this)

--- a/sdk/templates/upgrades-example/main-v1/daml.yaml.template
+++ b/sdk/templates/upgrades-example/main-v1/daml.yaml.template
@@ -1,0 +1,11 @@
+# for config file options, refer to
+# https://docs.daml.com/tools/assistant.html#project-config-file-daml-yaml
+
+sdk-version: __VERSION__
+name: __PROJECT_NAME__-main
+source: daml
+version: 1.0.0
+dependencies:
+  - daml-prim
+  - daml-stdlib
+  - daml3-script

--- a/sdk/templates/upgrades-example/main-v1/daml.yaml.template
+++ b/sdk/templates/upgrades-example/main-v1/daml.yaml.template
@@ -9,3 +9,7 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml3-script
+data-dependencies:
+  - ../interfaces/.daml/dist/__PROJECT_NAME__-interfaces-1.0.0.dar
+build-options:
+- --target=1.dev

--- a/sdk/templates/upgrades-example/main-v1/daml.yaml.template
+++ b/sdk/templates/upgrades-example/main-v1/daml.yaml.template
@@ -12,4 +12,4 @@ dependencies:
 data-dependencies:
   - ../interfaces/.daml/dist/__PROJECT_NAME__-interfaces-1.0.0.dar
 build-options:
-- --target=1.dev
+- --target=1.17

--- a/sdk/templates/upgrades-example/main-v1/daml/Main.daml
+++ b/sdk/templates/upgrades-example/main-v1/daml/Main.daml
@@ -1,6 +1,16 @@
-module Main where
+module Main where -- V1
 
-template T with
-    p: Party
+import Asset (Asset)
+import qualified Asset
+
+template IOU with
+    issuer: Party
+    owner: Party
+    value: Int
+    version: Text
   where
-    signatory p
+    signatory issuer, owner
+
+    interface instance Asset for IOU where
+      view = Asset.View owner ("IOU (" <> version <> ")")
+      getOwner = owner

--- a/sdk/templates/upgrades-example/main-v1/daml/Main.daml
+++ b/sdk/templates/upgrades-example/main-v1/daml/Main.daml
@@ -7,10 +7,10 @@ template IOU with
     issuer: Party
     owner: Party
     value: Int
-    version: Text
+    name: Text
   where
     signatory issuer, owner
 
     interface instance Asset for IOU where
-      view = Asset.View owner ("IOU (" <> version <> ")")
+      view = Asset.View owner ("IOU (" <> name <> ")")
       getOwner = owner

--- a/sdk/templates/upgrades-example/main-v1/daml/Main.daml
+++ b/sdk/templates/upgrades-example/main-v1/daml/Main.daml
@@ -1,0 +1,6 @@
+module Main where
+
+template T with
+    p: Party
+  where
+    signatory p

--- a/sdk/templates/upgrades-example/main-v2/daml.yaml.template
+++ b/sdk/templates/upgrades-example/main-v2/daml.yaml.template
@@ -1,0 +1,12 @@
+# for config file options, refer to
+# https://docs.daml.com/tools/assistant.html#project-config-file-daml-yaml
+
+sdk-version: __VERSION__
+name: __PROJECT_NAME__-main
+source: daml
+version: 2.0.0
+dependencies:
+  - daml-prim
+  - daml-stdlib
+  - daml3-script
+upgrades: ../main-v1/.daml/dist/__PROJECT_NAME__-main-1.0.0.dar

--- a/sdk/templates/upgrades-example/main-v2/daml.yaml.template
+++ b/sdk/templates/upgrades-example/main-v2/daml.yaml.template
@@ -9,4 +9,8 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml3-script
+data-dependencies:
+  - ../interfaces/.daml/dist/__PROJECT_NAME__-interfaces-1.0.0.dar
 upgrades: ../main-v1/.daml/dist/__PROJECT_NAME__-main-1.0.0.dar
+build-options:
+- --target=1.dev

--- a/sdk/templates/upgrades-example/main-v2/daml/Main.daml
+++ b/sdk/templates/upgrades-example/main-v2/daml/Main.daml
@@ -9,11 +9,14 @@ template IOU with
     issuer: Party
     owner: Party
     value: Int
-    version: Text
+    name: Text
     description: Optional Text
   where
     signatory issuer, owner
 
     interface instance Asset for IOU where
-      view = Asset.View owner ("IOU (" <> version <> ") " <> fromOptional "(No description)" description)
+      view =
+        case description of
+          None -> Asset.View owner ("IOU (" <> name <> ")")
+          Some d -> Asset.View owner ("IOU (" <> name <> ", " <> d <> ")")
       getOwner = owner

--- a/sdk/templates/upgrades-example/main-v2/daml/Main.daml
+++ b/sdk/templates/upgrades-example/main-v2/daml/Main.daml
@@ -1,0 +1,6 @@
+module Main where
+
+template T with
+    p: Party
+  where
+    signatory p

--- a/sdk/templates/upgrades-example/main-v2/daml/Main.daml
+++ b/sdk/templates/upgrades-example/main-v2/daml/Main.daml
@@ -1,6 +1,19 @@
-module Main where
+module Main where -- V2
 
-template T with
-    p: Party
+import Asset (Asset)
+import qualified Asset
+
+import DA.Optional
+
+template IOU with
+    issuer: Party
+    owner: Party
+    value: Int
+    version: Text
+    description: Optional Text
   where
-    signatory p
+    signatory issuer, owner
+
+    interface instance Asset for IOU where
+      view = Asset.View owner ("IOU (" <> version <> ") " <> fromOptional "(No description)" description)
+      getOwner = owner

--- a/sdk/templates/upgrades-example/multi-package.yaml
+++ b/sdk/templates/upgrades-example/multi-package.yaml
@@ -1,0 +1,5 @@
+packages:
+- ./interfaces
+- ./main-v1
+- ./main-v2
+- ./test

--- a/sdk/templates/upgrades-example/run-test.sh
+++ b/sdk/templates/upgrades-example/run-test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Looking for JQ..." >&2
+if ! which jq >&2; then
+  echo "Required executable 'jq' is not installed." >&2
+  exit 1
+fi
+
+echo "Building all dars..." >&2
+daml build --all
+
+echo "Uploading test DAR..." >&2
+daml ledger upload-dar --host localhost --port 6865 test/.daml/dist/*.dar
+
+echo "Determining package id of main-1.0.0..." >&2
+daml damlc inspect-dar test/.daml/dist/*.dar --json | \
+  jq '.packages | to_entries[] | select(.value.name == "upgrades-example-main" and .value.version == "1.0.0").key' \
+  > v1PackageId
+cat v1PackageId >&2
+
+echo "Running test script..." >&2
+daml script \
+  --ledger-host localhost --ledger-port 6865 \
+  --dar test/.daml/dist/*.dar --script-name Test:main \
+  --input-file v1PackageId \
+  --output-file test-output.json
+
+echo "Test output:" >&2
+jq . test-output.json

--- a/sdk/templates/upgrades-example/test/daml.yaml.template
+++ b/sdk/templates/upgrades-example/test/daml.yaml.template
@@ -2,15 +2,19 @@
 # https://docs.daml.com/tools/assistant.html#project-config-file-daml-yaml
 
 sdk-version: __VERSION__
-name: __PROJECT_NAME__-main
+name: __PROJECT_NAME__-test
 source: daml
-version: 2.0.0
+version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml3-script
 data-dependencies:
   - ../interfaces/.daml/dist/__PROJECT_NAME__-interfaces-1.0.0.dar
-upgrades: ../main-v1/.daml/dist/__PROJECT_NAME__-main-1.0.0.dar
+  - ../main-v1/.daml/dist/__PROJECT_NAME__-main-1.0.0.dar
+  - ../main-v2/.daml/dist/__PROJECT_NAME__-main-2.0.0.dar
+module-prefixes:
+  __PROJECT_NAME__-main-1.0.0: V1
+  __PROJECT_NAME__-main-2.0.0: V2
 build-options:
 - --target=1.17

--- a/sdk/templates/upgrades-example/test/daml/Test.daml
+++ b/sdk/templates/upgrades-example/test/daml/Test.daml
@@ -1,0 +1,58 @@
+module Test where
+
+import Daml.Script
+import Daml.Script.Internal
+
+import Asset (Asset)
+import qualified Asset
+import qualified V1.Main as V1
+import qualified V2.Main as V2
+
+main : Text -> Script ([Asset.View], SubmitError)
+main v1PackageIdRaw = do
+  a <- allocateParty "Alice"
+  v1Cid <- a `submit` createCmd V1.IOU with owner = a, issuer = a, value = 5, name = "C1"
+  v2Cid1 <- a `submit` createCmd V2.IOU with owner = a, issuer = a, value = 5, name = "C2", description = Some "My IOU"
+  v2Cid2 <- a `submit` createCmd V2.IOU with owner = a, issuer = a, value = 5, name = "C3", description = None
+
+  -- A V1 contract is upgraded to V2, then its view is computed using the V2
+  -- implementation of Asset.GetView
+  errOrView1 <- a `trySubmit` exerciseCmd (toInterfaceContractId @Asset v1Cid) Asset.GetView
+  view1 <- expectView errOrView1 "IOU (C1)"
+
+  -- A V2 contract's view is computed using the V2 implementation of
+  -- Asset.GetView
+  errOrView2 <- a `trySubmit` exerciseCmd (toInterfaceContractId @Asset v2Cid1) Asset.GetView
+  view2 <- expectView errOrView2 "IOU (C2, My IOU)"
+
+  let v1PackageId = PackageId v1PackageIdRaw
+  let v1SubmitOptions = actAs a <> packagePreference [v1PackageId]
+
+  -- A V2 contract is successfully downgraded to V1, then its view is computed
+  -- using the V1 implementation of Asset.GetView
+  errOrView3 <- v1SubmitOptions `trySubmit` exerciseCmd (toInterfaceContractId @Asset v2Cid2) Asset.GetView
+  view3 <- expectView errOrView3 "IOU (C3)"
+
+  -- A V2 contract tries to downgrade to V1, the downgrade fails because an
+  -- upgraded field `description` was set to a non-null value
+  errOrView4 <- v1SubmitOptions `trySubmit` exerciseCmd (toInterfaceContractId @Asset v2Cid1) Asset.GetView
+  err <- expectUpgradeError errOrView4 "DowngradeDropDefinedField"
+
+  pure ([view1, view2, view3], err)
+
+expectView : Either SubmitError Asset.View -> Text -> Script Asset.View
+expectView (Right view) description
+  | description == view.description = pure view
+  | otherwise = assertFail ("Expected Asset.View with description = \"" <> description <> "\"), got: " <> show view)
+expectView (Left a) _ =
+  assertFail ("Expected Asset.View, got SubmitError: " <> show a)
+
+expectUpgradeError : Either SubmitError Asset.View -> Text -> Script SubmitError
+expectUpgradeError (Left err@UpgradeError { errorType = actualErrorType }) expectedErrorType
+  | show actualErrorType == expectedErrorType = pure err
+  | otherwise = assertFail ("Expected UpgradeError with errorType = \"" <> expectedErrorType <> "\", got: " <> show err)
+expectUpgradeError (Left err) _ =
+  assertFail ("Expected UpgradeError, got different error: " <> show err)
+expectUpgradeError (Right b) _ =
+  assertFail ("Expected UpgradeError, got Asset.View: " <> show b)
+


### PR DESCRIPTION
Provides a template upgraded across two versions, 1.0.0 and 2.0.0, as well as a separate package defining an interface, and a separate package defining a test with four cases.

Two questions:
- Should we have a README to explain how this all works?
- Should we remove the dependency on `jq`?