### PR TITLE
Fix cheat sheet for 3.4

### DIFF
--- a/sdk/docs/manually-written/sdk/reference/cheat-sheet.rst
+++ b/sdk/docs/manually-written/sdk/reference/cheat-sheet.rst
@@ -1,5 +1,12 @@
 :orphan:
-:cheat_sheet_layout: True
+:show_main_header: True
+:hide_sidebars: True
+:layout: standalone
+
+.. raw:: html
+
+    <div class="cheat-sheet">
+
 
 Cheat Sheet
 ===========
@@ -46,4 +53,5 @@ Cheat Sheet
 
 .. raw:: html
 
+        </div>
     </div>

--- a/sdk/docs/manually-written/sdk/reference/daml-language-cheat-sheet.rst
+++ b/sdk/docs/manually-written/sdk/reference/daml-language-cheat-sheet.rst
@@ -10,4 +10,4 @@ Click to open the |cheat_sheet_link|
 
 .. |cheat_sheet_link| raw:: html
 
-   <a href="/build/3.3/reference/cheat-sheet.html" target="_blank">Daml language cheat sheet</a>.
+   <a href="/build/3.4/reference/cheat-sheet.html" target="_blank">Daml language cheat sheet</a>.

--- a/sdk/docs/sharable/sdk/reference/cheat-sheet.rst
+++ b/sdk/docs/sharable/sdk/reference/cheat-sheet.rst
@@ -1,5 +1,12 @@
 :orphan:
-:cheat_sheet_layout: True
+:show_main_header: True
+:hide_sidebars: True
+:layout: standalone
+
+.. raw:: html
+
+    <div class="cheat-sheet">
+
 
 Cheat Sheet
 ===========
@@ -46,4 +53,5 @@ Cheat Sheet
 
 .. raw:: html
 
+        </div>
     </div>

--- a/sdk/docs/sharable/sdk/reference/daml-language-cheat-sheet.rst
+++ b/sdk/docs/sharable/sdk/reference/daml-language-cheat-sheet.rst
@@ -10,4 +10,4 @@ Click to open the |cheat_sheet_link|
 
 .. |cheat_sheet_link| raw:: html
 
-   <a href="/build/3.3/reference/cheat-sheet.html" target="_blank">Daml language cheat sheet</a>.
+   <a href="/build/3.4/reference/cheat-sheet.html" target="_blank">Daml language cheat sheet</a>.


### PR DESCRIPTION
We recently broke the cheat sheet: https://docs.digitalasset-staging.com/build/3.4/reference/cheat-sheet. This PR fixes it for `3.4`.

Also, fixed the version in the link from `3.3` to `3.4`.

Tested locally.

Link to the PR for `3.3`:  https://github.com/digital-asset/daml/pull/21106.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
