### PR TITLE
Remove --wall-clock-time from daml.yaml intro templates

### DIFF
--- a/sdk/docs/daml-intro-7.yaml
+++ b/sdk/docs/daml-intro-7.yaml
@@ -9,6 +9,4 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time
 

--- a/sdk/docs/source/daml/intro/daml/daml-intro-1/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-1/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-10/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-10/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-11/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-11/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-12-part1/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-12-part1/daml.yaml.template
@@ -8,5 +8,3 @@ dependencies:
   - daml-script
 build-options:
   - --target=1.15
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-12-part2/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-12-part2/daml.yaml.template
@@ -10,5 +10,3 @@ data-dependencies:
   - ./intro12-part1.dar
 build-options:
   - --target=1.15
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-13/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-13/daml.yaml.template
@@ -7,5 +7,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-2/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-2/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-3/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-3/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-4/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-4/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-5/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-5/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-6/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-6/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-8/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-8/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-9/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-9/daml.yaml.template
@@ -8,5 +8,3 @@ dependencies:
   - daml-script
 data-dependencies:
   - ../intro7/assets.dar
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/patterns/daml.yaml.template
+++ b/sdk/docs/source/daml/patterns/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/templates/copy-trigger/daml.yaml.template
+++ b/sdk/templates/copy-trigger/daml.yaml.template
@@ -8,5 +8,3 @@ dependencies:
   - daml-stdlib
   - daml-trigger
 # trigger-dependencies-end
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/templates/empty-skeleton/daml.yaml.template
+++ b/sdk/templates/empty-skeleton/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time


### PR DESCRIPTION
The sample daml.yaml templates currently include these lines:

```
sandbox-options:
  - --wall-clock-time
```

However, due to #13497 , these samples do not run. The `--wall-clock-time` is not required for the samples and is in fact the default.

Related forum posts:

* [sandbox-options-wall-clock-time](https://discuss.daml.com/t/sandbox-options-wall-clock-time/5692/2?u=wallacekelly)
* [is-it-possible-to-start-canton-sandbox-in-static-time-mode-specified-in-the-daml-yaml-file](https://discuss.daml.com/t/is-it-possible-to-start-canton-sandbox-in-static-time-mode-specified-in-the-daml-yaml-file/4602/2?u=wallacekelly)