### PR TITLE
Allow LF17 when decoding dars, change LF1.16 for LF1.17 in a few places (#19774)

### DIFF
--- a/sdk/daml-lf/archive/src/main/protobuf/com/digitalasset/daml/lf/archive/daml_lf1.proto
+++ b/sdk/daml-lf/archive/src/main/protobuf/com/digitalasset/daml/lf/archive/daml_lf1.proto
@@ -52,6 +52,8 @@
 // * 13 -- 2021-04-06: Add BigNumeric
 // * 14 -- 2021-03-06: Add Exception
 // * 15 -- 2022-06-18: Add Interfaces
+// * 16 -- 2024-08-13: **Declared broken**
+// * 17 -- 2024-08-13: Upgrade support
 // * dev (special staging area for the next version to be released)
 
 syntax = "proto3";
@@ -1394,7 +1396,7 @@ message Update {
     Expr arg = 4;
 
     // exercise guard (Interface -> Bool)
-    Expr guard = 5;  // *optional*  *Available in versions >= 1.16*
+    Expr guard = 5;  // *optional*  *Available in versions >= 1.17*
   }
 
  // ExerciseByKey Update

--- a/sdk/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMajorVersion.scala
+++ b/sdk/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMajorVersion.scala
@@ -52,7 +52,7 @@ object LanguageMajorVersion {
   case object V1
       extends LanguageMajorVersion(
         pretty = "1",
-        minorAscending = List("6", "7", "8", "11", "12", "13", "14", "15"),
+        minorAscending = List("6", "7", "8", "11", "12", "13", "14", "15", "17"),
       )
 
   case object V2

--- a/sdk/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/sdk/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -43,7 +43,7 @@ object LanguageVersion {
   val AllV1 = Major.V1.supportedMinorVersions.map(LanguageVersion(Major.V1, _))
   val AllV2 = Major.V2.supportedMinorVersions.map(LanguageVersion(Major.V2, _))
 
-  val List(v1_6, v1_7, v1_8, v1_11, v1_12, v1_13, v1_14, v1_15, v1_dev) = AllV1: @nowarn(
+  val List(v1_6, v1_7, v1_8, v1_11, v1_12, v1_13, v1_14, v1_15, v1_17, v1_dev) = AllV1: @nowarn(
     "msg=match may not be exhaustive"
   )
   val List(v2_1, v2_dev) = AllV2: @nowarn("msg=match may not be exhaustive")

--- a/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
+++ b/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
@@ -735,15 +735,15 @@ case class TypecheckUpgrades(
     val compatibleNames = past.qualifiedName == present.qualifiedName
     val compatiblePackages =
       (packageMap.get(past.packageId), packageMap.get(present.packageId)) match {
-        // The two packages have LF versions < 1.16.
-        // They must be the exact same package as LF < 1.16 don't support upgrades.
+        // The two packages have LF versions < 1.17.
+        // They must be the exact same package as LF < 1.17 don't support upgrades.
         case (None, None) => past.packageId == present.packageId
-        // The two packages have LF versions >= 1.16.
+        // The two packages have LF versions >= 1.17.
         // The present package must be a valid upgrade of the past package. Since we validate uploaded packages in
         // topological order, the package version ordering is a proxy for the "upgrades" relationship.
         case (Some((pastName, pastVersion)), Some((presentName, presentVersion))) =>
           pastName == presentName && pastVersion <= presentVersion
-        // LF versions < 1.16 and >= 1.16 are not comparable.
+        // LF versions < 1.17 and >= 1.17 are not comparable.
         case (_, _) => false
       }
     compatibleNames && compatiblePackages

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -480,14 +480,14 @@ class IdeLedgerClient(
     makeEmptySubmissionError(script.Error.PartiesNotAllocated(unallocatedSubmitters))
 
   /* Given a daml-script CommandWithMeta, returns the corresponding IDE Ledger
-   * ApiCommand. If the CommandWithMeta has an explicit package id, or is <LF1.16,
+   * ApiCommand. If the CommandWithMeta has an explicit package id, or is <LF1.17,
    * the ApiCommand will have the same PackageRef, otherwise it will be
    * replaced with PackageRef.Name, such that the preprocess will replace it
    * according to package resolution
    */
   private def toCommand(
       cmdWithMeta: ScriptLedgerClient.CommandWithMeta,
-      // This map only contains packageIds >=LF1.16
+      // This map only contains packageIds >=LF1.17
       packageIdMap: PartialFunction[PackageId, ScriptLedgerClient.ReadablePackageId],
   ): ApiCommand = {
     def adjustTypeConRef(old: TypeConRef): TypeConRef =

--- a/sdk/daml-script/test/daml/upgrades/README.md
+++ b/sdk/daml-script/test/daml/upgrades/README.md
@@ -59,7 +59,7 @@ name: my-package
 versions: 2
 lf-version:
   1.15 -- @V 1
-  1.16 -- @V  2
+  1.17 -- @V  2
 depends:
   my-other-package-0.0.1 -- @V 1
   my-other-package-0.0.2 -- @V  2


### PR DESCRIPTION
Essentially forwardports those parts of #19774 which are still relevant