### PR TITLE
Forward port to 3.x: [TS] allows undefined to represent input of Optional (#19505)

### DIFF
--- a/sdk/daml-lf/encoder/src/test/lf/Synonym_all_.lf
+++ b/sdk/daml-lf/encoder/src/test/lf/Synonym_all_.lf
@@ -5,6 +5,6 @@ module SynonymMod {
 
   synonym Functor (f: * -> *) = <fmap: forall a b . (a -> b) -> f a -> f b> ;
 
-  val optionFunctorDict : |SynonymMod:Functor Option| = <fmap = ERROR @(forall a b. (a -> b) -> Option a -> Option b) "not implemented" > ;
+  val optionFunctorDict : ||SynonymMod:Functor Option|| = <fmap = ERROR @(forall a b. (a -> b) -> Option a -> Option b) "not implemented" > ;
 
 }

--- a/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
+++ b/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
@@ -78,6 +78,7 @@ private[parser] object Lexer extends RegexParsers {
       "]" ^^^ `]` |
       "*" ^^^ `*` |
       "=" ^^^ `=` |
+      "||" ^^^ `||` |
       "|" ^^^ `|` |
       """[a-zA-Z_\$][\w\$]*""".r ^^ (s => keywords.getOrElse(s, Id(s))) |
       """#\w+""".r ^^ ContractId |

--- a/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
+++ b/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
@@ -31,6 +31,7 @@ private[parser] object Token {
   case object `/\\` extends Token
   case object `_` extends Token
   case object `|` extends Token
+  case object `||` extends Token
   case object `cons` extends Token
   case object `nil` extends Token
   case object `some` extends Token

--- a/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/TypeParser.scala
+++ b/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/TypeParser.scala
@@ -62,7 +62,7 @@ private[parser] class TypeParser[P](parameters: ParserParameters[P]) {
     `<` ~>! rep1sep(fieldType, `,`) <~ `>` ^^ (fs => TStruct(Struct.assertFromSeq(fs)))
 
   private lazy val tTypeSynApp: Parser[Type] =
-    `|` ~> fullIdentifier ~ rep(typ0) <~ `|` ^^ { case id ~ tys => TSynApp(id, tys.to(ImmArray)) }
+    `||` ~> fullIdentifier ~ rep(typ0) <~ `||` ^^ { case id ~ tys => TSynApp(id, tys.to(ImmArray)) }
 
   lazy val typ0: Parser[Type] =
     `(` ~> typ <~ `)` |

--- a/sdk/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/sdk/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -119,6 +119,7 @@ class ParsersSpec(majorLanguageVersion: LanguageMajorVersion)
         "forall (a: *). Mod:T a" -> TForall((α.name, KStar), TApp(T, α)),
         "<f1: a, f2: Bool, f3:Mod:T>" ->
           TStruct(Struct.assertFromSeq(List(n"f1" -> α, n"f2" -> TBuiltin(BTBool), n"f3" -> T))),
+        "||Mod:T a||" -> TSynApp(T.tycon, ImmArray(α)),
       )
 
       forEvery(testCases)((stringToParse, expectedType) =>
@@ -531,7 +532,7 @@ class ParsersSpec(majorLanguageVersion: LanguageMajorVersion)
         """
           module Mod {
 
-            variant Tree (a : * ) = Leaf : Unit | Node : Mod:Tree.Node a ;
+            variant Tree (a : * ) = Node : Mod:Tree.Node a | Leaf : Unit | Undefined : Unit ;
             record Tree.Node (a: *) = { value: a, left : Mod:Tree a, right : Mod:Tree a };
             enum Color = Red | Green | Blue;
 
@@ -541,7 +542,9 @@ class ParsersSpec(majorLanguageVersion: LanguageMajorVersion)
       val varDef = DDataType(
         false,
         ImmArray(n"a" -> KStar),
-        DataVariant(ImmArray(n"Leaf" -> t"Unit", n"Node" -> t"Mod:Tree.Node a")),
+        DataVariant(
+          ImmArray(n"Node" -> t"Mod:Tree.Node a", n"Leaf" -> t"Unit", n"Undefined" -> t"Unit")
+        ),
       )
       val recDef = DDataType(
         false,

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/CollisionSpec.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/CollisionSpec.scala
@@ -155,7 +155,7 @@ class CollisionSpec(majorLanguageVersion: LanguageMajorVersion)
           metadata ( 'pkg' : '1.0.0' )
 
           module A {                    // fully resolved name: "A"
-            synonym B = |Mod:A|;        // fully resolved name: "A.B" (collision)
+            synonym B = ||Mod:A||;        // fully resolved name: "A.B" (collision)
           }
 
           module a.B {                  // fully resolved name: "a.B" (collision)
@@ -256,7 +256,7 @@ class CollisionSpec(majorLanguageVersion: LanguageMajorVersion)
           }
 
           module a.b {                    // fully resolved name: "A.B"
-            synonym c = |Mod:T|;          // fully resolved name: "A.B.C" (collision)
+            synonym c = ||Mod:T||;          // fully resolved name: "A.B.C" (collision)
           }
         """,
         // a package with case insensitive collision: a variant and a synonym have the same fully resoled name "A.B.C"
@@ -268,7 +268,7 @@ class CollisionSpec(majorLanguageVersion: LanguageMajorVersion)
           }
 
           module a.b {                    // fully resolved name: "A.B"
-            synonym c = |Mod:T|;          // fully resolved name: "A.B.C" (collision)
+            synonym c = ||Mod:T||;          // fully resolved name: "A.B.C" (collision)
           }
         """,
         // a package with case insensitive collision: a variant and a synonym have the same fully resoled name "A.B.C"
@@ -280,7 +280,7 @@ class CollisionSpec(majorLanguageVersion: LanguageMajorVersion)
           }
 
           module a.b {                    // fully resolved name: "A.B"
-            synonym c = |Mod:T|;          // fully resolved name: "A.B.C" (collision)
+            synonym c = ||Mod:T||;          // fully resolved name: "A.B.C" (collision)
           }
         """,
         // a package with case insensitive collision: two constructs have the same fully resoled name "A.B.C"
@@ -288,11 +288,11 @@ class CollisionSpec(majorLanguageVersion: LanguageMajorVersion)
           metadata ( 'pkg' : '1.0.0' )
 
           module A {                      // fully resolved name: "A"
-            synonym B.C = |Mod:T|;        // fully resolved name: "A.B.C"
+            synonym B.C = ||Mod:T||;      // fully resolved name: "A.B.C"
           }
 
           module a.b {                    // fully resolved name: "A.B"
-            synonym c = |Mod:T|;          // fully resolved name: "A.B.c"
+            synonym c = ||Mod:T||;        // fully resolved name: "A.B.c"
           }
         """,
         // a package with case insensitive collision: two constructs have the same fully resoled name "A.B.C"
@@ -300,11 +300,11 @@ class CollisionSpec(majorLanguageVersion: LanguageMajorVersion)
           metadata ( 'pkg' : '1.0.0' )
 
           module A {                      // fully resolved name: "A"
-            synonym B.C = |Mod:T|;        // fully resolved name: "A.B.C"
+            synonym B.C = ||Mod:T||;     // fully resolved name: "A.B.C"
           }
 
           module a.b {                    // fully resolved name: "A.B"
-            synonym c = |Mod:T|;          // fully resolved name: "A.B.c"
+            synonym c = ||Mod:T||;        // fully resolved name: "A.B.c"
           }
         """,
       )

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/RecursionSpec.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/RecursionSpec.scala
@@ -90,7 +90,7 @@ class RecursionSpec(majorLanguageVersion: LanguageMajorVersion)
          metadata ( 'pkg' : '1.0.0' )
          module Mod {
            synonym SynInt = Int64 ;
-           synonym SynSynInt = |Mod:SynInt| ;
+           synonym SynSynInt = ||Mod:SynInt|| ;
          }
        """
 
@@ -99,7 +99,7 @@ class RecursionSpec(majorLanguageVersion: LanguageMajorVersion)
       p"""
          metadata ( 'pkg' : '1.0.0' )
          module Mod {
-           synonym SynCycle = |Mod:SynCycle| ;
+           synonym SynCycle = ||Mod:SynCycle|| ;
          }
        """
 
@@ -109,8 +109,8 @@ class RecursionSpec(majorLanguageVersion: LanguageMajorVersion)
          metadata ( 'pkg' : '1.0.0' )
          module Mod {
            synonym SynInt = Int64 ;
-           synonym SynBad1 = |Mod:SynBad2| ;
-           synonym SynBad2 = List |Mod:SynBad1| ;
+           synonym SynBad1 = ||Mod:SynBad2|| ;
+           synonym SynBad2 = List ||Mod:SynBad1|| ;
          }
        """
 

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -649,7 +649,7 @@ abstract class TypingSpec(majorLanguageVersion: LanguageMajorVersion)
           { case _: EExpectedAnyType => },
         E"Λ (τ :⋆). λ (t: List (Option (∀ (α: ⋆). Int64))) → ⸨ to_any @(List (Option (∀ (α: ⋆). Int64))) t ⸩" -> //
           { case _: EExpectedAnyType => },
-        E"λ (e: |Mod:S|) → ⸨ to_any @|Mod:S| e ⸩" -> //
+        E"λ (e: ||Mod:S||) → ⸨ to_any @||Mod:S|| e ⸩" -> //
           { case _: EExpectedAnyType => },
         E"⸨ to_any @Int64 (Nil @Int64) ⸩" -> //
           { case _: ETypeMismatch => },
@@ -666,7 +666,7 @@ abstract class TypingSpec(majorLanguageVersion: LanguageMajorVersion)
           { case _: EExpectedAnyType => },
         E"Λ (τ :⋆). λ (t: Any) → ⸨ from_any @(List (Option (∀ (α: ⋆). Int64))) t ⸩" -> //
           { case _: EExpectedAnyType => },
-        E"λ (e: Any) → ⸨ from_any @|Mod:S| e ⸩" -> //
+        E"λ (e: Any) → ⸨ from_any @||Mod:S|| e ⸩" -> //
           { case _: EExpectedAnyType => },
         // ExpTypeRep
         E"⸨ type_rep @Mod:R ⸩" -> //
@@ -677,7 +677,7 @@ abstract class TypingSpec(majorLanguageVersion: LanguageMajorVersion)
           { case _: EExpectedAnyType => },
         E"⸨ type_rep @(∀(τ :⋆) . Int64) ⸩" -> //
           { case _: EExpectedAnyType => },
-        E"⸨ type_rep @|Mod:S| ⸩" -> //
+        E"⸨ type_rep @||Mod:S|| ⸩" -> //
           { case _: EExpectedAnyType => },
         // ExpToAnyException
         E"λ (r: Mod:T) → ⸨ to_any_exception @(Mod:T) r ⸩" -> //
@@ -691,7 +691,7 @@ abstract class TypingSpec(majorLanguageVersion: LanguageMajorVersion)
           { case _: EExpectedExceptionType => },
         E"Λ (τ :⋆). λ (t: ∀ (α : ⋆). Int64) → ⸨ to_any_exception @(∀ (α : ⋆). Int64) t ⸩" -> //
           { case _: EExpectedExceptionType => },
-        E"λ (e: |Mod:S|) → ⸨ to_any_exception  @|Mod:S| e ⸩" -> //
+        E"λ (e: ||Mod:S||) → ⸨ to_any_exception  @||Mod:S|| e ⸩" -> //
           { case _: EExpectedExceptionType => },
         E"λ (e: Mod:T) → ⸨ to_any_exception @(Mod:E) e ⸩" -> //
           { case _: ETypeMismatch => },
@@ -707,7 +707,7 @@ abstract class TypingSpec(majorLanguageVersion: LanguageMajorVersion)
           { case _: EExpectedExceptionType => },
         E"λ (t: ∀ (α : ⋆). Int64) → ⸨ from_any_exception @(∀ (α : ⋆). Int64) t ⸩" -> //
           { case _: EExpectedExceptionType => },
-        E"λ (e: Any) → ⸨ from_any_exception  @|Mod:S| e ⸩" -> //
+        E"λ (e: Any) → ⸨ from_any_exception  @||Mod:S|| e ⸩" -> //
           { case _: EExpectedExceptionType => },
         // ExpThrow
         E"⸨ throw @Mod:R @Mod:E nothing ⸩" -> //
@@ -730,7 +730,7 @@ abstract class TypingSpec(majorLanguageVersion: LanguageMajorVersion)
           { case _: EExpectedExceptionType => },
         E"Λ (τ :⋆). λ (e: ∀ (α : ⋆). Int64) →  ⸨ throw @τ @(∀ (α : ⋆). Int64) e ⸩" -> //
           { case _: EExpectedExceptionType => },
-        E"Λ (τ :⋆). λ (e: |Mod:S|) →  ⸨ throw @τ @(∀ (α : ⋆). Int64) e ⸩" -> //
+        E"Λ (τ :⋆). λ (e: ||Mod:S||) →  ⸨ throw @τ @(∀ (α : ⋆). Int64) e ⸩" -> //
           { case _: EExpectedExceptionType => },
         E"Λ (τ: ⋆) (σ: ⋆). λ (e: σ) →  ⸨ throw @τ @Mod:E e ⸩" -> //
           { case _: ETypeMismatch => },
@@ -1732,31 +1732,31 @@ abstract class TypingSpec(majorLanguageVersion: LanguageMajorVersion)
       val testCases = Table(
         "expression" ->
           "expected type",
-        E"(( λ (e : |Mod:SynInt|) → () )) " ->
+        E"(( λ (e : ||Mod:SynInt||) → () )) " ->
           T"(( Int64 → Unit ))",
-        E"(( λ (e : |Mod:SynSynInt|) → () )) " ->
+        E"(( λ (e : ||Mod:SynSynInt||) → () )) " ->
           T"(( Int64 → Unit ))",
-        E"(( λ (e : |Mod:SynIdentity Int64|) → () )) " ->
+        E"(( λ (e : ||Mod:SynIdentity Int64||) → () )) " ->
           T"(( Int64 → Unit ))",
-        E"(( λ (e : |Mod:SynIdentity |Mod:SynIdentity Int64||) → () )) " ->
+        E"(( λ (e : ||Mod:SynIdentity ||Mod:SynIdentity Int64|| ||) → () )) " ->
           T"(( Int64 → Unit ))",
-        E"(( λ (e : |Mod:SynList Date|) → () )) " ->
+        E"(( λ (e : ||Mod:SynList Date||) → () )) " ->
           T"(( List Date → Unit ))",
-        E"(( λ (e : |Mod:SynSelfFunc Text|) → () )) " ->
+        E"(( λ (e : ||Mod:SynSelfFunc Text||) → () )) " ->
           T"(( (Text → Text) → Unit ))",
-        E"(( λ (e : |Mod:SynFunc Text Date|) → () )) " ->
+        E"(( λ (e : ||Mod:SynFunc Text Date||) → () )) " ->
           T"(( (Text → Date) → Unit ))",
-        E"(( λ (e : |Mod:SynPair Text Date|) → () )) " ->
+        E"(( λ (e : ||Mod:SynPair Text Date||) → () )) " ->
           T"(( <one:Text, two: Date> → Unit ))",
         E"(( λ (e : forall (a:*) . a) → () )) " ->
           T"(( (forall (a:*) . a) → Unit ))",
-        E"(( λ (e : |Mod:SynIdentity (forall (a:*) . a)|) → () )) " ->
+        E"(( λ (e : ||Mod:SynIdentity (forall (a:*) . a)||) → () )) " ->
           T"(( (forall (a:*) . a) → Unit ))",
-        E"(( λ (e : forall (a:*) . |Mod:SynIdentity a|) → () )) " ->
+        E"(( λ (e : forall (a:*) . ||Mod:SynIdentity a||) → () )) " ->
           T"(( (forall (a:*) . a) → Unit ))",
-        E"(( λ (e : |Mod:SynHigh List|) → () )) " ->
+        E"(( λ (e : ||Mod:SynHigh List||) → () )) " ->
           T"(( List Int64 → Unit ))",
-        E"(( λ (e : |Mod:SynHigh2 GenMap Party|) → () )) " ->
+        E"(( λ (e : ||Mod:SynHigh2 GenMap Party||) → () )) " ->
           T"(( (GenMap Party Party) → Unit ))",
       )
 
@@ -1769,16 +1769,16 @@ abstract class TypingSpec(majorLanguageVersion: LanguageMajorVersion)
     "reject ill formed type synonym application" in {
       val testCases = Table(
         "badly formed type synonym application",
-        E"(( λ (e : |Mod:MissingSyn|) → () )) ",
-        E"(( λ (e : |Mod:SynInt Text|) → () )) ",
-        E"(( λ (e : |Mod:SynIdentity|) → () )) ",
-        E"(( λ (e : |Mod:SynIdentity Text Text|) → () )) ",
-        E"(( λ (e : |Mod:SynPair Text|) → () )) ",
-        E"(( λ (e : |Mod:SynPair Text Text Text|) → () )) ",
-        E"(( λ (e : |Mod:SynIdentity List|) → () )) ",
-        E"(( λ (e : |Mod:SynHigh Text|) → () )) ",
-        E"(( λ (e : |Mod:SynHigh GenMap|) → () )) ",
-        E"(( λ (e : |Mod:SynHigh2 List Party|) → () )) ",
+        E"(( λ (e : ||Mod:MissingSyn||) → () )) ",
+        E"(( λ (e : ||Mod:SynInt Text||) → () )) ",
+        E"(( λ (e : ||Mod:SynIdentity||) → () )) ",
+        E"(( λ (e : ||Mod:SynIdentity Text Text||) → () )) ",
+        E"(( λ (e : ||Mod:SynPair Text||) → () )) ",
+        E"(( λ (e : ||Mod:SynPair Text Text Text||) → () )) ",
+        E"(( λ (e : ||Mod:SynIdentity List||) → () )) ",
+        E"(( λ (e : ||Mod:SynHigh Text||) → () )) ",
+        E"(( λ (e : ||Mod:SynHigh GenMap||) → () )) ",
+        E"(( λ (e : ||Mod:SynHigh2 List Party||) → () )) ",
       )
 
       forEvery(testCases) { exp =>
@@ -1895,7 +1895,7 @@ abstract class TypingSpec(majorLanguageVersion: LanguageMajorVersion)
          enum Color = Red | Green | Blue ;
 
          synonym SynInt = Int64 ;
-         synonym SynSynInt = |Mod:SynInt| ;
+         synonym SynSynInt = ||Mod:SynInt|| ;
          synonym SynIdentity (a: *) = a ;
          synonym SynList (a: *) = List a ;
          synonym SynSelfFunc (a: *) = a -> a ;

--- a/sdk/language-support/ts/daml-types/index.test.ts
+++ b/sdk/language-support/ts/daml-types/index.test.ts
@@ -17,6 +17,7 @@ describe("@daml/types", () => {
   it("optional", () => {
     const dict = Optional(Text);
     expect(dict.decoder.run(null).ok).toBe(true);
+    expect(dict.decoder.run(undefined).ok).toBe(true);
     expect(dict.decoder.run("X").ok).toBe(true);
     expect(dict.decoder.run([]).ok).toBe(false);
     expect(dict.decoder.run(["X"]).ok).toBe(false);
@@ -25,12 +26,14 @@ describe("@daml/types", () => {
   it("nested optionals", () => {
     const dict = Optional(Optional(Text));
     expect(dict.decoder.run(null).ok).toBe(true);
+    expect(dict.decoder.run(undefined).ok).toBe(true);
     expect(dict.decoder.run([]).ok).toBe(true);
     expect(dict.decoder.run(["X"]).ok).toBe(true);
     expect(dict.decoder.run("X").ok).toBe(false);
     expect(dict.decoder.run([["X"]]).ok).toBe(false);
     expect(dict.decoder.run([[]]).ok).toBe(false);
     expect(dict.decoder.run([null]).ok).toBe(false);
+    expect(dict.decoder.run([undefined]).ok).toBe(false);
   });
   it("genmap", () => {
     const { encode, decoder } = Map(Text, Text);

--- a/sdk/language-support/ts/daml-types/index.ts
+++ b/sdk/language-support/ts/daml-types/index.ts
@@ -564,7 +564,9 @@ class OptionalWorker<T> implements Serializable<Optional<T>> {
         }
       };
     }
-    this.decoder = jtv.oneOf(jtv.constant(null), this.innerDecoder);
+    this.decoder = jtv
+      .optional(jtv.oneOf(jtv.constant(null), this.innerDecoder))
+      .map(x => (x === undefined ? null : x));
   }
 }
 


### PR DESCRIPTION
Identical forward port of https://github.com/digital-asset/daml/pull/19505 and https://github.com/digital-asset/daml/pull/20066