### PR TITLE
Structured types and hashing for upgrades

### DIFF
--- a/sdk/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/StructuralType.scala
+++ b/sdk/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/StructuralType.scala
@@ -29,49 +29,35 @@ object StructuralType {
 
     case object TextF extends StructuralTypeF
 
-    final case class ContractIdF(arg: StructuralTypeF) extends StructuralTypeF
+    final case class ContractIdF(templateId: Ref.Identifier) extends StructuralTypeF
 
-    final case class OptionalF(arg: StructuralTypeF) extends StructuralTypeF
+    final case class OptionalF(arg: Option[StructuralTypeF]) extends StructuralTypeF
 
-    final case class ListF(arg: StructuralTypeF) extends StructuralTypeF
+    final case class ListF(arg: FrontStack[StructuralTypeF]) extends StructuralTypeF
 
-    final case class StructuralListF(arg: FrontStack[StructuralTypeF]) extends StructuralTypeF
+    final case class MapF(arg: ArraySeq[(StructuralTypeF, StructuralTypeF)]) extends StructuralTypeF
 
-    final case class MapF(keyT: StructuralTypeF, valueT: StructuralTypeF) extends StructuralTypeF
-
-    final case class StructuralMapF(arg: ArraySeq[(StructuralTypeF, StructuralTypeF)])
-        extends StructuralTypeF
-
-    final case class TextMapF(arg: StructuralTypeF) extends StructuralTypeF
-
-    final case class StructuralTextMapF(arg: ArraySeq[StructuralTypeF]) extends StructuralTypeF
+    final case class TextMapF(arg: ArraySeq[StructuralTypeF]) extends StructuralTypeF
 
     final case class RecordF(
-        tyCon: Ref.TypeConName,
+        tyCon: Ref.QualifiedName,
         pkgName: Ref.PackageName,
-        fieldNames: ArraySeq[Ref.Name],
-        fieldTypes: ArraySeq[StructuralTypeF],
+        fieldInfo: ArraySeq[(Ref.Name, Int, StructuralTypeF)],
     ) extends StructuralTypeF
 
     final case class VariantF(
-        tyCon: Ref.TypeConName,
+        tyCon: Ref.QualifiedName,
         pkgName: Ref.PackageName,
-        cons: ArraySeq[Ref.Name],
-        consTypes: ArraySeq[StructuralTypeF],
-    ) extends StructuralTypeF
-
-    final case class StructuralVariantF(
-        tyCon: Ref.TypeConName,
-        pkgName: Ref.PackageName,
-        cons: ArraySeq[Ref.Name],
-        consTypes: ArraySeq[StructuralTypeF],
         variant: Ref.Name,
+        variantIndex: Int,
+        variantType: StructuralTypeF,
     ) extends StructuralTypeF
 
     final case class EnumF(
-        tyCon: Ref.TypeConName,
+        tyCon: Ref.QualifiedName,
         pkgName: Ref.PackageName,
-        cons: ArraySeq[Ref.Name],
+        cons: Ref.Name,
+        consIndex: Int,
     ) extends StructuralTypeF
   }
 

--- a/sdk/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/StructuralType.scala
+++ b/sdk/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/StructuralType.scala
@@ -9,56 +9,56 @@ import com.digitalasset.daml.lf.data.{FrontStack, Numeric, Ref}
 import scala.collection.immutable.ArraySeq
 
 object StructuralType {
-  sealed abstract class StructuralTypeF extends Product with Serializable
+  sealed abstract class StructuralType extends Product with Serializable
 
-  object StructuralTypeF {
+  object StructuralType {
 
-    case object UnitF extends StructuralTypeF
+    case object UnitT extends StructuralType
 
-    case object BoolF extends StructuralTypeF
+    case object BoolT extends StructuralType
 
-    case object Int64F extends StructuralTypeF
+    case object Int64T extends StructuralType
 
-    case object DateF extends StructuralTypeF
+    case object DateT extends StructuralType
 
-    case object TimestampF extends StructuralTypeF
+    case object TimestampT extends StructuralType
 
-    final case class NumericF(scale: Numeric.Scale) extends StructuralTypeF
+    final case class NumericT(scale: Numeric.Scale) extends StructuralType
 
-    case object PartyF extends StructuralTypeF
+    case object PartyT extends StructuralType
 
-    case object TextF extends StructuralTypeF
+    case object TextT extends StructuralType
 
-    final case class ContractIdF(templateId: Ref.Identifier) extends StructuralTypeF
+    final case class ContractIdT(templateId: Ref.Identifier) extends StructuralType
 
-    final case class OptionalF(arg: Option[StructuralTypeF]) extends StructuralTypeF
+    final case class OptionalT(arg: Option[StructuralType]) extends StructuralType
 
-    final case class ListF(arg: FrontStack[StructuralTypeF]) extends StructuralTypeF
+    final case class ListT(arg: FrontStack[StructuralType]) extends StructuralType
 
-    final case class MapF(arg: ArraySeq[(StructuralTypeF, StructuralTypeF)]) extends StructuralTypeF
+    final case class MapT(arg: ArraySeq[(StructuralType, StructuralType)]) extends StructuralType
 
-    final case class TextMapF(arg: ArraySeq[StructuralTypeF]) extends StructuralTypeF
+    final case class TextMapT(arg: ArraySeq[StructuralType]) extends StructuralType
 
-    final case class RecordF(
+    final case class RecordT(
         tyCon: Ref.QualifiedName,
         pkgName: Ref.PackageName,
-        fieldInfo: ArraySeq[(Ref.Name, Int, StructuralTypeF)],
-    ) extends StructuralTypeF
+        fieldInfo: ArraySeq[(Ref.Name, Int, StructuralType)],
+    ) extends StructuralType
 
-    final case class VariantF(
+    final case class VariantT(
         tyCon: Ref.QualifiedName,
         pkgName: Ref.PackageName,
         variant: Ref.Name,
         variantIndex: Int,
-        variantType: StructuralTypeF,
-    ) extends StructuralTypeF
+        variantType: StructuralType,
+    ) extends StructuralType
 
-    final case class EnumF(
+    final case class EnumT(
         tyCon: Ref.QualifiedName,
         pkgName: Ref.PackageName,
         cons: Ref.Name,
         consIndex: Int,
-    ) extends StructuralTypeF
+    ) extends StructuralType
   }
 
   sealed abstract class Error extends Throwable

--- a/sdk/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/StructuralType.scala
+++ b/sdk/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/StructuralType.scala
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf
+package language
+
+import com.digitalasset.daml.lf.data.{FrontStack, Numeric, Ref}
+
+import scala.collection.immutable.ArraySeq
+
+object StructuralType {
+  sealed abstract class StructuralTypeF extends Product with Serializable
+
+  object StructuralTypeF {
+
+    case object UnitF extends StructuralTypeF
+
+    case object BoolF extends StructuralTypeF
+
+    case object Int64F extends StructuralTypeF
+
+    case object DateF extends StructuralTypeF
+
+    case object TimestampF extends StructuralTypeF
+
+    final case class NumericF(scale: Numeric.Scale) extends StructuralTypeF
+
+    case object PartyF extends StructuralTypeF
+
+    case object TextF extends StructuralTypeF
+
+    final case class ContractIdF(arg: StructuralTypeF) extends StructuralTypeF
+
+    final case class OptionalF(arg: StructuralTypeF) extends StructuralTypeF
+
+    final case class ListF(arg: StructuralTypeF) extends StructuralTypeF
+
+    final case class StructuralListF(arg: FrontStack[StructuralTypeF]) extends StructuralTypeF
+
+    final case class MapF(keyT: StructuralTypeF, valueT: StructuralTypeF) extends StructuralTypeF
+
+    final case class StructuralMapF(arg: ArraySeq[(StructuralTypeF, StructuralTypeF)])
+        extends StructuralTypeF
+
+    final case class TextMapF(arg: StructuralTypeF) extends StructuralTypeF
+
+    final case class StructuralTextMapF(arg: ArraySeq[StructuralTypeF]) extends StructuralTypeF
+
+    final case class RecordF(
+        tyCon: Ref.TypeConName,
+        pkgName: Ref.PackageName,
+        fieldNames: ArraySeq[Ref.Name],
+        fieldTypes: ArraySeq[StructuralTypeF],
+    ) extends StructuralTypeF
+
+    final case class VariantF(
+        tyCon: Ref.TypeConName,
+        pkgName: Ref.PackageName,
+        cons: ArraySeq[Ref.Name],
+        consTypes: ArraySeq[StructuralTypeF],
+    ) extends StructuralTypeF
+
+    final case class StructuralVariantF(
+        tyCon: Ref.TypeConName,
+        pkgName: Ref.PackageName,
+        cons: ArraySeq[Ref.Name],
+        consTypes: ArraySeq[StructuralTypeF],
+        variant: Ref.Name,
+    ) extends StructuralTypeF
+
+    final case class EnumF(
+        tyCon: Ref.TypeConName,
+        pkgName: Ref.PackageName,
+        cons: ArraySeq[Ref.Name],
+    ) extends StructuralTypeF
+  }
+
+  sealed abstract class Error extends Throwable
+
+  object Error {
+    final case class StructuralTypeError(msg: String) extends Error
+  }
+}

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -22,7 +22,7 @@ import com.daml.scalautil.Statement.discard
 import com.digitalasset.daml.lf.crypto.HashUtils.{HashTracer, formatByteToHexString}
 import com.digitalasset.daml.lf.data.Ref.Name
 import com.digitalasset.daml.lf.language.LanguageVersion
-import com.digitalasset.daml.lf.language.StructuralType.StructuralTypeF
+import com.digitalasset.daml.lf.language.StructuralType.StructuralType
 import com.digitalasset.daml.lf.transaction._
 import com.digitalasset.daml.lf.value.Value.ContractId
 import scalaz.Order
@@ -1043,7 +1043,7 @@ object Hash {
       .addStringSet(actAs)
       .build
 
-  def hashStructuralType(structType: StructuralTypeF): Hash = {
+  def hashStructuralType(structType: StructuralType): Hash = {
     def newHashBuilder: LegacyBuilder = {
       val structuralTypeName = structType.getClass.getSimpleName
 
@@ -1057,31 +1057,31 @@ object Hash {
     }
 
     structType match {
-      case StructuralTypeF.NumericF(scale) =>
+      case StructuralType.NumericT(scale) =>
         newHashBuilder.addIntWithContext(scale, "scale").build
 
-      case StructuralTypeF.ContractIdF(templateId) =>
+      case StructuralType.ContractIdT(templateId) =>
         newHashBuilder
           .addStringWithContext(templateId.toString, "templateId")
           .build
 
-      case StructuralTypeF.OptionalF(None) =>
+      case StructuralType.OptionalT(None) =>
         newHashBuilder.addIntWithContext(0, "None").build
 
-      case StructuralTypeF.OptionalF(Some(arg)) =>
+      case StructuralType.OptionalT(Some(arg)) =>
         newHashBuilder
           .addIntWithContext(1, "Some")
           .addHash(hashStructuralType(arg), "arg")
           .build
 
-      case StructuralTypeF.ListF(arg) =>
+      case StructuralType.ListT(arg) =>
         newHashBuilder
           .iterateOver(arg.iterator.zipWithIndex, arg.length) { case (b, (typeT, index)) =>
             b.addHash(hashStructuralType(typeT), s"typeT($index)")
           }
           .build
 
-      case StructuralTypeF.MapF(arg) =>
+      case StructuralType.MapT(arg) =>
         newHashBuilder
           .iterateOver(arg.zipWithIndex.iterator, arg.size) { case (b, ((keyT, valueT), index)) =>
             b.addHash(hashStructuralType(keyT), s"keyT($index)")
@@ -1089,14 +1089,14 @@ object Hash {
           }
           .build
 
-      case StructuralTypeF.TextMapF(arg) =>
+      case StructuralType.TextMapT(arg) =>
         newHashBuilder
           .iterateOver(arg.zipWithIndex.iterator, arg.size) { case (b, (valueT, index)) =>
             b.addHash(hashStructuralType(valueT), s"valueT($index)")
           }
           .build
 
-      case StructuralTypeF.RecordF(tyCon, pkgName, fieldInfo) =>
+      case StructuralType.RecordT(tyCon, pkgName, fieldInfo) =>
         newHashBuilder
           .addStringWithContext(tyCon.toString, "tyCon")
           .addStringWithContext(pkgName, "pkgName")
@@ -1108,7 +1108,7 @@ object Hash {
           }
           .build
 
-      case StructuralTypeF.VariantF(tyCon, pkgName, variant, variantIndex, variantType) =>
+      case StructuralType.VariantT(tyCon, pkgName, variant, variantIndex, variantType) =>
         newHashBuilder
           .addStringWithContext(tyCon.toString, "tyCon")
           .addStringWithContext(pkgName, "pkgName")
@@ -1117,7 +1117,7 @@ object Hash {
           .addHash(hashStructuralType(variantType), "variantType")
           .build
 
-      case StructuralTypeF.EnumF(tyCon, pkgName, cons, consIndex) =>
+      case StructuralType.EnumT(tyCon, pkgName, cons, consIndex) =>
         newHashBuilder
           .addStringWithContext(tyCon.toString, "tyCon")
           .addStringWithContext(pkgName, "pkgName")


### PR DESCRIPTION
PoC: structured typing and hashing for upgrades.

- [x] define `StructuralType.StructuredTypeF` (c.f. `TypeDestructor.SerializableTypeF`
- [x] define hashing scheme for `StructuralType.StructuredTypeF`
- [x] define how `SValue` and `Ast.Type` can be translated to `StructuralType.StructuredTypeF`
- [ ] where possible, convert recursive implementations using tail recursion
- [ ] implement `destruct: Ast.Type => SerializableTypeF`
- [ ] implement `(Value, Ast.Type) => Hash` layer of code
- [ ] testing

Notes:
- this PR initially aims for correctness rather than efficiency
- we start our PoC by assuming that a `Value` has been converted into an `SValue` using the type `Ast.Type`
    - an extra coding layer needs to be implemented to achieve this
