### PR TITLE
Ignore invalid keys upon prefetching

### DIFF
--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
@@ -292,14 +292,13 @@ private[engine] final class Preprocessor(
       prefetchKeys: Seq[GlobalKey],
       disclosedKeyHashes: Set[crypto.Hash],
   ): Seq[GlobalKey] = {
+
     val exercisedKeys = commands.iterator.collect {
       case speedy.Command.ExerciseByKey(templateId, contractKey, _, _) =>
+        // Might return None in case the key is invalid (e.g. includes a ContractId)
         speedy.Speedy.Machine
           .globalKey(pkgInterface, templateId, contractKey)
-          .getOrElse(
-            throw Error.Preprocessing.ContractIdInContractKey(contractKey.toUnnormalizedValue)
-          )
-    }
+    }.flatten
     val undisclosedKeys =
       (exercisedKeys ++ prefetchKeys).filterNot(key => disclosedKeyHashes.contains(key.hash))
     undisclosedKeys.distinct.toSeq


### PR DESCRIPTION
Fixes the Canton CI: https://app.circleci.com/pipelines/github/DACH-NY/canton?branch=upstream-upgrade-2.10.0-snapshot.20241206.13125.0.vd0fb6537-main-2.x

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
