### PR TITLE
wrap prefetchKeys in safelyRun

### DIFF
--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
@@ -278,7 +278,7 @@ private[engine] final class Preprocessor(
       ResultError(
         Error.Preprocessing.Internal(
           NameOf.qualifiedNameOfCurrentFunc,
-          "unsafeExtractExercisedKey should not need packages",
+          "unsafePrefetchKeys should not need packages",
           None,
         )
       )

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
@@ -273,7 +273,25 @@ private[engine] final class Preprocessor(
       commands: ImmArray[speedy.Command],
       prefetchKeys: Seq[GlobalKey],
       disclosedKeyHashes: Set[crypto.Hash],
-  ): Result[Unit] = {
+  ): Result[Unit] =
+    safelyRun(
+      ResultError(
+        Error.Preprocessing.Internal(
+          NameOf.qualifiedNameOfCurrentFunc,
+          "unsafeExtractExercisedKey should not need packages",
+          None,
+        )
+      )
+    )(unsafePrefetchKeys(commands, prefetchKeys, disclosedKeyHashes)).flatMap { undisclosedKeys =>
+      if (undisclosedKeys.nonEmpty) ResultPrefetch(undisclosedKeys.toSeq, () => ResultDone.Unit)
+      else ResultDone.Unit
+    }
+
+  private def unsafePrefetchKeys(
+      commands: ImmArray[speedy.Command],
+      prefetchKeys: Seq[GlobalKey],
+      disclosedKeyHashes: Set[crypto.Hash],
+  ): Seq[GlobalKey] = {
     val exercisedKeys = commands.iterator.collect {
       case speedy.Command.ExerciseByKey(templateId, contractKey, _, _) =>
         speedy.Speedy.Machine
@@ -284,8 +302,7 @@ private[engine] final class Preprocessor(
     }
     val undisclosedKeys =
       (exercisedKeys ++ prefetchKeys).filterNot(key => disclosedKeyHashes.contains(key.hash))
-    if (undisclosedKeys.nonEmpty) ResultPrefetch(undisclosedKeys.toSeq, () => ResultDone.Unit)
-    else ResultDone.Unit
+    undisclosedKeys.distinct.toSeq
   }
 }
 


### PR DESCRIPTION
Follow up to #20439. Exceptions are turned into results only if this happens inside a `safelyRun`.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
