### PR TITLE
IDE ledger adds suffix on committed contract IDs

### DIFF
--- a/sdk/daml-lf/ide-ledger/BUILD.bazel
+++ b/sdk/daml-lf/ide-ledger/BUILD.bazel
@@ -34,6 +34,7 @@ da_scala_library(
         "//daml-lf/transaction",
         "//libs-scala/contextualized-logging",
         "//libs-scala/scala-utils",
+        "@maven//:com_google_protobuf_protobuf_java",
     ],
 )
 

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -81,7 +81,7 @@ class IdeLedgerClient(
   private[this] def makePreprocessor =
     new preprocessing.CommandPreprocessor(
       compiledPackages.pkgInterface,
-      requireContractIdSuffix = false,
+      requireContractIdSuffix = true,
     )
 
   // Given a set of disabled packages, filter out all definitions from those packages from the original compiled packages


### PR DESCRIPTION
Before `IdeLedgerRunner` commits a transaction, it adds a 00 suffix to all new contract IDs. Also, its `CommandPreprocessor`now checks that all contract IDs have a suffix.

This PR is needed to test that we can convert a `Text` to `ContractId` only if it's a global `ContractId`.
```haskell
main = script do
  p <- allocateParty "alice"
  cid1 <- p `submit` createCmd (A p)
  let hid1 = show cid1
  fromHex hid1 === cid1 // should succeed
```

I'll push this test in a subsequent PR, that also defines `HasFromHex (ContractId a)`



<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
