### PR TITLE
Add warning for upload of daml-script

### DIFF
--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/admin/PackageUpgradeValidator.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/admin/PackageUpgradeValidator.scala
@@ -282,4 +282,24 @@ class PackageUpgradeValidator(
           (oldPkgId2, oldPkg2),
         )
     }
+
+  def warnDamlScriptUpload(
+      mainPackage: (Ref.PackageId, Ast.Package),
+      allPackages: List[(Ref.PackageId, Ast.Package)],
+  )(implicit
+      loggingContext: LoggingContextWithTrace
+  ): Unit = {
+    def showPackage(pkg: (Ref.PackageId, Ast.Package)): String =
+      s"${pkg._1} (${pkg._2.metadata.name}-${pkg._2.metadata.version})"
+
+    allPackages.foreach{case (pkgId, pkg) => pkg.metadata.name match {
+      case "daml-script" | "daml3-script" | "daml-script-lts" | "daml-script-lts-stable" =>
+        logger.warn(
+          "Upload of daml-script is deprecated, and will be prevented in Daml 3.3+. " +
+            s"Please remove the package ${showPackage((pkgId, pkg))} " +
+            s"from the dependencies of ${showPackage(mainPackage)}, and move any script tests to a separate package."
+        )
+      case _ =>
+    }}
+  }
 }

--- a/sdk/daml-lf/validation/BUILD.bazel
+++ b/sdk/daml-lf/validation/BUILD.bazel
@@ -323,6 +323,10 @@ da_scala_test_suite(
             "//test-common:upgrades-SucceedsWhenDepsDowngradeVersionsWithoutUsingDatatypes-dep-v2.dar",
             "//test-common:upgrades-SucceedsWhenDepsDowngradeVersionsWithoutUsingDatatypes-v1.dar",
             "//test-common:upgrades-SucceedsWhenDepsDowngradeVersionsWithoutUsingDatatypes-v2.dar",
+
+            # Tests for daml-script upload warning
+            "//test-common:upload-depends-on-script.dar",
+            "//test-common:upload-depends-on-script3.dar",
         ],
         flaky = True,
         scala_deps = [

--- a/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/UpgradeCheckMain.scala
+++ b/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/UpgradeCheckMain.scala
@@ -54,6 +54,8 @@ object UpgradeCheckMain {
         archive
       }
 
+      dars.foreach(dar => validator.warnDamlScriptUpload(dar.main, dar.all))
+
       val validation = validator.validateUpgrade(archives.toList)
       Await.result(validation.value, Duration.Inf) match {
         case Left(err: Validation.Upgradeability.Error) =>

--- a/sdk/test-common/BUILD.bazel
+++ b/sdk/test-common/BUILD.bazel
@@ -530,6 +530,21 @@ da_scala_dar_resources_library(
 ]
 
 [
+    daml_compile(
+        name = "upload-depends-on-script{}".format(scriptSuffix),
+        srcs = ["src/main/daml/upgrades/DependsOnScript/Main.daml"],
+        data_dependencies = ["//daml-script/daml{scriptSuffix}:daml{scriptSuffix}-script.dar".format(scriptSuffix = scriptSuffix)],
+        target = "2.1",
+        version = "1.0.0",
+        visibility = ["//visibility:public"],
+    )
+    for scriptSuffix in [
+        "",
+        "3",
+    ]
+]
+
+[
     [
         filegroup(
             name = "upgrades-{}-files".format(identifier),

--- a/sdk/test-common/src/main/daml/upgrades/DependsOnScript/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/DependsOnScript/Main.daml
@@ -1,0 +1,12 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+import Daml.Script
+
+main : Script ()
+main = pure ()
+
+data SomeSerializableType = SomeSerializableType
+


### PR DESCRIPTION
In 3.2, we will warn on upload of daml-script to canton. In 3.3, we will prevent it entirely.