### PR TITLE
Fix upgrades example template

### DIFF
--- a/sdk/templates/upgrades-example/run-test.sh.template
+++ b/sdk/templates/upgrades-example/run-test.sh.template
@@ -15,7 +15,7 @@ daml ledger upload-dar --host localhost --port 6865 test/.daml/dist/*.dar
 
 echo "Determining package id of main-1.0.0..." >&2
 daml damlc inspect-dar test/.daml/dist/*.dar --json | \
-  jq '.packages | to_entries[] | select(.value.name == "upgrades-example-main" and .value.version == "1.0.0").key' \
+  jq '.packages | to_entries[] | select(.value.name == "__PROJECT_NAME__-main" and .value.version == "1.0.0").key' \
   > v1PackageId
 cat v1PackageId >&2
 

--- a/sdk/templates/upgrades-example/test/daml/Test.daml
+++ b/sdk/templates/upgrades-example/test/daml/Test.daml
@@ -36,7 +36,9 @@ main v1PackageIdRaw = do
   -- A V2 contract tries to downgrade to V1, the downgrade fails because an
   -- upgraded field `description` was set to a non-null value
   errOrView4 <- v1SubmitOptions `trySubmit` exerciseCmd (toInterfaceContractId @Asset v2Cid1) Asset.GetView
-  err <- expectUpgradeError errOrView4 "DowngradeDropDefinedField"
+  err <- expectUpgradeError errOrView4 $ \case
+    DowngradeDropDefinedField { expectedType = "Main:IOU" } -> None
+    x -> Some (show (DowngradeDropDefinedField { expectedType = "Main:IOU" }), show x)
 
   pure ([view1, view2, view3], err)
 
@@ -47,10 +49,12 @@ expectView (Right view) description
 expectView (Left a) _ =
   assertFail ("Expected Asset.View, got SubmitError: " <> show a)
 
-expectUpgradeError : Either SubmitError Asset.View -> Text -> Script SubmitError
-expectUpgradeError (Left err@UpgradeError { errorType = actualErrorType }) expectedErrorType
-  | show actualErrorType == expectedErrorType = pure err
-  | otherwise = assertFail ("Expected UpgradeError with errorType = \"" <> expectedErrorType <> "\", got: " <> show err)
+expectUpgradeError : Either SubmitError Asset.View -> (UpgradeErrorType -> Maybe (Text, Text)) -> Script SubmitError
+expectUpgradeError (Left err@UpgradeError { errorType = upgradeErrorType }) testErrorType =
+  case testErrorType upgradeErrorType of
+    None -> pure err
+    Some (expectedMsg, actualMsg) ->
+      assertFail ("Expected " <> expectedMsg <> ", got: " <> actualMsg)
 expectUpgradeError (Left err) _ =
   assertFail ("Expected UpgradeError, got different error: " <> show err)
 expectUpgradeError (Right b) _ =


### PR DESCRIPTION
A couple of bugfixes for issues with the upgrades example template originally merged in https://github.com/digital-asset/daml/pull/20385, the two commit messages should be reasonably explanatory as to what the issues were.