### PR TITLE
Port #20106 and #20187

### DIFF
--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.daml.lf
 package engine
 
-import com.digitalasset.daml.lf.data.Ref.{Identifier, Name, PackageId, PackageRef}
+import com.digitalasset.daml.lf.data.Ref.{Identifier, QualifiedName, Name, PackageId, PackageRef}
 import com.digitalasset.daml.lf.language.{Ast, LookupError}
 import com.digitalasset.daml.lf.transaction.{
   GlobalKey,
@@ -98,22 +98,56 @@ final class ValueEnricher(
       ResultError(Error.Preprocessing.Lookup(error))
   }
 
+  // deprecated
   def enrichChoiceArgument(
       templateId: Identifier,
       interfaceId: Option[Identifier],
       choiceName: Name,
       value: Value,
+  ): Result[Value] = enrichChoiceArgument(
+    templateId.packageId,
+    templateId.qualifiedName,
+    interfaceId,
+    choiceName,
+    value,
+  )
+
+  def enrichChoiceArgument(
+      packageId: PackageId,
+      templateName: QualifiedName,
+      interfaceId: Option[Identifier],
+      choiceName: Name,
+      value: Value,
   ): Result[Value] =
-    handleLookup(pkgInterface.lookupChoice(templateId, interfaceId, choiceName))
+    handleLookup(
+      pkgInterface.lookupChoice(Identifier(packageId, templateName), interfaceId, choiceName)
+    )
       .flatMap(choice => enrichValue(choice.argBinder._2, value))
 
+  // deprecated
   def enrichChoiceResult(
       templateId: Identifier,
       interfaceId: Option[Identifier],
       choiceName: Name,
       value: Value,
+  ): Result[Value] = enrichChoiceResult(
+    templateId.packageId,
+    templateId.qualifiedName,
+    interfaceId,
+    choiceName,
+    value,
+  )
+
+  def enrichChoiceResult(
+      packageId: PackageId,
+      templateName: QualifiedName,
+      interfaceId: Option[Identifier],
+      choiceName: Name,
+      value: Value,
   ): Result[Value] =
-    handleLookup(pkgInterface.lookupChoice(templateId, interfaceId, choiceName))
+    handleLookup(
+      pkgInterface.lookupChoice(Identifier(packageId, templateName), interfaceId, choiceName)
+    )
       .flatMap(choice => enrichValue(choice.returnType, value))
 
   def enrichContractKey(tyCon: Identifier, value: Value): Result[Value] =


### PR DESCRIPTION
Creates overloads of `enrichChoiceArgument` and `enrichChoiceResult` that pass in the package id explicitly.

This change was originally done in 2.10 to support having ExercisedEvent's whose templateId had the same package id as the CreatedEvent of the corresponding contract, even if the package had been upgraded in the meantime. Whether to continue that behaviour in 3.x has yet to be decided, but this change would support making the decision explicit, regardless.

Extracted from https://github.com/digital-asset/daml/pull/20106 and https://github.com/digital-asset/daml/pull/20187


<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
