### PR TITLE
No longer run LoadTesting.scala and CatAndFoodTriggerSimulation.scala on windows

### DIFF
--- a/sdk/triggers/tests/BUILD.bazel
+++ b/sdk/triggers/tests/BUILD.bazel
@@ -12,6 +12,7 @@ load(
     "LF_MAJOR_VERSIONS",
     "lf_version_default_or_latest",
 )
+load("@os_info//:os_info.bzl", "is_windows")
 
 da_scala_library(
     name = "test-utils",
@@ -226,7 +227,7 @@ da_scala_test_suite(
         "@maven//:io_grpc_grpc_netty",
         "@maven//:io_netty_netty_handler",
     ],
-)
+) if not is_windows else None
 
 da_scala_library(
     name = "trigger-simulation-lib",
@@ -382,4 +383,4 @@ da_scala_test_suite(
         "@maven//:io_grpc_grpc_netty",
         "@maven//:io_netty_netty_handler",
     ],
-)
+) if not is_windows else None


### PR DESCRIPTION
`LoadTesting.scala` and `CatAndFoodTriggerSimulation.scala` have a high probability of failing in CI on windows. Moreover, windows testing here is offering little value. Hence, this PR disables these tests for windows *only*.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
