### PR TITLE
Add LATEST to labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,6 +3,7 @@
 Standard-Change:
 - changed-files:
   - any-glob-to-any-file: 'ci/**'
+  - any-glob-to-any-file: 'sdk/LATEST'
   - any-glob-to-any-file: 'sdk/ci/**'
   - any-glob-to-any-file: 'sdk/release/**'
   - any-glob-to-any-file: 'sdk/build-scripts/**'


### PR DESCRIPTION
The auto-labeler removes the label from PRs like https://github.com/digital-asset/daml/pull/21050 because LATEST is missing from its config file.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
