### PR TITLE
disable the daily snapshot on 2.x

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -333,7 +333,7 @@ jobs:
           cd sdk
           eval "$(./dev-env/bin/dade-assist)"
 
-          for branch in main main-2.x; do
+          for branch in main; do
             sha=$(git rev-parse origin/$branch)
             az extension add --name azure-devops
             trap "az devops logout" EXIT


### PR DESCRIPTION
Now that we have cut a 2.10 release line and don't expect to ever create a 2.11 release, we prevent 2.11 snapshots from being created and their corresponding jars from being published to maven.