### PR TITLE
Daml-script forward ports

### DIFF
--- a/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -348,7 +348,7 @@ damlStartTestsWithoutValidation getDamlStart =
                 , "  let isAlice x = \"Alice\" `isInfixOf` partyToText x.party"
                 , "  Some aliceDetails <- find isAlice <$> listKnownParties"
                 , "  let alice = party aliceDetails"
-                , "  alice `submit` createCmd (S alice)"
+                , "  alice `submit` createExactCmd (S alice)"
                 , "  pure alice"
                 ]
         hPutChar startStdin 'r'

--- a/sdk/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioRunner.scala
+++ b/sdk/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioRunner.scala
@@ -9,8 +9,16 @@ import com.digitalasset.daml.lf.data.{ImmArray, Ref, Time}
 import com.digitalasset.daml.lf.engine.{Engine, Result, ResultDone, ResultError, ValueEnricher}
 import com.digitalasset.daml.lf.engine.preprocessing.ValueTranslator
 import com.digitalasset.daml.lf.language.{Ast, LanguageMajorVersion, LookupError}
-import com.digitalasset.daml.lf.transaction.{GlobalKey, NodeId, SubmittedTransaction}
-import com.digitalasset.daml.lf.value.Value.{ContractId, VersionedContractInstance}
+import com.digitalasset.daml.lf.transaction.{
+  FatContractInstance,
+  GlobalKey,
+  GlobalKeyWithMaintainers,
+  NodeId,
+  SubmittedTransaction,
+  TransactionVersion,
+  Versioned,
+}
+import com.digitalasset.daml.lf.value.Value.ContractId
 import com.digitalasset.daml.lf.speedy._
 import com.digitalasset.daml.lf.speedy.SExpr.{SEApp, SEValue, SExpr}
 import com.digitalasset.daml.lf.speedy.SResult._
@@ -220,7 +228,7 @@ private[lf] object ScenarioRunner {
         coid: ContractId,
         actAs: Set[Party],
         readAs: Set[Party],
-        cbPresent: VersionedContractInstance => Unit,
+        cbPresent: FatContractInstance => Unit,
     ): Either[Error, Unit]
     def lookupKey(
         gk: GlobalKey,
@@ -245,7 +253,7 @@ private[lf] object ScenarioRunner {
         acoid: ContractId,
         actAs: Set[Party],
         readAs: Set[Party],
-        callback: VersionedContractInstance => Unit,
+        callback: FatContractInstance => Unit,
     ): Either[Error, Unit] =
       handleUnsafe(lookupContractUnsafe(acoid, actAs, readAs, callback))
 
@@ -253,7 +261,7 @@ private[lf] object ScenarioRunner {
         acoid: ContractId,
         actAs: Set[Party],
         readAs: Set[Party],
-        callback: VersionedContractInstance => Unit,
+        callback: FatContractInstance => Unit,
     ) = {
 
       val effectiveAt = ledger.currentTime
@@ -265,7 +273,7 @@ private[lf] object ScenarioRunner {
         acoid,
       ) match {
         case ScenarioLedger.LookupOk(coinst) =>
-          callback(coinst.toImplementation.toCreateNode.versionedCoinst)
+          callback(coinst)
 
         case ScenarioLedger.LookupContractNotFound(coid) =>
           // This should never happen, hence we don't have a specific
@@ -460,13 +468,20 @@ private[lf] object ScenarioRunner {
                 coid,
                 committers,
                 readAs,
-                (vcoinst: VersionedContractInstance) => callback(vcoinst.unversioned),
+                (fcoinst: FatContractInstance) =>
+                  callback(fcoinst.toImplementation.toCreateNode.versionedCoinst.unversioned),
               ) match {
                 case Left(err) => SubmissionError(err, enrich(ledgerMachine.incompleteTransaction))
                 case Right(_) => go()
               }
-            case Question.Update.NeedUpgradeVerification(_, _, _, _, callback) =>
-              callback(None)
+            case Question.Update.NeedUpgradeVerification(
+                  coid,
+                  signatories,
+                  observers,
+                  keyOpt,
+                  callback,
+                ) =>
+              checkContractUpgradable(coid, signatories, observers, keyOpt, callback, ledger)
               go()
             case Question.Update.NeedKey(keyWithMaintainers, committers, callback) =>
               ledger.lookupKey(
@@ -508,6 +523,57 @@ private[lf] object ScenarioRunner {
       }
     }
     go()
+  }
+
+  private[lf] def checkContractUpgradable[R](
+      coid: ContractId,
+      signatories: Set[Ref.Party],
+      observers: Set[Ref.Party],
+      keyWithMaintainers: Option[GlobalKeyWithMaintainers],
+      callback: Option[String] => Unit,
+      ledger: LedgerApi[R],
+  ) = {
+    val stakeholders = signatories ++ observers
+    val maybeKeyWithMaintainers =
+      keyWithMaintainers.map(Versioned(TransactionVersion.StableVersions.max, _))
+
+    // Mostly copied from StoreBackedCommandExecutor
+    def checkProvidedContractMetadataAgainstRecomputed(
+        original: FatContractInstance
+    ): Either[String, Unit] = {
+      def check[T](recomputed: T, original: T)(desc: String): Either[String, Unit] =
+        Either.cond(recomputed == original, (), s"$desc mismatch: $original vs $recomputed")
+
+      val originalSignatories = original.signatories.toSet
+      val originalStakeholders = original.stakeholders.toSet
+
+      for {
+        _ <- check(signatories, originalSignatories)("signatories")
+        recomputedObservers = stakeholders -- signatories
+        originalObservers = originalStakeholders -- originalSignatories
+        _ <- check(recomputedObservers, originalObservers)("observers")
+        _ <- check(keyWithMaintainers, original.contractKeyWithMaintainers)(
+          "key value and maintainers"
+        )
+      } yield ()
+    }
+
+    ledger.lookupContract(
+      coid,
+      signatories,
+      observers,
+      (fcoinst: FatContractInstance) => {
+        callback(checkProvidedContractMetadataAgainstRecomputed(fcoinst).left.toOption)
+      },
+    ) match {
+      case Left(err) =>
+        callback(
+          Some(
+            s"Failed to recompute contract metadata from ($signatories, $stakeholders, $maybeKeyWithMaintainers): $err"
+          )
+        )
+      case Right(_) => ()
+    }
   }
 
   private[lf] def nextSeed(submissionSeed: crypto.Hash): crypto.Hash =

--- a/sdk/daml-script/daml3/Daml/Script.daml
+++ b/sdk/daml-script/daml3/Daml/Script.daml
@@ -106,6 +106,10 @@ module Daml.Script
   , submitUser
   , submitUserOn
   , tryToEither
+
+  , -- Upgrades features
+    PackageId (..)  
+  , packagePreference
   ) where
 
 import Daml.Script.Internal.LowLevel

--- a/sdk/daml-script/daml3/Daml/Script/Internal.daml
+++ b/sdk/daml-script/daml3/Daml/Script/Internal.daml
@@ -24,10 +24,6 @@ module Daml.Script.Internal
   , unvetDarOnParticipant
   , unsafeUnvetDarOnParticipant
 
-  , -- Upgrades EA features
-    PackageId (..)  
-  , packagePreference
-
   , -- Concurrent submit
     concurrently
   , trySubmitConcurrently

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -384,7 +384,6 @@ object Runner {
       warningLog: WarningLog = Speedy.Machine.newWarningLog,
       profile: Profile = Speedy.Machine.newProfile,
       canceled: () => Option[RuntimeException] = () => None,
-      enableContractUpgrading: Boolean = false,
   )(implicit
       ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
@@ -401,7 +400,6 @@ object Runner {
       warningLog,
       profile,
       canceled,
-      enableContractUpgrading,
     )._1
 
   // Same as run above but requires use of IdeLedgerClient, gives additional context back
@@ -448,7 +446,6 @@ object Runner {
       warningLog: WarningLog,
       profile: Profile,
       canceled: () => Option[RuntimeException],
-      enableContractUpgrading: Boolean = false,
   )(implicit
       ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
@@ -474,7 +471,7 @@ object Runner {
       case (_: Script.Function, None) =>
         throw new RuntimeException(s"The script ${scriptId} requires an argument.")
     }
-    val runner = new Runner(compiledPackages, scriptAction, timeMode, enableContractUpgrading)
+    val runner = new Runner(compiledPackages, scriptAction, timeMode)
     runner.runWithClients(initialClients, traceLog, warningLog, profile, canceled)
   }
 
@@ -490,7 +487,6 @@ private[lf] class Runner(
     val compiledPackages: CompiledPackages,
     val script: Script.Action,
     val timeMode: ScriptTimeMode,
-    val enableContractUpgrading: Boolean = false,
 ) extends StrictLogging {
 
   // We overwrite the definition of 'fromLedgerValue' with an identity function.
@@ -552,8 +548,6 @@ private[lf] class Runner(
       throw new IllegalArgumentException("Couldn't get daml script package name")
     ) match {
       case "daml-script" =>
-        if (enableContractUpgrading)
-          throw new IllegalArgumentException("daml2-script does not support Upgrades natively.")
         new v1.Runner(this).runWithClients(initialClients, traceLog, warningLog, profile, canceled)
       case "daml3-script" =>
         new v2.Runner(this, initialClients, traceLog, warningLog, profile, canceled).getResult()

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -479,8 +479,7 @@ object Runner {
     compiledPackages.pkgInterface
       .lookupPackage(pkgId)
       .toOption
-      .map(_.metadata)
-      .map(meta => meta.name.toString)
+      .map(_.metadata.name.toString)
 }
 
 private[lf] class Runner(

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -127,7 +127,6 @@ object RunnerMain {
               config.timeMode,
               traceLog,
               warningLog,
-              enableContractUpgrading = config.enableContractUpgrading,
             )
           _ <- Future {
             outputFile.foreach { outputFile =>

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMainConfig.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMainConfig.scala
@@ -23,7 +23,6 @@ case class RunnerMainConfig(
     // and specifying the default for better error messages.
     applicationId: Option[Option[Ref.ApplicationId]],
     uploadDar: Boolean,
-    enableContractUpgrading: Boolean,
 )
 
 object RunnerMainConfig {
@@ -77,7 +76,6 @@ private[script] case class RunnerMainConfigIntermediate(
     // Legacy behaviour is to upload the dar when using --all and over grpc. None represents that behaviour
     // We will drop this for daml3, such that we default to not uploading.
     uploadDar: Option[Boolean],
-    enableContractUpgrading: Boolean,
 ) {
   import RunnerMainConfigIntermediate._
 
@@ -118,7 +116,6 @@ private[script] case class RunnerMainConfigIntermediate(
         maxInboundMessageSize = maxInboundMessageSize,
         applicationId = applicationId,
         uploadDar = resolvedUploadDar,
-        enableContractUpgrading = enableContractUpgrading,
       )
     } yield config
 
@@ -315,7 +312,6 @@ private[script] object RunnerMainConfigIntermediate {
         maxInboundMessageSize = RunnerMainConfig.DefaultMaxInboundMessageSize,
         applicationId = None,
         uploadDar = None,
-        enableContractUpgrading = false,
       ),
     )
 }

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/IdeLedgerClient.scala
@@ -47,6 +47,7 @@ import scalaz.syntax.foldable._
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
+import scala.collection.mutable
 
 // Client for the script service.
 class IdeLedgerClient(
@@ -304,6 +305,33 @@ class IdeLedgerClient(
         preprocessor.unsafePreprocessApiCommands(Map.empty, commands.to(ImmArray))
       val translated = compiledPackages.compiler.unsafeCompile(speedyCommands, speedyDisclosures)
 
+      // A default package map for when using LF1.17 with old daml-script
+      // Needed for interface exercises, which will perform a soft fetch, and ask for package resolution
+      // Assumes single package per name and gives this package. If multiple, throws recommending daml-script-beta
+      val packageMap: Map[PackageName, PackageId] =
+        compiledPackages.packageIds
+          .collect(
+            Function.unlift(pkgId =>
+              for {
+                pkgSig <- compiledPackages.pkgInterface.lookupPackage(pkgId).toOption
+                if pkgSig.upgradable
+                meta <- pkgSig.metadata
+              } yield (meta.name, pkgId)
+            )
+          )
+          .foldLeft(mutable.Map.empty[PackageName, PackageId]) { case (mPkgMap, (pkgName, pkgId)) =>
+            mPkgMap
+              .lift(pkgName)
+              .foreach(altPkgId =>
+                throw new IllegalArgumentException(
+                  s"Multiple Package IDs ($pkgId, $altPkgId) for package with name $pkgName. If you want to use SCU, use daml-script-beta."
+                )
+              )
+            mPkgMap.update(pkgName, pkgId)
+            mPkgMap
+          }
+          .toMap
+
       val ledgerApi = ScenarioRunner.ScenarioLedgerApi(ledger)
       val result =
         ScenarioRunner.submit(
@@ -314,11 +342,7 @@ class IdeLedgerClient(
           translated,
           optLocation,
           nextSeed(),
-          packageResolution = Map(
-            PackageName.assertFromString("-dummy-package-name-") -> PackageId.assertFromString(
-              "-homePackageId-"
-            )
-          ),
+          packageMap,
           traceLog = traceLog,
           warningLog = warningLog,
         )(Script.DummyLoggingContext)

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Runner.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/Runner.scala
@@ -37,7 +37,6 @@ private[lf] class Runner(
   private val initialClientsV2 = initialClients.map(
     ScriptLedgerClient.realiseScriptLedgerClient(
       _,
-      unversionedRunner.enableContractUpgrading,
       unversionedRunner.extendedCompiledPackages,
     )
   )

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -602,6 +602,13 @@ class IdeLedgerClient(
           )
         } catch {
           case Error.Preprocessing.Lookup(err) => Left(makeLookupError(err))
+          // Expose type mismatches as unknown errors to match canton behaviour. Later this should be fully expressed as a SubmitError
+          case Error.Preprocessing.TypeMismatch(_, _, msg) =>
+            Left(
+              makeEmptySubmissionError(
+                scenario.Error.Internal("COMMAND_PREPROCESSING_FAILED(0, 00000000): " + msg)
+              )
+            )
         }
 
       val eitherSpeedyDisclosures

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -200,8 +200,8 @@ class IdeLedgerClient(
     )
 
     valueTranslator.strictTranslateValue(TTyCon(templateId), arg) match {
-      case Left(_) =>
-        sys.error("computeView: translateValue failed")
+      case Left(e) =>
+        sys.error(s"computeView: translateValue failed: $e")
 
       case Right(argument) =>
         val compiler: speedy.Compiler = compiledPackages.compiler

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
@@ -77,7 +77,6 @@ object ScriptLedgerClient {
 
   def realiseScriptLedgerClient(
       ledger: abstractLedgers.ScriptLedgerClient,
-      enableContractUpgrading: Boolean,
       compiledPackages: CompiledPackages,
   )(implicit namedLoggerFactory: NamedLoggerFactory): ScriptLedgerClient =
     ledger match {
@@ -86,12 +85,9 @@ object ScriptLedgerClient {
           grpcClient,
           applicationId,
           oAdminClient,
-          enableContractUpgrading,
           compiledPackages,
         )
       case abstractLedgers.IdeLedgerClient(pureCompiledPackages, traceLog, warningLog, canceled) =>
-        if (enableContractUpgrading)
-          throw new IllegalArgumentException("The IDE Ledger client does not support Upgrades")
         new IdeLedgerClient(
           pureCompiledPackages,
           traceLog,
@@ -121,8 +117,6 @@ trait ScriptLedgerClient {
   ): Future[Seq[ScriptLedgerClient.ActiveContract]]
 
   protected def transport: String
-
-  val enableContractUpgrading: Boolean = false
 
   final protected def unsupportedOn(what: String) =
     Future.failed(

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
@@ -61,7 +61,6 @@ class GrpcLedgerClient(
     val grpcClient: LedgerClient,
     val applicationId: Option[Ref.ApplicationId],
     val oAdminClient: Option[AdminLedgerClient],
-    override val enableContractUpgrading: Boolean = false,
     val compiledPackages: CompiledPackages,
 ) extends ScriptLedgerClient {
   override val transport = "gRPC API"
@@ -86,7 +85,7 @@ class GrpcLedgerClient(
     val pkgName = Runner
       .getPackageName(compiledPackages, identifier.packageId)
       .getOrElse(throw new IllegalArgumentException("Couldn't get package name"))
-    if (explicitPackageId || !enableContractUpgrading) converted
+    if (explicitPackageId) converted
     else converted.copy(packageId = "#" + pkgName)
   }
 

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
@@ -82,11 +82,12 @@ class GrpcLedgerClient(
       explicitPackageId: Boolean,
   ): api.Identifier = {
     val converted = toApiIdentifier(identifier)
-    val pkgName = Runner
-      .getPackageName(compiledPackages, identifier.packageId)
-      .getOrElse(throw new IllegalArgumentException("Couldn't get package name"))
-    if (explicitPackageId) converted
-    else converted.copy(packageId = "#" + pkgName)
+
+    compiledPackages.pkgInterface
+      .lookupPackage(identifier.packageId)
+      .toOption
+      .filter(pkgSig => pkgSig.supportsUpgrades(identifier.packageId) && !explicitPackageId)
+      .fold(converted)(pkgSig => converted.copy(packageId = "#" + pkgSig.metadata.name.toString))
   }
 
   // TODO[SW]: Currently do not support querying with explicit package id, interface for this yet to be determined

--- a/sdk/daml-script/test/daml/upgrades/DataChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/DataChanges.daml
@@ -46,10 +46,7 @@ main = tests
   , ("Succeeds if a nested enum is an old case when downgrading", templateEnumDowngradeFromOld)
   , ("Fails if a nested enum is a removed case", templateEnumUpgradeToRemoved)
   , ("Fails if a nested enum is an additional case when downgrading", templateEnumDowngradeFromNew)
-  , ("Fails if an optional field is set on a choice when downgrading", \case
-        -- TODO: Disabled on IdeLedger because this seems to break the IdeLedger for mysterious reasons and in horrible ways
-        TestState { runMode = IdeLedger } -> pure ()
-        state -> templateOptionalFieldOnChoiceSetWhenDowngrading state)
+  , ("Fails if an optional field is set on a choice when downgrading", templateOptionalFieldOnChoiceSetWhenDowngrading)
   -- Template optional field set when downgrading
   , tofswdViaInterfaceInCommandLocal
   , tofswdViaInterfaceInCommandGlobal

--- a/sdk/daml-script/test/daml/upgrades/DataChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/DataChanges.daml
@@ -46,7 +46,10 @@ main = tests
   , ("Succeeds if a nested enum is an old case when downgrading", templateEnumDowngradeFromOld)
   , ("Fails if a nested enum is a removed case", templateEnumUpgradeToRemoved)
   , ("Fails if a nested enum is an additional case when downgrading", templateEnumDowngradeFromNew)
-  , ("Fails if an optional field is set on a choice when downgrading", templateOptionalFieldOnChoiceSetWhenDowngrading)
+  , ("Fails if an optional field is set on a choice when downgrading", \case
+        -- TODO: Disabled on IdeLedger because this seems to break the IdeLedger for mysterious reasons and in horrible ways
+        TestState { runMode = IdeLedger } -> pure ()
+        state -> templateOptionalFieldOnChoiceSetWhenDowngrading state)
   -- Template optional field set when downgrading
   , tofswdViaInterfaceInCommandLocal
   , tofswdViaInterfaceInCommandGlobal
@@ -77,6 +80,8 @@ templateInvalidChange shouldSucceed makeV1Contract v2Choice = test $ do
   case (res, shouldSucceed) of
     (Right "V2", True) -> pure ()
     (Left (WronglyTypedContract {}), False) -> pure ()
+    -- IDE Ledger doesn't apply obfuscation, instead the lookup error is wrapped in SCrash
+    (Left (UnknownError msg), False) | "SErrorCrash" `isInfixOf` msg -> pure ()
     (Left (UnknownError msg), False) | "An error occurred." `isInfixOf` msg -> pure ()
     _ -> assertFail $ "Expected " <> (if shouldSucceed then "success" else "specific failure") <> " but got " <> show res
 
@@ -296,6 +301,8 @@ templateEnumDowngradeFromNew = test $ do
   res <- a `trySubmit` exerciseExactCmd cidV1 V1.EnumAdditionalCall
 
   case res of
+    -- IDE Ledger doesn't apply obfuscation, instead the lookup error is wrapped in SCrash
+    Left (UnknownError msg) | "SErrorCrash" `isInfixOf` msg -> pure ()
     Left (UnknownError msg) | "An error occurred." `isInfixOf` msg -> pure ()
     _ -> assertFail $ "Expected specific failure but got " <> show res
 

--- a/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
+++ b/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
@@ -7,6 +7,7 @@ module InterfaceViews (main) where
 
 import UpgradeTestLib
 import FixedInterface
+import FixedInterfaceViewTemplate
 import FixedInterfaceCaller
 import qualified V1.Interfaces as V1
 import qualified V2.Interfaces as V2
@@ -15,20 +16,41 @@ import DA.Foldable
 import DA.Optional
 import DA.Text
 
+-- Fixed template so interface view can contain a contract ID
+{- PACKAGE
+name: fixed-interface-view-template
+versions: 1
+-}
+
+{- MODULE
+package: fixed-interface-view-template
+contents: |
+  module FixedInterfaceViewTemplate where
+
+  template FIVT with
+      fivtOwner : Party
+    where
+    signatory fivtOwner
+-}
+
 -- Fixed package containing only the interface
 {- PACKAGE
 name: fixed-interface-view
 versions: 1
+depends: fixed-interface-view-template-1.0.0
 -}
 
 {- MODULE
 package: fixed-interface-view
 contents: |
   module FixedInterface where
+  import FixedInterfaceViewTemplate
 
   data IV = IV with
-    owner : Party
-    payload : Int
+      owner : Party
+      payload : Int
+      oContractId : Optional (ContractId FIVT)
+    deriving (Eq, Show)
 
   interface I where
     viewtype IV
@@ -70,7 +92,9 @@ contents: |
 {- PACKAGE
 name: interface-views
 versions: 2
-depends: fixed-interface-view-1.0.0
+depends: |
+  fixed-interface-view-1.0.0
+  fixed-interface-view-template-1.0.0
 -}
 
 {- MODULE
@@ -79,6 +103,7 @@ contents: |
   module Interfaces where
 
   import FixedInterface
+  import FixedInterfaceViewTemplate
   import DA.Optional
 
   template FITemplate with
@@ -87,10 +112,10 @@ contents: |
     signatory party
 
     interface instance I for FITemplate where
-      view = IV party 0   -- @V 1
-      view = IV party 1   -- @V  2
-      getVersion = "V1"   -- @V 1
-      getVersion = "V2"   -- @V  2
+      view = IV party 0 None -- @V 1
+      view = IV party 1 None -- @V  2
+      getVersion = "V1"      -- @V 1
+      getVersion = "V2"      -- @V  2
 
     -- Following two choices exist here for convenience. They could be in a separate package which depends on this,
     -- but additional unnecessary packages simply wastes time.
@@ -108,6 +133,16 @@ contents: |
       do
         fetch icid
         pure ()
+
+  template FITemplateWithContractId with
+      party : Party
+      cid : ContractId FIVT
+    where
+    signatory party
+
+    interface instance I for FITemplateWithContractId where
+      view = IV party 0 (Some cid)
+      getVersion = "V1"
 -}
 
 main : TestTree
@@ -115,6 +150,7 @@ main = tests
   [ ("Calling an interface choice at command level fails as intended when the view is modified", exerciseCommandShouldFail)
   , ("Calling an interface choice in choice body fails as intended when the view is modified", exerciseInChoiceBodyShouldFail)
   , ("fetchFromInterface fails as intended when the view is modified", fetchFromInterfaceShouldFail)
+  , ("queryInterfactContractId can query interfaces with contract ID in the view", queryInterfaceContractIdInView)
   ]
 
 setupAliceAndInterface : Script (Party, ContractId I)
@@ -146,3 +182,12 @@ fetchFromInterfaceShouldFail = test $ do
   case res of
     Left (DevError Upgrade msg) | "View mismatch" `isInfixOf` msg -> pure ()
     _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)
+
+queryInterfaceContractIdInView : Test
+queryInterfaceContractIdInView = test $ do
+  alice <- allocateParty "alice"
+  fivtCid <- alice `submit` createExactCmd FIVT with fivtOwner = alice
+  cid <- alice `submit` createExactCmd V1.FITemplateWithContractId with party = alice, cid = fivtCid
+  let icid = toInterfaceContractId @I cid
+  res <- queryInterfaceContractId alice icid
+  res === Some (IV with owner = alice, payload = 0, oContractId = Some fivtCid)

--- a/sdk/daml-script/test/daml/upgrades/LedgerApiAddedRemovedChoices.daml
+++ b/sdk/daml-script/test/daml/upgrades/LedgerApiAddedRemovedChoices.daml
@@ -79,12 +79,12 @@ explicitRemovedV1ChoiceV2Contract = choiceTest @V1.AddedRemovedChoiceTemplate (`
 implicitRemovedV1ChoiceV2Contract : Test
 implicitRemovedV1ChoiceV2Contract =
   genericUpgradeTest @V1.AddedRemovedChoiceTemplate (`V2.AddedRemovedChoiceTemplate` None) V1.OldRemovedChoice False $ \case
-    Left (UnknownError msg) | "unknown choice OldRemovedChoice" `isInfixOf` msg -> pure ()
+    Left (UnknownError msg) | "OldRemovedChoice" `isInfixOf` msg -> pure ()
     res -> assertFail $ "Expected unknown choice error, got " <> show res
 
 implicitRemovedV1ChoiceV1Contract : Test
 implicitRemovedV1ChoiceV1Contract =
   genericUpgradeTest @V1.AddedRemovedChoiceTemplate V1.AddedRemovedChoiceTemplate V1.OldRemovedChoice False $ \case
-    Left (UnknownError msg) | "unknown choice OldRemovedChoice" `isInfixOf` msg -> pure ()
+    Left (UnknownError msg) | "OldRemovedChoice" `isInfixOf` msg -> pure ()
     res -> assertFail $ "Expected unknown choice error, got " <> show res
 

--- a/sdk/daml-script/test/daml/upgrades/VariantChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/VariantChanges.daml
@@ -63,6 +63,8 @@ templateInvalidChange shouldSucceed makeV1Contract v2Choice = test $ do
     (Left (DevError Upgrade _), False) -> pure ()
     (Left (WronglyTypedContract {}), False) -> pure ()
     (Left (UnknownError msg), False) | "An error occurred." `isInfixOf` msg -> pure ()
+    -- IDE Ledger doesn't apply obfuscation, instead the lookup error is wrapped in SCrash
+    (Left (UnknownError msg), False) | "SErrorCrash" `isInfixOf` msg -> pure ()
     _ -> assertFail $ "Expected " <> (if shouldSucceed then "success" else "specific failure") <> " but got " <> show res
 
 {- PACKAGE

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/UpgradesIT.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/UpgradesIT.scala
@@ -55,14 +55,13 @@ class UpgradesIT extends AsyncWordSpec with AbstractScriptTest with Inside with 
   // Maybe provide our own tracer that doesn't tag, it makes the logs very long
   "Multi-participant Daml Script Upgrades" should {
     testCases.foreach { testCase =>
-      // IDE tests are disabled until IDE support is forward ported.
-      (testCase.name + " on IDE Ledger") ignore {
+      (testCase.name + " on IDE Ledger") in {
         for {
           // Build dars
           (testDarPath, _) <- testUtil.buildTestCaseDarMemoized(testCase)
 
           // Create ide ledger client
-          testDar = CompiledDar.read(testDarPath, Runner.compilerConfig(LanguageMajorVersion.V1))
+          testDar = CompiledDar.read(testDarPath, Runner.compilerConfig(LanguageMajorVersion.V2))
           participants <- Runner.ideLedgerClient(
             testDar.compiledPackages,
             newTraceLog,
@@ -80,7 +79,6 @@ class UpgradesIT extends AsyncWordSpec with AbstractScriptTest with Inside with 
               )
             ),
             dar = testDar,
-            enableContractUpgrading = true,
           )
         } yield succeed
       }
@@ -133,7 +131,6 @@ class UpgradesIT extends AsyncWordSpec with AbstractScriptTest with Inside with 
               )
             ),
             dar = testDar,
-            enableContractUpgrading = true,
           )
         } yield succeed
       }

--- a/sdk/daml-script/test/src/test-utils/scala/com/digitalasset/daml/lf/engine/script/test/AbstractScriptTest.scala
+++ b/sdk/daml-script/test/src/test-utils/scala/com/digitalasset/daml/lf/engine/script/test/AbstractScriptTest.scala
@@ -60,7 +60,6 @@ trait AbstractScriptTest extends CantonFixture with PekkoBeforeAndAfterAll {
       name: Ref.QualifiedName,
       inputValue: Option[Value] = None,
       dar: CompiledDar,
-      enableContractUpgrading: Boolean = false,
   )(implicit ec: ExecutionContext): Future[SValue] = {
     val scriptId = Ref.Identifier(dar.mainPkg, name)
     def converter(input: Value, typ: Ast.Type) =
@@ -79,7 +78,6 @@ trait AbstractScriptTest extends CantonFixture with PekkoBeforeAndAfterAll {
         inputValue,
         clients,
         timeMode,
-        enableContractUpgrading = enableContractUpgrading,
       )
   }
 


### PR DESCRIPTION
- [04e807e](https://github.com/digital-asset/daml/pull/20595/commits/04e807e1bb9181fca986b694dcf03c7590507723): direct forward port, quite broken
- [8f281c0](https://github.com/digital-asset/daml/pull/20595/commits/8f281c0189ca31a8d5d161c2513062abb73cfa9c): Fix for a above, which also brings over relevant logic from some PRs we won't be porting (i.e. removal of enableContractUpgrades flag which happened in a PR relating to LF1.15)
- [42e1abc](https://github.com/digital-asset/daml/pull/20595/commits/42e1abc93c7cbaf6f2689eeabdfe1414d949dcd0): Mostly an LF1.15 PR, brought over some small parts for consistency
- [a1c5e62](https://github.com/digital-asset/daml/pull/20595/commits/a1c5e6209433ca8d33bd77b3a97d409baebc90f6): Direct port
- [efaeb1c](https://github.com/digital-asset/daml/pull/20595/commits/efaeb1c08c8d1f77c57240ac19209e5806107d5d): Direct port
- [75df97d](https://github.com/digital-asset/daml/pull/20595/commits/75df97dfc2a381a61a37bec20a019dfda5b6a66a): Missing commit from original IDE support PR, which updates CollectAuthority to use `FatContractInstance`
- [e2e0ee2](https://github.com/digital-asset/daml/pull/20595/commits/e2e0ee24fcd0bf574fc83e975d7e2a830661fd65): Fixes issue that arises when using hot-reload and exercise by package name. Since package validation has been disabled, the package store ends up in a bad state and throws an error about a package not existing. Presumably from a package map (from unit id to package id) picking only one of the keys, as we've allowed the same package name and version to be uploaded twice.