### PR TITLE
Acquired interface query/subscription filters

### DIFF
--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/index/IndexServiceImpl.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/index/IndexServiceImpl.scala
@@ -37,7 +37,6 @@ import com.digitalasset.canton.logging.{
   LoggingContextWithTrace,
   NamedLoggerFactory,
   NamedLogging,
-  TracedLogger,
 }
 import com.digitalasset.canton.metrics.LedgerApiServerMetrics
 import com.digitalasset.canton.pekkostreams.dispatcher.Dispatcher
@@ -345,7 +344,6 @@ private[index] class IndexServiceImpl(
               alwaysPopulateArguments = false,
             ).toList
           ).flatMapConcat { case InternalEventFormat(templateFilter, eventProjectionProperties) =>
-            //logger.warn(s"$templateFilter")
             ledgerDao.updateReader
               .getActiveContracts(
                 activeAt = activeAt,
@@ -803,7 +801,6 @@ object IndexServiceImpl {
       alwaysPopulateArguments: Boolean,
   )(implicit
       contextualizedErrorLogger: ContextualizedErrorLogger,
-      loggingContext: LoggingContextWithTrace
   ): () => Option[(TemplatePartiesFilter, EventProjectionProperties)] = {
     @volatile var metadata: PackageMetadata = null
     @volatile var filters: Option[(TemplatePartiesFilter, EventProjectionProperties)] = None
@@ -826,7 +823,7 @@ object IndexServiceImpl {
       eventFormat: EventFormat,
       metadata: PackageMetadata,
       alwaysPopulateArguments: Boolean,
-  )(implicit contextualizedErrorLogger: ContextualizedErrorLogger): Option[InternalEventFormat] = {
+  ): Option[InternalEventFormat] = {
     val templateFilter: Map[Identifier, Option[Set[Party]]] =
       IndexServiceImpl.templateFilter(metadata, eventFormat)
 
@@ -839,7 +836,6 @@ object IndexServiceImpl {
       val eventProjectionProperties = EventProjectionProperties(
         eventFormat = eventFormat,
         interfaceImplementedBy =
-          //interfaceId => metadata.interfacesImplementedBy.getOrElse(interfaceId, Set.empty),
           interfaceId => interfacesImplementedByWithUpgrades(metadata, interfaceId),
         resolveTypeConRef = metadata.resolveTypeConRef,
         alwaysPopulateArguments = alwaysPopulateArguments,
@@ -856,22 +852,18 @@ object IndexServiceImpl {
     }
   }
 
-  private def interfacesImplementedByWithUpgrades(metadata: PackageMetadata, interfaceId: Ref.Identifier)(implicit contextualizedErrorLogger: ContextualizedErrorLogger): Set[(Ref.Identifier, Ref.Identifier)] =
+  private def interfacesImplementedByWithUpgrades(metadata: PackageMetadata, interfaceId: Ref.Identifier): Set[(Ref.Identifier, Ref.Identifier)] =
     for {
       originalImplementor <- metadata.interfacesImplementedBy.getOrElse(interfaceId, Set.empty)
-      _ = contextualizedErrorLogger.warn(s"ORIGINAL IMPLEMENTOR: $originalImplementor")
       (packageName, _) <- metadata.packageIdVersionMap.get(originalImplementor.packageId).toSet
-      _ = contextualizedErrorLogger.warn(s"PACKAGE NAME: $packageName")
       implementor <- metadata.resolveTypeConRef(Ref.TypeConRef(Ref.PackageRef.Name(packageName), originalImplementor.qualifiedName))
-      _ = contextualizedErrorLogger.warn(s"IMPLEMENTOR: $implementor")
     } yield (originalImplementor, implementor)
 
 
   private def templateIds(
       metadata: PackageMetadata,
       cumulativeFilter: CumulativeFilter,
-  )(implicit contextualizedErrorLogger: ContextualizedErrorLogger): Set[Identifier] = {
-    contextualizedErrorLogger.warn(s"Start templateIds")
+  ): Set[Identifier] = {
     val fromInterfacesDefs = cumulativeFilter.interfaceFilters.view
       .map(_.interfaceTypeRef)
       .flatMap(metadata.resolveTypeConRef(_))
@@ -882,15 +874,13 @@ object IndexServiceImpl {
       .map(_.templateTypeRef)
       .flatMap(metadata.resolveTypeConRef(_))
 
-    val result = fromInterfacesDefs ++ fromTemplateDefs
-    contextualizedErrorLogger.warn(s"End templateIds: $result")
-    result
+    fromInterfacesDefs ++ fromTemplateDefs
   }
 
   private[index] def templateFilter(
       metadata: PackageMetadata,
       eventFormat: EventFormat,
-  )(implicit contextualizedErrorLogger: ContextualizedErrorLogger): Map[Identifier, Option[Set[Party]]] = {
+  ): Map[Identifier, Option[Set[Party]]] = {
     val templatesFilterByParty =
       eventFormat.filtersByParty.view.foldLeft(Map.empty[Identifier, Option[Set[Party]]]) {
         case (acc, (party, cumulativeFilter)) =>
@@ -916,7 +906,7 @@ object IndexServiceImpl {
   // template-wildcard for the parties or party-wildcards of the filter given
   private[index] def wildcardFilter(
       eventFormat: EventFormat
-  )(implicit contextualizedErrorLogger: ContextualizedErrorLogger): Option[Set[Party]] = {
+  ): Option[Set[Party]] = {
     val emptyFiltersMessage =
       "Found transaction filter with both template and interface filters being empty, but the" +
         "request should have already been rejected in validation"

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/EventProjectionProperties.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/EventProjectionProperties.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved
 // SPDX-License-Identifier: Apache-2.0
 
 package com.digitalasset.canton.platform.store.dao
@@ -7,7 +7,6 @@ import com.digitalasset.canton.ledger.api.{CumulativeFilter, EventFormat, Templa
 import com.digitalasset.canton.platform.store.dao.EventProjectionProperties.Projection
 import com.digitalasset.daml.lf.data.Ref.*
 
-import com.daml.error.{ContextualizedErrorLogger}
 import scala.collection.View
 
 /** This class encapsulates the logic of how contract arguments and interface views are being
@@ -79,7 +78,7 @@ object EventProjectionProperties {
       interfaceImplementedBy: Identifier => Set[(Identifier, Identifier)],
       resolveTypeConRef: TypeConRef => Set[Identifier],
       alwaysPopulateArguments: Boolean,
-  )(implicit contextualizedErrorLogger: ContextualizedErrorLogger): EventProjectionProperties = {
+  ): EventProjectionProperties = {
     EventProjectionProperties(
       verbose = eventFormat.verbose,
       templateWildcardWitnesses = templateWildcardWitnesses(eventFormat, alwaysPopulateArguments),
@@ -145,7 +144,7 @@ object EventProjectionProperties {
       apiEventFormat: EventFormat,
       interfaceImplementedBy: Identifier => Set[(Identifier, Identifier)],
       resolveTypeConRef: TypeConRef => Set[Identifier],
-  )(implicit contextualizedErrorLogger: ContextualizedErrorLogger): Map[Option[String], Map[Identifier, Projection]] = {
+  ): Map[Option[String], Map[Identifier, Projection]] = {
     val partyFilterPairs =
       apiEventFormat.filtersByParty.view.map { case (p, f) =>
         (Some(p), f)
@@ -156,11 +155,8 @@ object EventProjectionProperties {
     } yield {
       val interfaceFilterProjections = for {
         interfaceFilter <- cumulativeFilter.interfaceFilters.view
-        _ = contextualizedErrorLogger.warn(s"INTERFACE FILTER: $interfaceFilter")
         interfaceId <- resolveTypeConRef(interfaceFilter.interfaceTypeRef)
-        _ = contextualizedErrorLogger.warn(s"INTERFACE ID: $interfaceId")
         (originalImplementor, implementor) <- interfaceImplementedBy(interfaceId).view
-        _ = contextualizedErrorLogger.warn(s"IMPLEMENTOR: $implementor")
       } yield implementor -> Projection(
         interfaces = if (interfaceFilter.includeView) Set((originalImplementor, interfaceId)) else Set.empty,
         createdEventBlob = interfaceFilter.includeCreatedEventBlob,

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/ACSReader.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/ACSReader.scala
@@ -112,6 +112,10 @@ class ACSReader(
       eventProjectionProperties,
     )
       .watchTermination()(endSpanOnTermination(span))
+      .map(response => {
+        logger.warn(s"STREAMING RESPONSE: $response")
+        response
+      })
   }
 
   private def doStreamActiveContracts(

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/ACSReader.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/ACSReader.scala
@@ -112,10 +112,6 @@ class ACSReader(
       eventProjectionProperties,
     )
       .watchTermination()(endSpanOnTermination(span))
-      .map(response => {
-        logger.warn(s"STREAMING RESPONSE: $response")
-        response
-      })
   }
 
   private def doStreamActiveContracts(

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/LfValueTranslation.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/LfValueTranslation.scala
@@ -450,13 +450,13 @@ final class LfValueTranslation(
         .map(toContractKeyApi(verbose))
     )
     def asyncInterfaceViews =
-      MonadUtil.sequentialTraverse(renderResult.interfaces.toList)(interfaceId =>
+      MonadUtil.sequentialTraverse(renderResult.interfaces.toList)({ case (originalImplementorTemplateId, interfaceId) =>
         computeInterfaceView(
-          templateId,
+          originalImplementorTemplateId,
           value.unversioned,
           interfaceId,
         ).flatMap(toInterfaceView(eventProjectionProperties.verbose, interfaceId))
-      )
+      })
 
     def asyncCreatedEventBlob = condFuture(renderResult.createdEventBlob) {
       (for {

--- a/sdk/daml-script/test/daml/upgrades/Interfaces.daml
+++ b/sdk/daml-script/test/daml/upgrades/Interfaces.daml
@@ -219,7 +219,7 @@ main = tests
   , ("Calling a new interface choice uses the highest version implementation at choice body level by default", defaultHighestVersionChoiceImplementationForNewInterfaceUpdate)
   , ("Package map preference is used for new interface implementation selection at command level", newInterfaceChoicePackagePreferenceCommand)
   , ("Package map preference is used for new interface implementation selection at choice body level", newInterfaceChoicePackagePreferenceUpdate)
-  , broken ("queryInterfaceContractId works as intended in the presence of upgraded packages with new interface instances", queryNewInterfaceUpgrades)
+  , ("queryInterfaceContractId works as intended in the presence of upgraded packages with new interface instances", queryNewInterfaceUpgrades)
   , ("fetchFromInterface works as intended in the presence of upgraded packages with new interface instances", fetchFromNewInterfaceUpgrades)
   -- IDE Ledger doesn't support unvetting
   -- Can't unvet old version of package on 3x, even though v2 exists.
@@ -389,6 +389,12 @@ queryInterfaceUpgrades = test $ do
 queryNewInterfaceUpgrades : Test
 queryNewInterfaceUpgrades = test $ do
   (alice, icid) <- setupAliceAndV1NewInterface
+  res <- fromSomeNote "Failed to find contract" <$> alice `queryInterfaceContractId` icid
+  res.owner === alice
+  (alice, icid) <- setupAliceAndV2NewInterface
+  res <- fromSomeNote "Failed to find contract" <$> alice `queryInterfaceContractId` icid
+  res.owner === alice
+  (alice, icid) <- setupAliceAndV3NewInterface
   res <- fromSomeNote "Failed to find contract" <$> alice `queryInterfaceContractId` icid
   res.owner === alice
 


### PR DESCRIPTION
~~Do not merge until https://github.com/digital-asset/daml/pull/20818 goes in~~ Work is now primarily on Canton - only the daml tests here need to be kept.

Implementing acquired interface filters
At time of opening this PR, just a basic implementation doing the simplest possible thing

~~I'll move this over to Canton next week and start running tests there.~~ https://github.com/DACH-NY/canton/pull/24515