### PR TITLE
Fix data-deps warnings and remove redundant error info

### DIFF
--- a/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -1223,7 +1223,8 @@ generateSrcPkgFromLf envConfig pkg = do
         , "{-# LANGUAGE AllowAmbiguousTypes #-}"
         , "{-# LANGUAGE MagicHash #-}"
         , "{-# LANGUAGE DatatypeContexts #-}"
-        , "{-# OPTIONS_GHC -Wno-unused-imports -Wno-missing-methods -Wno-deprecations #-}"
+        , -- TODO[SW] Fix -Wno-deprecations in GHC to disable warnings/deprecations with categories as well as those uncategorised
+          "{-# OPTIONS_GHC -Wno-unused-imports -Wno-missing-methods -Wno-deprecations -Wno-x-exceptions -Wno-x-ledger-time -Wno-x-crypto #-}"
         ]
 
 -- | A reference that can appear in a type or expression. We need to track

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -121,8 +121,8 @@ private[lf] object Pretty {
           prettyContractId(key.cids.head)
       case ValueNesting(limit) =>
         text(s"Value exceeds maximum nesting value of $limit")
-      case FailureStatus(errorId, cantonCategoryId, errorMessage, _) =>
-        text(s"User failure: $errorId (error category $cantonCategoryId): $errorMessage")
+      case FailureStatus(errorId, _, errorMessage, _) =>
+        text(s"User failure: $errorId: $errorMessage")
       case Upgrade(error) =>
         error match {
           case Upgrade.ValidationFailed(

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
@@ -350,9 +350,10 @@ object GrpcErrorParser {
             metadata = errorInfo.metadata.toMap.removedAll(cantonFields)
             trace = errorInfo.metadata.get("exercise_trace")
             // Drop prefix so we give back the exact message in the throwing daml code
-            messageWithoutPrefix <- "^.+?error category \\d+\\): (.*)$".r
-              .findFirstMatchIn(message)
-              .map(_.group(1))
+            messageWithoutPrefix <- message.indexOf(errorId) match {
+              case -1 => None
+              case i => Some(message.drop(i + errorId.length + 2))
+            }
           } yield SubmitError.FailureStatusError(
             IE.FailureStatus(errorId, category, messageWithoutPrefix, metadata),
             trace,

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/DamlScriptTestRunnerDev.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/DamlScriptTestRunnerDev.scala
@@ -20,7 +20,7 @@ class DamlScriptTestRunnerDev extends DamlScriptTestRunner {
   override lazy val darFiles = List(trySubmitTestDarPath)
 
   val expectedContractNotActiveResponse =
-    """FAILURE (com.digitalasset.daml.lf.engine.free.InterpretationError: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.GeneralError:GeneralError (error category 9): contractNotActive no additional info)"""
+    """FAILURE (com.digitalasset.daml.lf.engine.free.InterpretationError: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.GeneralError:GeneralError: contractNotActive no additional info)"""
 
   "daml-script command line" should {
     "pick up all scripts and returns somewhat sensible outputs for daml-script features" in
@@ -34,7 +34,7 @@ class DamlScriptTestRunnerDev extends DamlScriptTestRunner {
            |Submit:failureStatusError SUCCESS
            |Submit:fetchEmptyContractKeyMaintainers SUCCESS
            |Submit:prefetchContractKeys SUCCESS
-           |Submit:truncatedError FAILURE (com.digitalasset.daml.lf.engine.free.InterpretationError: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.GeneralError:GeneralError (error category 9): EXPECTED_TRUNCATED_ERROR)
+           |Submit:truncatedError FAILURE (com.digitalasset.daml.lf.engine.free.InterpretationError: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.GeneralError:GeneralError: EXPECTED_TRUNCATED_ERROR)
            |Submit:wronglyTypedContract SUCCESS
            |""".stripMargin,
       )

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/DamlScriptTestRunnerStable.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/DamlScriptTestRunnerStable.scala
@@ -44,10 +44,10 @@ class DamlScriptTestRunnerStable extends DamlScriptTestRunner {
           |ExceptionSemantics:tryContext FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: NOT_FOUND: CONTRACT_NOT_FOUND(11,XXXXXXXX): Contract could not be found with id XXXXXXXX
           |ExceptionSemantics:uncaughtArithmeticError SUCCESS
           |ExceptionSemantics:uncaughtUserException SUCCESS
-          |ExceptionSemantics:unhandledArithmeticError FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: DAML_FAILURE(9,XXXXXXXX): Interpretation error: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.ArithmeticError:ArithmeticError (error category 9): ArithmeticError while evaluating (DIV_INT64 1 0).
+          |ExceptionSemantics:unhandledArithmeticError FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: DAML_FAILURE(9,XXXXXXXX): Interpretation error: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.ArithmeticError:ArithmeticError: ArithmeticError while evaluating (DIV_INT64 1 0).
           |    in choice XXXXXXXX:ExceptionSemantics:T:ThrowArithmeticError on contract XXXXXXXXXX (#1)
           |    in create-and-exercise command XXXXXXXX:ExceptionSemantics:T:ThrowArithmeticError.
-          |ExceptionSemantics:unhandledUserException FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: DAML_FAILURE(9,XXXXXXXX): Interpretation error: Error: User failure: UNHANDLED_EXCEPTION/ExceptionSemantics:E (error category 9): E
+          |ExceptionSemantics:unhandledUserException FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: DAML_FAILURE(9,XXXXXXXX): Interpretation error: Error: User failure: UNHANDLED_EXCEPTION/ExceptionSemantics:E: E
           |    in choice XXXXXXXX:ExceptionSemantics:T:Throw on contract XXXXXXXXXX (#1)
           |    in create-and-exercise command XXXXXXXX:ExceptionSemantics:T:Throw.
           |ExceptionSemanticsWithKeys:duplicateKey FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: SErrorDamlException(UserError(Expected submit to fail but it succeeded)
@@ -55,7 +55,7 @@ class DamlScriptTestRunnerStable extends DamlScriptTestRunner {
           |MoreChoiceObserverDivulgence:test FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: NOT_FOUND: CONTRACT_NOT_FOUND(11,XXXXXXXX): Contract could not be found with id XXXXXXXX
           |MultiTest:disclosuresByKeyTest SUCCESS
           |MultiTest:disclosuresTest SUCCESS
-          |MultiTest:inactiveDisclosureDoesNotFailDuringSubmission FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: DAML_FAILURE(9,XXXXXXXX): Interpretation error: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.GeneralError:GeneralError (error category 9): Here
+          |MultiTest:inactiveDisclosureDoesNotFailDuringSubmission FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: DAML_FAILURE(9,XXXXXXXX): Interpretation error: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.GeneralError:GeneralError: Here
           |    in choice XXXXXXXX:MultiTest:Helper:FailWith on contract XXXXXXXXXX (#1)
           |    in exercise command XXXXXXXX:MultiTest:Helper:FailWith on contract XXXXXXXXXX.
           |MultiTest:listKnownPartiesTest SUCCESS
@@ -66,14 +66,14 @@ class DamlScriptTestRunnerStable extends DamlScriptTestRunner {
           |ScriptExample:initializeUser SUCCESS
           |ScriptExample:test SUCCESS
           |ScriptTest:clearUsers SUCCESS
-          |ScriptTest:failingTest FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: DAML_FAILURE(9,XXXXXXXX): Interpretation error: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.AssertionFailed:AssertionFailed (error category 9): Assertion failed
+          |ScriptTest:failingTest FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: DAML_FAILURE(9,XXXXXXXX): Interpretation error: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.AssertionFailed:AssertionFailed: Assertion failed
           |    in choice XXXXXXXX:ScriptTest:C:ShouldFail on contract XXXXXXXXXX (#0)
           |    in exercise command XXXXXXXX:ScriptTest:C:ShouldFail on contract XXXXXXXXXX.
           |ScriptTest:listKnownPartiesTest SUCCESS
           |ScriptTest:multiPartySubmission SUCCESS
           |ScriptTest:partyIdHintTest SUCCESS
           |ScriptTest:sleepTest SUCCESS
-          |ScriptTest:stackTrace FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: DAML_FAILURE(9,XXXXXXXX): Interpretation error: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.AssertionFailed:AssertionFailed (error category 9): Assertion failed
+          |ScriptTest:stackTrace FAILURE (com.digitalasset.daml.lf.engine.script.Script$FailedCmd: Command Submit failed: FAILED_PRECONDITION: DAML_FAILURE(9,XXXXXXXX): Interpretation error: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.AssertionFailed:AssertionFailed: Assertion failed
           |    in choice XXXXXXXX:ScriptTest:C:ShouldFail on contract XXXXXXXXXX (#1)
           |    in create-and-exercise command XXXXXXXX:ScriptTest:C:ShouldFail.
           |ScriptTest:test0 SUCCESS
@@ -98,9 +98,9 @@ class DamlScriptTestRunnerStable extends DamlScriptTestRunner {
           |TestContractId:testContractId SUCCESS
           |TestExceptions:test SUCCESS
           |TestExceptions:try_catch_recover SUCCESS
-          |TestExceptions:try_catch_then_abort FAILURE (com.digitalasset.daml.lf.engine.free.InterpretationError: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.GeneralError:GeneralError (error category 9): expected exception)
-          |TestExceptions:try_catch_then_error FAILURE (com.digitalasset.daml.lf.engine.free.InterpretationError: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.GeneralError:GeneralError (error category 9): expected exception)
-          |TestExceptions:try_catch_then_fail FAILURE (com.digitalasset.daml.lf.engine.free.InterpretationError: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.GeneralError:GeneralError (error category 9): expected exception)
+          |TestExceptions:try_catch_then_abort FAILURE (com.digitalasset.daml.lf.engine.free.InterpretationError: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.GeneralError:GeneralError: expected exception)
+          |TestExceptions:try_catch_then_error FAILURE (com.digitalasset.daml.lf.engine.free.InterpretationError: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.GeneralError:GeneralError: expected exception)
+          |TestExceptions:try_catch_then_fail FAILURE (com.digitalasset.daml.lf.engine.free.InterpretationError: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.GeneralError:GeneralError: expected exception)
           |TestFailWithStatus:attemptToOverwriteMetadata SUCCESS
           |TestFailWithStatus:cannotCatch SUCCESS
           |TestFailWithStatus:haltsExecution SUCCESS

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/MultiParticipantIT.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/MultiParticipantIT.scala
@@ -120,7 +120,7 @@ class MultiParticipantIT(override val majorLanguageVersion: LanguageMajorVersion
                 case Failure(exception) => Success(exception)
               }
         } yield error.getMessage should include(
-          "User failure: UNHANDLED_EXCEPTION/DA.Exception.GeneralError:GeneralError (error category 9): Here"
+          "User failure: UNHANDLED_EXCEPTION/DA.Exception.GeneralError:GeneralError: Here"
         )
       }
     }


### PR DESCRIPTION
Data-deps had the "-Wno-deprecation" flag on the generated code, but it seems warnings with categories are still thrown. This shows a problem with the GHC implementation.
I don't think its worth doing to 3.3, so for now, i've just explicitly added the flags to the generated code. For main-3.x, I will fix the GHC implementation.

I've also removed a bit of duplication in the error messages for failure status (repeating the error category)
I wanted to remove more of the duplication (specifically the additional "Error:"), but this changes tests in canton, and in the test tool, which would need additional exclusions, and also isn't worth delaying the release IMO.
Similarly this will be fixed for 3.4, and perhaps a 3.3 patch.
