### PR TITLE
Bump versions update copyright year

### DIFF
--- a/sdk/compatibility/versions/UpdateVersions.hs
+++ b/sdk/compatibility/versions/UpdateVersions.hs
@@ -43,7 +43,7 @@ headVersion = SemVer.initial
 -- We include this here so buildifier does not modify this file.
 copyrightHeader :: [T.Text]
 copyrightHeader =
-    [ "# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved."
+    [ "# Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved."
     , "# SPDX-License-Identifier: Apache-2.0"
     ]
 


### PR DESCRIPTION
We're getting invalid version update PRs that just switch the copyright year from 2025 to 2024. I've updated the script to use 2025, so this shouldn't happen anymore.
