### PR TITLE
Add tryFailureStatus to daml-script

### DIFF
--- a/sdk/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/sdk/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -97,7 +97,6 @@ allowedToImportInternal :: Map.Map LF.PackageName (Set.Set GHC.ModuleName)
 allowedToImportInternal = Map.fromList $ fmap (bimap LF.PackageName $ Set.fromList . map GHC.mkModuleName)
   [ ( "daml-script"
     , [ "Daml.Script.Internal.LowLevel"
-      , "Daml.Script.Internal.Questions.Testing"
       , "Daml.Script.Internal.Questions.UserManagement"
       ]
     )

--- a/sdk/compiler/damlc/tests/daml-test-files/TryCommands.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/TryCommands.daml
@@ -12,6 +12,7 @@ import Daml.Script
 import Daml.Script.Internal
 import DA.Assert
 import DA.Text
+import qualified DA.TextMap as Map
 
 template Name
   with
@@ -60,6 +61,14 @@ tryCommandsContractNotActive = do
 -- Check that the lifted error can be caught
 liftedFailedCmdException : Script ()
 liftedFailedCmdException = do
-  try
-    liftFailedCommandToException $ failedAuthScript ()
-  catch (e : FailedCmd) -> e === failedAuthError
+  res <- tryFailureStatus $ liftFailedCommandToFailureStatus $ failedAuthScript ()
+  case res of
+    Right _ -> fail "Expected failure, got success"
+    Left fs
+      | fs.message == getErrorMessage failedAuthError.errorMessage
+      , fs.meta == Map.fromList
+          [ ("commandName", getCommandName failedAuthError.commandName)
+          , ("className", getErrorClassName failedAuthError.errorClassName)
+          ]
+      -> pure ()
+    Left _ -> fail "Incorrect failure status reported"

--- a/sdk/compiler/damlc/tests/daml-test-files/TryFailureStatus.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/TryFailureStatus.daml
@@ -1,0 +1,137 @@
+-- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# OPTIONS_GHC -Wno-x-exceptions #-}
+
+module TryFailureStatus where
+
+import Daml.Script
+import DA.Exception
+import DA.Fail
+import DA.TextMap
+
+-- Can catch failure status
+-- Can catch regular exception
+-- Can catch daml pseudo exception
+-- works in a tryToEither
+-- tryToEither works in it
+-- ^ above two for pseudo exception
+--
+
+exampleFailureStatus : FailureStatus
+exampleFailureStatus = FailureStatus "my-error-code" InvalidGivenCurrentSystemStateOther "Something went wrong!" $ fromList [("thing-that-went-wrong", "something")]
+
+exampleGeneralError : GeneralError
+exampleGeneralError = GeneralError "my-general-error"
+
+exampleGeneralErrorFailureStatus : FailureStatus
+exampleGeneralErrorFailureStatus = FailureStatus "UNHANDLED_EXCEPTION/DA.Exception.GeneralError:GeneralError" InvalidGivenCurrentSystemStateOther "my-general-error" mempty
+
+exampleInvalidUserId : InvalidUserId
+exampleInvalidUserId = InvalidUserId "invalid-user-id"
+
+exampleInvalidUserIdFailureStatus : FailureStatus
+exampleInvalidUserIdFailureStatus = FailureStatus "UNHANDLED_EXCEPTION/Daml.Script.Internal.Questions.UserManagement:InvalidUserId" InvalidGivenCurrentSystemStateOther "invalid-user-id" mempty
+
+canCatchPureFailureStatus : Script ()
+canCatchPureFailureStatus = do
+  res <- tryFailureStatus $ pure $ failWithStatusPure @() exampleFailureStatus
+  case res of
+    Left fs | fs == exampleFailureStatus -> pure ()
+    _ -> fail $ "Expected exampleFailureStatus but got " <> show res
+
+canCatchPureException : Script ()
+canCatchPureException = do
+  res <- tryFailureStatus $ pure $ throwPure @_ @() exampleGeneralError
+  case res of
+    Left fs | fs == exampleGeneralErrorFailureStatus -> pure ()
+    _ -> fail $ "Expected exampleGeneralErrorFailureStatus but got " <> show res
+
+canCatchFailureStatus : Script ()
+canCatchFailureStatus = do
+  res <- tryFailureStatus $ failWithStatus @_ @() exampleFailureStatus
+  case res of
+    Left fs | fs == exampleFailureStatus -> pure ()
+    _ -> fail $ "Expected exampleFailureStatus but got " <> show res
+
+canCatchException : Script ()
+canCatchException = do
+  res <- tryFailureStatus $ (throw exampleGeneralError : Script ())
+  case res of
+    Left fs | fs == exampleGeneralErrorFailureStatus -> pure ()
+    _ -> fail $ "Expected exampleGeneralErrorFailureStatus but got " <> show res
+
+
+canCatchDamlScriptException : Script ()
+canCatchDamlScriptException = do
+  res <- tryFailureStatus $ (throw exampleInvalidUserId : Script ())
+  case res of
+    Left fs | fs == exampleInvalidUserIdFailureStatus -> pure ()
+    _ -> fail $ "Expected exampleInvalidUserIdFailureStatus but got " <> show res
+
+
+tryToEitherWorksWithin : Script ()
+tryToEitherWorksWithin = do
+  res <- tryFailureStatus $ do
+    try
+      throw exampleGeneralError
+    catch
+      GeneralError _ -> pure ()
+  case res of
+    Right _ -> pure ()
+    _ -> fail $ "Expected success but got " <> show res
+
+worksWithinTryToEither : Script ()
+worksWithinTryToEither = do
+  try do
+    res <- tryFailureStatus $ (throw exampleGeneralError : Script ())
+    case res of
+      Left fs | fs == exampleGeneralErrorFailureStatus -> pure ()
+      _ -> fail $ "Expected exampleGeneralErrorFailureStatus but got " <> show res
+  catch
+
+doubleTryToEitherWorksWithin : Script ()
+doubleTryToEitherWorksWithin = do
+  res <- tryFailureStatus $ do
+    try
+      try
+        throw exampleGeneralError
+      catch
+    catch
+      GeneralError _ -> pure ()
+  case res of
+    Right _ -> pure ()
+    _ -> fail $ "Expected success but got " <> show res
+
+tryToEitherWorksWithinDamlScriptException : Script ()
+tryToEitherWorksWithinDamlScriptException = do
+  res <- tryFailureStatus $ do
+    try
+      throw exampleInvalidUserId
+    catch
+      InvalidUserId _ -> pure ()
+  case res of
+    Right _ -> pure ()
+    _ -> fail $ "Expected success but got " <> show res
+
+worksWithinTryToEitherDamlScriptException : Script ()
+worksWithinTryToEitherDamlScriptException = do
+  try do
+    res <- tryFailureStatus $ (throw exampleInvalidUserId : Script ())
+    case res of
+      Left fs | fs == exampleInvalidUserIdFailureStatus -> pure ()
+      _ -> fail $ "Expected exampleInvalidUserIdFailureStatus but got " <> show res
+  catch
+
+doubleTryToEitherWorksWithinDamlScriptException : Script ()
+doubleTryToEitherWorksWithinDamlScriptException = do
+  res <- tryFailureStatus $ do
+    try
+      try
+        throw exampleInvalidUserId
+      catch
+    catch
+      InvalidUserId _ -> pure ()
+  case res of
+    Right _ -> pure ()
+    _ -> fail $ "Expected success but got " <> show res

--- a/sdk/daml-lf/ide-ledger/src/main/scala/com/digitalasset/daml/lf/script/Error.scala
+++ b/sdk/daml-lf/ide-ledger/src/main/scala/com/digitalasset/daml/lf/script/Error.scala
@@ -88,7 +88,9 @@ object Error {
       err: language.LookupError,
       packageMeta: Option[PackageMetadata],
       packageId: PackageId,
-  ) extends Error
+  ) extends Error {
+    override def toString = s"LookupError: $err\n$packageMeta\n$packageId"
+  }
 
   final case class DisclosureDecoding(message: String) extends Error
 }

--- a/sdk/daml-script/daml/Daml/Script.daml
+++ b/sdk/daml-script/daml/Daml/Script.daml
@@ -113,6 +113,7 @@ module Daml.Script
   , submitUser
   , submitUserOn
   , tryToEither
+  , tryFailureStatus
 
 #ifdef DAML_CRYPTO
   , Secp256k1KeyPair

--- a/sdk/daml-script/daml/Daml/Script/Internal.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal.daml
@@ -9,7 +9,7 @@ module Daml.Script.Internal
   , ErrorMessage (..)
   , tryCommands
   , FailedCmd (..)
-  , liftFailedCommandToException
+  , liftFailedCommandToFailureStatus
 
   , -- Packages
     PackageName (..)

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/Exceptions.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/Exceptions.daml
@@ -11,6 +11,7 @@ import DA.Exception
 import DA.Optional
 import Daml.Script.Internal.LowLevel
 import DA.Fail
+import DA.Stack
 
 data Catch = Catch with
   act : () -> LedgerValue
@@ -59,3 +60,13 @@ instance IsQuestion FailWithStatus t where command = "FailWithStatus"
 
 instance ActionFailWithStatus Script where
   failWithStatus = lift . FailWithStatus
+
+data TryFailureStatus = TryFailureStatus with
+  act : () -> LedgerValue
+  dummy : ()
+instance IsQuestion TryFailureStatus (Either FailureStatus x) where command = "TryFailureStatus"
+
+tryFailureStatus : (HasCallStack => Script a) -> Script (Either FailureStatus a)
+tryFailureStatus act = lift TryFailureStatus with
+  act = \() -> toLedgerValue act
+  dummy = ()

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/Exceptions.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/Exceptions.daml
@@ -15,6 +15,8 @@ import DA.Stack
 
 data Catch = Catch with
   act : () -> LedgerValue
+  -- Dummy value needed to ensure this record isn't treated as an old-style typeclass by data-deps
+  -- (defined as any record where all definitions are () -> X)
   dummy : ()
 instance IsQuestion Catch (Either AnyException x) where command = "Catch"
 

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/Testing.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/Testing.daml
@@ -6,9 +6,8 @@ module Daml.Script.Internal.Questions.Testing where
 import Daml.Script.Internal.LowLevel
 import Daml.Script.Internal.Questions.Exceptions ()
 import DA.Bifunctor
-import DA.Exception
-import GHC.Types (primitive)
-import DA.Record
+import qualified DA.TextMap as TextMap
+import DA.Fail
 
 newtype CommandName = CommandName
   with getCommandName : Text
@@ -45,25 +44,17 @@ data FailedCmd = FailedCmd with
     errorMessage : ErrorMessage
   deriving (Eq, Show)
 
-instance HasThrow FailedCmd where
-    throwPure _ = error "Tried to throw daml-script pseudo-exception"
-
-instance GetField "message" FailedCmd Text where
-    getField (FailedCmd _ _ msg) = getErrorMessage msg
-
-instance HasMessage FailedCmd where
-    message (FailedCmd _ _ msg) = getErrorMessage msg
-
--- These primitives do not check that the type arguments are real templates
--- they also use the same internal representation in the engine as exceptions
--- (SBToAny, SBFromAny)
--- So we hijack them until Daml 3.4, where either exceptions are removed, or not serializable
-instance HasToAnyException FailedCmd where
-    toAnyException = anyToAnyException . primitive @"EToAnyTemplate"
-
-instance HasFromAnyException FailedCmd where
-    fromAnyException = primitive @"EFromAnyTemplate" . anyExceptionToAny
-
 -- Runs a script and lifts FailedCmd scala exceptions into the FailedCmd daml exception, which can be caught via try-catch
-liftFailedCommandToException : Script a -> Script a
-liftFailedCommandToException act = tryCommands act >>= either throw pure
+liftFailedCommandToFailureStatus : Script a -> Script a
+liftFailedCommandToFailureStatus act = tryCommands act >>= either (failWithStatus . failedCmdToFailureStatus) pure
+  where
+    failedCmdToFailureStatus : FailedCmd -> FailureStatus
+    failedCmdToFailureStatus (FailedCmd cmdName className errMessage) =
+      FailureStatus with
+        errorId = "UNHANDLED_EXCEPTION/Daml.Script:FailedCmd"
+        category = InvalidGivenCurrentSystemStateOther
+        message = getErrorMessage errMessage
+        meta = TextMap.fromList
+          [ ("commandName", getCommandName cmdName)
+          , ("className", getErrorClassName className)
+          ]

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
@@ -126,10 +126,58 @@ object ScriptF {
   }
 
   final case class Throw(exc: SAny) extends Cmd {
-    override def execute(
-        env: Env
-    )(implicit ec: ExecutionContext, mat: Materializer, esf: ExecutionSequencerFactory) =
-      Future.successful(SBThrow(SEValue(exc)))
+    override def executeWithRunner(env: Env, runner: v2.Runner, convertLegacyExceptions: Boolean)(
+        implicit
+        ec: ExecutionContext,
+        mat: Materializer,
+        esf: ExecutionSequencerFactory,
+    ): Future[SExpr] = {
+      def makeFailureStatus(name: Identifier, msg: String) =
+        Future.failed(
+          free.InterpretationError(
+            SError.SErrorDamlException(
+              IE.FailureStatus(
+                "UNHANDLED_EXCEPTION/" + name.qualifiedName.toString,
+                Ast.FCInvalidGivenCurrentSystemStateOther.cantonCategoryId,
+                msg,
+                Map(),
+              )
+            )
+          )
+        )
+      def userManagementDef(name: String) =
+        env.scriptIds.damlScriptModule("Daml.Script.Internal.Questions.UserManagement", name)
+      val invalidUserId = userManagementDef("InvalidUserId")
+      val userAlreadyExists = userManagementDef("UserAlreadyExists")
+      val userNotFound = userManagementDef("UserNotFound")
+      (exc, convertLegacyExceptions) match {
+        // Pseudo exceptions defined by daml-script need explicit conversion logic, as compiler won't generate them
+        // Can be removed in 3.4, when exceptions will be replaced with FailureStatus
+        case (SAnyException(SRecord(`invalidUserId`, _, ArrayList(SText(msg)))), true) =>
+          makeFailureStatus(invalidUserId, msg)
+        case (
+              SAnyException(
+                SRecord(`userAlreadyExists`, _, ArrayList(SRecord(_, _, ArrayList(SText(userId)))))
+              ),
+              true,
+            ) =>
+          makeFailureStatus(userAlreadyExists, "User already exists: " + userId)
+        case (
+              SAnyException(
+                SRecord(`userNotFound`, _, ArrayList(SRecord(_, _, ArrayList(SText(userId)))))
+              ),
+              true,
+            ) =>
+          makeFailureStatus(userNotFound, "User not found: " + userId)
+        case _ => Future.successful(SBThrow(SEValue(exc)))
+      }
+    }
+
+    override def execute(env: Env)(implicit
+        ec: ExecutionContext,
+        mat: Materializer,
+        esf: ExecutionSequencerFactory,
+    ): Future[SExpr] = Future.failed(new NotImplementedError)
   }
 
   final case class Catch(act: SValue) extends Cmd {
@@ -164,6 +212,55 @@ object ScriptF {
                 )
             }
 
+          case Failure(e) => Future.failed(e)
+        }
+
+    override def execute(env: Env)(implicit
+        ec: ExecutionContext,
+        mat: Materializer,
+        esf: ExecutionSequencerFactory,
+    ): Future[SExpr] = Future.failed(new NotImplementedError)
+  }
+
+  final case class TryFailureStatus(act: SValue) extends Cmd {
+    override def executeWithRunner(env: Env, runner: v2.Runner, convertLegacyExceptions: Boolean)(
+        implicit
+        ec: ExecutionContext,
+        mat: Materializer,
+        esf: ExecutionSequencerFactory,
+    ): Future[SExpr] =
+      runner
+        .run(SEAppAtomic(SEValue(act), Array(SEValue(SUnit))), convertLegacyExceptions = true)
+        .transformWith {
+          case Success(v) =>
+            Future.successful(SEAppAtomic(right, Array(SEValue(v))))
+          case Failure(
+                free.InterpretationError(
+                  SError.SErrorDamlException(
+                    IE.FailureStatus(errorId, failureCategory, errorMessage, metadata)
+                  )
+                )
+              ) =>
+            import com.daml.script.converter.Converter.record
+            Future.successful(
+              SEAppAtomic(
+                left,
+                Array(
+                  SEValue(
+                    record(
+                      StablePackagesV2.FailureStatus,
+                      ("errorId", SText(errorId)),
+                      ("category", SInt64(failureCategory.toLong)),
+                      ("message", SText(errorMessage)),
+                      (
+                        "meta",
+                        SMap(true, metadata.map { case (k, v) => (SText(k), SText(v)) }),
+                      ),
+                    )
+                  )
+                ),
+              )
+            )
           case Failure(e) => Future.failed(e)
         }
 
@@ -1042,6 +1139,13 @@ object ScriptF {
       case _ => Left(s"Expected Throw payload but got $v")
     }
 
+  private def parseTryFailureStatus(v: SValue): Either[String, TryFailureStatus] =
+    v match {
+      // TryFailureStatus includes a dummy field for old style typeclass LF encoding, we ignore it here.
+      case SRecord(_, _, ArrayList(act, _)) => Right(TryFailureStatus(act))
+      case _ => Left(s"Expected TryFailureStatus payload but got $v")
+    }
+
   private def parseValidateUserId(v: SValue): Either[String, ValidateUserId] =
     v match {
       case SRecord(_, _, ArrayList(userName)) =>
@@ -1212,6 +1316,7 @@ object ScriptF {
       case ("ListAllPackages", 1) => parseEmpty(ListAllPackages())(v)
       case ("TryCommands", 1) => parseTryCommands(v)
       case ("FailWithStatus", 1) => parseFailWithStatus(v)
+      case ("TryFailureStatus", 1) => parseTryFailureStatus(v)
       case _ => Left(s"Unknown command $commandName - Version $version")
     }
 

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
@@ -152,7 +152,7 @@ object ScriptF {
       val userNotFound = userManagementDef("UserNotFound")
       (exc, convertLegacyExceptions) match {
         // Pseudo exceptions defined by daml-script need explicit conversion logic, as compiler won't generate them
-        // Can be removed in 3.4, when exceptions will be replaced with FailureStatus
+        // Can be removed in 3.4, when exceptions will be replaced with FailureStatus (https://github.com/DACH-NY/canton/issues/23881)
         case (SAnyException(SRecord(`invalidUserId`, _, ArrayList(SText(msg)))), true) =>
           makeFailureStatus(invalidUserId, msg)
         case (

--- a/sdk/daml-script/test/daml/UpgradeTestLib.daml
+++ b/sdk/daml-script/test/daml/UpgradeTestLib.daml
@@ -25,6 +25,7 @@ module UpgradeTestLib (
 import Daml.Script
 import Daml.Script.Internal
 import DA.Assert
+import DA.Fail
 import DA.Foldable
 import DA.Time
 
@@ -69,7 +70,7 @@ subtree group cases = (group, tests cases)
 -- | Used to tag a test as failing by erroring in any way, once all this behaviour works, this function can be removed
 brokenScript : Test -> Test
 brokenScript act testState = do
-  tryToEither (\() -> liftFailedCommandToException $ act testState) >>= \case
+  tryFailureStatus (liftFailedCommandToFailureStatus $ act testState) >>= \case
     Right _ -> assertFail "Expected failed and got success! Did you fix this logic? Remove the wrapping `broken` to mark this as working."
     Left _ -> pure ()
 
@@ -77,10 +78,10 @@ withUnvettedPackageOnParticipant : Text -> Text -> ParticipantName -> Script a -
 withUnvettedPackageOnParticipant packageName packageVersion participant act = do
   let pkg = PackageName packageName packageVersion
   unvetPackagesOnParticipant [pkg] participant
-  res <- tryToEither (\() -> liftFailedCommandToException act)
+  res <- tryFailureStatus $ liftFailedCommandToFailureStatus act
   vetPackagesOnParticipant [pkg] participant
   case res of
-    Left e -> throwAnyException e
+    Left fs -> failWithStatus fs
     Right r -> pure r
 
 expectPackageMissingFailure : Either SubmitError a -> Script ()
@@ -95,12 +96,12 @@ withUnvettedPackage packageName packageVersion act = do
   unsafeUnvetPackages [pkg] (Some participant0)
   unsafeUnvetPackages [pkg] (Some participant1)
   sleep $ seconds 1
-  res <- tryToEither (\() -> liftFailedCommandToException act)
+  res <- tryFailureStatus $ liftFailedCommandToFailureStatus act
   unsafeVetPackages [pkg] (Some participant0)
   unsafeVetPackages [pkg] (Some participant1)
   sleep $ seconds 1
   case res of
-    Left e -> throwAnyException e
+    Left fs -> failWithStatus fs
     Right r -> pure r
 
 broken : (Text, Test) -> (Text, Test)

--- a/sdk/docs/sharable/sdk/reference/daml-script/api/Daml-Script-Internal-LowLevel.rst
+++ b/sdk/docs/sharable/sdk/reference/daml-script/api/Daml-Script-Internal-LowLevel.rst
@@ -38,6 +38,8 @@ Typeclasses
 
   **instance** `IsQuestion <class-daml-script-internal-lowlevel-isquestion-79227_>`_ :ref:`Throw <type-daml-script-internal-questions-exceptions-throw-53740>` t
 
+  **instance** `IsQuestion <class-daml-script-internal-lowlevel-isquestion-79227_>`_ :ref:`TryFailureStatus <type-daml-script-internal-questions-exceptions-tryfailurestatus-59844>` (`Either <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-types-either-56020>`_ `FailureStatus <https://docs.daml.com/daml/stdlib/DA-Fail.html#type-da-internal-fail-types-failurestatus-69615>`_ x)
+
   **instance** `IsQuestion <class-daml-script-internal-lowlevel-isquestion-79227_>`_ :ref:`ListAllPackages <type-daml-script-internal-questions-packages-listallpackages-28931>` \[:ref:`PackageName <type-daml-script-internal-questions-packages-packagename-68696>`\]
 
   **instance** `IsQuestion <class-daml-script-internal-lowlevel-isquestion-79227_>`_ :ref:`ListVettedPackages <type-daml-script-internal-questions-packages-listvettedpackages-5133>` \[:ref:`PackageName <type-daml-script-internal-questions-packages-packagename-68696>`\]
@@ -99,9 +101,13 @@ Data Types
 
   **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"act\" :ref:`Catch <type-daml-script-internal-questions-exceptions-catch-84605>` (() \-\> `LedgerValue <type-daml-script-internal-lowlevel-ledgervalue-66913_>`_)
 
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"act\" :ref:`TryFailureStatus <type-daml-script-internal-questions-exceptions-tryfailurestatus-59844>` (() \-\> `LedgerValue <type-daml-script-internal-lowlevel-ledgervalue-66913_>`_)
+
   **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"act\" :ref:`TryCommands <type-daml-script-internal-questions-testing-trycommands-91696>` `LedgerValue <type-daml-script-internal-lowlevel-ledgervalue-66913_>`_
 
   **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"act\" :ref:`Catch <type-daml-script-internal-questions-exceptions-catch-84605>` (() \-\> `LedgerValue <type-daml-script-internal-lowlevel-ledgervalue-66913_>`_)
+
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"act\" :ref:`TryFailureStatus <type-daml-script-internal-questions-exceptions-tryfailurestatus-59844>` (() \-\> `LedgerValue <type-daml-script-internal-lowlevel-ledgervalue-66913_>`_)
 
   **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"act\" :ref:`TryCommands <type-daml-script-internal-questions-testing-trycommands-91696>` `LedgerValue <type-daml-script-internal-lowlevel-ledgervalue-66913_>`_
 

--- a/sdk/docs/sharable/sdk/reference/daml-script/api/Daml-Script-Internal-Questions-Exceptions.rst
+++ b/sdk/docs/sharable/sdk/reference/daml-script/api/Daml-Script-Internal-Questions-Exceptions.rst
@@ -102,6 +102,38 @@ Data Types
 
   **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"exc\" `Throw <type-daml-script-internal-questions-exceptions-throw-53740_>`_ `AnyException <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-anyexception-7004>`_
 
+.. _type-daml-script-internal-questions-exceptions-tryfailurestatus-59844:
+
+**data** `TryFailureStatus <type-daml-script-internal-questions-exceptions-tryfailurestatus-59844_>`_
+
+  .. _constr-daml-script-internal-questions-exceptions-tryfailurestatus-15589:
+
+  `TryFailureStatus <constr-daml-script-internal-questions-exceptions-tryfailurestatus-15589_>`_
+
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+
+       * - Field
+         - Type
+         - Description
+       * - act
+         - () \-\> :ref:`LedgerValue <type-daml-script-internal-lowlevel-ledgervalue-66913>`
+         -
+       * - dummy
+         - ()
+         -
+
+  **instance** :ref:`IsQuestion <class-daml-script-internal-lowlevel-isquestion-79227>` `TryFailureStatus <type-daml-script-internal-questions-exceptions-tryfailurestatus-59844_>`_ (`Either <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-types-either-56020>`_ `FailureStatus <https://docs.daml.com/daml/stdlib/DA-Fail.html#type-da-internal-fail-types-failurestatus-69615>`_ x)
+
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"act\" `TryFailureStatus <type-daml-script-internal-questions-exceptions-tryfailurestatus-59844_>`_ (() \-\> :ref:`LedgerValue <type-daml-script-internal-lowlevel-ledgervalue-66913>`)
+
+  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"dummy\" `TryFailureStatus <type-daml-script-internal-questions-exceptions-tryfailurestatus-59844_>`_ ()
+
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"act\" `TryFailureStatus <type-daml-script-internal-questions-exceptions-tryfailurestatus-59844_>`_ (() \-\> :ref:`LedgerValue <type-daml-script-internal-lowlevel-ledgervalue-66913>`)
+
+  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"dummy\" `TryFailureStatus <type-daml-script-internal-questions-exceptions-tryfailurestatus-59844_>`_ ()
+
 Functions
 ---------
 
@@ -119,4 +151,9 @@ Functions
 
 `throwAnyException <function-daml-script-internal-questions-exceptions-throwanyexception-70957_>`_
   \: `AnyException <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-anyexception-7004>`_ \-\> :ref:`Script <type-daml-script-internal-lowlevel-script-4781>` t
+
+.. _function-daml-script-internal-questions-exceptions-tryfailurestatus-576:
+
+`tryFailureStatus <function-daml-script-internal-questions-exceptions-tryfailurestatus-576_>`_
+  \: :ref:`Script <type-daml-script-internal-lowlevel-script-4781>` a \-\> :ref:`Script <type-daml-script-internal-lowlevel-script-4781>` (`Either <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-types-either-56020>`_ `FailureStatus <https://docs.daml.com/daml/stdlib/DA-Fail.html#type-da-internal-fail-types-failurestatus-69615>`_ a)
 

--- a/sdk/docs/sharable/sdk/reference/daml-script/api/Daml-Script-Internal-Questions-Testing.rst
+++ b/sdk/docs/sharable/sdk/reference/daml-script/api/Daml-Script-Internal-Questions-Testing.rst
@@ -131,21 +131,11 @@ Data Types
 
   **instance** `Show <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360>`_ `FailedCmd <type-daml-script-internal-questions-testing-failedcmd-88074_>`_
 
-  **instance** `HasFromAnyException <https://docs.daml.com/daml/stdlib/DA-Exception.html#class-da-internal-exception-hasfromanyexception-16788>`_ `FailedCmd <type-daml-script-internal-questions-testing-failedcmd-88074_>`_
-
-  **instance** `HasMessage <https://docs.daml.com/daml/stdlib/DA-Exception.html#class-da-internal-exception-hasmessage-3179>`_ `FailedCmd <type-daml-script-internal-questions-testing-failedcmd-88074_>`_
-
-  **instance** `HasThrow <https://docs.daml.com/daml/stdlib/DA-Exception.html#class-da-internal-exception-hasthrow-30284>`_ `FailedCmd <type-daml-script-internal-questions-testing-failedcmd-88074_>`_
-
-  **instance** `HasToAnyException <https://docs.daml.com/daml/stdlib/DA-Exception.html#class-da-internal-exception-hastoanyexception-55973>`_ `FailedCmd <type-daml-script-internal-questions-testing-failedcmd-88074_>`_
-
   **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"commandName\" `FailedCmd <type-daml-script-internal-questions-testing-failedcmd-88074_>`_ `CommandName <type-daml-script-internal-questions-testing-commandname-12991_>`_
 
   **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"errorClassName\" `FailedCmd <type-daml-script-internal-questions-testing-failedcmd-88074_>`_ `ErrorClassName <type-daml-script-internal-questions-testing-errorclassname-49861_>`_
 
   **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"errorMessage\" `FailedCmd <type-daml-script-internal-questions-testing-failedcmd-88074_>`_ `ErrorMessage <type-daml-script-internal-questions-testing-errormessage-78991_>`_
-
-  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"message\" `FailedCmd <type-daml-script-internal-questions-testing-failedcmd-88074_>`_ `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
 
   **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"commandName\" `FailedCmd <type-daml-script-internal-questions-testing-failedcmd-88074_>`_ `CommandName <type-daml-script-internal-questions-testing-commandname-12991_>`_
 
@@ -191,8 +181,8 @@ Functions
 `tryCommands <function-daml-script-internal-questions-testing-trycommands-17332_>`_
   \: :ref:`Script <type-daml-script-internal-lowlevel-script-4781>` a \-\> :ref:`Script <type-daml-script-internal-lowlevel-script-4781>` (`Either <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-types-either-56020>`_ `FailedCmd <type-daml-script-internal-questions-testing-failedcmd-88074_>`_ a)
 
-.. _function-daml-script-internal-questions-testing-liftfailedcommandtoexception-73435:
+.. _function-daml-script-internal-questions-testing-liftfailedcommandtofailurestatus-62416:
 
-`liftFailedCommandToException <function-daml-script-internal-questions-testing-liftfailedcommandtoexception-73435_>`_
+`liftFailedCommandToFailureStatus <function-daml-script-internal-questions-testing-liftfailedcommandtofailurestatus-62416_>`_
   \: :ref:`Script <type-daml-script-internal-lowlevel-script-4781>` a \-\> :ref:`Script <type-daml-script-internal-lowlevel-script-4781>` a
 


### PR DESCRIPTION
Adds `tryFailureStatus : (HasCallStack => Script a) -> Script (Either FailureStatus a)` to daml-script
We use the `HasCallStack` constraint to achieve laziness, previously you would need `() -> Script a`, which isn't very ergonomic.

Sadly, since daml-script exceptions are "pseudo" exceptions, i.e. implement the classes necessary but are not tagged as exceptions to the engine, they do not get the def ref for conversion to failure status.
I have fixed this in the implementation for Throw in daml-script, since the conversion is trivial. Once we remove exceptions, these will be converted to FailureStatus and this logic can be removed.

I have also updated `liftFailedCommandToException` to `liftFailedCommandToFailureStatus`, and change the upgrade runtime tests to catch failure status, over exceptions, for marked broken tests.

