### PR TITLE
Revert commenting out the removal of POSTGRESQL_ROOT_DIR in build.sh

### DIFF
--- a/sdk/build.sh
+++ b/sdk/build.sh
@@ -127,7 +127,7 @@ function start_postgresql() {
 function stop_postgresql() {
   if [[ -e "$POSTGRESQL_DATA_DIR" ]]; then
     bazel run -- @postgresql_dev_env//:pg_ctl -w --pgdata="$POSTGRESQL_DATA_DIR" --mode=immediate stop || :
-    #rm -rf "$POSTGRESQL_ROOT_DIR"
+    rm -rf "$POSTGRESQL_ROOT_DIR"
   fi
 }
 trap stop_postgresql EXIT


### PR DESCRIPTION
What it says on the tin - I accidentally commented out a line while debugging https://github.com/digital-asset/daml/pull/20741 and committed/merged it, just need a rubber stamp to revert that.