### PR TITLE
Report flaky tests as github issues.

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -77,6 +77,7 @@ jobs:
         is_release: variables.is_release
         test_mode: ${{parameters.test_mode}}
     - template: upload-bazel-metrics.yml
+    - template: report-flakes.yml
     - bash: |
         set -euo pipefail
         if [ -d sdk ]; then
@@ -152,6 +153,7 @@ jobs:
         is_split_release: $(is_split_release)
         test_mode: ${{parameters.test_mode}}
     - template: upload-bazel-metrics.yml
+    - template: report-flakes.yml
     - template: tell-slack-failed.yml
       parameters:
         trigger_sha: '$(trigger_sha)'

--- a/ci/macOS.yml
+++ b/ci/macOS.yml
@@ -53,6 +53,9 @@ jobs:
     # Do not upload metrics for m1
     - ${{ if eq(parameters.name, 'macos') }}:
       - template: upload-bazel-metrics.yml
+    # Do not report flakes for m1
+    - ${{ if eq(parameters.name, 'macos') }}:
+      - template: report-flakes.yml
     - template: tell-slack-failed.yml
       parameters:
         trigger_sha: '$(trigger_sha)'

--- a/ci/report-flakes.yml
+++ b/ci/report-flakes.yml
@@ -1,0 +1,14 @@
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+steps:
+  - bash: |
+      set -euo pipefail
+      eval "$(cd sdk; dev-env/bin/dade-assist)"
+      python ci/report_flakes.py $(System.AccessToken) $(Build.SourceBranchName) sdk/test-events.json
+    condition: and(
+      succeededOrFailed(),
+      eq(variables['Build.SourceBranchName'], 'main'))
+    displayName: 'Report flaky tests'
+    env:
+      GH_TOKEN: $(GH_DAML_READWRITE)

--- a/ci/report_flakes.py
+++ b/ci/report_flakes.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import tempfile
 import urllib.parse
+import urllib.request
 
 from typing import List
 
@@ -141,11 +142,8 @@ def az_set_logs_ttl(access_token: str, days: int):
     url = "".join([
         os.environ['SYSTEM_COLLECTIONURI'],
         os.environ['SYSTEM_TEAMPROJECT'],
-        "/_apis/build/retention/leases"
+        "/_apis/build/retention/leases?api-version=7.1"
     ])
-    parsed_url = urllib.parse.urlparse(url)
-    host = parsed_url.netloc
-    path = parsed_url.path + "?api-version=7.1"
     headers = {
         'Authorization': f"Bearer {access_token}",
         'Content-Type': 'application/json'
@@ -159,13 +157,9 @@ def az_set_logs_ttl(access_token: str, days: int):
             "runId": os.environ['BUILD_BUILDID']
         }
     ]
-    conn = http.client.HTTPSConnection(host)
-    conn.request("POST", path, body=json.dumps(data), headers=headers)
-    response = conn.getresponse()
-    if response.status != 200:
-        raise Exception(
-            f"Request failed with status {response.status}: {response.reason}")
-    conn.close()
+    req = urllib.request.Request(
+        url, data=json.dumps(data).encode(), headers=headers)
+    urllib.request.urlopen(req)
 
 
 if __name__ == "__main__":

--- a/ci/report_flakes.py
+++ b/ci/report_flakes.py
@@ -1,0 +1,180 @@
+import datetime
+import http.client
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import urllib.parse
+
+from typing import List
+
+milestone = "M97 Flaky Tests"
+
+
+def run_cmd(cmd: List[str]):
+    """
+    Runs a command with capture_ouput=True. Returns the result object if it
+    succeeds, otherwise logs stdout and stderror and raises an exception.
+    """
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"ERROR while executing command:")
+        print(f"Command was {cmd}")
+        print(f"stderr was {result.stderr}")
+        print(f"stdout was {result.stdout}")
+        raise Exception("command failed")
+    return result
+
+
+def call_gh(*args):
+    """
+    Calls the gh command line tool with the given arguments.
+    """
+    return run_cmd(["gh"] + list(args))
+
+
+def extract_failed_tests(report_filename: str):
+    """
+    Extracts the names of the failed tests from the given report file.
+    """
+    result = run_cmd([
+        "jq",
+        "-r", 'select(.testResult.status == "FAILED") | .id.testResult.label',
+        report_filename])
+    return result.stdout.splitlines()
+
+
+def report_failed_test(branch: str, test_name: str):
+    """
+    Reports a failed test as a github issue. If a github issue already exists
+    for that failed test then adds an entry to its body.
+    """
+    title = f"[{branch}] Flaky {test_name}"
+    result = call_gh(
+        "issue",
+        "list",
+        "--repo", "digital-asset/daml",
+        "--author", "githubuser-da",
+        "--milestone", milestone,
+        "--state", "all",
+        "--search", f"in:title {test_name}",
+        "--json", "number,title,body,closed")
+    matches = [
+        e
+        for e in json.loads(result.stdout)
+        if e["title"] == title
+    ]
+    if matches:
+        match = matches[0]
+        id, body, closed = str(match["number"]), match["body"], match["closed"]
+        if closed:
+            gh_reopen_issue(id)
+        gh_update_issue(id, body)
+    else:
+        gh_create_issue(title)
+
+
+def gh_create_issue(title: str):
+    """
+    Create a new github flaky test issue for the given test name.
+    """
+    body = ("This issue was created automatically by the CI. "
+            "Please fix the test before closing the issue."
+            "\n\n"
+            f"{mk_issue_entry()}")
+    with tempfile.NamedTemporaryFile(delete=False, mode='w') as temp_file:
+        temp_file.write(body)
+        temp_file.close()
+        result = call_gh(
+            "issue",
+            "create",
+            "--milestone", milestone,
+            "--title", title,
+            "--body-file", temp_file.name)
+    print(f"Created issue {result.stdout.strip()}")
+
+
+def mk_issue_entry():
+    """
+    Returns a string of the form "date url:<url>" where <url> is a link to the
+    build logs for the current job and task.
+    """
+    date = datetime.datetime.now(datetime.timezone.utc)
+    date_str = date.strftime("%Y-%m-%d %H:%M:%S")
+    url = "https://dev.azure.com/digitalasset/daml/_build/results?"
+    url += urllib.parse.urlencode({
+        "buildId": os.environ["BUILD_BUILDID"],
+        "view": "logs",
+        "j": os.environ["SYSTEM_JOBID"],
+    })
+    return f"{date_str} [logs]({url})"
+
+
+def gh_update_issue(id: str, body: str):
+    """
+    Updates the body of the given issue with a new entry.
+    """
+    new_body = f"{body}\n{mk_issue_entry()}"
+    with tempfile.NamedTemporaryFile(delete=False, mode='w') as temp_file:
+        temp_file.write(new_body)
+        temp_file.close()
+        call_gh("issue", "edit", id, "--body-file", temp_file.name)
+    print(f"Added a line to issue {id}")
+
+
+def gh_reopen_issue(id: str):
+    """
+    Re-opens a github issue given its id.
+    """
+    call_gh("issue", "reopen", id)
+    print(f"Re-opened issue {id}")
+
+
+# This would be more consise with the requests library, but it fails to install
+# via nix on macOS.
+def az_set_logs_ttl(access_token: str, days: int):
+    """
+    Creates a lease for the logs of the current build ensuring that they won't
+    be deleted for the given number of days.
+    """
+    url = "".join([
+        os.environ['SYSTEM_COLLECTIONURI'],
+        os.environ['SYSTEM_TEAMPROJECT'],
+        "/_apis/build/retention/leases"
+    ])
+    parsed_url = urllib.parse.urlparse(url)
+    host = parsed_url.netloc
+    path = parsed_url.path + "?api-version=7.1"
+    headers = {
+        'Authorization': f"Bearer {access_token}",
+        'Content-Type': 'application/json'
+    }
+    data = [
+        {
+            "daysValid": days,
+            "definitionId": os.environ['SYSTEM_DEFINITIONID'],
+            "ownerId": f"User:{os.environ['BUILD_REQUESTEDFORID']}",
+            "protectPipeline": False,
+            "runId": os.environ['BUILD_BUILDID']
+        }
+    ]
+    conn = http.client.HTTPSConnection(host)
+    conn.request("POST", path, body=json.dumps(data), headers=headers)
+    response = conn.getresponse()
+    if response.status != 200:
+        raise Exception(
+            f"Request failed with status {response.status}: {response.reason}")
+    conn.close()
+
+
+if __name__ == "__main__":
+    [_, access_token, branch, report_filename] = sys.argv
+    failing_tests = extract_failed_tests(report_filename)
+    print(f"Reporting {len(failing_tests)} failing tests as github issues.")
+    for test_name in failing_tests:
+        print(f"Reporting {test_name}")
+        report_failed_test(branch, test_name)
+    if failing_tests:
+        print('Increasing logs retention to 2 years')
+        az_set_logs_ttl(access_token, 365 * 2)


### PR DESCRIPTION
Make the CI report tests that fail on `main` as github issues, following canton's [example](https://github.com/DACH-NY/canton/milestone/31). The behavior is similar to that of canton:
  - Issues are reported under the newly created ["M97 Flaky Tests" milestone](https://github.com/digital-asset/daml/milestone/68), whose name is intentionally the same as that used by canton.
  - When a test target fails, if no issue exists for that target then it is created. Otherwise the issue is re-opened if necessary and a new line is appended to the issue's description. See [this example issue](https://github.com/digital-asset/daml/issues/20670) that was opened and modified many time by the CI during testing.

Implementation notes:
  - The bulk of the logic is in a python script which shells out to the `gh` tool.
  - The script extracts the failed test targets from the json report produced by bazel.
  - The `gh` tool requires a "non-basic" read-write token for issues. We only had a basic one and a read-only non-basic one. I asked security to create a new one, which is stored in the GH_DAML_READWRITE secret.
  - Our azure pipelines are configured to GC the logs after 30 days. When a flake is detected, the script calls the azure pipelines API to set a 2 year lease on the logs.
  - The script runs once per environment (linux intel, linux arm, etc.). This means that in theory we can run into race conditions where the same test flakes in two environments and the script then runs at the same time in the two environments. This could lead to missing lines in the issue description. I think it's ok as it's very unlikely to happen and if it happens we'll just be missing one line for one of the environments.
  - This also means we might end up setting many leases on the same logs. That doesn't seem to be an issue: the azure pipelines API accepts many leases.
  - Windows is too flaky so we don't report flakes there for now. Let's see how noisy it is already.