### PR TITLE
Preprocessor should not throw an interpretation error

### DIFF
--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
@@ -169,6 +169,12 @@ object Error {
       override def message: String =
         s"Template of prefetched contract key does not define a key: ${templateId} ($key)"
     }
+
+    final case class ContractIdInContractKey(key: Value) extends Error {
+      override def message: String =
+        s"Contract IDs are not supported in contract keys: ${key.cids.head.coid}"
+    }
+
   }
 
   // Error happening during interpretation

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
@@ -355,7 +355,11 @@ private[lf] final class CommandPreprocessor(
     val ckTtype = handleLookup(pkgInterface.lookupTemplateKey(templateId)).typ
     val preprocessedKey = translateArg(ckTtype, key.contractKey)
 
-    speedy.Speedy.Machine.assertGlobalKey(pkgInterface, templateId, preprocessedKey)
+    speedy.Speedy.Machine
+      .globalKey(pkgInterface, templateId, preprocessedKey)
+      .getOrElse(
+        throw Error.Preprocessing.ContractIdInContractKey(key.contractKey)
+      )
   }
 
 }

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
@@ -276,7 +276,11 @@ private[engine] final class Preprocessor(
   ): Result[Unit] = {
     val exercisedKeys = commands.iterator.collect {
       case speedy.Command.ExerciseByKey(templateId, contractKey, _, _) =>
-        speedy.Speedy.Machine.assertGlobalKey(pkgInterface, templateId, contractKey)
+        speedy.Speedy.Machine
+          .globalKey(pkgInterface, templateId, contractKey)
+          .getOrElse(
+            throw Error.Preprocessing.ContractIdInContractKey(contractKey.toUnnormalizedValue)
+          )
     }
     val undisclosedKeys =
       (exercisedKeys ++ prefetchKeys).filterNot(key => disclosedKeyHashes.contains(key.hash))

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -1739,14 +1739,26 @@ private[lf] object Speedy {
         }
     }
 
-    private[lf] def assertGlobalKey(
+    private[lf] def globalKey(
         pkgInterface: PackageInterface,
         templateId: Ref.Identifier,
         contractKey: SValue,
-    ): GlobalKey = {
+    ): Option[GlobalKey] = {
       val packageTxVersion = tmplId2TxVersion(pkgInterface, templateId)
       val pkgName = tmplId2PackageName(pkgInterface, templateId, packageTxVersion)
-      assertGlobalKey(packageTxVersion, pkgName, templateId, contractKey)
+      globalKey(packageTxVersion, pkgName, templateId, contractKey)
+    }
+
+    private[lf] def globalKey(
+        packageTxVersion: TxVersion,
+        pkgName: Option[PackageName],
+        templateId: TypeConName,
+        keyValue: SValue,
+    ): Option[GlobalKey] = {
+      val lfValue = keyValue.toNormalizedValue(packageTxVersion)
+      GlobalKey
+        .build(templateId, lfValue, KeyPackageName(pkgName, packageTxVersion))
+        .toOption
     }
 
     private[lf] def assertGlobalKey(
@@ -1754,14 +1766,11 @@ private[lf] object Speedy {
         pkgName: Option[PackageName],
         templateId: TypeConName,
         keyValue: SValue,
-    ) = {
-      val lfValue = keyValue.toNormalizedValue(packageTxVersion)
-      GlobalKey
-        .build(templateId, lfValue, KeyPackageName(pkgName, packageTxVersion))
+    ) =
+      globalKey(packageTxVersion, pkgName, templateId, keyValue)
         .getOrElse(
           throw SErrorDamlException(IError.ContractIdInContractKey(keyValue.toUnnormalizedValue))
         )
-    }
   }
 
   // Environment


### PR DESCRIPTION
Follow-up to #20431 and #20417. If the preprocessor fails with an interpretation error, this gets translated into an internal error rather than a `ResultError`, which breaks a number of tests in Canton. So let's us a proper Preprocessor error instead.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
