### PR TITLE
Small refactor to `TEXT_TO_HEX` and `HEX_TO_TEXT`

### DIFF
--- a/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Bytes.scala
+++ b/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Bytes.scala
@@ -27,6 +27,8 @@ final class Bytes private (protected val value: ByteString) extends AnyVal {
 
   def toHexString: Ref.HexString = Ref.HexString.encode(this)
 
+  def toStringUtf8: String = toByteString.toStringUtf8
+
   def startsWith(prefix: Bytes): Boolean = value.startsWith(prefix.value)
 
   def slice(begin: Int, end: Int): Bytes = new Bytes(value.substring(begin, end))
@@ -67,6 +69,9 @@ object Bytes {
 
   def fromString(s: String): Either[String, Bytes] =
     Ref.HexString.fromString(s).map(fromHexString)
+
+  def fromStringUtf8(s: String): Bytes =
+    Bytes.fromByteString(com.google.protobuf.ByteString.copyFromUtf8(s))
 
   def assertFromString(s: String): Bytes =
     assertRight(fromString(s))

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -33,7 +33,6 @@ import com.digitalasset.daml.lf.transaction.{
 }
 import com.digitalasset.daml.lf.value.{Value => V}
 
-import java.nio.charset.StandardCharsets
 import java.security.{
   InvalidKeyException,
   KeyFactory,
@@ -690,7 +689,7 @@ private[lf] object SBuiltinFun {
     ): Control[Q] = {
       try {
         val hexArg = Ref.HexString.assertFromString(getSText(args, 0))
-        val arg = new String(Ref.HexString.decode(hexArg).toByteArray, StandardCharsets.UTF_8)
+        val arg = Ref.HexString.decode(hexArg).toStringUtf8
 
         Control.Value(SText(arg))
       } catch {
@@ -710,7 +709,7 @@ private[lf] object SBuiltinFun {
   final case object SBEncodeHex extends SBuiltinPure(1) {
     override private[speedy] def executePure(args: util.ArrayList[SValue]): SValue = {
       val arg = getSText(args, 0)
-      val hexArg = Ref.HexString.encode(Bytes.fromByteArray(arg.getBytes(StandardCharsets.UTF_8)))
+      val hexArg = Ref.HexString.encode(Bytes.fromStringUtf8(arg))
 
       SText(hexArg)
     }

--- a/sdk/daml-lf/spec/daml-lf-2.rst
+++ b/sdk/daml-lf/spec/daml-lf-2.rst
@@ -4395,6 +4395,30 @@ ContractId functions
 
   [*Available in versions >= 1.11*]
 
+Cryptography functions
+~~~~~~~~~~~~~~~~~~~~~~
+
+In the following, we assume that all hex encoded strings are non-empty and use lower case hexadecimal notation.
+
+* ``TEXT_TO_HEX : 'Text' → 'Text'``
+
+   Given ASCII text, returns the hex string of the hex encoded ASCII text.
+
+* ``HEX_TO_TEXT : 'Text' → 'Text'``
+
+   Given a hex encoded string, returns the ASCII decoded text.
+
+* ``SECP256K1_BOOL : 'Text' → 'Text' → 'Text' → 'Bool'``
+
+   Given a hex string encoding a DER formatted Secp256k1 public key, a hex string encoded message
+   and a hex string encoded signature, return ``True`` when we are able to validate that
+   the message has been signed by the public key with the given signature. Otherwise, return ``False``.
+
+* ``KECCAK256_TEXT : 'Text' → 'Text'``
+
+   Given a hex string encoding a message, return the messages Keccak-256 digest as a hex
+   encoded string.
+
 List functions
 ~~~~~~~~~~~~~~
 

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/Crypto.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/Crypto.daml
@@ -10,6 +10,7 @@ module Daml.Script.Internal.Questions.Crypto where
 
 #else
 
+-- | HIDE
 module Daml.Script.Internal.Questions.Crypto(
   module Daml.Script.Internal.Questions.Crypto.Text
 ) where

--- a/sdk/docs/sharable/sdk/reference/daml-script/api/Daml-Script-Internal-Questions-Crypto.rst
+++ b/sdk/docs/sharable/sdk/reference/daml-script/api/Daml-Script-Internal-Questions-Crypto.rst
@@ -1,4 +1,0 @@
-.. Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
-.. SPDX-License-Identifier: Apache-2.0
-
-

--- a/sdk/docs/sharable/sdk/reference/daml-script/api/index.rst
+++ b/sdk/docs/sharable/sdk/reference/daml-script/api/index.rst
@@ -14,7 +14,6 @@ Scripts compiled with `daml3-script` before this time are still compatible.
 * :doc:`Daml.Script.Internal.LowLevel <Daml-Script-Internal-LowLevel>`
 * :doc:`Daml.Script.Internal.Questions <Daml-Script-Internal-Questions>`
 * :doc:`Daml.Script.Internal.Questions.Commands <Daml-Script-Internal-Questions-Commands>`
-* :doc:`Daml.Script.Internal.Questions.Crypto <Daml-Script-Internal-Questions-Crypto>`
 * :doc:`Daml.Script.Internal.Questions.Crypto.Text <Daml-Script-Internal-Questions-Crypto-Text>`
 * :doc:`Daml.Script.Internal.Questions.Exceptions <Daml-Script-Internal-Questions-Exceptions>`
 * :doc:`Daml.Script.Internal.Questions.Packages <Daml-Script-Internal-Questions-Packages>`


### PR DESCRIPTION
Address review comments from https://github.com/digital-asset/daml/pull/20875

- [x] update LF spec with new crypto related primitives
- [x] update `Bytes` from `toStringUt8` and `fromStringUtf8` members
- [x] manage empty `Daml-Script-Internal-Questions-Crypto.rst` document

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
