### PR TITLE
disable daily-compat for main-2.x

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -20,7 +20,6 @@ schedules:
   branches:
     include:
     - main
-    - main-2.x
   always: true
 
 jobs:


### PR DESCRIPTION
Now that we've cut release/2.10.x we don't intend to develop on main-2.x anymore.