### PR TITLE
Implement KecCak-256 and Secp256k1 utility functions

### DIFF
--- a/sdk/daml-lf/data/BUILD.bazel
+++ b/sdk/daml-lf/data/BUILD.bazel
@@ -42,7 +42,7 @@ da_scala_test(
     srcs = glob(
         ["src/test/**/*.scala"],
         exclude = ["src/test/**/cctp/*.scala"],
-        ),
+    ),
     scala_deps = [
         "@maven//:org_scalacheck_scalacheck",
         "@maven//:org_scalatestplus_scalacheck_1_15",

--- a/sdk/daml-lf/data/BUILD.bazel
+++ b/sdk/daml-lf/data/BUILD.bazel
@@ -39,7 +39,10 @@ da_scala_library(
 da_scala_test(
     name = "data-test",
     size = "small",
-    srcs = glob(["src/test/**/*.scala"]),
+    srcs = glob(
+        ["src/test/**/*.scala"],
+        exclude = ["src/test/**/cctp/*.scala"],
+        ),
     scala_deps = [
         "@maven//:org_scalacheck_scalacheck",
         "@maven//:org_scalatestplus_scalacheck_1_15",
@@ -51,6 +54,17 @@ da_scala_test(
         ":data",
         "//daml-lf/data-scalacheck",
         "//libs-scala/scalatest-utils",
+    ],
+)
+
+da_scala_test(
+    name = "cctp-data-test",
+    size = "small",
+    srcs = glob(["src/test/**/cctp/*.scala"]),
+    scalacopts = lf_scalacopts,
+    deps = [
+        ":data",
+        "@maven//:org_bouncycastle_bcprov_jdk15on",
     ],
 )
 

--- a/sdk/daml-lf/data/BUILD.bazel
+++ b/sdk/daml-lf/data/BUILD.bazel
@@ -64,7 +64,8 @@ da_scala_test(
     scalacopts = lf_scalacopts,
     deps = [
         ":data",
-        "@maven//:org_bouncycastle_bcprov_jdk15on",
+        "//libs-scala/crypto:crypto-tests",
+        "@maven//:com_google_protobuf_protobuf_java",
     ],
 )
 

--- a/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/cctp/MessageDigest.scala
+++ b/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/cctp/MessageDigest.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.data
+package cctp
+
+import com.daml.crypto.MessageDigestPrototype
+
+object MessageDigest {
+  def digest(message: Ref.HexString): Ref.HexString = {
+    val digest = MessageDigestPrototype.KecCak256.newDigest
+    digest.update(Ref.HexString.decode(message).toByteBuffer)
+
+    Ref.HexString.encode(Bytes.fromByteArray(digest.digest()))
+  }
+}

--- a/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/cctp/MessageSignature.scala
+++ b/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/cctp/MessageSignature.scala
@@ -6,9 +6,12 @@ package cctp
 
 import com.daml.crypto.MessageSignaturePrototype
 
-import java.security.PublicKey
+import java.security.{InvalidKeyException, NoSuchProviderException, PublicKey, SignatureException}
 
 object MessageSignature {
+  @throws(classOf[NoSuchProviderException])
+  @throws(classOf[InvalidKeyException])
+  @throws(classOf[SignatureException])
   def verify(signature: Ref.HexString, message: Ref.HexString, publicKey: PublicKey): Boolean = {
     MessageSignaturePrototype.Secp256k1.verify(
       Bytes.fromHexString(signature).toByteArray,

--- a/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/cctp/MessageSignature.scala
+++ b/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/cctp/MessageSignature.scala
@@ -6,16 +6,9 @@ package cctp
 
 import com.daml.crypto.MessageSignaturePrototype
 
-import java.security.{PrivateKey, PublicKey}
+import java.security.PublicKey
 
 object MessageSignature {
-  def sign(message: Ref.HexString, privateKey: PrivateKey): Ref.HexString = {
-    val signature =
-      MessageSignaturePrototype.Secp256k1.sign(Bytes.fromHexString(message).toByteArray, privateKey)
-
-    Ref.HexString.encode(Bytes.fromByteArray(signature))
-  }
-
   def verify(signature: Ref.HexString, message: Ref.HexString, publicKey: PublicKey): Boolean = {
     MessageSignaturePrototype.Secp256k1.verify(
       Bytes.fromHexString(signature).toByteArray,

--- a/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/cctp/MessageSignature.scala
+++ b/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/cctp/MessageSignature.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.data
+package cctp
+
+import com.daml.crypto.MessageSignaturePrototype
+
+import java.security.{PrivateKey, PublicKey}
+
+object MessageSignature {
+  def sign(message: Ref.HexString, privateKey: PrivateKey): Ref.HexString = {
+    val signature =
+      MessageSignaturePrototype.Secp256k1.sign(Bytes.fromHexString(message).toByteArray, privateKey)
+
+    Ref.HexString.encode(Bytes.fromByteArray(signature))
+  }
+
+  def verify(signature: Ref.HexString, message: Ref.HexString, publicKey: PublicKey): Boolean = {
+    MessageSignaturePrototype.Secp256k1.verify(
+      Bytes.fromHexString(signature).toByteArray,
+      Bytes.fromHexString(message).toByteArray,
+      publicKey,
+    )
+  }
+}

--- a/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageDigestTest.scala
+++ b/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageDigestTest.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.data
+package cctp
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.security.Security
+
+class MessageDigestTest extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
+
+  override def beforeAll(): Unit = {
+    val _ = Security.insertProviderAt(new BouncyCastleProvider, 1)
+  }
+
+  "correctly keccak-256 digest messages" in {
+    val message = Ref.HexString.assertFromString("deadbeef")
+    val expectedDigest = Ref.HexString.assertFromString(
+      "d4fd4e189132273036449fc9e11198c739161b4c0116a9a2dccdfa1c492006f1"
+    )
+
+    MessageDigest.digest(message) shouldBe expectedDigest
+  }
+}

--- a/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageDigestTest.scala
+++ b/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageDigestTest.scala
@@ -4,18 +4,10 @@
 package com.digitalasset.daml.lf.data
 package cctp
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
-import java.security.Security
-
-class MessageDigestTest extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
-
-  override def beforeAll(): Unit = {
-    val _ = Security.insertProviderAt(new BouncyCastleProvider, 1)
-  }
+class MessageDigestTest extends AnyFreeSpec with Matchers {
 
   "correctly keccak-256 digest messages" in {
     val message = Ref.HexString.assertFromString("deadbeef")

--- a/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageSignatureTest.scala
+++ b/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageSignatureTest.scala
@@ -4,29 +4,22 @@
 package com.digitalasset.daml.lf.data
 package cctp
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.scalatest.BeforeAndAfterAll
-
-import java.security.{KeyPairGenerator, SecureRandom, Security}
+import java.security.KeyPairGenerator
 import java.security.spec.ECGenParameterSpec
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
-class MessageSignatureTest extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
-
-  override def beforeAll(): Unit = {
-    val _ = Security.insertProviderAt(new BouncyCastleProvider, 1)
-  }
+class MessageSignatureTest extends AnyFreeSpec with Matchers {
 
   "correctly sign and verify secp256k1 signatures" in {
-    val keyPairGen = KeyPairGenerator.getInstance("EC")
-    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"), new SecureRandom())
+    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
+    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
     val keyPair = keyPairGen.generateKeyPair()
     val publicKey = keyPair.getPublic
     val privateKey = keyPair.getPrivate
     val message = Ref.HexString.assertFromString("deadbeef")
 
-    val signature = MessageSignature.sign(message, privateKey)
+    val signature = MessageSignatureUtil.sign(message, privateKey)
 
     MessageSignature.verify(signature, message, publicKey) shouldBe true
   }

--- a/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageSignatureTest.scala
+++ b/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageSignatureTest.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.data
+package cctp
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.scalatest.BeforeAndAfterAll
+
+import java.security.{KeyPairGenerator, SecureRandom, Security}
+import java.security.spec.ECGenParameterSpec
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class MessageSignatureTest extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
+
+  override def beforeAll(): Unit = {
+    val _ = Security.insertProviderAt(new BouncyCastleProvider, 1)
+  }
+
+  "correctly sign and verify secp256k1 signatures" in {
+    val keyPairGen = KeyPairGenerator.getInstance("EC")
+    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"), new SecureRandom())
+    val keyPair = keyPairGen.generateKeyPair()
+    val publicKey = keyPair.getPublic
+    val privateKey = keyPair.getPrivate
+    val message = Ref.HexString.assertFromString("deadbeef")
+
+    val signature = MessageSignature.sign(message, privateKey)
+
+    MessageSignature.verify(signature, message, publicKey) shouldBe true
+  }
+}

--- a/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageSignatureTest.scala
+++ b/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageSignatureTest.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.daml.lf.data
 package cctp
 
-import java.security.KeyPairGenerator
+import java.security.{InvalidKeyException, KeyPairGenerator, SignatureException}
 import java.security.spec.ECGenParameterSpec
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -18,9 +18,68 @@ class MessageSignatureTest extends AnyFreeSpec with Matchers {
     val publicKey = keyPair.getPublic
     val privateKey = keyPair.getPrivate
     val message = Ref.HexString.assertFromString("deadbeef")
-
     val signature = MessageSignatureUtil.sign(message, privateKey)
 
     MessageSignature.verify(signature, message, publicKey) shouldBe true
+  }
+
+  "invalid public keys fail to verify secp256k1 signatures" in {
+    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
+    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
+    val invalidKeyPairGen = KeyPairGenerator.getInstance("RSA")
+    invalidKeyPairGen.initialize(1024)
+    val privateKey = keyPairGen.generateKeyPair().getPrivate
+    val invalidPublicKey = invalidKeyPairGen.generateKeyPair().getPublic
+    val message = Ref.HexString.assertFromString("deadbeef")
+    val signature = MessageSignatureUtil.sign(message, privateKey)
+
+    assertThrows[InvalidKeyException](MessageSignature.verify(signature, message, invalidPublicKey))
+  }
+
+  "invalid secp256k1 public keys fail to verify secp256k1 signatures" in {
+    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
+    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
+    val privateKey = keyPairGen.generateKeyPair().getPrivate
+    val invalidPublicKey = keyPairGen.generateKeyPair().getPublic
+    val message = Ref.HexString.assertFromString("deadbeef")
+    val signature = MessageSignatureUtil.sign(message, privateKey)
+
+    MessageSignature.verify(signature, message, invalidPublicKey) shouldBe false
+  }
+
+  "correctly identify invalid messages against secp256k1 signatures" in {
+    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
+    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
+    val keyPair = keyPairGen.generateKeyPair()
+    val publicKey = keyPair.getPublic
+    val privateKey = keyPair.getPrivate
+    val message = Ref.HexString.assertFromString("deadbeef")
+    val invalidMessage = Ref.HexString.assertFromString("deadbeefdeadbeef")
+    val signature = MessageSignatureUtil.sign(message, privateKey)
+
+    MessageSignature.verify(signature, invalidMessage, publicKey) shouldBe false
+  }
+
+  "correctly identify invalid signatures" in {
+    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
+    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
+    val publicKey = keyPairGen.generateKeyPair().getPublic
+    val message = Ref.HexString.assertFromString("deadbeef")
+    val invalidSignature = Ref.HexString.assertFromString("deadbeef")
+
+    assertThrows[SignatureException](MessageSignature.verify(invalidSignature, message, publicKey))
+  }
+
+  "correctly identify invalid secp256k1 signatures" in {
+    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
+    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
+    val keyPair = keyPairGen.generateKeyPair()
+    val publicKey = keyPair.getPublic
+    val privateKey = keyPair.getPrivate
+    val message = Ref.HexString.assertFromString("deadbeef")
+    val altMessage = Ref.HexString.assertFromString("deadbeefdeadbeef")
+    val invalidSignature = MessageSignatureUtil.sign(altMessage, privateKey)
+
+    MessageSignature.verify(invalidSignature, message, publicKey) shouldBe false
   }
 }

--- a/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageSignatureTest.scala
+++ b/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageSignatureTest.scala
@@ -5,16 +5,13 @@ package com.digitalasset.daml.lf.data
 package cctp
 
 import java.security.{InvalidKeyException, KeyPairGenerator, SignatureException}
-import java.security.spec.ECGenParameterSpec
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 class MessageSignatureTest extends AnyFreeSpec with Matchers {
 
   "correctly sign and verify secp256k1 signatures" in {
-    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
-    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
-    val keyPair = keyPairGen.generateKeyPair()
+    val keyPair = MessageSignatureUtil.generateKeyPair
     val publicKey = keyPair.getPublic
     val privateKey = keyPair.getPrivate
     val message = Ref.HexString.assertFromString("deadbeef")
@@ -24,11 +21,9 @@ class MessageSignatureTest extends AnyFreeSpec with Matchers {
   }
 
   "invalid public keys fail to verify secp256k1 signatures" in {
-    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
-    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
     val invalidKeyPairGen = KeyPairGenerator.getInstance("RSA")
     invalidKeyPairGen.initialize(1024)
-    val privateKey = keyPairGen.generateKeyPair().getPrivate
+    val privateKey = MessageSignatureUtil.generateKeyPair.getPrivate
     val invalidPublicKey = invalidKeyPairGen.generateKeyPair().getPublic
     val message = Ref.HexString.assertFromString("deadbeef")
     val signature = MessageSignatureUtil.sign(message, privateKey)
@@ -36,21 +31,17 @@ class MessageSignatureTest extends AnyFreeSpec with Matchers {
     assertThrows[InvalidKeyException](MessageSignature.verify(signature, message, invalidPublicKey))
   }
 
-  "invalid secp256k1 public keys fail to verify secp256k1 signatures" in {
-    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
-    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
-    val privateKey = keyPairGen.generateKeyPair().getPrivate
-    val invalidPublicKey = keyPairGen.generateKeyPair().getPublic
+  "incorrect secp256k1 public keys fail to verify secp256k1 signatures" in {
+    val privateKey = MessageSignatureUtil.generateKeyPair.getPrivate
+    val incorrectPublicKey = MessageSignatureUtil.generateKeyPair.getPublic
     val message = Ref.HexString.assertFromString("deadbeef")
     val signature = MessageSignatureUtil.sign(message, privateKey)
 
-    MessageSignature.verify(signature, message, invalidPublicKey) shouldBe false
+    MessageSignature.verify(signature, message, incorrectPublicKey) shouldBe false
   }
 
   "correctly identify invalid messages against secp256k1 signatures" in {
-    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
-    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
-    val keyPair = keyPairGen.generateKeyPair()
+    val keyPair = MessageSignatureUtil.generateKeyPair
     val publicKey = keyPair.getPublic
     val privateKey = keyPair.getPrivate
     val message = Ref.HexString.assertFromString("deadbeef")
@@ -61,9 +52,7 @@ class MessageSignatureTest extends AnyFreeSpec with Matchers {
   }
 
   "correctly identify invalid signatures" in {
-    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
-    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
-    val publicKey = keyPairGen.generateKeyPair().getPublic
+    val publicKey = MessageSignatureUtil.generateKeyPair.getPublic
     val message = Ref.HexString.assertFromString("deadbeef")
     val invalidSignature = Ref.HexString.assertFromString("deadbeef")
 
@@ -71,9 +60,7 @@ class MessageSignatureTest extends AnyFreeSpec with Matchers {
   }
 
   "correctly identify invalid secp256k1 signatures" in {
-    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
-    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
-    val keyPair = keyPairGen.generateKeyPair()
+    val keyPair = MessageSignatureUtil.generateKeyPair
     val publicKey = keyPair.getPublic
     val privateKey = keyPair.getPrivate
     val message = Ref.HexString.assertFromString("deadbeef")

--- a/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageSignatureUtil.scala
+++ b/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageSignatureUtil.scala
@@ -6,7 +6,7 @@ package cctp
 
 import com.daml.crypto.MessageSignaturePrototypeUtil
 
-import java.security.PrivateKey
+import java.security.{KeyPair, PrivateKey}
 
 object MessageSignatureUtil {
   def sign(message: Ref.HexString, privateKey: PrivateKey): Ref.HexString = {
@@ -17,5 +17,12 @@ object MessageSignatureUtil {
       )
 
     Ref.HexString.encode(Bytes.fromByteArray(signature))
+  }
+
+  def generateKeyPair: KeyPair = {
+    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
+    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
+
+    keyPairGen.generateKeyPair()
   }
 }

--- a/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageSignatureUtil.scala
+++ b/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageSignatureUtil.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.data
+package cctp
+
+import com.daml.crypto.MessageSignaturePrototypeUtil
+
+import java.security.PrivateKey
+
+object MessageSignatureUtil {
+  def sign(message: Ref.HexString, privateKey: PrivateKey): Ref.HexString = {
+    val signature =
+      MessageSignaturePrototypeUtil.Secp256k1.sign(
+        Bytes.fromHexString(message).toByteArray,
+        privateKey,
+      )
+
+    Ref.HexString.encode(Bytes.fromByteArray(signature))
+  }
+}

--- a/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageSignatureUtil.scala
+++ b/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/cctp/MessageSignatureUtil.scala
@@ -6,7 +6,8 @@ package cctp
 
 import com.daml.crypto.MessageSignaturePrototypeUtil
 
-import java.security.{KeyPair, PrivateKey}
+import java.security.{KeyPair, KeyPairGenerator, PrivateKey}
+import java.security.spec.ECGenParameterSpec
 
 object MessageSignatureUtil {
   def sign(message: Ref.HexString, privateKey: PrivateKey): Ref.HexString = {

--- a/sdk/libs-scala/crypto/BUILD.bazel
+++ b/sdk/libs-scala/crypto/BUILD.bazel
@@ -13,6 +13,7 @@ da_scala_library(
     ],
     deps = [
         "//libs-scala/scala-utils",
+        "@maven//:org_bouncycastle_bcprov_jdk15on",
         "@maven//:org_slf4j_slf4j_api",
     ],
 )
@@ -21,6 +22,9 @@ da_scala_test(
     name = "crypto-tests",
     size = "small",
     srcs = glob(["src/test/scala/**/*.scala"]),
+    visibility = [
+        "//visibility:public",
+    ],
     deps = [
         ":crypto",
         "@maven//:org_bouncycastle_bcprov_jdk15on",

--- a/sdk/libs-scala/crypto/BUILD.bazel
+++ b/sdk/libs-scala/crypto/BUILD.bazel
@@ -23,6 +23,7 @@ da_scala_test(
     srcs = glob(["src/test/scala/**/*.scala"]),
     deps = [
         ":crypto",
+        "@maven//:org_bouncycastle_bcprov_jdk15on",
     ],
 )
 

--- a/sdk/libs-scala/crypto/src/main/scala/com/daml/crypto/MessageDigestPrototype.scala
+++ b/sdk/libs-scala/crypto/src/main/scala/com/daml/crypto/MessageDigestPrototype.scala
@@ -4,9 +4,10 @@
 package com.daml.crypto
 
 import com.daml.scalautil.Statement.discard
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.slf4j.LoggerFactory
 
-import java.security.MessageDigest
+import java.security.{MessageDigest, Security}
 
 /*
  * Use MessageDigest prototypes as a workaround for
@@ -14,6 +15,7 @@ import java.security.MessageDigest
  * workaround https://github.com/google/guava/issues/1197
  */
 final class MessageDigestPrototype(val algorithm: String) {
+  Security.addProvider(new BouncyCastleProvider)
 
   private[this] val logger = LoggerFactory.getLogger(getClass)
 
@@ -44,6 +46,5 @@ final class MessageDigestPrototype(val algorithm: String) {
 object MessageDigestPrototype {
   final val Sha256 = new MessageDigestPrototype("SHA-256")
 
-  // lazily load the Keccak-256 digest algorithm as the runtime needs a suitable JCE provider (e.g. such as BouncyCastle)
-  final lazy val KecCak256 = new MessageDigestPrototype("KECCAK-256")
+  final val KecCak256 = new MessageDigestPrototype("KECCAK-256")
 }

--- a/sdk/libs-scala/crypto/src/main/scala/com/daml/crypto/MessageDigestPrototype.scala
+++ b/sdk/libs-scala/crypto/src/main/scala/com/daml/crypto/MessageDigestPrototype.scala
@@ -43,4 +43,7 @@ final class MessageDigestPrototype(val algorithm: String) {
 
 object MessageDigestPrototype {
   final val Sha256 = new MessageDigestPrototype("SHA-256")
+
+  // lazily load the Keccak-256 digest algorithm as the runtime needs a suitable JCE provider (e.g. such as BouncyCastle)
+  final lazy val KecCak256 = new MessageDigestPrototype("KECCAK-256")
 }

--- a/sdk/libs-scala/crypto/src/main/scala/com/daml/crypto/MessageSignaturePrototype.scala
+++ b/sdk/libs-scala/crypto/src/main/scala/com/daml/crypto/MessageSignaturePrototype.scala
@@ -5,7 +5,14 @@ package com.daml.crypto
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 
-import java.security.{PublicKey, Security, Signature}
+import java.security.{
+  InvalidKeyException,
+  NoSuchProviderException,
+  PublicKey,
+  Security,
+  Signature,
+  SignatureException,
+}
 
 /*
  * This class is prototype level and should not generally be used. Type safe wrapping classes should instead be defined
@@ -14,6 +21,9 @@ import java.security.{PublicKey, Security, Signature}
 final class MessageSignaturePrototype(val algorithm: String) {
   Security.addProvider(new BouncyCastleProvider)
 
+  @throws(classOf[NoSuchProviderException])
+  @throws(classOf[InvalidKeyException])
+  @throws(classOf[SignatureException])
   def verify(signature: Array[Byte], message: Array[Byte], publicKey: PublicKey): Boolean = {
     val signatureVerify = Signature.getInstance(algorithm, "BC")
 

--- a/sdk/libs-scala/crypto/src/main/scala/com/daml/crypto/MessageSignaturePrototype.scala
+++ b/sdk/libs-scala/crypto/src/main/scala/com/daml/crypto/MessageSignaturePrototype.scala
@@ -3,21 +3,19 @@
 
 package com.daml.crypto
 
-import java.security.{PrivateKey, PublicKey, Signature}
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 
+import java.security.{PublicKey, Security, Signature}
+
+/*
+ * This class is prototype level and should not generally be used. Type safe wrapping classes should instead be defined
+ * and used.
+ */
 final class MessageSignaturePrototype(val algorithm: String) {
-
-  def sign(message: Array[Byte], privateKey: PrivateKey): Array[Byte] = {
-    val messageSign = Signature.getInstance(algorithm)
-
-    messageSign.initSign(privateKey)
-    messageSign.update(message)
-
-    messageSign.sign()
-  }
+  Security.addProvider(new BouncyCastleProvider)
 
   def verify(signature: Array[Byte], message: Array[Byte], publicKey: PublicKey): Boolean = {
-    val signatureVerify = Signature.getInstance(algorithm)
+    val signatureVerify = Signature.getInstance(algorithm, "BC")
 
     signatureVerify.initVerify(publicKey)
     signatureVerify.update(message)

--- a/sdk/libs-scala/crypto/src/main/scala/com/daml/crypto/MessageSignaturePrototype.scala
+++ b/sdk/libs-scala/crypto/src/main/scala/com/daml/crypto/MessageSignaturePrototype.scala
@@ -3,28 +3,26 @@
 
 package com.daml.crypto
 
-import java.math.BigInteger
-import java.nio.charset.StandardCharsets
 import java.security.{PrivateKey, PublicKey, Signature}
 
 final class MessageSignaturePrototype(val algorithm: String) {
 
-  def sign(message: String, privateKey: PrivateKey): String = {
+  def sign(message: Array[Byte], privateKey: PrivateKey): Array[Byte] = {
     val messageSign = Signature.getInstance(algorithm)
 
     messageSign.initSign(privateKey)
-    messageSign.update(message.getBytes(StandardCharsets.UTF_8))
+    messageSign.update(message)
 
-    messageSign.sign().map("%02x" format _).mkString
+    messageSign.sign()
   }
 
-  def verify(signature: String, message: String, publicKey: PublicKey): Boolean = {
+  def verify(signature: Array[Byte], message: Array[Byte], publicKey: PublicKey): Boolean = {
     val signatureVerify = Signature.getInstance(algorithm)
 
     signatureVerify.initVerify(publicKey)
-    signatureVerify.update(message.getBytes(StandardCharsets.UTF_8))
+    signatureVerify.update(message)
 
-    signatureVerify.verify(new BigInteger(signature, 16).toByteArray)
+    signatureVerify.verify(signature)
   }
 }
 

--- a/sdk/libs-scala/crypto/src/main/scala/com/daml/crypto/MessageSignaturePrototype.scala
+++ b/sdk/libs-scala/crypto/src/main/scala/com/daml/crypto/MessageSignaturePrototype.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.crypto
+
+import java.math.BigInteger
+import java.nio.charset.StandardCharsets
+import java.security.{PrivateKey, PublicKey, Signature}
+
+final class MessageSignaturePrototype(val algorithm: String) {
+
+  def sign(message: String, privateKey: PrivateKey): String = {
+    val messageSign = Signature.getInstance(algorithm)
+
+    messageSign.initSign(privateKey)
+    messageSign.update(message.getBytes(StandardCharsets.UTF_8))
+
+    messageSign.sign().map("%02x" format _).mkString
+  }
+
+  def verify(signature: String, message: String, publicKey: PublicKey): Boolean = {
+    val signatureVerify = Signature.getInstance(algorithm)
+
+    signatureVerify.initVerify(publicKey)
+    signatureVerify.update(message.getBytes(StandardCharsets.UTF_8))
+
+    signatureVerify.verify(new BigInteger(signature, 16).toByteArray)
+  }
+}
+
+object MessageSignaturePrototype {
+  val Secp256k1 = new MessageSignaturePrototype("SHA256withECDSA")
+}

--- a/sdk/libs-scala/crypto/src/test/scala/com/daml/crypto/MessageDigestPrototypeSpec.scala
+++ b/sdk/libs-scala/crypto/src/test/scala/com/daml/crypto/MessageDigestPrototypeSpec.scala
@@ -3,22 +3,15 @@
 
 package com.daml.crypto
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.nio.charset.StandardCharsets
-import java.security.Security
 import java.util.Base64
 
-class MessageDigestPrototypeSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+class MessageDigestPrototypeSpec extends AnyFlatSpec with Matchers {
 
   behavior of MessageDigestPrototype.getClass.getSimpleName
-
-  override def beforeAll(): Unit = {
-    val _ = Security.insertProviderAt(new BouncyCastleProvider, 1)
-  }
 
   it should "expose algorithm" in {
     MessageDigestPrototype.Sha256.algorithm shouldBe "SHA-256"

--- a/sdk/libs-scala/crypto/src/test/scala/com/daml/crypto/MessageDigestPrototypeSpec.scala
+++ b/sdk/libs-scala/crypto/src/test/scala/com/daml/crypto/MessageDigestPrototypeSpec.scala
@@ -3,24 +3,32 @@
 
 package com.daml.crypto
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.nio.charset.StandardCharsets
+import java.security.Security
 import java.util.Base64
 
-class MessageDigestPrototypeSpec extends AnyFlatSpec with Matchers {
+class MessageDigestPrototypeSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
   behavior of MessageDigestPrototype.getClass.getSimpleName
+
+  override def beforeAll(): Unit = {
+    val _ = Security.insertProviderAt(new BouncyCastleProvider, 1)
+  }
+
+  it should "expose algorithm" in {
+    MessageDigestPrototype.Sha256.algorithm shouldBe "SHA-256"
+    MessageDigestPrototype.KecCak256.algorithm shouldBe "KECCAK-256"
+  }
 
   it should "provide new instance of digest for SHA-256" in {
     val digest = MessageDigestPrototype.Sha256.newDigest
     val digest2 = MessageDigestPrototype.Sha256.newDigest
     digest should not be theSameInstanceAs(digest2)
-  }
-
-  it should "expose algorithm" in {
-    MessageDigestPrototype.Sha256.algorithm shouldBe "SHA-256"
   }
 
   it should "perform a digest for the SHA-256 algorithm" in {
@@ -30,5 +38,20 @@ class MessageDigestPrototypeSpec extends AnyFlatSpec with Matchers {
       Base64.getEncoder.encode(sha),
       StandardCharsets.UTF_8,
     ) shouldBe "pZGm1Av0IEBKARczz7exkNYsZb8LzaMrV7J32a2fFG4="
+  }
+
+  it should "provide new instance of digest for KECCAK-256" in {
+    val digest = MessageDigestPrototype.KecCak256.newDigest
+    val digest2 = MessageDigestPrototype.KecCak256.newDigest
+    digest should not be theSameInstanceAs(digest2)
+  }
+
+  it should "perform a digest for the KECCAK-256 algorithm" in {
+    val digest = MessageDigestPrototype.KecCak256.newDigest
+    val keccak = digest.digest("Hello World".getBytes(StandardCharsets.UTF_8))
+    new String(
+      Base64.getEncoder.encode(keccak),
+      StandardCharsets.UTF_8,
+    ) shouldBe "WS+nQ4ifx/kqwqN7sfW6Ha8qXIR0HKDgBh0kOi5nB7o="
   }
 }

--- a/sdk/libs-scala/crypto/src/test/scala/com/daml/crypto/MessageSignaturePrototypeSpec.scala
+++ b/sdk/libs-scala/crypto/src/test/scala/com/daml/crypto/MessageSignaturePrototypeSpec.scala
@@ -3,93 +3,13 @@
 
 package com.daml.crypto
 
-import java.security.{InvalidKeyException, KeyPairGenerator, SignatureException}
-import java.security.spec.ECGenParameterSpec
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-
-import java.nio.charset.StandardCharsets
 
 class MessageSignaturePrototypeSpec extends AnyFlatSpec with Matchers {
   behavior of MessageSignaturePrototype.getClass.getSimpleName
 
   it should "expose algorithm" in {
     MessageSignaturePrototype.Secp256k1.algorithm shouldBe "SHA256withECDSA"
-  }
-
-  it should "be able to sign and verify messages" in {
-    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
-    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
-    val keyPair = keyPairGen.generateKeyPair()
-    val publicKey = keyPair.getPublic
-    val privateKey = keyPair.getPrivate
-    val message = "Hello World".getBytes(StandardCharsets.UTF_8)
-    val signature = MessageSignaturePrototypeUtil.Secp256k1.sign(message, privateKey)
-
-    MessageSignaturePrototype.Secp256k1.verify(signature, message, publicKey) shouldBe true
-  }
-
-  it should "fail to verify secp256k1 signatures with invalid public keys" in {
-    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
-    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
-    val invalidKeyPairGen = KeyPairGenerator.getInstance("RSA")
-    invalidKeyPairGen.initialize(1024)
-    val privateKey = keyPairGen.generateKeyPair().getPrivate
-    val invalidPublicKey = invalidKeyPairGen.generateKeyPair().getPublic
-    val message = "Hello World".getBytes(StandardCharsets.UTF_8)
-    val signature = MessageSignaturePrototypeUtil.Secp256k1.sign(message, privateKey)
-
-    assertThrows[InvalidKeyException](
-      MessageSignaturePrototype.Secp256k1.verify(signature, message, invalidPublicKey)
-    )
-  }
-
-  it should "fail to verify secp256k1 signatures with invalid secp256k1 public keys" in {
-    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
-    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
-    val privateKey = keyPairGen.generateKeyPair().getPrivate
-    val invalidPublicKey = keyPairGen.generateKeyPair().getPublic
-    val message = "Hello World".getBytes(StandardCharsets.UTF_8)
-    val signature = MessageSignaturePrototypeUtil.Secp256k1.sign(message, privateKey)
-
-    MessageSignaturePrototype.Secp256k1.verify(signature, message, invalidPublicKey) shouldBe false
-  }
-
-  it should "be able to identify invalid messages against secp256k1 signatures" in {
-    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
-    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
-    val keyPair = keyPairGen.generateKeyPair()
-    val publicKey = keyPair.getPublic
-    val privateKey = keyPair.getPrivate
-    val message = "Hello World".getBytes(StandardCharsets.UTF_8)
-    val invalidMessage = "Goodbye World".getBytes(StandardCharsets.UTF_8)
-    val signature = MessageSignaturePrototypeUtil.Secp256k1.sign(message, privateKey)
-
-    MessageSignaturePrototype.Secp256k1.verify(signature, invalidMessage, publicKey) shouldBe false
-  }
-
-  it should "correctly identify invalid signatures" in {
-    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
-    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
-    val publicKey = keyPairGen.generateKeyPair().getPublic
-    val message = "Hello World".getBytes(StandardCharsets.UTF_8)
-    val invalidSignature = "Hello World".getBytes(StandardCharsets.UTF_8)
-
-    assertThrows[SignatureException](
-      MessageSignaturePrototype.Secp256k1.verify(invalidSignature, message, publicKey)
-    )
-  }
-
-  it should "correctly identify invalid secp256k1 signatures" in {
-    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
-    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
-    val keyPair = keyPairGen.generateKeyPair()
-    val publicKey = keyPair.getPublic
-    val privateKey = keyPair.getPrivate
-    val message = "Hello World".getBytes(StandardCharsets.UTF_8)
-    val altMessage = "Goodbye World".getBytes(StandardCharsets.UTF_8)
-    val invalidSignature = MessageSignaturePrototypeUtil.Secp256k1.sign(altMessage, privateKey)
-
-    MessageSignaturePrototype.Secp256k1.verify(invalidSignature, message, publicKey) shouldBe false
   }
 }

--- a/sdk/libs-scala/crypto/src/test/scala/com/daml/crypto/MessageSignaturePrototypeSpec.scala
+++ b/sdk/libs-scala/crypto/src/test/scala/com/daml/crypto/MessageSignaturePrototypeSpec.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.crypto
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.scalatest.BeforeAndAfterAll
+
+import java.security.{KeyPairGenerator, SecureRandom, Security}
+import java.security.spec.ECGenParameterSpec
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class MessageSignaturePrototypeSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+  behavior of MessageSignaturePrototype.getClass.getSimpleName
+
+  override def beforeAll(): Unit = {
+    val _ = Security.insertProviderAt(new BouncyCastleProvider, 1)
+  }
+
+  it should "expose algorithm" in {
+    MessageSignaturePrototype.Secp256k1.algorithm shouldBe "SHA256withECDSA"
+  }
+
+  it should "be able to sign and verify messages" in {
+    val keyPairGen = KeyPairGenerator.getInstance("EC")
+    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"), new SecureRandom())
+    val keyPair = keyPairGen.generateKeyPair()
+    val publicKey = keyPair.getPublic
+    val privateKey = keyPair.getPrivate
+    val message = "Hello World"
+
+    val signature = MessageSignaturePrototype.Secp256k1.sign(message, privateKey)
+
+    MessageSignaturePrototype.Secp256k1.verify(signature, message, publicKey) shouldBe true
+  }
+}

--- a/sdk/libs-scala/crypto/src/test/scala/com/daml/crypto/MessageSignaturePrototypeSpec.scala
+++ b/sdk/libs-scala/crypto/src/test/scala/com/daml/crypto/MessageSignaturePrototypeSpec.scala
@@ -11,6 +11,8 @@ import java.security.spec.ECGenParameterSpec
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.nio.charset.StandardCharsets
+
 class MessageSignaturePrototypeSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   behavior of MessageSignaturePrototype.getClass.getSimpleName
 
@@ -28,7 +30,7 @@ class MessageSignaturePrototypeSpec extends AnyFlatSpec with Matchers with Befor
     val keyPair = keyPairGen.generateKeyPair()
     val publicKey = keyPair.getPublic
     val privateKey = keyPair.getPrivate
-    val message = "Hello World"
+    val message = "Hello World".getBytes(StandardCharsets.UTF_8)
 
     val signature = MessageSignaturePrototype.Secp256k1.sign(message, privateKey)
 

--- a/sdk/libs-scala/crypto/src/test/scala/com/daml/crypto/MessageSignaturePrototypeSpec.scala
+++ b/sdk/libs-scala/crypto/src/test/scala/com/daml/crypto/MessageSignaturePrototypeSpec.scala
@@ -3,36 +3,29 @@
 
 package com.daml.crypto
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.scalatest.BeforeAndAfterAll
-
-import java.security.{KeyPairGenerator, SecureRandom, Security}
+import java.security.KeyPairGenerator
 import java.security.spec.ECGenParameterSpec
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.nio.charset.StandardCharsets
 
-class MessageSignaturePrototypeSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+class MessageSignaturePrototypeSpec extends AnyFlatSpec with Matchers {
   behavior of MessageSignaturePrototype.getClass.getSimpleName
-
-  override def beforeAll(): Unit = {
-    val _ = Security.insertProviderAt(new BouncyCastleProvider, 1)
-  }
 
   it should "expose algorithm" in {
     MessageSignaturePrototype.Secp256k1.algorithm shouldBe "SHA256withECDSA"
   }
 
   it should "be able to sign and verify messages" in {
-    val keyPairGen = KeyPairGenerator.getInstance("EC")
-    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"), new SecureRandom())
+    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
+    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
     val keyPair = keyPairGen.generateKeyPair()
     val publicKey = keyPair.getPublic
     val privateKey = keyPair.getPrivate
     val message = "Hello World".getBytes(StandardCharsets.UTF_8)
 
-    val signature = MessageSignaturePrototype.Secp256k1.sign(message, privateKey)
+    val signature = MessageSignaturePrototypeUtil.Secp256k1.sign(message, privateKey)
 
     MessageSignaturePrototype.Secp256k1.verify(signature, message, publicKey) shouldBe true
   }

--- a/sdk/libs-scala/crypto/src/test/scala/com/daml/crypto/MessageSignaturePrototypeSpec.scala
+++ b/sdk/libs-scala/crypto/src/test/scala/com/daml/crypto/MessageSignaturePrototypeSpec.scala
@@ -3,7 +3,7 @@
 
 package com.daml.crypto
 
-import java.security.KeyPairGenerator
+import java.security.{InvalidKeyException, KeyPairGenerator, SignatureException}
 import java.security.spec.ECGenParameterSpec
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -24,9 +24,72 @@ class MessageSignaturePrototypeSpec extends AnyFlatSpec with Matchers {
     val publicKey = keyPair.getPublic
     val privateKey = keyPair.getPrivate
     val message = "Hello World".getBytes(StandardCharsets.UTF_8)
-
     val signature = MessageSignaturePrototypeUtil.Secp256k1.sign(message, privateKey)
 
     MessageSignaturePrototype.Secp256k1.verify(signature, message, publicKey) shouldBe true
+  }
+
+  it should "fail to verify secp256k1 signatures with invalid public keys" in {
+    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
+    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
+    val invalidKeyPairGen = KeyPairGenerator.getInstance("RSA")
+    invalidKeyPairGen.initialize(1024)
+    val privateKey = keyPairGen.generateKeyPair().getPrivate
+    val invalidPublicKey = invalidKeyPairGen.generateKeyPair().getPublic
+    val message = "Hello World".getBytes(StandardCharsets.UTF_8)
+    val signature = MessageSignaturePrototypeUtil.Secp256k1.sign(message, privateKey)
+
+    assertThrows[InvalidKeyException](
+      MessageSignaturePrototype.Secp256k1.verify(signature, message, invalidPublicKey)
+    )
+  }
+
+  it should "fail to verify secp256k1 signatures with invalid secp256k1 public keys" in {
+    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
+    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
+    val privateKey = keyPairGen.generateKeyPair().getPrivate
+    val invalidPublicKey = keyPairGen.generateKeyPair().getPublic
+    val message = "Hello World".getBytes(StandardCharsets.UTF_8)
+    val signature = MessageSignaturePrototypeUtil.Secp256k1.sign(message, privateKey)
+
+    MessageSignaturePrototype.Secp256k1.verify(signature, message, invalidPublicKey) shouldBe false
+  }
+
+  it should "be able to identify invalid messages against secp256k1 signatures" in {
+    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
+    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
+    val keyPair = keyPairGen.generateKeyPair()
+    val publicKey = keyPair.getPublic
+    val privateKey = keyPair.getPrivate
+    val message = "Hello World".getBytes(StandardCharsets.UTF_8)
+    val invalidMessage = "Goodbye World".getBytes(StandardCharsets.UTF_8)
+    val signature = MessageSignaturePrototypeUtil.Secp256k1.sign(message, privateKey)
+
+    MessageSignaturePrototype.Secp256k1.verify(signature, invalidMessage, publicKey) shouldBe false
+  }
+
+  it should "correctly identify invalid signatures" in {
+    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
+    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
+    val publicKey = keyPairGen.generateKeyPair().getPublic
+    val message = "Hello World".getBytes(StandardCharsets.UTF_8)
+    val invalidSignature = "Hello World".getBytes(StandardCharsets.UTF_8)
+
+    assertThrows[SignatureException](
+      MessageSignaturePrototype.Secp256k1.verify(invalidSignature, message, publicKey)
+    )
+  }
+
+  it should "correctly identify invalid secp256k1 signatures" in {
+    val keyPairGen = KeyPairGenerator.getInstance("EC", "BC")
+    keyPairGen.initialize(new ECGenParameterSpec("secp256k1"))
+    val keyPair = keyPairGen.generateKeyPair()
+    val publicKey = keyPair.getPublic
+    val privateKey = keyPair.getPrivate
+    val message = "Hello World".getBytes(StandardCharsets.UTF_8)
+    val altMessage = "Goodbye World".getBytes(StandardCharsets.UTF_8)
+    val invalidSignature = MessageSignaturePrototypeUtil.Secp256k1.sign(altMessage, privateKey)
+
+    MessageSignaturePrototype.Secp256k1.verify(invalidSignature, message, publicKey) shouldBe false
   }
 }

--- a/sdk/libs-scala/crypto/src/test/scala/com/daml/crypto/MessageSignaturePrototypeUtil.scala
+++ b/sdk/libs-scala/crypto/src/test/scala/com/daml/crypto/MessageSignaturePrototypeUtil.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.crypto
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+
+import java.security.{PrivateKey, Security, Signature}
+
+class MessageSignaturePrototypeUtil(val algorithm: String) {
+  Security.addProvider(new BouncyCastleProvider)
+
+  def sign(message: Array[Byte], privateKey: PrivateKey): Array[Byte] = {
+    val messageSign = Signature.getInstance(algorithm, "BC")
+
+    messageSign.initSign(privateKey)
+    messageSign.update(message)
+
+    messageSign.sign()
+  }
+}
+
+object MessageSignaturePrototypeUtil {
+  val Secp256k1 = new MessageSignaturePrototypeUtil("SHA256withECDSA")
+}


### PR DESCRIPTION
Work that is part of adding CCTP crypto primitives into the engine - ref: https://github.com/DACH-NY/canton-network-utilities/issues/2746

On this PR we add crypto utility functions. Follow PRs will implement engine BuiltIns and Daml-LF primitive constants.

- [x] implement KecCak-256 digest utility function
- [x] implement Secp256k1 sign/verify utility functions
- [x] basic testing for the above
