### PR TITLE
change verify-docs-synchronized to use a tmp dir (#21090)

### DIFF
--- a/sdk/ci/synchronize-docs.sh
+++ b/sdk/ci/synchronize-docs.sh
@@ -5,7 +5,8 @@
 set -euo pipefail
 
 DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-SHARABLE_DIR="$DIR/../docs/sharable"
+DEFAULT_SHARABLE_DIR="$DIR/../docs/sharable"
+SHARABLE_DIR="${1:-$DEFAULT_SHARABLE_DIR}"
 MANUAL_DIR="$DIR/../docs/manually-written"
 
 cd $DIR/..

--- a/sdk/ci/verify-docs-synchronized.sh
+++ b/sdk/ci/verify-docs-synchronized.sh
@@ -9,14 +9,13 @@ set -euo pipefail
 
 DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-DIR_TO_CHECK=$DIR/../docs/sharable
-TEMP_DIR=$(mktemp -d)
+OLD_SHARABLE=$DIR/../docs/sharable
+NEW_SHARABLE=$(mktemp -d)
+trap "rm -rf $NEW_SHARABLE" EXIT
 
-cp -r $DIR_TO_CHECK $TEMP_DIR
-
-$DIR/synchronize-docs.sh
+$DIR/synchronize-docs.sh $NEW_SHARABLE
 
 echo "Comparing the docs, expecting no diff:"
-diff -r $DIR_TO_CHECK $TEMP_DIR/sharable # If there's any diff, the diff will return 1 and fail the script
+diff -r $NEW_SHARABLE $OLD_SHARABLE # If there's any diff, the diff will return 1 and fail the script
 
 echo "SUCCESS"


### PR DESCRIPTION
Backport #21090 so that any PRs that fail doc checks don't break agents.