### PR TITLE
Port Upgrade error changes

### DIFF
--- a/sdk/canton/base/daml-errors/src/main/scala/com/daml/error/ErrorResource.scala
+++ b/sdk/canton/base/daml-errors/src/main/scala/com/daml/error/ErrorResource.scala
@@ -34,7 +34,7 @@ object ErrorResource {
   lazy val SynchronizerId: ErrorResource = ErrorResource("SYNCHRONIZER_ID")
   lazy val SynchronizerAlias: ErrorResource = ErrorResource("SYNCHRONIZER_ALIAS")
   lazy val Offset: ErrorResource = ErrorResource("OFFSET")
-  lazy val UpgradeErrorType: ErrorResource = ErrorResource("UPGRADE_ERROR_TYPE")
+  lazy val FieldType: ErrorResource = ErrorResource("FIELD_TYPE")
 
   lazy val all: Seq[ErrorResource] = Seq(
     CommandId,
@@ -48,6 +48,7 @@ object ErrorResource {
     ExceptionText,
     ExceptionType,
     ExceptionValue,
+    FieldType,
     IdentityProviderConfig,
     InterfaceId,
     Offset,
@@ -58,7 +59,6 @@ object ErrorResource {
     SynchronizerId,
     TemplateId,
     TransactionId,
-    UpgradeErrorType,
     User,
   )
 

--- a/sdk/canton/base/daml-errors/src/main/scala/com/daml/error/ErrorResource.scala
+++ b/sdk/canton/base/daml-errors/src/main/scala/com/daml/error/ErrorResource.scala
@@ -35,6 +35,7 @@ object ErrorResource {
   lazy val SynchronizerAlias: ErrorResource = ErrorResource("SYNCHRONIZER_ALIAS")
   lazy val Offset: ErrorResource = ErrorResource("OFFSET")
   lazy val ExpectedType: ErrorResource = ErrorResource("EXPECTED_TYPE")
+  lazy val FieldIndex: ErrorResource = ErrorResource("FIELD_INDEX")
 
   lazy val all: Seq[ErrorResource] = Seq(
     CommandId,
@@ -49,6 +50,7 @@ object ErrorResource {
     ExceptionType,
     ExceptionValue,
     ExpectedType,
+    FieldIndex,
     IdentityProviderConfig,
     InterfaceId,
     Offset,

--- a/sdk/canton/base/daml-errors/src/main/scala/com/daml/error/ErrorResource.scala
+++ b/sdk/canton/base/daml-errors/src/main/scala/com/daml/error/ErrorResource.scala
@@ -34,7 +34,7 @@ object ErrorResource {
   lazy val SynchronizerId: ErrorResource = ErrorResource("SYNCHRONIZER_ID")
   lazy val SynchronizerAlias: ErrorResource = ErrorResource("SYNCHRONIZER_ALIAS")
   lazy val Offset: ErrorResource = ErrorResource("OFFSET")
-  lazy val FieldType: ErrorResource = ErrorResource("FIELD_TYPE")
+  lazy val ExpectedType: ErrorResource = ErrorResource("EXPECTED_TYPE")
 
   lazy val all: Seq[ErrorResource] = Seq(
     CommandId,
@@ -48,7 +48,7 @@ object ErrorResource {
     ExceptionText,
     ExceptionType,
     ExceptionValue,
-    FieldType,
+    ExpectedType,
     IdentityProviderConfig,
     InterfaceId,
     Offset,

--- a/sdk/canton/base/daml-errors/src/main/scala/com/daml/error/ErrorResource.scala
+++ b/sdk/canton/base/daml-errors/src/main/scala/com/daml/error/ErrorResource.scala
@@ -34,6 +34,7 @@ object ErrorResource {
   lazy val SynchronizerId: ErrorResource = ErrorResource("SYNCHRONIZER_ID")
   lazy val SynchronizerAlias: ErrorResource = ErrorResource("SYNCHRONIZER_ALIAS")
   lazy val Offset: ErrorResource = ErrorResource("OFFSET")
+  lazy val UpgradeErrorType: ErrorResource = ErrorResource("UPGRADE_ERROR_TYPE")
 
   lazy val all: Seq[ErrorResource] = Seq(
     CommandId,
@@ -49,15 +50,16 @@ object ErrorResource {
     ExceptionValue,
     IdentityProviderConfig,
     InterfaceId,
+    Offset,
     PackageName,
     Parties,
     Party,
+    SynchronizerAlias,
+    SynchronizerId,
     TemplateId,
     TransactionId,
+    UpgradeErrorType,
     User,
-    SynchronizerId,
-    SynchronizerAlias,
-    Offset,
   )
 
   def fromString(str: String): Option[ErrorResource] = all.find(_.asString == str)

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
@@ -144,6 +144,9 @@ object RejectionGenerators {
         case e: LfInterpretationError.ValueNesting =>
           CommandExecutionErrors.Interpreter.ValueNesting
             .Reject(renderedMessage, e)
+        case LfInterpretationError.Upgrade(error) =>
+          CommandExecutionErrors.Interpreter.UpgradeError
+            .Reject(renderedMessage, error)
         case LfInterpretationError.Dev(_, err) =>
           CommandExecutionErrors.Interpreter.InterpretationDevError
             .Reject(renderedMessage, err)

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
@@ -155,6 +155,11 @@ object RejectionGenerators {
         case LfInterpretationError.Upgrade(error: LfInterpretationError.Upgrade.ViewMismatch) =>
           CommandExecutionErrors.Interpreter.UpgradeError.ViewMismatch
             .Reject(renderedMessage, error)
+        case LfInterpretationError.Upgrade(
+              error: LfInterpretationError.Upgrade.DowngradeFailed
+            ) =>
+          CommandExecutionErrors.Interpreter.UpgradeError.DowngradeFailed
+            .Reject(renderedMessage, error)
         case LfInterpretationError.Dev(_, err) =>
           CommandExecutionErrors.Interpreter.InterpretationDevError
             .Reject(renderedMessage, err)

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
@@ -144,8 +144,16 @@ object RejectionGenerators {
         case e: LfInterpretationError.ValueNesting =>
           CommandExecutionErrors.Interpreter.ValueNesting
             .Reject(renderedMessage, e)
-        case LfInterpretationError.Upgrade(error) =>
-          CommandExecutionErrors.Interpreter.UpgradeError
+        case LfInterpretationError.Upgrade(error: LfInterpretationError.Upgrade.ValidationFailed) =>
+          CommandExecutionErrors.Interpreter.UpgradeError.ValidationFailed
+            .Reject(renderedMessage, error)
+        case LfInterpretationError.Upgrade(
+              error: LfInterpretationError.Upgrade.DowngradeDropDefinedField
+            ) =>
+          CommandExecutionErrors.Interpreter.UpgradeError.DowngradeDropDefinedField
+            .Reject(renderedMessage, error)
+        case LfInterpretationError.Upgrade(error: LfInterpretationError.Upgrade.ViewMismatch) =>
+          CommandExecutionErrors.Interpreter.UpgradeError.ViewMismatch
             .Reject(renderedMessage, error)
         case LfInterpretationError.Dev(_, err) =>
           CommandExecutionErrors.Interpreter.InterpretationDevError

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
@@ -792,7 +792,7 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
             ) {
           override def resources: Seq[(ErrorResource, String)] =
             Seq(
-              (ErrorResource.FieldType, err.expectedType.pretty)
+              (ErrorResource.ExpectedType, err.expectedType.pretty)
             )
         }
       }

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
@@ -51,6 +51,9 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
       f,
     )
 
+  def encodeParties(parties: Set[Ref.Party]): Seq[(ErrorResource, String)] =
+    Seq((ErrorResource.Parties, parties.mkString(",")))
+
   @Explanation(
     """This error occurs if the participant fails to execute a transaction via the interactive submission service.
       |"""
@@ -734,7 +737,7 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
     }
 
     @Explanation("Errors that occur when trying to upgrade a contract")
-    object UpgradeError {
+    object UpgradeError extends ErrorGroup {
       @Explanation("Validation fails when trying to upgrade the contract")
       @Resolution(
         "Verify that neither the signatories, nor the observers, nor the contract key, nor the key's maintainers have changed"
@@ -753,19 +756,18 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
               cause = cause
             ) {
 
-          override def resources: Seq[(ErrorResource, String)] =
+          override def resources: Seq[(ErrorResource, String)] = {
+            val optKeyResources = err.keyOpt.fold(Seq.empty[(ErrorResource, String)])(key =>
+              withEncodedValue(key.globalKey.key) { encodedKey =>
+                Seq((ErrorResource.ContractKey, encodedKey), (ErrorResource.PackageName, key.globalKey.packageName)) ++ encodeParties(key.maintainers)
+            })
+
             Seq(
               (ErrorResource.ContractId, err.coid.coid),
               (ErrorResource.TemplateId, err.srcTemplateId.toString),
               (ErrorResource.TemplateId, err.dstTemplateId.toString),
-              (ErrorResource.Parties, err.signatories.toString),
-              (ErrorResource.Parties, err.observers.toString),
-            ) ++ err.keyOpt.fold(Seq.empty[(ErrorResource, String)])(key =>
-              Seq(
-                (ErrorResource.ContractKey, key.globalKey.toString),
-                (ErrorResource.Parties, key.maintainers.toString),
-              )
-            )
+            ) ++ encodeParties(err.signatories) ++ encodeParties(err.observers) ++ optKeyResources
+          }
         }
       }
 
@@ -773,7 +775,7 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
         "An optional contract field with a value of Some may not be dropped during downgrading"
       )
       @Resolution(
-        "Ensure optional contract fields with a value of Some are not dropped"
+        "There is data that is newer than the implementation using it, and thus is not compatible. Ensure new data (i.e. those with additional fields as `Some`) is only used with new/compatible choices"
       )
       object DowngradeDropDefinedField
           extends ErrorCode(
@@ -797,7 +799,7 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
 
       @Explanation("View mismatch when trying to upgrade the contract")
       @Resolution(
-        "Verify that the views of the contract have not changed"
+        "Verify that the interface views of the contract have not changed"
       )
       object ViewMismatch
           extends ErrorCode(

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
@@ -733,6 +733,29 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
       ) extends DamlErrorWithDefiniteAnswer(cause = cause) {}
     }
 
+    // TODO https://github.com/digital-asset/daml/issues/18616: use a non-Dev based error code
+    @Explanation("Upgrade validation fails when trying to upgrade the contract")
+    @Resolution("Verify that neither the signatories, nor the observers, nor the contract key, nor the key's maintainers have changed")
+    object UpgradeError extends ErrorCode(
+      id = "INTERPRETATION_UPGRADE_ERROR",
+      ErrorCategory.InvalidGivenCurrentSystemStateOther,
+    ) {
+      final case class Reject(
+                               override val cause: String,
+                               err: LfInterpretationError.Upgrade.Error,
+                             )(implicit
+                               loggingContext: ContextualizedErrorLogger
+                             ) extends DamlErrorWithDefiniteAnswer(
+        cause = cause
+      ) {
+
+        override def resources: Seq[(ErrorResource, String)] =
+          Seq(
+            (ErrorResource.DevErrorType, err.getClass.getSimpleName)
+          )
+      }
+    }
+
     @Explanation(
       """This error is a catch-all for errors thrown by in-development features, and should never be thrown in production."""
     )

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
@@ -733,7 +733,6 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
       ) extends DamlErrorWithDefiniteAnswer(cause = cause) {}
     }
 
-    // TODO https://github.com/digital-asset/daml/issues/18616: use a non-Dev based error code
     @Explanation("Upgrade validation fails when trying to upgrade the contract")
     @Resolution("Verify that neither the signatories, nor the observers, nor the contract key, nor the key's maintainers have changed")
     object UpgradeError extends ErrorCode(
@@ -751,7 +750,8 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
 
         override def resources: Seq[(ErrorResource, String)] =
           Seq(
-            (ErrorResource.DevErrorType, err.getClass.getSimpleName)
+            // Class name is reported to help clients (e.g. daml-script) discriminate the type of upgrade error
+            (ErrorResource.UpgradeErrorType, err.getClass.getSimpleName)
           )
       }
     }

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
@@ -792,7 +792,8 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
             ) {
           override def resources: Seq[(ErrorResource, String)] =
             Seq(
-              (ErrorResource.ExpectedType, err.expectedType.pretty)
+              (ErrorResource.ExpectedType, err.expectedType.pretty),
+              (ErrorResource.FieldIndex, err.fieldIndex.toString),
             )
         }
       }
@@ -821,6 +822,32 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
               (ErrorResource.InterfaceId, err.iterfaceId.toString),
               (ErrorResource.TemplateId, err.srcTemplateId.toString),
               (ErrorResource.TemplateId, err.dstTemplateId.toString),
+            )
+        }
+      }
+
+      @Explanation(
+        "An optional contract field with a value of Some may not be dropped during downgrading"
+      )
+      @Resolution(
+        "There is data that is newer than the implementation using it, and thus is not compatible. Ensure new data (i.e. those with additional fields as `Some`) is only used with new/compatible choices"
+      )
+      object DowngradeFailed
+        extends ErrorCode(
+          id = "INTERPRETATION_UPGRADE_ERROR_DOWNGRADE_FAILED",
+          ErrorCategory.InvalidGivenCurrentSystemStateOther,
+        ) {
+        final case class Reject(
+            override val cause: String,
+            err: LfInterpretationError.Upgrade.DowngradeFailed,
+        )(implicit
+            loggingContext: ContextualizedErrorLogger
+        ) extends DamlErrorWithDefiniteAnswer(
+              cause = cause
+            ) {
+          override def resources: Seq[(ErrorResource, String)] =
+            Seq(
+              (ErrorResource.ExpectedType, err.expectedType.pretty),
             )
         }
       }

--- a/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/Conversions.scala
+++ b/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/Conversions.scala
@@ -258,14 +258,20 @@ final class Conversions(
                       speedy.Pretty.prettyDamlException(interpretationError).render(80)
                     )
                   case _: Dev.Upgrade =>
+                    // TODO https://github.com/digital-asset/daml/issues/18616: remove this case when issue completes
                     proto.ScriptError.UpgradeError.newBuilder.setMessage(
                       speedy.Pretty.prettyDamlException(interpretationError).render(80)
                     )
                 }
+              case _: Upgrade =>
+                proto.ScriptError.UpgradeError.newBuilder.setMessage(
+                  speedy.Pretty.prettyDamlException(interpretationError).render(80)
+                )
               case err @ Dev(_, _) =>
                 builder.setCrash(s"Unexpected Dev error: " + err.toString)
             }
         }
+
       case Error.ContractNotEffective(coid, tid, effectiveAt) =>
         builder.setScriptContractNotEffective(
           proto.ScriptError.ContractNotEffective.newBuilder

--- a/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/Conversions.scala
+++ b/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/Conversions.scala
@@ -257,11 +257,6 @@ final class Conversions(
                     proto.ScriptError.CCTPError.newBuilder.setMessage(
                       speedy.Pretty.prettyDamlException(interpretationError).render(80)
                     )
-                  case _: Dev.Upgrade =>
-                    // TODO https://github.com/digital-asset/daml/issues/18616: remove this case when issue completes
-                    proto.ScriptError.UpgradeError.newBuilder.setMessage(
-                      speedy.Pretty.prettyDamlException(interpretationError).render(80)
-                    )
                 }
               case _: Upgrade =>
                 proto.ScriptError.UpgradeError.newBuilder.setMessage(

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -149,10 +149,9 @@ private[lf] object Pretty {
                   text("recomputed maintainers are") & prettyParties(key.maintainers) /
                     text("recomputed key is") & prettyValue(verbose = false)(key.value)
               })
-          case Upgrade.DowngradeDropDefinedField(_, _) =>
-            text(
-              "An optional contract field with a value of Some may not be dropped during downgrading"
-            )
+          case Upgrade.DowngradeDropDefinedField(_, fieldIndex, _) =>
+            text(s"An optional contract field (field offset $fieldIndex)") /
+              text("with a value of Some may not be dropped during downgrading")
           case Upgrade.ViewMismatch(
                 coid,
                 iterfaceId,
@@ -176,6 +175,9 @@ private[lf] object Pretty {
                 "in the destination contract is"
               ) & prettyValue(false)(dstViewValue)
           }
+          case Upgrade.DowngradeFailed(expectedType, actualValue) =>
+            text("Attempt to downgrade ") & prettyValue(false)(actualValue) /
+              text(s" to the variant or enum constructor type ${expectedType.pretty}")
         }
       case Dev(_, error) =>
         error match {

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -120,6 +120,35 @@ private[lf] object Pretty {
           prettyContractId(key.cids.head)
       case ValueNesting(limit) =>
         text(s"Value exceeds maximum nesting value of $limit")
+      case Upgrade(
+            Upgrade.ValidationFailed(
+              coid,
+              srcTemplateId,
+              dstTemplateId,
+              signatories,
+              observers,
+              keyOpt,
+              _,
+            )
+          ) =>
+        text("Validation fails when trying to upgrade the contract") & prettyContractId(
+          coid
+        ) & text("from") & prettyTypeConName(srcTemplateId) & text(
+          "to"
+        ) & prettyTypeConName(
+          dstTemplateId
+        ) /
+          text(
+            "Verify that neither the signatories, nor the observers, nor the contract key, nor the key's maintainers have changed"
+          ) /
+          text("recomputed signatories are") & prettyParties(signatories) /
+          text("recomputed observers are") & prettyParties(observers) /
+          (keyOpt match {
+            case None => Doc.empty
+            case Some(key) =>
+              text("recomputed maintainers are") & prettyParties(key.maintainers) /
+                text("recomputed key is") & prettyValue(verbose = false)(key.value)
+          })
       case Dev(_, error) =>
         error match {
           case Dev.Conformance(provided, recomputed, details) =>
@@ -215,35 +244,8 @@ private[lf] object Pretty {
                   text(cause)
             }
           case Dev.Upgrade(error) =>
+            // TODO https://github.com/digital-asset/daml/issues/18616: migrate remaining cases out of Dev
             error match {
-              case Dev.Upgrade.ValidationFailed(
-                    coid,
-                    srcTemplateId,
-                    dstTemplateId,
-                    signatories,
-                    observers,
-                    keyOpt,
-                    _,
-                  ) =>
-                text("Validation fails when trying to upgrade the contract") & prettyContractId(
-                  coid
-                ) & text("from") & prettyTypeConName(srcTemplateId) & text(
-                  "to"
-                ) & prettyTypeConName(
-                  dstTemplateId
-                ) /
-                  text(
-                    "Verify that neither the signatories, nor the observers, nor the contract key, nor the key's maintainers have changed"
-                  ) /
-                  text("recomputed signatories are") & prettyParties(signatories) /
-                  text("recomputed observers are") & prettyParties(observers) /
-                  (keyOpt match {
-                    case None => Doc.empty
-                    case Some(key) =>
-                      text("recomputed maintainers are") & prettyParties(key.maintainers) /
-                        text("recomputed key is") & prettyValue(false)(key.value)
-                  })
-
               case Dev.Upgrade.DowngradeDropDefinedField(_, _) =>
                 text(
                   "An optional contract field with a value of Some may not be dropped during downgrading"

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -1290,18 +1290,15 @@ private[lf] object SBuiltinFun {
                               executeExpression(machine, SEPreventCatch(dstView)) { dstViewValue =>
                                 if (srcViewValue != dstViewValue) {
                                   Control.Error(
-                                    IE.Dev(
-                                      NameOf.qualifiedNameOfCurrentFunc,
-                                      IE.Dev.Upgrade(
-                                        IE.Dev.Upgrade.ViewMismatch(
-                                          coid,
-                                          interfaceId,
-                                          srcTplId,
-                                          dstTplId,
-                                          srcView = srcViewValue.toUnnormalizedValue,
-                                          dstView = dstViewValue.toUnnormalizedValue,
-                                        )
-                                      ),
+                                    IE.Upgrade(
+                                      IE.Upgrade.ViewMismatch(
+                                        coid,
+                                        interfaceId,
+                                        srcTplId,
+                                        dstTplId,
+                                        srcView = srcViewValue.toUnnormalizedValue,
+                                        dstView = dstViewValue.toUnnormalizedValue,
+                                      )
                                     )
                                   )
                                 } else

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -2424,20 +2424,17 @@ private[lf] object SBuiltinFun {
       case Nil => k()
       case errors =>
         Control.Error(
-          IE.Dev(
-            NameOf.qualifiedNameOfCurrentFunc,
-            IE.Dev.Upgrade(
-              // TODO(https://github.com/digital-asset/daml/issues/20305): also include the original metadata
-              IE.Dev.Upgrade.ValidationFailed(
-                coid = coid,
-                srcTemplateId = original.templateId,
-                dstTemplateId = recomputed.templateId,
-                signatories = recomputed.signatories,
-                observers = recomputed.observers,
-                keyOpt = recomputed.keyOpt.map(_.globalKeyWithMaintainers),
-                msg = errors.mkString("['", "', '", "']"),
-              )
-            ),
+          IE.Upgrade(
+            // TODO(https://github.com/digital-asset/daml/issues/20305): also include the original metadata
+            IE.Upgrade.ValidationFailed(
+              coid = coid,
+              srcTemplateId = original.templateId,
+              dstTemplateId = recomputed.templateId,
+              signatories = recomputed.signatories,
+              observers = recomputed.observers,
+              keyOpt = recomputed.keyOpt.map(_.globalKeyWithMaintainers),
+              msg = errors.mkString("['", "', '", "']"),
+            )
           )
         )
     }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -1275,11 +1275,8 @@ private[lf] object Speedy {
                             List.empty // ok, drop
                           case V.ValueOptional(Some(_)) =>
                             throw SErrorDamlException(
-                              IError.Dev(
-                                NameOf.qualifiedNameOfCurrentFunc,
-                                IError.Dev.Upgrade(
-                                  IError.Dev.Upgrade.DowngradeDropDefinedField(ty, value)
-                                ),
+                              IError.Upgrade(
+                                IError.Upgrade.DowngradeDropDefinedField(ty, value)
                               )
                             )
                           case _ =>

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -1218,13 +1218,15 @@ private[lf] object Speedy {
                 Destructor.destruct(ty) match {
                   case Right(enumF: EnumF) =>
                     val rank =
-                      enumF.consRank(consName).getOrElse(
-                        throw SErrorDamlException(
-                          IError.Upgrade(
-                            IError.Upgrade.DowngradeFailed(ty, value)
+                      enumF
+                        .consRank(consName)
+                        .getOrElse(
+                          throw SErrorDamlException(
+                            IError.Upgrade(
+                              IError.Upgrade.DowngradeFailed(ty, value)
+                            )
                           )
                         )
-                      )
                     SValue.SEnum(enumF.tyCon, consName, rank)
                   case _ =>
                     typeMismatch
@@ -1319,13 +1321,15 @@ private[lf] object Speedy {
             Destructor.destruct(ty) match {
               case Right(variantF: VariantF[_]) =>
                 val rank =
-                  variantF.consRank(variant).getOrElse(
-                    throw SErrorDamlException(
-                      IError.Upgrade(
-                        IError.Upgrade.DowngradeFailed(ty, value)
+                  variantF
+                    .consRank(variant)
+                    .getOrElse(
+                      throw SErrorDamlException(
+                        IError.Upgrade(
+                          IError.Upgrade.DowngradeFailed(ty, value)
+                        )
                       )
-                    ),
-                  )
+                    )
                 val a = variantF.consTypes(rank)
                 SValue.SVariant(variantF.tyCon, variant, rank, go(a, value))
               case _ =>

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -9,7 +9,7 @@ import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.data.{FrontStack, ImmArray, NoCopy, Ref, Time}
 import com.digitalasset.daml.lf.interpretation.{Error => IError}
 import com.digitalasset.daml.lf.language.Ast._
-import com.digitalasset.daml.lf.language.{LookupError, PackageInterface, TypeDestructor}
+import com.digitalasset.daml.lf.language.{PackageInterface, TypeDestructor}
 import com.digitalasset.daml.lf.language.LanguageVersionRangeOps._
 import com.digitalasset.daml.lf.speedy.Compiler.{CompilationError, PackageNotFound}
 import com.digitalasset.daml.lf.speedy.PartialTransaction.NodeSeeds
@@ -1205,12 +1205,6 @@ private[lf] object Speedy {
       import TypeDestructor.SerializableTypeF._
       val Destructor = TypeDestructor(compiledPackages.pkgInterface)
 
-      def assertRight[X](x: Either[LookupError, X]): X =
-        x match {
-          case Right(value) => value
-          case Left(error) => throw SErrorCrash(NameOf.qualifiedNameOfCurrentFunc, error.pretty)
-        }
-
       def go(ty: Type, value: V): SValue = {
         def typeMismatch = throw SErrorCrash(
           NameOf.qualifiedNameOfCurrentFunc,
@@ -1220,10 +1214,18 @@ private[lf] object Speedy {
         value match {
           case leaf: V.ValueCidlessLeaf =>
             leaf match {
-              case V.ValueEnum(_, value) =>
+              case V.ValueEnum(_, consName) =>
                 Destructor.destruct(ty) match {
                   case Right(enumF: EnumF) =>
-                    SValue.SEnum(enumF.tyCon, value, assertRight(enumF.consRank(value)))
+                    val rank =
+                      enumF.consRank(consName).getOrElse(
+                        throw SErrorDamlException(
+                          IError.Upgrade(
+                            IError.Upgrade.DowngradeFailed(ty, value)
+                          )
+                        )
+                      )
+                    SValue.SEnum(enumF.tyCon, consName, rank)
                   case _ =>
                     typeMismatch
                 }
@@ -1276,7 +1278,7 @@ private[lf] object Speedy {
                           case V.ValueOptional(Some(_)) =>
                             throw SErrorDamlException(
                               IError.Upgrade(
-                                IError.Upgrade.DowngradeDropDefinedField(ty, value)
+                                IError.Upgrade.DowngradeDropDefinedField(ty, i.toLong, value)
                               )
                             )
                           case _ =>
@@ -1316,7 +1318,14 @@ private[lf] object Speedy {
           case V.ValueVariant(_, variant, value) =>
             Destructor.destruct(ty) match {
               case Right(variantF: VariantF[_]) =>
-                val rank = assertRight(variantF.consRank(variant))
+                val rank =
+                  variantF.consRank(variant).getOrElse(
+                    throw SErrorDamlException(
+                      IError.Upgrade(
+                        IError.Upgrade.DowngradeFailed(ty, value)
+                      )
+                    ),
+                  )
                 val a = variantF.consTypes(rank)
                 SValue.SVariant(variantF.tyCon, variant, rank, go(a, value))
               case _ =>

--- a/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinInterfaceTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinInterfaceTest.scala
@@ -137,8 +137,8 @@ class SBuiltinInterfaceUpgradeTest extends AnyFreeSpec with Matchers with Inside
           compiledPackages = compiledPackages,
           committers = Set(alice),
         )
-      ) { case Success(Left(SErrorDamlException(IE.Dev(_, IE.Dev.Upgrade(upgradeError))))) =>
-        upgradeError shouldBe a[IE.Dev.Upgrade.ViewMismatch]
+      ) { case Success(Left(SErrorDamlException(IE.Upgrade(upgradeError)))) =>
+        upgradeError shouldBe a[IE.Upgrade.ViewMismatch]
       }
     }
   }
@@ -157,8 +157,8 @@ class SBuiltinInterfaceUpgradeTest extends AnyFreeSpec with Matchers with Inside
           compiledPackages = compiledPackages,
           committers = Set(alice),
         )
-      ) { case Success(Left(SErrorDamlException(IE.Dev(_, IE.Dev.Upgrade(upgradeError))))) =>
-        upgradeError shouldBe a[IE.Dev.Upgrade.ViewMismatch]
+      ) { case Success(Left(SErrorDamlException(IE.Upgrade(upgradeError)))) =>
+        upgradeError shouldBe a[IE.Upgrade.ViewMismatch]
       }
     }
   }

--- a/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
@@ -62,6 +62,126 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
     """
   }
 
+  val variantPkgIdV1: Ref.PackageId = Ref.PackageId.assertFromString("-variant-v1-")
+  private lazy val variantPkgV1 = {
+    // unknown variant type constructor
+    implicit def pkgId: Ref.PackageId = variantPkgIdV1
+    p""" metadata ( '-upgrade-test-' : '1.0.0' )
+    module M {
+
+      variant @serializable D = tag : Int64 | label : Text;
+
+      record @serializable T = { sig: Party, obs: Party, data: M:D };
+      template (this: T) = {
+        precondition True;
+        signatories '-pkg1-':M:mkList (M:T {sig} this) (None @Party);
+        observers '-pkg1-':M:mkList (M:T {obs} this) (None @Party);
+      };
+
+      val do_fetch: ContractId M:T -> Update M:T =
+        \(cId: ContractId M:T) ->
+          fetch_template @M:T cId;
+    }
+    """
+  }
+
+  val variantPkgIdV2: Ref.PackageId = Ref.PackageId.assertFromString("-variant-v2-")
+  private lazy val variantPkgV2 = {
+    // unknown variant type constructor
+    implicit def pkgId: Ref.PackageId = variantPkgIdV2
+    p""" metadata ( '-upgrade-test-' : '2.0.0' )
+    module M {
+
+      variant @serializable D = label : Text;
+
+      record @serializable T = { sig: Party, obs: Party, data: M:D };
+      template (this: T) = {
+        precondition True;
+        signatories '-pkg1-':M:mkList (M:T {sig} this) (None @Party);
+        observers '-pkg1-':M:mkList (M:T {obs} this) (None @Party);
+      };
+
+      val do_fetch: ContractId M:T -> Update M:T =
+        \(cId: ContractId M:T) ->
+          fetch_template @M:T cId;
+    }
+    """
+  }
+
+  val enumPkgIdV1: Ref.PackageId = Ref.PackageId.assertFromString("-enum-v1-")
+  private lazy val enumPkgV1 = {
+    // unknown enum type constructor
+    implicit def pkgId: Ref.PackageId = enumPkgIdV1
+    p""" metadata ( '-upgrade-test-' : '1.0.0' )
+    module M {
+
+      enum @serializable D = Black | White;
+
+      record @serializable T = { sig: Party, obs: Party, data: M:D };
+      template (this: T) = {
+        precondition True;
+        signatories '-pkg1-':M:mkList (M:T {sig} this) (None @Party);
+        observers '-pkg1-':M:mkList (M:T {obs} this) (None @Party);
+      };
+
+      val do_fetch: ContractId M:T -> Update M:T =
+        \(cId: ContractId M:T) ->
+          fetch_template @M:T cId;
+    }
+    """
+  }
+
+  val enumPkgIdV2: Ref.PackageId = Ref.PackageId.assertFromString("-enum-v2-")
+  private lazy val enumPkgV2 = {
+    // unknown enum type constructor
+    implicit def pkgId: Ref.PackageId = enumPkgIdV2
+    p""" metadata ( '-upgrade-test-' : '2.0.0' )
+    module M {
+
+      enum @serializable D = White;
+
+      record @serializable T = { sig: Party, obs: Party, data: M:D };
+      template (this: T) = {
+        precondition True;
+        signatories '-pkg1-':M:mkList (M:T {sig} this) (None @Party);
+        observers '-pkg1-':M:mkList (M:T {obs} this) (None @Party);
+      };
+
+      val do_fetch: ContractId M:T -> Update M:T =
+        \(cId: ContractId M:T) ->
+          fetch_template @M:T cId;
+    }
+    """
+  }
+
+  lazy val pkgId0 = Ref.PackageId.assertFromString("-pkg0-")
+  private lazy val pkg0 = {
+    implicit def pkgId: Ref.PackageId = pkgId0
+    p""" metadata ( '-upgrade-test-' : '1.0.0' )
+    module M {
+
+      record @serializable T = { sig: Party, obs: Party, aNumber: Int64 };
+      template (this: T) = {
+        precondition True;
+        signatories M:mkList (M:T {sig} this) (None @Party);
+        observers M:mkList (M:T {obs} this) (None @Party);
+        key @Party (M:T {sig} this) (\ (p: Party) -> Cons @Party [p] Nil @Party);
+      };
+
+      val do_fetch: ContractId M:T -> Update M:T =
+        \(cId: ContractId M:T) ->
+          fetch_template @M:T cId;
+
+      val mkList: Party -> Option Party -> List Party =
+        \(sig: Party) -> \(optSig: Option Party) ->
+          case optSig of
+            None -> Cons @Party [sig] Nil @Party
+          | Some extraSig -> Cons @Party [sig, extraSig] Nil @Party;
+
+    }
+    """
+  }
+
   val pkgId1 = Ref.PackageId.assertFromString("-pkg1-")
   private lazy val pkg1 = {
     implicit def pkgId: Ref.PackageId = pkgId1
@@ -105,7 +225,6 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
   }
 
   val pkgId2: Ref.PackageId = Ref.PackageId.assertFromString("-pkg2-")
-
   private lazy val pkg2 = {
     // adds a choice to T
     implicit def pkgId: Ref.PackageId = pkgId2
@@ -209,6 +328,11 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
     PureCompiledPackages.assertBuild(
       Map(
         ifacePkgId -> ifacePkg,
+        variantPkgIdV1 -> variantPkgV1,
+        variantPkgIdV2 -> variantPkgV2,
+        enumPkgIdV1 -> enumPkgV1,
+        enumPkgIdV2 -> enumPkgV2,
+        pkgId0 -> pkg0,
         pkgId1 -> pkg1,
         pkgId2 -> pkg2,
         pkgId3 -> pkg3,
@@ -451,7 +575,7 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
       )
 
       inside(res) { case Left(SError.SErrorDamlException(IE.Upgrade(e))) =>
-        e shouldBe IE.Upgrade.DowngradeDropDefinedField(t"'-pkg2-':M:T", v1_extraSome)
+        e shouldBe IE.Upgrade.DowngradeDropDefinedField(t"'-pkg2-':M:T", 3, v1_extraSome)
       }
     }
 
@@ -475,11 +599,40 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
         v shouldBe v1_base
       }
     }
+
+    "unknown variant constructor -- should be rejected" in {
+      val tag = ValueInt64(42)
+      val v1Arg = makeRecord(
+        ValueParty(alice),
+        ValueParty(bob),
+        ValueVariant(None, Ref.Name.assertFromString("tag"), tag),
+      )
+
+      inside(
+        go(e"'-variant-v2-':M:do_fetch", ContractInstance(pkgName, pkg1Ver, i"'-variant-v1-':M:T", v1Arg))
+      ) { case Left(SError.SErrorDamlException(IE.Upgrade(e))) =>
+        e shouldBe IE.Upgrade.DowngradeFailed(t"'-variant-v2-':M:D", tag)
+      }
+    }
+
+    "unknown enum constructor -- should be rejected" in {
+      val black = ValueEnum(None, Ref.Name.assertFromString("Black"))
+      val v1Arg = makeRecord(
+        ValueParty(alice),
+        ValueParty(bob),
+        black,
+      )
+
+      inside(go(e"'-enum-v2-':M:do_fetch", ContractInstance(pkgName, pkg1Ver, i"'-enum-v1-':M:T", v1Arg))) {
+        case Left(SError.SErrorDamlException(IE.Upgrade(e))) =>
+          e shouldBe IE.Upgrade.DowngradeFailed(t"'-enum-v2-':M:D", black)
+      }
+    }
   }
 
   "upgrade" - {
     "be able to fetch a same contract using different versions" in {
-      // The following code is not properly typed, but emulates two commands that fetch a same contract using different versions.
+      // The following code is not properly typed, but emulates two commands that fetch the same contract using different versions.
       val res = go(
         e"""\(cid: ContractId '-pkg1-':M:T) ->
                ubind

--- a/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
@@ -609,7 +609,10 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
       )
 
       inside(
-        go(e"'-variant-v2-':M:do_fetch", ContractInstance(pkgName, pkg1Ver, i"'-variant-v1-':M:T", v1Arg))
+        go(
+          e"'-variant-v2-':M:do_fetch",
+          ContractInstance(pkgName, pkg1Ver, i"'-variant-v1-':M:T", v1Arg),
+        )
       ) { case Left(SError.SErrorDamlException(IE.Upgrade(e))) =>
         e shouldBe IE.Upgrade.DowngradeFailed(t"'-variant-v2-':M:D", tag)
       }
@@ -623,9 +626,10 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
         black,
       )
 
-      inside(go(e"'-enum-v2-':M:do_fetch", ContractInstance(pkgName, pkg1Ver, i"'-enum-v1-':M:T", v1Arg))) {
-        case Left(SError.SErrorDamlException(IE.Upgrade(e))) =>
-          e shouldBe IE.Upgrade.DowngradeFailed(t"'-enum-v2-':M:D", black)
+      inside(
+        go(e"'-enum-v2-':M:do_fetch", ContractInstance(pkgName, pkg1Ver, i"'-enum-v1-':M:T", v1Arg))
+      ) { case Left(SError.SErrorDamlException(IE.Upgrade(e))) =>
+        e shouldBe IE.Upgrade.DowngradeFailed(t"'-enum-v2-':M:D", black)
       }
     }
   }

--- a/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
@@ -450,8 +450,8 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
         ContractInstance(pkgName, pkg3Ver, i"'-pkg3-':M:T", v1_extraSome),
       )
 
-      inside(res) { case Left(SError.SErrorDamlException(IE.Dev(_, IE.Dev.Upgrade(e)))) =>
-        e shouldBe IE.Dev.Upgrade.DowngradeDropDefinedField(t"'-pkg2-':M:T", v1_extraSome)
+      inside(res) { case Left(SError.SErrorDamlException(IE.Upgrade(e))) =>
+        e shouldBe IE.Upgrade.DowngradeDropDefinedField(t"'-pkg2-':M:T", v1_extraSome)
       }
     }
 

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
@@ -158,8 +158,11 @@ object Error {
 
     // TODO https://github.com/digital-asset/daml/issues/17647:
     //  - add coid, srcTmplId (alternatively pkgId of srcTmplId), and dstTempId
-    final case class DowngradeDropDefinedField(expectedType: Ast.Type, actualValue: Value)
-        extends Error
+    final case class DowngradeDropDefinedField(
+        expectedType: Ast.Type,
+        fieldIndex: Long,
+        actualValue: Value,
+    ) extends Error
 
     final case class ViewMismatch(
         coid: ContractId,
@@ -169,6 +172,9 @@ object Error {
         srcView: Value,
         dstView: Value,
     ) extends Error
+
+    final case class DowngradeFailed(expectedType: Ast.Type, actualValue: Value) extends Error
+
   }
 
   // Error that can be thrown by dev or PoC feature only

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
@@ -141,6 +141,22 @@ object Error {
     */
   final case class ValueNesting(limit: Int) extends Error
 
+  sealed case class Upgrade(error: Upgrade.Error) extends Error
+
+  object Upgrade {
+    sealed abstract class Error extends Serializable with Product
+
+    final case class ValidationFailed(
+        coid: ContractId,
+        srcTemplateId: TypeConName,
+        dstTemplateId: TypeConName,
+        signatories: Set[Party],
+        observers: Set[Party],
+        keyOpt: Option[GlobalKeyWithMaintainers],
+        msg: String,
+    ) extends Error
+  }
+
   // Error that can be thrown by dev or PoC feature only
   final case class Dev(location: String, error: Dev.Error) extends Error
 
@@ -170,19 +186,10 @@ object Error {
         details: String,
     ) extends Error
 
+    // TODO https://github.com/digital-asset/daml/issues/18616: migrate Upgrade error cases out of Dev
     object Upgrade {
 
       sealed abstract class Error extends Serializable with Product
-
-      final case class ValidationFailed(
-          coid: ContractId,
-          srcTemplateId: TypeConName,
-          dstTemplateId: TypeConName,
-          signatories: Set[Party],
-          observers: Set[Party],
-          keyOpt: Option[GlobalKeyWithMaintainers],
-          msg: String,
-      ) extends Error
 
       // TODO https://github.com/digital-asset/daml/issues/17647:
       //  - add coid, srcTmplId (alternatively pkgId of srcTmplId), and dstTempId

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
@@ -155,6 +155,20 @@ object Error {
         keyOpt: Option[GlobalKeyWithMaintainers],
         msg: String,
     ) extends Error
+
+    // TODO https://github.com/digital-asset/daml/issues/17647:
+    //  - add coid, srcTmplId (alternatively pkgId of srcTmplId), and dstTempId
+    final case class DowngradeDropDefinedField(expectedType: Ast.Type, actualValue: Value)
+        extends Error
+
+    final case class ViewMismatch(
+        coid: ContractId,
+        iterfaceId: TypeConName,
+        srcTemplateId: TypeConName,
+        dstTemplateId: TypeConName,
+        srcView: Value,
+        dstView: Value,
+    ) extends Error
   }
 
   // Error that can be thrown by dev or PoC feature only
@@ -176,35 +190,11 @@ object Error {
       final case class MalformedSignature(signature: String, cause: String) extends Error
     }
 
-    // TODO https://github.com/digital-asset/daml/issues/17647
-    // - move as normal interpretation Error
-    sealed case class Upgrade(error: Upgrade.Error) extends Error
-
     sealed case class Conformance(
         provided: Node.Create,
         recomputed: Node.Create,
         details: String,
     ) extends Error
-
-    // TODO https://github.com/digital-asset/daml/issues/18616: migrate Upgrade error cases out of Dev
-    object Upgrade {
-
-      sealed abstract class Error extends Serializable with Product
-
-      // TODO https://github.com/digital-asset/daml/issues/17647:
-      //  - add coid, srcTmplId (alternatively pkgId of srcTmplId), and dstTempId
-      final case class DowngradeDropDefinedField(expectedType: Ast.Type, actualValue: Value)
-          extends Error
-
-      final case class ViewMismatch(
-          coid: ContractId,
-          iterfaceId: TypeConName,
-          srcTemplateId: TypeConName,
-          dstTemplateId: TypeConName,
-          srcView: Value,
-          dstView: Value,
-      ) extends Error
-    }
 
     /** A choice guard returned false, invalidating some expectation. */
     final case class ChoiceGuardFailed(

--- a/sdk/daml-script/daml/Daml/Script.daml
+++ b/sdk/daml-script/daml/Daml/Script.daml
@@ -17,6 +17,7 @@ module Daml.Script
   -- Error types
   , SubmitError (..)
   , DevErrorType (..)
+  , UpgradeErrorType (..)
   -- Submit options
   , actAs
   , readAs

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
@@ -25,11 +25,14 @@ data UpgradeErrorType
         keyOpt : Optional (AnyContractKey, [Party])
   | DowngradeDropDefinedField with
         expectedType : Text
+        fieldIndex : Int
   | ViewMismatch with
         coid : AnyContractId
         iterfaceId : TemplateTypeRep
         srcTemplateId : TemplateTypeRep
         dstTemplateId : TemplateTypeRep
+  | DowngradeFailed with
+        expectedType : Text
 
 -- | Errors that will be promoted to SubmitError once stable - code needs to be kept in sync with SubmitError.scala
 data DevErrorType
@@ -200,7 +203,9 @@ instance Show UpgradeErrorType where
   show err = case err of
     ValidationFailed coid _srcTemplateId _dstTemplateId signatories observers _keyOpt ->
       "Validation failed for contract " <> show coid <> " (Signatories: " <> show signatories <> ", Observers: " <> show observers <> ")"
-    DowngradeDropDefinedField expectedType ->
-      "Cannot drop Some field in record to downgrade to " <> show expectedType
+    DowngradeDropDefinedField expectedType rank ->
+      "Cannot drop Some field at position " <> show rank <> " in record to downgrade to " <> show expectedType
     ViewMismatch coid _iterfaceId _srcTemplateId _dstTemplateId ->
       "Interface view mismatch between versions for contract " <> show coid
+    DowngradeFailed expectedType ->
+      "Could not downgrade from new variant/enum constructor to " <> show expectedType

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
@@ -6,6 +6,7 @@ module Daml.Script.Internal.Questions.Submit.Error
   , ContractNotFoundAdditionalInfo -- Don't export constructors, users should not be able to rely on the structure.
   , isNotActive
   , SubmitError (..)
+  , UpgradeErrorType (..)
   ) where
 
 import Daml.Script.Internal.Questions.Util
@@ -13,6 +14,12 @@ import DA.NonEmpty
 import DA.Text
 import DA.Foldable (foldMap)
 import DA.Exception
+
+data UpgradeErrorType
+  = ValidationFailed
+  | DowngradeDropDefinedField
+  | ViewMismatch
+  deriving Show
 
 -- | Errors that will be promoted to SubmitError once stable - code needs to be kept in sync with SubmitError.scala
 data DevErrorType
@@ -127,7 +134,8 @@ data SubmitError
       localVerdictLockedKeys : [AnyContractKey]
           -- ^ Locked contract keys
   | -- | Upgrade exception
-    UpgradeError with -- We just give the error's prettied message. Scripts doesn't need anything more right now.
+    UpgradeError with -- We just give the error's simple class name and the prettied message it generates. Scripts doesn't need anything more right now.
+      errorType : UpgradeErrorType
       errorMessage : Text
   | -- | Development feature exceptions
     DevError with -- We just give the error's simple class name and the prettied message it generates. Scripts doesn't need anything more right now.
@@ -173,7 +181,7 @@ instance Show SubmitError where
     ValueNesting limit -> "Exceeded maximum nesting depth for values - limit: " <> show limit
     LocalVerdictLockedContracts cids -> "Attempted to use locked contracts: " <> show cids
     LocalVerdictLockedKeys _ -> "Attempted to use locked contract keys"
-    UpgradeError msg -> "UpgradeError: \"" <> msg <> "\""
+    UpgradeError ty msg -> "UpgradeError of type " <> show ty <> " and message \"" <> msg <> "\""
     DevError ty msg -> "DevError of type " <> show ty <> " and message \"" <> msg <> "\""
     UnknownError msg -> "Unknown error: " <> msg
     TruncatedError ty msg -> "TruncatedError of type " <> ty <> " and message \"" <> msg <> "\""

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
@@ -30,7 +30,6 @@ data UpgradeErrorType
         iterfaceId : TemplateTypeRep
         srcTemplateId : TemplateTypeRep
         dstTemplateId : TemplateTypeRep
-  deriving Show
 
 -- | Errors that will be promoted to SubmitError once stable - code needs to be kept in sync with SubmitError.scala
 data DevErrorType
@@ -192,7 +191,16 @@ instance Show SubmitError where
     ValueNesting limit -> "Exceeded maximum nesting depth for values - limit: " <> show limit
     LocalVerdictLockedContracts cids -> "Attempted to use locked contracts: " <> show cids
     LocalVerdictLockedKeys _ -> "Attempted to use locked contract keys"
-    UpgradeError ty msg -> "UpgradeError of type " <> show ty <> " and message \"" <> msg <> "\""
+    UpgradeError ty msg -> "UpgradeError: " <> show ty <> "\n with message \"" <> msg <> "\""
     DevError ty msg -> "DevError of type " <> show ty <> " and message \"" <> msg <> "\""
     UnknownError msg -> "Unknown error: " <> msg
     TruncatedError ty msg -> "TruncatedError of type " <> ty <> " and message \"" <> msg <> "\""
+
+instance Show UpgradeErrorType where
+  show err = case err of
+    ValidationFailed coid _srcTemplateId _dstTemplateId signatories observers _keyOpt ->
+      "Validation failed for contract " <> show coid <> " (Signatories: " <> show signatories <> ", Observers: " <> show observers <> ")"
+    DowngradeDropDefinedField expectedType ->
+      "Cannot drop Some field in record to downgrade to " <> show expectedType
+    ViewMismatch coid _iterfaceId _srcTemplateId _dstTemplateId ->
+      "Interface view mismatch between versions for contract " <> show coid

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
@@ -16,9 +16,20 @@ import DA.Foldable (foldMap)
 import DA.Exception
 
 data UpgradeErrorType
-  = ValidationFailed
-  | DowngradeDropDefinedField
-  | ViewMismatch
+  = ValidationFailed with
+        coid : AnyContractId
+        srcTemplateId : TemplateTypeRep
+        dstTemplateId : TemplateTypeRep
+        signatories : [Party]
+        observers : [Party]
+        keyOpt : Optional (AnyContractKey, [Party])
+  | DowngradeDropDefinedField with
+        expectedType : Text
+  | ViewMismatch with
+        coid : AnyContractId
+        iterfaceId : TemplateTypeRep
+        srcTemplateId : TemplateTypeRep
+        dstTemplateId : TemplateTypeRep
   deriving Show
 
 -- | Errors that will be promoted to SubmitError once stable - code needs to be kept in sync with SubmitError.scala
@@ -134,7 +145,7 @@ data SubmitError
       localVerdictLockedKeys : [AnyContractKey]
           -- ^ Locked contract keys
   | -- | Upgrade exception
-    UpgradeError with -- We just give the error's simple class name and the prettied message it generates. Scripts doesn't need anything more right now.
+    UpgradeError with
       errorType : UpgradeErrorType
       errorMessage : Text
   | -- | Development feature exceptions

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
@@ -18,7 +18,6 @@ import DA.Exception
 data DevErrorType
   = ChoiceGuardFailed
   | WronglyTypedContractSoft
-  | Upgrade
   | UnknownNewFeature -- ^ This should never happen - Update Scripts when you see this!
   deriving Show
 
@@ -127,6 +126,9 @@ data SubmitError
     LocalVerdictLockedKeys with
       localVerdictLockedKeys : [AnyContractKey]
           -- ^ Locked contract keys
+  | -- | Upgrade exception
+    UpgradeError with -- We just give the error's prettied message. Scripts doesn't need anything more right now.
+      errorMessage : Text
   | -- | Development feature exceptions
     DevError with -- We just give the error's simple class name and the prettied message it generates. Scripts doesn't need anything more right now.
       devErrorType : DevErrorType
@@ -171,6 +173,7 @@ instance Show SubmitError where
     ValueNesting limit -> "Exceeded maximum nesting depth for values - limit: " <> show limit
     LocalVerdictLockedContracts cids -> "Attempted to use locked contracts: " <> show cids
     LocalVerdictLockedKeys _ -> "Attempted to use locked contract keys"
+    UpgradeError msg -> "UpgradeError: \"" <> msg <> "\""
     DevError ty msg -> "DevError of type " <> show ty <> " and message \"" <> msg <> "\""
     UnknownError msg -> "Unknown error: " <> msg
     TruncatedError ty msg -> "TruncatedError of type " <> ty <> " and message \"" <> msg <> "\""

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
@@ -302,7 +302,7 @@ object GrpcErrorParser {
       case "INTERPRETATION_UPGRADE_ERROR_DOWNGRADE_DROP_DEFINED_FIELD" =>
         caseErr {
           case Seq(
-                (ErrorResource.FieldType, expectedType)
+                (ErrorResource.ExpectedType, expectedType)
               ) =>
             SubmitError.UpgradeError.DowngradeDropDefinedField(expectedType, message)
         }

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
@@ -4,7 +4,11 @@
 package com.digitalasset.daml.lf.engine.script.v2.ledgerinteraction
 
 import com.digitalasset.daml.lf.data.Ref._
-import com.digitalasset.daml.lf.transaction.{GlobalKey, GlobalKeyWithMaintainers, TransactionVersion}
+import com.digitalasset.daml.lf.transaction.{
+  GlobalKey,
+  GlobalKeyWithMaintainers,
+  TransactionVersion,
+}
 import com.digitalasset.daml.lf.value.Value.ContractId
 import com.digitalasset.daml.lf.value.ValueCoder
 import com.daml.nonempty.NonEmpty

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
@@ -244,6 +244,8 @@ object GrpcErrorParser {
         caseErr { case Seq((ErrorResource.ContractId, cid)) =>
           SubmitError.ContractIdComparability(cid)
         }
+      case "INTERPRETATION_UPGRADE_ERROR" =>
+        SubmitError.UpgradeError(message)
       case "INTERPRETATION_DEV_ERROR" =>
         caseErr { case Seq((ErrorResource.DevErrorType, errorType)) =>
           SubmitError.DevError(errorType, message)

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
@@ -244,9 +244,65 @@ object GrpcErrorParser {
         caseErr { case Seq((ErrorResource.ContractId, cid)) =>
           SubmitError.ContractIdComparability(cid)
         }
-      case "INTERPRETATION_UPGRADE_ERROR" =>
-        caseErr { case Seq((ErrorResource.UpgradeErrorType, errorType)) =>
-          SubmitError.UpgradeError(errorType, message)
+      case "INTERPRETATION_UPGRADE_ERROR_VALIDATION_FAILED" =>
+        caseErr {
+          case Seq(
+                (ErrorResource.ContractId, coid),
+                (ErrorResource.TemplateId, srcTemplateId),
+                (ErrorResource.TemplateId, dstTemplateId),
+                (ErrorResource.Parties, signatories),
+                (ErrorResource.Parties, observers),
+              ) =>
+            SubmitError.UpgradeError.ValidationFailed(
+              ContractId.assertFromString(coid),
+              Identifier.assertFromString(srcTemplateId),
+              Identifier.assertFromString(dstTemplateId),
+              signatories,
+              observers,
+              None,
+              message,
+            )
+          case Seq(
+                (ErrorResource.ContractId, coid),
+                (ErrorResource.TemplateId, srcTemplateId),
+                (ErrorResource.TemplateId, dstTemplateId),
+                (ErrorResource.Parties, signatories),
+                (ErrorResource.Parties, observers),
+                (ErrorResource.ContractKey, globalKey),
+                (ErrorResource.Parties, maintainers),
+              ) =>
+            SubmitError.UpgradeError.ValidationFailed(
+              ContractId.assertFromString(coid),
+              Identifier.assertFromString(srcTemplateId),
+              Identifier.assertFromString(dstTemplateId),
+              signatories,
+              observers,
+              Some((globalKey, maintainers)),
+              message,
+            )
+        }
+      case "INTERPRETATION_UPGRADE_ERROR_DOWNGRADE_DROP_DEFINED_FIELD" =>
+        caseErr {
+          case Seq(
+                (ErrorResource.FieldType, expectedType)
+              ) =>
+            SubmitError.UpgradeError.DowngradeDropDefinedField(expectedType, message)
+        }
+      case "INTERPRETATION_UPGRADE_ERROR_VIEW_MISMATCH" =>
+        caseErr {
+          case Seq(
+                (ErrorResource.ContractId, coid),
+                (ErrorResource.InterfaceId, iterfaceId),
+                (ErrorResource.TemplateId, srcTemplateId),
+                (ErrorResource.TemplateId, dstTemplateId),
+              ) =>
+            SubmitError.UpgradeError.ViewMismatch(
+              ContractId.assertFromString(coid),
+              Identifier.assertFromString(iterfaceId),
+              Identifier.assertFromString(srcTemplateId),
+              Identifier.assertFromString(dstTemplateId),
+              message,
+            )
         }
       case "INTERPRETATION_DEV_ERROR" =>
         caseErr { case Seq((ErrorResource.DevErrorType, errorType)) =>

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
@@ -245,7 +245,9 @@ object GrpcErrorParser {
           SubmitError.ContractIdComparability(cid)
         }
       case "INTERPRETATION_UPGRADE_ERROR" =>
-        SubmitError.UpgradeError(message)
+        caseErr { case Seq((ErrorResource.UpgradeErrorType, errorType)) =>
+          SubmitError.UpgradeError(errorType, message)
+        }
       case "INTERPRETATION_DEV_ERROR" =>
         caseErr { case Seq((ErrorResource.DevErrorType, errorType)) =>
           SubmitError.DevError(errorType, message)

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
@@ -302,9 +302,14 @@ object GrpcErrorParser {
       case "INTERPRETATION_UPGRADE_ERROR_DOWNGRADE_DROP_DEFINED_FIELD" =>
         caseErr {
           case Seq(
-                (ErrorResource.ExpectedType, expectedType)
+                (ErrorResource.ExpectedType, expectedType),
+                (ErrorResource.FieldIndex, fieldIndex),
               ) =>
-            SubmitError.UpgradeError.DowngradeDropDefinedField(expectedType, message)
+            SubmitError.UpgradeError.DowngradeDropDefinedField(
+              expectedType,
+              fieldIndex.toLong,
+              message,
+            )
         }
       case "INTERPRETATION_UPGRADE_ERROR_VIEW_MISMATCH" =>
         caseErr {
@@ -322,6 +327,15 @@ object GrpcErrorParser {
               message,
             )
         }
+
+      case "INTERPRETATION_UPGRADE_ERROR_DOWNGRADE_FAILED" =>
+        caseErr {
+          case Seq(
+                (ErrorResource.ExpectedType, expectedType)
+              ) =>
+            SubmitError.UpgradeError.DowngradeFailed(expectedType, message)
+        }
+
       case "INTERPRETATION_DEV_ERROR" =>
         caseErr { case Seq((ErrorResource.DevErrorType, errorType)) =>
           SubmitError.DevError(errorType, message)

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -354,10 +354,10 @@ class IdeLedgerClient(
       case ContractIdInContractKey(_) => SubmitError.ContractIdInContractKey()
       case ContractIdComparability(cid) => SubmitError.ContractIdComparability(cid.toString)
       case ValueNesting(limit) => SubmitError.ValueNesting(limit)
-      case e: Upgrade =>
-        // TODO https://github.com/digital-asset/daml/issues/18616: ensure relevant structured data is capturec
+      case e @ Upgrade(innerError) =>
         SubmitError.UpgradeError(
-          Pretty.prettyDamlException(e).renderWideStream.mkString
+          innerError.getClass.getSimpleName,
+          Pretty.prettyDamlException(e).renderWideStream.mkString,
         )
       case e @ Dev(_, innerError) =>
         SubmitError.DevError(

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -367,6 +367,12 @@ class IdeLedgerClient(
       case e @ Upgrade(innerError: Upgrade.DowngradeDropDefinedField) =>
         SubmitError.UpgradeError.DowngradeDropDefinedField(
           innerError.expectedType.pretty,
+          innerError.fieldIndex,
+          Pretty.prettyDamlException(e).renderWideStream.mkString,
+        )
+      case e @ Upgrade(innerError: Upgrade.DowngradeFailed) =>
+        SubmitError.UpgradeError.DowngradeFailed(
+          innerError.expectedType.pretty,
           Pretty.prettyDamlException(e).renderWideStream.mkString,
         )
       case e @ Upgrade(innerError: Upgrade.ViewMismatch) =>

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -354,9 +354,27 @@ class IdeLedgerClient(
       case ContractIdInContractKey(_) => SubmitError.ContractIdInContractKey()
       case ContractIdComparability(cid) => SubmitError.ContractIdComparability(cid.toString)
       case ValueNesting(limit) => SubmitError.ValueNesting(limit)
-      case e @ Upgrade(innerError) =>
-        SubmitError.UpgradeError(
-          innerError.getClass.getSimpleName,
+      case e @ Upgrade(innerError: Upgrade.ValidationFailed) =>
+        SubmitError.UpgradeError.ValidationFailed(
+          innerError.coid,
+          innerError.srcTemplateId,
+          innerError.dstTemplateId,
+          innerError.signatories.toString,
+          innerError.observers.toString,
+          innerError.keyOpt.map(key => (key.globalKey.toString, key.maintainers.toString)),
+          Pretty.prettyDamlException(e).renderWideStream.mkString,
+        )
+      case e @ Upgrade(innerError: Upgrade.DowngradeDropDefinedField) =>
+        SubmitError.UpgradeError.DowngradeDropDefinedField(
+          innerError.expectedType.pretty,
+          Pretty.prettyDamlException(e).renderWideStream.mkString,
+        )
+      case e @ Upgrade(innerError: Upgrade.ViewMismatch) =>
+        SubmitError.UpgradeError.ViewMismatch(
+          innerError.coid,
+          innerError.iterfaceId,
+          innerError.srcTemplateId,
+          innerError.dstTemplateId,
           Pretty.prettyDamlException(e).renderWideStream.mkString,
         )
       case e @ Dev(_, innerError) =>

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -359,9 +359,9 @@ class IdeLedgerClient(
           innerError.coid,
           innerError.srcTemplateId,
           innerError.dstTemplateId,
-          innerError.signatories.toString,
-          innerError.observers.toString,
-          innerError.keyOpt.map(key => (key.globalKey.toString, key.maintainers.toString)),
+          innerError.signatories,
+          innerError.observers,
+          innerError.keyOpt,
           Pretty.prettyDamlException(e).renderWideStream.mkString,
         )
       case e @ Upgrade(innerError: Upgrade.DowngradeDropDefinedField) =>

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -354,6 +354,11 @@ class IdeLedgerClient(
       case ContractIdInContractKey(_) => SubmitError.ContractIdInContractKey()
       case ContractIdComparability(cid) => SubmitError.ContractIdComparability(cid.toString)
       case ValueNesting(limit) => SubmitError.ValueNesting(limit)
+      case e: Upgrade =>
+        // TODO https://github.com/digital-asset/daml/issues/18616: ensure relevant structured data is capturec
+        SubmitError.UpgradeError(
+          Pretty.prettyDamlException(e).renderWideStream.mkString
+        )
       case e @ Dev(_, innerError) =>
         SubmitError.DevError(
           innerError.getClass.getSimpleName,

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
@@ -398,6 +398,25 @@ object SubmitError {
       )
   }
 
+  final case class UpgradeError(message: String) extends SubmitError {
+    // TODO https://github.com/digital-asset/daml/issues/18616: use a non-Dev based error code
+    override def toDamlSubmitError(env: Env): SValue = {
+      val upgradeErrorTypeIdentifier =
+        env.scriptIds.damlScriptModule(
+          "Daml.Script.Internal.Questions.Submit.Error",
+          "DevErrorType",
+        )
+      val upgradeErrorType = SEnum(upgradeErrorTypeIdentifier, Name.assertFromString("Upgrade"), 2)
+
+      SubmitErrorConverters(env).damlScriptError(
+        "DevError",
+        20,
+        ("devErrorType", upgradeErrorType),
+        ("devErrorMessage", SText(message)),
+      )
+    }
+  }
+
   final case class DevError(errorType: String, message: String) extends SubmitError {
     // This code needs to be kept in sync with daml-script#Error.daml
     override def toDamlSubmitError(env: Env): SValue = {

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
@@ -430,8 +430,6 @@ object SubmitError {
           SEnum(devErrorTypeIdentifier, Name.assertFromString("ChoiceGuardFailed"), 0)
         case "WronglyTypedContractSoft" =>
           SEnum(devErrorTypeIdentifier, Name.assertFromString("WronglyTypedContractSoft"), 1)
-        case "Upgrade" =>
-          SEnum(devErrorTypeIdentifier, Name.assertFromString("Upgrade"), 2)
         case _ => SEnum(devErrorTypeIdentifier, Name.assertFromString("UnknownNewFeature"), 3)
       }
       SubmitErrorConverters(env).damlScriptError(

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
@@ -399,20 +399,11 @@ object SubmitError {
   }
 
   final case class UpgradeError(message: String) extends SubmitError {
-    // TODO https://github.com/digital-asset/daml/issues/18616: use a non-Dev based error code
     override def toDamlSubmitError(env: Env): SValue = {
-      val upgradeErrorTypeIdentifier =
-        env.scriptIds.damlScriptModule(
-          "Daml.Script.Internal.Questions.Submit.Error",
-          "DevErrorType",
-        )
-      val upgradeErrorType = SEnum(upgradeErrorTypeIdentifier, Name.assertFromString("Upgrade"), 2)
-
       SubmitErrorConverters(env).damlScriptError(
-        "DevError",
+        "UpgradeError",
         20,
-        ("devErrorType", upgradeErrorType),
-        ("devErrorMessage", SText(message)),
+        ("errorMessage", SText(message)),
       )
     }
   }
@@ -434,7 +425,7 @@ object SubmitError {
       }
       SubmitErrorConverters(env).damlScriptError(
         "DevError",
-        20,
+        21,
         ("devErrorType", devErrorType),
         ("devErrorMessage", SText(message)),
       )
@@ -445,7 +436,7 @@ object SubmitError {
     override def toDamlSubmitError(env: Env): SValue =
       SubmitErrorConverters(env).damlScriptError(
         "UnknownError",
-        21,
+        22,
         ("unknownErrorMessage", SText(message)),
       )
   }
@@ -454,7 +445,7 @@ object SubmitError {
     override def toDamlSubmitError(env: Env): SValue =
       SubmitErrorConverters(env).damlScriptError(
         "TruncatedError",
-        22,
+        23,
         ("truncatedErrorType", SText(errType)),
         ("truncatedErrorMessage", SText(message)),
       )

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
@@ -455,14 +455,18 @@ object SubmitError {
       }
     }
 
-    sealed case class DowngradeDropDefinedField(expectedType: String, message: String)
-        extends SubmitError {
+    sealed case class DowngradeDropDefinedField(
+        expectedType: String,
+        fieldIndex: Long,
+        message: String,
+    ) extends SubmitError {
       override def toDamlSubmitError(env: Env): SValue = {
         val upgradeErrorType = damlScriptUpgradeErrorType(
           env,
           "DowngradeDropDefinedField",
           1,
           ("expectedType", SText(expectedType)),
+          ("fieldIndex", SInt64(fieldIndex)),
         )
         SubmitErrorConverters(env).damlScriptError(
           "UpgradeError",
@@ -498,6 +502,24 @@ object SubmitError {
         )
       }
     }
+
+    sealed case class DowngradeFailed(expectedType: String, message: String) extends SubmitError {
+      override def toDamlSubmitError(env: Env): SValue = {
+        val upgradeErrorType = damlScriptUpgradeErrorType(
+          env,
+          "DowngradeFailed",
+          3,
+          ("expectedType", SText(expectedType)),
+        )
+        SubmitErrorConverters(env).damlScriptError(
+          "UpgradeError",
+          20,
+          ("errorType", upgradeErrorType),
+          ("errorMessage", SText(message)),
+        )
+      }
+    }
+
   }
 
   final case class DevError(errorType: String, message: String) extends SubmitError {

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
@@ -398,11 +398,25 @@ object SubmitError {
       )
   }
 
-  final case class UpgradeError(message: String) extends SubmitError {
+  final case class UpgradeError(errorType: String, message: String) extends SubmitError {
     override def toDamlSubmitError(env: Env): SValue = {
+      val upgradeErrorTypeIdentifier =
+        env.scriptIds.damlScriptModule(
+          "Daml.Script.Internal.Questions.Submit.Error",
+          "UpgradeErrorType",
+        )
+      val upgradeErrorType = errorType match {
+        case "ValidationFailed" =>
+          SEnum(upgradeErrorTypeIdentifier, Name.assertFromString("ValidationFailed"), 0)
+        case "DowngradeDropDefinedField" =>
+          SEnum(upgradeErrorTypeIdentifier, Name.assertFromString("DowngradeDropDefinedField"), 1)
+        case "ViewMismatch" =>
+          SEnum(upgradeErrorTypeIdentifier, Name.assertFromString("ViewMismatch"), 2)
+      }
       SubmitErrorConverters(env).damlScriptError(
         "UpgradeError",
         20,
+        ("errorType", upgradeErrorType),
         ("errorMessage", SText(message)),
       )
     }

--- a/sdk/daml-script/test/daml/upgrades/ContractKeys.daml
+++ b/sdk/daml-script/test/daml/upgrades/ContractKeys.daml
@@ -661,7 +661,7 @@ exerciseUpdateKeyUpgraded = test $ do
 expectMetadataChangedError : Either SubmitError a -> Script ()
 expectMetadataChangedError r = case r of
     Right _ -> assertFail "Expected failure but got success"
-    Left (UpgradeError msg)
+    Left (UpgradeError ValidationFailed msg)
       | "Verify that neither the signatories, nor the observers, nor the contract key, nor the key's maintainers have changed" `isInfixOf` msg
       -> pure ()
     Left e -> assertFail $ "Expected Upgrade error but got " <> show e

--- a/sdk/daml-script/test/daml/upgrades/ContractKeys.daml
+++ b/sdk/daml-script/test/daml/upgrades/ContractKeys.daml
@@ -1,8 +1,11 @@
 -- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
 module ContractKeys (main) where
 
+import DA.List (sort)
 import DA.Text (isInfixOf)
 
 import UpgradeTestLib
@@ -303,7 +306,7 @@ fetchKeyChangedExprChangedValue : Test
 fetchKeyChangedExprChangedValue = test $ do
   a <- allocateParty "alice"
   cid <- a `submit` createExactCmd (V1.ChangedKeyExpr a True)
-  expectMetadataChangedError =<<
+  expectMetadataChangedError @V2.ChangedKeyExpr (V2.ChangedKeyExprKey a True) [a] =<<
     a `trySubmit` createAndExerciseCmd (V2.ChangedKeyExprHelper a) (V2.ChangedKeyExprFetch $ coerceContractId cid)
 
 fbiKeyChangedExprSameValue : Test
@@ -317,7 +320,7 @@ fbiKeyChangedExprChangedValue : Test
 fbiKeyChangedExprChangedValue = test $ do
   a <- allocateParty "alice"
   cid <- a `submit` createExactCmd (V1.ChangedKeyExpr a True)
-  expectMetadataChangedError =<<
+  expectMetadataChangedError @V2.ChangedKeyExpr (V2.ChangedKeyExprKey a True) [a] =<<
     a `trySubmit` createAndExerciseCmd (V2.ChangedKeyExprHelper a) (V2.ChangedKeyExprFetchByInterface $ coerceContractId cid)
 
 fbkKeyChangedExprSameValue : Test
@@ -332,7 +335,7 @@ fbkKeyChangedExprChangedValue : Test
 fbkKeyChangedExprChangedValue = test $ do
   a <- allocateParty "alice"
   cid <- a `submit` createExactCmd (V1.ChangedKeyExpr a True)
-  expectMetadataChangedError =<<
+  expectMetadataChangedError @V2.ChangedKeyExpr (V2.ChangedKeyExprKey a True) [a] =<<
     a `trySubmit` createAndExerciseCmd (V2.ChangedKeyExprHelper a) (V2.ChangedKeyExprFetchByKey $ V2.ChangedKeyExprKey a False)
 
 exerciseKeyChangedExprSameValue : Test
@@ -374,35 +377,35 @@ exerciseKeyChangedExprChangedValue : Test
 exerciseKeyChangedExprChangedValue = test $ do
   a <- allocateParty "alice"
   cid <- a `submit` createExactCmd (V1.ChangedKeyExpr a True)
-  expectMetadataChangedError =<<
+  expectMetadataChangedError @V2.ChangedKeyExpr (V2.ChangedKeyExprKey a True) [a] =<<
     a `trySubmit` createAndExerciseCmd (V2.ChangedKeyExprHelper a) (V2.ChangedKeyExprExercise $ coerceContractId cid)
 
 ebiKeyChangedExprChangedValue : Test
 ebiKeyChangedExprChangedValue = test $ do
   a <- allocateParty "alice"
   cid <- a `submit` createExactCmd (V1.ChangedKeyExpr a True)
-  expectMetadataChangedError =<<
+  expectMetadataChangedError @V2.ChangedKeyExpr (V2.ChangedKeyExprKey a True) [a] =<<
     a `trySubmit` createAndExerciseCmd (V2.ChangedKeyExprHelper a) (V2.ChangedKeyExprExerciseByInterface $ coerceContractId cid)
 
 ebkKeyChangedExprChangedValue : Test
 ebkKeyChangedExprChangedValue = test $ do
   a <- allocateParty "alice"
   _ <- a `submit` createExactCmd (V1.ChangedKeyExpr a True)
-  expectMetadataChangedError =<<
+  expectMetadataChangedError @V2.ChangedKeyExpr (V2.ChangedKeyExprKey a True) [a] =<<
     a `trySubmit` createAndExerciseCmd (V2.ChangedKeyExprHelper a) (V2.ChangedKeyExprExerciseByKey $ V2.ChangedKeyExprKey a False)
 
 exerciseCmdKeyChangedExprChangedValue : Test
 exerciseCmdKeyChangedExprChangedValue = test $ do
   a <- allocateParty "alice"
   cid <- a `submit` createExactCmd (V1.ChangedKeyExpr a True)
-  expectMetadataChangedError =<<
+  expectMetadataChangedError @V2.ChangedKeyExpr (V2.ChangedKeyExprKey a True) [a] =<<
     a `trySubmit` exerciseExactCmd @V2.ChangedKeyExpr (coerceContractId cid) V2.ChangedKeyExprCall
 
 ebkCmdKeyChangedExprChangedValue : Test
 ebkCmdKeyChangedExprChangedValue = test $ do
   a <- allocateParty "alice"
   _ <- a `submit` createExactCmd (V1.ChangedKeyExpr a True)
-  expectMetadataChangedError =<<
+  expectMetadataChangedError @V2.ChangedKeyExpr (V2.ChangedKeyExprKey a True) [a] =<<
     a `trySubmit` exerciseByKeyExactCmd @V2.ChangedKeyExpr (V2.ChangedKeyExprKey a False) V2.ChangedKeyExprCall
 
 {- MODULE
@@ -503,7 +506,7 @@ fetchMaintainersChangedExprChangedValue = test $ do
   a <- allocateParty "alice"
   b <- allocateParty "bob"
   cid <- a `submit` createExactCmd (V1.ChangedMaintainersExpr a b)
-  expectMetadataChangedError =<<
+  expectMetadataChangedError @V2.ChangedMaintainersExpr (V2.ChangedMaintainersExprKey a b) [b] =<<
     a `trySubmit` createAndExerciseCmd (V2.ChangedMaintainersExprHelper a) (V2.ChangedMaintainersExprFetch $ coerceContractId cid)
 
 fbkMaintainersChangedExprSameValue : Test
@@ -519,7 +522,7 @@ fbkMaintainersChangedExprChangedValue = test $ do
   a <- allocateParty "alice"
   b <- allocateParty "bob"
   cid <- a `submit` createExactCmd (V1.ChangedMaintainersExpr a b)
-  expectMetadataChangedError =<<
+  expectMetadataChangedError @V2.ChangedMaintainersExpr (V2.ChangedMaintainersExprKey a b) [b] =<<
     a `trySubmit` createAndExerciseCmd (V2.ChangedMaintainersExprHelper a) (V2.ChangedMaintainersExprFetchByKey $ V2.ChangedMaintainersExprKey a b)
 
 exerciseMaintainersChangedExprSameValue : Test
@@ -555,7 +558,7 @@ exerciseMaintainersChangedExprChangedValue = test $ do
   a <- allocateParty "alice"
   b <- allocateParty "bob"
   cid <- a `submit` createExactCmd (V1.ChangedMaintainersExpr a b)
-  expectMetadataChangedError =<<
+  expectMetadataChangedError @V2.ChangedMaintainersExpr (V2.ChangedMaintainersExprKey a b) [b] =<<
     a `trySubmit` createAndExerciseCmd (V2.ChangedMaintainersExprHelper a) (V2.ChangedMaintainersExprExercise $ coerceContractId cid)
 
 ebkMaintainersChangedExprChangedValue : Test
@@ -563,7 +566,7 @@ ebkMaintainersChangedExprChangedValue = test $ do
   a <- allocateParty "alice"
   b <- allocateParty "bob"
   _ <- a `submit` createExactCmd (V1.ChangedMaintainersExpr a b)
-  expectMetadataChangedError =<<
+  expectMetadataChangedError @V2.ChangedMaintainersExpr (V2.ChangedMaintainersExprKey a b) [b] =<<
     a `trySubmit` createAndExerciseCmd (V2.ChangedMaintainersExprHelper a) (V2.ChangedMaintainersExprExerciseByKey $ V2.ChangedMaintainersExprKey a b)
 
 exerciseCmdMaintainersChangedExprChangedValue : Test
@@ -571,7 +574,7 @@ exerciseCmdMaintainersChangedExprChangedValue = test $ do
   a <- allocateParty "alice"
   b <- allocateParty "bob"
   cid <- a `submit` createExactCmd (V1.ChangedMaintainersExpr a b)
-  expectMetadataChangedError =<<
+  expectMetadataChangedError @V2.ChangedMaintainersExpr (V2.ChangedMaintainersExprKey a b) [b] =<<
     a `trySubmit` exerciseExactCmd @V2.ChangedMaintainersExpr (coerceContractId cid) V2.ChangedMaintainersExprCall
 
 ebkCmdMaintainersChangedExprChangedValue : Test
@@ -579,7 +582,7 @@ ebkCmdMaintainersChangedExprChangedValue = test $ do
   a <- allocateParty "alice"
   b <- allocateParty "bob"
   _ <- a `submit` createExactCmd (V1.ChangedMaintainersExpr a b)
-  expectMetadataChangedError =<<
+  expectMetadataChangedError @V2.ChangedMaintainersExpr (V2.ChangedMaintainersExprKey a b) [b] =<<
     a `trySubmit` exerciseByKeyExactCmd @V2.ChangedMaintainersExpr (V2.ChangedMaintainersExprKey a b) V2.ChangedMaintainersExprCall
 
 {- MODULE
@@ -658,10 +661,12 @@ exerciseUpdateKeyUpgraded = test $ do
 
 ------------------------------------------------------------------------------------------------------------------------
 
-expectMetadataChangedError : Either SubmitError a -> Script ()
-expectMetadataChangedError r = case r of
+expectMetadataChangedError : forall t k a. (HasTemplateTypeRep t, HasFromAnyContractKey t k, Eq k) => k -> [Party] -> Either SubmitError a -> Script ()
+expectMetadataChangedError key maintainers r = case r of
     Right _ -> assertFail "Expected failure but got success"
-    Left (UpgradeError ValidationFailed msg)
-      | "Verify that neither the signatories, nor the observers, nor the contract key, nor the key's maintainers have changed" `isInfixOf` msg
+    Left (UpgradeError (ValidationFailed _ _ _ _ _ (Some (foundKey, foundMaintainers))) msg)
+      | fromAnyContractKey @t foundKey == Some key &&
+        sort maintainers == sort foundMaintainers &&
+        "Verify that neither the signatories, nor the observers, nor the contract key, nor the key's maintainers have changed" `isInfixOf` msg
       -> pure ()
     Left e -> assertFail $ "Expected Upgrade error but got " <> show e

--- a/sdk/daml-script/test/daml/upgrades/ContractKeys.daml
+++ b/sdk/daml-script/test/daml/upgrades/ContractKeys.daml
@@ -661,7 +661,7 @@ exerciseUpdateKeyUpgraded = test $ do
 expectMetadataChangedError : Either SubmitError a -> Script ()
 expectMetadataChangedError r = case r of
     Right _ -> assertFail "Expected failure but got success"
-    Left (DevError Upgrade msg)
+    Left (UpgradeError msg)
       | "Verify that neither the signatories, nor the observers, nor the contract key, nor the key's maintainers have changed" `isInfixOf` msg
       -> pure ()
     Left e -> assertFail $ "Expected Upgrade error but got " <> show e

--- a/sdk/daml-script/test/daml/upgrades/DataChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/DataChanges.daml
@@ -518,7 +518,7 @@ templateOptionalFieldsSetWhenDowngradingTest trailer f = ("Fails if an optional 
     b <- allocatePartyOn "bob" participant0
     res <- f a b
     case res of
-      Left (DevError Upgrade msg) | "An optional contract field with a value of Some may not be dropped during downgrading" `isInfixOf` msg -> pure ()
+      Left (UpgradeError msg) | "An optional contract field with a value of Some may not be dropped during downgrading" `isInfixOf` msg -> pure ()
       _ -> assertFail $ "Expected specific failure but got " <> show res
 
 tofswdViaCIDExerciseInCommandGlobal : (Text, Test)

--- a/sdk/daml-script/test/daml/upgrades/DataChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/DataChanges.daml
@@ -518,7 +518,7 @@ templateOptionalFieldsSetWhenDowngradingTest trailer f = ("Fails if an optional 
     b <- allocatePartyOn "bob" participant0
     res <- f a b
     case res of
-      Left (UpgradeError msg) | "An optional contract field with a value of Some may not be dropped during downgrading" `isInfixOf` msg -> pure ()
+      Left (UpgradeError DowngradeDropDefinedField msg) | "An optional contract field with a value of Some may not be dropped during downgrading" `isInfixOf` msg -> pure ()
       _ -> assertFail $ "Expected specific failure but got " <> show res
 
 tofswdViaCIDExerciseInCommandGlobal : (Text, Test)

--- a/sdk/daml-script/test/daml/upgrades/DataChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/DataChanges.daml
@@ -77,7 +77,7 @@ templateInvalidChange shouldSucceed makeV1Contract v2Choice = test $ do
   case (res, shouldSucceed) of
     (Right "V2", True) -> pure ()
     (Left (WronglyTypedContract {}), False) -> pure ()
-    -- IDE Ledger doesn't apply obfuscation, instead the lookup error is wrapped in SCrash
+    (Left (UpgradeError (DowngradeFailed _) msg), False) -> pure ()
     (Left (UnknownError msg), False) | "SErrorCrash" `isInfixOf` msg -> pure ()
     (Left (UnknownError msg), False) | "An error occurred." `isInfixOf` msg -> pure ()
     _ -> assertFail $ "Expected " <> (if shouldSucceed then "success" else "specific failure") <> " but got " <> show res
@@ -298,8 +298,7 @@ templateEnumDowngradeFromNew = test $ do
   res <- a `trySubmit` exerciseExactCmd cidV1 V1.EnumAdditionalCall
 
   case res of
-    -- IDE Ledger doesn't apply obfuscation, instead the lookup error is wrapped in SCrash
-    Left (UnknownError msg) | "SErrorCrash" `isInfixOf` msg -> pure ()
+    Left (UpgradeError (DowngradeFailed _) msg) -> pure ()
     Left (UnknownError msg) | "An error occurred." `isInfixOf` msg -> pure ()
     _ -> assertFail $ "Expected specific failure but got " <> show res
 
@@ -518,7 +517,7 @@ templateOptionalFieldsSetWhenDowngradingTest trailer f = ("Fails if an optional 
     b <- allocatePartyOn "bob" participant0
     res <- f a b
     case res of
-      Left (UpgradeError (DowngradeDropDefinedField _) msg) | "An optional contract field with a value of Some may not be dropped during downgrading" `isInfixOf` msg -> pure ()
+      Left (UpgradeError (DowngradeDropDefinedField "OptionalFieldsAdded:OptionalFieldsAdded" 1) _) -> pure ()
       _ -> assertFail $ "Expected specific failure but got " <> show res
 
 tofswdViaCIDExerciseInCommandGlobal : (Text, Test)

--- a/sdk/daml-script/test/daml/upgrades/DataChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/DataChanges.daml
@@ -518,7 +518,7 @@ templateOptionalFieldsSetWhenDowngradingTest trailer f = ("Fails if an optional 
     b <- allocatePartyOn "bob" participant0
     res <- f a b
     case res of
-      Left (UpgradeError DowngradeDropDefinedField msg) | "An optional contract field with a value of Some may not be dropped during downgrading" `isInfixOf` msg -> pure ()
+      Left (UpgradeError (DowngradeDropDefinedField _) msg) | "An optional contract field with a value of Some may not be dropped during downgrading" `isInfixOf` msg -> pure ()
       _ -> assertFail $ "Expected specific failure but got " <> show res
 
 tofswdViaCIDExerciseInCommandGlobal : (Text, Test)

--- a/sdk/daml-script/test/daml/upgrades/Exceptions.daml
+++ b/sdk/daml-script/test/daml/upgrades/Exceptions.daml
@@ -209,7 +209,7 @@ contents: |
 -}
 
 assertIsUpgradeError : Either SubmitError a -> Script ()
-assertIsUpgradeError (Left (UpgradeError _)) = pure ()
+assertIsUpgradeError (Left (UpgradeError _ _)) = pure ()
 assertIsUpgradeError (Left e) = fail $ "Expected upgrade error but got " <> show e
 assertIsUpgradeError _ = fail "Expected upgrade error but got success"
 

--- a/sdk/daml-script/test/daml/upgrades/Exceptions.daml
+++ b/sdk/daml-script/test/daml/upgrades/Exceptions.daml
@@ -209,7 +209,7 @@ contents: |
 -}
 
 assertIsUpgradeError : Either SubmitError a -> Script ()
-assertIsUpgradeError (Left (DevError Upgrade _)) = pure ()
+assertIsUpgradeError (Left (UpgradeError _)) = pure ()
 assertIsUpgradeError (Left e) = fail $ "Expected upgrade error but got " <> show e
 assertIsUpgradeError _ = fail "Expected upgrade error but got success"
 

--- a/sdk/daml-script/test/daml/upgrades/Fetch.daml
+++ b/sdk/daml-script/test/daml/upgrades/Fetch.daml
@@ -185,9 +185,7 @@ mkFetchDowngradedSome trailer f = ("Fail to downgrade a contract with Somes when
     b <- allocatePartyOn "bob" participant0
     res <- f a b
     case res of
-      Left (UpgradeError (DowngradeDropDefinedField _) msg)
-        | "An optional contract field with a value of Some may not be dropped during downgrading" `isInfixOf` msg
-        -> pure ()
+      Left (UpgradeError (DowngradeDropDefinedField "Fetch:FetchTemplate" 1) _) -> pure ()
       res -> assertFail $ "Expected UpgradeError, got " <> show res
 
 fetchDowngradedSomeGlobal : (Text, Test)

--- a/sdk/daml-script/test/daml/upgrades/Fetch.daml
+++ b/sdk/daml-script/test/daml/upgrades/Fetch.daml
@@ -185,7 +185,7 @@ mkFetchDowngradedSome trailer f = ("Fail to downgrade a contract with Somes when
     b <- allocatePartyOn "bob" participant0
     res <- f a b
     case res of
-      Left (UpgradeError msg)
+      Left (UpgradeError DowngradeDropDefinedField msg)
         | "An optional contract field with a value of Some may not be dropped during downgrading" `isInfixOf` msg
         -> pure ()
       res -> assertFail $ "Expected UpgradeError, got " <> show res

--- a/sdk/daml-script/test/daml/upgrades/Fetch.daml
+++ b/sdk/daml-script/test/daml/upgrades/Fetch.daml
@@ -185,7 +185,7 @@ mkFetchDowngradedSome trailer f = ("Fail to downgrade a contract with Somes when
     b <- allocatePartyOn "bob" participant0
     res <- f a b
     case res of
-      Left (UpgradeError DowngradeDropDefinedField msg)
+      Left (UpgradeError (DowngradeDropDefinedField _) msg)
         | "An optional contract field with a value of Some may not be dropped during downgrading" `isInfixOf` msg
         -> pure ()
       res -> assertFail $ "Expected UpgradeError, got " <> show res

--- a/sdk/daml-script/test/daml/upgrades/Fetch.daml
+++ b/sdk/daml-script/test/daml/upgrades/Fetch.daml
@@ -185,10 +185,10 @@ mkFetchDowngradedSome trailer f = ("Fail to downgrade a contract with Somes when
     b <- allocatePartyOn "bob" participant0
     res <- f a b
     case res of
-      Left (DevError Upgrade msg)
+      Left (UpgradeError msg)
         | "An optional contract field with a value of Some may not be dropped during downgrading" `isInfixOf` msg
         -> pure ()
-      res -> assertFail $ "Expected DevError Upgrade, got " <> show res
+      res -> assertFail $ "Expected UpgradeError, got " <> show res
 
 fetchDowngradedSomeGlobal : (Text, Test)
 fetchDowngradedSomeGlobal = mkFetchDowngradedSome "static global" $ \a b -> do

--- a/sdk/daml-script/test/daml/upgrades/FromInterface.daml
+++ b/sdk/daml-script/test/daml/upgrades/FromInterface.daml
@@ -147,5 +147,5 @@ fromInterfaceInvalidDowngrade = test $ do
   res <- a `trySubmit` createAndExerciseCmd (TestHelper a) InvalidDowngrade
   case res of
     Right _ -> fail "Expected failure but got success"
-    Left (UpgradeError DowngradeDropDefinedField msg) | "field with a value of Some may not be dropped" `isInfixOf` msg -> pure ()
+    Left (UpgradeError (DowngradeDropDefinedField _) msg) | "field with a value of Some may not be dropped" `isInfixOf` msg -> pure ()
     Left e -> fail $ "Expected Upgrade error but got " <> show e

--- a/sdk/daml-script/test/daml/upgrades/FromInterface.daml
+++ b/sdk/daml-script/test/daml/upgrades/FromInterface.daml
@@ -147,5 +147,5 @@ fromInterfaceInvalidDowngrade = test $ do
   res <- a `trySubmit` createAndExerciseCmd (TestHelper a) InvalidDowngrade
   case res of
     Right _ -> fail "Expected failure but got success"
-    Left (UpgradeError (DowngradeDropDefinedField _) msg) | "field with a value of Some may not be dropped" `isInfixOf` msg -> pure ()
+    Left (UpgradeError (DowngradeDropDefinedField "InterfaceImplementer:IITemplate" 1) _) -> pure ()
     Left e -> fail $ "Expected Upgrade error but got " <> show e

--- a/sdk/daml-script/test/daml/upgrades/FromInterface.daml
+++ b/sdk/daml-script/test/daml/upgrades/FromInterface.daml
@@ -147,5 +147,5 @@ fromInterfaceInvalidDowngrade = test $ do
   res <- a `trySubmit` createAndExerciseCmd (TestHelper a) InvalidDowngrade
   case res of
     Right _ -> fail "Expected failure but got success"
-    Left (UpgradeError msg) | "field with a value of Some may not be dropped" `isInfixOf` msg -> pure ()
+    Left (UpgradeError DowngradeDropDefinedField msg) | "field with a value of Some may not be dropped" `isInfixOf` msg -> pure ()
     Left e -> fail $ "Expected Upgrade error but got " <> show e

--- a/sdk/daml-script/test/daml/upgrades/FromInterface.daml
+++ b/sdk/daml-script/test/daml/upgrades/FromInterface.daml
@@ -147,5 +147,5 @@ fromInterfaceInvalidDowngrade = test $ do
   res <- a `trySubmit` createAndExerciseCmd (TestHelper a) InvalidDowngrade
   case res of
     Right _ -> fail "Expected failure but got success"
-    Left (DevError Upgrade msg) | "field with a value of Some may not be dropped" `isInfixOf` msg -> pure ()
+    Left (UpgradeError msg) | "field with a value of Some may not be dropped" `isInfixOf` msg -> pure ()
     Left e -> fail $ "Expected Upgrade error but got " <> show e

--- a/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
+++ b/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
@@ -164,7 +164,7 @@ exerciseCommandShouldFail = test $ do
   (alice, icid) <- setupAliceAndInterface
   res <- alice `trySubmit` exerciseCmd icid GetVersion
   case res of
-      Left (UpgradeError msg) | "View mismatch" `isInfixOf` msg -> pure ()
+      Left (UpgradeError ViewMismatch msg) | "View mismatch" `isInfixOf` msg -> pure ()
       _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)
 
 exerciseInChoiceBodyShouldFail : Test
@@ -172,7 +172,7 @@ exerciseInChoiceBodyShouldFail = test $ do
   (alice, icid) <- setupAliceAndInterface
   res <- alice `trySubmit` createAndExerciseCmd (Caller with party = alice) (CallInterface with icid = icid)
   case res of
-    Left (UpgradeError msg) | "View mismatch" `isInfixOf` msg -> pure ()
+    Left (UpgradeError ViewMismatch msg) | "View mismatch" `isInfixOf` msg -> pure ()
     _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)
 
 fetchFromInterfaceShouldFail : Test
@@ -180,7 +180,7 @@ fetchFromInterfaceShouldFail = test $ do
   (alice, icid) <- setupAliceAndInterface
   res <- alice `trySubmit` createAndExerciseExactCmd (V2.FITemplate with party = alice) (V2.FetchFromInterface with icid = icid)
   case res of
-    Left (UpgradeError msg) | "View mismatch" `isInfixOf` msg -> pure ()
+    Left (UpgradeError ViewMismatch msg) | "View mismatch" `isInfixOf` msg -> pure ()
     _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)
 
 queryInterfaceContractIdInView : Test

--- a/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
+++ b/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
@@ -164,7 +164,7 @@ exerciseCommandShouldFail = test $ do
   (alice, icid) <- setupAliceAndInterface
   res <- alice `trySubmit` exerciseCmd icid GetVersion
   case res of
-      Left (DevError Upgrade msg) | "View mismatch" `isInfixOf` msg -> pure ()
+      Left (UpgradeError msg) | "View mismatch" `isInfixOf` msg -> pure ()
       _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)
 
 exerciseInChoiceBodyShouldFail : Test
@@ -172,7 +172,7 @@ exerciseInChoiceBodyShouldFail = test $ do
   (alice, icid) <- setupAliceAndInterface
   res <- alice `trySubmit` createAndExerciseCmd (Caller with party = alice) (CallInterface with icid = icid)
   case res of
-    Left (DevError Upgrade msg) | "View mismatch" `isInfixOf` msg -> pure ()
+    Left (UpgradeError msg) | "View mismatch" `isInfixOf` msg -> pure ()
     _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)
 
 fetchFromInterfaceShouldFail : Test
@@ -180,7 +180,7 @@ fetchFromInterfaceShouldFail = test $ do
   (alice, icid) <- setupAliceAndInterface
   res <- alice `trySubmit` createAndExerciseExactCmd (V2.FITemplate with party = alice) (V2.FetchFromInterface with icid = icid)
   case res of
-    Left (DevError Upgrade msg) | "View mismatch" `isInfixOf` msg -> pure ()
+    Left (UpgradeError msg) | "View mismatch" `isInfixOf` msg -> pure ()
     _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)
 
 queryInterfaceContractIdInView : Test

--- a/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
+++ b/sdk/daml-script/test/daml/upgrades/InterfaceViews.daml
@@ -164,15 +164,27 @@ exerciseCommandShouldFail = test $ do
   (alice, icid) <- setupAliceAndInterface
   res <- alice `trySubmit` exerciseCmd icid GetVersion
   case res of
-      Left (UpgradeError ViewMismatch msg) | "View mismatch" `isInfixOf` msg -> pure ()
-      _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)
+    Left (UpgradeError (ViewMismatch foundCid foundInterfaceId foundSrcTemplateTypeRep foundDstTemplateTypeRep) msg)
+     | fromAnyContractId @V1.FITemplate foundCid == Some (fromInterfaceContractId @V1.FITemplate icid) &&
+       foundInterfaceId == templateTypeRep @I &&
+       foundSrcTemplateTypeRep == templateTypeRep @V1.FITemplate &&
+       foundDstTemplateTypeRep == templateTypeRep @V2.FITemplate &&
+       "View mismatch" `isInfixOf` msg
+     -> pure ()
+    _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)
 
 exerciseInChoiceBodyShouldFail : Test
 exerciseInChoiceBodyShouldFail = test $ do
   (alice, icid) <- setupAliceAndInterface
   res <- alice `trySubmit` createAndExerciseCmd (Caller with party = alice) (CallInterface with icid = icid)
   case res of
-    Left (UpgradeError ViewMismatch msg) | "View mismatch" `isInfixOf` msg -> pure ()
+    Left (UpgradeError (ViewMismatch foundCid foundInterfaceId foundSrcTemplateTypeRep foundDstTemplateTypeRep) msg)
+     | fromAnyContractId @V1.FITemplate foundCid == Some (fromInterfaceContractId @V1.FITemplate icid) &&
+       foundInterfaceId == templateTypeRep @I &&
+       foundSrcTemplateTypeRep == templateTypeRep @V1.FITemplate &&
+       foundDstTemplateTypeRep == templateTypeRep @V2.FITemplate &&
+       "View mismatch" `isInfixOf` msg
+     -> pure ()
     _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)
 
 fetchFromInterfaceShouldFail : Test
@@ -180,7 +192,13 @@ fetchFromInterfaceShouldFail = test $ do
   (alice, icid) <- setupAliceAndInterface
   res <- alice `trySubmit` createAndExerciseExactCmd (V2.FITemplate with party = alice) (V2.FetchFromInterface with icid = icid)
   case res of
-    Left (UpgradeError ViewMismatch msg) | "View mismatch" `isInfixOf` msg -> pure ()
+    Left (UpgradeError (ViewMismatch foundCid foundInterfaceId foundSrcTemplateTypeRep foundDstTemplateTypeRep) msg)
+     | fromAnyContractId @V1.FITemplate foundCid == Some (fromInterfaceContractId @V1.FITemplate icid) &&
+       foundInterfaceId == templateTypeRep @I &&
+       foundSrcTemplateTypeRep == templateTypeRep @V1.FITemplate &&
+       foundDstTemplateTypeRep == templateTypeRep @V2.FITemplate &&
+       "View mismatch" `isInfixOf` msg
+     -> pure ()
     _ -> assertFail ("Expected fetchFromInterface to fail, got " <> show res)
 
 queryInterfaceContractIdInView : Test

--- a/sdk/daml-script/test/daml/upgrades/MetadataChanged.daml
+++ b/sdk/daml-script/test/daml/upgrades/MetadataChanged.daml
@@ -1030,7 +1030,7 @@ expectSuccess r = case r of
 expectMetadataChangedError : Either SubmitError a -> Script ()
 expectMetadataChangedError r = case r of
     Right _ -> assertFail "Expected failure but got success"
-    Left (UpgradeError ValidationFailed msg)
+    Left (UpgradeError (ValidationFailed _ _ _ _ _ _) msg)
       | "Verify that neither the signatories, nor the observers, nor the contract key, nor the key's maintainers have changed" `isInfixOf` msg
       -> pure ()
     Left e -> assertFail $ "Expected Upgrade error but got " <> show e

--- a/sdk/daml-script/test/daml/upgrades/MetadataChanged.daml
+++ b/sdk/daml-script/test/daml/upgrades/MetadataChanged.daml
@@ -1030,11 +1030,7 @@ expectSuccess r = case r of
 expectMetadataChangedError : Either SubmitError a -> Script ()
 expectMetadataChangedError r = case r of
     Right _ -> assertFail "Expected failure but got success"
-    Left e -> pure ()
-    -- TODO(https://github.com/DACH-NY/canton/issues/23824): restore this more precise test once the SCU error improvements have been ported to 3.x
-    {-
-    Left (UpgradeError msg)
+    Left (UpgradeError ValidationFailed msg)
       | "Verify that neither the signatories, nor the observers, nor the contract key, nor the key's maintainers have changed" `isInfixOf` msg
       -> pure ()
     Left e -> assertFail $ "Expected Upgrade error but got " <> show e
-    -}

--- a/sdk/daml-script/test/daml/upgrades/SignatoryObserverChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/SignatoryObserverChanges.daml
@@ -116,7 +116,7 @@ signatoryObserverUpgrade shouldSucceed sigF obsF exerciseChoice = test $ do
   res <- trySubmitMulti [alice, bob, charlie] [] $ exerciseChoice cid
   case (res, shouldSucceed) of
     (Right _, True) -> pure ()
-    (Left (DevError Upgrade msg), False)
+    (Left (UpgradeError msg), False)
       | "Verify that neither the signatories, nor the observers, nor the contract key, nor the key's maintainers have changed" `isInfixOf` msg
       -> pure ()
     _ -> assertFail $ "Expected " <> (if shouldSucceed then "success" else "Upgrade error") <> " but got " <> show res

--- a/sdk/daml-script/test/daml/upgrades/SignatoryObserverChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/SignatoryObserverChanges.daml
@@ -116,7 +116,7 @@ signatoryObserverUpgrade shouldSucceed sigF obsF exerciseChoice = test $ do
   res <- trySubmitMulti [alice, bob, charlie] [] $ exerciseChoice cid
   case (res, shouldSucceed) of
     (Right _, True) -> pure ()
-    (Left (UpgradeError msg), False)
+    (Left (UpgradeError ValidationFailed msg), False)
       | "Verify that neither the signatories, nor the observers, nor the contract key, nor the key's maintainers have changed" `isInfixOf` msg
       -> pure ()
     _ -> assertFail $ "Expected " <> (if shouldSucceed then "success" else "Upgrade error") <> " but got " <> show res

--- a/sdk/daml-script/test/daml/upgrades/SignatoryObserverChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/SignatoryObserverChanges.daml
@@ -7,6 +7,7 @@ import UpgradeTestLib
 import qualified V1.SignatoryObserverChanges as V1
 import qualified V2.SignatoryObserverChanges as V2
 import qualified V1.IfaceMod as Iface
+import DA.List (sort)
 import DA.Text
 
 {- PACKAGE
@@ -116,8 +117,13 @@ signatoryObserverUpgrade shouldSucceed sigF obsF exerciseChoice = test $ do
   res <- trySubmitMulti [alice, bob, charlie] [] $ exerciseChoice cid
   case (res, shouldSucceed) of
     (Right _, True) -> pure ()
-    (Left (UpgradeError ValidationFailed msg), False)
-      | "Verify that neither the signatories, nor the observers, nor the contract key, nor the key's maintainers have changed" `isInfixOf` msg
+    (Left (UpgradeError (ValidationFailed foundCid foundSrcTemplateTypeRep foundDstTemplateTypeRep foundSignatories foundObservers None) msg), False)
+      | fromAnyContractId @V1.SignatoryObserverChangesTemplate foundCid == Some cid &&
+        foundSrcTemplateTypeRep == templateTypeRep @V1.SignatoryObserverChangesTemplate &&
+        foundDstTemplateTypeRep == templateTypeRep @V2.SignatoryObserverChangesTemplate &&
+        sort foundSignatories == sort postSignatories &&
+        sort foundObservers == sort foundObservers &&
+        "Verify that neither the signatories, nor the observers, nor the contract key, nor the key's maintainers have changed" `isInfixOf` msg
       -> pure ()
     _ -> assertFail $ "Expected " <> (if shouldSucceed then "success" else "Upgrade error") <> " but got " <> show res
 

--- a/sdk/daml-script/test/daml/upgrades/VariantChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/VariantChanges.daml
@@ -60,7 +60,7 @@ templateInvalidChange shouldSucceed makeV1Contract v2Choice = test $ do
   case (res, shouldSucceed) of
     (Right "V1", True) -> pure ()
     (Right "V2", True) -> pure ()
-    (Left (DevError Upgrade _), False) -> pure ()
+    (Left (UpgradeError _), False) -> pure ()
     (Left (WronglyTypedContract {}), False) -> pure ()
     (Left (UnknownError msg), False) | "An error occurred." `isInfixOf` msg -> pure ()
     -- IDE Ledger doesn't apply obfuscation, instead the lookup error is wrapped in SCrash

--- a/sdk/daml-script/test/daml/upgrades/VariantChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/VariantChanges.daml
@@ -60,7 +60,7 @@ templateInvalidChange shouldSucceed makeV1Contract v2Choice = test $ do
   case (res, shouldSucceed) of
     (Right "V1", True) -> pure ()
     (Right "V2", True) -> pure ()
-    (Left (UpgradeError _), False) -> pure ()
+    (Left (UpgradeError _ _), False) -> pure ()
     (Left (WronglyTypedContract {}), False) -> pure ()
     (Left (UnknownError msg), False) | "An error occurred." `isInfixOf` msg -> pure ()
     -- IDE Ledger doesn't apply obfuscation, instead the lookup error is wrapped in SCrash

--- a/sdk/docs/sharable/daml-script/api/Daml-Script-Internal-Questions-Submit-Error.rst
+++ b/sdk/docs/sharable/daml-script/api/Daml-Script-Internal-Questions-Submit-Error.rst
@@ -57,11 +57,6 @@ Data Types
   `WronglyTypedContractSoft <constr-daml-script-internal-questions-submit-error-wronglytypedcontractsoft-93780_>`_
 
 
-  .. _constr-daml-script-internal-questions-submit-error-upgrade-90081:
-
-  `Upgrade <constr-daml-script-internal-questions-submit-error-upgrade-90081_>`_
-
-
   .. _constr-daml-script-internal-questions-submit-error-unknownnewfeature-96345:
 
   `UnknownNewFeature <constr-daml-script-internal-questions-submit-error-unknownnewfeature-96345_>`_
@@ -425,6 +420,26 @@ Data Types
          - \[`AnyContractKey <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193>`_\]
          - Locked contract keys
 
+  .. _constr-daml-script-internal-questions-submit-error-upgradeerror-4562:
+
+  `UpgradeError <constr-daml-script-internal-questions-submit-error-upgradeerror-4562_>`_
+
+    Upgrade exception
+
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+
+       * - Field
+         - Type
+         - Description
+       * - errorType
+         - `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_
+         -
+       * - errorMessage
+         - `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
+         -
+
   .. _constr-daml-script-internal-questions-submit-error-deverror-73533:
 
   `DevError <constr-daml-script-internal-questions-submit-error-deverror-73533_>`_
@@ -505,6 +520,10 @@ Data Types
 
   **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"duplicateContractKey\" `SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284_>`_ (`Optional <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153>`_ `AnyContractKey <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193>`_)
 
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"errorMessage\" `SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284_>`_ `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
+
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"errorType\" `SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284_>`_ `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_
+
   **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"exc\" `SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284_>`_ (`Optional <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153>`_ `AnyException <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-anyexception-7004>`_)
 
   **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"expectedKey\" `SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284_>`_ `AnyContractKey <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193>`_
@@ -561,6 +580,10 @@ Data Types
 
   **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"duplicateContractKey\" `SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284_>`_ (`Optional <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153>`_ `AnyContractKey <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193>`_)
 
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"errorMessage\" `SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284_>`_ `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
+
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"errorType\" `SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284_>`_ `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_
+
   **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"exc\" `SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284_>`_ (`Optional <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153>`_ `AnyException <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-anyexception-7004>`_)
 
   **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"expectedKey\" `SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284_>`_ `AnyContractKey <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193>`_
@@ -598,6 +621,139 @@ Data Types
   **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"unknownErrorMessage\" `SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284_>`_ `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
 
   **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"userErrorMessage\" `SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284_>`_ `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
+
+.. _type-daml-script-internal-questions-submit-error-upgradeerrortype-94779:
+
+**data** `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_
+
+  .. _constr-daml-script-internal-questions-submit-error-validationfailed-35370:
+
+  `ValidationFailed <constr-daml-script-internal-questions-submit-error-validationfailed-35370_>`_
+
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+
+       * - Field
+         - Type
+         - Description
+       * - coid
+         - :ref:`AnyContractId <type-daml-script-internal-questions-util-anycontractid-11399>`
+         -
+       * - srcTemplateId
+         - `TemplateTypeRep <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
+         -
+       * - dstTemplateId
+         - `TemplateTypeRep <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
+         -
+       * - signatories
+         - \[`Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_\]
+         -
+       * - observers
+         - \[`Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_\]
+         -
+       * - keyOpt
+         - `Optional <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153>`_ (`AnyContractKey <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193>`_, \[`Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_\])
+         -
+
+  .. _constr-daml-script-internal-questions-submit-error-downgradedropdefinedfield-50092:
+
+  `DowngradeDropDefinedField <constr-daml-script-internal-questions-submit-error-downgradedropdefinedfield-50092_>`_
+
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+
+       * - Field
+         - Type
+         - Description
+       * - expectedType
+         - `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
+         -
+       * - fieldIndex
+         - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+         -
+
+  .. _constr-daml-script-internal-questions-submit-error-viewmismatch-75035:
+
+  `ViewMismatch <constr-daml-script-internal-questions-submit-error-viewmismatch-75035_>`_
+
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+
+       * - Field
+         - Type
+         - Description
+       * - coid
+         - :ref:`AnyContractId <type-daml-script-internal-questions-util-anycontractid-11399>`
+         -
+       * - iterfaceId
+         - `TemplateTypeRep <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
+         -
+       * - srcTemplateId
+         - `TemplateTypeRep <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
+         -
+       * - dstTemplateId
+         - `TemplateTypeRep <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
+         -
+
+  .. _constr-daml-script-internal-questions-submit-error-downgradefailed-38019:
+
+  `DowngradeFailed <constr-daml-script-internal-questions-submit-error-downgradefailed-38019_>`_
+
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+
+       * - Field
+         - Type
+         - Description
+       * - expectedType
+         - `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
+         -
+
+  **instance** `Show <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360>`_ `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_
+
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"coid\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ :ref:`AnyContractId <type-daml-script-internal-questions-util-anycontractid-11399>`
+
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"dstTemplateId\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ `TemplateTypeRep <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
+
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"errorType\" `SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284_>`_ `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_
+
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"expectedType\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
+
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"fieldIndex\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"iterfaceId\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ `TemplateTypeRep <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
+
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"keyOpt\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ (`Optional <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153>`_ (`AnyContractKey <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193>`_, \[`Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_\]))
+
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"observers\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ \[`Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_\]
+
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"signatories\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ \[`Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_\]
+
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"srcTemplateId\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ `TemplateTypeRep <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
+
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"coid\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ :ref:`AnyContractId <type-daml-script-internal-questions-util-anycontractid-11399>`
+
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"dstTemplateId\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ `TemplateTypeRep <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
+
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"errorType\" `SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284_>`_ `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_
+
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"expectedType\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
+
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"fieldIndex\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"iterfaceId\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ `TemplateTypeRep <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
+
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"keyOpt\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ (`Optional <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153>`_ (`AnyContractKey <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193>`_, \[`Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_\]))
+
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"observers\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ \[`Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_\]
+
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"signatories\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ \[`Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_\]
+
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"srcTemplateId\" `UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779_>`_ `TemplateTypeRep <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
 
 Functions
 ---------

--- a/sdk/docs/sharable/daml-script/api/Daml-Script-Internal-Questions-Util.rst
+++ b/sdk/docs/sharable/daml-script/api/Daml-Script-Internal-Questions-Util.rst
@@ -37,6 +37,8 @@ Data Types
 
   **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"additionalInfoCid\" :ref:`ContractNotFoundAdditionalInfo <type-daml-script-internal-questions-submit-error-contractnotfoundadditionalinfo-6199>` `AnyContractId <type-daml-script-internal-questions-util-anycontractid-11399_>`_
 
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"coid\" :ref:`UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779>` `AnyContractId <type-daml-script-internal-questions-util-anycontractid-11399_>`_
+
   **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"contractId\" :ref:`SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284>` `AnyContractId <type-daml-script-internal-questions-util-anycontractid-11399_>`_
 
   **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"contractId\" :ref:`Created <type-daml-script-internal-questions-transactiontree-created-98301>` `AnyContractId <type-daml-script-internal-questions-util-anycontractid-11399_>`_
@@ -50,6 +52,8 @@ Data Types
   **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"templateId\" `AnyContractId <type-daml-script-internal-questions-util-anycontractid-11399_>`_ `TemplateTypeRep <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
 
   **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"additionalInfoCid\" :ref:`ContractNotFoundAdditionalInfo <type-daml-script-internal-questions-submit-error-contractnotfoundadditionalinfo-6199>` `AnyContractId <type-daml-script-internal-questions-util-anycontractid-11399_>`_
+
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"coid\" :ref:`UpgradeErrorType <type-daml-script-internal-questions-submit-error-upgradeerrortype-94779>` `AnyContractId <type-daml-script-internal-questions-util-anycontractid-11399_>`_
 
   **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"contractId\" :ref:`SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284>` `AnyContractId <type-daml-script-internal-questions-util-anycontractid-11399_>`_
 


### PR DESCRIPTION
- [8234129](https://github.com/digital-asset/daml/pull/20769/commits/8234129e2cb077f058f1866ea33a1810ffd129d4):
  Mostly direct, account for some changes to SBuiltin
- [38cf060](https://github.com/digital-asset/daml/pull/20769/commits/38cf0604a06c6de9983d869310f41f190ed71f94):
  Same as above
- [f9423d1](https://github.com/digital-asset/daml/pull/20769/commits/f9423d18985cbc288c117f33b3cd66645c8b4007):
  Same again, with some changes removed as to tests that don't exist yet
- [efd919f](https://github.com/digital-asset/daml/pull/20769/commits/efd919f5175918ca13f9b7cf3c37e16825f49c63):
  Same as above, fix a note from Paul who ported tests before this error detail was here
- [b2beb7f](https://github.com/digital-asset/daml/pull/20769/commits/b2beb7f847e34df3ed5c6aa2eaa04699bae34ed2):
  Straightforward port, had to drop some references to an error relating specifically to LF1.15
- [d4928e8](https://github.com/digital-asset/daml/pull/20769/commits/d4928e87fd90cc0e9a4c2d1f5fa4d5f947cbbf35):
  Same as above, however this commit doesn't build, as can't derive Show instance for UpgradeError in 2.1
  This is because it uses AnyContractKey, and the show instance for that is only available in 2.dev
- [0ced7f0](https://github.com/digital-asset/daml/pull/20769/commits/0ced7f03b96f7643c63ec9ed315605294c2caccd):
  Wrote an explicit Show instance for UpgradeError, which doesn't try to show the AnyKey
- [69622b4](https://github.com/digital-asset/daml/pull/20769/commits/69622b491786183eb850e83d0a826244a746a8fb):
  Noticed that we have "FieldType" on the DropField exception, but its no the type of the field, but the type of the record
  Since we're adding "FieldIndex" in the next commit (which is the index of the actual field), I've renamed this one to "ExpectedType"
- [d4c3d85](https://github.com/digital-asset/daml/pull/20769/commits/d4c3d85bc6ef5df20e7ecb02f04cc2ebbcce6e06):
  Straight forward port, again removing references to the LF1.15 error
- [f92c650](https://github.com/digital-asset/daml/pull/20769/commits/f92c650528556d20d602c6efd6393d2d9702a1f3):
  Just the pre-push formatter

Canton cherry-pick commit for when code-drop to canton fails:
https://github.com/DACH-NY/canton/pull/23981
  