### PR TITLE
remove obsolete TODO

### DIFF
--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/admin/PackageUpgradeValidator.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/admin/PackageUpgradeValidator.scala
@@ -32,8 +32,6 @@ object PackageUpgradeValidator {
   type PackageMap = Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)]
 }
 
-// TODO(i16362): Should have unit tests on canton-side for this code as per discussion in https://github.com/DACH-NY/canton/pull/21040#discussion_r1734646573
-// https://github.com/DACH-NY/canton/issues/16362
 class PackageUpgradeValidator(
     getLfArchive: LoggingContextWithTrace => Ref.PackageId => FutureUnlessShutdown[Option[Archive]],
     val loggerFactory: NamedLoggerFactory,


### PR DESCRIPTION
Part of https://github.com/DACH-NY/canton/issues/16362. TODO is now fixed by daml-[lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesCheckSpec.scala](https://github.com/digital-asset/daml/blob/a0abd19fe28e9af05001176aa95c0d9946fd372b/sdk/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/upgrade/UpgradesCheckSpec.scala) and [daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/UpgradeCheckMain.scala](https://github.com/digital-asset/daml/blob/a0abd19fe28e9af05001176aa95c0d9946fd372b/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/UpgradeCheckMain.scala) .
