### PR TITLE
retroactively enable Fetch.interface_id in 2.1 transactions

### DIFF
--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -1403,13 +1403,11 @@ private[lf] object SBuiltinFun {
         args: util.ArrayList[SValue],
         machine: Machine[Q],
     ): Control.Expression = {
-      val txVersion = machine.tmplId2TxVersion(interfaceId)
       val e = SEBuiltinFun(
         SBUInsertFetchNode(
           getSAnyContract(args, 0)._1,
           byKey = false,
-          interfaceId =
-            Option.when(txVersion >= TransactionVersion.minFetchInterfaceId)(interfaceId),
+          interfaceId = Some(interfaceId),
         )
       )
       Control.Expression(e)

--- a/sdk/daml-lf/transaction/src/main/protobuf/com/digitalasset/daml/lf/transaction.proto
+++ b/sdk/daml-lf/transaction/src/main/protobuf/com/digitalasset/daml/lf/transaction.proto
@@ -54,8 +54,8 @@ message Node {
   message Fetch {
     bytes contract_id = 1;
     string package_name = 2;
-    com.digitalasset.daml.lf.value.Identifier template_id = 3; // require
-    com.digitalasset.daml.lf.value.Identifier interface_id = 7; // optional *since dev*
+    com.digitalasset.daml.lf.value.Identifier template_id = 3; // required
+    com.digitalasset.daml.lf.value.Identifier interface_id = 7; // optional
     repeated string non_maintainer_signatories = 4;
     repeated string non_signatory_stakeholders = 5;
     repeated string actors = 6;

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -255,9 +255,7 @@ object TransactionCoder {
     discard(builder.setContractId(node.coid.toBytes.toByteString))
     discard(builder.setPackageName(node.packageName))
     discard(builder.setTemplateId(ValueCoder.encodeIdentifier(node.templateId)))
-    if (version >= TransactionVersion.minFetchInterfaceId) {
-      node.interfaceId.foreach(iface => builder.setInterfaceId(ValueCoder.encodeIdentifier(iface)))
-    }
+    node.interfaceId.foreach(iface => builder.setInterfaceId(ValueCoder.encodeIdentifier(iface)))
     non_maintainer_signatories.foreach(builder.addNonMaintainerSignatories)
     non_signatory_stakeholders.foreach(builder.addNonSignatoryStakeholders)
     node.actingParties.foreach(builder.addActors)
@@ -468,7 +466,7 @@ object TransactionCoder {
       pkgName <- decodePackageName(msg.getPackageName)
       templateId <- ValueCoder.decodeIdentifier(msg.getTemplateId)
       interfaceId <-
-        if (nodeVersion >= TransactionVersion.minFetchInterfaceId && msg.hasInterfaceId) {
+        if (msg.hasInterfaceId) {
           ValueCoder.decodeIdentifier(msg.getInterfaceId).map(Some(_))
         } else {
           Right(None)

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -64,8 +64,6 @@ object TransactionVersion {
 
   private[lf] val minPackageVersion = LanguageVersion.Features.persistedPackageVersion
 
-  private[lf] val minFetchInterfaceId = LanguageVersion.v2_dev
-
   val VDev = LanguageVersion.v2_dev
 
   private[lf] def txVersion(tx: Transaction) = {


### PR DESCRIPTION
Part of https://github.com/DACH-NY/canton/issues/23825.

Interfaces are not used yet in Canton Network and every participant upgrades canton at the same time. Thus is it ok to pretend that field was always supported in LF 2.1 transactions.