### PR TITLE
Fix reporting `UpgradeError` and `CryptoError` in Daml Studio

### DIFF
--- a/sdk/compiler/damlc/tests/daml-test-files/CCTPMintToken.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/CCTPMintToken.daml
@@ -37,72 +37,93 @@ template MintToken with
     signatory owner
     ensure secp256k1 signature (keccak256 (serialize burnMessage)) publicKey
 
+burnMessage1 = BurnMessage with
+  version = "00000001"
+  burnToken = "3517c087b52939457009670b62e4ebed4f0460beb6aa6323aca9055cb466b8fe"
+  mintRecipient = "19da614fb886703d58063b8d45974f5625e9189f24bab2209277f28506798e33"
+  amount = "0000000000000000000000000000000000000000000000000000000000000001"
+  messageSender = "b05b55170b4fb7095ed658e521b491fb0de98f47947f455e416c4cdbc1446518"
+privateKey1 = "30818d020100301006072a8648ce3d020106052b8104000a0476307402010104207308c95bf6e240ed8de37b5a7c5f453d88ece2b5e93c02ef985e8553f856474aa00706052b8104000aa144034200043f4ae6efb79de2cf60636219110f11b695d5c1776c0b0dad1468672fba1c6f6acf79396b8403e110cbf60ccd7aefab4c541d49844a51049fcbd22dae1a51d681"
+publicKey1 = "3056301006072a8648ce3d020106052b8104000a034200043f4ae6efb79de2cf60636219110f11b695d5c1776c0b0dad1468672fba1c6f6acf79396b8403e110cbf60ccd7aefab4c541d49844a51049fcbd22dae1a51d681"
+signature1 = "3046022100bdbe3c37aa32885baedc4f3b6a6fdf3064ccb841e1ed7e269b8735b289743a4c0221009d31a1fe4175a2133d74dabf75afb77aec8eeb40d3089487d9333d05ae13793c"
+expectedDigest = "b03c694bc07762ef8f08a0260d68dd6ecc9da10a6fe1c1abfb6a21f71e88ff1c"
+
 main =
-  let burnMessage = BurnMessage with
-        version = "00000001"
-        burnToken = "3517c087b52939457009670b62e4ebed4f0460beb6aa6323aca9055cb466b8fe"
-        mintRecipient = "19da614fb886703d58063b8d45974f5625e9189f24bab2209277f28506798e33"
-        amount = "0000000000000000000000000000000000000000000000000000000000000001"
-        messageSender = "b05b55170b4fb7095ed658e521b491fb0de98f47947f455e416c4cdbc1446518"
-      spoofBurnMessage = BurnMessage with
-        version = "00000001"
-        burnToken = "3517c087b52939457009670b62e4ebed4f0460beb6aa6323aca9055cb466b8fe"
-        mintRecipient = "19da614fb886703d58063b8d45974f5625e9189f24bab2209277f28506798e33"
-        amount = "1000000000000000000000000000000000000000000000000000000000000000"
-        messageSender = "b05b55170b4fb7095ed658e521b491fb0de98f47947f455e416c4cdbc1446518"
-      privateKey = "30818d020100301006072a8648ce3d020106052b8104000a0476307402010104207308c95bf6e240ed8de37b5a7c5f453d88ece2b5e93c02ef985e8553f856474aa00706052b8104000aa144034200043f4ae6efb79de2cf60636219110f11b695d5c1776c0b0dad1468672fba1c6f6acf79396b8403e110cbf60ccd7aefab4c541d49844a51049fcbd22dae1a51d681"
-      publicKey = "3056301006072a8648ce3d020106052b8104000a034200043f4ae6efb79de2cf60636219110f11b695d5c1776c0b0dad1468672fba1c6f6acf79396b8403e110cbf60ccd7aefab4c541d49844a51049fcbd22dae1a51d681"
-      invalidPublicKey = "30569f300d06092a864886f70d010101050003818d00308189028181009107a23dd899451c443f40f00c43361b5476794ba1c04b83da5a46dc8c6b7ff86e58de42a0a798fc4a85d8b3c63f75b5410a76f2e501c86de2eeeb"
-      incorrectPublicKey = "3056301006072a8648ce3d020106052b8104000a03420004c1741ea55443e7f2a93673b176d4fa6af7b53492b3ebe72e858561ca6280f4d2c5ed8d7bf6897d70ac105a992812a7a5ab1689867d0ac730ee119c60e5646c10"
-      expectedDigest = "b03c694bc07762ef8f08a0260d68dd6ecc9da10a6fe1c1abfb6a21f71e88ff1c"
-      burnMessageSignature = "3046022100bdbe3c37aa32885baedc4f3b6a6fdf3064ccb841e1ed7e269b8735b289743a4c0221009d31a1fe4175a2133d74dabf75afb77aec8eeb40d3089487d9333d05ae13793c"
-      malformedSignature = "3046beefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
-      invalidSignature = "30450221009944dfb75e1e46006dd6922ba41145ab47dd00da2af75027a95589764fb5e72902200ac5c17d31d102dbdde75e4f5809dccbba9a118cf4a6bffd50108e8444bb69b5"
+  script do
+    ((keccak256 (serialize burnMessage1)) === expectedDigest)
+
+    testKeyPair <- secp256k1generatekeypair
+    testKeyPairSignature <- secp256k1sign testKeyPair.privateKey expectedDigest
+    (secp256k1 testKeyPairSignature expectedDigest testKeyPair.publicKey === True)
+
+    actualSignature <- secp256k1sign privateKey1 expectedDigest
+    (signature1 === actualSignature)
+    alice <- allocateParty "Alice"
+    submit alice do
+      createCmd MintToken with
+        publicKey = publicKey1
+        burnMessage = burnMessage1
+        signature = signature1
+        owner = alice
+
+spoofBurnMessageMustFail =
+  let
+    spoofBurnMessage = BurnMessage with
+      version = "00000001"
+      burnToken = "3517c087b52939457009670b62e4ebed4f0460beb6aa6323aca9055cb466b8fe"
+      mintRecipient = "19da614fb886703d58063b8d45974f5625e9189f24bab2209277f28506798e33"
+      amount = "1000000000000000000000000000000000000000000000000000000000000000"  
+      messageSender = "b05b55170b4fb7095ed658e521b491fb0de98f47947f455e416c4cdbc1446518"
   in
     script do
-      ((keccak256 (serialize burnMessage)) === expectedDigest)
-
-      testKeyPair <- secp256k1generatekeypair
-      testKeyPairSignature <- secp256k1sign testKeyPair.privateKey expectedDigest
-      (secp256k1 testKeyPairSignature expectedDigest testKeyPair.publicKey === True)
-
-      actualBurnMessageSignature <- secp256k1sign privateKey expectedDigest
-      (burnMessageSignature === actualBurnMessageSignature)
       alice <- allocateParty "Alice"
       submitMustFail alice do
         createCmd MintToken with
-          publicKey = publicKey
+          publicKey = publicKey1
           burnMessage = spoofBurnMessage
-          signature = burnMessageSignature
+          signature = signature1
           owner = alice
-      submitMustFail alice do
-        createCmd MintToken with
-          publicKey = incorrectPublicKey
-          burnMessage = burnMessage
-          signature = burnMessageSignature
-          owner = alice
-      submitMustFail alice do
-        createCmd MintToken with
-          publicKey = publicKey
-          burnMessage = burnMessage
-          signature = invalidSignature
-          owner = alice
-      submitMustFail alice do
-        createCmd MintToken with
-          publicKey = invalidPublicKey
-          burnMessage = burnMessage
-          signature = burnMessageSignature
-          owner = alice
-      submitMustFail alice do
-        createCmd MintToken with
-          publicKey = publicKey
-          burnMessage = burnMessage
-          signature = malformedSignature
-          owner = alice
-      _ <- submit alice do
-        createCmd MintToken with
-          publicKey = publicKey
-          burnMessage = burnMessage
-          signature = burnMessageSignature
-          owner = alice
-      pure ()
+
+-- precondition fails
+incorrectPublicKeyMustFail =
+  script do
+    alice <- allocateParty "Alice"
+    submitMustFail alice do
+      createCmd MintToken with
+        publicKey = "3056301006072a8648ce3d020106052b8104000a03420004c1741ea55443e7f2a93673b176d4fa6af7b53492b3ebe72e858561ca6280f4d2c5ed8d7bf6897d70ac105a992812a7a5ab1689867d0ac730ee119c60e5646c10"
+        burnMessage = burnMessage1
+        signature = signature1
+        owner = alice
+
+-- precondition fails
+invalidSignatureMustFail =
+  script do
+    alice <- allocateParty "Alice"
+    submitMustFail alice do
+      createCmd MintToken with
+        publicKey = publicKey1
+        burnMessage = burnMessage1
+        signature = "30450221009944dfb75e1e46006dd6922ba41145ab47dd00da2af75027a95589764fb5e72902200ac5c17d31d102dbdde75e4f5809dccbba9a118cf4a6bffd50108e8444bb69b5"
+        owner = alice
+
+-- @ERROR range=110:1-110:25; Malformed public key for 30569f300d06092a864886f70d010101050003818d00308189028181009107a23dd899451c443f40f00c43361b5476794ba1c04b83da5a46dc8c6b7ff86e58de42a0a798fc4a85d8b3c63f75b5410a76f2e501c86de2eeeb
+invalidPublicKeyMustFail =
+  script do
+    alice <- allocateParty "Alice"
+    submit alice do
+      createCmd MintToken with
+        publicKey = "30569f300d06092a864886f70d010101050003818d00308189028181009107a23dd899451c443f40f00c43361b5476794ba1c04b83da5a46dc8c6b7ff86e58de42a0a798fc4a85d8b3c63f75b5410a76f2e501c86de2eeeb"
+        burnMessage = burnMessage1
+        signature = signature1
+        owner = alice
+
+-- @ERROR range=121:1-121:27; Malformed signature for 3046beefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+malformedSignatureMustFail =
+  script do
+    alice <- allocateParty "Alice"
+    submit alice do
+      createCmd MintToken with
+        publicKey = publicKey1
+        burnMessage = burnMessage1
+        signature = "3046beefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        owner = alice

--- a/sdk/compiler/script-service/client/src/DA/Daml/LF/PrettyScript.hs
+++ b/sdk/compiler/script-service/client/src/DA/Daml/LF/PrettyScript.hs
@@ -546,6 +546,9 @@ prettyScriptErrorError lvl (Just err) =  do
         [ "Malformed contract id:"
         , label_ "Contract id:" $ ltext scriptError_MalformedContractIdValue
         ]
+    ScriptErrorErrorCryptoError ScriptError_CryptoError {..} -> do
+      pure $ text $ TL.toStrict scriptError_CryptoErrorMessage
+
 
 partyDifference :: V.Vector Party -> V.Vector Party -> Doc SyntaxClass
 partyDifference with without =

--- a/sdk/compiler/script-service/protos/script_service.proto
+++ b/sdk/compiler/script-service/protos/script_service.proto
@@ -388,7 +388,8 @@ message ScriptError {
     UpgradeError upgrade_error = 44;
     FailureStatusError failure_status_error = 45;
     MalformedContractId malformed_contract_id = 47;
-    // next is 48;
+    CryptoError crypto_error = 48;
+    // next is 49;
   }
 }
 

--- a/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/Conversions.scala
+++ b/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/Conversions.scala
@@ -284,8 +284,10 @@ final class Conversions(
                     )
                 }
               case _: Upgrade =>
-                proto.ScriptError.UpgradeError.newBuilder.setMessage(
-                  speedy.Pretty.prettyDamlException(interpretationError).render(80)
+                builder.setUpgradeError(
+                  proto.ScriptError.UpgradeError.newBuilder.setMessage(
+                    speedy.Pretty.prettyDamlException(interpretationError).render(80)
+                  )
                 )
               case _: Crypto =>
                 proto.ScriptError.CryptoError.newBuilder.setMessage(

--- a/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/Conversions.scala
+++ b/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/Conversions.scala
@@ -290,8 +290,10 @@ final class Conversions(
                   )
                 )
               case _: Crypto =>
-                proto.ScriptError.CryptoError.newBuilder.setMessage(
-                  speedy.Pretty.prettyDamlException(interpretationError).render(80)
+                builder.setCryptoError(
+                  proto.ScriptError.CryptoError.newBuilder.setMessage(
+                    speedy.Pretty.prettyDamlException(interpretationError).render(80)
+                  )
                 )
               case err @ Dev(_, _) =>
                 builder.setCrash(s"Unexpected Dev error: " + err.toString)


### PR DESCRIPTION
This is the quick fix for #21120.

I added some checks in daml test files for Crypto errors. For upgrade errors, we don't yet have the test infrastructure, but I'll check manually that it works as expected.

I'll work on splitting the upgrade and crypto errors in different data variants in a subsequent PR.