### PR TITLE
Stop upgrade-check tool getting build-options

### DIFF
--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -2046,7 +2046,7 @@ cmdUseDamlYamlArgs = \case
   Repl -> True
   GenerateMultiPackageManifest -> False -- Just reads config files
   MultiIde -> False
-  UpgradeCheck -> True -- will also read the multi-package manifest if available
+  UpgradeCheck -> False -- just reads the DARs it is given
 
 withProjectRoot' :: ProjectOpts -> ((FilePath -> IO FilePath) -> IO a) -> IO a
 withProjectRoot' ProjectOpts{..} act =


### PR DESCRIPTION
I had accidentally set `cmdUseDamlYamlArgs` to `True`, which meant upgrade-check was receiving build-options flags it would read as paths. One-line fix is to change True to False

Example, with daml.yaml. 

```
...
build-options:
- --target=1.17
```

Running `daml upgrade-check` would lead to the following error:
```
Error reading DAR at path --target=1.17: --target=1.17: openBinaryFile: does not exist (No such file or directory)
```