### PR TITLE
Port "allow upgrading key types in the participant #19780"

### DIFF
--- a/sdk/daml-lf/validation/BUILD.bazel
+++ b/sdk/daml-lf/validation/BUILD.bazel
@@ -237,6 +237,8 @@ da_scala_test_suite(
             "//test-common:upgrades-FailsWhenTemplateAddsKeyType-v2.dar",
             "//test-common:upgrades-FailsWhenTemplateChangesKeyType-v1.dar",
             "//test-common:upgrades-FailsWhenTemplateChangesKeyType-v2.dar",
+            "//test-common:upgrades-SucceedsWhenTemplateUpgradesKeyType-v1.dar",
+            "//test-common:upgrades-SucceedsWhenTemplateUpgradesKeyType-v2.dar",
             "//test-common:upgrades-FailsWhenTemplateChoiceChangesItsReturnType-v1.dar",
             "//test-common:upgrades-FailsWhenTemplateChoiceChangesItsReturnType-v2.dar",
             "//test-common:upgrades-FailsWhenTemplateRemovesKeyType-v1.dar",

--- a/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
+++ b/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Upgrading.scala
@@ -8,7 +8,7 @@ import scala.util.{Try, Success, Failure}
 import com.digitalasset.daml.lf.data.Ref.TypeConName
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.language.Ast._
-import com.digitalasset.daml.lf.language.{Ast, LanguageVersion, PackageInterface}
+import com.digitalasset.daml.lf.language.{Ast, LanguageVersion}
 
 import scala.annotation.tailrec
 
@@ -406,168 +406,7 @@ case class TypecheckUpgrades(
 ) {
   import TypecheckUpgrades._
 
-  private lazy val packageId: Upgrading[Ref.PackageId] = packages.map(_._1)
   private lazy val `package`: Upgrading[Ast.Package] = packages.map(_._2)
-
-  private val packageInterface: Upgrading[PackageInterface] =
-    packages.map { case (pkgId, pkgAst) => PackageInterface(Map(pkgId -> pkgAst)) }
-
-  /** The set of type constructors whose definitions are structurally equal between the
-    * past and present packages. It is built by building the largest fixed point of
-    * [[genStructurallyEqualTyConsStep]], which removes type constructors whose definitions
-    * are not structurally equal from a set. The set is seeded with the qualified names of
-    *  all type constructors present in both packages and whose definitions are serializable.
-    */
-  private lazy val structurallyEqualTyCons: Set[Ref.QualifiedName] = {
-    def tyCons(pkg: Ast.Package): Set[Ref.QualifiedName] = {
-      pkg.modules.flatMap { case (moduleName, module) =>
-        module.definitions.collect {
-          case (name, dt: DDataType) if dt.serializable =>
-            Ref.QualifiedName(moduleName, name)
-        }
-      }.toSet
-    }
-    val commonTyCons = tyCons(`package`.past).intersect(tyCons(`package`.present))
-    genStructurallyEqualTyCons(commonTyCons)
-  }
-
-  /** Computes the fixed point of genStructurallyEqualTyConsStep.
-    */
-  @tailrec
-  private def genStructurallyEqualTyCons(tyCons: Set[Ref.QualifiedName]): Set[Ref.QualifiedName] = {
-    val newTyCOns = genStructurallyEqualTyConsStep(tyCons)
-    if (newTyCOns == tyCons) tyCons
-    else genStructurallyEqualTyCons(newTyCOns)
-  }
-
-  /** For each type constructor name in [[tyCons]], checks that the definition of [[tyCons]] in
-    * the past and present packages are structurally equal, assuming that the type constructors
-    * in [[tyCons]] are structurally equal. Removes those that aren't.
-    */
-  def genStructurallyEqualTyConsStep(tyCons: Set[Ref.QualifiedName]): Set[Ref.QualifiedName] = {
-    tyCons.filter { name =>
-      val pastTypeConName = TypeConName(packageId.past, name)
-      val presentTypeConName = TypeConName(packageId.present, name)
-      structurallyEqualDataTypes(
-        tyCons,
-        Util.handleLookup(
-          Context.DefDataType(pastTypeConName),
-          packageInterface.past
-            .lookupDataType(pastTypeConName),
-        ),
-        Util.handleLookup(
-          Context.DefDataType(presentTypeConName),
-          packageInterface.present
-            .lookupDataType(presentTypeConName),
-        ),
-      )
-    }
-  }
-
-  /** Checks that [[pastDataType]] and [[presentDataType]] are structurally equal, assuming that
-    * the type constructors in [[tyCons]] are structurally equal.
-    */
-  def structurallyEqualDataTypes(
-      tyCons: Set[Ref.QualifiedName],
-      pastDataType: DDataType,
-      presentDataType: DDataType,
-  ): Boolean =
-    structurallyEqualDataCons(
-      tyCons,
-      Closure(Env().extend(pastDataType.params.map(_._1)), pastDataType.cons),
-      Closure(Env().extend(presentDataType.params.map(_._1)), presentDataType.cons),
-    )
-
-  /** Checks that [[pastCons]] and [[presentCons]] are structurally equal, assuming that
-    * the type constructors in [[tyCons]] are structurally equal.
-    */
-  private def structurallyEqualDataCons(
-      tyCons: Set[Ref.QualifiedName],
-      pastCons: Closure[DataCons],
-      presentCons: Closure[DataCons],
-  ): Boolean =
-    (pastCons.value, presentCons.value) match {
-      case (DataRecord(pastFields), DataRecord(presentFields)) =>
-        pastFields.length == presentFields.length &&
-        pastFields.iterator.zip(presentFields.iterator).forall {
-          case ((pastFieldName, pastType), (presentFieldName, presentType)) =>
-            pastFieldName == presentFieldName &&
-            structurallyEqualTypes(
-              tyCons,
-              Closure(pastCons.env, pastType),
-              Closure(presentCons.env, presentType),
-            )
-        }
-      case (DataVariant(pastVariants), DataVariant(presentVariants)) =>
-        pastVariants.length == presentVariants.length &&
-        pastVariants.iterator.zip(presentVariants.iterator).forall {
-          case ((pastVariantName, pastType), (presentVariantName, presentType)) =>
-            pastVariantName == presentVariantName &&
-            structurallyEqualTypes(
-              tyCons,
-              Closure(pastCons.env, pastType),
-              Closure(presentCons.env, presentType),
-            )
-        }
-      case (DataEnum(pastConstructors), DataEnum(presentConstructors)) =>
-        pastConstructors.length == presentConstructors.length &&
-        pastConstructors.iterator.zip(presentConstructors.iterator).forall {
-          case (pastCtor, presentCtor) => pastCtor == presentCtor
-        }
-      case _ =>
-        false
-    }
-
-  /** Checks that [[pastType]] and [[presentType]] are structurally equal, assuming that
-    * the type constructors in [[tyCons]] are structurally equal.
-    */
-  private def structurallyEqualTypes(
-      tyCons: Set[Ref.QualifiedName],
-      pastType: Closure[Ast.Type],
-      presentType: Closure[Ast.Type],
-  ): Boolean =
-    structurallyEqualTypes(
-      tyCons,
-      pastType.env,
-      presentType.env,
-      List((pastType.value, presentType.value)),
-    )
-
-  /** A stack-safe version of [[structurallyEqualTypes]] that uses a work list.
-    */
-  @tailrec
-  private def structurallyEqualTypes(
-      tyCons: Set[Ref.QualifiedName],
-      envPast: Env,
-      envPresent: Env,
-      trips: List[(Type, Type)],
-  ): Boolean = {
-    trips match {
-      case Nil => true
-      case (t1, t2) :: trips =>
-        (t1, t2) match {
-          case (TVar(x1), TVar(x2)) =>
-            envPast.binderDepth(x1) == envPresent.binderDepth(x2) &&
-            structurallyEqualTypes(tyCons, envPast, envPresent, trips)
-          case (TNat(n1), TNat(n2)) =>
-            n1 == n2 && structurallyEqualTypes(tyCons, envPast, envPresent, trips)
-          case (TTyCon(c1), TTyCon(c2)) =>
-            // Either c1 and c2 are the same type constructor from the exact same package (e.g. Tuple2),
-            // or they must have the same qualified name and be structurally equal by co-induction
-            // hypothesis.
-            (c1 == c2 ||
-              (c1.qualifiedName == c2.qualifiedName &&
-                tyCons.contains(c1.qualifiedName))) &&
-            structurallyEqualTypes(tyCons, envPast, envPresent, trips)
-          case (TApp(f1, a1), TApp(f2, a2)) =>
-            structurallyEqualTypes(tyCons, envPast, envPresent, (f1, f2) :: (a1, a2) :: trips)
-          case (TBuiltin(b1), TBuiltin(b2)) =>
-            b1 == b2 && structurallyEqualTypes(tyCons, envPast, envPresent, trips)
-          case _ =>
-            false
-        }
-    }
-  }
 
   private def check(): Try[Unit] = {
     for {
@@ -797,13 +636,7 @@ case class TypecheckUpgrades(
       case Upgrading(None, None) => Success(());
       case Upgrading(Some(pastKey), Some(presentKey)) => {
         val keyPastPresent = Upgrading(pastKey.typ, presentKey.typ)
-        if (
-          !structurallyEqualTypes(
-            structurallyEqualTyCons,
-            Closure(Env(), pastKey.typ),
-            Closure(Env(), presentKey.typ),
-          )
-        )
+        if (!checkType(Upgrading(Closure(Env(), pastKey.typ), Closure(Env(), presentKey.typ))))
           fail(UpgradeError.TemplateChangedKeyType(templateName, keyPastPresent))
         else
           Success(())

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesCheckSpec.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesCheckSpec.scala
@@ -535,6 +535,21 @@ final class UpgradesCheckSpec extends AsyncWordSpec with Matchers with Inside {
         ),
       )
     }
+    s"Succeeds when template upgrades its key type" in {
+      testPackages(
+        Seq(
+          "test-common/upgrades-SucceedsWhenTemplateUpgradesKeyType-v1.dar",
+          "test-common/upgrades-SucceedsWhenTemplateUpgradesKeyType-v2.dar",
+        ),
+        Seq(
+          (
+            "test-common/upgrades-SucceedsWhenTemplateUpgradesKeyType-v1.dar",
+            "test-common/upgrades-SucceedsWhenTemplateUpgradesKeyType-v2.dar",
+            None,
+          )
+        )
+      )
+    }
     s"Fails when template removes key type" in {
       testPackages(
         Seq(

--- a/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesCheckSpec.scala
+++ b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesCheckSpec.scala
@@ -547,7 +547,7 @@ final class UpgradesCheckSpec extends AsyncWordSpec with Matchers with Inside {
             "test-common/upgrades-SucceedsWhenTemplateUpgradesKeyType-v2.dar",
             None,
           )
-        )
+        ),
       )
     }
     s"Fails when template removes key type" in {

--- a/sdk/test-common/BUILD.bazel
+++ b/sdk/test-common/BUILD.bazel
@@ -302,6 +302,7 @@ da_scala_dar_resources_library(
         ("FailsWhenOldFieldIsDeletedFromTemplateChoice", {}, {}),
         ("FailsWhenTemplateAddsKeyType", {}, {}),
         ("FailsWhenTemplateChangesKeyType", {}, {}),
+        ("SucceedsWhenTemplateUpgradesKeyType", {}, {}),
         ("FailsWhenTemplateChangesKeyTypeSuperficially", {}, {}),
         ("FailsWhenTemplateChoiceChangesItsReturnType", {}, {}),
         ("FailsWhenTemplateRemovesKeyType", {}, {}),

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenTemplateChangesKeyType/v1/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenTemplateChangesKeyType/v1/Main.daml
@@ -3,13 +3,12 @@
 
 module Main where
 
-data T = T with
-  i : Int
+data T = T {}
 
 template A with
     p : Party
     q : Party
   where
     signatory p
-    key (p, T 0) : (Party, T)
+    key (p, T) : (Party, T)
     maintainer (fst key)

--- a/sdk/test-common/src/main/daml/upgrades/FailsWhenTemplateChangesKeyType/v2/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/FailsWhenTemplateChangesKeyType/v2/Main.daml
@@ -3,15 +3,14 @@
 
 module Main where
 
-data T = T with
-  i : Int
-  j : Optional Int
+data T = T {}
+data U = U {}
 
 template A with
     p : Party
     q : Party
   where
     signatory p
-    key (p, T 0 None) : (Party, T)
+    key (p, U) : (Party, U)
     maintainer (fst key)
 

--- a/sdk/test-common/src/main/daml/upgrades/SucceedsWhenTemplateUpgradesKeyType/v1/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/SucceedsWhenTemplateUpgradesKeyType/v1/Main.daml
@@ -1,4 +1,4 @@
--- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
 module Main where

--- a/sdk/test-common/src/main/daml/upgrades/SucceedsWhenTemplateUpgradesKeyType/v1/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/SucceedsWhenTemplateUpgradesKeyType/v1/Main.daml
@@ -1,0 +1,15 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+data T = T with
+  i : Int
+
+template A with
+    p : Party
+    q : Party
+  where
+    signatory p
+    key (p, T 0) : (Party, T)
+    maintainer (fst key)

--- a/sdk/test-common/src/main/daml/upgrades/SucceedsWhenTemplateUpgradesKeyType/v2/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/SucceedsWhenTemplateUpgradesKeyType/v2/Main.daml
@@ -1,4 +1,4 @@
--- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
 module Main where

--- a/sdk/test-common/src/main/daml/upgrades/SucceedsWhenTemplateUpgradesKeyType/v2/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/SucceedsWhenTemplateUpgradesKeyType/v2/Main.daml
@@ -1,0 +1,17 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+data T = T with
+  i : Int
+  j : Optional Int
+
+template A with
+    p : Party
+    q : Party
+  where
+    signatory p
+    key (p, T 0 None) : (Party, T)
+    maintainer (fst key)
+


### PR DESCRIPTION
Also went over `allow upgrading keys during re-interpretation (#19792)`, nothing in that PR needs to be ported because it is all either obsolete or already represented.