### PR TITLE
remove daml-script-1.17

### DIFF
--- a/sdk/BUILD
+++ b/sdk/BUILD
@@ -233,7 +233,7 @@ da_haskell_repl(
         "//compiler/damlc/tests:damlc-test",
         "//compiler/damlc/tests:generate-simple-dalf",
         "//compiler/damlc/tests:incremental",
-        "//compiler/damlc/tests:integration-v1dev",
+        "//compiler/damlc/tests:integration-script2-v1dev",
         "//compiler/damlc/tests:packaging",
         "//daml-assistant:daml",
         "//daml-assistant:test",

--- a/sdk/compiler/damlc/tests/BUILD.bazel
+++ b/sdk/compiler/damlc/tests/BUILD.bazel
@@ -6,7 +6,7 @@ load("@os_info//:os_info.bzl", "is_darwin", "is_intel", "is_windows")
 load(":util.bzl", "damlc_compile_test")
 load("//rules_daml:daml.bzl", "daml_compile", "daml_compile_with_dalf", "generate_and_track_dar_hash_file")
 load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
-load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS", "LF_MAJOR_VERSIONS", "lf_version_default_or_latest", "mangle_for_damlc")
+load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS", "LEGACY_DAML_SCRIPT_LF_VERSIONS", "LF_MAJOR_VERSIONS", "lf_version_default_or_latest", "mangle_for_damlc")
 load("//compiler/damlc:util.bzl", "ghc_pkg")
 
 # Tests for the lax CLI parser + damlc CLI parser
@@ -59,7 +59,7 @@ da_haskell_test(
     data = [
         "//compiler/damlc",
         "//daml-script/daml:daml-script.dar",
-        "//daml-script/daml:daml-script-1.17.dar",
+        "//daml-script/daml-lts:daml-script-lts-1.17.dar",
     ],
     hackage_deps = [
         "base",
@@ -194,7 +194,7 @@ da_haskell_library(
             "//compiler/damlc/pkg-db",
             "//compiler/damlc/stable-packages",
             "//compiler/scenario-service/server:scenario_service_jar",
-            "//daml-script/daml:daml-script-{version}.dar".format(version = version),
+            "//daml-script/daml:daml-script-{version}.dar".format(version = version) if version in LEGACY_DAML_SCRIPT_LF_VERSIONS else "//daml-script/daml-lts:daml-script-lts-{version}.dar".format(version = version),
             "@jq_dev_env//:jq",
             ghc_pkg,
         ],
@@ -744,7 +744,6 @@ da_haskell_test(
             "//compiler/damlc",
             "@damlc_legacy",
             "//compiler/damlc/tests:generate-simple-dalf",
-            "//daml-script/daml:daml-script-1.17.dar",
             "//daml-script/daml-lts:daml-script-lts-1.17.dar",
             # Feel free to update this to 0.13.55 once that is frozen.
             ":dars/old-proj-0.13.55-snapshot.20200309.3401.0.6f8c3ad8-1.8.dar",
@@ -1271,7 +1270,7 @@ da_haskell_test(
         "//compiler/damlc/pkg-db",
         "//compiler/damlc/stable-packages",
         "//compiler/scenario-service/server:scenario_service_jar",
-        "//daml-script/daml:daml-script-1.17.dar",
+        "//daml-script/daml-lts:daml-script-lts-1.17.dar",
         ghc_pkg,
     ],
     hackage_deps = [

--- a/sdk/compiler/damlc/tests/BUILD.bazel
+++ b/sdk/compiler/damlc/tests/BUILD.bazel
@@ -208,43 +208,46 @@ da_haskell_library(
             ":integration-lib",
         ],
     )
-    for version in COMPILER_LF_VERSIONS
+    for version in LEGACY_DAML_SCRIPT_LF_VERSIONS
 ]
 
-da_haskell_test(
-    name = "integration-v117-script2",
-    size = "large",
-    srcs = ["src/DA/Test/DamlcIntegrationMain.hs"],
-    args = [
-        "--daml-lf-version",
-        "1.17",
-        "--daml-script-v2",
-        "true",
-    ],
-    data = [
-        ":bond-trading",
-        ":cant-skip-preprocessor",
-        ":daml-test-files",
-        ":package-vetting-package-a.dar",
-        ":package-vetting-package-b.dar",
-        ":query-lf-lib",
-        "//compiler/damlc/pkg-db",
-        "//compiler/damlc/stable-packages",
-        "//compiler/scenario-service/server:scenario_service_jar",
-        "//daml-script/daml-lts:daml-script-lts-1.17.dar",
-        "@jq_dev_env//:jq",
-        ghc_pkg,
-    ],
-    hackage_deps = [
-        "base",
-    ],
-    main_function = "DA.Test.DamlcIntegrationMain.main",
-    src_strip_prefix = "src",
-    visibility = ["//visibility:public"],
-    deps = [
-        ":integration-lib",
-    ],
-)
+[
+    da_haskell_test(
+        name = "integration-script2-{}".format(mangle_for_damlc(version)),
+        size = "large",
+        srcs = ["src/DA/Test/DamlcIntegrationMain.hs"],
+        args = [
+            "--daml-lf-version",
+            "1.17",
+            "--daml-script-v2",
+            "true",
+        ],
+        data = [
+            ":bond-trading",
+            ":cant-skip-preprocessor",
+            ":daml-test-files",
+            ":package-vetting-package-a.dar",
+            ":package-vetting-package-b.dar",
+            ":query-lf-lib",
+            "//compiler/damlc/pkg-db",
+            "//compiler/damlc/stable-packages",
+            "//compiler/scenario-service/server:scenario_service_jar",
+            "//daml-script/daml-lts:daml-script-lts-1.17.dar",
+            "@jq_dev_env//:jq",
+            ghc_pkg,
+        ],
+        hackage_deps = [
+            "base",
+        ],
+        main_function = "DA.Test.DamlcIntegrationMain.main",
+        src_strip_prefix = "src",
+        visibility = ["//visibility:public"],
+        deps = [
+            ":integration-lib",
+        ],
+    )
+    for version in [v for v in COMPILER_LF_VERSIONS if not (v in LEGACY_DAML_SCRIPT_LF_VERSIONS)]
+]
 
 # Tests for daml-doc
 da_haskell_test(

--- a/sdk/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -38,7 +38,7 @@ main = withSdkVersions $ do
         let targetDevVersion = LF.version1_17
         let exceptionsVersion = minExceptionVersion LF.V1
         let simpleDalfLfVersion = LF.defaultOrLatestStable LF.V1
-        scriptDar <- locateRunfiles (mainWorkspace </> "daml-script" </> "daml" </> "daml-script-1.17.dar")
+        scriptDar <- locateRunfiles (mainWorkspace </> "daml-script" </> "daml-lts" </> "daml-script-lts-1.17.dar")
         oldProjDar <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "tests" </> "dars" </> "old-proj-0.13.55-snapshot.20200309.3401.0.6f8c3ad8-1.8.dar")
         let lfVersionTestPairs = lfVersionTestPairsV1
         return TestArgs{..}

--- a/sdk/compiler/damlc/tests/src/DA/Test/ScriptService_1_17.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/ScriptService_1_17.hs
@@ -55,7 +55,7 @@ main = withSdkVersions $ do
       setEnv "TASTY_NUM_THREADS" "1" True
 
       -- Package DB setup, we only need to do this once so we do it at the beginning.
-      scriptDar <- locateRunfiles $ mainWorkspace </> "daml-script/daml/daml-script-1.17.dar"
+      scriptDar <- locateRunfiles $ mainWorkspace </> "daml-script/daml-lts/daml-script-lts-1.17.dar"
       writeFileUTF8 "daml.yaml" $
         unlines
           [ "sdk-version: " <> sdkVersion,
@@ -65,6 +65,7 @@ main = withSdkVersions $ do
             "dependencies:",
             "- daml-prim",
             "- daml-stdlib",
+            "data-dependencies:",
             "- " <> show scriptDar
           ]
       withPackageConfig (ProjectPath ".") $ \PackageConfigFields {..} -> do

--- a/sdk/compiler/damlc/tests/src/DamlcTest.hs
+++ b/sdk/compiler/damlc/tests/src/DamlcTest.hs
@@ -30,7 +30,7 @@ main = withSdkVersions $ do
     setEnv "TASTY_NUM_THREADS" "1" True
     damlc <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> exe "damlc")
     scriptDar <- locateRunfiles (mainWorkspace </> "daml-script" </> "daml" </> "daml-script.dar")
-    script117Dar <- locateRunfiles (mainWorkspace </> "daml-script" </> "daml" </> "daml-script-1.17.dar")
+    script117Dar <- locateRunfiles (mainWorkspace </> "daml-script" </> "daml-lts" </> "daml-script-lts-1.17.dar")
 
     defaultMain (tests damlc scriptDar script117Dar)
 

--- a/sdk/daml-script/daml/BUILD.bazel
+++ b/sdk/daml-script/daml/BUILD.bazel
@@ -4,7 +4,7 @@
 # TODO Once daml_compile uses build instead of package we should use
 # daml_compile instead of a genrule.
 load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
-load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS")
+load("//daml-lf/language:daml-lf.bzl", "LEGACY_DAML_SCRIPT_LF_VERSIONS")
 
 # Build one DAR per LF version to bundle with the SDK.
 # Also build one DAR with the default LF version for test-cases.
@@ -46,7 +46,7 @@ EOF
         tools = ["//compiler/damlc"],
         visibility = ["//visibility:public"],
     )
-    for lf_version in COMPILER_LF_VERSIONS + [""]
+    for lf_version in LEGACY_DAML_SCRIPT_LF_VERSIONS + [""]
     for suffix in [("-" + lf_version) if lf_version else ""]
 ]
 
@@ -54,7 +54,7 @@ filegroup(
     name = "daml-script-dars",
     srcs = [
         "daml-script-{}.dar".format(lf_version)
-        for lf_version in COMPILER_LF_VERSIONS
+        for lf_version in LEGACY_DAML_SCRIPT_LF_VERSIONS
     ],
     visibility = ["//visibility:public"],
 )

--- a/sdk/daml-script/test/BUILD.bazel
+++ b/sdk/daml-script/test/BUILD.bazel
@@ -15,6 +15,8 @@ load("@os_info//:os_info.bzl", "is_windows")
 load("//rules_daml:daml.bzl", "daml_compile")
 load(
     "//daml-lf/language:daml-lf.bzl",
+    "COMPILER_LF_VERSIONS",
+    "LEGACY_DAML_SCRIPT_LF_VERSIONS",
     "lf_version_configuration",
     "mangle_for_damlc",
 )
@@ -117,8 +119,9 @@ EOF
         visibility = ["//visibility:public"],
     )
     for lf_version in [
-        "1.17",
-        "1.dev",
+        v
+        for v in COMPILER_LF_VERSIONS
+        if not (v in LEGACY_DAML_SCRIPT_LF_VERSIONS)
     ]
 ]
 

--- a/sdk/daml-script/test/BUILD.bazel
+++ b/sdk/daml-script/test/BUILD.bazel
@@ -85,14 +85,14 @@ EOF
     genrule(
         name = "script-test-{}".format(lf_version),
         srcs =
-            glob(["**/*.daml"]) + ["//daml-script/daml:daml-script-{}.dar".format(lf_version)],
+            glob(["**/*.daml"]) + ["//daml-script/daml-lts:daml-script-lts-{}.dar".format(lf_version)],
         outs = ["script-test-{}.dar".format(lf_version)],
         cmd = """
       set -eou pipefail
       TMP_DIR=$$(mktemp -d)
       mkdir -p $$TMP_DIR/daml
       cp -L $(location :daml/TestChoiceAuthority.daml) $$TMP_DIR/daml
-      cp -L $(location //daml-script/daml:daml-script-{lf_version}.dar) $$TMP_DIR/
+      cp -L $(location //daml-script/daml-lts:daml-script-lts-{lf_version}.dar) $$TMP_DIR/
       cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: {sdk}
 name: script-test-{mangled_lf_version}
@@ -103,7 +103,8 @@ build-options:
 dependencies:
   - daml-stdlib
   - daml-prim
-  - daml-script-{lf_version}.dar
+data-dependencies:
+  - daml-script-lts-{lf_version}.dar
 EOF
       $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location script-test-{lf_version}.dar)
       rm -rf $$TMP_DIR
@@ -116,7 +117,8 @@ EOF
         visibility = ["//visibility:public"],
     )
     for lf_version in [
-        "1.15",
+        "1.17",
+        "1.dev",
     ]
 ]
 

--- a/sdk/daml-script/test/BUILD.bazel
+++ b/sdk/daml-script/test/BUILD.bazel
@@ -117,8 +117,6 @@ EOF
     )
     for lf_version in [
         "1.15",
-        "1.17",
-        "1.dev",
     ]
 ]
 
@@ -374,8 +372,6 @@ da_scala_test(
     data = [
         "//daml-script/daml:daml-script-1.14.dar",
         "//daml-script/daml:daml-script-1.15.dar",
-        "//daml-script/daml:daml-script-1.17.dar",
-        "//daml-script/daml:daml-script-1.dev.dar",
         "//daml-script/daml-lts:daml-script-lts-1.14.dar",
         "//daml-script/daml-lts:daml-script-lts-1.15.dar",
         "//daml-script/daml-lts:daml-script-lts-1.17.dar",

--- a/sdk/docs/BUILD.bazel
+++ b/sdk/docs/BUILD.bazel
@@ -592,7 +592,7 @@ daml_test(
         srcs = glob(["source/daml/intro/daml/daml-intro-8/**/*.daml"]),
         additional_compiler_flags = ["-Wupgrade-exceptions"],
         target = version,
-        deps = ["//daml-script/daml:daml-script-{}.dar".format(version)],
+        deps = ["//daml-script/daml-lts:daml-script-lts-{}.dar".format(version)],
     )
     for version in LF_DEV_VERSIONS
 ]

--- a/sdk/docs/BUILD.bazel
+++ b/sdk/docs/BUILD.bazel
@@ -591,8 +591,8 @@ daml_test(
         name = "daml-intro-8-daml-test-{}".format(version),
         srcs = glob(["source/daml/intro/daml/daml-intro-8/**/*.daml"]),
         additional_compiler_flags = ["-Wupgrade-exceptions"],
+        data_deps = ["//daml-script/daml-lts:daml-script-lts-{}.dar".format(version)],
         target = version,
-        deps = ["//daml-script/daml-lts:daml-script-lts-{}.dar".format(version)],
     )
     for version in LF_DEV_VERSIONS
 ]

--- a/sdk/docs/source/daml/intro/daml/daml-intro-8/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-8/daml.yaml.template
@@ -5,4 +5,4 @@ version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-lts

--- a/sdk/test-common/BUILD.bazel
+++ b/sdk/test-common/BUILD.bazel
@@ -145,7 +145,7 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-dep-v1".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/dep-v1/*.daml".format(identifier)]),
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
+            data_dependencies = ["//daml-script/daml-lts:daml-script-lts-1.17.dar"],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             project_name = "upgrades-example-{}-dep".format(identifier),
             target = "1.17",
@@ -155,7 +155,7 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-dep-v2".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/dep-v2/*.daml".format(identifier)]),
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
+            data_dependencies = ["//daml-script/daml-lts:daml-script-lts-1.17.dar"],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             project_name = "upgrades-example-{}-dep".format(identifier),
             target = "1.17",
@@ -169,8 +169,10 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-v1".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/v1/*.daml".format(identifier)]),
-            data_dependencies = ["//test-common:upgrades-{}-dep-v1.dar".format(identifier)],
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
+            data_dependencies = [
+                "//test-common:upgrades-{}-dep-v1.dar".format(identifier),
+                "//daml-script/daml-lts:daml-script-lts-1.17.dar",
+            ],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             project_name = "upgrades-example-{}".format(identifier),
             target = "1.17",
@@ -180,8 +182,10 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-v2".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/v2/*.daml".format(identifier)]),
-            data_dependencies = ["//test-common:upgrades-{}-dep-v2.dar".format(identifier)],
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
+            data_dependencies = [
+                "//test-common:upgrades-{}-dep-v2.dar".format(identifier),
+                "//daml-script/daml-lts:daml-script-lts-1.17.dar",
+            ],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             project_name = "upgrades-example-{}".format(identifier),
             target = "1.17",
@@ -207,7 +211,7 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-dep".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/dep/*.daml".format(identifier)]),
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
+            data_dependencies = ["//daml-script/daml-lts:daml-script-lts-1.17.dar"],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             project_name = "upgrades-example-{}-dep".format(identifier),
             target = "1.17",
@@ -254,7 +258,7 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-dep-v1".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/dep-v1/*.daml".format(identifier)]),
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
+            data_dependencies = ["//daml-script/daml-lts:daml-script-lts-1.17.dar"],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             project_name = "upgrades-example-{}-dep".format(identifier),
             target = "1.17",
@@ -264,7 +268,7 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-dep-v2".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/dep-v2/*.daml".format(identifier)]),
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
+            data_dependencies = ["//daml-script/daml-lts:daml-script-lts-1.17.dar"],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             project_name = "upgrades-example-{}-dep".format(identifier),
             target = "1.17",
@@ -278,8 +282,10 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-v1".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/v1/*.daml".format(identifier)]),
-            data_dependencies = ["//test-common:upgrades-{}-dep-v2.dar".format(identifier)],
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
+            data_dependencies = [
+                "//test-common:upgrades-{}-dep-v2.dar".format(identifier),
+                "//daml-script/daml-lts:daml-script-lts-1.17.dar",
+            ],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             project_name = "upgrades-example-{}".format(identifier),
             target = "1.17",
@@ -289,8 +295,10 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-v2".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/v2/*.daml".format(identifier)]),
-            data_dependencies = ["//test-common:upgrades-{}-dep-v1.dar".format(identifier)],
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
+            data_dependencies = [
+                "//test-common:upgrades-{}-dep-v1.dar".format(identifier),
+                "//daml-script/daml-lts:daml-script-lts-1.17.dar",
+            ],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             project_name = "upgrades-example-{}".format(identifier),
             target = "1.17",
@@ -324,8 +332,7 @@ da_scala_dar_resources_library(
             data_dependencies = v1opts.get(
                 "data_dependencies",
                 default = [],
-            ),
-            dependencies = ["//daml-script/daml:daml-script-{}.dar".format(opts_get_lf_version(v1opts))],
+            ) + ["//daml-script/daml-lts:daml-script-lts-{}.dar".format(opts_get_lf_version(v1opts))],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             module_prefixes = v1opts.get(
                 "module_prefixes",
@@ -342,8 +349,7 @@ da_scala_dar_resources_library(
             data_dependencies = v2opts.get(
                 "data_dependencies",
                 default = [],
-            ),
-            dependencies = ["//daml-script/daml:daml-script-{}.dar".format(opts_get_lf_version(v2opts))],
+            ) + ["//daml-script/daml-lts:daml-script-lts-{}.dar".format(opts_get_lf_version(v2opts))],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             module_prefixes = v2opts.get(
                 "module_prefixes",
@@ -579,7 +585,7 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-dep-dep-v1".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/dep-dep-v1/*.daml".format(identifier)]),
-            dependencies = ["//daml-script/daml:daml-script-1.dev.dar"],
+            data_dependencies = ["//daml-script/daml-lts:daml-script-lts-1.dev.dar"],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             project_name = "upgrades-example-{}-dep-dep".format(identifier),
             target = "1.dev",
@@ -589,7 +595,7 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-dep-dep-v2".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/dep-dep-v2/*.daml".format(identifier)]),
-            dependencies = ["//daml-script/daml:daml-script-1.dev.dar"],
+            data_dependencies = ["//daml-script/daml-lts:daml-script-lts-1.dev.dar"],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             project_name = "upgrades-example-{}-dep-dep".format(identifier),
             target = "1.dev",
@@ -603,8 +609,10 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-dep-v1".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/dep-v1/*.daml".format(identifier)]),
-            data_dependencies = ["//test-common:upgrades-{}-dep-dep-v1.dar".format(identifier)],
-            dependencies = ["//daml-script/daml:daml-script-1.dev.dar"],
+            data_dependencies = [
+                "//test-common:upgrades-{}-dep-dep-v1.dar".format(identifier),
+                "//daml-script/daml-lts:daml-script-lts-1.dev.dar",
+            ],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             project_name = "upgrades-example-{}-dep".format(identifier),
             target = "1.dev",
@@ -614,8 +622,10 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-dep-v2".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/dep-v2/*.daml".format(identifier)]),
-            data_dependencies = ["//test-common:upgrades-{}-dep-dep-v2.dar".format(identifier)],
-            dependencies = ["//daml-script/daml:daml-script-1.dev.dar"],
+            data_dependencies = [
+                "//test-common:upgrades-{}-dep-dep-v2.dar".format(identifier),
+                "//daml-script/daml-lts:daml-script-lts-1.dev.dar",
+            ],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             project_name = "upgrades-example-{}-dep".format(identifier),
             target = "1.dev",
@@ -632,8 +642,8 @@ da_scala_dar_resources_library(
             data_dependencies = [
                 "//test-common:upgrades-{}-dep-v1.dar".format(identifier),
                 "//test-common:upgrades-{}-dep-dep-v1.dar".format(identifier),
+                "//daml-script/daml-lts:daml-script-lts-1.dev.dar",
             ],
-            dependencies = ["//daml-script/daml:daml-script-1.dev.dar"],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             project_name = "upgrades-example-{}".format(identifier),
             target = "1.dev",
@@ -646,8 +656,8 @@ da_scala_dar_resources_library(
             data_dependencies = [
                 "//test-common:upgrades-{}-dep-v2.dar".format(identifier),
                 "//test-common:upgrades-{}-dep-dep-v2.dar".format(identifier),
+                "//daml-script/daml-lts:daml-script-lts-1.dev.dar",
             ],
-            dependencies = ["//daml-script/daml:daml-script-1.dev.dar"],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             project_name = "upgrades-example-{}".format(identifier),
             target = "1.dev",
@@ -675,7 +685,7 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-v1a".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/v1a/*.daml".format(identifier)]),
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
+            data_dependencies = ["//daml-script/daml-lts:daml-script-lts-1.17.dar"],
             project_name = "upgrades-example-{}".format(identifier),
             target = "1.17",
             version = "1.0.0",
@@ -684,7 +694,7 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-v1b".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/v1b/*.daml".format(identifier)]),
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
+            data_dependencies = ["//daml-script/daml-lts:daml-script-lts-1.17.dar"],
             project_name = "upgrades-example-{}".format(identifier),
             target = "1.17",
             version = "1.0.0",
@@ -732,7 +742,7 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-v1".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/v1/*.daml".format(identifier)]),
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
+            data_dependencies = ["//daml-script/daml-lts:daml-script-lts-1.17.dar"],
             project_name = "upgrades-example-{}".format(identifier),
             target = "1.17",
             version = "1.0.0",
@@ -741,7 +751,7 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-v2".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/v2/*.daml".format(identifier)]),
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
+            data_dependencies = ["//daml-script/daml-lts:daml-script-lts-1.17.dar"],
             project_name = "upgrades-example-{}".format(identifier),
             target = "1.17",
             # We want to check the validity of this upgrade on the ledger
@@ -754,7 +764,7 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-v3".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/v3/*.daml".format(identifier)]),
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
+            data_dependencies = ["//daml-script/daml-lts:daml-script-lts-1.17.dar"],
             project_name = "upgrades-example-{}".format(identifier),
             target = "1.17",
             # We want to check the validity of this upgrade on the ledger
@@ -784,7 +794,7 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-dep-v1".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/dep-v1/*.daml".format(identifier)]),
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
+            data_dependencies = ["//daml-script/daml-lts:daml-script-lts-1.17.dar"],
             project_name = "upgrades-example-{}-dep".format(identifier),
             target = "1.17",
             version = "1.0.0",
@@ -793,7 +803,7 @@ da_scala_dar_resources_library(
         daml_compile(
             name = "upgrades-{}-dep-v2".format(identifier),
             srcs = glob(["src/main/daml/upgrades/{}/dep-v2/*.daml".format(identifier)]),
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
+            data_dependencies = ["//daml-script/daml-lts:daml-script-lts-1.17.dar"],
             project_name = "upgrades-example-{}-dep".format(identifier),
             target = "1.17",
             # We want to check the validity of this upgrade on the ledger
@@ -809,8 +819,8 @@ da_scala_dar_resources_library(
             data_dependencies = [
                 "//test-common:upgrades-{}-dep-v1.dar".format(identifier),
                 "//test-common:upgrades-{}-dep-v2.dar".format(identifier),
+                "//daml-script/daml-lts:daml-script-lts-1.17.dar",
             ],
-            dependencies = ["//daml-script/daml:daml-script-1.17.dar"],
             ghc_options = default_damlc_opts + ["--ghc-option=-Wno-unused-imports"],
             module_prefixes = {
                 "upgrades-example-{}-dep-1.0.0".format(identifier): "V1",


### PR DESCRIPTION
Also daml-script-1.dev.

Tests that were relying on daml-script-1.17 or daml-script-1.dev now data-depend on daml-script-lts-1.17 or  daml-script-lts-1.dev. 

Also checked that 1.17 is no longer distributed:
```
$ daml-sdk-head --skip-jars
$ find ~/.daml/sdk/0.0.0/ -name '*.dar' | grep daml-script-
/home/polux/.daml/sdk/0.0.0/daml-libs/daml-script-lts-stable-1.15.dar
/home/polux/.daml/sdk/0.0.0/daml-libs/daml-script-lts-1.17.dar
/home/polux/.daml/sdk/0.0.0/daml-libs/daml-script-lts-1.15.dar
/home/polux/.daml/sdk/0.0.0/daml-libs/daml-script-1.15.dar
/home/polux/.daml/sdk/0.0.0/daml-libs/daml-script-lts-stable-1.14.dar
/home/polux/.daml/sdk/0.0.0/daml-libs/daml-script-1.14.dar
/home/polux/.daml/sdk/0.0.0/daml-libs/daml-script-lts-stable-1.dev.dar
/home/polux/.daml/sdk/0.0.0/daml-libs/daml-script-lts-1.14.dar
/home/polux/.daml/sdk/0.0.0/daml-libs/daml-script-lts-1.dev.dar
/home/polux/.daml/sdk/0.0.0/daml-libs/daml-script-lts-stable-1.17.dar
```