### PR TITLE
Change triggers AllInDar export method

### DIFF
--- a/sdk/triggers/daml/Daml/Trigger.daml
+++ b/sdk/triggers/daml/Daml/Trigger.daml
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Daml.Trigger
  ( query
@@ -44,6 +45,7 @@ module Daml.Trigger
  , fromArchived
  , CompletionStatus(..)
  , RegisteredTemplates(..)
+ , pattern AllInDar
  , registeredTemplate
  , RelTime(..)
  , getReadAs
@@ -62,6 +64,11 @@ import DA.Optional
 import Daml.Trigger.Internal
 import Daml.Trigger.LowLevel hiding (BatchTrigger, Trigger)
 import qualified Daml.Trigger.LowLevel as LowLevel
+
+-- Deprecated pattern syn, must be top level for exports to work
+{-# DEPRECATED AllInDar "Use AllTemplates instead" #-}
+pattern AllInDar : RegisteredTemplates
+pattern AllInDar = AllTemplates
 
 -- public API
 

--- a/sdk/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/sdk/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -35,7 +35,8 @@ module Daml.Trigger.LowLevel
   , fromExercise
   , fromExerciseByKey
   , fromCreateAndExercise
-  , RegisteredTemplates(AllInDar, ..)
+  , RegisteredTemplates(..)
+  , pattern AllInDar
   , registeredTemplate
   , RelTime(..)
   , execStateT

--- a/sdk/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/sdk/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -36,7 +36,6 @@ module Daml.Trigger.LowLevel
   , fromExerciseByKey
   , fromCreateAndExercise
   , RegisteredTemplates(..)
-  , pattern AllInDar
   , registeredTemplate
   , RelTime(..)
   , execStateT
@@ -223,10 +222,6 @@ newtype RegisteredTemplate = RegisteredTemplate TemplateTypeRep
 data RegisteredTemplates
   = AllTemplates -- ^ Listen to events for all templates known by the triggers' runner.
   | RegisteredTemplates [RegisteredTemplate]
-
-{-# DEPRECATED AllInDar "Use AllTemplates instead" #-}
-pattern AllInDar : RegisteredTemplates
-pattern AllInDar = AllTemplates
 
 registeredTemplate : forall t. Template t => RegisteredTemplate
 registeredTemplate = RegisteredTemplate (templateTypeRep @t)


### PR DESCRIPTION
See #20481 
Explicit exports can't handle dropping this export as it was part of the export of another data type, and we don't deep search the exports.
This quick fix works by moving the pattern to a top level export, so it is pruned correctly.
