### PR TITLE
Update multi-package.yaml searching

### DIFF
--- a/sdk/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
+++ b/sdk/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
@@ -197,7 +197,6 @@ withPackageConfig projectPath f = do
 findMultiPackageConfig :: ProjectPath -> IO (Maybe ProjectPath)
 findMultiPackageConfig projectPath = do
   filePath <- canonicalizePath $ unwrapProjectPath projectPath
-  hPutStrLn stderr filePath
   flip loopM filePath $ \path -> do
     hasMultiPackage <- doesFileExist $ path </> multiPackageConfigName
     if hasMultiPackage

--- a/sdk/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
+++ b/sdk/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
@@ -197,6 +197,7 @@ withPackageConfig projectPath f = do
 findMultiPackageConfig :: ProjectPath -> IO (Maybe ProjectPath)
 findMultiPackageConfig projectPath = do
   filePath <- canonicalizePath $ unwrapProjectPath projectPath
+  hPutStrLn stderr filePath
   flip loopM filePath $ \path -> do
     hasMultiPackage <- doesFileExist $ path </> multiPackageConfigName
     if hasMultiPackage

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -883,10 +883,9 @@ execBuild projectOpts opts mbOutFile incrementalBuild initPkgDb enableMultiPacka
     pkgPath <- liftIO getCanonDefaultProjectPath
     mPkgConfig <- ContT $ withMaybeConfig $ withPackageConfig pkgPath
     liftIO $ if getEnableMultiPackage enableMultiPackage then do
+      -- If running build --all, search from invocation location, as package location is irrelevant
       mMultiPackagePath <- getMultiPackagePath multiPackageLocation $ if getMultiPackageBuildAll buildAll then Just execPath else Nothing
       -- At this point, if mMultiPackagePath is Just, we know it points to a multi-package.yaml
-      -- TODO: For regular build, its important that we look from the package
-      -- for build --all, "current package" has no significance, and we should instead search from run dir
 
       case (getMultiPackageBuildAll buildAll, mPkgConfig, mMultiPackagePath) of
         -- We're attempting to multi-package build --all, so we require that we have a multi-package.yaml, but do not care if we have a daml.yaml


### PR DESCRIPTION
Running `daml build` internally searches for a daml.yaml and multi-package.yaml
Currently, we first search for a daml.yaml (based either on execution location, or the --project-root flag), then look for a multi-package.yaml above this.
However, when running `daml build --all`, this approach doesn't make sense, as there may be a daml.yaml above this directory serving only to provide an sdk-version, which stops us from seeing a multi-package.yaml at the execution directory (as reported by @judywu-da)
This PR updates the searching logic for multi-package.yaml to start from current directory, when using `--all`