### PR TITLE
Add test asserting correct handling of non-normalized keys

### DIFF
--- a/sdk/compatibility/bazel_tools/testing.bzl
+++ b/sdk/compatibility/bazel_tools/testing.bzl
@@ -771,6 +771,21 @@ excluded_test_tool_tests = [
             },
         ],
     },
+    # New test (TXEventsByContractKeyDecimalNonNormalized) introduced
+    # that was asserts a previously existing bug that
+    # prohibited correct fetching of events by contract key
+    # when they contained non-normalized numeric values
+    {
+        "start": "2.10.0-snapshot.20241218.1",
+        "platform_ranges": [
+            {
+                "end": "2.10.0-snapshot.20241218.0",
+                "exclusions": [
+                    "EventQueryServiceIT:TXEventsByContractKeyDecimalNonNormalized",
+                ],
+            },
+        ],
+    },
 ]
 
 def in_range(version, range):

--- a/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/EventQueryServiceIT.scala
+++ b/sdk/ledger-test-tool/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/EventQueryServiceIT.scala
@@ -7,9 +7,11 @@ import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
+import com.daml.ledger.api.v1.event.CreatedEvent
 import com.daml.ledger.api.v1.event_query_service.{
   GetEventsByContractIdRequest,
   GetEventsByContractKeyRequest,
+  GetEventsByContractKeyResponse,
 }
 import com.daml.ledger.api.v1.value._
 import com.daml.ledger.javaapi.data.Party
@@ -369,7 +371,7 @@ class EventQueryServiceIT extends LedgerTestSuite {
       ledger: ParticipantTestContext,
       party: Party,
       numericValue: String,
-  )(implicit ec: ExecutionContext) =
+  )(implicit ec: ExecutionContext): Future[(GetEventsByContractKeyResponse, Option[CreatedEvent])] =
     for {
       tx <- ledger.submitAndWaitForTransaction(
         ledger.submitAndWaitRequest(

--- a/sdk/test-common/src/main/daml/model/Test.daml
+++ b/sdk/test-common/src/main/daml/model/Test.daml
@@ -341,6 +341,16 @@ template TextKey
       controller tkParty
       do create this with tkDisclosedTo = tkNewDisclosedTo
 
+type Amount = Numeric 6
+
+template KeyedByDecimal with
+    party: Party
+    amount: Amount
+  where
+    signatory party
+    key (party, amount): (Party, Amount)
+    maintainer key._1
+
 template TextKeyOperations
   with
     tkoParty: Party


### PR DESCRIPTION
This behavior has been fixed as part of https://github.com/digital-asset/daml/pull/20585 work stream by @simonmaxen-da . This PR merely merges the original conformance test asserting the incorrect behavior.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
