### PR TITLE
Backport "Allow deleting exceptions and interfaces in upgrades, but don't disallow redefining them (#20636)"

### DIFF
--- a/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
+++ b/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
@@ -221,6 +221,11 @@ object UpgradeError {
     override def message: String =
       s"The upgraded $origin has changed the kind of one of its type variables."
   }
+
+  final case class TriedToUpgradeException(exception: Ref.DottedName) extends Error {
+    override def message: String =
+      s"Tried to upgrade exception $exception, but exceptions cannot be upgraded. They should be removed in any upgrading package."
+  }
 }
 
 sealed abstract class UpgradedRecordOrigin
@@ -512,7 +517,29 @@ case class TypecheckUpgrades(
       ifaces,
       (arg: (Ref.DottedName, Upgrading[(Ast.DDataType, Ast.DefInterface)])) => {
         val (name, _) = arg
-        fail(UpgradeError.TriedToUpgradeIface(name))
+        // TODO (dylant-da): Re-enable this line once the -Wupgrade-interfaces
+        // flag on the compiler goes away and interface upgrades are always an
+        // error
+        // fail(UpgradeError.TriedToUpgradeIface(name))
+        val _ = UpgradeError.TriedToUpgradeIface(name)
+        Try(())
+      },
+    ).map(_ => ())
+  }
+
+  private def checkContinuedExceptions(
+      exceptions: Map[Ref.DottedName, Upgrading[(Ast.DDataType, Ast.DefException)]]
+  ): Try[Unit] = {
+    tryAll(
+      exceptions,
+      (arg: (Ref.DottedName, Upgrading[(Ast.DDataType, Ast.DefException)])) => {
+        val (name, _) = arg
+        // TODO (dylant-da): Re-enable this line once the -Wupgrade-exceptions
+        // flag on the compiler goes away and exception upgrades are always an
+        // error
+        // fail(UpgradeError.TriedToUpgradeException(name))
+        val _ = UpgradeError.TriedToUpgradeException(name)
+        Try(())
       },
     ).map(_ => ())
   }

--- a/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
+++ b/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
@@ -221,11 +221,6 @@ object UpgradeError {
     override def message: String =
       s"The upgraded $origin has changed the kind of one of its type variables."
   }
-
-  final case class TriedToUpgradeException(exception: Ref.DottedName) extends Error {
-    override def message: String =
-      s"Tried to upgrade exception $exception, but exceptions cannot be upgraded. They should be removed in any upgrading package."
-  }
 }
 
 sealed abstract class UpgradedRecordOrigin
@@ -517,9 +512,9 @@ case class TypecheckUpgrades(
       ifaces,
       (arg: (Ref.DottedName, Upgrading[(Ast.DDataType, Ast.DefInterface)])) => {
         val (name, _) = arg
-        // TODO (dylant-da): Re-enable this line once the -Wupgrade-interfaces
-        // flag on the compiler goes away and interface upgrades are always an
-        // error
+        // TODO (dylant-da): Re-enable this line if the -Wupgrade-interfaces
+        // flag on the compiler goes away and interface upgrades become an
+        // always-error
         // fail(UpgradeError.TriedToUpgradeIface(name))
         val _ = UpgradeError.TriedToUpgradeIface(name)
         Try(())
@@ -534,24 +529,12 @@ case class TypecheckUpgrades(
       exceptions,
       (arg: (Ref.DottedName, Upgrading[(Ast.DDataType, Ast.DefException)])) => {
         val (name, _) = arg
-        // TODO (dylant-da): Re-enable this line once the -Wupgrade-exceptions
-        // flag on the compiler goes away and exception upgrades are always an
-        // error
+        // TODO (dylant-da): Re-enable this line if the -Wupgrade-exceptions
+        // flag on the compiler goes away and exception upgrades become an
+        // always-error
         // fail(UpgradeError.TriedToUpgradeException(name))
         val _ = UpgradeError.TriedToUpgradeException(name)
         Try(())
-      },
-    ).map(_ => ())
-  }
-
-  private def checkContinuedExceptions(
-      exceptions: Map[Ref.DottedName, Upgrading[(Ast.DDataType, Ast.DefException)]]
-  ): Try[Unit] = {
-    tryAll(
-      exceptions,
-      (arg: (Ref.DottedName, Upgrading[(Ast.DDataType, Ast.DefException)])) => {
-        val (name, _) = arg
-        fail(UpgradeError.TriedToUpgradeException(name))
       },
     ).map(_ => ())
   }

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesCheckSpec.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesCheckSpec.scala
@@ -134,9 +134,13 @@ final class UpgradesCheckSpec extends AsyncWordSpec with Matchers with Inside {
           (
             "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v1.dar",
             "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v2.dar",
-            Some(
-              "Tried to upgrade exception E, but exceptions cannot be upgraded. They should be removed in any upgrading package."
-            ),
+            // TODO (dylant-da): Re-enable this line if the -Wupgrade-exceptions
+            // flag on the compiler goes away and exception upgrades become an
+            // always-error
+            // Some(
+            //  "Tried to upgrade exception E, but exceptions cannot be upgraded. They should be removed in any upgrading package."
+            // ),
+            None,
           )
         ),
       )
@@ -1405,44 +1409,6 @@ final class UpgradesCheckSpec extends AsyncWordSpec with Matchers with Inside {
       testPackage(
         "test-common/upgrades-daml-script-lts-dep-lf17-on-lf17.dar",
         "Upload of .*package .* contains .*daml-script.* as a dependency.",
-      )
-    }
-
-    "Succeeds when an exception is only defined in the initial package." in {
-      testPackages(
-        Seq(
-          "test-common/upgrades-SucceedsWhenAnExceptionIsOnlyDefinedInTheInitialPackage-v1.dar",
-          "test-common/upgrades-SucceedsWhenAnExceptionIsOnlyDefinedInTheInitialPackage-v2.dar",
-        ),
-        Seq(
-          (
-            "test-common/upgrades-SucceedsWhenAnExceptionIsOnlyDefinedInTheInitialPackage-v1.dar",
-            "test-common/upgrades-SucceedsWhenAnExceptionIsOnlyDefinedInTheInitialPackage-v2.dar",
-            None,
-          )
-        ),
-      )
-    }
-
-    "Fails when an exception is defined in an upgrading package when it was already in the prior package." in {
-      testPackages(
-        Seq(
-          "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v1.dar",
-          "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v2.dar",
-        ),
-        Seq(
-          (
-            "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v1.dar",
-            "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v2.dar",
-            // TODO (dylant-da): Re-enable this line if the -Wupgrade-exceptions
-            // flag on the compiler goes away and exception upgrades become an
-            // always-error
-            // Some(
-            //  "Tried to upgrade exception E, but exceptions cannot be upgraded. They should be removed in any upgrading package."
-            // ),
-            None,
-          )
-        ),
       )
     }
   }

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesCheckSpec.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesCheckSpec.scala
@@ -1209,9 +1209,13 @@ final class UpgradesCheckSpec extends AsyncWordSpec with Matchers with Inside {
           (
             "test-common/upgrades-FailsWhenAnInterfaceIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v1.dar",
             "test-common/upgrades-FailsWhenAnInterfaceIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v2.dar",
-            Some(
-              "Tried to upgrade interface I, but interfaces cannot be upgraded. They should be removed in any upgrading package."
-            ),
+            // TODO (dylant-da): Re-enable this test once the -Wupgrade-interfaces
+            // flag on the compiler goes away and interface upgrades are always an
+            // error
+            // Some(
+            //  "Tried to upgrade interface I, but interfaces cannot be upgraded. They should be removed in any upgrading package."
+            // ),
+            None,
           )
         ),
       )
@@ -1401,6 +1405,44 @@ final class UpgradesCheckSpec extends AsyncWordSpec with Matchers with Inside {
       testPackage(
         "test-common/upgrades-daml-script-lts-dep-lf17-on-lf17.dar",
         "Upload of .*package .* contains .*daml-script.* as a dependency.",
+      )
+    }
+
+    "Succeeds when an exception is only defined in the initial package." in {
+      testPackages(
+        Seq(
+          "test-common/upgrades-SucceedsWhenAnExceptionIsOnlyDefinedInTheInitialPackage-v1.dar",
+          "test-common/upgrades-SucceedsWhenAnExceptionIsOnlyDefinedInTheInitialPackage-v2.dar",
+        ),
+        Seq(
+          (
+            "test-common/upgrades-SucceedsWhenAnExceptionIsOnlyDefinedInTheInitialPackage-v1.dar",
+            "test-common/upgrades-SucceedsWhenAnExceptionIsOnlyDefinedInTheInitialPackage-v2.dar",
+            None,
+          )
+        ),
+      )
+    }
+
+    "Fails when an exception is defined in an upgrading package when it was already in the prior package." in {
+      testPackages(
+        Seq(
+          "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v1.dar",
+          "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v2.dar",
+        ),
+        Seq(
+          (
+            "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v1.dar",
+            "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v2.dar",
+            // TODO (dylant-da): Re-enable this test once the -Wupgrade-exceptions
+            // flag on the compiler goes away and exception upgrades are always an
+            // error
+            // Some(
+            //  "Tried to upgrade exception E, but exceptions cannot be upgraded. They should be removed in any upgrading package."
+            // ),
+            None,
+          )
+        ),
       )
     }
   }

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesCheckSpec.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesCheckSpec.scala
@@ -1209,9 +1209,9 @@ final class UpgradesCheckSpec extends AsyncWordSpec with Matchers with Inside {
           (
             "test-common/upgrades-FailsWhenAnInterfaceIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v1.dar",
             "test-common/upgrades-FailsWhenAnInterfaceIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v2.dar",
-            // TODO (dylant-da): Re-enable this test once the -Wupgrade-interfaces
-            // flag on the compiler goes away and interface upgrades are always an
-            // error
+            // TODO (dylant-da): Re-enable this line if the -Wupgrade-interfaces
+            // flag on the compiler goes away and interface upgrades become an
+            // always-error
             // Some(
             //  "Tried to upgrade interface I, but interfaces cannot be upgraded. They should be removed in any upgrading package."
             // ),
@@ -1434,9 +1434,9 @@ final class UpgradesCheckSpec extends AsyncWordSpec with Matchers with Inside {
           (
             "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v1.dar",
             "test-common/upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v2.dar",
-            // TODO (dylant-da): Re-enable this test once the -Wupgrade-exceptions
-            // flag on the compiler goes away and exception upgrades are always an
-            // error
+            // TODO (dylant-da): Re-enable this line if the -Wupgrade-exceptions
+            // flag on the compiler goes away and exception upgrades become an
+            // always-error
             // Some(
             //  "Tried to upgrade exception E, but exceptions cannot be upgraded. They should be removed in any upgrading package."
             // ),


### PR DESCRIPTION
Compiler-side flags let you disable this error, so the upload checker should allow it, otherwise we have a situation where the upload checks are stricter than the compiler checks.

Backport of https://github.com/digital-asset/daml/pull/20636
