### PR TITLE
Restore lf value normalization

### DIFF
--- a/sdk/daml-lf/engine/src/test/daml/BasicTests.daml
+++ b/sdk/daml-lf/engine/src/test/daml/BasicTests.daml
@@ -24,6 +24,17 @@ template Simple
       controller p
       do pure "hello"
 
+template SimpleNumeric
+  with
+    p: Party
+    num: Numeric 4
+  where
+    signatory p
+
+    choice HelloNumeric : Text
+      controller p
+      do pure "hello"
+
 template SimpleMultiParty
   with
     p1: Party

--- a/sdk/daml-lf/engine/src/test/daml/BasicTests.daml
+++ b/sdk/daml-lf/engine/src/test/daml/BasicTests.daml
@@ -35,6 +35,17 @@ template SimpleNumeric
       controller p
       do pure "hello"
 
+template SimpleTrailingNone
+  with
+    p: Party
+    opt: Optional Int
+  where
+    signatory p
+
+    choice HelloTrailingNone : Text
+      controller p
+      do pure "hello"
+
 template SimpleMultiParty
   with
     p1: Party

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -59,6 +59,7 @@ import scala.annotation.nowarn
 import scala.collection.immutable.HashMap
 import scala.language.implicitConversions
 import scala.math.Ordered.orderingToOrdered
+import com.digitalasset.daml.lf.interpretation.{Error => IE}
 
 class EngineTestV2 extends EngineTest(LanguageMajorVersion.V2)
 
@@ -153,6 +154,69 @@ class EngineTest(majorLanguageVersion: LanguageMajorVersion)
       interpretResult.map { case (tx, _) => byKeyNodes(tx).size } shouldBe Right(0)
     }
 
+  }
+
+  "command with disclosure" should {
+    "reject disclosures with un-normalized numeric values" in {
+    "reject disclosures with non-normalized numeric values" in {
+      val templateId = Identifier(basicTestsPkgId, "BasicTests:SimpleNumeric")
+      val cid = toContractId("BasicTests:SimpleNumeric:1")
+      val command =
+        ApiCommand.Exercise(
+          templateId.toRef,
+          cid,
+          "HelloNumeric",
+          ValueRecord(Some(Identifier(basicTestsPkgId, "BasicTests:HelloNumeric")), ImmArray.Empty),
+        )
+      val readAs = (Set.empty: Set[Party])
+
+      val res = preprocessor
+        .preprocessApiCommands(Map.empty, ImmArray(command))
+        .consume(Map.empty, lookupPackage, Map.empty)
+      res shouldBe a[Right[_, _]]
+
+      val disclosure =
+        FatContractInstance.fromCreateNode(
+          Node.Create(
+            coid = cid,
+            packageName = basicTestsPkg.pkgName,
+            packageVersion = basicTestsPkg.pkgVersion,
+            templateId = templateId,
+            arg = ValueRecord(
+              Some(templateId),
+              ImmArray(
+                Some[Name]("p") -> ValueParty(party),
+                // The static type of "num" is Numeric 4 but the value below only has 2 decimal places. Because
+                // numeric values in disclosures must be normalized, we expect this to disclosure to be rejected
+                // by the engine in SBImportInputContract with a conformance error.
+                Some[Name]("num") -> ValueNumeric(Numeric.assertFromString("12.12")),
+              ),
+            ),
+            signatories = Set(party),
+            stakeholders = Set(party),
+            keyOpt = None,
+            version = basicTestsPkg.languageVersion,
+          ),
+          Time.Timestamp.now(),
+          Bytes.Empty,
+        )
+
+      val result = suffixLenientEngine
+        .submit(
+          submitters = Set(party),
+          readAs = readAs,
+          cmds = ApiCommands(ImmArray(command), Time.Timestamp.now(), "test"),
+          disclosures = ImmArray(disclosure),
+          participantId = participant,
+          submissionSeed = hash("exercise command with disclosure"),
+          prefetchKeys = Seq.empty,
+        )
+        .consume(Map.empty, lookupPackage, Map.empty)
+
+      inside(result) { case Left(Error.Interpretation(DamlException(IE.Dev(_, err)), _)) =>
+        err shouldBe a[IE.Dev.Conformance]
+      }
+    }
   }
 
   "multi-party create command" should {

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/UpgradeTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/UpgradeTest.scala
@@ -1839,17 +1839,6 @@ object UpgradeTest {
       // Some of the patterns below are verbose and could be simplified with a pattern guard, but we favor this style
       // because it is compatible exhaustivness checker.
       (testCase, operation, catchBehavior, entryPoint, contractOrigin) match {
-        // TODO(https://github.com/DACH-NY/canton/issues/23826): re-enable key upgrade/downgrade tests once
-        //   SValue.toNormalizedValue drops trailing Nones. It currently doesn't, which means checkContractUpgradable
-        //   will always fail on keys that differ, even if they normalize to the same value.
-        case (
-              ValidKeyUpgradeAdditionalField | ValidKeyDowngradeAdditionalField,
-              _,
-              _,
-              _,
-              _,
-            ) =>
-          None
         case (_, Fetch | FetchInterface | FetchByKey | LookupByKey, _, Command, _) =>
           None // There are no fetch* or lookupByKey commands
         case (_, Exercise | ExerciseInterface, _, Command, Local) =>

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValueEnricherSpec.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValueEnricherSpec.scala
@@ -50,7 +50,7 @@ class ValueEnricherSpec(majorLanguageVersion: LanguageMajorVersion)
         module Mod {
 
           record @serializable MyUnit = {};
-          record @serializable Record = { field : Int64 };
+          record @serializable Record = { field : Int64, optField: Option Int64 };
           variant @serializable Variant = variant1 : Text | variant2 : Int64 ;
           enum @serializable Enum = value1 | value2;
 
@@ -147,8 +147,25 @@ class ValueEnricherSpec(majorLanguageVersion: LanguageMajorVersion)
       ),
       (
         TTyCon("Mod:Record"),
+        ValueRecord(None, ImmArray(None -> ValueInt64(33), None -> ValueNone)),
+        ValueRecord(
+          Some("Mod:Record"),
+          ImmArray(
+            Some[Ref.Name]("field") -> ValueInt64(33),
+            Some[Ref.Name]("optField") -> ValueNone,
+          ),
+        ),
+      ),
+      (
+        TTyCon("Mod:Record"),
         ValueRecord(None, ImmArray(None -> ValueInt64(33))),
-        ValueRecord(Some("Mod:Record"), ImmArray(Some[Ref.Name]("field") -> ValueInt64(33))),
+        ValueRecord(
+          Some("Mod:Record"),
+          ImmArray(
+            Some[Ref.Name]("field") -> ValueInt64(33),
+            Some[Ref.Name]("optField") -> ValueNone,
+          ),
+        ),
       ),
       (
         TTyCon("Mod:Variant"),
@@ -278,7 +295,7 @@ class ValueEnricherSpec(majorLanguageVersion: LanguageMajorVersion)
         )
 
       val outputRecord =
-        ValueRecord("Mod:Record", ImmArray("field" -> ValueInt64(33)))
+        ValueRecord("Mod:Record", ImmArray("field" -> ValueInt64(33), "optField" -> ValueNone))
 
       val outputTransaction = buildTransaction(
         outputContract,

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -6,6 +6,7 @@ package speedy
 
 import com.daml.nameof.NameOf
 import com.daml.scalautil.Statement.discard
+import com.digitalasset.daml.lf.crypto.Hash.hashContractInstance
 import com.digitalasset.daml.lf.data.Numeric.Scale
 import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.data._
@@ -2108,11 +2109,31 @@ private[lf] object SBuiltinFun {
       )
       val recomputed = contractInfo.toCreateNode(contract.contractId)
       val provided = contract.toCreateNode
-      if (provided != recomputed) {
-        val mismatchingFields =
-          provided.productElementNames.zipWithIndex.collect {
-            case (field, i) if provided.productElement(i) != recomputed.productElement(i) => field
-          }
+      val mismatchingFields =
+        provided.productElementNames.zipWithIndex.flatMap {
+          // Because [recomputed] was obtained by creating a normal value out of the svalue obtained by translating the
+          // original contract, the following line is basically testing that
+          // translateValue(arg, typ).toNormalizedValue == arg modulo None values.
+          // It would seem as if that's a law that should hold for all args, and thus doesn't need testing. But this is
+          // not the case: if arg contains a numeric value that is not in normal form w.r.t. its scale
+          // (e.g. 1.12 of scale 5), then the renormalized value will be different from the original one.
+          // We want to catch and rejects such cases. The only difference we want to allow is for Nones to be dropped.
+          case ("arg", _) =>
+            Option.when(
+              hashContractInstance(
+                provided.packageName,
+                provided.templateId,
+                provided.arg,
+              ) != hashContractInstance(
+                recomputed.packageName,
+                recomputed.templateId,
+                recomputed.arg,
+              )
+            )("arg")
+          case (field, i) =>
+            Option.when(provided.productElement(i) != recomputed.productElement(i))(field)
+        }
+      if (mismatchingFields.nonEmpty) {
         Control.Error(
           IE.Dev(
             NameOf.qualifiedNameOfCurrentFunc,

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -68,15 +68,19 @@ sealed abstract class SValue {
         case SBool(x) => V.ValueBool(x)
         case SUnit => V.ValueUnit
         case SDate(x) => V.ValueDate(x)
-        case r: SRecord =>
-          V.ValueRecord(
-            maybeEraseTypeInfo(r.id),
-            (r.fields.toSeq.view zip r.values.iterator().asScala)
-              .map { case (field, sv) =>
-                (maybeEraseTypeInfo(field), go(sv, nextMaxNesting))
-              }
-              .to(ImmArray),
-          )
+        case SRecord(id, names0, values0) =>
+          val n =
+            if (normalize)
+              // we drop trailing None fields
+              values0.asScala.reverseIterator.dropWhile(_ == SValue.SValue.None).size
+            else
+              values0.size()
+          val values = (names0.toSeq.view.take(n) zip values0.asScala)
+            .map { case (name, sv) =>
+              maybeEraseTypeInfo(name) -> go(sv, nextMaxNesting)
+            }
+            .to(ImmArray)
+          V.ValueRecord(maybeEraseTypeInfo(id), values)
         case SVariant(id, variant, _, sv) =>
           V.ValueVariant(maybeEraseTypeInfo(id), variant, go(sv, nextMaxNesting))
         case SEnum(id, constructor, _) =>

--- a/sdk/daml-script/test/daml/upgrades/ContractKeys.daml
+++ b/sdk/daml-script/test/daml/upgrades/ContractKeys.daml
@@ -108,12 +108,9 @@ main = tests
   , subtree "Changed key type"
     [ subtree "Unchanged key value (modulo trailing `None`s)"
       [ ("queryContractKey, src=v1 tgt=v2", queryKeyUpgraded)
-      -- TODO(https://github.com/DACH-NY/canton/issues/23826): restore once keys are normalized
-      , broken ("exerciseByKeyCmd, src=v1 tgt=v2", exerciseCmdKeyUpgraded)
-      -- TODO(https://github.com/DACH-NY/canton/issues/23826): restore once keys are normalized
-      , broken ("fetch, src=v1 tgt=v2", fetchKeyUpgraded)
-      -- TODO(https://github.com/DACH-NY/canton/issues/23826): restore once keys are normalized
-      , broken ("exerciseByKey, src=v1 tgt=v2", exerciseUpdateKeyUpgraded)
+      , ("exerciseByKeyCmd, src=v1 tgt=v2", exerciseCmdKeyUpgraded)
+      , ("fetch, src=v1 tgt=v2", fetchKeyUpgraded)
+      , ("exerciseByKey, src=v1 tgt=v2", exerciseUpdateKeyUpgraded)
       ]
     ]
   ]

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -138,7 +138,7 @@
 - Evaluation order of successful lookup_by_key of a local contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3188)
 - Evaluation order of successful lookup_by_key of a non-cached global contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3055)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L36)
-- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2256)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2314)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L262)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version, where one is new to V2 within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L266)
 - Smart Contract Upgrade: Can catch same errors thrown by different choice versions within Update: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L258)

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -138,7 +138,7 @@
 - Evaluation order of successful lookup_by_key of a local contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3188)
 - Evaluation order of successful lookup_by_key of a non-cached global contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3055)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L36)
-- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2193)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2256)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L262)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version, where one is new to V2 within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L266)
 - Smart Contract Upgrade: Can catch same errors thrown by different choice versions within Update: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L258)

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -138,7 +138,7 @@
 - Evaluation order of successful lookup_by_key of a local contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3188)
 - Evaluation order of successful lookup_by_key of a non-cached global contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3055)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L36)
-- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2314)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2317)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L262)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version, where one is new to V2 within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L266)
 - Smart Contract Upgrade: Can catch same errors thrown by different choice versions within Update: [Exceptions.daml](daml-script/test/daml/upgrades/Exceptions.daml#L258)


### PR DESCRIPTION
Part of https://github.com/DACH-NY/canton/issues/23826

Restore https://github.com/digital-asset/daml/pull/19989 which had been [rolled back](https://github.com/digital-asset/daml/pull/20171). The rollback PR was undoing both https://github.com/digital-asset/daml/pull/19989 and https://github.com/digital-asset/daml/pull/20036 at the same time to fix [an ACS import issue](https://github.com/DACH-NY/canton-network-node/issues/15640). However, only https://github.com/digital-asset/daml/pull/20036 was responsible for the ACS import  and https://github.com/digital-asset/daml/pull/19989 alone should be safe.

Said otherwise, after this PR we will be normalizing LF values produced by the engine (i.e. dropping trailing Nones), but we will **not** require that disclosures and input contracts be normalized.

The reasons for re-introducing the normalization are twofold:
- If keys are not normalized, key look-ups fail in the presence of upgrades.
- More generally, the structural equality on (sub-)transactions doesn't account for upgrades unless transactions are normalized. Writing equality modulo upgrades is hard, error-prone and potentially slow.

It is fine not to assume that input contracts are disclosures are normalized because input contracts and disclosures are saturated with Nones based on their type upon being imported into the engine.

Because `toNormalizedValue` now drops trailing Nones, the conformance test performed by `SBImportInputContract`, which checks in essence that `disclosure == import(disclosure).toNormalizedValue`, now rejects disclosures with trailing Nones. We want to keep that check because it ensures that numerical values and maps are normalized, which should be the case even for pre-3.3 disclosures. But for backwards compatibility with pre-3.3 disclosures, we want to relax that equality check to be performed modulo trailing Nones. We achieve this by comparing the upgrade-friendly hashes of the original and the recomputed disclosure. This PR adds two engine test cases: one for disclosures with non-normalized numeric values (should be rejected), and one for disclosure with trailing nones (should be accepted).