### PR TITLE
Backport #21134 to 2.10: Fix reporting of upgrade error in DAML studio

### DIFF
--- a/sdk/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/sdk/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -268,8 +268,10 @@ final class Conversions(
                     )
                 }
               case _: Upgrade =>
-                proto.ScenarioError.UpgradeError.newBuilder.setMessage(
-                  speedy.Pretty.prettyDamlException(interpretationError).render(80)
+                builder.setUpgradeError(
+                  proto.ScenarioError.UpgradeError.newBuilder.setMessage(
+                    speedy.Pretty.prettyDamlException(interpretationError).render(80)
+                  )
                 )
               case err @ Dev(_, _) =>
                 builder.setCrash(s"Unexpected Dev error: " + err.toString)


### PR DESCRIPTION
Backport of #21134 to 2.10, but only for `UpgradeError` (`CryptoError` did not exist at the time).

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
