### PR TITLE
disable the daily compat job on 2.x

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -20,7 +20,6 @@ schedules:
   branches:
     include:
     - main
-    - main-2.x
   always: true
 
 jobs:


### PR DESCRIPTION
https://github.com/digital-asset/daml/pull/20513 didn't work as expected because schedules are read from the branch they run on.