### PR TITLE
Remove legacy daml-script upload dar default

### DIFF
--- a/sdk/daml-script/runner/src/test/scala/com/digitalasset/daml/lf/engine/script/NonTlsRunnerMainTest.scala
+++ b/sdk/daml-script/runner/src/test/scala/com/digitalasset/daml/lf/engine/script/NonTlsRunnerMainTest.scala
@@ -25,8 +25,7 @@ final class NonTlsRunnerMainTest extends AsyncFreeSpec with RunnerMainTestBaseCa
           Right(Seq("Ran myScript")),
           Some(false),
         )
-      // Checks we upload following the legacy behaviour, and throw our warning
-      "Succeeds with all run, no-upload-flag, default uploading behaviour" in
+      "Succeeds with all run, no-upload" in
         testDamlScriptCanton(
           dars(1),
           Seq(
@@ -38,33 +37,13 @@ final class NonTlsRunnerMainTest extends AsyncFreeSpec with RunnerMainTestBaseCa
           ),
           Right(
             Seq(
-              "WARNING: Implicitly using the legacy behaviour",
-              "TestScript:myOtherScript SUCCESS",
-              "TestScript:myScript SUCCESS",
-            )
-          ),
-          Some(true),
-        )
-      "Succeeds with all run, explicit no-upload" in
-        testDamlScriptCanton(
-          dars(2),
-          Seq(
-            "--ledger-host",
-            "localhost",
-            "--ledger-port",
-            ports.head.toString,
-            "--all",
-            "--upload-dar=no",
-          ),
-          Right(
-            Seq(
               "TestScript:myOtherScript SUCCESS",
               "TestScript:myScript SUCCESS",
             )
           ),
           Some(false),
         )
-      "Succeeds with single run, explicit upload" in
+      "Succeeds with single run, upload flag" in
         testDamlScriptCanton(
           dars(3),
           Seq(

--- a/sdk/daml-script/runner/src/test/scala/com/digitalasset/daml/lf/engine/script/TlsRunnerMainTest.scala
+++ b/sdk/daml-script/runner/src/test/scala/com/digitalasset/daml/lf/engine/script/TlsRunnerMainTest.scala
@@ -38,8 +38,7 @@ final class TlsRunnerMainTest extends AsyncFreeSpec with RunnerMainTestBaseCanto
           Right(Seq("Ran myScript")),
           Some(false),
         )
-      // Checks we upload following the legacy behaviour, and throw our warning
-      "Succeeds with all run, no-upload-flag, default uploading behaviour" in
+      "Succeeds with all run, no-upload" in
         testDamlScriptCanton(
           dars(1),
           Seq(
@@ -51,33 +50,13 @@ final class TlsRunnerMainTest extends AsyncFreeSpec with RunnerMainTestBaseCanto
           ) ++ tlsArgs,
           Right(
             Seq(
-              "WARNING: Implicitly using the legacy behaviour",
-              "TestScript:myOtherScript SUCCESS",
-              "TestScript:myScript SUCCESS",
-            )
-          ),
-          Some(true),
-        )
-      "Succeeds with all run, explicit no-upload" in
-        testDamlScriptCanton(
-          dars(2),
-          Seq(
-            "--ledger-host",
-            "localhost",
-            "--ledger-port",
-            ports.head.toString,
-            "--all",
-            "--upload-dar=no",
-          ) ++ tlsArgs,
-          Right(
-            Seq(
               "TestScript:myOtherScript SUCCESS",
               "TestScript:myScript SUCCESS",
             )
           ),
           Some(false),
         )
-      "Succeeds with single run, explicit upload" in
+      "Succeeds with single run, upload flag" in
         testDamlScriptCanton(
           dars(3),
           Seq(

--- a/sdk/daml-script/test/src/test-utils/scala/com/digitalasset/daml/lf/engine/script/test/DamlScriptTestRunner.scala
+++ b/sdk/daml-script/test/src/test-utils/scala/com/digitalasset/daml/lf/engine/script/test/DamlScriptTestRunner.scala
@@ -41,6 +41,8 @@ trait DamlScriptTestRunner extends AnyWordSpec with CantonFixture with Matchers 
       "localhost",
       "--ledger-port",
       port.toString,
+      "--upload-dar",
+      "yes",
     )
 
     discard(cmd ! ProcessLogger(log, log))


### PR DESCRIPTION
This behaviour has been deprecated for 17 months now, it can finally go. 