### PR TITLE
Do not limit contract/package visibility to external contracts

### DIFF
--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -126,23 +126,6 @@ object Blinding {
     }.toSeq
   }
 
-  /** Calculate the packages needed by each party in order to reinterpret its projection.
-    *
-    * This needs to include both packages needed by the engine at reinterpretation time
-    * and the originating contract package needed for contract model conformance checking.
-    *
-    * @param tx               transaction whose packages are required
-    * @param contractPackages the contracts used by the transaction together with their creating packages
-    */
-  def partyPackages(
-      tx: VersionedTransaction,
-      contractPackages: Map[ContractId, Ref.PackageId] = Map.empty,
-  ): Relation[Party, PackageId] = {
-    val (BlindingInfo(disclosure, _), contractVisibility) =
-      BlindingTransaction.calculateBlindingInfoWithContractVisibility(tx)
-    partyPackages(tx, disclosure, contractVisibility, contractPackages)
-  }
-
   private[engine] def partyPackageRequirements(
       tx: VersionedTransaction,
       disclosure: Relation[NodeId, Party],

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -105,8 +105,16 @@ class EngineTest(langVersion: LanguageVersion)
       interpretResult shouldBe a[Right[_, _]]
     }
 
+    val Right((tx, txMeta)) = interpretResult
+
+    "include created contracts in metadata" in {
+      txMeta.contractPackages shouldBe tx.nodes.values
+        .collect({ case c: Node.Create => c.coid -> c.templateId.packageId })
+        .toMap
+    }
+
     "reinterpret to the same result" in {
-      val Right((tx, txMeta)) = interpretResult
+
       val stx = suffix(tx)
 
       val Right((rtx, newMeta)) =
@@ -121,6 +129,7 @@ class EngineTest(langVersion: LanguageVersion)
         )
       isReplayedBy(stx, rtx) shouldBe Right(())
       txMeta.nodeSeeds shouldBe newMeta.nodeSeeds
+
     }
 
     "be validated" in {

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
@@ -98,7 +98,12 @@ object BlindingTransaction {
 
           action match {
 
-            case _: Node.Create => state
+            case create: Node.Create =>
+              state.divulgeCoidTo(
+                Set.empty,
+                witnesses,
+                create.coid,
+              )
 
             case lbk: Node.LookupByKey =>
               lbk.result.fold(state) { coid =>

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -25,14 +25,14 @@
 - Tail call optimization: Tail recursion does not blow the scala JVM stack.: [TailCallTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala#L19)
 
 ## Confidentiality:
-- ensure correct privacy for create node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L43)
-- ensure correct privacy for exercise node (consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L55)
-- ensure correct privacy for exercise node (non-consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L76)
-- ensure correct privacy for exercise subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L154)
-- ensure correct privacy for fetch node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L98)
-- ensure correct privacy for lookup-by-key node (found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L111)
-- ensure correct privacy for lookup-by-key node (not-found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L132)
-- ensure correct privacy for rollback subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L229)
+- ensure correct privacy for create node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L38)
+- ensure correct privacy for exercise node (consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L50)
+- ensure correct privacy for exercise node (non-consuming): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L71)
+- ensure correct privacy for exercise subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L149)
+- ensure correct privacy for fetch node: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L93)
+- ensure correct privacy for lookup-by-key node (found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L106)
+- ensure correct privacy for lookup-by-key node (not-found): [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L127)
+- ensure correct privacy for rollback subtree: [BlindingSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala#L224)
 
 ## Integrity:
 - Evaluation order of create with authorization failure: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L589)
@@ -149,7 +149,7 @@
 - Evaluation order of successful lookup_by_key of a local contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3120)
 - Evaluation order of successful lookup_by_key of a non-cached global contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L2956)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L35)
-- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2132)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2139)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L273)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version, where one is new to V2 within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L277)
 - Smart Contract Upgrade: Can catch same errors thrown by different choice versions within Update: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L269)

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -149,7 +149,7 @@
 - Evaluation order of successful lookup_by_key of a local contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3120)
 - Evaluation order of successful lookup_by_key of a non-cached global contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L2956)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L35)
-- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2139)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2141)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L273)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version, where one is new to V2 within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L277)
 - Smart Contract Upgrade: Can catch same errors thrown by different choice versions within Update: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L269)


### PR DESCRIPTION
**Background**

`Transaction.Metadata.contractPackages` is returned by `Engine.submit` and contains mappings of contract id to _original package id_.

This structure is later passed into `Blinding.contractPartyPackages` to construct the mapping  Party->PackageId.
```scala
contractPartyPackages(
      contractPackages: Map[ContractId, Ref.PackageId],
      contractVisibility: Relation[ContractId, Party],
  ): Iterable[(Party, PackageId)]
```

This mapping can then be used to verify what package are needed by different participants.

**Change**
Prior to this change the only contracts included were suffixed (committed) contracts. This change also includes unsuffixed/uncommited contracts. This is useful when a contract created in one canton view is used as an input in a different canton view as we want to ensure the creating package is (check-only) available to all canton participants consuming that view.

Once this is merged canton can be upgraded to report a better error messages, see:
https://github.com/DACH-NY/canton/pull/23023






