### PR TITLE
extend ResultPrefetch with contract IDs

### DIFF
--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -382,7 +382,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
               )
             }
 
-        case ResultPrefetch(keys, resume) =>
+        case ResultPrefetch(_, keys, resume) =>
           // prefetch the contract keys via the mutable state cache / batch aggregator
           keys
             .parTraverse_(key =>

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/LfValueTranslation.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/LfValueTranslation.scala
@@ -565,7 +565,7 @@ final class LfValueTranslation(
           case LfEngine.ResultNeedUpgradeVerification(_, _, _, _, _) =>
             Future.failed(new IllegalStateException("View computation must be a pure function"))
 
-          case LfEngine.ResultPrefetch(_, resume) =>
+          case LfEngine.ResultPrefetch(_, _, resume) =>
             goAsync(resume())
         }
 

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/util/DAMLe.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/util/DAMLe.scala
@@ -437,7 +437,7 @@ class DAMLe(
           contracts.verifyMetadata(coid, metadata).value.flatMap { verification =>
             handleResultInternal(contracts, resume(verification))
           }
-        case ResultPrefetch(_, resume) =>
+        case ResultPrefetch(_, _, resume) =>
           // we do not need to prefetch here as Canton includes the keys as a static map in Phase 3
           handleResultInternal(contracts, resume())
       }

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -150,8 +150,13 @@ class Engine(val config: EngineConfig) {
       processedCmds <- preprocessor.preprocessApiCommands(pkgResolution, cmds.commands)
       processedPrefetchKeys <- preprocessor.preprocessApiContractKeys(pkgResolution, prefetchKeys)
       preprocessedDiscsAndKeys <- preprocessor.preprocessDisclosedContracts(disclosures)
-      (processedDiscs, disclosedKeyHashes) = preprocessedDiscsAndKeys
-      _ <- preprocessor.prefetchKeys(processedCmds, processedPrefetchKeys, disclosedKeyHashes)
+      (processedDiscs, disclosedContractIds, disclosedKeyHashes) = preprocessedDiscsAndKeys
+      _ <- preprocessor.prefetchContractIdsAndKeys(
+        processedCmds,
+        processedPrefetchKeys,
+        disclosedContractIds,
+        disclosedKeyHashes,
+      )
       result <-
         interpretCommands(
           validating = false,

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
@@ -64,7 +64,7 @@ private[lf] final class CommandPreprocessor(
       contractId: Value.ContractId,
       choiceId: Ref.ChoiceName,
       argument: Value,
-  ): speedy.Command =
+  ): speedy.Command with speedy.ApiCommand =
     handleLookup(pkgInterface.lookupTemplateOrInterface(typeId)) match {
       case TemplateOrInterface.Template(_) =>
         unsafePreprocessExerciseTemplate(typeId, contractId, choiceId, argument)
@@ -77,7 +77,7 @@ private[lf] final class CommandPreprocessor(
       contractId: Value.ContractId,
       choiceId: Ref.ChoiceName,
       argument: Value,
-  ): speedy.Command = {
+  ): speedy.Command.ExerciseTemplate = {
     val choice = handleLookup(pkgInterface.lookupTemplateChoice(templateId, choiceId))
     speedy.Command.ExerciseTemplate(
       templateId = templateId,
@@ -92,7 +92,7 @@ private[lf] final class CommandPreprocessor(
       contractId: Value.ContractId,
       choiceId: Ref.ChoiceName,
       argument: Value,
-  ): speedy.Command = {
+  ): speedy.Command.ExerciseInterface = {
     val choice = handleLookup(pkgInterface.lookupInterfaceChoice(ifaceId, choiceId))
     speedy.Command.ExerciseInterface(
       interfaceId = ifaceId,
@@ -170,7 +170,7 @@ private[lf] final class CommandPreprocessor(
   private[preprocessing] def unsafePreprocessApiCommand(
       pkgResolution: Map[Ref.PackageName, Ref.PackageId],
       cmd: command.ApiCommand,
-  ): speedy.Command =
+  ): speedy.Command with speedy.ApiCommand =
     cmd match {
       case command.ApiCommand.Create(templateRef, argument) =>
         val templateId =
@@ -261,13 +261,13 @@ private[lf] final class CommandPreprocessor(
   def unsafePreprocessApiCommands(
       pkgResolution: Map[Ref.PackageName, Ref.PackageId],
       cmds: ImmArray[command.ApiCommand],
-  ): ImmArray[speedy.Command] =
+  ): ImmArray[speedy.Command with speedy.ApiCommand] =
     cmds.map(unsafePreprocessApiCommand(pkgResolution, _))
 
   @throws[Error.Preprocessing.Error]
   def unsafePreprocessDisclosedContracts(
       discs: ImmArray[FatContractInstance]
-  ): (ImmArray[speedy.DisclosedContract], Set[Hash]) = {
+  ): (ImmArray[speedy.DisclosedContract], Set[Value.ContractId], Set[Hash]) = {
     var contractIds: Set[Value.ContractId] = Set.empty
     val contractKeyHashes = Set.newBuilder[Hash]
 
@@ -280,7 +280,7 @@ private[lf] final class CommandPreprocessor(
       }
       unsafePreprocessDisclosedContract(disclosedContract)
     }
-    preprocessedDiscs -> contractKeyHashes.result()
+    (preprocessedDiscs, contractIds, contractKeyHashes.result())
   }
 
   @throws[Error.Preprocessing.Error]

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
@@ -213,14 +213,14 @@ private[engine] final class Preprocessor(
   def preprocessApiCommands(
       pkgResolution: Map[Ref.PackageName, Ref.PackageId],
       cmds: data.ImmArray[command.ApiCommand],
-  ): Result[ImmArray[speedy.Command]] =
+  ): Result[ImmArray[speedy.Command with speedy.ApiCommand]] =
     safelyRun(pullPackage(pkgResolution, cmds.toSeq.view.map(_.typeRef))) {
       commandPreprocessor.unsafePreprocessApiCommands(pkgResolution, cmds)
     }
 
   def preprocessDisclosedContracts(
       discs: data.ImmArray[FatContractInstance]
-  ): Result[(ImmArray[speedy.DisclosedContract], Set[Hash])] =
+  ): Result[(ImmArray[speedy.DisclosedContract], Set[Value.ContractId], Set[Hash])] =
     safelyRun(pullPackage(discs.toSeq.view.map(_.templateId))) {
       commandPreprocessor.unsafePreprocessDisclosedContracts(discs)
     }
@@ -275,9 +275,10 @@ private[engine] final class Preprocessor(
       commandPreprocessor.unsafePreprocessApiContractKeys(pkgResolution, keys)
     }
 
-  private[engine] def prefetchKeys(
-      commands: ImmArray[speedy.Command],
+  private[engine] def prefetchContractIdsAndKeys(
+      commands: ImmArray[speedy.Command with speedy.ApiCommand],
       prefetchKeys: Seq[GlobalKey],
+      disclosedContractIds: Set[Value.ContractId],
       disclosedKeyHashes: Set[Hash],
   ): Result[Unit] =
     safelyRun(
@@ -288,10 +289,39 @@ private[engine] final class Preprocessor(
           None,
         )
       )
-    )(unsafePrefetchKeys(commands, prefetchKeys, disclosedKeyHashes)).flatMap { undisclosedKeys =>
-      if (undisclosedKeys.nonEmpty) ResultPrefetch(undisclosedKeys.toSeq, () => ResultDone.Unit)
+    ) {
+      val keysToPrefetch = unsafePrefetchKeys(commands, prefetchKeys, disclosedKeyHashes)
+      val contractIdsToPrefetch = unsafePrefetchContractIds(commands, disclosedContractIds)
+      (keysToPrefetch, contractIdsToPrefetch)
+    }.flatMap { case (keysToPrefetch, contractIdsToPrefetch) =>
+      if (keysToPrefetch.nonEmpty || contractIdsToPrefetch.nonEmpty)
+        ResultPrefetch(contractIdsToPrefetch.toSeq, keysToPrefetch.toSeq, () => ResultDone.Unit)
       else ResultDone.Unit
     }
+
+  private def unsafePrefetchContractIds(
+      commands: ImmArray[speedy.Command with speedy.ApiCommand],
+      disclosedContractIds: Set[Value.ContractId],
+  ): Set[Value.ContractId] = {
+    val contractIdsInCommands =
+      commands.iterator.foldLeft(Set.empty[Value.ContractId])((acc, cmd) =>
+        cmd match {
+          case speedy.Command.ExerciseTemplate(_, contractId, _, argument) =>
+            SValue.addContractIds(argument, acc + contractId.value)
+          case speedy.Command.ExerciseInterface(_, contractId, _, argument) =>
+            SValue.addContractIds(argument, acc + contractId.value)
+          case speedy.Command.ExerciseByKey(_, _, _, argument) =>
+            // No need to look at the key because keys cannot contain contract IDs
+            SValue.addContractIds(argument, acc)
+          case speedy.Command.Create(_, argument) =>
+            SValue.addContractIds(argument, acc)
+          case speedy.Command.CreateAndExercise(_, createArgument, _, choiceArgument) =>
+            SValue.addContractIds(choiceArgument, SValue.addContractIds(createArgument, acc))
+        }
+      )
+    val prefetchContractIds = contractIdsInCommands -- disclosedContractIds
+    prefetchContractIds
+  }
 
   private def unsafePrefetchKeys(
       commands: ImmArray[speedy.Command],

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
@@ -213,7 +213,7 @@ private[engine] final class Preprocessor(
   def preprocessApiCommands(
       pkgResolution: Map[Ref.PackageName, Ref.PackageId],
       cmds: data.ImmArray[command.ApiCommand],
-  ): Result[ImmArray[speedy.Command with speedy.ApiCommand]] =
+  ): Result[ImmArray[speedy.ApiCommand]] =
     safelyRun(pullPackage(pkgResolution, cmds.toSeq.view.map(_.typeRef))) {
       commandPreprocessor.unsafePreprocessApiCommands(pkgResolution, cmds)
     }
@@ -276,7 +276,7 @@ private[engine] final class Preprocessor(
     }
 
   private[engine] def prefetchContractIdsAndKeys(
-      commands: ImmArray[speedy.Command with speedy.ApiCommand],
+      commands: ImmArray[speedy.ApiCommand],
       prefetchKeys: Seq[GlobalKey],
       disclosedContractIds: Set[Value.ContractId],
       disclosedKeyHashes: Set[Hash],
@@ -295,12 +295,12 @@ private[engine] final class Preprocessor(
       (keysToPrefetch, contractIdsToPrefetch)
     }.flatMap { case (keysToPrefetch, contractIdsToPrefetch) =>
       if (keysToPrefetch.nonEmpty || contractIdsToPrefetch.nonEmpty)
-        ResultPrefetch(contractIdsToPrefetch.toSeq, keysToPrefetch.toSeq, () => ResultDone.Unit)
+        ResultPrefetch(contractIdsToPrefetch.toSeq, keysToPrefetch, () => ResultDone.Unit)
       else ResultDone.Unit
     }
 
   private def unsafePrefetchContractIds(
-      commands: ImmArray[speedy.Command with speedy.ApiCommand],
+      commands: ImmArray[speedy.ApiCommand],
       disclosedContractIds: Set[Value.ContractId],
   ): Set[Value.ContractId] = {
     val contractIdsInCommands =

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Command.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Command.scala
@@ -14,7 +14,7 @@ import com.digitalasset.daml.lf.transaction.FatContractInstance
 private[lf] sealed abstract class Command extends Product with Serializable
 
 /** Marker trait for preprocessed commands that can result from [[com.digitalasset.daml.lf.command.ApiCommand]]s */
-private[lf] sealed trait ApiCommand extends Product with Serializable
+private[lf] sealed trait ApiCommand extends Command
 
 private[lf] object Command {
 
@@ -22,8 +22,7 @@ private[lf] object Command {
   final case class Create(
       templateId: Identifier,
       argument: SValue,
-  ) extends Command
-      with ApiCommand
+  ) extends ApiCommand
 
   /** Exercise a template choice, not by interface */
   final case class ExerciseTemplate(
@@ -31,8 +30,7 @@ private[lf] object Command {
       contractId: SContractId,
       choiceId: ChoiceName,
       argument: SValue,
-  ) extends Command
-      with ApiCommand
+  ) extends ApiCommand
 
   /** Exercise an interface choice. This is used for exercising an interface
     * on the ledger api, where the template id is unknown.
@@ -42,16 +40,14 @@ private[lf] object Command {
       contractId: SContractId,
       choiceId: ChoiceName,
       argument: SValue,
-  ) extends Command
-      with ApiCommand
+  ) extends ApiCommand
 
   final case class ExerciseByKey(
       templateId: Identifier,
       contractKey: SValue,
       choiceId: ChoiceName,
       argument: SValue,
-  ) extends Command
-      with ApiCommand
+  ) extends ApiCommand
 
   /** Fetch a template, not by interface */
   final case class FetchTemplate(
@@ -75,8 +71,7 @@ private[lf] object Command {
       createArgument: SValue,
       choiceId: ChoiceName,
       choiceArgument: SValue,
-  ) extends Command
-      with ApiCommand
+  ) extends ApiCommand
 
   final case class LookupByKey(
       templateId: Identifier,

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Command.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Command.scala
@@ -13,6 +13,9 @@ import com.digitalasset.daml.lf.transaction.FatContractInstance
 // ---------------------
 private[lf] sealed abstract class Command extends Product with Serializable
 
+/** Marker trait for preprocessed commands that can result from [[com.digitalasset.daml.lf.command.ApiCommand]]s */
+private[lf] sealed trait ApiCommand extends Product with Serializable
+
 private[lf] object Command {
 
   /** Create a template, not by interface */
@@ -20,6 +23,7 @@ private[lf] object Command {
       templateId: Identifier,
       argument: SValue,
   ) extends Command
+      with ApiCommand
 
   /** Exercise a template choice, not by interface */
   final case class ExerciseTemplate(
@@ -28,6 +32,7 @@ private[lf] object Command {
       choiceId: ChoiceName,
       argument: SValue,
   ) extends Command
+      with ApiCommand
 
   /** Exercise an interface choice. This is used for exercising an interface
     * on the ledger api, where the template id is unknown.
@@ -38,6 +43,7 @@ private[lf] object Command {
       choiceId: ChoiceName,
       argument: SValue,
   ) extends Command
+      with ApiCommand
 
   final case class ExerciseByKey(
       templateId: Identifier,
@@ -45,6 +51,7 @@ private[lf] object Command {
       choiceId: ChoiceName,
       argument: SValue,
   ) extends Command
+      with ApiCommand
 
   /** Fetch a template, not by interface */
   final case class FetchTemplate(
@@ -69,6 +76,7 @@ private[lf] object Command {
       choiceId: ChoiceName,
       choiceArgument: SValue,
   ) extends Command
+      with ApiCommand
 
   final case class LookupByKey(
       templateId: Identifier,

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v1/ledgerinteraction/IdeLedgerClient.scala
@@ -298,7 +298,7 @@ class IdeLedgerClient(
             identity,
           )
       )
-      val (speedyDisclosures, _) =
+      val (speedyDisclosures, _, _) =
         preprocessor.unsafePreprocessDisclosedContracts(disclosedContracts.to(ImmArray))
 
       val speedyCommands =

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -627,7 +627,7 @@ class IdeLedgerClient(
           contracts = fatContacts
           disclosures <-
             try {
-              val (preprocessedDisclosed, _) =
+              val (preprocessedDisclosed, _, _) =
                 preprocessor.unsafePreprocessDisclosedContracts(contracts)
               Right(preprocessedDisclosed)
             } catch {


### PR DESCRIPTION
Part of https://github.com/DACH-NY/canton/issues/23152: The goal is to move the contract ID prefetching logic from https://github.com/DACH-NY/canton/blob/2523da067c93ec0dd3ad570a16175a93d9a13e1e/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandExecutor.scala#L83-L108 into Daml engine. This way, there is less chance of overlooking certain prefetch scenarios (as is currently the case for example for contract IDs mentioned in choice arguments of exercise-by-key commands).

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
