### PR TITLE
adapt to new prefetchContractKeys option on LAPI 

### DIFF
--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/GrpcLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/GrpcLedgerClient.scala
@@ -278,6 +278,7 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Option[R
       ledgerId = grpcClient.ledgerId.unwrap,
       applicationId = applicationId.getOrElse(""),
       commandId = UUID.randomUUID.toString,
+      prefetchContractKeys = Seq.empty,
     )
     val request = SubmitAndWaitRequest(Some(apiCommands))
     val transactionTreeF = grpcClient.commandServiceClient


### PR DESCRIPTION
https://github.com/DACH-NY/canton/pull/22885 will break the Canton code drop. This should suffice to fix it. :crossed_fingers: 

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
