### PR TITLE
disable UvettedPackages tests for now

### DIFF
--- a/sdk/daml-script/test/daml/upgrades/UnvettedPackages.daml
+++ b/sdk/daml-script/test/daml/upgrades/UnvettedPackages.daml
@@ -15,7 +15,10 @@ import DA.Time (seconds)
 
 -- These tests rely on unvetting, none of them will work on IDE
 main : TestTree
-main = tests $
+main = tests $ []
+
+-- TODO: restore these tests once waiting for unvetting to have propagated is fixed
+testsToRestore =
   [ subtree "exercise"
     -- TODO(https://github.com/DACH-NY/canton/issues/25018): All thes transactions below are expected to fail but succeed.
     [ brokenOnIDELedger ("Exercise a choice against a V1 contract with V1 unvetted on submitter via Command (should change the expectation to fails)", v1UnvettedOnSubmitterCommand)


### PR DESCRIPTION
The tests are flaky because the 1s wait after unvetting is not always enough. While we figure out the proper way to wait for the change to propagate, we disable this test. I disable it that way in order to preserve compilation errors if daml-script changes.