### PR TITLE
docs: stop creating toctrees that mess with docs site

### DIFF
--- a/sdk/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/sdk/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -33,17 +33,12 @@ renderRst env = \case
     RenderDocs docText -> docTextToRst docText
     RenderAnchor anchor -> [".. _" <> unAnchor anchor <> ":"]
     RenderIndex moduleNames ->
-        [ ".. toctree::"
-        , "   :maxdepth: 3"
-        , "   :titlesonly:"
-        , ""
-        ] ++
         [ T.concat
-            [ "   "
+            [ "* :doc:`"
             , unModulename moduleName
             , " <"
             , T.pack (moduleNameToFileName moduleName)
-            , ">"
+            , ">`"
             ]
         | moduleName <- moduleNames
         ]

--- a/sdk/compiler/damlc/daml-doc/test/DA/Daml/Doc/Render/Tests.hs
+++ b/sdk/compiler/damlc/daml-doc/test/DA/Daml/Doc/Render/Tests.hs
@@ -240,18 +240,14 @@ mkExpectRst asFolder anchor name descr templates classes adts fcts = T.unlines .
 
 expectRstIndex :: T.Text
 expectRstIndex = T.unlines
-  [ ".. toctree::"
-  , "   :maxdepth: 3"
-  , "   :titlesonly:"
-  , ""
-  , "   Empty <Empty>"
-  , "   Function1 <Function1>"
-  , "   Function3 <Function3>"
-  , "   FunctionCtx <FunctionCtx>"
-  , "   MultiLineField <MultiLineField>"
-  , "   OnlyClass <OnlyClass>"
-  , "   TwoTypes <TwoTypes>"
-  , "   Typedef <Typedef>"
+  [ "* :doc:`Empty <Empty>`"
+  , "* :doc:`Function1 <Function1>`"
+  , "* :doc:`Function3 <Function3>`"
+  , "* :doc:`FunctionCtx <FunctionCtx>`"
+  , "* :doc:`MultiLineField <MultiLineField>`"
+  , "* :doc:`OnlyClass <OnlyClass>`"
+  , "* :doc:`TwoTypes <TwoTypes>`"
+  , "* :doc:`Typedef <Typedef>`"
   ]
 
 expectMarkdown :: [T.Text]

--- a/sdk/docs/manually-written/sdk/reference/daml/stdlib/index2.rst
+++ b/sdk/docs/manually-written/sdk/reference/daml/stdlib/index2.rst
@@ -1,6 +1,0 @@
-
-Daml StdLib
-===========
-
-To reenable the existing file, remove the toctree from the build process, as the toc tree in there conflicts with the
-main toctree.

--- a/sdk/docs/sharable/sdk/reference/daml-script/api/index.rst
+++ b/sdk/docs/sharable/sdk/reference/daml-script/api/index.rst
@@ -10,25 +10,21 @@ The Daml Script library defines the API used to implement Daml scripts. See :doc
 Note that this is the Daml 3 version of the Daml-Script library. It is not compatible with scripts compiled using `daml-script` before Daml 3.3.
 Scripts compiled with `daml3-script` before this time are still compatible.
 
-.. toctree::
-   :maxdepth: 3
-   :titlesonly:
-
-   Daml.Script <Daml-Script>
-   Daml.Script.Internal.LowLevel <Daml-Script-Internal-LowLevel>
-   Daml.Script.Internal.Questions <Daml-Script-Internal-Questions>
-   Daml.Script.Internal.Questions.Commands <Daml-Script-Internal-Questions-Commands>
-   Daml.Script.Internal.Questions.Crypto <Daml-Script-Internal-Questions-Crypto>
-   Daml.Script.Internal.Questions.Crypto.Text <Daml-Script-Internal-Questions-Crypto-Text>
-   Daml.Script.Internal.Questions.Exceptions <Daml-Script-Internal-Questions-Exceptions>
-   Daml.Script.Internal.Questions.Packages <Daml-Script-Internal-Questions-Packages>
-   Daml.Script.Internal.Questions.PartyManagement <Daml-Script-Internal-Questions-PartyManagement>
-   Daml.Script.Internal.Questions.Query <Daml-Script-Internal-Questions-Query>
-   Daml.Script.Internal.Questions.Submit <Daml-Script-Internal-Questions-Submit>
-   Daml.Script.Internal.Questions.Submit.Error <Daml-Script-Internal-Questions-Submit-Error>
-   Daml.Script.Internal.Questions.Testing <Daml-Script-Internal-Questions-Testing>
-   Daml.Script.Internal.Questions.Time <Daml-Script-Internal-Questions-Time>
-   Daml.Script.Internal.Questions.TransactionTree <Daml-Script-Internal-Questions-TransactionTree>
-   Daml.Script.Internal.Questions.UserManagement <Daml-Script-Internal-Questions-UserManagement>
-   Daml.Script.Internal.Questions.Util <Daml-Script-Internal-Questions-Util>
+* :doc:`Daml.Script <Daml-Script>`
+* :doc:`Daml.Script.Internal.LowLevel <Daml-Script-Internal-LowLevel>`
+* :doc:`Daml.Script.Internal.Questions <Daml-Script-Internal-Questions>`
+* :doc:`Daml.Script.Internal.Questions.Commands <Daml-Script-Internal-Questions-Commands>`
+* :doc:`Daml.Script.Internal.Questions.Crypto <Daml-Script-Internal-Questions-Crypto>`
+* :doc:`Daml.Script.Internal.Questions.Crypto.Text <Daml-Script-Internal-Questions-Crypto-Text>`
+* :doc:`Daml.Script.Internal.Questions.Exceptions <Daml-Script-Internal-Questions-Exceptions>`
+* :doc:`Daml.Script.Internal.Questions.Packages <Daml-Script-Internal-Questions-Packages>`
+* :doc:`Daml.Script.Internal.Questions.PartyManagement <Daml-Script-Internal-Questions-PartyManagement>`
+* :doc:`Daml.Script.Internal.Questions.Query <Daml-Script-Internal-Questions-Query>`
+* :doc:`Daml.Script.Internal.Questions.Submit <Daml-Script-Internal-Questions-Submit>`
+* :doc:`Daml.Script.Internal.Questions.Submit.Error <Daml-Script-Internal-Questions-Submit-Error>`
+* :doc:`Daml.Script.Internal.Questions.Testing <Daml-Script-Internal-Questions-Testing>`
+* :doc:`Daml.Script.Internal.Questions.Time <Daml-Script-Internal-Questions-Time>`
+* :doc:`Daml.Script.Internal.Questions.TransactionTree <Daml-Script-Internal-Questions-TransactionTree>`
+* :doc:`Daml.Script.Internal.Questions.UserManagement <Daml-Script-Internal-Questions-UserManagement>`
+* :doc:`Daml.Script.Internal.Questions.Util <Daml-Script-Internal-Questions-Util>`
 

--- a/sdk/docs/sharable/sdk/reference/daml/stdlib/index.rst
+++ b/sdk/docs/sharable/sdk/reference/daml/stdlib/index.rst
@@ -17,45 +17,41 @@ The :ref:`Prelude <module-prelude-72703>` module is imported automatically in ev
 
 Here is a complete list of modules in the standard library:
 
-.. toctree::
-   :maxdepth: 3
-   :titlesonly:
-
-   Prelude <Prelude>
-   DA.Action <DA-Action>
-   DA.Action.State <DA-Action-State>
-   DA.Action.State.Class <DA-Action-State-Class>
-   DA.Assert <DA-Assert>
-   DA.Bifunctor <DA-Bifunctor>
-   DA.Crypto.Text <DA-Crypto-Text>
-   DA.Date <DA-Date>
-   DA.Either <DA-Either>
-   DA.Exception <DA-Exception>
-   DA.Fail <DA-Fail>
-   DA.Foldable <DA-Foldable>
-   DA.Functor <DA-Functor>
-   DA.Internal.Interface.AnyView <DA-Internal-Interface-AnyView>
-   DA.Internal.Interface.AnyView.Types <DA-Internal-Interface-AnyView-Types>
-   DA.List <DA-List>
-   DA.List.BuiltinOrder <DA-List-BuiltinOrder>
-   DA.List.Total <DA-List-Total>
-   DA.Logic <DA-Logic>
-   DA.Map <DA-Map>
-   DA.Math <DA-Math>
-   DA.Monoid <DA-Monoid>
-   DA.NonEmpty <DA-NonEmpty>
-   DA.NonEmpty.Types <DA-NonEmpty-Types>
-   DA.Numeric <DA-Numeric>
-   DA.Optional <DA-Optional>
-   DA.Record <DA-Record>
-   DA.Semigroup <DA-Semigroup>
-   DA.Set <DA-Set>
-   DA.Stack <DA-Stack>
-   DA.Text <DA-Text>
-   DA.Time <DA-Time>
-   DA.Traversable <DA-Traversable>
-   DA.Tuple <DA-Tuple>
-   DA.Validation <DA-Validation>
-   GHC.Show.Text <GHC-Show-Text>
-   GHC.Tuple.Check <GHC-Tuple-Check>
+* :doc:`Prelude <Prelude>`
+* :doc:`DA.Action <DA-Action>`
+* :doc:`DA.Action.State <DA-Action-State>`
+* :doc:`DA.Action.State.Class <DA-Action-State-Class>`
+* :doc:`DA.Assert <DA-Assert>`
+* :doc:`DA.Bifunctor <DA-Bifunctor>`
+* :doc:`DA.Crypto.Text <DA-Crypto-Text>`
+* :doc:`DA.Date <DA-Date>`
+* :doc:`DA.Either <DA-Either>`
+* :doc:`DA.Exception <DA-Exception>`
+* :doc:`DA.Fail <DA-Fail>`
+* :doc:`DA.Foldable <DA-Foldable>`
+* :doc:`DA.Functor <DA-Functor>`
+* :doc:`DA.Internal.Interface.AnyView <DA-Internal-Interface-AnyView>`
+* :doc:`DA.Internal.Interface.AnyView.Types <DA-Internal-Interface-AnyView-Types>`
+* :doc:`DA.List <DA-List>`
+* :doc:`DA.List.BuiltinOrder <DA-List-BuiltinOrder>`
+* :doc:`DA.List.Total <DA-List-Total>`
+* :doc:`DA.Logic <DA-Logic>`
+* :doc:`DA.Map <DA-Map>`
+* :doc:`DA.Math <DA-Math>`
+* :doc:`DA.Monoid <DA-Monoid>`
+* :doc:`DA.NonEmpty <DA-NonEmpty>`
+* :doc:`DA.NonEmpty.Types <DA-NonEmpty-Types>`
+* :doc:`DA.Numeric <DA-Numeric>`
+* :doc:`DA.Optional <DA-Optional>`
+* :doc:`DA.Record <DA-Record>`
+* :doc:`DA.Semigroup <DA-Semigroup>`
+* :doc:`DA.Set <DA-Set>`
+* :doc:`DA.Stack <DA-Stack>`
+* :doc:`DA.Text <DA-Text>`
+* :doc:`DA.Time <DA-Time>`
+* :doc:`DA.Traversable <DA-Traversable>`
+* :doc:`DA.Tuple <DA-Tuple>`
+* :doc:`DA.Validation <DA-Validation>`
+* :doc:`GHC.Show.Text <GHC-Show-Text>`
+* :doc:`GHC.Tuple.Check <GHC-Tuple-Check>`
 

--- a/sdk/docs/sharable/sdk/reference/daml/stdlib/index2.rst
+++ b/sdk/docs/sharable/sdk/reference/daml/stdlib/index2.rst
@@ -1,6 +1,0 @@
-
-Daml StdLib
-===========
-
-To reenable the existing file, remove the toctree from the build process, as the toc tree in there conflicts with the
-main toctree.


### PR DESCRIPTION
Before this change, the RST rendering would create toctrees that mess with the docs page toctree. Now, we just reference using the :doc: primitive.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
