### PR TITLE
Add transaction tracing to ledger time primitive

### DIFF
--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -1862,7 +1862,12 @@ private[lf] object SBuiltinFun {
 
       val time = getSTimestamp(args, 0)
 
-      machine.needTime(now => Control.Value(SBool(now < time)))
+      machine.needTime(now => {
+        // We only generate a transaction trace for the last exercise command
+        val message = machine.transactionTrace(1)
+        machine.traceLog.add(message, machine.getLastLocation)(machine.loggingContext)
+        Control.Value(SBool(now < time))
+      })
     }
   }
 

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -684,7 +684,7 @@ private[lf] object Speedy {
 
     private[speedy] var lastCommand: Option[Command] = None
 
-    def transactionTrace(maxLength: Int): String = {
+    def transactionTrace(numOfExerciseNodes: Int): String = {
       def prettyTypeId(typeId: TypeConName): String =
         s"${typeId.packageId.take(8)}:${typeId.qualifiedName}"
       def prettyCoid(coid: V.ContractId): String = coid.coid.take(10)


### PR DESCRIPTION
- [x] Rename `maxLength` parameter to `transactionTrace`
- [x] add transaction tracing to ledger-time-lt primitive to aid debugging of Daml code
- [ ] testing