### PR TITLE
Add Engine.buildGlobalKey

### DIFF
--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -287,6 +287,10 @@ class Engine(val config: EngineConfig = Engine.StableConfig, allowLF2: Boolean =
           )
     } yield validationResult
 
+  def translateKey(identifier: Identifier, key: Value): Result[Value] = {
+    preprocessor.translateKey(identifier: Identifier, key: Value).map(_.toUnnormalizedValue)
+  }
+
   private[engine] def loadPackage(pkgId: PackageId, context: language.Reference): Result[Unit] =
     ResultNeedPackage(
       pkgId,

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -13,6 +13,7 @@ import com.daml.lf.speedy.SExpr.{SEApp, SExpr}
 import com.daml.lf.speedy.Speedy.{Machine, PureMachine, UpdateMachine}
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.transaction.{
+  GlobalKey,
   Node,
   SubmittedTransaction,
   Versioned,
@@ -287,8 +288,12 @@ class Engine(val config: EngineConfig = Engine.StableConfig, allowLF2: Boolean =
           )
     } yield validationResult
 
-  def translateKey(identifier: Identifier, key: Value): Result[Value] = {
-    preprocessor.translateKey(identifier: Identifier, key: Value).map(_.toUnnormalizedValue)
+  /** Builds a GlobalKey based on a normalised representation of the provided key
+    * @param templateId - the templateId associated with the contract key
+    * @param key - a representation of the key that may be un-normalized
+    */
+  def buildGlobalKey(templateId: Identifier, key: Value): Result[GlobalKey] = {
+    preprocessor.buildGlobalKey(templateId: Identifier, key: Value)
   }
 
   private[engine] def loadPackage(pkgId: PackageId, context: language.Reference): Result[Unit] =

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
@@ -6,7 +6,7 @@ package engine
 package preprocessing
 
 import com.daml.lf.command.ApiContractKey
-import com.daml.lf.data.Ref.PackageRef
+import com.daml.lf.data.Ref.{PackageRef, TypeConName}
 import com.daml.lf.data._
 import com.daml.lf.language.Ast
 import com.daml.lf.transaction.GlobalKey
@@ -355,13 +355,17 @@ private[lf] final class CommandPreprocessor(
         templateRef,
         key.contractKey,
       )
-    val ckTtype = handleLookup(pkgInterface.lookupTemplateKey(templateId)).typ
-    val preprocessedKey = translateArg(ckTtype, upgradable(templateId), key.contractKey)
+    unsafePreprocessContractKey(key.contractKey, templateId)
+  }
 
+  @throws[Error.Preprocessing.Error]
+  def unsafePreprocessContractKey(contractKey: Value, templateId: TypeConName): GlobalKey = {
+    val ckTtype: Ast.Type = handleLookup(pkgInterface.lookupTemplateKey(templateId)).typ
+    val preprocessedKey = translateArg(ckTtype, upgradable(templateId), contractKey)
     speedy.Speedy.Machine
       .globalKey(pkgInterface, templateId, preprocessedKey)
       .getOrElse(
-        throw Error.Preprocessing.ContractIdInContractKey(key.contractKey)
+        throw Error.Preprocessing.ContractIdInContractKey(contractKey)
       )
   }
 

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
@@ -44,6 +44,12 @@ private[engine] final class Preprocessor(
 
   import compiledPackages.pkgInterface
 
+  private val valueTranslator =
+    new ValueTranslator(
+      pkgInterface = pkgInterface,
+      checkV1ContractIdSuffixes = requireV1ContractIdSuffix,
+    )
+
   val commandPreprocessor =
     new CommandPreprocessor(
       pkgInterface = pkgInterface,
@@ -201,6 +207,16 @@ private[engine] final class Preprocessor(
         }
       } yield m.updated(pkgName, pkgId)
     )
+
+  def translateKey(
+      templateId: Ref.TypeConName,
+      contractKey: Value,
+  ): Result[speedy.SValue] = {
+    safelyRun(pullPackage(Seq(templateId))) {
+      val ckType = handleLookup(pkgInterface.lookupTemplateKey(templateId)).typ
+      valueTranslator.unsafeTranslateValue(ty = ckType, upgradable = true, value = contractKey)
+    }
+  }
 
   /** Translates  LF commands to a speedy commands.
     */

--- a/sdk/daml-lf/engine/src/test/daml/BasicTests.daml
+++ b/sdk/daml-lf/engine/src/test/daml/BasicTests.daml
@@ -383,13 +383,14 @@ template NoMaintainer
         pure ()
 
 
-data NumericKey = NumericKey {sig: Party, n4: (Numeric 4)} deriving (Eq, Ord, Show)
+data NumericKey = NumericKey {sig: Party, n4: (Numeric 4), i: Optional Int} deriving (Eq, Ord, Show)
 
 template TypedKey
   with
     sig: Party
     n4: (Numeric 4)
+    i: Optional Int
   where
     signatory sig
-    key NumericKey {sig = sig; n4 = n4} : NumericKey
+    key NumericKey {sig = sig; n4 = n4; i=i} : NumericKey
     maintainer key.sig

--- a/sdk/daml-lf/engine/src/test/daml/BasicTests.daml
+++ b/sdk/daml-lf/engine/src/test/daml/BasicTests.daml
@@ -381,3 +381,15 @@ template NoMaintainer
       controller sig
       do
         pure ()
+
+
+data NumericKey = NumericKey {sig: Party, n4: (Numeric 4)} deriving (Eq, Ord, Show)
+
+template TypedKey
+  with
+    sig: Party
+    n4: (Numeric 4)
+  where
+    signatory sig
+    key NumericKey {sig = sig; n4 = n4} : NumericKey
+    maintainer key.sig

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -149,7 +149,7 @@
 - Evaluation order of successful lookup_by_key of a local contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3120)
 - Evaluation order of successful lookup_by_key of a non-cached global contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L2956)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L35)
-- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2241)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2243)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L273)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version, where one is new to V2 within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L277)
 - Smart Contract Upgrade: Can catch same errors thrown by different choice versions within Update: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L269)

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -149,7 +149,7 @@
 - Evaluation order of successful lookup_by_key of a local contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3120)
 - Evaluation order of successful lookup_by_key of a non-cached global contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L2956)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L35)
-- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2220)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2241)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L273)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version, where one is new to V2 within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L277)
 - Smart Contract Upgrade: Can catch same errors thrown by different choice versions within Update: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L269)

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -149,7 +149,7 @@
 - Evaluation order of successful lookup_by_key of a local contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3120)
 - Evaluation order of successful lookup_by_key of a non-cached global contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L2956)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L35)
-- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2141)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2220)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L273)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version, where one is new to V2 within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L277)
 - Smart Contract Upgrade: Can catch same errors thrown by different choice versions within Update: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L269)


### PR DESCRIPTION
Canton 2.x has a service to lookup events by contact key. To ensure the correct hash is produced the key must be well typed, in particular:
- Fields must be in the correct order
- Numeric fields must be scaled in line with the key definition

This PR adds `Engine.buildGlobalKey` that takes a value and returns a well typed value.

This change needed to support https://github.com/DACH-NY/canton/pull/23410
