### PR TITLE
HOTFIX: port #19237 from main-2.x into main

### DIFF
--- a/sdk/fmt.sh
+++ b/sdk/fmt.sh
@@ -49,11 +49,11 @@ check_diff() {
   # $1 merge_base
   # $2 regex
   # "${@:3}" command
-  changed_files=$(git diff --name-only --diff-filter=ACMRT "$1" | grep '^sdk/' | sed 's|^sdk/||' | grep $2 | grep -E -v '^canton(-3x)?/' || [[ $? == 1 ]])
-  if [[ -n "$changed_files" ]]; then
-    run "${@:3}" ${changed_files[@]:-}
-  else
+  readarray -t changed_files < <(git diff --name-only --diff-filter=ACMRT "$1" | grep $2 | grep -E -v '^sdk/canton(-3x)?/' || [[ $? == 1 ]])
+  if [[ -z "${changed_files[@]}" ]]; then
     echo "No changed file to check matching '$2', skipping."
+  else
+    run "${@:3}" ${changed_files[@]##sdk/}
   fi
 }
 


### PR DESCRIPTION
Port https://github.com/digital-asset/daml/pull/19237
The `fmt.sh --diff` command was already mostly fixed by
https://github.com/digital-asset/daml/pull/19098
but still contained the bug where in the bash we were treating a scalar as an array. Here that's fixed, allowing us to take advantage of array operations to strip the prefix.