### PR TITLE
Enable interfaces by default on 3.x

### DIFF
--- a/sdk/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/sdk/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -2625,9 +2625,7 @@ checkInterfacesEnabled :: Env -> ConvertM ()
 checkInterfacesEnabled env =
   unless (getEnableInterfaces (envEnableInterfaces env)) do
     unsupported
-      "Interfaces are forbidden by default. To enable them, add \
-      \`--enable-interfaces=yes` to `build-options` in the project's \
-      \`daml.yaml` file."
+      "Interfaces have been disabled by the `--enable-interfaces=no` flag. To enable them, remove that flag from the `build-options` in this project's daml.yaml file"
       ()
 
 ---------------------------------------------------------------------

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -257,12 +257,12 @@ studioAutorunAllScriptsOpt =
 
 enableInterfacesOpt :: Parser EnableInterfaces
 enableInterfacesOpt = EnableInterfaces <$>
-    flagYesNoAuto "enable-interfaces" False desc internal
+    flagYesNoAuto "enable-interfaces" True desc internal
     where
         desc =
             "Enable/disable support for interfaces as a language feature. \
             \If disabled, defining interfaces and interface instances is a compile-time error. \
-            \Off by default."
+            \On by default."
 
 dlintRulesFileParser :: Parser DlintRulesFile
 dlintRulesFileParser =

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -656,7 +656,6 @@ tests damlc =
           , "  - daml-stdlib"
           , "build-options:"
           , "  - --target=" <> LF.renderVersion lfVersion
-          , "  - --enable-interfaces=yes"
           ]
             ++ ["  - --typecheck-upgrades=no" | not doTypecheck]
             ++ ["  - -Wupgrade-interfaces" | warnBadInterfaceInstances ]

--- a/sdk/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -2279,7 +2279,7 @@ tests TestArgs{..} =
           damlYamlBody name extraDeps dataDeps = unlines
             [ "sdk-version: " <> sdkVersion
             , "name: " <> name
-            , "build-options: [--target="<> LF.renderVersion targetDevVersion <>", --enable-interfaces=yes]"
+            , "build-options: [--target="<> LF.renderVersion targetDevVersion <>"]"
             , "source: ."
             , "version: 0.1.0"
             , "dependencies: [" <> intercalate ", " (["daml-prim", "daml-stdlib"] <> fmap show extraDeps) <> "]"
@@ -2733,7 +2733,6 @@ tests TestArgs{..} =
     defTestOptions = DataDependenciesTestOptions
         { buildOptions =
             [ "--target=" <> LF.renderVersion targetDevVersion
-            , "--enable-interfaces=yes"
             , "-Wupgrade-interfaces"
             ]
         , extraDeps = []

--- a/sdk/compiler/damlc/tests/src/DamlcTest.hs
+++ b/sdk/compiler/damlc/tests/src/DamlcTest.hs
@@ -104,7 +104,6 @@ testsForDamlcValidate damlc = testGroup "damlc validate-dar"
         , "source: ."
         , "dependencies: [daml-prim, daml-stdlib]"
         , "build-options:"
-        , "- --enable-interfaces=yes"
         , "- -Wupgrade-interfaces"
         ]
       writeFileUTF8 (projDir </> "Good.daml") $ unlines
@@ -132,7 +131,6 @@ testsForDamlcValidate damlc = testGroup "damlc validate-dar"
         , "source: ."
         , "dependencies: [daml-prim, daml-stdlib]"
         , "build-options:"
-        , "- --enable-interfaces=yes"
         , "- -Wupgrade-interfaces"
         ]
       writeFileUTF8 (projDir </> "Interface.daml") $ unlines

--- a/sdk/daml-script/test/src/test-utils/scala/com/digitalasset/daml/lf/engine/script/test/UpgradeTestUtil.scala
+++ b/sdk/daml-script/test/src/test-utils/scala/com/digitalasset/daml/lf/engine/script/test/UpgradeTestUtil.scala
@@ -212,7 +212,7 @@ object UpgradeTestUtil {
         dataDeps =
           dataDeps.map(dar => DataDep(dar.path, Some((dar.versionedName, s"V${dar.version}")))),
         tmpDir = Some(tmpDir),
-        opts = Seq("--enable-interfaces=yes"),
+        opts = Seq(),
       )
     }
   }

--- a/sdk/docs/source/daml-script/template-root/daml.yaml.template
+++ b/sdk/docs/source/daml-script/template-root/daml.yaml.template
@@ -5,7 +5,6 @@ version: 0.0.1
 # script-build-options-begin
 build-options:
   - --target=2.1
-  - --enable-interfaces=yes
   - -Wupgrade-interfaces
 # script-build-options-end
 # script-dependencies-begin

--- a/sdk/rules_daml/daml.bzl
+++ b/sdk/rules_daml/daml.bzl
@@ -359,8 +359,7 @@ def daml_compile(
         stdout = name + ".stdout",
         ghc_options =
             ghc_options +
-            (["--enable-scenarios=yes"] if enable_scenarios and (target == None or _supports_scenarios(target)) else []) +
-            (["--enable-interfaces=yes"] if enable_interfaces else []),
+            (["--enable-scenarios=yes"] if enable_scenarios and (target == None or _supports_scenarios(target)) else []),
         damlc = damlc_for_target(target),
         **kwargs
     )
@@ -538,7 +537,7 @@ $$DAMLC test {enable_interfaces} {damlc_opts} --files {files}
             deps = " ".join(["$(rootpaths %s)" % dep for dep in deps]),
             data_deps = " ".join(["$(rootpaths %s)" % dep for dep in data_deps]),
             module_prefixes = "\n".join(["  {}: {}".format(k, v) for k, v in module_prefixes.items()]),
-            enable_interfaces = "--enable-interfaces=yes" if enable_interfaces else "",
+            enable_interfaces = "--enable-interfaces=no" if not enable_interfaces else "",
             damlc_opts = " ".join(default_damlc_opts + additional_compiler_flags),
             cp_srcs = "\n".join([
                 "mkdir -p $$(dirname {dest}); cp -f {src} {dest}".format(

--- a/sdk/rules_daml/daml.bzl
+++ b/sdk/rules_daml/daml.bzl
@@ -359,7 +359,8 @@ def daml_compile(
         stdout = name + ".stdout",
         ghc_options =
             ghc_options +
-            (["--enable-scenarios=yes"] if enable_scenarios and (target == None or _supports_scenarios(target)) else []),
+            (["--enable-scenarios=yes"] if enable_scenarios and (target == None or _supports_scenarios(target)) else []) +
+            (["--enable-interfaces=no"] if not enable_interfaces and using_local_compiler(target) else []),
         damlc = damlc_for_target(target),
         **kwargs
     )


### PR DESCRIPTION
Addresses https://github.com/DACH-NY/canton/issues/23828

Making the flag on by default is equivalent to making the SDK have that flag - it essentially dispatches to `daml build` internally.