### PR TITLE
Forbid daml-script at startup and upload time

### DIFF
--- a/sdk/canton/community/app-base/src/main/scala/com/digitalasset/canton/config/CantonConfig.scala
+++ b/sdk/canton/community/app-base/src/main/scala/com/digitalasset/canton/config/CantonConfig.scala
@@ -396,6 +396,7 @@ trait CantonConfig {
         // TODO(i21341) Remove the flag before going to production
         experimentalEnableTopologyEvents = participantParameters.experimentalEnableTopologyEvents,
         enableExternalAuthorization = participantParameters.enableExternalAuthorization,
+        allowDamlScriptUpload = participantParameters.allowDamlScriptUpload,
       )
     }
 

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/PackageServiceErrors.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/PackageServiceErrors.scala
@@ -330,5 +330,37 @@ object PackageServiceErrors extends PackageServiceErrorGroup {
             ),
           )
     }
+
+    @Explanation(
+      """Upload of Daml-Script is heavily deprecated in Daml 3.2, and will be forbidden in Daml 3.3"""
+    )
+    @Resolution(
+      """Remove Daml-Script from the dependencies of the uploaded package.
+        |For Daml 3.2 only, `parameters.allow-daml-script-upload = true` can be added to your participant config
+        |""".stripMargin
+    )
+    object IllegalDamlScriptUpload
+        extends ErrorCode(
+          id = "ILLEGAL_DAML_SCRIPT_UPLOAD",
+          ErrorCategory.InvalidIndependentOfSystemState,
+        ) {
+      final case class Error(
+          packages: List[(Ref.PackageId, Ref.PackageName, Ref.PackageVersion)]
+      )(implicit
+          val loggingContext: ContextualizedErrorLogger
+      ) extends DamlError(
+            cause = {
+              val packagesStr = packages.map{case (pkgId, pkgName, pkgVersion) => s"  - $pkgId ($pkgName-$pkgVersion)\n"}
+              s"Illegal upload of daml-script package(s)\n$packagesStr" +
+                "Uploading of daml-script to canton is deprecated in Daml 3.2, and will be disallowed in 3.3\n" +
+                "Please remove daml-script from the dependencies of the uploaded dar\n" +
+                "To temporarily avoid this error, add `parameters.allow-daml-script-upload = true` to your participant config, but be aware that this parameter will not exist in Daml 3.3"
+            },
+            extraContext = Map(
+              "packageIds" -> packages.map(_._1),
+              
+            ),
+          )
+    }
   }
 }

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/ParticipantNode.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/ParticipantNode.scala
@@ -534,10 +534,12 @@ class ParticipantNodeBootstrap(
               packageMetadataViewConfig = config.parameters.packageMetadataView,
               packageOps = createPackageOps(syncDomainPersistentStateManager),
               timeouts = parameterConfig.processingTimeouts,
+              allowDamlScriptUpload = parameterConfig.allowDamlScriptUpload,
             ),
           loggerFactory = loggerFactory,
         )
         _ <- EitherT.right(packageServiceContainer.initializeNext())
+        _ <- packageServiceContainer.asEval.value.checkForDamlScript()
 
         sequencerInfoLoader = new SequencerInfoLoader(
           parameterConfig.processingTimeouts,

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/ParticipantNodeParameters.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/ParticipantNodeParameters.scala
@@ -31,6 +31,7 @@ final case class ParticipantNodeParameters(
     unsafeEnableOnlinePartyReplication: Boolean,
     experimentalEnableTopologyEvents: Boolean,
     enableExternalAuthorization: Boolean,
+    allowDamlScriptUpload: Boolean,
 ) extends CantonNodeParameters
     with HasGeneralCantonNodeParameters {
   override def dontWarnOnDeprecatedPV: Boolean = protocolConfig.dontWarnOnDeprecatedPV
@@ -81,5 +82,6 @@ object ParticipantNodeParameters {
     unsafeEnableOnlinePartyReplication = false,
     experimentalEnableTopologyEvents = true,
     enableExternalAuthorization = false,
+    allowDamlScriptUpload = false,
   )
 }

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/config/LocalParticipantConfig.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/config/LocalParticipantConfig.scala
@@ -274,6 +274,7 @@ object TestingTimeServiceConfig {
   * @param packageMetadataView Initialization parameters for the package metadata in-memory store.
   * @param experimentalEnableTopologyEvents If true, topology events are propagated to the Ledger API clients
   * @param enableExternalAuthorization If true, external authentication is supported
+  * @param allowDamlScriptUpload Deprecated: Allow daml-script to be uploaded to the ledger. This will be removed in Daml 3.3.
   */
 final case class ParticipantNodeParameterConfig(
     adminWorkflow: AdminWorkflowConfig = AdminWorkflowConfig(),
@@ -307,6 +308,7 @@ final case class ParticipantNodeParameterConfig(
     unsafeEnableOnlinePartyReplication: Boolean = false,
     experimentalEnableTopologyEvents: Boolean = false,
     enableExternalAuthorization: Boolean = false,
+    allowDamlScriptUpload: Boolean = false,
 ) extends LocalNodeParametersConfig
 
 /** Parameters for the participant node's stores

--- a/sdk/canton/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/reassignment/DAMLeTestInstance.scala
+++ b/sdk/canton/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/reassignment/DAMLeTestInstance.scala
@@ -52,6 +52,7 @@ object DAMLeTestInstance {
       enableUpgradeValidation = false,
       futureSupervisor = FutureSupervisor.Noop,
       exitOnFatalFailures = true,
+      allowDamlScriptUpload = false,
       timeouts = timeouts,
       loggerFactory = loggerFactory,
       packageMetadataView = NoopPackageMetadataView,


### PR DESCRIPTION
Initial PR to test daml, will create a canton PR before merging anything here.