### PR TITLE
Enable multi-ide by default and tweak direnv installer message

### DIFF
--- a/sdk/compiler/daml-extension/package.json
+++ b/sdk/compiler/daml-extension/package.json
@@ -120,8 +120,8 @@
                 },
                 "daml.multiPackageIdeSupport": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enables the Initial Access support for multi-package compatibility in the IDE."
+                    "default": true,
+                    "description": "Enables support for multi-package projects in the IDE."
                 },
                 "daml.multiPackageIdeGradleSupport": {
                     "type": "boolean",

--- a/sdk/compiler/daml-extension/src/extension.ts
+++ b/sdk/compiler/daml-extension/src/extension.ts
@@ -223,9 +223,9 @@ async function startLanguageServers(context: ExtensionContext) {
 
   if (envrcExistsWithoutExt) {
     const warningMessage =
-      "Found an .envrc file but the recommended direnv VSCode extension was not installed. Daml IDE may fail to start due to missing environment." +
-      "\nWould you like to install this extension or attempt to continue without it?";
-    const installAnswer = "Install extension";
+      "Found an .envrc file but the recommended direnv VSCode extension is not installed. Daml IDE may fail to start due to missing environment variables." +
+      "\nWould you like to install the recommended direnv extension or attempt to continue without it?";
+    const installAnswer = "Open marketplace";
     const doNotInstallAnswer = "Continue without";
     const neverInstallAnswer = "Do not ask again";
     const doNotInstallkey = "no-install-direnv";


### PR DESCRIPTION
Small tweaks following chat with Curtis, to make the buttons less scary.
Changed the multi-ide to be enabled by default, and updated the message to match