### PR TITLE
skip flaky test collection if bazel didn't produce a report

### DIFF
--- a/ci/report-flakes.yml
+++ b/ci/report-flakes.yml
@@ -5,7 +5,13 @@ steps:
   - bash: |
       set -euo pipefail
       eval "$(cd sdk; dev-env/bin/dade-assist)"
-      python ci/report_flakes.py $(System.AccessToken) $(Build.SourceBranchName) sdk/test-events.json
+
+      report="sdk/test-events.json"
+      if [ -f $report ]; then
+        python ci/report_flakes.py $(System.AccessToken) $(Build.SourceBranchName) $report
+      else
+        echo "$report not found, skipping"
+      fi
     condition: and(
       succeededOrFailed(),
       eq(variables['Build.SourceBranchName'], 'main'))


### PR DESCRIPTION
Alternatively I could have copied [this condition](https://github.com/digital-asset/daml/blob/7674a555b565eaeec66ed615528b609e09d71370/ci/build-unix.yml#L29-L32) but then they need to be kept in sync and this is akward because `skip` is defined locally in `build-unix.yml`. So instead I do what `upload-bazel-metrics.yml` does: I dynamically skip based on the presence of the report. It is a bit more brittle because if bazel stops producing a report we may not notice. But I think the alternative is worse.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
