### PR TITLE
Significantly bump msys2 to fix bazel install failures/slowness

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -122,8 +122,6 @@ jobs:
 - template: blackduck.yml
 
 - job: Windows
-  # Temporarily disable windows as Bazel fails to install
-  condition: false
   dependsOn:
     - check_for_release
   variables:

--- a/sdk/dev-env/windows/manifests/msys2.json
+++ b/sdk/dev-env/windows/manifests/msys2.json
@@ -24,7 +24,7 @@
         "https://repo.msys2.org/msys/x86_64/xz-5.2.5-1-x86_64.pkg.tar.xz#/xz.msys2"
     ],
     "url": [
-        "https://storage.googleapis.com/daml-binaries/dev-env/windows/20221021/msys2-base-x86_64-20220128.tar.xz",
+        "https://github.com/msys2/msys2-installer/releases/download/2025-02-21/msys2-base-x86_64-20250221.tar.xz",
         "https://storage.googleapis.com/daml-binaries/dev-env/windows/20221021/mingw-w64-x86_64-jq-1.6-4-any.pkg.tar.zst#/jq.msys2",
         "https://storage.googleapis.com/daml-binaries/dev-env/windows/20221021/gnu-netcat-0.7.1-1-x86_64.pkg.tar.xz#/netcat.msys2",
         "https://storage.googleapis.com/daml-binaries/dev-env/windows/20221021/patch-2.7.6-1-x86_64.pkg.tar.xz#/patch.msys2",
@@ -46,7 +46,7 @@
         "https://storage.googleapis.com/daml-binaries/dev-env/windows/20221021/xz-5.2.5-1-x86_64.pkg.tar.xz#/xz.msys2"
     ],
     "hash": [
-        "b667a7ec3840c0437c718d6851c93794bd8a6837ba642fd90702e8769febad6a",
+        "850589091e731d14b234447084737ca62aee1cc1e3c10be62fcdc12b8263d70b",
         "c9903f4bf07402dbecf250d531e6d07748c62560d8d67de487ae56692c14aab0",
         "32fa739d26fd49a3f8c22717ae338472d71d4798844cbc0db5e7780131fe69aa",
         "5c18ce8979e9019d24abd2aee7ddcdf8824e31c4c7e162a204d4dc39b3b73776",


### PR DESCRIPTION
Bazel has been failing to install on windows machines. We found this was because its dependency, msys2, wasn't able to run its install script, which grabbed certain pinned deps from pacman's index.
It appears the failure is related to outdated signing keys, and after much exploration, we found that simply updating msys2 allowed pacman to install more recent versions of `zip`, `unzip` and `gcc`, which were the problematic dependencies.
These have been bumped via msys2 to the following versions
```
zip: 3.0-3 -> 3.0-4
unzip: 6.0-2 -> 6.0-3
gcc: 11.2.0-8 -> 14.2.0-2
```
This also includes all the updated/additional dependencies that comes with updating `gcc`
We also found similar key issues around install other dependencies like `perl` were fixed by this change to msys2, though our perl is pinned, so we assume this is a result of `pacman` updating, rather than `perl`.
We lastly found that this update sped up the install _significantly_, going from around 40 minutes to less than 5, as we're no longer pinging a bunch of mirrors for artifacts that don't exist anymore, and presumably downloading them at very slow speeds.

This update does however have some risk, as we don't have much visibility into the full dependency tree changes of these utils, its possible there have been updates we haven't noticed. However I would argue that having dependencies that are so old they are being removed from public mirrors is more risky than updating them.

This PR only updates msys2, but doesn't re-enable windows CI yet. We intend to wait for confirmation from security before allowing these updated dependencies to run on a CI machine with our secrets. I will not merge this PR until we have confirmation and have re-enabled windows.

There is lastly the question of whether we should copy the updated msys2 over to our google cloud, to match the previous behaviour. This may give slightly faster download speed/reliability, but is unlikely to ever be removed, as was the risk with the other artifacts we pushed to gcloud.