### PR TITLE
Java Bindings: make `InclusiveFilter.ofTemplateIds` compatible with 2.7 ledger api

### DIFF
--- a/sdk/.pre-commit-config.yaml
+++ b/sdk/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       name: scalafmt
       language: system
       require_serial: true
-      entry: "scalafmt --respect-project-filters"
+      entry: "scalafmt -c sdk/.scalafmt.conf --respect-project-filters"
       types: [scala]
     - id: javafmt
       name: javafmt

--- a/sdk/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/TransactionsClientImplTest.scala
+++ b/sdk/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/TransactionsClientImplTest.scala
@@ -10,7 +10,6 @@ import com.daml.ledger.rxjava.grpc.helpers.TransactionGenerator._
 import com.daml.ledger.rxjava.grpc.helpers.{DataLayerHelpers, LedgerServices, TestConfiguration}
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset.Value.Absolute
-import com.daml.ledger.api.v1.transaction_filter.TemplateFilter
 import com.daml.ledger.api.v1.value.Identifier
 import io.reactivex.Observable
 import org.scalacheck.Shrink
@@ -18,6 +17,7 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
 final class TransactionsClientImplTest
@@ -79,15 +79,9 @@ final class TransactionsClientImplTest
         request.end shouldBe Some(LedgerOffset(Absolute("2")))
         val filter = request.filter.get.filtersByParty
         filter.keySet shouldBe Set("Alice")
-        filter("Alice").inclusive.get.templateFilters.toSet shouldBe Set(
-          TemplateFilter(
-            Some(Identifier("p1", moduleName = "m1", entityName = "e1")),
-            includeCreatedEventBlob = false,
-          ),
-          TemplateFilter(
-            Some(Identifier("p2", moduleName = "m2", entityName = "e2")),
-            includeCreatedEventBlob = false,
-          ),
+        (filter("Alice").inclusive.get.templateIds: @nowarn("cat=deprecation")).toSet shouldBe Set(
+          Identifier("p1", moduleName = "m1", entityName = "e1"),
+          Identifier("p2", moduleName = "m2", entityName = "e2"),
         )
         request.verbose shouldBe true
     }
@@ -150,15 +144,9 @@ final class TransactionsClientImplTest
         request.end shouldBe Some(LedgerOffset(Absolute("2")))
         val filter = request.filter.get.filtersByParty
         filter.keySet shouldBe Set("Alice")
-        filter("Alice").inclusive.get.templateFilters.toSet shouldBe Set(
-          TemplateFilter(
-            Some(Identifier("p1", moduleName = "m1", entityName = "e1")),
-            includeCreatedEventBlob = false,
-          ),
-          TemplateFilter(
-            Some(Identifier("p2", moduleName = "m2", entityName = "e2")),
-            includeCreatedEventBlob = false,
-          ),
+        (filter("Alice").inclusive.get.templateIds: @nowarn("cat=deprecation")).toSet shouldBe Set(
+          Identifier("p1", moduleName = "m1", entityName = "e1"),
+          Identifier("p2", moduleName = "m2", entityName = "e2"),
         )
         request.verbose shouldBe true
     }

--- a/sdk/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/InclusiveFilter.java
+++ b/sdk/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/InclusiveFilter.java
@@ -11,7 +11,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -56,12 +55,7 @@ public final class InclusiveFilter extends Filter {
   }
 
   public static InclusiveFilter ofTemplateIds(@NonNull Set<@NonNull Identifier> templateIds) {
-    return new InclusiveFilter(
-        Collections.emptyMap(),
-        templateIds.stream()
-            .collect(
-                Collectors.toUnmodifiableMap(
-                    Function.identity(), tId -> Template.HIDE_CREATED_EVENT_BLOB)));
+    return new InclusiveFilter(templateIds, Collections.emptyMap());
   }
 
   @NonNull


### PR DESCRIPTION
So that a client can use 2.8 java bindings with a 2.7 ledger version.

From >=2.9 this compatibility should not be needed.