### PR TITLE
Restore deleted javadoc files

### DIFF
--- a/sdk/docs/BUILD.bazel
+++ b/sdk/docs/BUILD.bazel
@@ -252,8 +252,6 @@ genrule(
     # Copy Javadoc using unzip to avoid having to know the path to the 'jar' binary. Note flag to overwrite
     unzip -q -o $(locations //language-support/java:javadoc) -d $$DIR/html/sdk/sdlc-howtos/applications/integrate/bindings-java/javadocs
     # Remove JAR metadata
-    rm -r $$DIR/html/sdk/sdlc-howtos/applications/integrate/bindings-java/javadocs/com/daml/ledger/api/v2/interactive/transaction/v1/InteractiveSubmissionDataOuterClass* \
-          $$DIR/html/sdk/sdlc-howtos/applications/integrate/bindings-java/javadocs/com/daml/ledger/api/v2/interactive/transaction/v1/class-use/InteractiveSubmissionDataOuterClass*
     rm -r $$DIR/html/sdk/sdlc-howtos/applications/integrate/bindings-java/javadocs/META-INF
 
     # Copy generated documentation for typescript libraries


### PR DESCRIPTION
Restored the previously deleted javadocs. Without it, the links in https://docs.digitalasset-staging.com/javadocs/3.3/com/daml/ledger/api/v2/interactive/transaction/v1/package-summary are not working.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
