### PR TITLE
Fix for #20352

### DIFF
--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -647,6 +647,13 @@ class IdeLedgerClient(
           )
         } catch {
           case Error.Preprocessing.Lookup(err) => Left(makeLookupError(err))
+          // Expose type mismatches as unknown errors to match canton behaviour. Later this should be fully expressed as a SubmitError
+          case Error.Preprocessing.TypeMismatch(_, _, msg) =>
+            Left(
+              makeEmptySubmissionError(
+                scenario.Error.Internal("COMMAND_PREPROCESSING_FAILED(0, 00000000): " + msg)
+              )
+            )
         }
 
       val eitherSpeedyDisclosures

--- a/sdk/daml-script/test/daml/upgrades/DataChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/DataChanges.daml
@@ -46,10 +46,7 @@ main = tests
   , ("Succeeds if a nested enum is an old case when downgrading", templateEnumDowngradeFromOld)
   , ("Fails if a nested enum is a removed case", templateEnumUpgradeToRemoved)
   , ("Fails if a nested enum is an additional case when downgrading", templateEnumDowngradeFromNew)
-  , ("Fails if an optional field is set on a choice when downgrading", \case
-        -- TODO: Disabled on IdeLedger because this seems to break the IdeLedger for mysterious reasons and in horrible ways
-        TestState { runMode = IdeLedger } -> pure ()
-        state -> templateOptionalFieldOnChoiceSetWhenDowngrading state)
+  , ("Fails if an optional field is set on a choice when downgrading", templateOptionalFieldOnChoiceSetWhenDowngrading)
   -- Template optional field set when downgrading
   , tofswdViaInterfaceInCommandLocal
   , tofswdViaInterfaceInCommandGlobal


### PR DESCRIPTION
Addresses #20352 the cheap way for now

Daml-script currently packed TypeMismatch errors from canton as UnknownErrors, as canton packs them as generic preprocessing errors.
IDE Ledger was not catching this error, we now pack it explicitly into Unknown so the behaviours match.

We can find a nicer solution after some discussion, for now we just want tests to pass for the Rc.