### PR TITLE
TS Codegen: add unit test for decoding

### DIFF
--- a/sdk/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/sdk/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -204,6 +204,83 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+const encodedAllTypes = {
+  unit: {},
+  bool: true,
+  int: "5",
+  text: "Hello",
+  date: "2019-04-04",
+  time: "2019-12-31T12:34:56.789Z",
+  party: ALICE_PARTY,
+  contractId: "contractId",
+  optional: "5", // Some 5
+  optional2: null, // None
+  optionalOptionalInt: ["5"], // Some (Some 5)
+  optionalOptionalInt2: [], // Some (None)
+  optionalOptionalInt3: null, // None
+  list: [true, false],
+  textMap: DAML_TEXTMAP ? { alice: "2", "bob & carl": "3" } : {},
+  monoRecord: {
+    name: "Alice from Wonderland",
+    party: ALICE_PARTY,
+    age: "5",
+    friends: [],
+  },
+  polyRecord: { one: "10", two: "XYZ" },
+  imported: { field: { something: "pqr" } },
+  archiveX: {},
+  either: { tag: "Right", value: "really?" },
+  tuple: { _1: "12", _2: "mmm" },
+  enum: "Red",
+  enumList: ["Red", "Blue", "Yellow"],
+  enumList2: ["Red", "Blue", "Yellow"],
+  optcol1: { tag: "Transparent1", value: {} },
+  optcol2: { tag: "Color2", value: { color2: "Red" } }, // 'Red' is of type Color
+  optcol3: {
+    tag: "Color2",
+    value: { color2: "Blue" },
+  },
+  variant: {
+    tag: "Add",
+    value: {
+      _1: { tag: "Lit", value: "1" },
+      _2: { tag: "Lit", value: "2" },
+    },
+  },
+  optionalVariant: {
+    tag: "Add",
+    value: {
+      _1: { tag: "Lit", value: "1" },
+      _2: { tag: "Lit", value: "2" },
+    },
+  },
+  sumProd: { tag: "Corge", value: { x: "1", y: "Garlpy" } },
+  optionalSumProd: { tag: "Corge", value: { x: "1", y: "Garlpy" } },
+  parametericSumProd: {
+    tag: "Add2",
+    value: {
+      lhs: { tag: "Lit2", value: "1" },
+      rhs: { tag: "Lit2", value: "2" },
+    },
+  },
+  optionalOptionalParametericSumProd: [
+    {
+      tag: "Add2",
+      value: {
+        lhs: { tag: "Lit2", value: "1" },
+        rhs: { tag: "Lit2", value: "2" },
+      },
+    },
+  ],
+  n0: "3.0", // Numeric 0
+  n5: "3.14159", // Numeric 5
+  n10: "3.1415926536", // Numeric 10
+  rec: { recOptional: null, recList: [], recGenMap: [] },
+  voidRecord: null,
+  voidEnum: null,
+  genMap: [[{ tag: "Lit2", value: "0" }, "1"]],
+};
+
 describe("decoders for recursive types do not loop", () => {
   test("recursive enum", () => {
     expect(buildAndLint.Main.Expr(Int).decoder.run(undefined).ok).toBe(false);
@@ -220,6 +297,28 @@ describe("decoders for recursive types do not loop", () => {
   test("uninhabited enum", () => {
     expect(buildAndLint.Main.VoidEnum.decoder.run(undefined).ok).toBe(false);
   });
+});
+
+describe("decoder", () => {
+  test("with all fields set", () => {
+    const decoded = buildAndLint.Main.AllTypes.decoder.run(encodedAllTypes);
+    expect({ ...decoded, result: undefined }).toEqual({ ok: true });
+  });
+  // TODO(https://github.com/DACH-NY/canton-network-utilities/issues/2716) Fix and uncomment these
+  /*
+  test("with simple optional field absent", () => {
+    const decoded = buildAndLint.Main.AllTypes.decoder.run(
+      {...encodedAllTypes, optional: undefined}
+    );
+    expect({...decoded, result: undefined}).toEqual({ok: true});
+  });
+  test("with nested optional field absent", () => {
+    const decoded = buildAndLint.Main.AllTypes.decoder.run(
+      {...encodedAllTypes, optionalOptionalInt: undefined}
+    );
+    expect({...decoded, result: undefined}).toEqual({ok: true});
+  });
+  */
 });
 
 function doCreateFetchAndExercise<Pkg extends string>(


### PR DESCRIPTION
Two new tests are currently failing because we don't support decoding a missing Optional field.

See https://github.com/DACH-NY/canton-network-utilities/issues/2716

We should really probably add a bunch more unit tests for the decoder in here, but this was the minimum to reproduce the bug above.

The test can be run most efficiently with:
```
BUILD_AND_LINT_TEST_NAME_PATTERN=decoder bazel run tests:build-and-lint-test
```