### PR TITLE
change verify-docs-synchronized to use a tmp dir

### DIFF
--- a/sdk/ci/synchronize-docs.sh
+++ b/sdk/ci/synchronize-docs.sh
@@ -5,7 +5,8 @@
 set -euo pipefail
 
 DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-SHARABLE_DIR="$DIR/../docs/sharable"
+DEFAULT_SHARABLE_DIR="$DIR/../docs/sharable"
+SHARABLE_DIR="${1:-$DEFAULT_SHARABLE_DIR}"
 MANUAL_DIR="$DIR/../docs/manually-written"
 
 cd $DIR/..

--- a/sdk/ci/verify-docs-synchronized.sh
+++ b/sdk/ci/verify-docs-synchronized.sh
@@ -9,14 +9,12 @@ set -euo pipefail
 
 DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-TMP_DIR=$(mktemp -d)
-cp -r $DIR/../docs/sharable $TMP_DIR
-
+OLD_SHARABLE=$DIR/../docs/sharable
 NEW_SHARABLE=$(mktemp -d)
 
 $DIR/synchronize-docs.sh $NEW_SHARABLE
 
 echo "Comparing the docs, expecting no diff:"
-diff -r $NEW_SHARABLE $TMP_DIR/sharable # If there's any diff, the diff will return 1 and fail the script
+diff -r $NEW_SHARABLE $OLD_SHARABLE # If there's any diff, the diff will return 1 and fail the script
 
 echo "SUCCESS"

--- a/sdk/ci/verify-docs-synchronized.sh
+++ b/sdk/ci/verify-docs-synchronized.sh
@@ -9,14 +9,14 @@ set -euo pipefail
 
 DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-DIR_TO_CHECK=$DIR/../docs/sharable
-TEMP_DIR=$(mktemp -d)
+TMP_DIR=$(mktemp -d)
+cp -r $DIR/../docs/sharable $TMP_DIR
 
-cp -r $DIR_TO_CHECK $TEMP_DIR
+NEW_SHARABLE=$(mktemp -d)
 
-$DIR/synchronize-docs.sh
+$DIR/synchronize-docs.sh $NEW_SHARABLE
 
 echo "Comparing the docs, expecting no diff:"
-diff -r $DIR_TO_CHECK $TEMP_DIR/sharable # If there's any diff, the diff will return 1 and fail the script
+diff -r $NEW_SHARABLE $TMP_DIR/sharable # If there's any diff, the diff will return 1 and fail the script
 
 echo "SUCCESS"

--- a/sdk/ci/verify-docs-synchronized.sh
+++ b/sdk/ci/verify-docs-synchronized.sh
@@ -11,6 +11,7 @@ DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 OLD_SHARABLE=$DIR/../docs/sharable
 NEW_SHARABLE=$(mktemp -d)
+trap "rm -rf $NEW_SHARABLE" EXIT
 
 $DIR/synchronize-docs.sh $NEW_SHARABLE
 


### PR DESCRIPTION
Tested locally that the verify script leaves no unchecked files, and that the synchronize script still works when called with no arguments.