### PR TITLE
restore and fix unvetting tests

### DIFF
--- a/sdk/daml-script/test/daml/UpgradeTestLib.daml
+++ b/sdk/daml-script/test/daml/UpgradeTestLib.daml
@@ -17,6 +17,7 @@ module UpgradeTestLib (
   broken,
   brokenOnCanton,
   brokenOnIDELedger,
+  waitForCid,
   withUnvettedPackage,
   withUnvettedPackageOnParticipant,
   module Daml.Script,
@@ -29,6 +30,7 @@ import Daml.Script.Internal
 import DA.Assert
 import DA.Fail
 import DA.Foldable
+import DA.Time
 
 import DA.Text qualified as T
 
@@ -124,3 +126,17 @@ brokenOnIDELedger (name, act) =
     IdeLedger -> brokenScript act testState
     _ -> act testState
   )
+
+waitForCid : (Template t, HasEnsure t) => Party -> ContractId t -> Script ()
+waitForCid = waitManyTimesForCid 20
+
+waitManyTimesForCid : (Template t, HasEnsure t) => Int -> Party -> ContractId t -> Script ()
+waitManyTimesForCid tries p cid
+  | tries <= 0 = abort $ "Cid " <> show cid <> " did not appear"
+  | otherwise = do
+    r <- queryContractId p cid
+    case r of
+      None -> do
+        sleep (milliseconds 200)
+        waitManyTimesForCid (tries - 1) p cid
+      Some _ -> pure ()

--- a/sdk/daml-script/test/daml/UpgradeTestLib.daml
+++ b/sdk/daml-script/test/daml/UpgradeTestLib.daml
@@ -140,3 +140,4 @@ waitManyTimesForCid tries p cid
         sleep (milliseconds 200)
         waitManyTimesForCid (tries - 1) p cid
       Some _ -> pure ()
+      

--- a/sdk/daml-script/test/daml/upgrades/Fetch.daml
+++ b/sdk/daml-script/test/daml/upgrades/Fetch.daml
@@ -144,9 +144,8 @@ main = tests
   , fetchDowngradedSomeDynamicDisclosed
 
   -- TODO(https://github.com/DACH-NY/canton/issues/24950): fix the IDE ledger
-  -- TODO(https://github.com/DACH-NY/canton/issues/25366): re-enable these tests
---  ,  brokenOnIDELedger ("Upgrade a contract when fetching where the source package (V1) is unvetted", fetchUpgradedSourceUnvetted)
---  , brokenOnIDELedger ("Downgrade a contract with Nones when fetching where the source package (V2) is unvetted", fetchDowngradedNoneSourceUnvetted)
+  , brokenOnIDELedger ("Upgrade a contract when fetching where the source package (V1) is unvetted", fetchUpgradedSourceUnvetted)
+  , brokenOnIDELedger ("Downgrade a contract with Nones when fetching where the source package (V2) is unvetted", fetchDowngradedNoneSourceUnvetted)
   ]
 
 exerciseV1Util : Choice V1.FetchHelper c r => Party -> c -> Script r
@@ -232,6 +231,10 @@ fetchDowngradedSomeDynamicDisclosed = mkFetchDowngradedSome "dynamic disclosed" 
   let cidIface = coerceContractId @V2.FetchTemplate @FetchIface cid
   (actAs b <> packagePreference [fetchV1] <> disclose disclosureCid) `trySubmit` exerciseExactCmd helperCid (V1.DoFetchIfaceWithCtl cidIface b)
 
+expectPackageNotVetted (Right _) = fail "Expected failure, got success."
+expectPackageNotVetted (Left (UnknownError (isInfixOf "PACKAGE_NOT_VETTED_BY_RECIPIENTS" -> True))) = pure ()
+expectPackageNotVetted (Left e) = fail $ "Expected package missing error, got " <> show e
+
 fetchUpgradedSourceUnvetted : Test
 fetchUpgradedSourceUnvetted = test $ do
   a <- allocatePartyOn "alice" participant0
@@ -241,9 +244,7 @@ fetchUpgradedSourceUnvetted = test $ do
   withUnvettedPackageOnParticipant "fetch" "1.0.0" participant0 $ do
     let v2Cid = coerceContractId @V1.FetchTemplate @V2.FetchTemplate cid
     res <- a `tryExerciseV2Util` V2.DoFetch with cid = v2Cid
-    case res of
-      Right v2Name -> v2Name === V2.FetchTemplate with party = a, newField = None
-      Left err -> assertFail $ "Expected success but got " <> show err
+    expectPackageNotVetted res
 
 fetchDowngradedNoneSourceUnvetted : Test
 fetchDowngradedNoneSourceUnvetted = test $ do
@@ -254,7 +255,4 @@ fetchDowngradedNoneSourceUnvetted = test $ do
   withUnvettedPackageOnParticipant "fetch" "2.0.0" participant0 $ do
     let v1Cid = coerceContractId @V2.FetchTemplate @V1.FetchTemplate cid
     res <- a `tryExerciseV1Util` V1.DoFetch with cid = v1Cid
-
-    case res of
-      Right v1Name -> v1Name === V1.FetchTemplate with party = a
-      Left err -> assertFail $ "Expected success but got " <> show err
+    expectPackageNotVetted res

--- a/sdk/daml-script/test/daml/upgrades/Interfaces.daml
+++ b/sdk/daml-script/test/daml/upgrades/Interfaces.daml
@@ -222,9 +222,7 @@ main = tests
   , ("queryInterfaceContractId works as intended in the presence of upgraded packages with new interface instances", queryNewInterfaceUpgrades)
   , ("fetchFromInterface works as intended in the presence of upgraded packages with new interface instances", fetchFromNewInterfaceUpgrades)
   -- IDE Ledger doesn't support unvetting
-  -- Can't unvet old version of package on 3x, even though v2 exists.
-  -- TODO(https://github.com/DACH-NY/canton/issues/25366): re-enable this test
-  --, brokenOnIDELedger ("Can fetch interface from V1 contract when V1 unvetted", fetchWithoutV1)
+  , brokenOnIDELedger ("Can fetch interface from V1 contract when V1 unvetted", fetchWithoutV1)
   ]
 
 setupAliceAndInterface : Script (Party, ContractId I)
@@ -415,5 +413,9 @@ fetchWithoutV1 : Test
 fetchWithoutV1 = test $ do
   (alice, icid) <- setupAliceAndInterface
   withUnvettedPackageOnParticipant "interfaces" "1.0.0" participant0 $ do
-    alice `submit` createAndExerciseCmd (V2.FITemplate alice None) (V2.FetchInterface icid)
-  pure ()
+    res <- alice `trySubmit` createAndExerciseCmd (V2.FITemplate alice None) (V2.FetchInterface icid)
+    expectPackageNotVetted res
+ where
+  expectPackageNotVetted (Right _) = fail "Expected failure, got success."
+  expectPackageNotVetted (Left (UnknownError (isInfixOf "PACKAGE_NOT_VETTED_BY_RECIPIENTS" -> True))) = pure ()
+  expectPackageNotVetted (Left e) = fail $ "Expected package missing error, got " <> show e

--- a/sdk/daml-script/test/daml/upgrades/LedgerApiChoiceNestedUpgrade.daml
+++ b/sdk/daml-script/test/daml/upgrades/LedgerApiChoiceNestedUpgrade.daml
@@ -56,8 +56,7 @@ main = tests
   , ("Explicitly call a V2 choice on a V1 contract over the ledger-api, expect V2 implementation used, and contract upgraded. (Nested)", explicitV2ChoiceV1ContractNested)
   , ("Call a V1 choice without package ID on a V1 contract over the ledger-api, expect V2 implementation used, contract + argument upgraded, daml-script downgrades return type. (Nested)", inferredV1ChoiceV1ContractNested)
   , ("Call a V2 choice without package ID on a V1 contract over the ledger-api, expect V2 implementation used, and contract upgraded. (Nested)", inferredV2ChoiceV1ContractNested)
-  -- TODO(https://github.com/DACH-NY/canton/issues/25366): re-enable this test
-  -- , ("Call a V2 choice without package ID on a V1 contract over the ledger-api, with V2 unvetted, expect V1 implementation used, argument downgraded, daml-script upgrades return type. (Nested)", inferredV1ChoiceV1ContractWithoutV2Nested)
+   , ("Call a V2 choice without package ID on a V1 contract over the ledger-api, with V2 unvetted, expect V1 implementation used, argument downgraded, daml-script upgrades return type. (Nested)", inferredV1ChoiceV1ContractWithoutV2Nested)
   , ("Explicitly call a V1 choice on a V2 contract over the ledger-api, expect V1 implementation used, and contract downgraded. (Nested)", explicitV1ChoiceV2ContractNested)
   , ("Explicitly call a V2 choice on a V2 contract over the ledger-api, expect V2 implementation used. (Nested)", explicitV2ChoiceV2ContractNested)
   ]

--- a/sdk/daml-script/test/daml/upgrades/MultiParticipant.daml
+++ b/sdk/daml-script/test/daml/upgrades/MultiParticipant.daml
@@ -32,8 +32,8 @@ main : TestTree
 main = tests
   [ ("Both participants have v2, upgraded create succeeds.", bothParticipantsV2)
   -- TODO(https://github.com/DACH-NY/canton/issues/25366): re-enable these tests
-  --, brokenOnIDELedger ("Submitting participant has v2, other has v1, expect v1 used.", submitV2OtherV1)
-  --, brokenOnIDELedger ("Submitting participant has v1, other has v2, expect v1 used.", submitV1OtherV2)
+  , brokenOnIDELedger ("Submitting participant has v2, other has v1, expect v1 used.", submitV2OtherV1)
+  , brokenOnIDELedger ("Submitting participant has v1, other has v2, expect v1 used.", submitV1OtherV2)
   ]
 
 bothParticipantsV2 : Test

--- a/sdk/daml-script/test/daml/upgrades/PackageSelection.daml
+++ b/sdk/daml-script/test/daml/upgrades/PackageSelection.daml
@@ -27,10 +27,7 @@ contents: |
 -}
 
 main : TestTree
-main = tests []
-
--- TODO(https://github.com/DACH-NY/canton/issues/25366): re-enable these tests
-toRestore =
+main = tests
   [ brokenOnIDELedger ("Chooses the v1 contract if v2 is unvetted and package id is omitted.", packageSelectionChoosesVettedPackages)
   , brokenOnIDELedger ("Fails when exercising an interface choice on a contract whose creation package is missing", exercisingInterfaceWithMissingInstanceFails)
   , brokenOnIDELedger ("Fails when trying to fetch a contract by interface whose creation package is missing", fetchingInterfaceWithMissingImplementationFails)

--- a/sdk/daml-script/test/daml/upgrades/UnvettedPackages.daml
+++ b/sdk/daml-script/test/daml/upgrades/UnvettedPackages.daml
@@ -15,10 +15,7 @@ import DA.Time (seconds)
 
 -- These tests rely on unvetting, none of them will work on IDE
 main : TestTree
-main = tests $ []
-
--- TODO(https://github.com/DACH-NY/canton/issues/25366): re-enable these tests
-toRestore =
+main = tests $
   [ subtree "exercise"
     -- TODO(https://github.com/DACH-NY/canton/issues/25018): All thes transactions below are expected to fail but succeed.
     [ broken ("Exercise a choice against a V1 contract with V1 unvetted on submitter via Command (should change the expectation to fails)", v1UnvettedOnSubmitterCommand)
@@ -258,7 +255,9 @@ unvettedTest makeSubmission assertResult participant sigs obs = do
   -- and as such, cannot have their signatures included simply using `submitMulti`
   cidV1 <-
     foldlA
-      (\cid p -> p `submit` exerciseExactCmd cid V1.PromoteObserver with newSig = p)
+      (\cid p -> do
+        waitForCid p cid
+        p `submit` exerciseExactCmd cid V1.PromoteObserver with newSig = p)
       cidV1Prelim
       sigs
   let cidV2 = coerceContractId @V1.TestTemplate @V2.TestTemplate cidV1
@@ -429,6 +428,7 @@ fetchDisclosedSubmitter participant makeChoice = test $ do
       disclosure <- fromSome <$> queryDisclosure alice cidV2
       -- Setup helper with alice as a signatory, so the disclosure can be fetched
       cidWithoutAlice <- bob `submit` createCmd ((testTemplateHelper bob) with obs = [alice])
+      waitForCid alice cidWithoutAlice
       cidWithAlice <- alice `submit` exerciseExactCmd cidWithoutAlice HelperPromoteObserver with newSig = alice
       (actAs bob <> disclose disclosure) `trySubmit` exerciseCmd cidWithAlice (makeChoice cidV2 iid)
     )


### PR DESCRIPTION
https://github.com/digital-asset/daml/pull/21081 disabled all daml-script test using unvetting because some of them had become apparently flaky. It turns out that:
- Interfaces.daml was not flaky but consistently failing after https://github.com/DACH-NY/canton/pull/25184. This PR changes the test to expect a failure, as it should now.
- Fetch.daml was failing for the same reason. Fixed the test expectations.
- Unvetting.daml was flaky but for a reason unrelated to unvetting: it creates a contract on participant0 and immediately exercises a choice on it on participant1 without waiting for the contract to propagate. For some reason the code drop increased the likelihood of this to happen. I now properly wait for the contract to be visible.
- The other tests involving unvetting were fine and I restore them here too.