### PR TITLE
Backport #20474

### DIFF
--- a/sdk/docs/daml-intro-7.yaml
+++ b/sdk/docs/daml-intro-7.yaml
@@ -9,6 +9,4 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time
 

--- a/sdk/docs/source/daml/intro/daml/daml-intro-1/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-1/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-10/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-10/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-11/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-11/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-12-part1/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-12-part1/daml.yaml.template
@@ -8,5 +8,3 @@ dependencies:
   - daml-script
 build-options:
   - --target=1.15
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-12-part2/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-12-part2/daml.yaml.template
@@ -10,5 +10,3 @@ data-dependencies:
   - ./intro12-part1.dar
 build-options:
   - --target=1.15
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-13/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-13/daml.yaml.template
@@ -7,5 +7,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-2/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-2/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-3/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-3/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-4/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-4/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-5/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-5/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-6/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-6/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-8/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-8/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/intro/daml/daml-intro-9/daml.yaml.template
+++ b/sdk/docs/source/daml/intro/daml/daml-intro-9/daml.yaml.template
@@ -8,5 +8,3 @@ dependencies:
   - daml-script
 data-dependencies:
   - ../intro7/assets.dar
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/docs/source/daml/patterns/daml.yaml.template
+++ b/sdk/docs/source/daml/patterns/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time

--- a/sdk/templates/empty-skeleton/daml.yaml.template
+++ b/sdk/templates/empty-skeleton/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml3-script
-sandbox-options:
-  - --wall-clock-time


### PR DESCRIPTION
`--wall-clock-time` is the default on main 3.x as well, so we can forward port this freely: https://github.com/digital-asset/daml/pull/20474