### PR TITLE
Remove daml package and daml merge-dars

### DIFF
--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -95,11 +95,6 @@ targetFileNameOpt = optionOnce (Just <$> str) $
         <> long "dar-name"
         <> value Nothing
 
-packageNameOpt :: Parser GHC.UnitId
-packageNameOpt = fmap GHC.stringToUnitId $ argument str $
-       metavar "PACKAGE-NAME"
-    <> help "Name of the Daml package"
-
 lfVersionOpt :: Parser LF.Version
 lfVersionOpt = optionOnce (str >>= select) $
        metavar "DAML-LF-VERSION"

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -88,13 +88,6 @@ optionalOutputFileOpt = optionOnce (Just <$> str) $
     <> long "output"
     <> value Nothing
 
-targetFileNameOpt :: Parser (Maybe String)
-targetFileNameOpt = optionOnce (Just <$> str) $
-        metavar "DAR_NAME"
-        <> help "Target file name of DAR package"
-        <> long "dar-name"
-        <> value Nothing
-
 lfVersionOpt :: Parser LF.Version
 lfVersionOpt = optionOnce (str >>= select) $
        metavar "DAML-LF-VERSION"


### PR DESCRIPTION
daml package has been marked as deprecated for a very long time, its time has come.
daml merge-dars is ancient, internal, not used anywhere and opposes our _vision_, be gone with it
