### PR TITLE
Refactor warning flag parsing, put deprecated exceptions under flag parser

### DIFF
--- a/sdk/compiler/daml-lf-tools-util/BUILD.bazel
+++ b/sdk/compiler/daml-lf-tools-util/BUILD.bazel
@@ -4,7 +4,7 @@
 load("//bazel_tools:haskell.bzl", "da_haskell_library", "da_haskell_test")
 
 da_haskell_library(
-    name = "daml-lf-tools",
+    name = "daml-lf-tools-util",
     srcs = glob(["src/**/*.hs"]),
     hackage_deps = [
         "ansi-wl-pprint",
@@ -33,33 +33,8 @@ da_haskell_library(
     deps = [
         "//compiler/daml-lf-ast",
         "//compiler/damlc/daml-lf-util",
-        "//compiler/daml-lf-tools-util",
         "//compiler/damlc/daml-package-config",
         "//daml-assistant:daml-project-config",
         "//libs-haskell/da-hs-base",
-    ],
-)
-
-da_haskell_test(
-    name = "tests",
-    srcs = glob(["tests/**/*.hs"]),
-    data = [],
-    hackage_deps = [
-        "base",
-        "containers",
-        "filepath",
-        "tasty",
-        "tasty-hunit",
-        "text",
-    ],
-    main_function = "DA.Daml.LF.Simplifier.Tests.main",
-    src_strip_prefix = "tests",
-    visibility = ["//visibility:public"],
-    deps = [
-        ":daml-lf-tools",
-        "//compiler/daml-lf-ast",
-        "//libs-haskell/bazel-runfiles",
-        "//libs-haskell/da-hs-base",
-        "//libs-haskell/test-utils",
     ],
 )

--- a/sdk/compiler/daml-lf-tools-util/src/Data/HList.hs
+++ b/sdk/compiler/daml-lf-tools-util/src/Data/HList.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Data.HList where
+
+import Data.Kind (Type)
+import Data.Functor.Contravariant
+
+-- Allows us to create higher-order lists from tuples, relate them to Sums, and
+-- relate them back to tuples
+data Product (xs :: [Type]) where
+  ProdZ :: Product '[]
+  ProdT :: a -> Product xs -> Product (a ': xs)
+
+class ProductTupleIso xs tuple | xs -> tuple, tuple -> xs where
+  toTuple :: Product xs -> tuple
+  fromTuple :: tuple -> Product xs
+
+instance ProductTupleIso '[x1, x2] (x1, x2) where
+  toTuple (ProdT x1 (ProdT x2 ProdZ)) = (x1, x2)
+  fromTuple (x1, x2) = ProdT x1 (ProdT x2 ProdZ)
+
+instance ProductTupleIso '[x1, x2, x3] (x1, x2, x3) where
+  toTuple (ProdT x1 (ProdT x2 (ProdT x3 ProdZ))) = (x1, x2, x3)
+  fromTuple (x1, x2, x3) = ProdT x1 (ProdT x2 (ProdT x3 ProdZ))
+
+instance ProductTupleIso '[x1, x2, x3, x4] (x1, x2, x3, x4) where
+  toTuple (ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 ProdZ)))) = (x1, x2, x3, x4)
+  fromTuple (x1, x2, x3, x4) = ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 ProdZ)))
+
+instance ProductTupleIso '[x1, x2, x3, x4, x5] (x1, x2, x3, x4, x5) where
+  toTuple (ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 ProdZ))))) = (x1, x2, x3, x4, x5)
+  fromTuple (x1, x2, x3, x4, x5) = ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 ProdZ))))
+
+instance ProductTupleIso '[x1, x2, x3, x4, x5, x6] (x1, x2, x3, x4, x5, x6) where
+  toTuple (ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 ProdZ)))))) = (x1, x2, x3, x4, x5, x6)
+  fromTuple (x1, x2, x3, x4, x5, x6) = ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 ProdZ)))))
+
+instance ProductTupleIso '[x1, x2, x3, x4, x5, x6, x7] (x1, x2, x3, x4, x5, x6, x7) where
+  toTuple (ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 (ProdT x7 ProdZ))))))) = (x1, x2, x3, x4, x5, x6, x7)
+  fromTuple (x1, x2, x3, x4, x5, x6, x7) = ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 (ProdT x7 ProdZ))))))
+
+instance ProductTupleIso '[x1, x2, x3, x4, x5, x6, x7, x8] (x1, x2, x3, x4, x5, x6, x7, x8) where
+  toTuple (ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 (ProdT x7 (ProdT x8 ProdZ)))))))) = (x1, x2, x3, x4, x5, x6, x7, x8)
+  fromTuple (x1, x2, x3, x4, x5, x6, x7, x8) = ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 (ProdT x7 (ProdT x8 ProdZ)))))))
+
+instance ProductTupleIso '[x1, x2, x3, x4, x5, x6, x7, x8, x9] (x1, x2, x3, x4, x5, x6, x7, x8, x9) where
+  toTuple (ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 (ProdT x7 (ProdT x8 (ProdT x9 ProdZ))))))))) = (x1, x2, x3, x4, x5, x6, x7, x8, x9)
+  fromTuple (x1, x2, x3, x4, x5, x6, x7, x8, x9) = ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 (ProdT x7 (ProdT x8 (ProdT x9 ProdZ))))))))
+
+instance ProductTupleIso '[x1, x2, x3, x4, x5, x6, x7, x8, x9, x10] (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) where
+  toTuple (ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 (ProdT x7 (ProdT x8 (ProdT x9 (ProdT x10 ProdZ)))))))))) = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10)
+  fromTuple (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) = ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 (ProdT x7 (ProdT x8 (ProdT x9 (ProdT x10 ProdZ)))))))))
+
+data Sum (rest :: [Type]) where
+  SumL :: a -> Sum (a ': xs)
+  SumR :: Sum xs -> Sum (a ': xs)
+
+toEither :: Sum (x ': y) -> Either x (Sum y)
+toEither = eitherSum Left Right
+
+fromEither :: Either x (Sum y) -> Sum (x ': y)
+fromEither = either SumL SumR
+
+eitherSum :: (l -> x) -> (Sum r -> x) -> Sum (l ': r) -> x
+eitherSum lx _  (SumL l) = lx l
+eitherSum _  rx (SumR r) = rx r
+
+class SplitF f where
+  splitF :: f (Either a b) -> (f a, f b)
+
+class Split f xs where
+  type SplitType f xs :: [Type]
+  split :: f (Sum xs) -> Product (SplitType f xs)
+
+instance Split f '[] where
+  type SplitType f '[] = '[]
+  split = const ProdZ
+
+instance (SplitF f, Contravariant f, Split f rest) => Split f (a ': rest) where
+  type SplitType f (a ': rest) = f a ': SplitType f rest
+  split a = uncurry ProdT $ fmap split $ splitF $ contramap fromEither a
+
+class CombineF f where
+  combineF :: (f a, f b) -> f (Either a b)
+  combineZ :: f a
+
+class Combine f (xs :: [Type]) where
+  type CombineType f xs :: [Type]
+  combine :: Product (CombineType f xs) -> f (Sum xs)
+
+instance (CombineF f) => Combine f '[] where
+  type CombineType f '[] = '[]
+  combine ProdZ = combineZ
+
+instance (CombineF f, Contravariant f, Combine f xs) => Combine f (a ': xs) where
+  type CombineType f (a ': xs) = f a ': CombineType f xs
+  combine (ProdT left restSum) =
+    let rest = combine restSum
+    in
+    contramap toEither $ combineF (left, rest)
+
+combineFromTuple :: (ProductTupleIso (CombineType f xs) t, Combine f xs) => t -> f (Sum xs)
+combineFromTuple = combine . fromTuple
+
+splitToTuple :: (ProductTupleIso (SplitType f xs) t, Split f xs) => f (Sum xs) -> t
+splitToTuple = toTuple . split

--- a/sdk/compiler/daml-lf-tools-util/src/Data/HList.hs
+++ b/sdk/compiler/daml-lf-tools-util/src/Data/HList.hs
@@ -1,6 +1,7 @@
 -- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE DataKinds #-}

--- a/sdk/compiler/daml-lf-tools-util/src/Data/HList.hs
+++ b/sdk/compiler/daml-lf-tools-util/src/Data/HList.hs
@@ -1,3 +1,6 @@
+-- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -5,7 +8,9 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Data.HList where
+module Data.HList (
+        module Data.HList
+    ) where
 
 import Data.Kind (Type)
 import Data.Functor.Contravariant
@@ -109,3 +114,4 @@ combineFromTuple = combine . fromTuple
 
 splitToTuple :: (ProductTupleIso (SplitType f xs) t, Split f xs) => f (Sum xs) -> t
 splitToTuple = toTuple . split
+

--- a/sdk/compiler/daml-lf-tools-util/src/Data/HList.hs
+++ b/sdk/compiler/daml-lf-tools-util/src/Data/HList.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE DataKinds #-}
@@ -20,46 +19,6 @@ import Data.Functor.Contravariant
 data Product (xs :: [Type]) where
   ProdZ :: Product '[]
   ProdT :: a -> Product xs -> Product (a ': xs)
-
-class ProductTupleIso xs tuple | xs -> tuple, tuple -> xs where
-  toTuple :: Product xs -> tuple
-  fromTuple :: tuple -> Product xs
-
-instance ProductTupleIso '[x1, x2] (x1, x2) where
-  toTuple (ProdT x1 (ProdT x2 ProdZ)) = (x1, x2)
-  fromTuple (x1, x2) = ProdT x1 (ProdT x2 ProdZ)
-
-instance ProductTupleIso '[x1, x2, x3] (x1, x2, x3) where
-  toTuple (ProdT x1 (ProdT x2 (ProdT x3 ProdZ))) = (x1, x2, x3)
-  fromTuple (x1, x2, x3) = ProdT x1 (ProdT x2 (ProdT x3 ProdZ))
-
-instance ProductTupleIso '[x1, x2, x3, x4] (x1, x2, x3, x4) where
-  toTuple (ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 ProdZ)))) = (x1, x2, x3, x4)
-  fromTuple (x1, x2, x3, x4) = ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 ProdZ)))
-
-instance ProductTupleIso '[x1, x2, x3, x4, x5] (x1, x2, x3, x4, x5) where
-  toTuple (ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 ProdZ))))) = (x1, x2, x3, x4, x5)
-  fromTuple (x1, x2, x3, x4, x5) = ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 ProdZ))))
-
-instance ProductTupleIso '[x1, x2, x3, x4, x5, x6] (x1, x2, x3, x4, x5, x6) where
-  toTuple (ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 ProdZ)))))) = (x1, x2, x3, x4, x5, x6)
-  fromTuple (x1, x2, x3, x4, x5, x6) = ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 ProdZ)))))
-
-instance ProductTupleIso '[x1, x2, x3, x4, x5, x6, x7] (x1, x2, x3, x4, x5, x6, x7) where
-  toTuple (ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 (ProdT x7 ProdZ))))))) = (x1, x2, x3, x4, x5, x6, x7)
-  fromTuple (x1, x2, x3, x4, x5, x6, x7) = ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 (ProdT x7 ProdZ))))))
-
-instance ProductTupleIso '[x1, x2, x3, x4, x5, x6, x7, x8] (x1, x2, x3, x4, x5, x6, x7, x8) where
-  toTuple (ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 (ProdT x7 (ProdT x8 ProdZ)))))))) = (x1, x2, x3, x4, x5, x6, x7, x8)
-  fromTuple (x1, x2, x3, x4, x5, x6, x7, x8) = ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 (ProdT x7 (ProdT x8 ProdZ)))))))
-
-instance ProductTupleIso '[x1, x2, x3, x4, x5, x6, x7, x8, x9] (x1, x2, x3, x4, x5, x6, x7, x8, x9) where
-  toTuple (ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 (ProdT x7 (ProdT x8 (ProdT x9 ProdZ))))))))) = (x1, x2, x3, x4, x5, x6, x7, x8, x9)
-  fromTuple (x1, x2, x3, x4, x5, x6, x7, x8, x9) = ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 (ProdT x7 (ProdT x8 (ProdT x9 ProdZ))))))))
-
-instance ProductTupleIso '[x1, x2, x3, x4, x5, x6, x7, x8, x9, x10] (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) where
-  toTuple (ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 (ProdT x7 (ProdT x8 (ProdT x9 (ProdT x10 ProdZ)))))))))) = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10)
-  fromTuple (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) = ProdT x1 (ProdT x2 (ProdT x3 (ProdT x4 (ProdT x5 (ProdT x6 (ProdT x7 (ProdT x8 (ProdT x9 (ProdT x10 ProdZ)))))))))
 
 data Sum (rest :: [Type]) where
   SumL :: a -> Sum (a ': xs)
@@ -108,10 +67,3 @@ instance (CombineF f, Contravariant f, Combine f xs) => Combine f (a ': xs) wher
     let rest = combine restSum
     in
     contramap toEither $ combineF (left, rest)
-
-combineFromTuple :: (ProductTupleIso (CombineType f xs) t, Combine f xs) => t -> f (Sum xs)
-combineFromTuple = combine . fromTuple
-
-splitToTuple :: (ProductTupleIso (SplitType f xs) t, Split f xs) => f (Sum xs) -> t
-splitToTuple = toTuple . split
-

--- a/sdk/compiler/daml-lf-tools/BUILD.bazel
+++ b/sdk/compiler/daml-lf-tools/BUILD.bazel
@@ -7,6 +7,7 @@ da_haskell_library(
     name = "daml-lf-tools",
     srcs = glob(["src/**/*.hs"]),
     hackage_deps = [
+        "ansi-wl-pprint",
         "base",
         "containers",
         "deepseq",
@@ -17,6 +18,7 @@ da_haskell_library(
         "hashable",
         "lens",
         "mtl",
+        "optparse-applicative",
         "recursion-schemes",
         "safe",
         "shake",

--- a/sdk/compiler/daml-lf-tools/BUILD.bazel
+++ b/sdk/compiler/daml-lf-tools/BUILD.bazel
@@ -32,8 +32,8 @@ da_haskell_library(
     visibility = ["//visibility:public"],
     deps = [
         "//compiler/daml-lf-ast",
-        "//compiler/damlc/daml-lf-util",
         "//compiler/daml-lf-tools-util",
+        "//compiler/damlc/daml-lf-util",
         "//compiler/damlc/daml-package-config",
         "//daml-assistant:daml-project-config",
         "//libs-haskell/da-hs-base",

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
@@ -32,7 +32,7 @@ module DA.Daml.LF.TypeChecker.Env(
     emptyGamma,
     SomeErrorOrWarning(..),
     getWarningStatusF,
-    damlWarningFlags,
+    warningFlags,
     ) where
 
 import           Control.Lens hiding (Context)
@@ -56,7 +56,7 @@ data Gamma = Gamma
     -- ^ The packages in scope.
   , _lfVersion :: Version
     -- ^ The Daml-LF version of the package being type checked.
-  , _damlWarningFlags :: DamlWarningFlags ErrorOrWarning
+  , _warningFlags :: WarningFlags ErrorOrWarning
     -- ^ Function for relaxing errors into warnings and strictifying warnings into errors
   }
 
@@ -68,9 +68,9 @@ class SomeErrorOrWarning d where
 getLfVersion :: MonadGamma m => m Version
 getLfVersion = view lfVersion
 
-getWarningStatusF :: forall m gamma. MonadGammaF gamma m => Getter gamma Gamma -> ErrorOrWarning -> m DamlWarningFlagStatus
+getWarningStatusF :: forall m gamma. MonadGammaF gamma m => Getter gamma Gamma -> ErrorOrWarning -> m WarningFlagStatus
 getWarningStatusF getter warnableError = do
-  flags <- view (getter . damlWarningFlags)
+  flags <- view (getter . warningFlags)
   pure (getWarningStatus flags warnableError)
 
 getWorld :: MonadGamma m => m World
@@ -104,7 +104,7 @@ match p e x = either (const (throwWithContext e)) pure (matching p x)
 -- | Environment containing only the packages in scope but no type or term
 -- variables.
 emptyGamma :: World -> Version -> Gamma
-emptyGamma world version = Gamma ContextNone mempty mempty world version (mkDamlWarningFlags damlWarningFlagParserTypeChecker [])
+emptyGamma world version = Gamma ContextNone mempty mempty world version (mkWarningFlags warningFlagParserTypeChecker [])
 
 -- | Run a computation in the current environment extended by a new type
 -- variable/kind binding. Does not fail on shadowing.

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
@@ -104,7 +104,7 @@ match p e x = either (const (throwWithContext e)) pure (matching p x)
 -- | Environment containing only the packages in scope but no type or term
 -- variables.
 emptyGamma :: World -> Version -> Gamma
-emptyGamma world version = Gamma ContextNone mempty mempty world version (mkWarningFlags warningFlagParserTypeChecker [])
+emptyGamma world version = Gamma ContextNone mempty mempty world version (mkWarningFlags warningFlagParser [])
 
 -- | Run a computation in the current environment extended by a new type
 -- variable/kind binding. Does not fail on shadowing.

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -586,7 +586,7 @@ instance Pretty Error where
   pPrint = \case
     EUnwarnableError err -> pPrint err
     EErrorOrWarning err ->
-      case dwfpSuggestFlag warningFlagParser err of
+      case wfpSuggestFlag warningFlagParser err of
         Just name ->
           vcat
             [ pPrint err
@@ -995,7 +995,7 @@ instance Pretty Warning where
   pPrint = \case
     WContext ctx warning -> prettyWithContext ctx (Left warning)
     WErrorToWarning err ->
-      case dwfpSuggestFlag warningFlagParser err of
+      case wfpSuggestFlag warningFlagParser err of
         Just name ->
           vcat
             [ pPrint err

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -19,16 +19,16 @@ module DA.Daml.LF.TypeChecker.Error(
     UnerrorableWarning,
     PackageUpgradeOrigin(..),
     UpgradeMismatchReason(..),
-    DamlWarningFlag(..),
-    DamlWarningFlags(..),
-    DamlWarningFlagStatus(..),
-    parseRawDamlWarningFlag,
+    WarningFlag(..),
+    WarningFlags(..),
+    WarningFlagStatus(..),
+    parseWarningFlag,
     getWarningStatus,
     upgradeInterfacesFlagSpec,
     upgradeExceptionsFlagSpec,
     templateInterfaceDependsOnScriptFlagSpec,
-    damlWarningFlagParserTypeChecker,
-    mkDamlWarningFlags,
+    warningFlagParserTypeChecker,
+    mkWarningFlags,
     combineParsers
     ) where
 
@@ -340,8 +340,8 @@ instance Pretty ErrorOrWarning where
         ]
     pprintDep (pkgId, meta) = pPrint pkgId <> " (" <> pPrint (packageName meta) <> ", " <> pPrint (packageVersion meta) <> ")"
 
-damlWarningFlagParserTypeChecker :: DamlWarningFlagParser ErrorOrWarning
-damlWarningFlagParserTypeChecker = mkDamlWarningFlagParser
+warningFlagParserTypeChecker :: WarningFlagParser ErrorOrWarning
+warningFlagParserTypeChecker = mkWarningFlagParser
   (\case
       WEUpgradeShouldDefineIfacesAndTemplatesSeparately {} -> AsError
       WEUpgradeShouldDefineIfaceWithoutImplementation {} -> AsError
@@ -374,8 +374,8 @@ damlWarningFlagParserTypeChecker = mkDamlWarningFlagParser
   , templateHasNewInterfaceInstanceFlagSpec
   ]
 
-upgradedTemplateChangedFlagSpec :: DamlWarningFlagSpec ErrorOrWarning
-upgradedTemplateChangedFlagSpec = DamlWarningFlagSpec "upgraded-template-expression-changed" False $
+upgradedTemplateChangedFlagSpec :: WarningFlagSpec ErrorOrWarning
+upgradedTemplateChangedFlagSpec = WarningFlagSpec "upgraded-template-expression-changed" False $
     \case
         WEUpgradedTemplateChangedPrecondition {} -> True
         WEUpgradedTemplateChangedSignatories {} -> True
@@ -385,60 +385,60 @@ upgradedTemplateChangedFlagSpec = DamlWarningFlagSpec "upgraded-template-express
         WEUpgradedTemplateChangedKeyMaintainers {} -> True
         _ -> False
 
-upgradedChoiceChangedFlagSpec :: DamlWarningFlagSpec ErrorOrWarning
-upgradedChoiceChangedFlagSpec = DamlWarningFlagSpec "upgraded-choice-expression-changed" False $
+upgradedChoiceChangedFlagSpec :: WarningFlagSpec ErrorOrWarning
+upgradedChoiceChangedFlagSpec = WarningFlagSpec "upgraded-choice-expression-changed" False $
     \case
         WEUpgradedChoiceChangedControllers {} -> True
         WEUpgradedChoiceChangedObservers {} -> True
         WEUpgradedChoiceChangedAuthorizers {} -> True
         _ -> False
 
-couldNotExtractUpgradedExpressionFlagSpec :: DamlWarningFlagSpec ErrorOrWarning
-couldNotExtractUpgradedExpressionFlagSpec = DamlWarningFlagSpec "could-not-extract-upgraded-expression" False $
+couldNotExtractUpgradedExpressionFlagSpec :: WarningFlagSpec ErrorOrWarning
+couldNotExtractUpgradedExpressionFlagSpec = WarningFlagSpec "could-not-extract-upgraded-expression" False $
     \case
         WECouldNotExtractForUpgradeChecking {} -> True
         _ -> False
 
-upgradeInterfacesFlagSpec :: DamlWarningFlagSpec ErrorOrWarning
-upgradeInterfacesFlagSpec = DamlWarningFlagSpec "upgrade-interfaces" False $
+upgradeInterfacesFlagSpec :: WarningFlagSpec ErrorOrWarning
+upgradeInterfacesFlagSpec = WarningFlagSpec "upgrade-interfaces" False $
     \case
         WEUpgradeShouldDefineIfacesAndTemplatesSeparately {} -> True
         WEUpgradeShouldDefineIfaceWithoutImplementation {} -> True
         WEUpgradeShouldDefineTplInSeparatePackage {} -> True
         _ -> False
 
-upgradeExceptionsFlagSpec :: DamlWarningFlagSpec ErrorOrWarning
-upgradeExceptionsFlagSpec = DamlWarningFlagSpec "upgrade-exceptions" False $
+upgradeExceptionsFlagSpec :: WarningFlagSpec ErrorOrWarning
+upgradeExceptionsFlagSpec = WarningFlagSpec "upgrade-exceptions" False $
     \case
         WEUpgradeShouldDefineExceptionsAndTemplatesSeparately {} -> True
         _ -> False
 
-upgradeDependencyMetadataFlagSpec :: DamlWarningFlagSpec ErrorOrWarning
-upgradeDependencyMetadataFlagSpec = DamlWarningFlagSpec "upgrade-dependency-metadata" False $
+upgradeDependencyMetadataFlagSpec :: WarningFlagSpec ErrorOrWarning
+upgradeDependencyMetadataFlagSpec = WarningFlagSpec "upgrade-dependency-metadata" False $
     \case
         WEDependencyHasUnparseableVersion {} -> True
         _ -> False
 
-unusedDependencyFlagSpec :: DamlWarningFlagSpec ErrorOrWarning
-unusedDependencyFlagSpec = DamlWarningFlagSpec "unused-dependency" False $
+unusedDependencyFlagSpec :: WarningFlagSpec ErrorOrWarning
+unusedDependencyFlagSpec = WarningFlagSpec "unused-dependency" False $
     \case
         WEUnusedDependency {} -> True
         _ -> False
 
-ownUpgradeDependencyFlagSpec :: DamlWarningFlagSpec ErrorOrWarning
-ownUpgradeDependencyFlagSpec = DamlWarningFlagSpec "upgrades-own-dependency" False $
+ownUpgradeDependencyFlagSpec :: WarningFlagSpec ErrorOrWarning
+ownUpgradeDependencyFlagSpec = WarningFlagSpec "upgrades-own-dependency" False $
     \case
         WEOwnUpgradeDependency {} -> True
         _ -> False
 
-templateInterfaceDependsOnScriptFlagSpec :: DamlWarningFlagSpec ErrorOrWarning
-templateInterfaceDependsOnScriptFlagSpec = DamlWarningFlagSpec "template-interface-depends-on-daml-script" False $
+templateInterfaceDependsOnScriptFlagSpec :: WarningFlagSpec ErrorOrWarning
+templateInterfaceDependsOnScriptFlagSpec = WarningFlagSpec "template-interface-depends-on-daml-script" False $
     \case
         WETemplateInterfaceDependsOnScript {} -> True
         _ -> False
 
-templateHasNewInterfaceInstanceFlagSpec :: DamlWarningFlagSpec ErrorOrWarning
-templateHasNewInterfaceInstanceFlagSpec = DamlWarningFlagSpec "template-has-new-interface-instance" False $
+templateHasNewInterfaceInstanceFlagSpec :: WarningFlagSpec ErrorOrWarning
+templateHasNewInterfaceInstanceFlagSpec = WarningFlagSpec "template-has-new-interface-instance" False $
     \case
         WEForbiddenNewImplementation {} -> True
         _ -> False
@@ -586,7 +586,7 @@ instance Pretty Error where
   pPrint = \case
     EUnwarnableError err -> pPrint err
     EErrorOrWarning err ->
-      case dwfpSuggestFlag damlWarningFlagParserTypeChecker err of
+      case dwfpSuggestFlag warningFlagParserTypeChecker err of
         Just name ->
           vcat
             [ pPrint err
@@ -995,7 +995,7 @@ instance Pretty Warning where
   pPrint = \case
     WContext ctx warning -> prettyWithContext ctx (Left warning)
     WErrorToWarning err ->
-      case dwfpSuggestFlag damlWarningFlagParserTypeChecker err of
+      case dwfpSuggestFlag warningFlagParserTypeChecker err of
         Just name ->
           vcat
             [ pPrint err

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -27,7 +27,7 @@ module DA.Daml.LF.TypeChecker.Error(
     upgradeInterfacesFlagSpec,
     upgradeExceptionsFlagSpec,
     templateInterfaceDependsOnScriptFlagSpec,
-    warningFlagParserTypeChecker,
+    warningFlagParser,
     mkWarningFlags,
     combineParsers
     ) where
@@ -340,8 +340,8 @@ instance Pretty ErrorOrWarning where
         ]
     pprintDep (pkgId, meta) = pPrint pkgId <> " (" <> pPrint (packageName meta) <> ", " <> pPrint (packageVersion meta) <> ")"
 
-warningFlagParserTypeChecker :: WarningFlagParser ErrorOrWarning
-warningFlagParserTypeChecker = mkWarningFlagParser
+warningFlagParser :: WarningFlagParser ErrorOrWarning
+warningFlagParser = mkWarningFlagParser
   (\case
       WEUpgradeShouldDefineIfacesAndTemplatesSeparately {} -> AsError
       WEUpgradeShouldDefineIfaceWithoutImplementation {} -> AsError
@@ -586,7 +586,7 @@ instance Pretty Error where
   pPrint = \case
     EUnwarnableError err -> pPrint err
     EErrorOrWarning err ->
-      case dwfpSuggestFlag warningFlagParserTypeChecker err of
+      case dwfpSuggestFlag warningFlagParser err of
         Just name ->
           vcat
             [ pPrint err
@@ -995,7 +995,7 @@ instance Pretty Warning where
   pPrint = \case
     WContext ctx warning -> prettyWithContext ctx (Left warning)
     WErrorToWarning err ->
-      case dwfpSuggestFlag warningFlagParserTypeChecker err of
+      case dwfpSuggestFlag warningFlagParser err of
         Just name ->
           vcat
             [ pPrint err

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error/WarningFlags.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error/WarningFlags.hs
@@ -81,16 +81,10 @@ combineParsers left right =
   DamlWarningFlagParser
     { dwfpDefault = either (dwfpDefault left) (dwfpDefault right)
     , dwfpFlagParsers =
-        (fmap . fmap . fmap) toLeft (dwfpFlagParsers left) ++
-        (fmap . fmap . fmap) toRight (dwfpFlagParsers right)
+        (fmap . fmap . fmap) (mapFlagFilter (flip either (const False))) (dwfpFlagParsers left) ++
+        (fmap . fmap . fmap) (mapFlagFilter (either (const False))) (dwfpFlagParsers right)
     , dwfpSuggestFlag = either (dwfpSuggestFlag left) (dwfpSuggestFlag right)
     }
-
-toLeft :: DamlWarningFlag err -> DamlWarningFlag (Either err x)
-toLeft = mapFlagFilter (\x -> either x (const False))
-
-toRight :: DamlWarningFlag err -> DamlWarningFlag (Either x err)
-toRight = mapFlagFilter (\x -> either (const False) x)
 
 mapFlagFilter :: ((subErr -> Bool) -> superErr -> Bool) -> DamlWarningFlag subErr -> DamlWarningFlag superErr
 mapFlagFilter f flag = flag { rfFilter = f (rfFilter flag) }

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error/WarningFlags.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error/WarningFlags.hs
@@ -2,6 +2,43 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- | This module defines the logic around flags
+--
+-- A parser for a set of warning flags for warnings of type `err` is a
+-- `WarningFlagParser err`. It is constructed using `mkWarningFlagParser`, which
+-- takes multiple WarningFlagSpecs (one for each flag), and a total function
+-- which defines a default value for each possible warning (`dwfpDefault`).
+--
+-- The WarningFlagSpec specifies the name of a flag (`wfsName`), whether it
+-- should show up in the help (`wfsHidden`), and which errs it targets
+-- (`wfsFilter`). This lets a flag to target multiple possible warnings - for
+-- example, the `upgraded-template-expression-changed` affects the warning level
+-- for the following warnings:
+--   WEUpgradedTemplateChangedPrecondition,
+--   WEUpgradedTemplateChangedSignatories,
+--   WEUpgradedTemplateChangedObservers,
+--   WEUpgradedTemplateChangedAgreement,
+--   WEUpgradedTemplateChangedKeyExpression,
+--   WEUpgradedTemplateChangedKeyMaintainers
+--
+-- The `WarningFlagParser err` parses flags according to its specs from the
+-- command line to produce a `WarningFlags err` datatype - this datatype
+-- contains the same default function, and generates a WarningFlag for each flag
+-- that was specified on the command line. WarningFlag datatype copies verbatim
+-- the name and filter from the WarningFlagSpec that it originates from, along
+-- with the warning level that was specified.
+--
+-- The `WarningFlags err` datatype can be queried with `getWarningStatus` to get
+-- the WarningFlagStatus for any warning of type `err`. If the user specified
+-- the warning level for a flag which matches the warning, that warning level
+-- will be returned. If no flag was specified matching the warning, the
+-- warning's default level will be returned from `dwfDefault`.
+--
+-- A tuple of N WarningFlagParsers can be combined with combineParsers to
+-- produce a parser that will parse flags which match `Sum [err1, err2, ..., errN]`.
+-- The resulting `WarningFlags (Sum [err1, ..., errN])` can be split into a
+-- tuple of N new WarningFlags datatypes for each error type:
+-- `(WarningFlags err1, WarningFlags err2, ..., WarningFlags errN)`
+
 module DA.Daml.LF.TypeChecker.Error.WarningFlags (
         module DA.Daml.LF.TypeChecker.Error.WarningFlags
     ) where

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error/WarningFlags.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error/WarningFlags.hs
@@ -1,10 +1,7 @@
 -- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE DataKinds #-}
@@ -148,15 +145,15 @@ class ProductTupleIso xs tuple | xs -> tuple, tuple -> xs where
 
 instance ProductTupleIso '[a, b] (a, b) where
   toTuple (ProdT a (ProdT b ProdZ)) = (a, b)
-  fromTuple (a, b) = (ProdT a (ProdT b ProdZ))
+  fromTuple (a, b) = ProdT a (ProdT b ProdZ)
 
 instance ProductTupleIso '[a, b, c] (a, b, c) where
   toTuple (ProdT a (ProdT b (ProdT c ProdZ))) = (a, b, c)
-  fromTuple (a, b, c) = (ProdT a (ProdT b (ProdT c ProdZ)))
+  fromTuple (a, b, c) = ProdT a (ProdT b (ProdT c ProdZ))
 
 instance ProductTupleIso '[a, b, c, d] (a, b, c, d) where
   toTuple (ProdT a (ProdT b (ProdT c (ProdT d ProdZ)))) = (a, b, c, d)
-  fromTuple (a, b, c, d) = (ProdT a (ProdT b (ProdT c (ProdT d ProdZ))))
+  fromTuple (a, b, c, d) = ProdT a (ProdT b (ProdT c (ProdT d ProdZ)))
 
 data Sum (rest :: [Type]) where
   SumL :: a -> Sum (a ': xs)

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error/WarningFlags.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error/WarningFlags.hs
@@ -1,23 +1,16 @@
 -- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE TypeOperators #-}
-
 -- | This module defines the logic around flags
 module DA.Daml.LF.TypeChecker.Error.WarningFlags (
         module DA.Daml.LF.TypeChecker.Error.WarningFlags
     ) where
 
-import Data.Kind (Type)
 import Options.Applicative
 import qualified Text.PrettyPrint.ANSI.Leijen as PAL
 import qualified Data.List as L
 import Data.Functor.Contravariant
+import Data.HList
 
 data WarningFlagStatus
   = AsError -- -Werror=<name>
@@ -134,75 +127,24 @@ runParser parser =
       , "Available names are: " <> PAL.string (namesAsList parser)
       ]
 
-
-data Product (xs :: [Type]) where
-  ProdZ :: Product '[]
-  ProdT :: a -> Product xs -> Product (a ': xs)
-
-class ProductTupleIso xs tuple | xs -> tuple, tuple -> xs where
-  toTuple :: Product xs -> tuple
-  fromTuple :: tuple -> Product xs
-
-instance ProductTupleIso '[a, b] (a, b) where
-  toTuple (ProdT a (ProdT b ProdZ)) = (a, b)
-  fromTuple (a, b) = ProdT a (ProdT b ProdZ)
-
-instance ProductTupleIso '[a, b, c] (a, b, c) where
-  toTuple (ProdT a (ProdT b (ProdT c ProdZ))) = (a, b, c)
-  fromTuple (a, b, c) = ProdT a (ProdT b (ProdT c ProdZ))
-
-instance ProductTupleIso '[a, b, c, d] (a, b, c, d) where
-  toTuple (ProdT a (ProdT b (ProdT c (ProdT d ProdZ)))) = (a, b, c, d)
-  fromTuple (a, b, c, d) = ProdT a (ProdT b (ProdT c (ProdT d ProdZ)))
-
-data Sum (rest :: [Type]) where
-  SumL :: a -> Sum (a ': xs)
-  SumR :: Sum xs -> Sum (a ': xs)
-
-eitherSum :: (l -> x) -> (Sum r -> x) -> Sum (l ': r) -> x
-eitherSum lx _  (SumL l) = lx l
-eitherSum _  rx (SumR r) = rx r
-
 type WarningFlagParsers xs = WarningFlagParser (Sum xs)
 
-voidParser :: WarningFlagParsers '[]
-voidParser = mkWarningFlagParser (const (error "voidParser: should not be able to get a flag with SumR")) []
+combineParsers :: (ProductTupleIso (CombineType WarningFlagParser xs) r, Combine WarningFlagParser xs) => r -> WarningFlagParsers xs
+combineParsers = combineFromTuple
 
-combineParsers :: (ProductTupleIso (CombineParsersType xs) r, CombineParsers xs) => r -> WarningFlagParser (Sum xs)
-combineParsers = combineParsersInternal . fromTuple
-
-class CombineParsers (xs :: [Type]) where
-  type CombineParsersType xs :: [Type]
-  combineParsersInternal :: Product (CombineParsersType xs) -> WarningFlagParser (Sum xs)
-
-instance CombineParsers '[] where
-  type CombineParsersType '[] = '[]
-  combineParsersInternal ProdZ = voidParser
-
-instance CombineParsers xs => CombineParsers (a ': xs) where
-  type CombineParsersType (a ': xs) = WarningFlagParser a ': CombineParsersType xs
-  combineParsersInternal (ProdT left restSum) =
-    let rest = combineParsersInternal restSum
-    in
+instance CombineF WarningFlagParser where
+  combineF (left, rest) =
     WarningFlagParser
-      { dwfpDefault = eitherSum (dwfpDefault left) (dwfpDefault rest)
+      { dwfpDefault = either (dwfpDefault left) (dwfpDefault rest)
       , dwfpFlagParsers =
-          (fmap . fmap . fmap) (modifyWfFilter (flip eitherSum (const False))) (dwfpFlagParsers left) ++
-          (fmap . fmap . fmap) (modifyWfFilter (eitherSum (const False))) (dwfpFlagParsers rest)
-      , dwfpSuggestFlag = eitherSum (dwfpSuggestFlag left) (dwfpSuggestFlag rest)
+          (fmap . fmap . fmap) (modifyWfFilter (flip either (const False))) (dwfpFlagParsers left) ++
+          (fmap . fmap . fmap) (modifyWfFilter (either (const False))) (dwfpFlagParsers rest)
+      , dwfpSuggestFlag = either (dwfpSuggestFlag left) (dwfpSuggestFlag rest)
       }
+  combineZ = mkWarningFlagParser (const (error "voidParser: should not be able to get a flag with SumR")) []
 
-splitWarningFlags :: (ProductTupleIso (SplitWarningFlagsType xs) r, SplitWarningFlags xs) => WarningFlags (Sum xs) -> r
-splitWarningFlags = toTuple . splitWarningFlagsInternal
+splitWarningFlags :: (ProductTupleIso (SplitType WarningFlags xs) r, Split WarningFlags xs) => WarningFlags (Sum xs) -> r
+splitWarningFlags = splitToTuple
 
-class SplitWarningFlags xs where
-  type SplitWarningFlagsType xs :: [Type]
-  splitWarningFlagsInternal :: WarningFlags (Sum xs) -> Product (SplitWarningFlagsType xs)
-
-instance SplitWarningFlags '[] where
-  type SplitWarningFlagsType '[] = '[]
-  splitWarningFlagsInternal = const ProdZ
-
-instance SplitWarningFlags rest => SplitWarningFlags (a ': rest) where
-  type SplitWarningFlagsType (a ': rest) = WarningFlags a ': SplitWarningFlagsType rest
-  splitWarningFlagsInternal a = ProdT (contramap SumL a) (splitWarningFlagsInternal (contramap SumR a))
+instance SplitF WarningFlags where
+  splitF a = (contramap Left a, contramap Right a)

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error/WarningFlags.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error/WarningFlags.hs
@@ -166,8 +166,8 @@ runParser parser =
 
 type WarningFlagParsers xs = WarningFlagParser (Sum xs)
 
-combineParsers :: (ProductTupleIso (CombineType WarningFlagParser xs) r, Combine WarningFlagParser xs) => r -> WarningFlagParsers xs
-combineParsers = combineFromTuple
+combineParsers :: Combine WarningFlagParser xs => Product (CombineType WarningFlagParser xs) -> WarningFlagParsers xs
+combineParsers = combine
 
 instance CombineF WarningFlagParser where
   combineF (left, rest) =
@@ -180,8 +180,8 @@ instance CombineF WarningFlagParser where
       }
   combineZ = mkWarningFlagParser (const (error "voidParser: should not be able to get a flag with SumR")) []
 
-splitWarningFlags :: (ProductTupleIso (SplitType WarningFlags xs) r, Split WarningFlags xs) => WarningFlags (Sum xs) -> r
-splitWarningFlags = splitToTuple
+splitWarningFlags :: Split WarningFlags xs => WarningFlags (Sum xs) -> Product (SplitType WarningFlags xs)
+splitWarningFlags = split
 
 instance SplitF WarningFlags where
   splitF a = (contramap Left a, contramap Right a)

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error/WarningFlags.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error/WarningFlags.hs
@@ -73,6 +73,9 @@ instance Contravariant DamlWarningFlags where
       , dwfFlags = fmap (contramap f) dwfFlags
       }
 
+splitDamlWarningFlags :: DamlWarningFlags (Either err1 err2) -> (DamlWarningFlags err1, DamlWarningFlags err2)
+splitDamlWarningFlags flags = (contramap Left flags, contramap Right flags)
+
 combineParsers :: DamlWarningFlagParser err1 -> DamlWarningFlagParser err2 -> DamlWarningFlagParser (Either err1 err2)
 combineParsers left right =
   DamlWarningFlagParser

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error/WarningFlags.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error/WarningFlags.hs
@@ -168,16 +168,6 @@ type WarningFlagParsers xs = WarningFlagParser (Sum xs)
 voidParser :: WarningFlagParsers '[]
 voidParser = mkWarningFlagParser (const (error "voidParser: should not be able to get a flag with SumR")) []
 
---combineParsers :: WarningFlagParser left -> WarningFlagParser (Sum rest) -> WarningFlagParser (Sum (left ': rest))
---combineParsers left rest =
---  WarningFlagParser
---    { dwfpDefault = eitherSum (dwfpDefault left) (dwfpDefault rest)
---    , dwfpFlagParsers =
---        (fmap . fmap . fmap) (modifyWfFilter (flip eitherSum (const False))) (dwfpFlagParsers left) ++
---        (fmap . fmap . fmap) (modifyWfFilter (eitherSum (const False))) (dwfpFlagParsers rest)
---    , dwfpSuggestFlag = eitherSum (dwfpSuggestFlag left) (dwfpSuggestFlag rest)
---    }
-
 combineParsers :: (ProductTupleIso (CombineParsersType xs) r, CombineParsers xs) => r -> WarningFlagParser (Sum xs)
 combineParsers = combineParsersInternal . fromTuple
 

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -39,7 +39,7 @@ type TcPreUpgradeM = TcMF PreUpgradingEnv
 data PreUpgradingEnv = PreUpgradingEnv
   { pueVersion :: Version
   , pueUpgradeInfo :: UpgradeInfo
-  , pueWarningFlags :: DamlWarningFlags ErrorOrWarning
+  , pueWarningFlags :: WarningFlags ErrorOrWarning
   }
 
 data UpgradeInfo = UpgradeInfo
@@ -85,13 +85,13 @@ shouldTypecheckM = asks $ shouldTypecheck . pueUpgradeInfo
 
 mkGamma :: PreUpgradingEnv -> World -> Gamma
 mkGamma PreUpgradingEnv { pueVersion, pueWarningFlags } world =
-    set damlWarningFlags pueWarningFlags (emptyGamma world pueVersion)
+    set warningFlags pueWarningFlags (emptyGamma world pueVersion)
 
 gammaM :: World -> TcPreUpgradeM Gamma
 gammaM world = asks (flip mkGamma world)
 
 {- HLINT ignore "Use nubOrd" -}
-extractDiagnostics :: Version -> UpgradeInfo -> DamlWarningFlags ErrorOrWarning -> TcPreUpgradeM () -> [Diagnostic]
+extractDiagnostics :: Version -> UpgradeInfo -> WarningFlags ErrorOrWarning -> TcPreUpgradeM () -> [Diagnostic]
 extractDiagnostics version upgradeInfo warningFlags action =
   case runGammaF (PreUpgradingEnv version upgradeInfo warningFlags) action of
     Left err -> [toDiagnostic err]
@@ -112,14 +112,14 @@ mkUpgradedPkgWithNameAndVersion presentPkgId presentPkg =
 
 checkPackage
   :: LF.Package
-  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo -> DamlWarningFlags ErrorOrWarning
+  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo -> WarningFlags ErrorOrWarning
   -> Maybe (UpgradedPkgWithNameAndVersion, [UpgradedPkgWithNameAndVersion])
   -> [Diagnostic]
 checkPackage = checkPackageToDepth CheckOnlyMissingModules
 
 checkPackageToDepth
   :: CheckDepth -> LF.Package
-  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo -> DamlWarningFlags ErrorOrWarning
+  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo -> WarningFlags ErrorOrWarning
   -> Maybe (UpgradedPkgWithNameAndVersion, [UpgradedPkgWithNameAndVersion])
   -> [Diagnostic]
 checkPackageToDepth checkDepth pkg deps version upgradeInfo warningFlags mbUpgradedPkg =
@@ -165,7 +165,7 @@ checkPackageSingle mbContext pkg externalPkgs = do
 
 checkModule
   :: LF.World -> LF.Module
-  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo -> DamlWarningFlags ErrorOrWarning
+  -> [UpgradedPkgWithNameAndVersion] -> Version -> UpgradeInfo -> WarningFlags ErrorOrWarning
   -> Maybe (UpgradedPkgWithNameAndVersion, [UpgradedPkgWithNameAndVersion])
   -> [Diagnostic]
 checkModule world0 module_ deps version upgradeInfo warningFlags mbUpgradedPkg =

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/WarnInvalidDependencies.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/WarnInvalidDependencies.hs
@@ -22,12 +22,12 @@ checkPackage
   -> [LF.DalfPackage]
   -> LF.Version
   -> UpgradeInfo
-  -> DamlWarningFlags ErrorOrWarning
+  -> WarningFlags ErrorOrWarning
   -> [LF.DalfPackage]
   -> Maybe (UpgradedPkgWithNameAndVersion, [UpgradedPkgWithNameAndVersion])
   -> [Diagnostic]
 checkPackage pkg deps version upgradeInfo flags rootDeps mbUpgradedPackage = 
-  case runGamma (LF.initWorldSelf (LF.dalfPackagePkg <$> deps) pkg) version $ withReaderT (set damlWarningFlags flags) check of
+  case runGamma (LF.initWorldSelf (LF.dalfPackagePkg <$> deps) pkg) version $ withReaderT (set warningFlags flags) check of
     Left err -> [toDiagnostic err]
     Right ((), warnings) -> map toDiagnostic (nub warnings)
   where

--- a/sdk/compiler/damlc/BUILD.bazel
+++ b/sdk/compiler/damlc/BUILD.bazel
@@ -239,6 +239,7 @@ da_haskell_library(
         "//compiler/daml-lf-proto",
         "//compiler/daml-lf-reader",
         "//compiler/daml-lf-tools",
+        "//compiler/daml-lf-tools-util",
         "//compiler/damlc/daml-compiler",
         "//compiler/damlc/daml-desugar",
         "//compiler/damlc/daml-doc",

--- a/sdk/compiler/damlc/BUILD.bazel
+++ b/sdk/compiler/damlc/BUILD.bazel
@@ -298,7 +298,7 @@ genrule(
             --output=$(OUTS) \
             --package-name=daml-prim \
             --format=Json \
-            --disable-deprecated-exceptions-warning \
+            -Wno-deprecated-exceptions \
             --target={} \
             $(locations //compiler/damlc/daml-prim-src)
     """.format(lf_docs_version),
@@ -317,7 +317,7 @@ genrule(
             --output=$(OUTS) \
             --package-name=daml-stdlib \
             --format=Json \
-            --disable-deprecated-exceptions-warning \
+            -Wno-deprecated-exceptions \
             --target={} \
             $(locations //compiler/damlc/daml-stdlib-src)
     """.format(lf_docs_version),

--- a/sdk/compiler/damlc/BUILD.bazel
+++ b/sdk/compiler/damlc/BUILD.bazel
@@ -245,6 +245,7 @@ da_haskell_library(
         "//compiler/damlc/daml-ide",
         "//compiler/damlc/daml-ide-core",
         "//compiler/damlc/daml-lf-conversion",
+        "//compiler/damlc/daml-lf-conversion-errors",
         "//compiler/damlc/daml-opts",
         "//compiler/damlc/daml-opts:daml-opts-types",
         "//compiler/damlc/daml-package-config",

--- a/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -38,7 +38,6 @@ import qualified Data.ByteString.Lazy.Char8 as BSC
 import qualified Data.ByteString.Lazy.UTF8 as BSLUTF8
 import Data.Conduit (ConduitT)
 import Data.Conduit.Combinators (sourceFile, sourceLazy)
-import Data.Functor.Contravariant
 import Data.List.Extra
 import qualified Data.Map.Strict as Map
 import Data.Maybe
@@ -68,6 +67,7 @@ import qualified Data.SemVer as V
 import DA.Daml.Project.Types (ProjectPath (..), UnresolvedReleaseVersion(..))
 
 import SdkVersion.Class (SdkVersioned)
+import qualified DA.Daml.LF.TypeChecker.Error as TypeCheckerError
 
 -- | Create a DAR file by running a ZipArchive action.
 createDarFile :: Logger.Handle IO -> FilePath -> Zip.ZipArchive () -> IO ()
@@ -113,10 +113,10 @@ buildDar ::
     -> NormalizedFilePath
     -> FromDalf
     -> UpgradeInfo
-    -> DamlWarningFlags ErrorOrWarning
+    -> DamlWarningFlags TypeCheckerError.ErrorOrWarning
     -> Maybe ProjectPath
     -> IO (Maybe (Zip.ZipArchive (), Maybe LF.PackageId))
-buildDar service PackageConfigFields {..} ifDir dalfInput upgradeInfo warningFlags mbProjectPath = do
+buildDar service PackageConfigFields {..} ifDir dalfInput upgradeInfo typecheckerWarningFlags mbProjectPath = do
     liftIO $
         IdeLogger.logDebug (ideLogger service) $
         "Creating dar: " <> T.pack pSrc
@@ -171,8 +171,8 @@ buildDar service PackageConfigFields {..} ifDir dalfInput upgradeInfo warningFla
 
                  MaybeT $
                      runDiagnosticCheck $ diagsToIdeResult (toNormalizedFilePath' pSrc) $
-                         Upgrade.checkPackage pkg (map Upgrade.dalfPackageToUpgradedPkg (Map.elems dalfDependencies0)) lfVersion upgradeInfo (contramap Left warningFlags) mbUpgradedPackage
-                           <> WarnInvalidDependencies.checkPackage pkg (Map.elems dalfDependencies0) lfVersion upgradeInfo (contramap Left warningFlags) rootDepsDalfs mbUpgradedPackage
+                         Upgrade.checkPackage pkg (map Upgrade.dalfPackageToUpgradedPkg (Map.elems dalfDependencies0)) lfVersion upgradeInfo typecheckerWarningFlags mbUpgradedPackage
+                           <> WarnInvalidDependencies.checkPackage pkg (Map.elems dalfDependencies0) lfVersion upgradeInfo typecheckerWarningFlags rootDepsDalfs mbUpgradedPackage
                  let dalfDependencies =
                          [ (T.pack $ unitIdString unitId, LF.dalfPackageBytes pkg, LF.dalfPackageId pkg)
                          | (unitId, pkg) <- Map.toList dalfDependencies0

--- a/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -24,7 +24,7 @@ import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Resource (ResourceT)
 import qualified DA.Daml.LF.Ast as LF
 import DA.Daml.LF.Proto3.Archive (encodeArchiveAndHash)
-import DA.Daml.LF.TypeChecker.Error.WarningFlags (DamlWarningFlags)
+import DA.Daml.LF.TypeChecker.Error.WarningFlags (WarningFlags)
 import DA.Daml.LF.TypeChecker.Upgrade as Upgrade
 import DA.Daml.LF.TypeChecker.WarnInvalidDependencies as WarnInvalidDependencies
 import DA.Daml.Options (expandSdkPackages)
@@ -113,7 +113,7 @@ buildDar ::
     -> NormalizedFilePath
     -> FromDalf
     -> UpgradeInfo
-    -> DamlWarningFlags TypeCheckerError.ErrorOrWarning
+    -> WarningFlags TypeCheckerError.ErrorOrWarning
     -> Maybe ProjectPath
     -> IO (Maybe (Zip.ZipArchive (), Maybe LF.PackageId))
 buildDar service PackageConfigFields {..} ifDir dalfInput upgradeInfo typecheckerWarningFlags mbProjectPath = do

--- a/sdk/compiler/damlc/daml-lf-conversion-errors/src/DA/Daml/LFConversion/Errors.hs
+++ b/sdk/compiler/damlc/daml-lf-conversion-errors/src/DA/Daml/LFConversion/Errors.hs
@@ -22,22 +22,17 @@ import "ghc-lib" TyCoRep
 
 damlWarningFlagParserLFConversion :: DamlWarningFlagParser ErrorOrWarning
 damlWarningFlagParserLFConversion =
-  DamlWarningFlagParser
-    { dwfpFlagParsers = [(warnLargeTuplesName, warnLargeTuplesFlag)]
-    , dwfpDefault = \case
-        LargeTuple _ -> AsWarning
-    }
+  mkDamlWarningFlagParser
+    (\case
+        LargeTuple _ -> AsWarning)
+    [warnLargeTuplesFlagSpec]
 
-warnLargeTuplesName :: String
-warnLargeTuplesName = "large-tuples"
-
-warnLargeTuplesFlag :: DamlWarningFlagStatus -> DamlWarningFlag ErrorOrWarning
-warnLargeTuplesFlag status = RawDamlWarningFlag
-  { rfName = warnLargeTuplesName
-  , rfStatus = status
-  , rfFilter = \case
-      LargeTuple _ -> True
-  }
+warnLargeTuplesFlagSpec :: DamlWarningFlagSpec ErrorOrWarning
+warnLargeTuplesFlagSpec = DamlWarningFlagSpec
+  "large-tuples"
+  True
+  (\case
+      LargeTuple _ -> True)
 
 data ConversionState = ConversionState
     { freshTmVarCounter :: Int

--- a/sdk/compiler/damlc/daml-lf-conversion-errors/src/DA/Daml/LFConversion/Errors.hs
+++ b/sdk/compiler/damlc/daml-lf-conversion-errors/src/DA/Daml/LFConversion/Errors.hs
@@ -20,19 +20,14 @@ import DA.Daml.LF.TypeChecker.Error.WarningFlags
 
 import "ghc-lib" TyCoRep
 
-warningFlagParserLFConversion :: WarningFlagParser ErrorOrWarning
-warningFlagParserLFConversion =
+warningFlagParser :: WarningFlagParser ErrorOrWarning
+warningFlagParser =
   mkWarningFlagParser
     (\case
         LargeTuple _ -> AsWarning)
-    [warnLargeTuplesFlagSpec]
-
-warnLargeTuplesFlagSpec :: WarningFlagSpec ErrorOrWarning
-warnLargeTuplesFlagSpec = WarningFlagSpec
-  "large-tuples"
-  True
-  (\case
-      LargeTuple _ -> True)
+    [ WarningFlagSpec "large-tuples" True (\case
+        LargeTuple _ -> True)
+    ]
 
 data ConversionState = ConversionState
     { freshTmVarCounter :: Int

--- a/sdk/compiler/damlc/daml-lf-conversion-errors/src/DA/Daml/LFConversion/Errors.hs
+++ b/sdk/compiler/damlc/daml-lf-conversion-errors/src/DA/Daml/LFConversion/Errors.hs
@@ -20,15 +20,15 @@ import DA.Daml.LF.TypeChecker.Error.WarningFlags
 
 import "ghc-lib" TyCoRep
 
-damlWarningFlagParserLFConversion :: DamlWarningFlagParser ErrorOrWarning
-damlWarningFlagParserLFConversion =
-  mkDamlWarningFlagParser
+warningFlagParserLFConversion :: WarningFlagParser ErrorOrWarning
+warningFlagParserLFConversion =
+  mkWarningFlagParser
     (\case
         LargeTuple _ -> AsWarning)
     [warnLargeTuplesFlagSpec]
 
-warnLargeTuplesFlagSpec :: DamlWarningFlagSpec ErrorOrWarning
-warnLargeTuplesFlagSpec = DamlWarningFlagSpec
+warnLargeTuplesFlagSpec :: WarningFlagSpec ErrorOrWarning
+warnLargeTuplesFlagSpec = WarningFlagSpec
   "large-tuples"
   True
   (\case

--- a/sdk/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/sdk/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -81,7 +81,7 @@ module DA.Daml.LFConversion
     , ConversionEnv(..) -- exposed for testing
     ) where
 
-import           DA.Daml.LF.TypeChecker.Error.WarningFlags (DamlWarningFlags)
+import           DA.Daml.LF.TypeChecker.Error.WarningFlags (WarningFlags)
 import           DA.Daml.LFConversion.Primitives
 import           DA.Daml.LFConversion.MetadataEncoding
 import           DA.Daml.LFConversion.ConvertM
@@ -733,7 +733,7 @@ convertModule
     :: SdkVersioned
     => LF.Version
     -> EnableInterfaces
-    -> DamlWarningFlags ErrorOrWarning
+    -> WarningFlags ErrorOrWarning
     -> MS.Map UnitId DalfPackage
     -> MS.Map (GHC.UnitId, LF.ModuleName) LF.PackageId
     -> NormalizedFilePath
@@ -742,7 +742,7 @@ convertModule
       -- ^ Only used for information that isn't available in ModDetails.
     -> ModDetails
     -> Either FileDiagnostic (LF.Module, [FileDiagnostic])
-convertModule lfVersion enableInterfaces damlWarningFlags pkgMap stablePackages file coreModule modIface details = runConvertM (ConversionEnv file Nothing damlWarningFlags) $ do
+convertModule lfVersion enableInterfaces warningFlags pkgMap stablePackages file coreModule modIface details = runConvertM (ConversionEnv file Nothing warningFlags) $ do
     let
       env = mkEnv lfVersion enableInterfaces pkgMap stablePackages (cm_module coreModule)
       mc = extractModuleContents env coreModule modIface details

--- a/sdk/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/ConvertM.hs
+++ b/sdk/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/ConvertM.hs
@@ -18,7 +18,7 @@ module DA.Daml.LFConversion.ConvertM (
     StandaloneError(..),
     ErrorOrWarning(..),
     InvalidInterfaceError(..),
-    warningFlagParserLFConversion,
+    warningFlagParser,
   ) where
 
 import           DA.Daml.LFConversion.Errors

--- a/sdk/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/ConvertM.hs
+++ b/sdk/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/ConvertM.hs
@@ -19,7 +19,6 @@ module DA.Daml.LFConversion.ConvertM (
     ErrorOrWarning(..),
     InvalidInterfaceError(..),
     damlWarningFlagParserLFConversion,
-    warnLargeTuplesFlag
   ) where
 
 import           DA.Daml.LFConversion.Errors

--- a/sdk/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/ConvertM.hs
+++ b/sdk/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/ConvertM.hs
@@ -18,7 +18,7 @@ module DA.Daml.LFConversion.ConvertM (
     StandaloneError(..),
     ErrorOrWarning(..),
     InvalidInterfaceError(..),
-    damlWarningFlagParserLFConversion,
+    warningFlagParserLFConversion,
   ) where
 
 import           DA.Daml.LFConversion.Errors
@@ -42,7 +42,7 @@ import           DA.Daml.LF.TypeChecker.Error.WarningFlags
 data ConversionEnv = ConversionEnv
   { convModuleFilePath :: !NormalizedFilePath
   , convRange :: !(Maybe SourceLoc)
-  , convWarningFlags :: DamlWarningFlags ErrorOrWarning
+  , convWarningFlags :: WarningFlags ErrorOrWarning
   }
 
 newtype ConvertM a = ConvertM (ReaderT ConversionEnv (StateT ConversionState (Except FileDiagnostic)) a)
@@ -111,7 +111,7 @@ conversionWarningRaw msg = do
       fileDiagnostic = (convModuleFilePath, ShowDiag, diagnostic)
   modify $ \s -> s { warnings = fileDiagnostic : warnings s }
 
-getErrorOrWarningStatus :: ErrorOrWarning -> ConvertM DamlWarningFlagStatus
+getErrorOrWarningStatus :: ErrorOrWarning -> ConvertM WarningFlagStatus
 getErrorOrWarningStatus errOrWarn = do
    warningFlags <- asks convWarningFlags
    pure (getWarningStatus warningFlags errOrWarn)

--- a/sdk/compiler/damlc/daml-lf-conversion/test/DA/Daml/LFConversion/Tests.hs
+++ b/sdk/compiler/damlc/daml-lf-conversion/test/DA/Daml/LFConversion/Tests.hs
@@ -318,6 +318,6 @@ bignumericTests = testGroup "BigNumeric"
         let dummyEnv = ConversionEnv
               { convModuleFilePath = toNormalizedFilePath' ""
               , convRange = Nothing
-              , convWarningFlags = mkWarningFlags warningFlagParserLFConversion []
+              , convWarningFlags = mkWarningFlags warningFlagParser []
               }
         in runConvertM dummyEnv $ convertRationalBigNumeric (numerator r) (denominator r)

--- a/sdk/compiler/damlc/daml-lf-conversion/test/DA/Daml/LFConversion/Tests.hs
+++ b/sdk/compiler/damlc/daml-lf-conversion/test/DA/Daml/LFConversion/Tests.hs
@@ -318,6 +318,6 @@ bignumericTests = testGroup "BigNumeric"
         let dummyEnv = ConversionEnv
               { convModuleFilePath = toNormalizedFilePath' ""
               , convRange = Nothing
-              , convWarningFlags = mkDamlWarningFlags damlWarningFlagParserLFConversion []
+              , convWarningFlags = mkWarningFlags warningFlagParserLFConversion []
               }
         in runConvertM dummyEnv $ convertRationalBigNumeric (numerator r) (denominator r)

--- a/sdk/compiler/damlc/daml-opts/BUILD.bazel
+++ b/sdk/compiler/damlc/daml-opts/BUILD.bazel
@@ -27,6 +27,7 @@ da_haskell_library(
     deps = [
         "//compiler/daml-lf-ast",
         "//compiler/daml-lf-tools",
+        "//compiler/daml-lf-tools-util",
         "//compiler/damlc/daml-lf-conversion-errors",
         "//compiler/damlc/daml-package-config",
         "//daml-assistant:daml-project-config",

--- a/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -146,9 +146,9 @@ data Options = Options
   , optUpgradeInfo :: UpgradeInfo
   , optTypecheckerWarningFlags :: WarningFlags.DamlWarningFlags TypeCheckerError.ErrorOrWarning
   , optLfConversionWarningFlags :: WarningFlags.DamlWarningFlags LFConversion.ErrorOrWarning
+  , optInlineDamlCustomWarningFlags :: WarningFlags.DamlWarningFlags InlineDamlCustomWarnings
   , optIgnoreDataDepVisibility :: IgnoreDataDepVisibility
   , optForceUtilityPackage :: ForceUtilityPackage
-  , optInlineDamlCustomWarnings :: WarningFlags.DamlWarningFlags InlineDamlCustomWarnings
   }
 
 data InlineDamlCustomWarnings
@@ -328,9 +328,9 @@ defaultOptions mbVersion =
         , optUpgradeInfo = defaultUpgradeInfo
         , optTypecheckerWarningFlags = WarningFlags.mkDamlWarningFlags TypeCheckerError.damlWarningFlagParserTypeChecker []
         , optLfConversionWarningFlags = WarningFlags.mkDamlWarningFlags LFConversion.damlWarningFlagParserLFConversion []
+        , optInlineDamlCustomWarningFlags = WarningFlags.mkDamlWarningFlags inlineDamlCustomWarningsParser []
         , optIgnoreDataDepVisibility = IgnoreDataDepVisibility False
         , optForceUtilityPackage = ForceUtilityPackage False
-        , optInlineDamlCustomWarnings = WarningFlags.mkDamlWarningFlags inlineDamlCustomWarningsParser []
         }
 
 defaultUpgradeInfo :: UpgradeInfo

--- a/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -63,6 +63,7 @@ import Module (UnitId, stringToUnitId)
 import qualified System.Directory as Dir
 import System.FilePath
 import qualified DA.Daml.LF.TypeChecker.Error.WarningFlags as WarningFlags
+import Data.HList
 import qualified DA.Daml.LF.TypeChecker.Error as TypeCheckerError
 import qualified DA.Daml.LFConversion.Errors as LFConversion
 import DA.Daml.LF.TypeChecker.Upgrade (UpgradeInfo(..))
@@ -177,10 +178,9 @@ inlineDamlCustomWarningToGhcFlag flags = map go [minBound..maxBound]
 allWarningFlagParsers :: WarningFlags.WarningFlagParsers '[InlineDamlCustomWarnings, TypeCheckerError.ErrorOrWarning, LFConversion.ErrorOrWarning]
 allWarningFlagParsers =
   WarningFlags.combineParsers
-    ( warningFlagParserInlineDamlCustom
-    , TypeCheckerError.warningFlagParser
-    , LFConversion.warningFlagParser
-    )
+    (ProdT warningFlagParserInlineDamlCustom
+      (ProdT TypeCheckerError.warningFlagParser
+        (ProdT LFConversion.warningFlagParser ProdZ)))
 
 newtype IncrementalBuild = IncrementalBuild { getIncrementalBuild :: Bool }
   deriving Show

--- a/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -40,11 +40,11 @@ module DA.Daml.Options.Types
     , defaultUiWarnBadInterfaceInstances
     , defaultUiWarnBadExceptions
     , defaultUpgradeInfo
-    , damlWarningFlagParser
+    , warningFlagParser
     , inlineDamlCustomWarningsParser
     , inlineDamlCustomWarningToGhcFlag
-    , TypeCheckerError.damlWarningFlagParserTypeChecker
-    , LFConversion.damlWarningFlagParserLFConversion
+    , TypeCheckerError.warningFlagParserTypeChecker
+    , LFConversion.warningFlagParserLFConversion
     , InlineDamlCustomWarnings (..)
     ) where
 
@@ -144,9 +144,9 @@ data Options = Options
   -- ^ When running in IDE, some rules need access to the package name and version, but we don't want to use own
   -- unit-id, as script service assume it will be "main"
   , optUpgradeInfo :: UpgradeInfo
-  , optTypecheckerWarningFlags :: WarningFlags.DamlWarningFlags TypeCheckerError.ErrorOrWarning
-  , optLfConversionWarningFlags :: WarningFlags.DamlWarningFlags LFConversion.ErrorOrWarning
-  , optInlineDamlCustomWarningFlags :: WarningFlags.DamlWarningFlags InlineDamlCustomWarnings
+  , optTypecheckerWarningFlags :: WarningFlags.WarningFlags TypeCheckerError.ErrorOrWarning
+  , optLfConversionWarningFlags :: WarningFlags.WarningFlags LFConversion.ErrorOrWarning
+  , optInlineDamlCustomWarningFlags :: WarningFlags.WarningFlags InlineDamlCustomWarnings
   , optIgnoreDataDepVisibility :: IgnoreDataDepVisibility
   , optForceUtilityPackage :: ForceUtilityPackage
   }
@@ -155,15 +155,15 @@ data InlineDamlCustomWarnings
   = DisableDeprecatedExceptions
   deriving (Enum, Bounded, Ord, Eq, Show)
 
-inlineDamlCustomWarningsParser :: WarningFlags.DamlWarningFlagParser InlineDamlCustomWarnings
-inlineDamlCustomWarningsParser = WarningFlags.mkDamlWarningFlagParser
+inlineDamlCustomWarningsParser :: WarningFlags.WarningFlagParser InlineDamlCustomWarnings
+inlineDamlCustomWarningsParser = WarningFlags.mkWarningFlagParser
   (\case
     DisableDeprecatedExceptions -> WarningFlags.AsWarning)
-  [ WarningFlags.DamlWarningFlagSpec "deprecated-exceptions" True $ \case
+  [ WarningFlags.WarningFlagSpec "deprecated-exceptions" True $ \case
       DisableDeprecatedExceptions -> True
   ]
 
-inlineDamlCustomWarningToGhcFlag :: WarningFlags.DamlWarningFlags InlineDamlCustomWarnings -> [String]
+inlineDamlCustomWarningToGhcFlag :: WarningFlags.WarningFlags InlineDamlCustomWarnings -> [String]
 inlineDamlCustomWarningToGhcFlag flags = map go [minBound..maxBound]
   where
     toName :: InlineDamlCustomWarnings -> String
@@ -175,13 +175,13 @@ inlineDamlCustomWarningToGhcFlag flags = map go [minBound..maxBound]
         WarningFlags.AsWarning -> "-W" <> toName inlineWarning
         WarningFlags.Hidden -> "-Wno-" <> toName inlineWarning
 
-damlWarningFlagParser :: WarningFlags.DamlWarningFlagParser (Either InlineDamlCustomWarnings (Either TypeCheckerError.ErrorOrWarning LFConversion.ErrorOrWarning))
-damlWarningFlagParser =
+warningFlagParser :: WarningFlags.WarningFlagParser (Either InlineDamlCustomWarnings (Either TypeCheckerError.ErrorOrWarning LFConversion.ErrorOrWarning))
+warningFlagParser =
   WarningFlags.combineParsers
     inlineDamlCustomWarningsParser
     (WarningFlags.combineParsers
-      TypeCheckerError.damlWarningFlagParserTypeChecker
-      LFConversion.damlWarningFlagParserLFConversion)
+      TypeCheckerError.warningFlagParserTypeChecker
+      LFConversion.warningFlagParserLFConversion)
 
 newtype IncrementalBuild = IncrementalBuild { getIncrementalBuild :: Bool }
   deriving Show
@@ -326,9 +326,9 @@ defaultOptions mbVersion =
         , optAccessTokenPath = Nothing
         , optHideUnitId = False
         , optUpgradeInfo = defaultUpgradeInfo
-        , optTypecheckerWarningFlags = WarningFlags.mkDamlWarningFlags TypeCheckerError.damlWarningFlagParserTypeChecker []
-        , optLfConversionWarningFlags = WarningFlags.mkDamlWarningFlags LFConversion.damlWarningFlagParserLFConversion []
-        , optInlineDamlCustomWarningFlags = WarningFlags.mkDamlWarningFlags inlineDamlCustomWarningsParser []
+        , optTypecheckerWarningFlags = WarningFlags.mkWarningFlags TypeCheckerError.warningFlagParserTypeChecker []
+        , optLfConversionWarningFlags = WarningFlags.mkWarningFlags LFConversion.warningFlagParserLFConversion []
+        , optInlineDamlCustomWarningFlags = WarningFlags.mkWarningFlags inlineDamlCustomWarningsParser []
         , optIgnoreDataDepVisibility = IgnoreDataDepVisibility False
         , optForceUtilityPackage = ForceUtilityPackage False
         }

--- a/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -159,7 +159,7 @@ warningFlagParserInlineDamlCustom :: WarningFlags.WarningFlagParser InlineDamlCu
 warningFlagParserInlineDamlCustom = WarningFlags.mkWarningFlagParser
   (\case
     DisableDeprecatedExceptions -> WarningFlags.AsWarning)
-  [ WarningFlags.WarningFlagSpec "deprecated-exceptions" True $ \case
+  [ WarningFlags.WarningFlagSpec "deprecated-exceptions" False $ \case
       DisableDeprecatedExceptions -> True
   ]
 

--- a/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -41,11 +41,9 @@ module DA.Daml.Options.Types
     , defaultUiWarnBadInterfaceInstances
     , defaultUiWarnBadExceptions
     , defaultUpgradeInfo
-    , warningFlagParser
-    , inlineDamlCustomWarningsParser
+    , allWarningFlagParsers
+    , warningFlagParserInlineDamlCustom
     , inlineDamlCustomWarningToGhcFlag
-    , TypeCheckerError.warningFlagParserTypeChecker
-    , LFConversion.warningFlagParserLFConversion
     , InlineDamlCustomWarnings (..)
     ) where
 
@@ -156,8 +154,8 @@ data InlineDamlCustomWarnings
   = DisableDeprecatedExceptions
   deriving (Enum, Bounded, Ord, Eq, Show)
 
-inlineDamlCustomWarningsParser :: WarningFlags.WarningFlagParser InlineDamlCustomWarnings
-inlineDamlCustomWarningsParser = WarningFlags.mkWarningFlagParser
+warningFlagParserInlineDamlCustom :: WarningFlags.WarningFlagParser InlineDamlCustomWarnings
+warningFlagParserInlineDamlCustom = WarningFlags.mkWarningFlagParser
   (\case
     DisableDeprecatedExceptions -> WarningFlags.AsWarning)
   [ WarningFlags.WarningFlagSpec "deprecated-exceptions" True $ \case
@@ -176,12 +174,12 @@ inlineDamlCustomWarningToGhcFlag flags = map go [minBound..maxBound]
         WarningFlags.AsWarning -> "-W" <> toName inlineWarning
         WarningFlags.Hidden -> "-Wno-" <> toName inlineWarning
 
-warningFlagParser :: WarningFlags.WarningFlagParsers '[InlineDamlCustomWarnings, TypeCheckerError.ErrorOrWarning, LFConversion.ErrorOrWarning]
-warningFlagParser =
+allWarningFlagParsers :: WarningFlags.WarningFlagParsers '[InlineDamlCustomWarnings, TypeCheckerError.ErrorOrWarning, LFConversion.ErrorOrWarning]
+allWarningFlagParsers =
   WarningFlags.combineParsers
-    ( inlineDamlCustomWarningsParser
-    , TypeCheckerError.warningFlagParserTypeChecker
-    , LFConversion.warningFlagParserLFConversion
+    ( warningFlagParserInlineDamlCustom
+    , TypeCheckerError.warningFlagParser
+    , LFConversion.warningFlagParser
     )
 
 newtype IncrementalBuild = IncrementalBuild { getIncrementalBuild :: Bool }
@@ -327,9 +325,9 @@ defaultOptions mbVersion =
         , optAccessTokenPath = Nothing
         , optHideUnitId = False
         , optUpgradeInfo = defaultUpgradeInfo
-        , optTypecheckerWarningFlags = WarningFlags.mkWarningFlags TypeCheckerError.warningFlagParserTypeChecker []
-        , optLfConversionWarningFlags = WarningFlags.mkWarningFlags LFConversion.warningFlagParserLFConversion []
-        , optInlineDamlCustomWarningFlags = WarningFlags.mkWarningFlags inlineDamlCustomWarningsParser []
+        , optTypecheckerWarningFlags = WarningFlags.mkWarningFlags TypeCheckerError.warningFlagParser []
+        , optLfConversionWarningFlags = WarningFlags.mkWarningFlags LFConversion.warningFlagParser []
+        , optInlineDamlCustomWarningFlags = WarningFlags.mkWarningFlags warningFlagParserInlineDamlCustom []
         , optIgnoreDataDepVisibility = IgnoreDataDepVisibility False
         , optForceUtilityPackage = ForceUtilityPackage False
         }

--- a/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -3,6 +3,7 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE DataKinds #-}
 
 module DA.Daml.Options.Types
     ( Options(..)
@@ -175,13 +176,13 @@ inlineDamlCustomWarningToGhcFlag flags = map go [minBound..maxBound]
         WarningFlags.AsWarning -> "-W" <> toName inlineWarning
         WarningFlags.Hidden -> "-Wno-" <> toName inlineWarning
 
-warningFlagParser :: WarningFlags.WarningFlagParser (Either InlineDamlCustomWarnings (Either TypeCheckerError.ErrorOrWarning LFConversion.ErrorOrWarning))
+warningFlagParser :: WarningFlags.WarningFlagParsers '[InlineDamlCustomWarnings, TypeCheckerError.ErrorOrWarning, LFConversion.ErrorOrWarning]
 warningFlagParser =
   WarningFlags.combineParsers
-    inlineDamlCustomWarningsParser
-    (WarningFlags.combineParsers
-      TypeCheckerError.warningFlagParserTypeChecker
-      LFConversion.warningFlagParserLFConversion)
+    ( inlineDamlCustomWarningsParser
+    , TypeCheckerError.warningFlagParserTypeChecker
+    , LFConversion.warningFlagParserLFConversion
+    )
 
 newtype IncrementalBuild = IncrementalBuild { getIncrementalBuild :: Bool }
   deriving Show

--- a/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/sdk/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -164,16 +164,16 @@ inlineDamlCustomWarningsParser = WarningFlags.mkDamlWarningFlagParser
   ]
 
 inlineDamlCustomWarningToGhcFlag :: WarningFlags.DamlWarningFlags InlineDamlCustomWarnings -> [String]
-inlineDamlCustomWarningToGhcFlag flags = mapMaybe go [minBound..maxBound]
+inlineDamlCustomWarningToGhcFlag flags = map go [minBound..maxBound]
   where
     toName :: InlineDamlCustomWarnings -> String
     toName DisableDeprecatedExceptions = "x-exceptions"
 
     go inlineWarning =
       case WarningFlags.getWarningStatus flags inlineWarning of
-        WarningFlags.AsError -> Just $ "-Werror=" <> toName inlineWarning
-        WarningFlags.AsWarning -> Nothing -- "-W" <> toName inlineWarning
-        WarningFlags.Hidden -> Just $ "-Wno-" <> toName inlineWarning
+        WarningFlags.AsError -> "-Werror=" <> toName inlineWarning
+        WarningFlags.AsWarning -> "-W" <> toName inlineWarning
+        WarningFlags.Hidden -> "-Wno-" <> toName inlineWarning
 
 type ErrorOrWarning = Either TypeCheckerError.ErrorOrWarning LFConversion.ErrorOrWarning
 

--- a/sdk/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/sdk/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -505,7 +505,7 @@ setupDamlGHC mbProjectRoot options@Options{..} = do
   liftIO $ initUniqSupply 0 1
 
   let
-    ghcCustomOpts = optGhcCustomOpts ++ inlineDamlCustomWarningToGhcFlag optInlineDamlCustomWarnings
+    ghcCustomOpts = optGhcCustomOpts ++ inlineDamlCustomWarningToGhcFlag optInlineDamlCustomWarningFlags
 
   unless (null ghcCustomOpts) $ do
     damlDFlags <- getSessionDynFlags

--- a/sdk/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/sdk/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -505,11 +505,7 @@ setupDamlGHC mbProjectRoot options@Options{..} = do
   liftIO $ initUniqSupply 0 1
 
   let
-    ghcCustomOpts =
-      if getDisableDeprecatedExceptions optDisableDeprecatedExceptions
-        -- Add disable deprecations flag last, so it takes precedence over other options (such as -Werror)
-        then optGhcCustomOpts ++ ["-Wno-x-exceptions"]
-        else optGhcCustomOpts
+    ghcCustomOpts = optGhcCustomOpts ++ inlineDamlCustomWarningToGhcFlag optInlineDamlCustomWarnings
 
   unless (null ghcCustomOpts) $ do
     damlDFlags <- getSessionDynFlags

--- a/sdk/compiler/damlc/daml-prim-src/DA/Exception/ArithmeticError.daml
+++ b/sdk/compiler/damlc/daml-prim-src/DA/Exception/ArithmeticError.daml
@@ -18,7 +18,7 @@ module DA.Exception.ArithmeticError where
 
 import GHC.Types (Text)
 
-{-# DEPRECATED in "x-exceptions" ArithmeticError ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `--disable-deprecated-exceptions-warning` to disable this warning."] #-}
+{-# DEPRECATED in "x-exceptions" ArithmeticError ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `-Wno-deprecated-exceptions` to disable this warning."] #-}
 -- | Exception raised by an arithmetic operation, such as divide-by-zero or overflow.
 -- DEPRECATED: Use `failWithStatus` and `FailureStatus` over Daml Exceptions
 data ArithmeticError = ArithmeticError { message : Text }

--- a/sdk/compiler/damlc/daml-prim-src/DA/Exception/AssertionFailed.daml
+++ b/sdk/compiler/damlc/daml-prim-src/DA/Exception/AssertionFailed.daml
@@ -18,7 +18,7 @@ module DA.Exception.AssertionFailed where
 
 import GHC.Types (Text)
 
-{-# DEPRECATED in "x-exceptions" AssertionFailed ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `--disable-deprecated-exceptions-warning` to disable this warning."] #-}
+{-# DEPRECATED in "x-exceptions" AssertionFailed ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `-Wno-deprecated-exceptions` to disable this warning."] #-}
 -- | Exception raised by assert functions in DA.Assert
 -- DEPRECATED: Use `failWithStatus` and `FailureStatus` over Daml Exceptions
 data AssertionFailed = AssertionFailed { message : Text }

--- a/sdk/compiler/damlc/daml-prim-src/DA/Exception/GeneralError.daml
+++ b/sdk/compiler/damlc/daml-prim-src/DA/Exception/GeneralError.daml
@@ -18,7 +18,7 @@ module DA.Exception.GeneralError where
 
 import GHC.Types (Text)
 
-{-# DEPRECATED in "x-exceptions" GeneralError ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `--disable-deprecated-exceptions-warning` to disable this warning."] #-}
+{-# DEPRECATED in "x-exceptions" GeneralError ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `-Wno-deprecated-exceptions` to disable this warning."] #-}
 -- | Exception raised by `error`.
 -- DEPRECATED: Use `failWithStatus` and `FailureStatus` over Daml Exceptions
 data GeneralError = GeneralError { message : Text }

--- a/sdk/compiler/damlc/daml-prim-src/DA/Exception/PreconditionFailed.daml
+++ b/sdk/compiler/damlc/daml-prim-src/DA/Exception/PreconditionFailed.daml
@@ -18,7 +18,7 @@ module DA.Exception.PreconditionFailed where
 
 import GHC.Types (Text)
 
-{-# DEPRECATED in "x-exceptions" PreconditionFailed ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `--disable-deprecated-exceptions-warning` to disable this warning."] #-}
+{-# DEPRECATED in "x-exceptions" PreconditionFailed ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `-Wno-deprecated-exceptions` to disable this warning."] #-}
 -- | Exception raised when a contract is invalid, i.e. fails the ensure clause.
 -- DEPRECATED: Use `failWithStatus` and `FailureStatus` over Daml Exceptions
 data PreconditionFailed = PreconditionFailed { message : Text }

--- a/sdk/compiler/damlc/daml-stdlib-src/DA/Exception.daml
+++ b/sdk/compiler/damlc/daml-stdlib-src/DA/Exception.daml
@@ -15,7 +15,7 @@ module DA.Exception
 -- | Exception handling in Daml.
 -- DEPRECATED: Use `failWithStatus` and `FailureStatus` over Daml Exceptions
 module DA.Exception
-  {-# DEPRECATED in "x-exceptions" ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `--disable-deprecated-exceptions-warning` to disable this warning."] #-}
+  {-# DEPRECATED in "x-exceptions" ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `-Wno-deprecated-exceptions` to disable this warning."] #-}
   ( module X ) where
 
 import DA.Internal.Exception as X hiding (DamlException)

--- a/sdk/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
+++ b/sdk/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
@@ -35,7 +35,7 @@ import DA.Internal.Record
 -- | HIDE DatatypeContexts tag for user-defined exception types.
 -- Used internally by the Daml compiler.
 class DamlException
-{-# DEPRECATED in "x-exceptions" DamlException ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `--disable-deprecated-exceptions-warning` to disable this warning."] #-}
+{-# DEPRECATED in "x-exceptions" DamlException ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `-Wno-deprecated-exceptions` to disable this warning."] #-}
 instance DamlException
 
 --------------------------------------------------------------
@@ -49,28 +49,28 @@ type Exception e =
     , HasFromAnyException e
     )
 
-{-# DEPRECATED in "x-exceptions" throwPure ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `--disable-deprecated-exceptions-warning` to disable this warning."] #-}
+{-# DEPRECATED in "x-exceptions" throwPure ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `-Wno-deprecated-exceptions` to disable this warning."] #-}
 -- | Part of the `Exception` constraint.
 -- DEPRECATED: Use `failWithStatus` and `FailureStatus` over Daml Exceptions
 class HasThrow e where
     -- | Throw exception in a pure context.
     throwPure : forall t. e -> t
 
-{-# DEPRECATED in "x-exceptions" message ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `--disable-deprecated-exceptions-warning` to disable this warning."] #-}
+{-# DEPRECATED in "x-exceptions" message ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `-Wno-deprecated-exceptions` to disable this warning."] #-}
 -- | Part of the `Exception` constraint.
 -- DEPRECATED: Use `failWithStatus` and `FailureStatus` over Daml Exceptions
 class HasMessage e where
     -- | Get the error message associated with an exception.
     message : e -> Text
 
-{-# DEPRECATED in "x-exceptions" toAnyException ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `--disable-deprecated-exceptions-warning` to disable this warning."] #-}
+{-# DEPRECATED in "x-exceptions" toAnyException ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `-Wno-deprecated-exceptions` to disable this warning."] #-}
 -- | Part of the `Exception` constraint.
 -- DEPRECATED: Use `failWithStatus` and `FailureStatus` over Daml Exceptions
 class HasToAnyException e where
     -- | Convert an exception type to AnyException.
     toAnyException : e -> AnyException
 
-{-# DEPRECATED in "x-exceptions" fromAnyException ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `--disable-deprecated-exceptions-warning` to disable this warning."] #-}
+{-# DEPRECATED in "x-exceptions" fromAnyException ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `-Wno-deprecated-exceptions` to disable this warning."] #-}
 -- | Part of the `Exception` constraint.
 -- DEPRECATED: Use `failWithStatus` and `FailureStatus` over Daml Exceptions
 class HasFromAnyException e where
@@ -173,13 +173,13 @@ instance HasFromAnyException AssertionFailed where
 
 --------------------------------------------------------------
 
-{-# DEPRECATED in "x-exceptions" throw ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `--disable-deprecated-exceptions-warning` to disable this warning."] #-}
+{-# DEPRECATED in "x-exceptions" throw ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `-Wno-deprecated-exceptions` to disable this warning."] #-}
 -- | Action type in which `throw` is supported.
 -- DEPRECATED: Use `failWithStatus` and `FailureStatus` over Daml Exceptions
 class Action m => ActionThrow m where
     throw : Exception e => e -> m t
 
-{-# DEPRECATED in "x-exceptions" ActionCatch ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `--disable-deprecated-exceptions-warning` to disable this warning."] #-}
+{-# DEPRECATED in "x-exceptions" ActionCatch ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `-Wno-deprecated-exceptions` to disable this warning."] #-}
 -- | Action type in which `try ... catch ...` is supported.
 -- DEPRECATED: Avoid the use of catch in daml code, prefer error handling on client, and throwing using `failWithStatus`
 class ActionThrow m => ActionCatch m where

--- a/sdk/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/sdk/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -204,7 +204,7 @@ instance Ord TypeRep where
 
 #ifdef DAML_EXCEPTIONS
 
-{-# DEPRECATED in "x-exceptions" AnyException ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `--disable-deprecated-exceptions-warning` to disable this warning."] #-}
+{-# DEPRECATED in "x-exceptions" AnyException ["Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.", "Use `-Wno-deprecated-exceptions` to disable this warning."] #-}
 -- | A wrapper for all exception types.
 -- DEPRECATED: Use `failWithStatus` and `FailureStatus` over Daml Exceptions
 data AnyException = AnyException Opaque

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -135,7 +135,7 @@ import DA.Daml.Options.Types (EnableScriptService(..),
                               optSkipScriptValidation,
                               optThreads,
                               optUpgradeInfo,
-                              optDamlWarningFlags,
+                              optTypecheckerWarningFlags,
                               pkgNameVersion,
                               projectPackageDatabase)
 import DA.Daml.Package.Config (MultiPackageConfigFields(..),
@@ -990,7 +990,7 @@ buildEffect relativize pkgPath pkgConfig opts mbOutFile incrementalBuild initPkg
               (toNormalizedFilePath' $ fromMaybe ifaceDir $ optIfaceDir opts)
               (FromDalf False)
               (optUpgradeInfo opts)
-              (optDamlWarningFlags opts)
+              (optTypecheckerWarningFlags opts)
               (Just pkgPath)
       (dar, mPkgId) <- mbErr "ERROR: Creation of DAR file failed." mbDar
       createDarFile loggerH fp dar

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/UpgradeCheck.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/UpgradeCheck.hs
@@ -167,7 +167,7 @@ checkPackageAgainstPastPackages ((path, main, deps), pastPackages) = do
                   (upwnavPkg main) deps
                   LFV.version2_dev
                   (UpgradeInfo (Just (fromNormalizedFilePath path)) True)
-                  (mkDamlWarningFlags damlWarningFlagParserTypeChecker [])
+                  (mkWarningFlags warningFlagParserTypeChecker [])
                   (Just (closestPastPackageWithLowerVersion, closestPastPackageWithLowerVersionDeps))
           when (not (null errs)) (throwE [CEDiagnostic path errs])
       case minimumByMay ordFst $ pastPackageFilterVersion (\v -> v > rawVersion) of
@@ -179,7 +179,7 @@ checkPackageAgainstPastPackages ((path, main, deps), pastPackages) = do
                   (upwnavPkg closestPastPackageWithHigherVersion) closestPastPackageWithHigherVersionDeps
                   LFV.version2_dev
                   (UpgradeInfo (Just (fromNormalizedFilePath path)) True)
-                  (mkDamlWarningFlags damlWarningFlagParserTypeChecker [])
+                  (mkWarningFlags warningFlagParserTypeChecker [])
                   (Just (main, deps))
           when (not (null errs)) (throwE [CEDiagnostic path errs])
 

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/UpgradeCheck.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/UpgradeCheck.hs
@@ -30,6 +30,7 @@ import qualified Data.Validation as Validation
 import Data.Validation (Validation)
 import Data.Functor.Compose
 import DA.Daml.LF.TypeChecker.Error.WarningFlags
+import qualified DA.Daml.LF.TypeChecker.Error as TypeCheckerError
 
 -- Monad in which all checking operations run
 -- Occasionally we change to CheckMValidate
@@ -167,7 +168,7 @@ checkPackageAgainstPastPackages ((path, main, deps), pastPackages) = do
                   (upwnavPkg main) deps
                   LFV.version2_dev
                   (UpgradeInfo (Just (fromNormalizedFilePath path)) True)
-                  (mkWarningFlags warningFlagParserTypeChecker [])
+                  (mkWarningFlags TypeCheckerError.warningFlagParser [])
                   (Just (closestPastPackageWithLowerVersion, closestPastPackageWithLowerVersionDeps))
           when (not (null errs)) (throwE [CEDiagnostic path errs])
       case minimumByMay ordFst $ pastPackageFilterVersion (\v -> v > rawVersion) of
@@ -179,7 +180,7 @@ checkPackageAgainstPastPackages ((path, main, deps), pastPackages) = do
                   (upwnavPkg closestPastPackageWithHigherVersion) closestPastPackageWithHigherVersionDeps
                   LFV.version2_dev
                   (UpgradeInfo (Just (fromNormalizedFilePath path)) True)
-                  (mkWarningFlags warningFlagParserTypeChecker [])
+                  (mkWarningFlags TypeCheckerError.warningFlagParser [])
                   (Just (main, deps))
           when (not (null errs)) (throwE [CEDiagnostic path errs])
 

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -436,7 +436,7 @@ optionsParser numProcessors enableScriptService parsePkgName parseDlintUsage = d
     optTestFilter <- compilePatternExpr <$> optTestPattern
     let optHideUnitId = False
     optUpgradeInfo <- optUpgradeInfo
-    ~(optInlineDamlCustomWarnings, optTypecheckerWarningFlags, optLfConversionWarningFlags) <- optDamlWarningFlags
+    ~(optInlineDamlCustomWarningFlags, optTypecheckerWarningFlags, optLfConversionWarningFlags) <- optDamlWarningFlags
     optIgnoreDataDepVisibility <- optIgnoreDataDepVisibility
     optForceUtilityPackage <- forceUtilityPackageOpt
 

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -587,13 +587,10 @@ optionsParser numProcessors enableScriptService parsePkgName parseDlintUsage = d
 
     optDamlWarningFlags :: Parser (WarningFlags.DamlWarningFlags ErrorOrWarning)
     optDamlWarningFlags =
-      WarningFlags.mkDamlWarningFlags damlWarningFlagParser <$> many optRawDamlWarningFlag
-
-    optRawDamlWarningFlag :: Parser (WarningFlags.DamlWarningFlag ErrorOrWarning)
-    optRawDamlWarningFlag =
-      Options.Applicative.option
-        (eitherReader (WarningFlags.parseRawDamlWarningFlag damlWarningFlagParser))
-        (short 'W' <> helpDoc (Just helpStr))
+      WarningFlags.mkDamlWarningFlags damlWarningFlagParser <$>
+        many (Options.Applicative.option
+          (eitherReader (WarningFlags.parseRawDamlWarningFlag damlWarningFlagParser))
+          (short 'W' <> helpDoc (Just helpStr)))
       where
       helpStr =
         PAL.vcat

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -25,8 +25,6 @@ import qualified DA.Daml.LF.TypeChecker.Error.WarningFlags as WarningFlags
 import qualified DA.Daml.LF.TypeChecker.Error as TypeCheckerError
 import qualified DA.Daml.LFConversion.Errors as LFConversion
 
-import qualified Text.PrettyPrint.ANSI.Leijen as PAL
-
 -- | Pretty-printing documents with syntax-highlighting annotations.
 type Document = Pretty.Doc Pretty.SyntaxClass
 
@@ -580,25 +578,13 @@ optionsParser numProcessors enableScriptService parsePkgName parseDlintUsage = d
         idm
 
     optWarningFlags :: Parser (WarningFlags.WarningFlags InlineDamlCustomWarnings, WarningFlags.WarningFlags TypeCheckerError.ErrorOrWarning, WarningFlags.WarningFlags LFConversion.ErrorOrWarning)
-    optWarningFlags =
-      split3 . WarningFlags.mkWarningFlags warningFlagParser <$>
-        many (Options.Applicative.option
-          (eitherReader (WarningFlags.parseWarningFlag warningFlagParser))
-          (short 'W' <> helpDoc (Just helpStr)))
+    optWarningFlags = split3 <$> WarningFlags.runParser warningFlagParser
       where
       split3 flags123 =
         let (flags1, flags23) = WarningFlags.splitWarningFlags flags123
             (flags2, flags3) = WarningFlags.splitWarningFlags flags23
         in
         (flags1, flags2, flags3)
-
-      helpStr =
-        PAL.vcat
-          [ "Turn an error into a warning with -W<name> or -Wwarn=<name> or -Wno-error=<name>"
-          , "Turn a warning into an error with -Werror=<name>"
-          , "Disable warnings and errors with -Wno-<name>"
-          , "Available names are: " <> PAL.string (WarningFlags.namesAsList warningFlagParser)
-          ]
 
     optUpgradeInfo :: Parser UpgradeInfo
     optUpgradeInfo = do

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -579,7 +579,7 @@ optionsParser numProcessors enableScriptService parsePkgName parseDlintUsage = d
         idm
 
     optWarningFlags :: Parser (WarningFlags InlineDamlCustomWarnings, WarningFlags TypeCheckerError.ErrorOrWarning, WarningFlags LFConversion.ErrorOrWarning)
-    optWarningFlags = splitWarningFlags <$> runParser warningFlagParser
+    optWarningFlags = splitWarningFlags <$> runParser allWarningFlagParsers
 
     optUpgradeInfo :: Parser UpgradeInfo
     optUpgradeInfo = do

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -436,7 +436,7 @@ optionsParser numProcessors enableScriptService parsePkgName parseDlintUsage = d
     optTestFilter <- compilePatternExpr <$> optTestPattern
     let optHideUnitId = False
     optUpgradeInfo <- optUpgradeInfo
-    ~(optInlineDamlCustomWarningFlags, optTypecheckerWarningFlags, optLfConversionWarningFlags) <- optDamlWarningFlags
+    ~(optInlineDamlCustomWarningFlags, optTypecheckerWarningFlags, optLfConversionWarningFlags) <- optWarningFlags
     optIgnoreDataDepVisibility <- optIgnoreDataDepVisibility
     optForceUtilityPackage <- forceUtilityPackageOpt
 
@@ -579,16 +579,16 @@ optionsParser numProcessors enableScriptService parsePkgName parseDlintUsage = d
         "Typecheck upgrades."
         idm
 
-    optDamlWarningFlags :: Parser (WarningFlags.DamlWarningFlags InlineDamlCustomWarnings, WarningFlags.DamlWarningFlags TypeCheckerError.ErrorOrWarning, WarningFlags.DamlWarningFlags LFConversion.ErrorOrWarning)
-    optDamlWarningFlags =
-      split3 . WarningFlags.mkDamlWarningFlags damlWarningFlagParser <$>
+    optWarningFlags :: Parser (WarningFlags.WarningFlags InlineDamlCustomWarnings, WarningFlags.WarningFlags TypeCheckerError.ErrorOrWarning, WarningFlags.WarningFlags LFConversion.ErrorOrWarning)
+    optWarningFlags =
+      split3 . WarningFlags.mkWarningFlags warningFlagParser <$>
         many (Options.Applicative.option
-          (eitherReader (WarningFlags.parseRawDamlWarningFlag damlWarningFlagParser))
+          (eitherReader (WarningFlags.parseWarningFlag warningFlagParser))
           (short 'W' <> helpDoc (Just helpStr)))
       where
       split3 flags123 =
-        let (flags1, flags23) = WarningFlags.splitDamlWarningFlags flags123
-            (flags2, flags3) = WarningFlags.splitDamlWarningFlags flags23
+        let (flags1, flags23) = WarningFlags.splitWarningFlags flags123
+            (flags2, flags3) = WarningFlags.splitWarningFlags flags23
         in
         (flags1, flags2, flags3)
 
@@ -597,7 +597,7 @@ optionsParser numProcessors enableScriptService parsePkgName parseDlintUsage = d
           [ "Turn an error into a warning with -W<name> or -Wwarn=<name> or -Wno-error=<name>"
           , "Turn a warning into an error with -Werror=<name>"
           , "Disable warnings and errors with -Wno-<name>"
-          , "Available names are: " <> PAL.string (WarningFlags.namesAsList damlWarningFlagParser)
+          , "Available names are: " <> PAL.string (WarningFlags.namesAsList warningFlagParser)
           ]
 
     optUpgradeInfo :: Parser UpgradeInfo

--- a/sdk/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Options.hs
@@ -1,6 +1,7 @@
 -- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE DataKinds #-}
 module DA.Cli.Options
   ( module DA.Cli.Options
   ) where
@@ -21,7 +22,7 @@ import qualified DA.Service.Logger as Logger
 import qualified Module as GHC
 import qualified Text.ParserCombinators.ReadP as R
 import qualified Data.Text as T
-import qualified DA.Daml.LF.TypeChecker.Error.WarningFlags as WarningFlags
+import DA.Daml.LF.TypeChecker.Error.WarningFlags
 import qualified DA.Daml.LF.TypeChecker.Error as TypeCheckerError
 import qualified DA.Daml.LFConversion.Errors as LFConversion
 
@@ -577,14 +578,8 @@ optionsParser numProcessors enableScriptService parsePkgName parseDlintUsage = d
         "Typecheck upgrades."
         idm
 
-    optWarningFlags :: Parser (WarningFlags.WarningFlags InlineDamlCustomWarnings, WarningFlags.WarningFlags TypeCheckerError.ErrorOrWarning, WarningFlags.WarningFlags LFConversion.ErrorOrWarning)
-    optWarningFlags = split3 <$> WarningFlags.runParser warningFlagParser
-      where
-      split3 flags123 =
-        let (flags1, flags23) = WarningFlags.splitWarningFlags flags123
-            (flags2, flags3) = WarningFlags.splitWarningFlags flags23
-        in
-        (flags1, flags2, flags3)
+    optWarningFlags :: Parser (WarningFlags InlineDamlCustomWarnings, WarningFlags TypeCheckerError.ErrorOrWarning, WarningFlags LFConversion.ErrorOrWarning)
+    optWarningFlags = splitWarningFlags <$> runParser warningFlagParser
 
     optUpgradeInfo :: Parser UpgradeInfo
     optUpgradeInfo = do

--- a/sdk/compiler/damlc/pkg-db/util.bzl
+++ b/sdk/compiler/damlc/pkg-db/util.bzl
@@ -98,7 +98,7 @@ def _daml_package_rule_impl(ctx):
 
     package_db_dir = ctx.attr.package_db[PackageDb].db_dir
     disable_warn_large_tuples = "-Wno-large-tuples" if ctx.attr.disable_warn_large_tuples else "-Wlarge-tuples"
-    disable_deprecated_exceptions = "--disable-deprecated-exceptions-warning" if ctx.attr.disable_deprecated_exceptions else ""
+    disable_deprecated_exceptions = "-Wno-deprecated-exceptions" if ctx.attr.disable_deprecated_exceptions else ""
 
     ctx.actions.run_shell(
         outputs = [dalf, iface_dir],

--- a/sdk/compiler/damlc/tests/daml-test-files/ExceptionsDeprecatedDisabled.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/ExceptionsDeprecatedDisabled.daml
@@ -4,7 +4,7 @@
 -- @SUPPORTS-LF-FEATURE DAML_EXCEPTIONS
 
 -- Disable the warning using the GHC flag, so we can do it per file.
--- Normally you would use `--disable-deprecated-exceptions-warning` in your daml.yaml
+-- Normally you would use `-Wno-deprecated-exceptions` in your daml.yaml
 -- This file is a mirror of ExceptionsDeprecated.daml without the warning requirements, and an additional test
 {-# OPTIONS_GHC -Wno-x-exceptions #-}
 

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -301,14 +301,14 @@ getIntegrationTests registerTODO scriptService (packageDbPath, packageFlags) = d
                 , optPackageImports = packageFlags
                 , optDetailLevel = PrettyLevel (-1)
                 , optEnableInterfaces = EnableInterfaces True
-                , optDamlWarningFlags =
-                    WarningFlags.addDamlWarningFlags
+                , optWarningFlags =
+                    WarningFlags.addWarningFlags
                       [ WarningFlags.toLeft (WarningFlags.specToFlag upgradeInterfacesFlagSpec WarningFlags.AsWarning)
                       , WarningFlags.toLeft (WarningFlags.specToFlag upgradeExceptionsFlagSpec WarningFlags.AsWarning)
                       , -- Almost every test will report this, so we disable it at root
                         WarningFlags.toLeft (WarningFlags.specToFlag templateInterfaceDependsOnScriptFlagSpec WarningFlags.Hidden)
                       ]
-                      (optDamlWarningFlags opts0)
+                      (optWarningFlags opts0)
                 }
 
               mkIde options = do

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -83,7 +83,7 @@ import Outputable (ppr, showSDoc)
 import qualified Proto3.Suite.JSONPB as JSONPB
 import DA.Daml.Project.Types (unsafeResolveReleaseVersion, parseUnresolvedVersion)
 import qualified DA.Daml.LF.TypeChecker.Error.WarningFlags as WarningFlags
-import DA.Daml.LF.TypeChecker.Error (upgradeInterfacesFlag, upgradeExceptionsFlag, templateInterfaceDependsOnScriptFlag)
+import DA.Daml.LF.TypeChecker.Error (upgradeInterfacesFlagSpec, upgradeExceptionsFlagSpec, templateInterfaceDependsOnScriptFlagSpec)
 
 
 import Test.Tasty
@@ -303,10 +303,10 @@ getIntegrationTests registerTODO scriptService (packageDbPath, packageFlags) = d
                 , optEnableInterfaces = EnableInterfaces True
                 , optDamlWarningFlags =
                     WarningFlags.addDamlWarningFlags
-                      [ WarningFlags.toLeft (upgradeInterfacesFlag WarningFlags.AsWarning)
-                      , WarningFlags.toLeft (upgradeExceptionsFlag WarningFlags.AsWarning)
+                      [ WarningFlags.toLeft (WarningFlags.specToFlag upgradeInterfacesFlagSpec WarningFlags.AsWarning)
+                      , WarningFlags.toLeft (WarningFlags.specToFlag upgradeExceptionsFlagSpec WarningFlags.AsWarning)
                       , -- Almost every test will report this, so we disable it at root
-                        WarningFlags.toLeft (templateInterfaceDependsOnScriptFlag WarningFlags.Hidden)
+                        WarningFlags.toLeft (WarningFlags.specToFlag templateInterfaceDependsOnScriptFlagSpec WarningFlags.Hidden)
                       ]
                       (optDamlWarningFlags opts0)
                 }

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -301,14 +301,14 @@ getIntegrationTests registerTODO scriptService (packageDbPath, packageFlags) = d
                 , optPackageImports = packageFlags
                 , optDetailLevel = PrettyLevel (-1)
                 , optEnableInterfaces = EnableInterfaces True
-                , optWarningFlags =
+                , optTypecheckerWarningFlags =
                     WarningFlags.addWarningFlags
-                      [ WarningFlags.toLeft (WarningFlags.specToFlag upgradeInterfacesFlagSpec WarningFlags.AsWarning)
-                      , WarningFlags.toLeft (WarningFlags.specToFlag upgradeExceptionsFlagSpec WarningFlags.AsWarning)
+                      [ WarningFlags.specToFlag upgradeInterfacesFlagSpec WarningFlags.AsWarning
+                      , WarningFlags.specToFlag upgradeExceptionsFlagSpec WarningFlags.AsWarning
                       , -- Almost every test will report this, so we disable it at root
-                        WarningFlags.toLeft (WarningFlags.specToFlag templateInterfaceDependsOnScriptFlagSpec WarningFlags.Hidden)
+                        WarningFlags.specToFlag templateInterfaceDependsOnScriptFlagSpec WarningFlags.Hidden
                       ]
-                      (optWarningFlags opts0)
+                      (optTypecheckerWarningFlags opts0)
                 }
 
               mkIde options = do

--- a/sdk/daml-script/daml/BUILD.bazel
+++ b/sdk/daml-script/daml/BUILD.bazel
@@ -65,7 +65,7 @@ genrule(
             --base-url=https://docs.daml.com/daml-script/api/ \\
             --output-hoogle=$(location :daml-script-hoogle.txt) \\
             --output-anchor=$(location :daml-script-anchors.json) \\
-            --disable-deprecated-exceptions-warning \\
+            -Wno-deprecated-exceptions \\
             $(location :daml-script.json)
         $(execpath //bazel_tools/sh:mktgz) $(location :daml-script-rst.tar.gz) daml-script-rst
     """,
@@ -86,7 +86,7 @@ genrule(
             --package-name=daml-script \
             --format=Json \
             --target=2.dev \
-            --disable-deprecated-exceptions-warning \
+            -Wno-deprecated-exceptions \
             $(location Daml/Script.daml)
     """,
     tools = [

--- a/sdk/rules_daml/daml.bzl
+++ b/sdk/rules_daml/daml.bzl
@@ -38,7 +38,7 @@ def _daml_configure_impl(ctx):
         (["--target={}".format(target)] if target else []) +
         (["--typecheck-upgrades=no"] if not typecheck_upgrades and using_local_compiler(target) else []) +
         (["--force-utility-package=yes"] if force_utility_package and using_local_compiler(target) else []) +
-        (["--disable-deprecated-exceptions-warning"] if disable_deprecated_exceptions and using_local_compiler(target) else [])
+        (["-Wno-deprecated-exceptions"] if disable_deprecated_exceptions and using_local_compiler(target) else [])
     )
     ctx.actions.write(
         output = daml_yaml,


### PR DESCRIPTION
- Bring the custom warnings from https://github.com/digital-asset/daml/pull/20967 under the warning umbrella.
  - ~~Do we want to keep around the `--disable-deprecated-exceptions-warning` flag?~~ Sam confirmed we can get rid of it
- Store warning flags for different systems (type checker, lf conversion, ghc codegen) in different fields in Options, while still parsing them all together as one bundle.
- Make it a lot easier to add a warning flag, previously you had to bind a separate name, filter, and constructor, now you just put it all into a single `DamlWarningFlagSpec` and pass that to `mkDamlWarningFlagParser`.
- Turn all existing flags into specs.