### PR TITLE
SCU integration tests involving many subviews

### DIFF
--- a/sdk/daml-script/daml/Daml/Script/Internal.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal.daml
@@ -22,6 +22,9 @@ module Daml.Script.Internal
   , unvetPackages
   , unvetPackagesOnParticipant
 
+  , -- Party Management
+    allocateReplicatedPartyOn
+  , allocateReplicatedPartyWithHintOn
 
   , -- Concurrent submit
     concurrently

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/PartyManagement.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/PartyManagement.daml
@@ -6,11 +6,11 @@ module Daml.Script.Internal.Questions.PartyManagement where
 import Daml.Script.Internal.LowLevel
 import DA.Stack
 
+-- | An empty 'participants' means we pick the default one. Otherwise, the first participant of the list is considered
+-- to be the "main" one, which is the participant to which commands submitted by the allocated will be routed.
 data AllocateParty = AllocateParty with
   requestedName: Text
   idHint : Text
-  -- | An empty 'participants' means we pick the default one. Otherwise, the first participant of the list is considered
-  -- to be the "main" one, which is the participant to which commands submitted by the allocated will be routed.
   participants : [Text]
 instance IsQuestion AllocateParty Party where command = "AllocateParty"
 

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/PartyManagement.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/PartyManagement.daml
@@ -9,7 +9,9 @@ import DA.Stack
 data AllocateParty = AllocateParty with
   requestedName: Text
   idHint : Text
-  participant : Optional Text
+  -- | An empty 'participants' means we pick the default one. Otherwise, the first participant of the list is considered
+  -- to be the "main" one, which is the participant to which commands submitted by the allocated will be routed.
+  participants : [Text]
 instance IsQuestion AllocateParty Party where command = "AllocateParty"
 
 -- | A hint to the backing participant what party id to allocate.
@@ -24,7 +26,7 @@ allocateParty : HasCallStack => Text -> Script Party
 allocateParty requestedName = lift $ AllocateParty with
   requestedName = requestedName
   idHint = ""
-  participant = None
+  participants = []
 
 {-# DEPRECATED allocatePartyWithHint "Daml 3.3 compatibility helper, use 'allocatePartyByHint' instead of 'allocatePartyWithHint'" #-}
 -- | Deprecated
@@ -32,7 +34,7 @@ allocatePartyWithHint : HasCallStack => Text -> PartyIdHint -> Script Party
 allocatePartyWithHint requestedName (PartyIdHint idHint) = lift $ AllocateParty with
   requestedName = requestedName
   idHint = idHint
-  participant = None
+  participants = []
 
 -- | Allocate a party with the given id hint
 -- using the party management service.
@@ -40,7 +42,7 @@ allocatePartyByHint : HasCallStack => PartyIdHint -> Script Party
 allocatePartyByHint (PartyIdHint idHint) = lift $ AllocateParty with
   requestedName = ""
   idHint = idHint
-  participant = None
+  participants = []
 
 -- | Allocate a party with the given display name
 -- on the specified participant using the party management service.
@@ -50,10 +52,27 @@ allocatePartyOn requestedName participantName = allocatePartyWithHintOn requeste
 {-# DEPRECATED allocatePartyWithHintOn "Daml 3.3 compatibility helper, use 'allocatePartyByHintOn' instead of 'allocatePartyWithHintOn'" #-}
 -- | Deprecated
 allocatePartyWithHintOn : Text -> PartyIdHint -> ParticipantName -> Script Party
-allocatePartyWithHintOn requestedName (PartyIdHint idHint) (ParticipantName participant) = lift $ AllocateParty with
-  requestedName = requestedName
-  idHint = idHint
-  participant = Some participant
+allocatePartyWithHintOn requestedName idHint participant =
+  allocateReplicatedPartyWithHintOn requestedName idHint participant []
+
+-- TODO(https://github.com/digital-asset/daml/issues/21035): rework allocateParty to avoid the proliferation of variants
+-- | Allocate a party with the given display name on the specified main participant using the party management service
+-- and replicates it to the specified (possibly empty) list of additional participants. Commands submitted by the
+-- allocated party will be routed to the main participant.
+allocateReplicatedPartyOn : Text -> ParticipantName -> [ParticipantName] -> Script Party
+allocateReplicatedPartyOn requestedName mainParticipant additionalParticipants =
+  allocateReplicatedPartyWithHintOn requestedName (PartyIdHint "") mainParticipant additionalParticipants
+
+-- TODO(https://github.com/digital-asset/daml/issues/21035): rework allocateParty to avoid the proliferation of variants
+-- | Allocate a party with the given display name and id hint on the specified main participant using the party
+-- management service and replicates it to the specified (possibly empty) list of additional participants. Commands
+-- submitted by the allocated party will be routed to the main participant.
+allocateReplicatedPartyWithHintOn : Text -> PartyIdHint -> ParticipantName -> [ParticipantName] -> Script Party
+allocateReplicatedPartyWithHintOn requestedName (PartyIdHint idHint) mainParticipant additionalParticipants =
+  lift $ AllocateParty with
+    requestedName = requestedName
+    idHint = idHint
+    participants = map participantName (mainParticipant :: additionalParticipants)
 
 -- | Allocate a party with the given id hint
 -- on the specified participant using the party management service.
@@ -61,7 +80,7 @@ allocatePartyByHintOn : PartyIdHint -> ParticipantName -> Script Party
 allocatePartyByHintOn (PartyIdHint idHint) (ParticipantName participant) = lift $ AllocateParty with
   requestedName = ""
   idHint = idHint
-  participant = Some participant
+  participants = [participant]
 
 -- | The party details returned by the party management service.
 data PartyDetails = PartyDetails

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/PartyManagement.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/PartyManagement.daml
@@ -12,7 +12,10 @@ data AllocateParty = AllocateParty with
   requestedName: Text
   idHint : Text
   participants : [Text]
-instance IsQuestion AllocateParty Party where command = "AllocateParty"
+instance IsQuestion AllocateParty Party
+  where
+    command = "AllocateParty"
+    version = 2
 
 -- | A hint to the backing participant what party id to allocate.
 -- Must be a valid PartyIdString (as described in @value.proto@).

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -361,10 +361,20 @@ abstract class ConverterMethods(stablePackages: language.StablePackages) {
         Left(s"Expected SList but got $v")
     }
 
-  def toParticipantName(v: SValue): Either[String, Option[Participant]] = v match {
+  def toParticipantNames(v: SValue): Either[String, List[Participant]] = v match {
+    case SList(vs) => vs.toList.traverse(toParticipantName)
+    case _ => Left(s"Expected a list of participants but got $v")
+  }
+
+  def toOptionalParticipantName(v: SValue): Either[String, Option[Participant]] = v match {
     case SOptional(Some(SText(t))) => Right(Some(Participant(t)))
     case SOptional(None) => Right(None)
     case _ => Left(s"Expected optional participant name but got $v")
+  }
+
+  def toParticipantName(v: SValue): Either[String, Participant] = v match {
+    case SText(t) => Right(Participant(t))
+    case _ => Left(s"Expected participant name but got $v")
   }
 
   private def randomHex(rand: Random, length: Int) =

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
@@ -437,8 +437,8 @@ object ScriptF {
           case Right(client) => Future.successful(client)
           case Left(err) => Future.failed(new RuntimeException(err))
         }
-        _ <- toClient.importParty(party)
-        _ <- fromClient.exportParty(party, toClient.getParticipantUid)
+        _ <- toClient.proposePartyReplication(party, toClient.getParticipantUid)
+        _ <- fromClient.proposePartyReplication(party, toClient.getParticipantUid)
       } yield ()
 
       val mainParticipant = participants.headOption
@@ -457,30 +457,6 @@ object ScriptF {
         SEValue(SParty(party))
       }
     }
-  }
-  final case class ReplicateParty(
-      party: Party,
-      participant: Participant,
-  ) extends Cmd {
-    override def execute(env: Env)(implicit
-        ec: ExecutionContext,
-        mat: Materializer,
-        esf: ExecutionSequencerFactory,
-    ): Future[SExpr] =
-      for {
-        toClient <- env.clients.getParticipant(Some(participant)) match {
-          case Right(client) => Future.successful(client)
-          case Left(err) => Future.failed(new RuntimeException(err))
-        }
-        _ <- toClient.importParty(party)
-        fromClient <- env.clients.getPartiesParticipant(OneAnd(party, Set.empty)) match {
-          case Right(client) => Future.successful(client)
-          case Left(err) => Future.failed(new RuntimeException(err))
-        }
-        _ <- fromClient.exportParty(party, toClient.getParticipantUid)
-      } yield {
-        SEValue(SUnit)
-      }
   }
   final case class ListKnownParties(
       participant: Option[Participant]

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
@@ -439,6 +439,9 @@ object ScriptF {
         }
         _ <- toClient.proposePartyReplication(party, toClient.getParticipantUid)
         _ <- fromClient.proposePartyReplication(party, toClient.getParticipantUid)
+        _ <- Future.traverse(env.clients.participants.values)(client =>
+          client.waitUntilHostingVisible(party, toClient.getParticipantUid)
+        )
       } yield ()
 
       val mainParticipant = participants.headOption

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -1033,11 +1033,11 @@ class IdeLedgerClient(
   ): Future[List[ScriptLedgerClient.ReadablePackageId]] =
     Future.successful(getPackageIdMap().keys.toList)
 
-  override def proposePartyReplication(party: Ref.Party, toParticipantId: String)(implicit
-      ec: ExecutionContext,
-      esf: ExecutionSequencerFactory,
-      mat: Materializer,
-  ): Future[Unit] = Future.successful(())
+  override def proposePartyReplication(party: Ref.Party, toParticipantId: String): Future[Unit] =
+    Future.successful(())
+
+  override def waitUntilHostingVisible(party: Ref.Party, onParticipantUid: String): Future[Unit] =
+    Future.successful(())
 
   override def getParticipantUid: String = ""
 }

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -1032,4 +1032,18 @@ class IdeLedgerClient(
       mat: Materializer,
   ): Future[List[ScriptLedgerClient.ReadablePackageId]] =
     Future.successful(getPackageIdMap().keys.toList)
+
+  override def importParty(party: Ref.Party)(implicit
+      ec: ExecutionContext,
+      esf: ExecutionSequencerFactory,
+      mat: Materializer,
+  ): Future[Unit] = Future.successful(())
+
+  override def exportParty(party: Ref.Party, toParticipantId: String)(implicit
+      ec: ExecutionContext,
+      esf: ExecutionSequencerFactory,
+      mat: Materializer,
+  ): Future[Unit] = Future.successful(())
+
+  override def getParticipantUid: String = ""
 }

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -1033,13 +1033,7 @@ class IdeLedgerClient(
   ): Future[List[ScriptLedgerClient.ReadablePackageId]] =
     Future.successful(getPackageIdMap().keys.toList)
 
-  override def importParty(party: Ref.Party)(implicit
-      ec: ExecutionContext,
-      esf: ExecutionSequencerFactory,
-      mat: Materializer,
-  ): Future[Unit] = Future.successful(())
-
-  override def exportParty(party: Ref.Party, toParticipantId: String)(implicit
+  override def proposePartyReplication(party: Ref.Party, toParticipantId: String)(implicit
       ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
       mat: Materializer,

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
@@ -282,11 +282,9 @@ trait ScriptLedgerClient {
       mat: Materializer,
   ): Future[List[ScriptLedgerClient.ReadablePackageId]]
 
-  def proposePartyReplication(party: Ref.Party, toParticipantId: String)(implicit
-      ec: ExecutionContext,
-      esf: ExecutionSequencerFactory,
-      mat: Materializer,
-  ): Future[Unit]
+  def proposePartyReplication(party: Ref.Party, toParticipantId: String): Future[Unit]
+
+  def waitUntilHostingVisible(party: Ref.Party, onParticipantUid: String): Future[Unit]
 
   def getParticipantUid: String
 }

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
@@ -281,4 +281,18 @@ trait ScriptLedgerClient {
       esf: ExecutionSequencerFactory,
       mat: Materializer,
   ): Future[List[ScriptLedgerClient.ReadablePackageId]]
+
+  def importParty(party: Ref.Party)(implicit
+      ec: ExecutionContext,
+      esf: ExecutionSequencerFactory,
+      mat: Materializer,
+  ): Future[Unit]
+
+  def exportParty(party: Ref.Party, toParticipantId: String)(implicit
+      ec: ExecutionContext,
+      esf: ExecutionSequencerFactory,
+      mat: Materializer,
+  ): Future[Unit]
+
+  def getParticipantUid: String
 }

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/ScriptLedgerClient.scala
@@ -282,13 +282,7 @@ trait ScriptLedgerClient {
       mat: Materializer,
   ): Future[List[ScriptLedgerClient.ReadablePackageId]]
 
-  def importParty(party: Ref.Party)(implicit
-      ec: ExecutionContext,
-      esf: ExecutionSequencerFactory,
-      mat: Materializer,
-  ): Future[Unit]
-
-  def exportParty(party: Ref.Party, toParticipantId: String)(implicit
+  def proposePartyReplication(party: Ref.Party, toParticipantId: String)(implicit
       ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
       mat: Materializer,

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/AdminLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/AdminLedgerClient.scala
@@ -223,22 +223,7 @@ class AdminLedgerClient private[grpcLedgerClient] (
         }
       }
 
-  def importParty(partyId: String): Future[Unit] = {
-    for {
-      synchronizerId <- getSynchronizerId
-      hostingParticipants <- listHostingParticipants(partyId, synchronizerId)
-      _ <- topologyWriteServiceStub.authorize(
-        makePartyReplicationAuthorizeRequest(
-          hostingParticipants,
-          partyId,
-          participantUid,
-          synchronizerId,
-        )
-      )
-    } yield ()
-  }
-
-  def exportParty(partyId: String, toParticipantUid: String): Future[Unit] = {
+  def proposePartyReplication(partyId: String, toParticipantUid: String): Future[Unit] = {
     for {
       synchronizerId <- getSynchronizerId
       hostingParticipants <- listHostingParticipants(partyId, synchronizerId)

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
@@ -630,20 +630,7 @@ class GrpcLedgerClient(
       mat: Materializer,
   ): Future[List[ScriptLedgerClient.ReadablePackageId]] = unsupportedOn("listAllPackages")
 
-  override def importParty(party: Ref.Party)(implicit
-      ec: ExecutionContext,
-      esf: ExecutionSequencerFactory,
-      mat: Materializer,
-  ): Future[Unit] = {
-    val adminClient = oAdminClient.getOrElse(
-      throw new IllegalArgumentException(
-        "Attempted to use importParty without specifying a adminPort"
-      )
-    )
-    adminClient.importParty(party)
-  }
-
-  def exportParty(party: Ref.Party, toParticipantId: String)(implicit
+  def proposePartyReplication(party: Ref.Party, toParticipantId: String)(implicit
       ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
       mat: Materializer,
@@ -653,7 +640,7 @@ class GrpcLedgerClient(
         "Attempted to use exportParty without specifying a adminPort"
       )
     )
-    adminClient.exportParty(party, toParticipantId)
+    adminClient.proposePartyReplication(party, toParticipantId)
   }
 
   override def getParticipantUid: String = oAdminClient

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
@@ -630,17 +630,22 @@ class GrpcLedgerClient(
       mat: Materializer,
   ): Future[List[ScriptLedgerClient.ReadablePackageId]] = unsupportedOn("listAllPackages")
 
-  def proposePartyReplication(party: Ref.Party, toParticipantId: String)(implicit
-      ec: ExecutionContext,
-      esf: ExecutionSequencerFactory,
-      mat: Materializer,
-  ): Future[Unit] = {
+  override def proposePartyReplication(party: Ref.Party, toParticipantId: String): Future[Unit] = {
     val adminClient = oAdminClient.getOrElse(
       throw new IllegalArgumentException(
         "Attempted to use exportParty without specifying a adminPort"
       )
     )
     adminClient.proposePartyReplication(party, toParticipantId)
+  }
+
+  override def waitUntilHostingVisible(party: Ref.Party, onParticipantUid: String): Future[Unit] = {
+    val adminClient = oAdminClient.getOrElse(
+      throw new IllegalArgumentException(
+        "Attempted to use waitUntilHostingVisible without specifying a adminPort"
+      )
+    )
+    adminClient.waitUntilHostingVisible(party, onParticipantUid)
   }
 
   override def getParticipantUid: String = oAdminClient

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
@@ -629,4 +629,38 @@ class GrpcLedgerClient(
       esf: ExecutionSequencerFactory,
       mat: Materializer,
   ): Future[List[ScriptLedgerClient.ReadablePackageId]] = unsupportedOn("listAllPackages")
+
+  override def importParty(party: Ref.Party)(implicit
+      ec: ExecutionContext,
+      esf: ExecutionSequencerFactory,
+      mat: Materializer,
+  ): Future[Unit] = {
+    val adminClient = oAdminClient.getOrElse(
+      throw new IllegalArgumentException(
+        "Attempted to use importParty without specifying a adminPort"
+      )
+    )
+    adminClient.importParty(party)
+  }
+
+  def exportParty(party: Ref.Party, toParticipantId: String)(implicit
+      ec: ExecutionContext,
+      esf: ExecutionSequencerFactory,
+      mat: Materializer,
+  ): Future[Unit] = {
+    val adminClient = oAdminClient.getOrElse(
+      throw new IllegalArgumentException(
+        "Attempted to use exportParty without specifying a adminPort"
+      )
+    )
+    adminClient.exportParty(party, toParticipantId)
+  }
+
+  override def getParticipantUid: String = oAdminClient
+    .getOrElse(
+      throw new IllegalArgumentException(
+        "Attempted to use getParticipantUid without specifying a adminPort"
+      )
+    )
+    .participantUid
 }

--- a/sdk/daml-script/test/daml/UpgradeTestLib.daml
+++ b/sdk/daml-script/test/daml/UpgradeTestLib.daml
@@ -8,6 +8,9 @@ module UpgradeTestLib (
   TestState (..),
   participant0,
   participant1,
+  participant2,
+  participant3,
+  participant4,
   test,
   tests,
   subtree,
@@ -35,6 +38,15 @@ participant0 = ParticipantName "participant0"
 
 participant1 : ParticipantName
 participant1 = ParticipantName "participant1"
+
+participant2 : ParticipantName
+participant2 = ParticipantName "participant2"
+
+participant3 : ParticipantName
+participant3 = ParticipantName "participant3"
+
+participant4 : ParticipantName
+participant4 = ParticipantName "participant4"
 
 data RunMode
   = IdeLedger

--- a/sdk/daml-script/test/daml/upgrades/SubViews.daml
+++ b/sdk/daml-script/test/daml/upgrades/SubViews.daml
@@ -1,0 +1,221 @@
+-- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE ApplicativeDo #-}
+
+module SubViews (main) where
+
+import UpgradeTestLib
+import qualified V1.SubViewsAsset as V1
+import qualified V2.SubViewsAsset as V2
+import SubViewsInterface
+import SubViewsMain
+import PackageIds
+import DA.Foldable
+import DA.Optional
+import DA.Text
+
+{- PACKAGE
+name: sub-views-asset
+versions: 2
+-}
+
+{- MODULE
+package: sub-views-asset
+contents: |
+  module SubViewsAsset where
+
+  template Asset
+    with
+      sig : Party
+      extra : Optional Text                         -- @V2
+    where
+      signatory sig
+  
+      choice Cycle : ContractId Asset
+        with
+          ctl : Party
+          factoryId : ContractId AssetFactory
+        controller ctl
+          do exercise factoryId (CreateAsset sig)
+
+  template AssetFactory
+    with
+      sig : Party
+      extra : Optional Text                         -- @V2
+    where
+      signatory sig
+  
+      choice CreateAsset : ContractId Asset
+        with
+          ctl : Party
+        controller ctl
+          do
+            create (Asset sig)                     -- @V1
+            create (Asset sig extra)               -- @V2
+-}
+
+{- PACKAGE
+name: sub-views-iface
+versions: 1
+depends: |
+  sub-views-asset-1.0.0
+  sub-views-asset-2.0.0
+-}
+
+{- MODULE
+package: sub-views-iface
+contents: |
+  module SubViewsInterface where
+
+  import qualified V1.SubViewsAsset as V1
+  import qualified V2.SubViewsAsset as V2
+  
+  data AssetIView = AssetIView {}
+    deriving (Eq, Show)
+  
+  data I1View = I1View {}
+    deriving (Eq, Show)
+  
+  interface I1 where
+    viewtype I1View
+  
+    i1Choice : ContractId V1.AssetFactory -> Update (ContractId V1.Asset)
+  
+    choice I1Choice : ContractId V1.Asset
+      with
+        ctl : Party
+        factoryId : ContractId V1.AssetFactory
+      controller ctl
+        do i1Choice this factoryId
+  
+  
+  data I2View = I2View {}
+    deriving (Eq, Show)
+  
+  interface I2 where
+    viewtype I2View
+  
+    i2Choice : ContractId V2.Asset -> ContractId V2.AssetFactory -> Update (ContractId V2.Asset)
+  
+    choice I2Choice : ContractId V2.Asset
+      with
+        ctl : Party
+        cid : ContractId V2.Asset
+        factoryId : ContractId V2.AssetFactory
+      controller ctl
+        do i2Choice this cid factoryId
+-}
+
+{- PACKAGE
+name: sub-views-main
+versions: 1
+depends: |
+  sub-views-iface-1.0.0
+  sub-views-asset-1.0.0
+  sub-views-asset-2.0.0
+-}
+
+{- MODULE
+package: sub-views-main
+contents: |
+  module SubViewsMain where
+
+  import SubViewsInterface
+  import qualified V1.SubViewsAsset as V1
+  import qualified V2.SubViewsAsset as V2
+
+  template Top
+    with
+      party : Party
+    where
+      signatory party
+  
+      nonconsuming choice MkTransaction : ContractId V2.Asset
+        with
+          top1 : ContractId I1
+          top2 : ContractId I2
+          factoryId1 : ContractId V1.AssetFactory
+          factoryId2 : ContractId V2.AssetFactory
+        controller party
+          do cid <- exercise top1 (I1Choice party factoryId1)
+             exercise top2 (I2Choice party (coerceContractId @V1.Asset @V2.Asset cid) factoryId2)
+  
+  template Top1
+    with
+      sig : Party
+      obs : Party
+    where
+      signatory sig
+      observer obs
+  
+      interface instance I1 for Top1 where
+        view = I1View
+        i1Choice factoryId = exercise factoryId (V1.CreateAsset sig)
+  
+  template Top2
+    with
+      sig : Party
+      obs : Party
+    where
+      signatory sig
+      observer obs
+  
+      interface instance I2 for Top2 where
+        view = I2View
+        i2Choice cid factoryId = exercise cid (V2.Cycle sig factoryId)
+-}
+
+main : TestTree
+main = tests
+  [ ("a complex command involving upgrades, interfaces and many sub-views doesn't lead to a ledger fork", manySubViews)
+  ]
+
+{-
+Creates a transaction of the following shape, then archives #cid2 in a second transaction. Since p1, p2, p3, p4 and p5
+are hosted by different participants, this creates many different views. Since #cid2 is disclosed to most parties,
+archiving it successfully gives us some confidence that the transaction didn't create a ledger fork.
+
+  │   disclosed to: p1
+  └─> p1 exercises MkTransaction on #top with top1 = #top1; top2 = #top2; factoryId1 = #factory1; factoryId2 = #factory2
+
+      │   disclosed to: p1, p2
+      └─> p1 exercises I1Choice on #top1 with ctl = p1; factoryId = #factory1
+
+          │   disclosed to: p1, p2, p3
+          └─> p1 exercises CreateAsset (v1) on #factory1 with ctl = p1
+
+              │   disclosed to: p1, p2, p3
+              │   divulged to: p4
+              └─> p3 creates #cid = ScuViewAsset:Asset (v1) with sig = p3
+
+
+      │   disclosed to: p1, p4
+      └─> p1 exercises I2Choice on #top2 with ctl = p1; cid = cid; factoryId = #factory2
+
+          │   disclosed to: p1, p4, p3
+          └─> p1 exercises Cycle (v2) on #cid (upgraded to v2) with ctl = p1; factoryId = #factory2
+
+              │   disclosed to: p1, p4, p3, p5
+              └─> p3 exercises CreateAsset (v2) on #factory2 with ctl = p3
+
+                  │   disclosed to (since): p1, p4, p3, p5
+                  └─> p5 creates #cid2 = ScuViewAsset:Asset (v2) with sig = p5; extra = some "extra"
+-}
+manySubViews = test do
+  p1 <- allocatePartyOn "p1" participant0
+  p2 <- allocatePartyOn "p2" participant1
+  p3 <- allocateReplicatedPartyOn "p3" participant2 [participant0]
+  p4 <- allocatePartyOn "p4" participant3
+  p5 <- allocateReplicatedPartyOn "p5" participant4 [participant0]
+
+  top <- submit p1 (createCmd Top { party = p1 })
+  top1 <- toInterfaceContractId @I1 <$> submit p1 (createCmd Top1 { sig = p1, obs = p2 })
+  top2 <- toInterfaceContractId @I2 <$> submit p1 (createCmd Top2 { sig = p1, obs = p4 })
+  factory1 <- submit p3 (createCmd V1.AssetFactory { sig = p3 })
+  factory2 <- submit p5 (createCmd V2.AssetFactory { sig = p5, extra = Some "extra" })
+
+  asset <- (actAs p1 <> readAs [p3, p5]) `submit` (exerciseCmd top (MkTransaction top1 top2 factory1 factory2))
+  p5 `submit` (archiveCmd asset)
+
+  pure ()

--- a/sdk/daml-script/test/daml/upgrades/SubViews.daml
+++ b/sdk/daml-script/test/daml/upgrades/SubViews.daml
@@ -216,6 +216,6 @@ manySubViews = test do
   factory2 <- submit p5 (createCmd V2.AssetFactory { sig = p5, extra = Some "extra" })
 
   asset <- (actAs p1 <> readAs [p3, p5]) `submit` (exerciseCmd top (MkTransaction top1 top2 factory1 factory2))
-  p5 `submit` (archiveCmd asset)
+  p5 `submit` archiveCmd asset
 
   pure ()

--- a/sdk/docs/sharable/sdk/reference/daml-script/api/Daml-Script-Internal-Questions-PartyManagement.rst
+++ b/sdk/docs/sharable/sdk/reference/daml-script/api/Daml-Script-Internal-Questions-PartyManagement.rst
@@ -13,6 +13,9 @@ Data Types
 
 **data** `AllocateParty <type-daml-script-internal-questions-partymanagement-allocateparty-41025_>`_
 
+  An empty 'participants' means we pick the default one\. Otherwise, the first participant of the list is considered
+  to be the \"main\" one, which is the participant to which commands submitted by the allocated will be routed\.
+
   .. _constr-daml-script-internal-questions-partymanagement-allocateparty-9792:
 
   `AllocateParty <constr-daml-script-internal-questions-partymanagement-allocateparty-9792_>`_
@@ -30,21 +33,21 @@ Data Types
        * - idHint
          - `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
          -
-       * - participant
-         - `Optional <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153>`_ `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
+       * - participants
+         - \[`Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_\]
          -
 
   **instance** :ref:`IsQuestion <class-daml-script-internal-lowlevel-isquestion-79227>` `AllocateParty <type-daml-script-internal-questions-partymanagement-allocateparty-41025_>`_ `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
 
   **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"idHint\" `AllocateParty <type-daml-script-internal-questions-partymanagement-allocateparty-41025_>`_ `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
 
-  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"participant\" `AllocateParty <type-daml-script-internal-questions-partymanagement-allocateparty-41025_>`_ (`Optional <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153>`_ `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_)
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"participants\" `AllocateParty <type-daml-script-internal-questions-partymanagement-allocateparty-41025_>`_ \[`Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_\]
 
   **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"requestedName\" `AllocateParty <type-daml-script-internal-questions-partymanagement-allocateparty-41025_>`_ `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
 
   **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"idHint\" `AllocateParty <type-daml-script-internal-questions-partymanagement-allocateparty-41025_>`_ `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
 
-  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"participant\" `AllocateParty <type-daml-script-internal-questions-partymanagement-allocateparty-41025_>`_ (`Optional <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153>`_ `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_)
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"participants\" `AllocateParty <type-daml-script-internal-questions-partymanagement-allocateparty-41025_>`_ \[`Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_\]
 
   **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"requestedName\" `AllocateParty <type-daml-script-internal-questions-partymanagement-allocateparty-41025_>`_ `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
 
@@ -202,6 +205,24 @@ Functions
   \: `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_ \-\> `PartyIdHint <type-daml-script-internal-questions-partymanagement-partyidhint-14540_>`_ \-\> `ParticipantName <type-daml-script-internal-questions-partymanagement-participantname-88190_>`_ \-\> :ref:`Script <type-daml-script-internal-lowlevel-script-4781>` `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
 
   Deprecated
+
+.. _function-daml-script-internal-questions-partymanagement-allocatereplicatedpartyon-96671:
+
+`allocateReplicatedPartyOn <function-daml-script-internal-questions-partymanagement-allocatereplicatedpartyon-96671_>`_
+  \: `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_ \-\> `ParticipantName <type-daml-script-internal-questions-partymanagement-participantname-88190_>`_ \-\> \[`ParticipantName <type-daml-script-internal-questions-partymanagement-participantname-88190_>`_\] \-\> :ref:`Script <type-daml-script-internal-lowlevel-script-4781>` `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+
+  Allocate a party with the given display name on the specified main participant using the party management service
+  and replicates it to the specified (possibly empty) list of additional participants\. Commands submitted by the
+  allocated party will be routed to the main participant\.
+
+.. _function-daml-script-internal-questions-partymanagement-allocatereplicatedpartywithhinton-30144:
+
+`allocateReplicatedPartyWithHintOn <function-daml-script-internal-questions-partymanagement-allocatereplicatedpartywithhinton-30144_>`_
+  \: `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_ \-\> `PartyIdHint <type-daml-script-internal-questions-partymanagement-partyidhint-14540_>`_ \-\> `ParticipantName <type-daml-script-internal-questions-partymanagement-participantname-88190_>`_ \-\> \[`ParticipantName <type-daml-script-internal-questions-partymanagement-participantname-88190_>`_\] \-\> :ref:`Script <type-daml-script-internal-lowlevel-script-4781>` `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+
+  Allocate a party with the given display name and id hint on the specified main participant using the party
+  management service and replicates it to the specified (possibly empty) list of additional participants\. Commands
+  submitted by the allocated party will be routed to the main participant\.
 
 .. _function-daml-script-internal-questions-partymanagement-allocatepartybyhinton-5218:
 

--- a/sdk/test-common/canton/it-lib/src/main/scala/com/daml/integrationtest/CantonFixture.scala
+++ b/sdk/test-common/canton/it-lib/src/main/scala/com/daml/integrationtest/CantonFixture.scala
@@ -76,7 +76,7 @@ trait CantonFixtureWithResource[A]
   final case object CantonFixtureDebugRemoveTmpFiles extends CantonFixtureDebugMode
   final case object CantonFixtureDontDebug extends CantonFixtureDebugMode
 
-  protected val cantonFixtureDebugMode: CantonFixtureDebugMode = CantonFixtureDontDebug
+  protected val cantonFixtureDebugMode: CantonFixtureDebugMode = CantonFixtureDebugKeepTmpFiles
   def cantonFixtureDebugModeIsDebug: Boolean = cantonFixtureDebugMode match {
     case CantonFixtureDebugKeepTmpFiles | CantonFixtureDebugRemoveTmpFiles => true
     case _ => false

--- a/sdk/test-common/canton/it-lib/src/main/scala/com/daml/integrationtest/CantonFixture.scala
+++ b/sdk/test-common/canton/it-lib/src/main/scala/com/daml/integrationtest/CantonFixture.scala
@@ -76,7 +76,7 @@ trait CantonFixtureWithResource[A]
   final case object CantonFixtureDebugRemoveTmpFiles extends CantonFixtureDebugMode
   final case object CantonFixtureDontDebug extends CantonFixtureDebugMode
 
-  protected val cantonFixtureDebugMode: CantonFixtureDebugMode = CantonFixtureDebugKeepTmpFiles
+  protected val cantonFixtureDebugMode: CantonFixtureDebugMode = CantonFixtureDontDebug
   def cantonFixtureDebugModeIsDebug: Boolean = cantonFixtureDebugMode match {
     case CantonFixtureDebugKeepTmpFiles | CantonFixtureDebugRemoveTmpFiles => true
     case _ => false


### PR DESCRIPTION
Adds a daml-script upgrade tests which creates a large transaction involving interfaces and many sub-views. The shape of the transaction was designed with @meiersi-da who said that this shape would subsume several idealized real world CN scenarios. @meiersi-da, can you please have a look at `SubViews.daml`?

In order to make that test pass I had to:
- Split `UpgradesIT.scala` into two tests in order to support more than 2 participants for this test case.
- Introduce an `allocateReplicatedPartyOn` variant of `allocatePartyOn` in order to support replicating a party to more than one participant. The daml API has been discussed with @samuel-williams-da and I've opened https://github.com/digital-asset/daml/issues/21035 to eventually make it nicer. It's internal for now.