### PR TITLE
Blackduck: fix condition for running `blackduck_scan` on PRs

### DIFF
--- a/ci/blackduck.yml
+++ b/ci/blackduck.yml
@@ -8,7 +8,7 @@ jobs:
                        eq(variables['Build.SourceBranchName'], 'main-2.x')),
                     eq(variables['Build.DefinitionName'], 'digital-asset.daml-daily-compat')),
                 and(eq(variables['Build.DefinitionName'], 'PRs'),
-                    startsWith(variables['Build.SourceBranchName'], 'bump-blackduck-script-')))
+                    startsWith(variables['System.PullRequest.SourceBranch'], 'bump-blackduck-script-')))
   pool:
     name: ubuntu_20_04
     demands: assignment -equals default


### PR DESCRIPTION
As per https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
`Build.SourceBranchName` is the name of the `Build.SourceBranch`, which, for a pull request, is always "merge".
`System.PullRequest.SourceBranch` evaluates to the name of the branch that is being reviewed.