### PR TITLE
Remove deprecated warning flags

### DIFF
--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -273,7 +273,6 @@ instance Pretty ErrorOrWarning where
       vsep
         [ "This package defines both exceptions and templates. This may make this package and its dependents not upgradeable."
         , "It is recommended that exceptions are defined in their own package separate from their implementations."
-        , "Ignore this error message with the --warn-bad-exceptions=yes flag."
         ]
     WEDependsOnDatatypeFromNewDamlScript (depPkgId, depMeta) depLfVersion tcn ->
       vsep

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -21,9 +21,7 @@ import qualified DA.Service.Logger as Logger
 import qualified Module as GHC
 import qualified Text.ParserCombinators.ReadP as R
 import qualified Data.Text as T
-import qualified DA.Daml.LF.TypeChecker.Error as Error
 import qualified DA.Daml.LF.TypeChecker.Error.WarningFlags as WarningFlags
-import qualified DA.Daml.LFConversion.ConvertM as LFConversion
 
 import qualified Text.PrettyPrint.ANSI.Leijen as PAL
 
@@ -588,55 +586,9 @@ optionsParser numProcessors enableScenarioService parsePkgName parseDlintUsage =
         "Typecheck upgrades."
         idm
 
-    optWarnBadInterfaceInstances :: Parser (WarningFlags.DamlWarningFlag Error.ErrorOrWarning)
-    optWarnBadInterfaceInstances =
-      toDamlWarningFlag <$>
-        flagYesNoAutoNoDefault
-          "warn-bad-interface-instances"
-          "(Deprecated) Convert errors about bad, non-upgradeable interface instances into warnings."
-          hidden
-      where
-      toDamlWarningFlag auto =
-        if determineAuto defaultUiWarnBadInterfaceInstances auto
-        then Error.upgradeInterfacesFlag WarningFlags.AsWarning
-        else Error.upgradeInterfacesFlag WarningFlags.AsError
-
-    optWarnBadExceptions :: Parser (WarningFlags.DamlWarningFlag Error.ErrorOrWarning)
-    optWarnBadExceptions =
-      toDamlWarningFlag <$>
-        flagYesNoAutoNoDefault
-          "warn-bad-exceptions"
-          "(Deprecated) Convert errors about bad, non-upgradeable exceptions into warnings."
-          hidden
-      where
-      toDamlWarningFlag auto =
-        if determineAuto defaultUiWarnBadExceptions auto
-        then Error.upgradeExceptionsFlag WarningFlags.AsWarning
-        else Error.upgradeExceptionsFlag WarningFlags.AsError
-
-    allowLargeTuplesOpt :: Parser (WarningFlags.DamlWarningFlag LFConversion.ErrorOrWarning)
-    allowLargeTuplesOpt =
-      toDamlWarningFlag <$>
-        flagYesNoAutoNoDefault
-          "disable-warn-large-tuples"
-          "Do not warn when tuples of size > 5 are used."
-          internal
-      where
-      toDamlWarningFlag auto =
-        if determineAuto False auto
-        then LFConversion.warnLargeTuplesFlag WarningFlags.Hidden
-        else LFConversion.warnLargeTuplesFlag WarningFlags.AsWarning
-
-    optDamlWarningFlag :: Parser (WarningFlags.DamlWarningFlag ErrorOrWarning)
-    optDamlWarningFlag =
-      optRawDamlWarningFlag
-      <|> fmap WarningFlags.toLeft optWarnBadInterfaceInstances
-      <|> fmap WarningFlags.toLeft optWarnBadExceptions
-      <|> fmap WarningFlags.toRight allowLargeTuplesOpt
-
     optDamlWarningFlags :: Parser (WarningFlags.DamlWarningFlags ErrorOrWarning)
     optDamlWarningFlags =
-      WarningFlags.mkDamlWarningFlags damlWarningFlagParser <$> many optDamlWarningFlag
+      WarningFlags.mkDamlWarningFlags damlWarningFlagParser <$> many optRawDamlWarningFlag
 
     optRawDamlWarningFlag :: Parser (WarningFlags.DamlWarningFlag ErrorOrWarning)
     optRawDamlWarningFlag =

--- a/sdk/compiler/damlc/pkg-db/util.bzl
+++ b/sdk/compiler/damlc/pkg-db/util.bzl
@@ -97,7 +97,7 @@ def _daml_package_rule_impl(ctx):
     )
 
     package_db_dir = ctx.attr.package_db[PackageDb].db_dir
-    disable_warn_large_tuples = "yes" if ctx.attr.disable_warn_large_tuples else "no"
+    disable_warn_large_tuples = "-Wno-large-tuples" if ctx.attr.disable_warn_large_tuples else "-Wlarge-tuples"
 
     ctx.actions.run_shell(
         outputs = [dalf, iface_dir],
@@ -121,7 +121,7 @@ def _daml_package_rule_impl(ctx):
         --target {daml_lf_version} \
         --cpp {cpp} \
         --ghc-option=-Werror \
-        --disable-warn-large-tuples={disable_warn_large_tuples} \
+        {disable_warn_large_tuples} \
         -o {dalf_file} \
         {main}
 

--- a/sdk/compiler/damlc/tests/daml-test-files/Daml3ScriptTrySubmitConcurrently.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/Daml3ScriptTrySubmitConcurrently.daml
@@ -4,7 +4,7 @@
 -- @ SCRIPT-V2
 
 -- @ WARN range=20:1-20:52; Import of internal module Daml.Script.Internal of package daml3-script is discouraged, as this module will change without warning.
--- @ WARN warn-bad-exceptions
+-- @ WARN -Werror=upgrade-exceptions
 
 {-# LANGUAGE ApplicativeDo #-}
 

--- a/sdk/compiler/damlc/tests/daml-test-files/ExceptionSemantics.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/ExceptionSemantics.daml
@@ -6,7 +6,7 @@
 -- @ERROR range=117:1-117:25; Unhandled exception: DA.Exception.ArithmeticError:ArithmeticError with message = "ArithmeticError while evaluating (DIV_INT64 1 0)."
 -- @ERROR range=132:1-132:11; Attempt to fetch or exercise a contract not visible to the reading parties.
 -- @ERROR range=143:1-143:11; Attempt to exercise a consumed contract
--- @WARN warn-bad-exceptions
+-- @WARN -Werror=upgrade-exceptions
 module ExceptionSemantics where
 
 import Daml.Script

--- a/sdk/compiler/damlc/tests/daml-test-files/ExceptionSemanticsWithKeys.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/ExceptionSemanticsWithKeys.daml
@@ -3,7 +3,7 @@
 
 -- @SUPPORTS-LF-FEATURE DAML_EXCEPTIONS
 -- @SUPPORTS-LF-FEATURE DAML_CONTRACT_KEYS
--- @WARN warn-bad-exceptions
+-- @WARN -Werror=upgrade-exceptions
 
 module ExceptionSemanticsWithKeys where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/ExceptionSyntax.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/ExceptionSyntax.daml
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SUPPORTS-LF-FEATURE DAML_EXCEPTIONS
--- @WARN warn-bad-exceptions
+-- @WARN -Werror=upgrade-exceptions
 -- @QUERY-LF [ $pkg.modules[].exceptions[] ] | length == 1
 
 -- | Test that exception syntax is correctly handled.

--- a/sdk/compiler/damlc/tests/daml-test-files/InterfaceGuarded.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/InterfaceGuarded.daml
@@ -6,7 +6,7 @@
 -- @WARN -Werror=upgrade-interfaces
 -- @WARN -Werror=upgrade-interfaces
 -- @WARN -Werror=upgrade-interfaces
--- @WARN warn-bad-exceptions
+-- @WARN -Werror=upgrade-exceptions
 
 module InterfaceGuarded where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/RestrictedNameWarnings.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/RestrictedNameWarnings.daml
@@ -2,7 +2,7 @@
 -- @WARN range=15:5-15:8; `arg' is an unsupported field name, and may break without warning in future versions. Please use something else.
 -- @WARN range=20:5-20:9; `self' is an unsupported field name, and may break without warning in future versions. Please use something else.
 -- @WARN range=25:5-25:8; `arg' is an unsupported field name, and may break without warning in future versions. Please use something else.
--- @WARN warn-bad-exceptions
+-- @WARN -Werror=upgrade-exceptions
 
 module RestrictedNameWarnings where
 

--- a/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -127,7 +127,7 @@ damlStart tmpDir disableUpgradeValidation = do
             , "build-options:"
             , "- --target=2.1"
             ] ++ [ "- -Wno-upgrade-interfaces" | disableUpgradeValidation ]
-              ++ [ "- --warn-bad-interface-instances=yes\n- --warn-bad-exceptions=yes" | disableUpgradeValidation ]
+              ++ [ "- -Wupgrade-interfaces\n- -Wupgrade-exceptions" | disableUpgradeValidation ]
     writeFileUTF8 (projDir </> "daml/Main.daml") $
         unlines
             [ "module Main where"

--- a/sdk/docs/BUILD.bazel
+++ b/sdk/docs/BUILD.bazel
@@ -574,7 +574,7 @@ daml_test(
     daml_test(
         name = "daml-intro-8-daml-test-{}".format(version),
         srcs = glob(["source/daml/intro/daml/daml-intro-8/**/*.daml"]),
-        additional_compiler_flags = ["--warn-bad-exceptions=yes"],
+        additional_compiler_flags = ["-Wupgrade-exceptions"],
         target = version,
         deps = ["//daml-script/daml:daml-script-{}.dar".format(version)],
     )


### PR DESCRIPTION
We had three flags in 2.x that were deprecated in favour of their standardized `--warn` equivalents.

- `--warn-bad-interface-instances` was deprecated for `-Wupgrade-interfaces`
- `--warn-bad-exceptions` was deprecated for `-Wupgrade-exceptions`
- `--disable-warn-large-tuples` was deprecated for `-Wno-large-tuples`

Docs were already updated to refer to the non-deprecated warning flag versions.