### PR TITLE
Fix formatting in the proto file comments

### DIFF
--- a/sdk/daml-lf/ledger-api-value/src/main/protobuf/com/daml/ledger/api/v2/value.proto
+++ b/sdk/daml-lf/ledger-api-value/src/main/protobuf/com/daml/ledger/api/v2/value.proto
@@ -116,6 +116,7 @@ message RecordField {
 
 // Unique identifier of an entity.
 // Throughout this API, the following terminology is being used:
+//
 //   - if a Daml package-id is encoded in the package_id field, it is referred to as using a "package-id reference format"
 //   - if a Daml package-name is encoded in the package_id field, it is referred to as using a "package-name reference format"
 message Identifier {


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->

Quick fix for a failing build in Canton: https://app.circleci.com/pipelines/github/DACH-NY/canton/96974/workflows/1cca9229-80cd-4699-b64e-04e5d30dd714/jobs/2686402

```
[error] sdk/reference/lapi-value-proto-docs.rst.inc:68: ERROR: Unexpected indentation. [docutils]
```

This is because the comments from proto files are used as input for the `.rst` file.

Long-term fix needs to be discussed separately.
