### PR TITLE
Add `BTextToContractId` built-in function

### DIFF
--- a/sdk/compiler/script-service/client/src/DA/Daml/LF/PrettyScript.hs
+++ b/sdk/compiler/script-service/client/src/DA/Daml/LF/PrettyScript.hs
@@ -543,7 +543,7 @@ prettyScriptErrorError lvl (Just err) =  do
        pure $ text $ TL.toStrict scriptError_UpgradeErrorMessage
     ScriptErrorErrorMalformedContractId ScriptError_MalformedContractId {..} -> do
       pure $ vcat
-        [ "Malformed contract id:" <-> ltext scriptError_MalformedContractIdMessage
+        [ "Malformed contract id:"
         , label_ "Contract id:" $ ltext scriptError_MalformedContractIdValue
         ]
 

--- a/sdk/compiler/script-service/client/src/DA/Daml/LF/PrettyScript.hs
+++ b/sdk/compiler/script-service/client/src/DA/Daml/LF/PrettyScript.hs
@@ -541,6 +541,12 @@ prettyScriptErrorError lvl (Just err) =  do
         ]
     ScriptErrorErrorUpgradeError ScriptError_UpgradeError {..} -> do
        pure $ text $ TL.toStrict scriptError_UpgradeErrorMessage
+    ScriptErrorErrorMalformedContractId ScriptError_MalformedContractId {..} -> do
+      pure $ vcat
+        [ "Malformed contract id:" <-> ltext scriptError_MalformedContractIdMessage
+        , label_ "Contract id:" $ ltext scriptError_MalformedContractIdValue
+        ]
+
 partyDifference :: V.Vector Party -> V.Vector Party -> Doc SyntaxClass
 partyDifference with without =
   fcommasep $ map prettyParty $ S.toList $

--- a/sdk/compiler/script-service/protos/script_service.proto
+++ b/sdk/compiler/script-service/protos/script_service.proto
@@ -307,7 +307,6 @@ message ScriptError {
 
   message MalformedContractId {
     string value = 1;
-    string message = 2;
   }
 
   // The state of the ledger at the time of the error

--- a/sdk/compiler/script-service/protos/script_service.proto
+++ b/sdk/compiler/script-service/protos/script_service.proto
@@ -305,6 +305,11 @@ message ScriptError {
     repeated MetadataEntry metadata = 4;
   }
 
+  message MalformedContractId {
+    string value = 1;
+    string message = 2;
+  }
+
   // The state of the ledger at the time of the error
   repeated ScriptStep script_steps = 1;
   repeated Node nodes = 2;
@@ -383,7 +388,8 @@ message ScriptError {
     LookupError lookup_error = 43;
     UpgradeError upgrade_error = 44;
     FailureStatusError failure_status_error = 45;
-    // next is 47;
+    MalformedContractId malformed_contract_id = 47;
+    // next is 48;
   }
 }
 

--- a/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/Conversions.scala
+++ b/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/Conversions.scala
@@ -278,11 +278,9 @@ final class Conversions(
                         .setExpected(convertIdentifier(expected))
                         .addAllAccepted(accepted.map(convertIdentifier(_)).asJava)
                     )
-                  case Dev.MalformedContractId(value, message) =>
+                  case Dev.MalformedContractId(value) =>
                     builder.setMalformedContractId(
-                      proto.ScriptError.MalformedContractId.newBuilder
-                        .setValue(value)
-                        .setMessage(message)
+                      proto.ScriptError.MalformedContractId.newBuilder.setValue(value)
                     )
                 }
               case _: Upgrade =>

--- a/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/Conversions.scala
+++ b/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/Conversions.scala
@@ -278,6 +278,12 @@ final class Conversions(
                         .setExpected(convertIdentifier(expected))
                         .addAllAccepted(accepted.map(convertIdentifier(_)).asJava)
                     )
+                  case Dev.MalformedContractId(value, message) =>
+                    builder.setMalformedContractId(
+                      proto.ScriptError.MalformedContractId.newBuilder
+                        .setValue(value)
+                        .setMessage(message)
+                    )
                 }
               case _: Upgrade =>
                 proto.ScriptError.UpgradeError.newBuilder.setMessage(

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PhaseOne.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PhaseOne.scala
@@ -404,6 +404,7 @@ private[lf] final class PhaseOne(
           case BTextToParty => SBTextToParty
           case BTextToInt64 => SBTextToInt64
           case BTextToCodePoints => SBTextToCodePoints
+          case BTextToContractId => SBTextToContractId
           case BSHA256Text => SBSHA256Text
           case BKECCAK256Text => SBKECCAK256Text
           case BDecodeHex => SBDecodeHex

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -253,6 +253,9 @@ private[lf] object Pretty {
               ) & prettyTypeConId(
                 actual
               )
+          case Dev.MalformedContractId(value, cause) =>
+            text("Malformed contract id") & text(value) & text(":") /
+              text(cause)
         }
     }
   }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -253,9 +253,7 @@ private[lf] object Pretty {
               ) & prettyTypeConId(
                 actual
               )
-          case Dev.MalformedContractId(value, cause) =>
-            text("Malformed contract id") & text(value) & text(":") /
-              text(cause)
+          case Dev.MalformedContractId(value) => text(s"Malformed contract id \"$value\"")
         }
     }
   }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -586,14 +586,21 @@ private[lf] object SBuiltinFun {
     ): Control[Nothing] = {
       val value = getSText(args, 0)
       V.ContractId.V1.fromString(value) match {
+        case Right(cid) if !cid.isLocal => Control.Value(SContractId(cid))
+        case Right(_) =>
+          Control.Error(
+            IE.Dev(
+              NameOf.qualifiedNameOfCurrentFunc,
+              IE.Dev.MalformedContractId(value, "unexpected local contract ID"),
+            )
+          )
         case Left(error) =>
           Control.Error(
             IE.Dev(
               NameOf.qualifiedNameOfCurrentFunc,
-              IE.Dev.MalformedContractId(value, error)
+              IE.Dev.MalformedContractId(value, error),
             )
           )
-        case Right(cid) => Control.Value(SContractId(cid))
       }
     }
   }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -585,21 +585,11 @@ private[lf] object SBuiltinFun {
         machine: Machine[Q],
     ): Control[Nothing] = {
       val value = getSText(args, 0)
-      V.ContractId.V1.fromString(value) match {
+      V.ContractId.fromString(value) match {
         case Right(cid) if !cid.isLocal => Control.Value(SContractId(cid))
-        case Right(_) =>
+        case _ =>
           Control.Error(
-            IE.Dev(
-              NameOf.qualifiedNameOfCurrentFunc,
-              IE.Dev.MalformedContractId(value, "unexpected local contract ID"),
-            )
-          )
-        case Left(error) =>
-          Control.Error(
-            IE.Dev(
-              NameOf.qualifiedNameOfCurrentFunc,
-              IE.Dev.MalformedContractId(value, error),
-            )
+            IE.Dev(NameOf.qualifiedNameOfCurrentFunc, IE.Dev.MalformedContractId(value))
           )
       }
     }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -579,6 +579,25 @@ private[lf] object SBuiltinFun {
     }
   }
 
+  final case object SBTextToContractId extends SBuiltinFun(1) {
+    override private[speedy] def execute[Q](
+        args: util.ArrayList[SValue],
+        machine: Machine[Q],
+    ): Control[Nothing] = {
+      val value = getSText(args, 0)
+      V.ContractId.V1.fromString(value) match {
+        case Left(error) =>
+          Control.Error(
+            IE.Dev(
+              NameOf.qualifiedNameOfCurrentFunc,
+              IE.Dev.MalformedContractId(value, error)
+            )
+          )
+        case Right(cid) => Control.Value(SContractId(cid))
+      }
+    }
+  }
+
   final case object SBSHA256Text extends SBuiltinPure(1) {
     override private[speedy] def executePure(args: util.ArrayList[SValue]): SText =
       SText(Utf8.sha256(getSText(args, 0)))

--- a/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -771,7 +771,7 @@ class SBuiltinTest(majorLanguageVersion: LanguageMajorVersion)
         inside {
           evalApp(e"TEXT_TO_CONTRACT_ID", Array(SText(cid2AsHexString)))
         } { case Left(SError.SErrorDamlException(IE.Dev(_, error))) =>
-          error shouldBe IE.Dev.MalformedContractId(cid2AsHexString, "unexpected local contract ID")
+          error shouldBe IE.Dev.MalformedContractId(cid2AsHexString)
         }
       }
 
@@ -782,24 +782,15 @@ class SBuiltinTest(majorLanguageVersion: LanguageMajorVersion)
 
         inside(evalApp(e"TEXT_TO_CONTRACT_ID", Array(SText(invalidHexString)))) {
           case Left(SError.SErrorDamlException(IE.Dev(_, error))) =>
-            error shouldBe IE.Dev.MalformedContractId(
-              invalidHexString,
-              s"cannot parse HexString $invalidHexString",
-            )
+            error shouldBe IE.Dev.MalformedContractId(invalidHexString)
         }
         inside(evalApp(e"TEXT_TO_CONTRACT_ID", Array(SText(tooShortHexString)))) {
           case Left(SError.SErrorDamlException(IE.Dev(_, error))) =>
-            error shouldBe IE.Dev.MalformedContractId(
-              tooShortHexString,
-              s"cannot parse V1 ContractId \"$tooShortHexString\"",
-            )
+            error shouldBe IE.Dev.MalformedContractId(tooShortHexString)
         }
         inside(evalApp(e"TEXT_TO_CONTRACT_ID", Array(SText(tooLongHexString)))) {
           case Left(SError.SErrorDamlException(IE.Dev(_, error))) =>
-            error shouldBe IE.Dev.MalformedContractId(
-              tooLongHexString,
-              "the suffix is too long, expected at most 94 bytes, but got 95",
-            )
+            error shouldBe IE.Dev.MalformedContractId(tooLongHexString)
         }
       }
     }

--- a/sdk/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/sdk/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -514,6 +514,7 @@ object Ast {
   final case object BTextToNumeric
       extends BuiltinFunction // :  ∀s.  Numeric s → Text -> Optional (Numeric s)
   final case object BTextToCodePoints extends BuiltinFunction // : Text -> List Int64
+  final case object BTextToContractId extends BuiltinFunction // : forall a. Text -> ContractId a
 
   final case object BSHA256Text extends BuiltinFunction // : Text -> Text
 

--- a/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/sdk/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -388,6 +388,7 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
     "TEXT_TO_INT64" -> BTextToInt64,
     "TEXT_TO_NUMERIC" -> BTextToNumeric,
     "TEXT_TO_CODE_POINTS" -> BTextToCodePoints,
+    "TEXT_TO_CONTRACT_ID" -> BTextToContractId,
     "ERROR" -> BError,
     "LESS_NUMERIC" -> BLessNumeric,
     "LESS_EQ_NUMERIC" -> BLessEqNumeric,

--- a/sdk/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/sdk/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -227,6 +227,7 @@ class ParsersSpec(majorLanguageVersion: LanguageMajorVersion)
         "TIMESTAMP_TO_TEXT" -> BTimestampToText,
         "PARTY_TO_TEXT" -> BPartyToText,
         "DATE_TO_TEXT" -> BDateToText,
+        "TEXT_TO_CONTRACT_ID" -> BTextToContractId,
         "ERROR" -> BError,
         "LESS_NUMERIC" -> BLessNumeric,
         "LESS_EQ_NUMERIC" -> BLessEqNumeric,

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
@@ -281,6 +281,7 @@ object Error {
       final case class TransactionInputContracts(limit: Int) extends Error
     }
 
+    final case class MalformedContractId(value: String, cause: String) extends Error
   }
 
 }

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
@@ -281,7 +281,7 @@ object Error {
       final case class TransactionInputContracts(limit: Int) extends Error
     }
 
-    final case class MalformedContractId(value: String, cause: String) extends Error
+    final case class MalformedContractId(value: String) extends Error
   }
 
 }

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -192,6 +192,7 @@ object Value {
   sealed abstract class ContractId extends Product with Serializable {
     def coid: String
     def toBytes: Bytes
+    def isLocal: Boolean
     def version: ContractIdVersion
   }
 
@@ -201,6 +202,7 @@ object Value {
         with data.NoCopy {
       override lazy val toBytes: Bytes = V1.prefix ++ discriminator.bytes ++ suffix
       lazy val coid: Ref.HexString = toBytes.toHexString
+      override def isLocal: Boolean = suffix.isEmpty
       override def toString: String = s"ContractId($coid)"
       override def version: ContractIdVersion = ContractIdVersion.V1
     }
@@ -251,6 +253,7 @@ object Value {
     final case class V2 private (local: Bytes, suffix: Bytes) extends ContractId with data.NoCopy {
       override lazy val toBytes: Bytes = V2.prefix ++ local ++ suffix
       lazy val coid: Ref.HexString = toBytes.toHexString
+      override def isLocal: Boolean = suffix.isEmpty
       override def toString: String = s"ContractId($coid)"
       override def version: ContractIdVersion = ContractIdVersion.V2
 

--- a/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/sdk/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -258,6 +258,7 @@ private[validation] object Typing {
         TNumeric(alpha) ->: TText ->: TOptional(TNumeric(alpha)),
       ),
       BTextToCodePoints -> (TText ->: TList(TInt64)),
+      BTextToContractId -> TForall(alpha.name -> KStar, TText ->: TContractId(alpha)),
       BError -> TForall(alpha.name -> KStar, TText ->: alpha),
       // ComparisonsA
       BLessNumeric -> tNumComparison,


### PR DESCRIPTION
This is the first part of #21085, adding `BTextToContractId` as a built-in function in the interpreter. In the second part, I'll add the `BETextToContractId` primitive in damlc.


<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
