### PR TITLE
Add daml-script return values upgrade tests + bugfix by Sam

### DIFF
--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -730,14 +730,22 @@ class IdeLedgerClient(
         optLocation,
       ) match {
         case Right(ScenarioRunner.Commit(result, _, tx)) =>
+          val commandResultPackageIds = commands.flatMap(toCommandPackageIds(_))
+
           _ledger = result.newLedger
           val transaction = result.richTransaction.transaction
-          def convEvent(id: NodeId): Option[ScriptLedgerClient.TreeEvent] =
+          def convEvent(
+              id: NodeId,
+              oIntendedPackageId: Option[PackageId],
+          ): Option[ScriptLedgerClient.TreeEvent] =
             transaction.nodes(id) match {
               case create: Node.Create =>
                 Some(
                   ScriptLedgerClient.Created(
-                    create.templateId,
+                    oIntendedPackageId
+                      .fold(create.templateId)(intendedPackageId =>
+                        create.templateId.copy(packageId = intendedPackageId)
+                      ),
                     create.coid,
                     create.arg,
                     blob(create, result.richTransaction.effectiveAt),
@@ -746,19 +754,24 @@ class IdeLedgerClient(
               case exercise: Node.Exercise =>
                 Some(
                   ScriptLedgerClient.Exercised(
-                    exercise.templateId,
+                    oIntendedPackageId
+                      .fold(exercise.templateId)(intendedPackageId =>
+                        exercise.templateId.copy(packageId = intendedPackageId)
+                      ),
                     exercise.interfaceId,
                     exercise.targetCoid,
                     exercise.choiceId,
                     exercise.chosenValue,
                     exercise.exerciseResult.get,
-                    exercise.children.collect(Function.unlift(convEvent(_))).toList,
+                    exercise.children.collect(Function.unlift(convEvent(_, None))).toList,
                   )
                 )
               case _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback => None
             }
           val tree = ScriptLedgerClient.TransactionTree(
-            transaction.roots.collect(Function.unlift(convEvent(_))).toList
+            transaction.roots.toList
+              .zip(commandResultPackageIds)
+              .collect(Function.unlift { case (id, pkgId) => convEvent(id, Some(pkgId)) })
           )
           val results = ScriptLedgerClient.transactionTreeToCommandResults(tree)
           if (errorBehaviour == ScriptLedgerClient.SubmissionErrorBehaviour.MustFail)
@@ -784,6 +797,15 @@ class IdeLedgerClient(
       }
     }
   }
+
+  // Note that CreateAndExerciseCommand gives two results, so we duplicate the package id
+  private def toCommandPackageIds(cmd: ScriptLedgerClient.CommandWithMeta): List[PackageId] =
+    cmd.command match {
+      case command.CreateAndExerciseCommand(tmplRef, _, _, _) =>
+        List(tmplRef.assertToTypeConName.packageId, tmplRef.assertToTypeConName.packageId)
+      case cmd =>
+        List(cmd.typeRef.assertToTypeConName.packageId)
+    }
 
   override def allocateParty(partyIdHint: String, displayName: String)(implicit
       ec: ExecutionContext,

--- a/sdk/daml-script/test/daml/upgrades/LedgerApiChoiceUpgrade.daml
+++ b/sdk/daml-script/test/daml/upgrades/LedgerApiChoiceUpgrade.daml
@@ -11,6 +11,7 @@ import qualified V2.UpgradedChoice as V2
 import qualified V1.UpgradedChoiceClient as V1
 import qualified V2.UpgradedChoiceClient as V2
 import DA.Optional (fromSome)
+import PackageIds
 
 {- PACKAGE
 name: ledger-api-choice-upgrades
@@ -76,20 +77,23 @@ contents: |
           exercise (coerceContractId @V1.UpgradedChoiceTemplate @V2.UpgradedChoiceTemplate cid) (V2.UpgradedChoice "v1 to v1" None) -- @V 2
 -}
 
+v1PackageId : PackageId
+v1PackageId = getPackageId "ledger-api-choice-upgrades-1.0.0"
 
 main : TestTree
 main = tests
-  [ ("Explicitly call a V1 choice on a V1 contract over the ledger-api, expect V1 implementation used.", explicitV1ChoiceV1Contract)
-  , ("Explicitly call a V2 choice on a V1 contract over the ledger-api, expect V2 implementation used, and contract upgraded.", explicitV2ChoiceV1Contract)
-  , subtree "Call a V1 choice without package ID on a V1 contract over the ledger-api, expect V2 implementation used, contract + argument upgraded, daml-script downgrades return type." 
-     [ ("global contract", inferredV1ChoiceV1GlobalContract)
-     , ("disclosed contract", inferredV1ChoiceV1DisclosedContract)
-     , ("local contract", inferredV1ChoiceV1LocalContract)
-     ]
-  , ("Call a V2 choice without package ID on a V1 contract over the ledger-api, expect V2 implementation used, and contract upgraded.", inferredV2ChoiceV1Contract)
-  , broken ("Call a V2 choice without package ID on a V1 contract over the ledger-api, with V2 unvetted, expect V1 implementation used, argument downgraded, daml-script upgrades return type.", inferredV1ChoiceV1ContractWithoutV2)
-  , ("Explicitly call a V1 choice on a V2 contract over the ledger-api, expect V1 implementation used, and contract downgraded.", explicitV1ChoiceV2Contract)
-  , ("Explicitly call a V2 choice on a V2 contract over the ledger-api, expect V2 implementation used.", explicitV2ChoiceV2Contract)
+  [
+--  ("Explicitly call a V1 choice on a V1 contract over the ledger-api, expect V1 implementation used.", explicitV1ChoiceV1Contract)
+--  , ("Explicitly call a V2 choice on a V1 contract over the ledger-api, expect V2 implementation used, and contract upgraded.", explicitV2ChoiceV1Contract)
+--  , subtree "Call a V1 choice without package ID on a V1 contract over the ledger-api, expect V2 implementation used, contract + argument upgraded, daml-script downgrades return type."
+--     [ ("global contract", inferredV1ChoiceV1GlobalContract)
+--     , ("disclosed contract", inferredV1ChoiceV1DisclosedContract)
+--     , ("local contract", inferredV1ChoiceV1LocalContract)
+--     ]
+--  , ("Call a V2 choice without package ID on a V1 contract over the ledger-api, expect V2 implementation used, and contract upgraded.", inferredV2ChoiceV1Contract)
+   ("Call a V2 choice without package ID on a V1 contract over the ledger-api, with V2 unvetted, expect V1 implementation used, argument downgraded, daml-script upgrades return type.", inferredV1ChoiceV1ContractWithoutV2)
+--  , ("Explicitly call a V1 choice on a V2 contract over the ledger-api, expect V1 implementation used, and contract downgraded.", explicitV1ChoiceV2Contract)
+--  , ("Explicitly call a V2 choice on a V2 contract over the ledger-api, expect V2 implementation used.", explicitV2ChoiceV2Contract)
   ]
 
 choiceTest
@@ -147,11 +151,16 @@ inferredV2ChoiceV1Contract =
 
 -- If v2 isn't vetted, then omitting a package id and giving v1 arguments should use the v1 implementation
 -- Ledger-api still considers unvetted packages in package selection
--- IDE ledger doesn't support vettiing
+-- IDE ledger doesn't support vetting
 inferredV1ChoiceV1ContractWithoutV2 : Test
-inferredV1ChoiceV1ContractWithoutV2 =
-  withUnvettedDar "ledger-api-choice-upgrades-2.0.0" .
-    choiceTest @V1.UpgradedChoiceTemplate V1.UpgradedChoiceTemplate (V1.UpgradedChoice "v1 to v1") False (V1.UpgradedChoiceReturn "v1 to v1:V1")
+inferredV1ChoiceV1ContractWithoutV2 = test $ do
+  a <- allocatePartyOn "alice" participant0
+  cid <- a `submit` createExactCmd (V1.UpgradedChoiceTemplate a)
+  let cidV2 = coerceContractId @V1.UpgradedChoiceTemplate @V2.UpgradedChoiceTemplate cid
+  res <- (actAs a <> packagePreference [v1PackageId]) `trySubmit` exerciseCmd cidV2 (V2.UpgradedChoice "v1 to v1" None)
+  case res of
+    Right returnValue -> returnValue === (V2.UpgradedChoiceReturn "v1 to v1:V1" None)
+    Left err -> assertFail $ "Expected 'v1 to v1:V1:None' but got " <> show err
 
 explicitV1ChoiceV2Contract : Test
 explicitV1ChoiceV2Contract =

--- a/sdk/daml-script/test/daml/upgrades/LedgerApiChoiceUpgrade.daml
+++ b/sdk/daml-script/test/daml/upgrades/LedgerApiChoiceUpgrade.daml
@@ -80,20 +80,26 @@ contents: |
 v1PackageId : PackageId
 v1PackageId = getPackageId "ledger-api-choice-upgrades-1.0.0"
 
+v1ClientPackageId : PackageId
+v1ClientPackageId = getPackageId "ledger-api-choice-upgrades-client-1.0.0"
+
 main : TestTree
 main = tests
-  [
---  ("Explicitly call a V1 choice on a V1 contract over the ledger-api, expect V1 implementation used.", explicitV1ChoiceV1Contract)
---  , ("Explicitly call a V2 choice on a V1 contract over the ledger-api, expect V2 implementation used, and contract upgraded.", explicitV2ChoiceV1Contract)
---  , subtree "Call a V1 choice without package ID on a V1 contract over the ledger-api, expect V2 implementation used, contract + argument upgraded, daml-script downgrades return type."
---     [ ("global contract", inferredV1ChoiceV1GlobalContract)
---     , ("disclosed contract", inferredV1ChoiceV1DisclosedContract)
---     , ("local contract", inferredV1ChoiceV1LocalContract)
---     ]
---  , ("Call a V2 choice without package ID on a V1 contract over the ledger-api, expect V2 implementation used, and contract upgraded.", inferredV2ChoiceV1Contract)
-   ("Call a V2 choice without package ID on a V1 contract over the ledger-api, with V2 unvetted, expect V1 implementation used, argument downgraded, daml-script upgrades return type.", inferredV1ChoiceV1ContractWithoutV2)
---  , ("Explicitly call a V1 choice on a V2 contract over the ledger-api, expect V1 implementation used, and contract downgraded.", explicitV1ChoiceV2Contract)
---  , ("Explicitly call a V2 choice on a V2 contract over the ledger-api, expect V2 implementation used.", explicitV2ChoiceV2Contract)
+  [ ("Explicitly call a V1 choice on a V1 contract over the ledger-api, expect V1 implementation used.", explicitV1ChoiceV1Contract)
+  , ("Explicitly call a V2 choice on a V1 contract over the ledger-api, expect V2 implementation used, and contract upgraded.", explicitV2ChoiceV1Contract)
+  , subtree "Call a V1 choice without package ID on a V1 contract over the ledger-api, expect V2 implementation used, contract + argument upgraded, daml-script downgrades return type."
+     [ ("global contract", v1RequestV2PreferenceV1GlobalContract)
+     , ("disclosed contract", v1RequestV2PreferenceV1DisclosedContract)
+     , ("local contract", v1RequestV2PreferenceV1LocalContract)
+     ]
+  , ("Call a V2 choice without package ID on a V1 contract over the ledger-api, expect V2 implementation used, and contract upgraded.", inferredV2ChoiceV1Contract)
+  , subtree "Call a V2 choice without package ID on a V1 contract over the ledger-api, with package preference V1, expect V1 implementation used, daml-script upgrades return type."
+     [ ("global contract", v2RequestV1PreferenceV1GlobalContract)
+     , ("disclosed contract", v2RequestV1PreferenceV1DisclosedContract)
+     , ("local contract", v2RequestV1PreferenceV1LocalContract)
+     ]
+  , ("Explicitly call a V1 choice on a V2 contract over the ledger-api, expect V1 implementation used, and contract downgraded.", explicitV1ChoiceV2Contract)
+  , ("Explicitly call a V2 choice on a V2 contract over the ledger-api, expect V2 implementation used.", explicitV2ChoiceV2Contract)
   ]
 
 choiceTest
@@ -124,11 +130,11 @@ explicitV2ChoiceV1Contract =
 -- When inferring, the V1 contract and choice argument is upgraded, and the return type is downgraded directly by daml script.
 -- As such, we get the v2 implementation called, with the additional field set to None (as shown in the choice return)
 -- and since the extra data in the return will also be none, the downgrade can succeed.
-inferredV1ChoiceV1GlobalContract : Test
-inferredV1ChoiceV1GlobalContract =
+v1RequestV2PreferenceV1GlobalContract : Test
+v1RequestV2PreferenceV1GlobalContract =
   choiceTest @V1.UpgradedChoiceTemplate V1.UpgradedChoiceTemplate (V1.UpgradedChoice "v1 to v1") False (V1.UpgradedChoiceReturn "v1 to v1:V2:None")
 
-inferredV1ChoiceV1DisclosedContract = test $ do
+v1RequestV2PreferenceV1DisclosedContract = test $ do
   a <- allocatePartyOn "alice" participant0
   cid <- a `submit` createExactCmd (V1.UpgradedChoiceTemplate a)
   disclosure <- fromSome <$> queryDisclosure a cid
@@ -137,7 +143,7 @@ inferredV1ChoiceV1DisclosedContract = test $ do
     Right returnValue -> returnValue === (V1.UpgradedChoiceReturn "v1 to v1:V2:None")
     Left err -> assertFail $ "Expected 'v1 to v1:V2:None' but got " <> show err
 
-inferredV1ChoiceV1LocalContract = test $ do
+v1RequestV2PreferenceV1LocalContract = test $ do
   a <- allocatePartyOn "alice" participant0
   cid <- a `submit` createExactCmd (V1.UpgradedChoiceClientTemplate a)
   res <- a `trySubmit` exerciseCmd cid V1.CreateAndExercise
@@ -149,18 +155,36 @@ inferredV2ChoiceV1Contract : Test
 inferredV2ChoiceV1Contract =
   choiceTest @V2.UpgradedChoiceTemplate V1.UpgradedChoiceTemplate (V2.UpgradedChoice "v2 to v1" $ Some "extra") False (V2.UpgradedChoiceReturn "v2 to v1:V2:Some \"extra\"" $ Some "extra")
 
--- If v2 isn't vetted, then omitting a package id and giving v1 arguments should use the v1 implementation
--- Ledger-api still considers unvetted packages in package selection
--- IDE ledger doesn't support vetting
-inferredV1ChoiceV1ContractWithoutV2 : Test
-inferredV1ChoiceV1ContractWithoutV2 = test $ do
+v2RequestV1PreferenceV1GlobalContract : Test
+v2RequestV1PreferenceV1GlobalContract = test $ do
   a <- allocatePartyOn "alice" participant0
   cid <- a `submit` createExactCmd (V1.UpgradedChoiceTemplate a)
   let cidV2 = coerceContractId @V1.UpgradedChoiceTemplate @V2.UpgradedChoiceTemplate cid
   res <- (actAs a <> packagePreference [v1PackageId]) `trySubmit` exerciseCmd cidV2 (V2.UpgradedChoice "v1 to v1" None)
   case res of
     Right returnValue -> returnValue === (V2.UpgradedChoiceReturn "v1 to v1:V1" None)
-    Left err -> assertFail $ "Expected 'v1 to v1:V1:None' but got " <> show err
+    Left err -> assertFail $ "Expected 'v1 to v1:V1' but got " <> show err
+
+v2RequestV1PreferenceV1DisclosedContract : Test
+v2RequestV1PreferenceV1DisclosedContract = test $ do
+  a <- allocatePartyOn "alice" participant0
+  cid <- a `submit` createExactCmd (V1.UpgradedChoiceTemplate a)
+  disclosure <- fromSome <$> queryDisclosure a cid
+  let cidV2 = coerceContractId @V1.UpgradedChoiceTemplate @V2.UpgradedChoiceTemplate cid
+  res <- (actAs a <> disclose disclosure <> packagePreference [v1PackageId]) `trySubmit` exerciseCmd cidV2 (V2.UpgradedChoice "v1 to v1" None)
+  case res of
+    Right returnValue -> returnValue === (V2.UpgradedChoiceReturn "v1 to v1:V1" None)
+    Left err -> assertFail $ "Expected 'v1 to v1:V1' but got " <> show err
+
+v2RequestV1PreferenceV1LocalContract = test $ do
+  a <- allocatePartyOn "alice" participant0
+  cid <- a `submit` createExactCmd (V1.UpgradedChoiceClientTemplate a)
+  let cidV2 = coerceContractId @V1.UpgradedChoiceClientTemplate @V2.UpgradedChoiceClientTemplate cid
+  res <- (actAs a <> packagePreference [v1ClientPackageId]) `trySubmit` exerciseCmd cidV2 V2.CreateAndExercise
+  case res of
+    Right returnValue -> returnValue === (V2.UpgradedChoiceReturn "v1 to v1:V1" None)
+    Left err -> assertFail $ "Expected 'v1 to v1:V1' but got " <> show err
+
 
 explicitV1ChoiceV2Contract : Test
 explicitV1ChoiceV2Contract =


### PR DESCRIPTION
This addresses the following row in the test matrix:
> the choice return type has been changed in a compatible way in the target template, client needs to upgrade

I thought this was untestable with our test framework but thanks to package preference it is. It uncovered an IDE ledger bug that @samuel-williams-da  fixed with a commit on this very PR.