### PR TITLE
Fix publishing to Google OCI Registry

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,17 +130,16 @@ jobs:
       condition: and(succeeded(), not(eq(variables['skip-github'], 'TRUE')))
     - bash: |
         set -euo pipefail
-        # Note: The last branch that doesn't have the sdk subdirectory is 2.7.x,
-        # and I don't think we're planning any releases from that branch
-        cd sdk || exit 1
         # Note: this gets dev-env from the release commit, not the trigger commit
-        eval "$(./dev-env/bin/dade-assist)"
-        source $(bash-lib)
-        wrap_gcloud "$GCRED" "./ci/get-unifi.sh" 
-        ./ci/publish-oci.sh $(Build.StagingDirectory) $(release_tag) $REGISTRY
+        eval "$(cd sdk; ./dev-env/bin/dade-assist)"
+        # Authorize in GCLOUD
+        gcloud beta auth activate-service-account --key-file=<(echo "${GOOGLE_APPLICATION_CREDENTIALS_CONTENT}")
+        gcloud auth configure-docker europe-docker.pkg.dev
+        ./ci/get-unifi.sh "europe-docker.pkg.dev/da-images-dev/oci-playground/components/assistant:latest" 
+        ./ci/publish-oci.sh $(Build.StagingDirectory) $(release_tag) ${REGISTRY}
       name: publish_to_oci
       env:
-        GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
+        GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
         REGISTRY: "europe-docker.pkg.dev/da-images-dev/oci-private"
       condition: and(succeeded(), not(eq(variables['skip-github'], 'TRUE')))
     - bash: |

--- a/ci/split-release-job.yml
+++ b/ci/split-release-job.yml
@@ -118,12 +118,14 @@ jobs:
         set -euo pipefail
         # Note: this gets dev-env from the release commit, not the trigger commit
         eval "$(cd sdk; ./dev-env/bin/dade-assist)"
-        source $(bash-lib)
-        wrap_gcloud "$GCRED" "./ci/get-unifi.sh"
-        ./ci/publish-oci.sh $(Build.StagingDirectory) $(release_tag) $REGISTRY
+        # Authorize in GCLOUD
+        gcloud beta auth activate-service-account --key-file=<(echo "${GOOGLE_APPLICATION_CREDENTIALS_CONTENT}")
+        gcloud auth configure-docker europe-docker.pkg.dev
+        ./ci/get-unifi.sh "europe-docker.pkg.dev/da-images-dev/oci-playground/components/assistant:latest" 
+        ./ci/publish-oci.sh $(Build.StagingDirectory) $(release_tag) ${REGISTRY}
       name: publish_to_oci
       env:
-        GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
+        GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
         REGISTRY: "europe-docker.pkg.dev/da-images-dev/oci-private"
     - bash: |
         set -euo pipefail


### PR DESCRIPTION
Fix publishing to Google OCI Registry

* Fix auth in GLOUD for get `unifi`

* Use `oras` from Microsoft-hosted agents used for Azure Pipelines