### PR TITLE
Temporarily disable windows as Bazel fails to install

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -122,6 +122,8 @@ jobs:
 - template: blackduck.yml
 
 - job: Windows
+  # Temporarily disable windows as Bazel fails to install
+  condition: false
   dependsOn:
     - check_for_release
   variables:


### PR DESCRIPTION
Windows machines are rather broken right now, bazel/msys2 are failing to install.
Snapshots are still blocked sadly, but this should at least allow PRs to merge until @paulbrauner-da and I can fix this.