### PR TITLE
Allow deleting exceptions and interfaces in upgrades, but don't disallow redefining them

### DIFF
--- a/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
+++ b/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
@@ -216,6 +216,11 @@ object UpgradeError {
     override def message: String =
       s"The upgraded $origin has changed the kind of one of its type variables."
   }
+
+  final case class TriedToUpgradeException(exception: Ref.DottedName) extends Error {
+    override def message: String =
+      s"Tried to upgrade exception $exception, but exceptions cannot be upgraded. They should be removed in any upgrading package."
+  }
 }
 
 sealed abstract class UpgradedRecordOrigin
@@ -580,27 +585,36 @@ case class TypecheckUpgrades(
       module: Ast.Module
   ): (
       Map[Ref.DottedName, (Ast.DDataType, Ast.DefInterface)],
+      Map[Ref.DottedName, (Ast.DDataType, Ast.DefException)],
       Map[Ref.DottedName, Ast.DDataType],
   ) = {
     val datatypes: Map[Ref.DottedName, Ast.DDataType] = module.definitions.collect({
       case (name, dt: Ast.DDataType) => (name, dt)
     })
-    val (ifaces, other) = datatypes.partitionMap({ case (tcon, dt) =>
-      lookupInterface(module, tcon, dt)
+    val (ifaces, other1) = datatypes.partitionMap({ case (tcon, dt) =>
+      lookupInterfaceOrException(module, tcon, dt)
     })
-    (ifaces.toMap, other.toMap)
+    val (exceptions, other) = other1.partitionMap(identity)
+    (ifaces.toMap, exceptions.toMap, other.toMap)
   }
 
-  private def lookupInterface(
+  private def lookupInterfaceOrException(
       module: Ast.Module,
       tcon: Ref.DottedName,
       dt: Ast.DDataType,
   ): Either[
     (Ref.DottedName, (Ast.DDataType, Ast.DefInterface)),
-    (Ref.DottedName, Ast.DDataType),
+    Either[
+      (Ref.DottedName, (Ast.DDataType, Ast.DefException)),
+      (Ref.DottedName, Ast.DDataType),
+    ],
   ] = {
     module.interfaces.get(tcon) match {
-      case None => Right((tcon, dt))
+      case None =>
+        Right(module.exceptions.get(tcon) match {
+          case None => Right((tcon, dt))
+          case Some(exception) => Left((tcon, (dt, exception)))
+        })
       case Some(iface) => Left((tcon, (dt, iface)))
     }
   }
@@ -615,9 +629,10 @@ case class TypecheckUpgrades(
   }
 
   private def checkModule(module: Upgrading[Ast.Module]): Try[Unit] = {
-    val (pastIfaceDts, pastUnownedDts) = splitModuleDts(module.past)
-    val (presentIfaceDts, presentUnownedDts) = splitModuleDts(module.present)
+    val (pastIfaceDts, pastExceptionDts, pastUnownedDts) = splitModuleDts(module.past)
+    val (presentIfaceDts, presentExceptionDts, presentUnownedDts) = splitModuleDts(module.present)
     val ifaceDts = Upgrading(past = pastIfaceDts, present = presentIfaceDts)
+    val exceptionDts = Upgrading(past = pastExceptionDts, present = presentExceptionDts)
     val unownedDts = Upgrading(past = pastUnownedDts, present = presentUnownedDts)
 
     val moduleWithMetadata = module.map(ModuleWithMetadata)
@@ -630,6 +645,9 @@ case class TypecheckUpgrades(
 
       (_ifaceDel, ifaceExisting, _ifaceNew) = extractDelExistNew(ifaceDts)
       _ <- checkContinuedIfaces(ifaceExisting)
+
+      (_exceptionDel, exceptionExisting, _exceptionNew) = extractDelExistNew(exceptionDts)
+      _ <- checkContinuedExceptions(exceptionExisting)
 
       (instanceDel, _instanceExisting, instanceNew) = extractDelExistNew(
         module.map(flattenInstances)
@@ -655,7 +673,29 @@ case class TypecheckUpgrades(
       ifaces,
       (arg: (Ref.DottedName, Upgrading[(Ast.DDataType, Ast.DefInterface)])) => {
         val (name, _) = arg
-        fail(UpgradeError.TriedToUpgradeIface(name))
+        // TODO (dylant-da): Re-enable this line once the -Wupgrade-interfaces
+        // flag on the compiler goes away and interface upgrades are always an
+        // error
+        // fail(UpgradeError.TriedToUpgradeIface(name))
+        val _ = UpgradeError.TriedToUpgradeIface(name)
+        Try(())
+      },
+    ).map(_ => ())
+  }
+
+  private def checkContinuedExceptions(
+      exceptions: Map[Ref.DottedName, Upgrading[(Ast.DDataType, Ast.DefException)]]
+  ): Try[Unit] = {
+    tryAll(
+      exceptions,
+      (arg: (Ref.DottedName, Upgrading[(Ast.DDataType, Ast.DefException)])) => {
+        val (name, _) = arg
+        // TODO (dylant-da): Re-enable this line once the -Wupgrade-exceptions
+        // flag on the compiler goes away and exception upgrades are always an
+        // error
+        // fail(UpgradeError.TriedToUpgradeException(name))
+        val _ = UpgradeError.TriedToUpgradeException(name)
+        Try(())
       },
     ).map(_ => ())
   }

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesCheckSpec.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesCheckSpec.scala
@@ -1125,9 +1125,13 @@ final class UpgradesCheckSpec extends AsyncWordSpec with Matchers with Inside {
           (
             "test-common/upgrades-FailsWhenAnInterfaceIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v1.dar",
             "test-common/upgrades-FailsWhenAnInterfaceIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v2.dar",
-            Some(
-              "Tried to upgrade interface I, but interfaces cannot be upgraded. They should be removed in any upgrading package."
-            ),
+            // TODO (dylant-da): Re-enable this test once the -Wupgrade-interfaces
+            // flag on the compiler goes away and interface upgrades are always an
+            // error
+            // Some(
+            //  "Tried to upgrade interface I, but interfaces cannot be upgraded. They should be removed in any upgrading package."
+            // ),
+            None,
           )
         ),
       )
@@ -1301,38 +1305,42 @@ final class UpgradesCheckSpec extends AsyncWordSpec with Matchers with Inside {
 
     // TODO (dylant-da): Re-enable this test from 995efe7 after reversion in 20631
 
-    // "Succeeds when an exception is only defined in the initial package." in {
-    //  testPackages(
-    //    Seq(
-    //      "test-common/upgrades-SucceedsWhenAnExceptionIsOnlyDefinedInTheInitialPackage-v1.dar",
-    //      "test-common/upgrades-SucceedsWhenAnExceptionIsOnlyDefinedInTheInitialPackage-v2.dar",
-    //    ),
-    //    Seq(
-    //      (
-    //        "test-common/upgrades-SucceedsWhenAnExceptionIsOnlyDefinedInTheInitialPackage-v1.dar",
-    //        "test-common/upgrades-SucceedsWhenAnExceptionIsOnlyDefinedInTheInitialPackage-v2.dar",
-    //        None,
-    //      )
-    //    ),
-    //  )
-    // }
+    "Succeeds when an exception is only defined in the initial package." in {
+      testPackages(
+        Seq(
+          "test-common/upgrades-SucceedsWhenAnExceptionIsOnlyDefinedInTheInitialPackage-v1.dar",
+          "test-common/upgrades-SucceedsWhenAnExceptionIsOnlyDefinedInTheInitialPackage-v2.dar",
+        ),
+        Seq(
+          (
+            "test-common/upgrades-SucceedsWhenAnExceptionIsOnlyDefinedInTheInitialPackage-v1.dar",
+            "test-common/upgrades-SucceedsWhenAnExceptionIsOnlyDefinedInTheInitialPackage-v2.dar",
+            None,
+          )
+        ),
+      )
+    }
 
-    // "Fails when an exception is defined in an upgrading package when it was already in the prior package." in {
-    //  testPackages(
-    //    Seq(
-    //      "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v1.dar",
-    //      "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v2.dar",
-    //    ),
-    //    Seq(
-    //      (
-    //        "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v1.dar",
-    //        "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v2.dar",
-    //        Some(
-    //          "Tried to upgrade exception E, but exceptions cannot be upgraded. They should be removed in any upgrading package."
-    //        ),
-    //      )
-    //    ),
-    //  )
-    // }
+    "Fails when an exception is defined in an upgrading package when it was already in the prior package." in {
+      testPackages(
+        Seq(
+          "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v1.dar",
+          "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v2.dar",
+        ),
+        Seq(
+          (
+            "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v1.dar",
+            "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v2.dar",
+            // TODO (dylant-da): Re-enable this test once the -Wupgrade-exceptions
+            // flag on the compiler goes away and exception upgrades are always an
+            // error
+            // Some(
+            //  "Tried to upgrade exception E, but exceptions cannot be upgraded. They should be removed in any upgrading package."
+            // ),
+            None,
+          )
+        ),
+      )
+    }
   }
 }


### PR DESCRIPTION
Brings participant checks into line with compiler checks, which let you redefine interfaces and exceptions with -Wupgrade-interfaces and -Wupgrade-exceptions