### PR TITLE
Bump OpenJDK from 11 to 17 in Daml SDK Image

### DIFF
--- a/sdk/ci/docker/daml-sdk/Dockerfile
+++ b/sdk/ci/docker/daml-sdk/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 RUN apt-get update \
- && apt-get install -y curl openjdk-11-jre-headless \
+ && apt-get install -y curl openjdk-17-jre-headless \
  && rm -rf /var/lib/apt/lists/*
 ARG VERSION
 # This is needed to get the DNS requests


### PR DESCRIPTION
# Summary

This PR bumps the OpenJDK version from 11 to 17 in [the Daml SDK image](https://hub.docker.com/r/digitalasset/daml-sdk). The motivation for this change is to fix the unusable `daml test` in these images.

# Repro steps

1. Start an instance of the Daml SDK:

   ```
   docker run -it --rm digitalasset/daml-sdk:3.3.0-snapshot.20250410.0
   ```
 
2. Create a Daml project:

    ```
     daml new testing
    ```

3. Build the project:

    ```
    daml build --project-root testing
    ```

4. Run the tests:

    ```
    daml test --project-root testing
    ```

**Expected result**

The tests should complete successfully.

**Actual result**

`daml test` fails with:

```
Exception in thread "main" java.lang.UnsupportedClassVersionError:
com/daml/grpc/adapter/ExecutionSequencerFactory has been compiled by
a more recent version of the Java Runtime (class file version 61.0),
this version of the Java Runtime only recognizes class file versions up to 55.0
```

This general issue is also described in [the Daml forums](https://discuss.daml.com/t/error-a-more-recent-version-of-the-java-runtime-class-file-version-61-0/7489?u=wallacekelly).

# Fix

In the Daml SDK Dockerfile,

* replace  `apt-get install -y curl openjdk-11-jre-headless`
* with `apt-get install -y curl openjdk-17-jre-headless`

# Test locally

1. Copy the modified Dockerfile to your local file system.
2. Build a test image with `docker build . --build-arg VERSION=3.3.0-snapshot.20250319.0 --tag damlsdk:testing`
3. Start a test container with `docker run -it --rm damlsdk:testing`
4. Repeat the repro steps above. Observe that `daml test` succeeds.
5. Delete the test image with `docker image rm damlsdk:testing`.