### PR TITLE
Expose multi-package-example as a template

### DIFF
--- a/sdk/templates/BUILD.bazel
+++ b/sdk/templates/BUILD.bazel
@@ -54,6 +54,7 @@ genrule(
             "upgrades-example/**",
             "quickstart-java/**",
             "copy-trigger/**",
+            "multi-package-example/**",
             "gsg-trigger.patch",
         ],
         exclude = ["**/NO_AUTO_COPYRIGHT"],
@@ -86,6 +87,7 @@ genrule(
                  empty-skeleton \
                  create-daml-app \
                  upgrades-example \
+                 multi-package-example \
                  quickstart-java \
                  copy-trigger \
                  gsg-trigger; do


### PR DESCRIPTION
https://github.com/digital-asset/daml/pull/20489 created the multi-package-example, but didn't actually expose it to the bazel rule to be picked up by the participant. This fixes that by actually adding it to the bazel rule that generates the template list.