### PR TITLE
Remove `/sdk/canton` from codeowner control

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,9 +43,6 @@ sdk/release.sh         @digital-asset/daml-language
 /sdk/ledger-service/
 /sdk/runtime-components/ 
 
-# Canton code drop
-/sdk/canton/
-
 # Technical writers should review the docs
 /sdk/docs/manually-written @digital-asset/daml-docs
 


### PR DESCRIPTION
The justification provided to @nycnewman is as follows:

> We add files to codeowners that are either sensitive for some reason or have non-obvious side effects so need to be checked by a senior developer. This is only a minority of PRs.
> 
> With the SDK releases we are refreshing to the latest daily snapshot:
> - the daml version used in canton
> - the canton version used for daml testing
> 
> The purpose of the individual on SDK rotation is to check the automatically generated PR and fix up any problems.
> This is BAU and not sensitive.  There is no restriction for this to be `codeowner` only in canton repo and I suggest that we don’t need it in daml (especially as its only use is to support testing)