### PR TITLE
Forward port of Add logback.xml for filtering out noise in test-common/it-lib:it-lib

### DIFF
--- a/sdk/test-common/canton/it-lib/BUILD.bazel
+++ b/sdk/test-common/canton/it-lib/BUILD.bazel
@@ -14,6 +14,7 @@ da_scala_library(
         "//canton:community_app_deploy.jar",
         "//test-common/test-certificates",
     ],
+    resources = ["src/main/resources/logback.xml"],
     scala_deps = [
         "@maven//:io_spray_spray_json",
         "@maven//:org_apache_pekko_pekko_actor",

--- a/sdk/test-common/canton/it-lib/src/main/resources/logback.xml
+++ b/sdk/test-common/canton/it-lib/src/main/resources/logback.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $',
+                ''} %n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.netty" level="WARN"/>
+    <logger name="io.grpc.netty" level="WARN"/>
+    <logger name="ch.qos.logback" level="WARN"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
This is a forward port from 2.x of https://github.com/digital-asset/daml/pull/18981
* Add logback.xml for filtering out noise in test-common/it-lib:it-lib

* Correct path for logback

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
