### PR TITLE
Drop WEDependencyHasNoMetadataDespiteUpgradeability on 3.x

### DIFF
--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -241,7 +241,6 @@ data ErrorOrWarning
   | WEUpgradeShouldDefineIfaceWithoutImplementation !ModuleName !TypeConName !TypeConName
   | WEUpgradeShouldDefineTplInSeparatePackage !TypeConName !TypeConName
   | WEDependencyHasUnparseableVersion !PackageName !PackageVersion !PackageUpgradeOrigin
-  | WEDependencyHasNoMetadataDespiteUpgradeability !PackageId !PackageUpgradeOrigin
   | WEUpgradeShouldDefineExceptionsAndTemplatesSeparately
   | WEDependsOnDatatypeFromNewDamlScript (PackageId, PackageMetadata) Version !(Qualified TypeConName)
   | WEUpgradedTemplateChangedPrecondition !TypeConName ![Mismatch UpgradeMismatchReason]
@@ -280,8 +279,6 @@ instance Pretty ErrorOrWarning where
         ]
     WEDependencyHasUnparseableVersion pkgName version packageOrigin ->
       "Dependency " <> pPrint pkgName <> " of " <> pPrint packageOrigin <> " has a version which cannot be parsed: '" <> pPrint version <> "'"
-    WEDependencyHasNoMetadataDespiteUpgradeability pkgId packageOrigin ->
-      "Dependency with package ID " <> pPrint pkgId <> " of " <> pPrint packageOrigin <> " has no metadata, despite being compiled with an SDK version that supports metadata."
     WEUpgradeShouldDefineExceptionsAndTemplatesSeparately ->
       vsep
         [ "This package defines both exceptions and templates. This may make this package and its dependents not upgradeable."
@@ -337,7 +334,6 @@ damlWarningFlagParserTypeChecker = DamlWarningFlagParser
       WEUpgradeShouldDefineTplInSeparatePackage {} -> AsError
       WEUpgradeShouldDefineExceptionsAndTemplatesSeparately {} -> AsError
       WEDependencyHasUnparseableVersion {} -> AsWarning
-      WEDependencyHasNoMetadataDespiteUpgradeability {} -> AsWarning
       WEDependsOnDatatypeFromNewDamlScript {} -> AsWarning
       WEUpgradedTemplateChangedPrecondition {} -> AsWarning
       WEUpgradedTemplateChangedSignatories {} -> AsWarning
@@ -452,7 +448,6 @@ upgradeDependencyMetadataFilter :: ErrorOrWarning -> Bool
 upgradeDependencyMetadataFilter =
     \case
         WEDependencyHasUnparseableVersion {} -> True
-        WEDependencyHasNoMetadataDespiteUpgradeability {} -> True
         _ -> False
 
 data PackageUpgradeOrigin = UpgradingPackage | UpgradedPackage

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -29,7 +29,6 @@ import           Development.IDE.Types.Diagnostics
 import Data.Maybe (catMaybes, mapMaybe, isNothing)
 import Safe (maximumByMay, minimumByMay)
 import Data.Function (on)
-import Module (UnitId)
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
 import qualified DA.Daml.LF.TypeChecker.WarnUpgradedDependencies as WarnUpgradedDependencies

--- a/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -163,7 +163,7 @@ buildDar service PackageConfigFields {..} ifDir dalfInput upgradeInfo warningFla
                  dalfDependencies0 <- getDalfDependencies files
                  MaybeT $
                      runDiagnosticCheck $ diagsToIdeResult (toNormalizedFilePath' pSrc) $
-                         Upgrade.checkPackage pkg (map Upgrade.unitIdDalfPackageToUpgradedPkg (Map.toList dalfDependencies0)) lfVersion upgradeInfo (contramap Left warningFlags) mbUpgradedPackage
+                         Upgrade.checkPackage pkg (map Upgrade.dalfPackageToUpgradedPkg (Map.elems dalfDependencies0)) lfVersion upgradeInfo (contramap Left warningFlags) mbUpgradedPackage
                  let dalfDependencies =
                          [ (T.pack $ unitIdString unitId, LF.dalfPackageBytes pkg, LF.dalfPackageId pkg)
                          | (unitId, pkg) <- Map.toList dalfDependencies0


### PR DESCRIPTION
Addresses https://github.com/digital-asset/daml/issues/20046

In 2.x we had to try to extract package versions from the package unit ID - we'd whitelist those packages with no package version in the unit IDs, which ended up being only daml-prim because all other daml-prim-* packages had LF versions <= 1.15.

In 3.x, this approach failed because all daml-prim packages support upgrades - we solve this issue by no longer relying on the unit ID, and getting the version directly from package metadata instead.