### PR TITLE
XXX Old - Include originating contract packages when calculating party package

### DIFF
--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -14,6 +14,7 @@ import com.digitalasset.daml.lf.transaction.{
 }
 import com.digitalasset.daml.lf.ledger._
 import com.digitalasset.daml.lf.data.Relation
+import com.digitalasset.daml.lf.value.Value.ContractId
 
 import scala.annotation.tailrec
 
@@ -87,11 +88,37 @@ object Blinding {
 
   private[engine] def partyPackages(
       tx: VersionedTransaction,
-      blindingInfo: BlindingInfo,
+      disclosure: Relation[NodeId, Party],
+      contractVisibility: Relation[ContractId, Party],
+      contractPackages: Map[ContractId, Ref.PackageId],
   ): Relation[Party, Ref.PackageId] = {
-    val entries = blindingInfo.disclosure.view.flatMap { case (nodeId, parties) =>
+    Relation.from(
+      disclosedPartyPackages(tx, disclosure) ++
+        contractPartyPackages(contractPackages, contractVisibility)
+    )
+  }
+
+  // These are the packages needed for input contract validation
+  private def contractPartyPackages(
+      contractPackages: Map[ContractId, Ref.PackageId],
+      contractVisibility: Relation[ContractId, Party],
+  ): Iterable[(Party, PackageId)] = {
+    for {
+      (contractId, packageId) <- contractPackages.toSeq
+      party <- contractVisibility.getOrElse(contractId, Set.empty)
+    } yield party -> packageId
+  }
+
+  // These are the package needed for reinterpretation
+  private[engine] def disclosedPartyPackages(
+      tx: VersionedTransaction,
+      disclosure: Relation[NodeId, Party],
+  ): Seq[(Party, PackageId)] = {
+    disclosure.view.flatMap { case (nodeId, parties) =>
       def toEntries(tyCon: Ref.TypeConName) = parties.view.map(_ -> tyCon.packageId)
       tx.nodes(nodeId) match {
+        case fetch: Node.Fetch =>
+          toEntries(fetch.templateId) ++ fetch.interfaceId.toList.view.flatMap(toEntries)
         case action: Node.LeafOnlyAction =>
           toEntries(action.templateId)
         case exe: Node.Exercise =>
@@ -99,12 +126,24 @@ object Blinding {
         case _: Node.Rollback =>
           Iterable.empty
       }
-    }
-    Relation.from(entries)
+    }.toSeq
   }
 
-  /* Calculate the packages needed by a party to interpret the projection   */
-  def partyPackages(tx: VersionedTransaction): Relation[Party, PackageId] =
-    partyPackages(tx, blind(tx))
+  /** Calculate the packages needed by each party in order to reinterpret its projection.
+    *
+    * This needs to include both packages needed by the engine at reinterpretation time
+    * and the originating contract package needed for contract model conformance checking.
+    *
+    * @param tx transaction whose packages are required
+    * @param contractPackages the contracts used by the transaction together with their creating packages
+    */
+  def partyPackages(
+      tx: VersionedTransaction,
+      contractPackages: Map[ContractId, Ref.PackageId] = Map.empty,
+  ): Relation[Party, PackageId] = {
+    val (BlindingInfo(disclosure, _), contractVisibility) =
+      BlindingTransaction.calculateBlindingInfoWithContractVisibility(tx)
+    partyPackages(tx, disclosure, contractVisibility, contractPackages)
+  }
 
 }

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -417,7 +417,14 @@ class Engine(val config: EngineConfig) {
     def finish: Result[(SubmittedTransaction, Tx.Metadata)] =
       machine.finish match {
         case Right(
-              UpdateMachine.Result(tx, _, nodeSeeds, globalKeyMapping, disclosedCreateEvents)
+              UpdateMachine.Result(
+                tx,
+                _,
+                nodeSeeds,
+                globalKeyMapping,
+                disclosedCreateEvents,
+                contractPackages,
+              )
             ) =>
           deps(tx).flatMap { deps =>
             val meta = Tx.Metadata(
@@ -428,6 +435,9 @@ class Engine(val config: EngineConfig) {
               nodeSeeds = nodeSeeds,
               globalKeyMapping = globalKeyMapping,
               disclosedEvents = disclosedCreateEvents,
+              contractPackages = contractPackages ++ disclosedCreateEvents
+                .map(c => c.coid -> c.templateId.packageId)
+                .iterator,
             )
             config.profileDir.foreach { dir =>
               val desc = Engine.profileDesc(tx)

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -363,6 +363,10 @@ class EngineTest(majorLanguageVersion: LanguageMajorVersion)
         case Right(()) => ()
       }
     }
+
+    "return contract id package in metadata" in {
+      txMeta.contractPackages shouldBe Map(cid -> templateId.packageId)
+    }
   }
 
   "exercise-by-key command with missing key" should {
@@ -2628,6 +2632,7 @@ class EngineTestHelpers(majorLanguageVersion: LanguageMajorVersion) {
           nodeSeeds = state.nodeSeeds.toImmArray,
           globalKeyMapping = Map.empty,
           disclosedEvents = ImmArray.empty,
+          contractPackages = Map.empty,
         ),
       )
     )
@@ -2655,6 +2660,7 @@ class EngineTestHelpers(majorLanguageVersion: LanguageMajorVersion) {
       inside(result) { case Right((transaction, metadata)) =>
         transaction should haveDisclosedInputContracts(usedDisclosedContract)
         metadata should haveDisclosedEvents(usedDisclosedContract.contract.toCreateNode)
+        metadata should haveDisclosedContractIdPackages(usedDisclosedContract.contract.toCreateNode)
       }
     }
 
@@ -2681,6 +2687,26 @@ class EngineTestHelpers(majorLanguageVersion: LanguageMajorVersion) {
           expectedResult == actualResult,
           s"Failed with unexpected disclosed contracts: $expectedResult != $actualResult $debugMessage",
           s"Failed with unexpected disclosed contracts: $expectedResult == $actualResult",
+        )
+      }
+
+    def haveDisclosedContractIdPackages(
+        expectedProcessedDisclosedContracts: Node.Create*
+    ): Matcher[Tx.Metadata] =
+      Matcher { metadata =>
+        val expectedResult = Seq(expectedProcessedDisclosedContracts: _*)
+          .map(c => c.coid -> c.templateId.packageId)
+          .toMap
+        val actualResult = metadata.contractPackages
+
+        val missing = expectedResult -- actualResult.keySet
+
+        val debugMessage = s"Missing contractIds package mappings: $missing"
+
+        MatchResult(
+          missing.isEmpty,
+          s"Failed with missing disclosed contracts: $expectedResult != $actualResult $debugMessage",
+          s"Failed with missing disclosed contracts: $expectedResult == $actualResult",
         )
       }
 

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
@@ -15,13 +15,14 @@ import com.daml.nameof.NameOf
 object BlindingTransaction {
 
   private object BlindState {
-    val Empty = BlindState(Relation.empty, Relation.empty)
+    val Empty = BlindState(Relation.empty, Relation.empty, Relation.empty)
   }
 
   /** State to use while computing blindingInfo. */
   private final case class BlindState(
       disclosures: Relation[NodeId, Party],
       divulgences: Relation[ContractId, Party],
+      contractVisibility: Relation[ContractId, Party], // parties that witness the contract
   ) {
 
     def discloseNode(
@@ -39,23 +40,47 @@ object BlindingTransaction {
       )
     }
 
-    def divulgeCoidTo(witnesses: Set[Party], acoid: ContractId): BlindState = {
-      if (witnesses.nonEmpty) {
-        copy(
-          divulgences = divulgences
-            .updated(acoid, witnesses union divulgences.getOrElse(acoid, Set.empty))
-        )
-      } else {
-        this
-      }
+    def divulgeCoidTo(
+        divulgees: Set[Party],
+        witnesses: Set[Party],
+        acoid: ContractId,
+    ): BlindState = {
+      copy(
+        divulgences =
+          if (divulgees.nonEmpty)
+            divulgences.updated(acoid, divulgees union divulgences.getOrElse(acoid, Set.empty))
+          else divulgences,
+        contractVisibility = contractVisibility.updated(
+          acoid,
+          witnesses union contractVisibility.getOrElse(acoid, Set.empty),
+        ),
+      )
     }
 
   }
 
   /** Calculate blinding information for a transaction. */
-  def calculateBlindingInfo(
+  def calculateBlindingInfo(tx: VersionedTransaction): BlindingInfo = {
+    val (info, _) = calculateBlindingInfoWithContractVisibility(tx)
+    info
+  }
+
+  def calculateBlindingInfoWithContractVisibility(
       tx: VersionedTransaction
-  ): BlindingInfo = {
+  ): (BlindingInfo, Relation[ContractId, Party]) = {
+    val state = calculateBlindState(tx)
+    (
+      BlindingInfo(
+        disclosure = state.disclosures,
+        divulgence = state.divulgences,
+      ),
+      state.contractVisibility,
+    )
+  }
+
+  private def calculateBlindState(
+      tx: VersionedTransaction
+  ): BlindState = {
 
     val initialParentExerciseWitnesses: Set[Party] = Set.empty
 
@@ -74,18 +99,30 @@ object BlindingTransaction {
           action match {
 
             case _: Node.Create => state
-            case _: Node.LookupByKey => state
+
+            case lbk: Node.LookupByKey =>
+              lbk.result.fold(state) { coid =>
+                state.divulgeCoidTo(
+                  Set.empty,
+                  witnesses,
+                  coid,
+                )
+              }
 
             // fetch & exercise nodes cause divulgence
 
             case fetch: Node.Fetch =>
-              state
-                .divulgeCoidTo(parentExerciseWitnesses -- fetch.stakeholders, fetch.coid)
+              state.divulgeCoidTo(
+                parentExerciseWitnesses -- fetch.stakeholders,
+                witnesses,
+                fetch.coid,
+              )
 
             case ex: Node.Exercise =>
               val state1 =
                 state.divulgeCoidTo(
                   (parentExerciseWitnesses union ex.choiceObservers) -- ex.stakeholders,
+                  witnesses,
                   ex.targetCoid,
                 )
 
@@ -120,10 +157,8 @@ object BlindingTransaction {
         processNode(s, initialParentExerciseWitnesses, nodeId)
       }
 
-    BlindingInfo(
-      disclosure = finalState.disclosures,
-      divulgence = finalState.divulgences,
-    )
+    finalState
+
   }
 
 }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -30,7 +30,7 @@ import com.digitalasset.daml.lf.transaction.{
   IncompleteTransaction => IncompleteTx,
   TransactionVersion => TxVersion,
 }
-import com.digitalasset.daml.lf.value.Value.ValueArithmeticError
+import com.digitalasset.daml.lf.value.Value.{ContractId, ValueArithmeticError}
 import com.digitalasset.daml.lf.value.{Value => V}
 import com.daml.nameof.NameOf
 import com.daml.scalautil.Statement.discard
@@ -641,6 +641,7 @@ private[lf] object Speedy {
         zipSameLength(seeds, ptx.actionNodeSeeds.toImmArray),
         ptx.contractState.globalKeyInputs.transform((_, v) => v.toKeyMapping),
         disclosedCreateEvents,
+        contractsCache.view.mapValues(_.template.packageId).toMap,
       )
     }
 
@@ -778,6 +779,7 @@ private[lf] object Speedy {
         seeds: NodeSeeds,
         globalKeyMapping: Map[GlobalKey, KeyMapping],
         disclosedCreateEvent: ImmArray[Node.Create],
+        contractPackages: Map[ContractId, PackageId],
     )
   }
 

--- a/sdk/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioRunner.scala
+++ b/sdk/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioRunner.scala
@@ -493,7 +493,7 @@ private[lf] object ScenarioRunner {
           Interruption(continue)
         case SResult.SResultFinal(resultValue) =>
           ledgerMachine.finish match {
-            case Right(Speedy.UpdateMachine.Result(tx, locationInfo, _, _, _)) =>
+            case Right(Speedy.UpdateMachine.Result(tx, locationInfo, _, _, _, _)) =>
               ledger.commit(committers, readAs, location, enrich(tx), locationInfo) match {
                 case Left(err) =>
                   SubmissionError(err, enrich(ledgerMachine.incompleteTransaction))

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -666,7 +666,6 @@ object Transaction {
   private[lf] case object AliasedNode extends NotWellFormedErrorReason
 
   /** Transaction meta data
-    *
     * @param submissionSeed   Populated with the submission seed when returned from [[com.digitalasset.daml.lf.engine.Engine.submit]].
     * @param submissionTime   The submission time
     * @param usedPackages     The set of all packages that are needed for the interpretation of the command. This
@@ -679,6 +678,7 @@ object Transaction {
     *                         nodes to their seed.
     * @param globalKeyMapping Input key mappings inferred during interpretation.
     * @param disclosedEvents  Disclosed create events that have been used in this transaction.
+    * @param contractPackages The originating package associated with each contract id
     */
   final case class Metadata(
       submissionSeed: Option[crypto.Hash],
@@ -688,6 +688,7 @@ object Transaction {
       nodeSeeds: ImmArray[(NodeId, crypto.Hash)],
       globalKeyMapping: Map[GlobalKey, Option[Value.ContractId]],
       disclosedEvents: ImmArray[Node.Create],
+      contractPackages: Map[ContractId, PackageId],
   )
 
   def commitTransaction(submittedTransaction: SubmittedTransaction): CommittedTransaction =

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -22,14 +22,14 @@
 - Tail call optimization: Tail recursion does not blow the scala JVM stack.: [TailCallTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala#L18)
 
 ## Confidentiality:
-- ensure correct privacy for create node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L39)
-- ensure correct privacy for exercise node (consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L51)
-- ensure correct privacy for exercise node (non-consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L72)
-- ensure correct privacy for exercise subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L150)
-- ensure correct privacy for fetch node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L94)
-- ensure correct privacy for lookup-by-key node (found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L107)
-- ensure correct privacy for lookup-by-key node (not-found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L128)
-- ensure correct privacy for rollback subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L225)
+- ensure correct privacy for create node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L44)
+- ensure correct privacy for exercise node (consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L56)
+- ensure correct privacy for exercise node (non-consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L77)
+- ensure correct privacy for exercise subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L155)
+- ensure correct privacy for fetch node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L99)
+- ensure correct privacy for lookup-by-key node (found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L112)
+- ensure correct privacy for lookup-by-key node (not-found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L133)
+- ensure correct privacy for rollback subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L230)
 
 ## Integrity:
 - Evaluation order of create with authorization failure: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L588)

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -22,14 +22,14 @@
 - Tail call optimization: Tail recursion does not blow the scala JVM stack.: [TailCallTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala#L18)
 
 ## Confidentiality:
-- ensure correct privacy for create node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L42)
-- ensure correct privacy for exercise node (consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L54)
-- ensure correct privacy for exercise node (non-consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L75)
-- ensure correct privacy for exercise subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L153)
-- ensure correct privacy for fetch node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L97)
-- ensure correct privacy for lookup-by-key node (found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L110)
-- ensure correct privacy for lookup-by-key node (not-found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L131)
-- ensure correct privacy for rollback subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L228)
+- ensure correct privacy for create node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L39)
+- ensure correct privacy for exercise node (consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L51)
+- ensure correct privacy for exercise node (non-consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L72)
+- ensure correct privacy for exercise subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L150)
+- ensure correct privacy for fetch node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L94)
+- ensure correct privacy for lookup-by-key node (found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L107)
+- ensure correct privacy for lookup-by-key node (not-found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L128)
+- ensure correct privacy for rollback subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L225)
 
 ## Integrity:
 - Evaluation order of create with authorization failure: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L588)
@@ -138,7 +138,7 @@
 - Evaluation order of successful lookup_by_key of a local contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3196)
 - Evaluation order of successful lookup_by_key of a non-cached global contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3063)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L35)
-- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2081)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2085)
 - This checks that type checking in exercise_interface is done after checking activeness.: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L2059)
 - This checks that type checking is done after checking activeness.: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L1929)
 - This checks that type checking is done after checking activeness.: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L2995)


### PR DESCRIPTION
Forward port of 2.x changes:
- Include originating contract packages when calculating party packages (https://github.com/digital-asset/daml/pull/19793)
- Include all witnesses in contract visibility calculation (https://github.com/digital-asset/daml/pull/19995)
- 