### PR TITLE
Fix find_release_branches_for_commit when no flags are supplied as second argument

### DIFF
--- a/sdk/release.sh
+++ b/sdk/release.sh
@@ -179,7 +179,7 @@ release_branch_for_version() {
 # Takes a commit reference as its first argument.
 find_release_branches_for_commit() {
     git branch --all --format='%(refname:short)' --contains="$1" \
-      | grep "${2:-}" -E -x "origin/(release/[0-9]+.[0-9]+.x|main|main-2.x)"
+      | grep ${2:-} -E -x "origin/(release/[0-9]+.[0-9]+.x|main|main-2.x)"
 }
 
 # Takes a commit reference as its first argument, and a branch as its second argument.


### PR DESCRIPTION
The bug starts with:
```
# Takes a commit reference as its first argument.
find_release_branches_for_commit() {
    git branch --all --format='%(refname:short)' --contains="$1" \
      | grep "${2:-}" -E -x "origin/(release/[0-9]+.[0-9]+.x|main|main-2.x)"
}
```

If no second argument is supplied, the grep command will receive an empty string as its first argument. Because grep has positional arguments, it will consider this empty string argument to be a pattern, and the subsequent "origin/..." string as the name of a file.

Removing the quotes on the first argument to grep on the second last line ensures that if the argument is not supplied, then the argument disappears and grep receives `-E` as its first flag and "origin/..." as its first position argument.