### PR TITLE
Disable exercise of LF 1.15 interfaces with LF 1.17 implementation.

### DIFF
--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
@@ -158,6 +158,9 @@ object RejectionGenerators {
             ) =>
           CommandExecutionErrors.Interpreter.UpgradeError.DowngradeFailed
             .Reject(renderedMessage, error)
+        case error: LfInterpretationError.DisallowedInterfaceExercise =>
+          CommandExecutionErrors.Interpreter.DisallowedInterfaceExercise
+            .Reject(renderedMessage, error)
         case LfInterpretationError.Dev(_, err) =>
           CommandExecutionErrors.Interpreter.InterpretationDevError
             .Reject(renderedMessage, err)

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
@@ -801,6 +801,32 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
     }
 
     @Explanation(
+      "Exercise an LF 1.15 interface implemented by an LF 1.17 (or newer) template is disallowed since 2.10.1"
+    )
+    @Resolution(
+      "Use LF 1.17 for the interface definition."
+    )
+    object DisallowedInterfaceExercise
+      extends ErrorCode(
+        id = "DISALLOWED_INTERFACE_EXERCISE",
+        ErrorCategory.InvalidGivenCurrentSystemStateOther,
+      ) {
+
+      final case class Reject(
+                               override val cause: String,
+                               err: LfInterpretationError.DisallowedInterfaceExercise,
+                             )(implicit
+                               loggingContext: ContextualizedErrorLogger
+                             ) extends DamlErrorWithDefiniteAnswer(
+        cause = cause
+      ) {
+
+        override def resources: Seq[Nothing] =
+          Seq()
+      }
+    }
+
+    @Explanation(
       """This error is a catch-all for errors thrown by in-development features, and should never be thrown in production."""
     )
     @Resolution(

--- a/sdk/compiler/damlc/tests/BUILD.bazel
+++ b/sdk/compiler/damlc/tests/BUILD.bazel
@@ -211,6 +211,20 @@ da_haskell_library(
     for version in LEGACY_DAML_SCRIPT_LF_VERSIONS
 ]
 
+daml_compile(
+    name = "iface15",
+    srcs = ["daml/Interface15.daml"],
+    target = "1.15",
+)
+
+daml_compile(
+    name = "tmpl17",
+    srcs = ["daml/Template17.daml"],
+    data_dependencies = ["//daml-script/test:iface15.dar"],
+    dependencies = ["//daml-script/daml:daml-script.dar"],
+    target = "1.17",
+)
+
 [
     da_haskell_test(
         name = "integration-script2-{}".format(mangle_for_damlc(version)),

--- a/sdk/compiler/damlc/tests/BUILD.bazel
+++ b/sdk/compiler/damlc/tests/BUILD.bazel
@@ -211,20 +211,6 @@ da_haskell_library(
     for version in LEGACY_DAML_SCRIPT_LF_VERSIONS
 ]
 
-daml_compile(
-    name = "iface15",
-    srcs = ["daml/Interface15.daml"],
-    target = "1.15",
-)
-
-daml_compile(
-    name = "tmpl17",
-    srcs = ["daml/Template17.daml"],
-    data_dependencies = ["//daml-script/test:iface15.dar"],
-    dependencies = ["//daml-script/daml:daml-script.dar"],
-    target = "1.17",
-)
-
 [
     da_haskell_test(
         name = "integration-script2-{}".format(mangle_for_damlc(version)),

--- a/sdk/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/sdk/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -525,7 +525,7 @@ prettyScenarioErrorError lvl (Just err) =  do
         ]
     ScenarioErrorErrorUpgradeError ScenarioError_UpgradeError {..} -> do
        pure $ text $ TL.toStrict scenarioError_UpgradeErrorMessage
-    ScenarioErrorErrorDisallowInterfaceExercise (ScenarioError_DisallowInterfaceExercise coid ifaceId choiceName templId) -> do
+    ScenarioErrorErrorDisallowedInterfaceExercise (ScenarioError_DisallowedInterfaceExercise coid ifaceId choiceName templId) -> do
       pure $ vcat
         [ "Attempted to exercise an LF 1.15 interface implemented by an LF 1.17 (or newer) template, but this operation is disallowed since 2.10.1"
         , label_ "Contract: " $

--- a/sdk/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/sdk/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -525,6 +525,17 @@ prettyScenarioErrorError lvl (Just err) =  do
         ]
     ScenarioErrorErrorUpgradeError ScenarioError_UpgradeError {..} -> do
        pure $ text $ TL.toStrict scenarioError_UpgradeErrorMessage
+    ScenarioErrorErrorDisallowInterfaceExercise (ScenarioError_DisallowInterfaceExercise coid ifaceId choiceName templId) -> do
+      pure $ vcat
+        [ "Attempted to exercise an LF 1.15 interface implemented by an LF 1.17 (or newer) template, but this operation is disallowed since 2.10.1"
+        , label_ "Contract: " $
+            prettyMay "<missing contract>"
+              (prettyContractRef lvl world) coid
+        , label_ "Choice:" $ prettyChoiceId world ifaceId choiceName
+        , label_ "Template:" $
+            prettyMay "<missing template id>"
+              (prettyDefName lvl world) templId
+        ]
 partyDifference :: V.Vector Party -> V.Vector Party -> Doc SyntaxClass
 partyDifference with without =
   fcommasep $ map prettyParty $ S.toList $

--- a/sdk/compiler/scenario-service/protos/scenario_service.proto
+++ b/sdk/compiler/scenario-service/protos/scenario_service.proto
@@ -278,7 +278,7 @@ message ScenarioError {
     string message = 1;
   }
 
-  message DisallowInterfaceExercise {
+  message DisallowedInterfaceExercise {
     ContractRef contract_ref = 1;
     Identifier interface_id = 2;
     string choice_id = 3;
@@ -380,7 +380,7 @@ message ScenarioError {
     Empty cancelledByRequest = 41;
     LookupError lookup_error = 43;
     UpgradeError upgrade_error = 44;
-    DisallowInterfaceExercise disallow_interface_exercise = 45;
+    DisallowedInterfaceExercise disallowed_interface_exercise = 45;
     // next is 46;
   }
 }

--- a/sdk/compiler/scenario-service/protos/scenario_service.proto
+++ b/sdk/compiler/scenario-service/protos/scenario_service.proto
@@ -278,6 +278,13 @@ message ScenarioError {
     string message = 1;
   }
 
+  message DisallowInterfaceExercise {
+    ContractRef contract_ref = 1;
+    Identifier interface_id = 2;
+    string choice_id = 3;
+    Identifier template_id = 4;
+  }
+
   message LookupError {
     message NotFound {
       string not_found = 1;
@@ -373,7 +380,8 @@ message ScenarioError {
     Empty cancelledByRequest = 41;
     LookupError lookup_error = 43;
     UpgradeError upgrade_error = 44;
-    // next is 45;
+    DisallowInterfaceExercise disallow_interface_exercise = 45;
+    // next is 46;
   }
 }
 

--- a/sdk/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/sdk/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -271,9 +271,9 @@ final class Conversions(
                 proto.ScenarioError.UpgradeError.newBuilder.setMessage(
                   speedy.Pretty.prettyDamlException(interpretationError).render(80)
                 )
-              case DisallowInterfaceExercise(cid, ifaceId, tmplId) =>
-                builder.setDisallowInterfaceExercise(
-                  proto.ScenarioError.DisallowInterfaceExercise.newBuilder
+              case DisallowedInterfaceExercise(cid, ifaceId, tmplId) =>
+                builder.setDisallowedInterfaceExercise(
+                  proto.ScenarioError.DisallowedInterfaceExercise.newBuilder
                     .setContractRef(mkContractRef(cid, tmplId))
                     .setInterfaceId(convertIdentifier(ifaceId))
                 )

--- a/sdk/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/sdk/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -271,10 +271,11 @@ final class Conversions(
                 proto.ScenarioError.UpgradeError.newBuilder.setMessage(
                   speedy.Pretty.prettyDamlException(interpretationError).render(80)
                 )
-              case DisallowedInterfaceExercise(cid, ifaceId, tmplId) =>
+              case DisallowedInterfaceExercise(cid, ifaceId, choiceName, tmplId) =>
                 builder.setDisallowedInterfaceExercise(
                   proto.ScenarioError.DisallowedInterfaceExercise.newBuilder
                     .setContractRef(mkContractRef(cid, tmplId))
+                    .setChoiceId(choiceName)
                     .setInterfaceId(convertIdentifier(ifaceId))
                 )
               case err @ Dev(_, _) =>

--- a/sdk/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/sdk/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -271,6 +271,12 @@ final class Conversions(
                 proto.ScenarioError.UpgradeError.newBuilder.setMessage(
                   speedy.Pretty.prettyDamlException(interpretationError).render(80)
                 )
+              case DisallowInterfaceExercise(cid, ifaceId, tmplId) =>
+                builder.setDisallowInterfaceExercise(
+                  proto.ScenarioError.DisallowInterfaceExercise.newBuilder
+                    .setContractRef(mkContractRef(cid, tmplId))
+                    .setInterfaceId(convertIdentifier(ifaceId))
+                )
               case err @ Dev(_, _) =>
                 builder.setCrash(s"Unexpected Dev error: " + err.toString)
             }

--- a/sdk/daml-lf/engine/BUILD.bazel
+++ b/sdk/daml-lf/engine/BUILD.bazel
@@ -130,6 +130,7 @@ da_scala_test_suite(
         "//daml-lf/language",
         "//daml-lf/parser",
         "//daml-lf/transaction",
+        "//daml-lf/transaction:transaction_proto_java",
         "//daml-lf/transaction-test-lib",
         "//libs-scala/contextualized-logging",
         "//libs-scala/logging-entries",

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/MixLFUpgradeTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/MixLFUpgradeTest.scala
@@ -1,0 +1,198 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+
+import com.daml.lf.command.{ApiCommand, ApiCommands}
+import com.daml.lf.testing.parser.Implicits._
+import com.daml.lf.testing.parser.ParserParameters
+import com.daml.lf.data.{ImmArray, Ref, Time}
+import com.daml.lf.engine.{Engine, EngineConfig}
+import com.daml.lf.language.{LanguageMajorVersion, LanguageVersion}
+import com.daml.lf.transaction.{
+  SubmittedTransaction,
+  Transaction,
+  TransactionCoder,
+  VersionedTransaction,
+}
+import com.daml.lf.value.{Value, ValueCoder}
+import com.daml.logging.LoggingContext
+import org.scalatest.Inside
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class MixLFUpgradeTest extends AnyFreeSpec with Matchers with Inside {
+
+  import Ordering.Implicits._
+
+  def toPkgVersion(langVersion: LanguageVersion) =
+    langVersion match {
+      case LanguageVersion.v1_dev => "9999"
+      case otherwise => otherwise.minor.identifier
+    }
+
+  def buildIfacePkg(langVersion: LanguageVersion) = {
+    val pkgId = Ref.PackageId.assertFromString("ifacePkgId-" + langVersion.minor.identifier)
+    implicit val parserParameters: ParserParameters[this.type] = ParserParameters(
+      defaultPackageId = pkgId,
+      languageVersion = langVersion,
+    )
+
+    pkgId ->
+      p"""metadata ( '-interface-' : '${toPkgVersion(langVersion)}' )
+
+        module Mod {
+          record @serializable R = { p: Party, data: Text, extraData: Option Text };
+          record @serializable MyUnit = {};
+          interface (this: Iface) = {
+            viewtype Mod:MyUnit;
+            method data: Text;
+            choice @nonConsuming Choice (self) (arg: Mod:R) : Mod:R
+              , controllers (Cons @Party [Mod:R {p} arg] (Nil @Party))
+              to upure @Mod:R Mod:R {arg with data = APPEND_TEXT (Mod:R {data} arg) (call_method @Mod:Iface data this)};
+          } ;
+        }
+     """
+  }
+
+  def buildImplPkg(ifacePkgId: Ref.PackageId, langVersion: LanguageVersion, version: Int) = {
+    val pkgId = Ref.PackageId.assertFromString(
+      "implPkgId-" + version.toString + "-" + langVersion.minor.identifier
+    )
+    implicit val parserParameters: ParserParameters[this.type] = ParserParameters(
+      defaultPackageId = pkgId,
+      languageVersion = langVersion,
+    )
+
+    val ifaceId = s"'$ifacePkgId':Mod:Iface"
+    val ifaceRId = s"'$ifacePkgId':Mod:R"
+    val ifaceMyUnitId = s"'$ifacePkgId':Mod:MyUnit"
+
+    pkgId ->
+      p"""metadata ( '-implementation-' : '$version.${toPkgVersion(langVersion)}' )
+
+        module Mod {
+          record @serializable T = { p: Party, data: Text, extraData: Option Text };
+          template (this: T) = {
+            precondition True;
+            signatories Cons @Party [Mod:T {p} this] (Nil @Party);
+            observers Nil @Party;
+            agreement "";
+
+            choice @nonConsuming Choice (self) (arg: $ifaceRId) : $ifaceRId
+              , controllers (Cons @Party [$ifaceRId {p} arg] (Nil @Party))
+              to exercise_interface @$ifaceId Choice (COERCE_CONTRACT_ID @Mod:T @$ifaceId self) arg;
+
+            implements $ifaceId {
+              view = $ifaceMyUnitId {};
+              method data = Mod:T {data} this;
+            };
+          };
+        }
+     """
+  }
+
+  def checkSerializable(tx: VersionedTransaction): Unit = {
+    val serialized = TransactionCoder
+      .encodeTransaction(TransactionCoder.NidEncoder, ValueCoder.CidEncoder, tx)
+      .fold(x => sys.error(x.errorMessage), identity)
+    val deserialized = TransactionCoder
+      .decodeTransaction(TransactionCoder.NidDecoder, ValueCoder.CidDecoder, serialized)
+      .fold(x => sys.error(x.errorMessage), identity)
+    remy.log(deserialized == tx)
+    require(deserialized == tx)
+  }
+
+  val langVersions = LanguageVersion.AllV1.filter(LanguageVersion.v1_15 <= _)
+
+  assert(
+    langVersions.size == 3,
+    "carefully double check the versioning of node if a new LF is introduced.",
+  )
+
+  val alice = Ref.Party.assertFromString("Alice")
+  val participantId = Ref.ParticipantId.assertFromString("particitipant")
+  val seed = crypto.Hash.hashPrivateKey("seed")
+  implicit val logContext: LoggingContext = LoggingContext.ForTesting
+  val engineConfig = EngineConfig(
+    allowedLanguageVersions = LanguageVersion.AllVersions(LanguageMajorVersion.V1)
+  )
+
+  for (ifaceVersion <- langVersions) s"interface version = ${ifaceVersion.pretty}" - {
+    val entryIface @ (ifaceId, ifacePkg) = buildIfacePkg(ifaceVersion)
+
+    for (tmplVersion1 <- langVersions if ifaceVersion <= tmplVersion1)
+      s"implementation version = ${tmplVersion1.pretty}" - {
+
+        val broken =
+          (ifaceVersion < LanguageVersion.Features.smartContractUpgrade) && (LanguageVersion.Features.smartContractUpgrade <= tmplVersion1)
+
+        val entryImpl1 @ (implPkgId, implPkg) = buildImplPkg(ifaceId, tmplVersion1, 1)
+
+        val pkgs = Map(entryIface, entryImpl1)
+
+        s"exercise-by-interface succeeds" in {
+          val engine = new Engine(engineConfig)
+          val pkgMap = List(
+            ifaceId -> ifacePkg.metadata,
+            implPkgId -> implPkg.metadata,
+          ).collect { case (id, Some(m)) => id -> (m.name -> m.version) }.toMap
+          val pkgPref = Set(ifaceId, implPkgId)
+
+          val cmd = ApiCommand.CreateAndExercise(
+            Ref.Identifier(implPkgId, Ref.QualifiedName.assertFromString("Mod:T")),
+            Value.ValueRecord(
+              None,
+              ImmArray(
+                None -> Value.ValueParty(alice),
+                None -> Value.ValueText("implementation"),
+                None -> Value.ValueOptional(None),
+              ),
+            ),
+            Ref.Name.assertFromString("Choice"),
+            Value.ValueRecord(
+              None,
+              ImmArray(
+                None -> Value.ValueParty(alice),
+                None -> Value.ValueText("implementation"),
+                None -> Value.ValueOptional(None),
+              ),
+            ),
+          )
+
+          val result: Either[String, (SubmittedTransaction, Transaction.Metadata)] = scala.util
+            .Try {
+              engine
+                .submit(
+                  packageMap = pkgMap,
+                  packagePreference = pkgPref,
+                  submitters = Set(alice),
+                  readAs = Set.empty,
+                  cmds = ApiCommands(ImmArray(cmd), Time.Timestamp.Epoch, "cmdsRef"),
+                  disclosures = ImmArray.Empty,
+                  participantId = participantId,
+                  submissionSeed = seed,
+                  prefetchKeys = Seq.empty,
+                  engineLogger = None,
+                )
+                .consume(pkgs = pkgs)
+                .left
+                .map(_.toString)
+            }
+            .toEither
+            .left
+            .map(_.toString)
+            .flatten
+
+          inside(result) {
+            case Right((tx, _)) if !broken =>
+              checkSerializable(tx)
+              succeed
+            case Left(_) if broken =>
+              succeed
+          }
+        }
+      }
+  }
+
+}

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/MixLFUpgradeTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/MixLFUpgradeTest.scala
@@ -99,7 +99,6 @@ class MixLFUpgradeTest extends AnyFreeSpec with Matchers with Inside {
     val deserialized = TransactionCoder
       .decodeTransaction(TransactionCoder.NidDecoder, ValueCoder.CidDecoder, serialized)
       .fold(x => sys.error(x.errorMessage), identity)
-    remy.log(deserialized == tx)
     require(deserialized == tx)
   }
 

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/MixLFUpgradeTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/MixLFUpgradeTest.scala
@@ -199,7 +199,7 @@ class MixLFUpgradeTest extends AnyFreeSpec with Matchers with Inside {
                 assert(exe.templateId == tmplId)
                 assert(exe.interfaceId.contains(ifaceId))
 
-                // Check the trailing None fields are drop iff the interface >= 1.17
+                // Check the trailing None fields are dropped iff the interface >= 1.17
                 inside(exe.chosenValue) { case Value.ValueRecord(_, fields) =>
                   assert(fields.length == expectNumberOfField)
                 }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -209,7 +209,7 @@ private[lf] object Pretty {
               )
           }
         }
-      case DisallowInterfaceExercise(coid, ifaceId, choiceName, tmplId) =>
+      case DisallowedInterfaceExercise(coid, ifaceId, choiceName, tmplId) =>
         text(s"LF 1.15 interface choice implemented by LF 1.17 (or newer) template is disallowed") &
           text("when exercising choice") & prettyIdentifier(ifaceId) & text(":") & text(
             choiceName

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -209,6 +209,13 @@ private[lf] object Pretty {
               )
           }
         }
+      case DisallowInterfaceExercise(coid, ifaceId, choiceName, tmplId) =>
+        text(s"LF 1.15 interface choice implemented by LF 1.17 (or newer) template is disallowed") &
+          text("when exercising choice") & prettyIdentifier(ifaceId) & text(":") & text(
+            choiceName
+          ) /
+          text("on contract") & prettyContractId(coid) /
+          text("of template") & prettyTypeConName(tmplId)
       case Dev(_, error) =>
         error match {
           case Dev.Limit(error) =>

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -25,7 +25,7 @@ import com.daml.lf.transaction.{
   ContractStateMachine,
   GlobalKey,
   GlobalKeyWithMaintainers,
-  TransactionVersion,
+  TransactionVersion => TxVersion,
   TransactionErrors => TxErr,
 }
 import com.daml.lf.value.{Value => V}
@@ -1015,6 +1015,7 @@ private[lf] object SBuiltin {
         args: util.ArrayList[SValue],
         machine: UpdateMachine,
     ): Control[Question.Update] = {
+      import Ordering.Implicits._
 
       val coid = getSContractId(args, 1)
       val templateArg: SValue = args.get(5)
@@ -1034,12 +1035,21 @@ private[lf] object SBuiltin {
             case None => crash(s"unexpected missing contract $coid")
           }
         )
-        val interfaceVersion = interfaceId.map(machine.tmplId2TxVersion)
-        // Interfaces were added in LF1.15, therefore the interface version is 1.15+
-        // Interfaces in LF1.17 cannot have template version < interface version, as retroactive instances aren't supported in 17
-        // Therefore, if the interface support upgrades, we pick the interface version
-        // if it doesn't, then its 1.15, which is correct
-        val exerciseVersion = interfaceVersion.getOrElse(templateVersion)
+        val tmplVersion = machine.tmplId2TxVersion(templateId)
+
+        val exerciseVersion = interfaceId match {
+          case Some(ifaceId) =>
+            val ifaceVersion = machine.tmplId2TxVersion(ifaceId)
+            if (ifaceVersion < TxVersion.minUpgrade && TxVersion.minUpgrade <= tmplVersion)
+              throw SErrorDamlException(
+                IE.DisallowInterfaceExercise(coid, ifaceId, choiceId, templateId)
+              )
+            else
+              ifaceVersion max tmplVersion
+          case None =>
+            tmplVersion
+        }
+
         val chosenValue = args.get(0).toNormalizedValue(exerciseVersion)
         val controllers = extractParties(NameOf.qualifiedNameOfCurrentFunc, args.get(2))
         machine.enforceChoiceControllersLimit(
@@ -2277,7 +2287,7 @@ private[lf] object SBuiltin {
 
   private[this] def extractKey(
       location: String,
-      packageTxVersion: TransactionVersion,
+      packageTxVersion: TxVersion,
       pkgName: Option[Ref.PackageName],
       templateId: Ref.TypeConName,
       v: SValue,
@@ -2320,8 +2330,8 @@ private[lf] object SBuiltin {
     SBuiltin.SBStructCon(contractInfoPositionStruct)
 
   private def extractContractInfo(
-      tmplId2TxVersion: TypeConName => TransactionVersion,
-      tmplId2PackageName: (TypeConName, TransactionVersion) => Option[PackageName],
+      tmplId2TxVersion: TypeConName => TxVersion,
+      tmplId2PackageName: (TypeConName, TxVersion) => Option[PackageName],
       contractInfoStruct: SValue,
   ): ContractInfo = {
     contractInfoStruct match {

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1042,7 +1042,7 @@ private[lf] object SBuiltin {
             val ifaceVersion = machine.tmplId2TxVersion(ifaceId)
             if (ifaceVersion < TxVersion.minUpgrade && TxVersion.minUpgrade <= tmplVersion)
               throw SErrorDamlException(
-                IE.DisallowInterfaceExercise(coid, ifaceId, choiceId, templateId)
+                IE.DisallowedInterfaceExercise(coid, ifaceId, choiceId, templateId)
               )
             else
               ifaceVersion max tmplVersion

--- a/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TransactionVersionTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TransactionVersionTest.scala
@@ -48,7 +48,7 @@ class TransactionVersionTest(majorLanguageVersion: LanguageMajorVersion)
 
     // Post upgrades, we only consider a node 1.17 if the interface is 1.17
     // We do not support coimplements
-    "template version > interface" in {
+    "template version > interface" ignore {
       val pkgs = SpeedyTestLib.typeAndCompile(
         majorLanguageVersion,
         Map(

--- a/sdk/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -197,7 +197,7 @@ object Error {
 
   }
 
-  final case class DisallowInterfaceExercise(
+  final case class DisallowedInterfaceExercise(
       coid: ContractId,
       ifaceId: TypeConName,
       choiceName: ChoiceName,

--- a/sdk/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -197,6 +197,13 @@ object Error {
 
   }
 
+  final case class DisallowInterfaceExercise(
+      coid: ContractId,
+      ifaceId: TypeConName,
+      choiceName: ChoiceName,
+      templateId: TypeConName,
+  ) extends Error
+
   // Error that can be thrown by dev or PoC feature only
   final case class Dev(location: String, error: Dev.Error) extends Error
 

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -401,6 +401,11 @@ class IdeLedgerClient(
           innerError.actual,
           Pretty.prettyDamlException(e).renderWideStream.mkString,
         )
+      case e @ DisallowInterfaceExercise(_, _, _, _) =>
+        submitErrors.DevError(
+          e.getClass.getSimpleName,
+          Pretty.prettyDamlException(e).renderWideStream.mkString,
+        )
       case e @ Dev(_, innerError) =>
         submitErrors.DevError(
           innerError.getClass.getSimpleName,

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -401,7 +401,7 @@ class IdeLedgerClient(
           innerError.actual,
           Pretty.prettyDamlException(e).renderWideStream.mkString,
         )
-      case e @ DisallowInterfaceExercise(_, _, _, _) =>
+      case e @ DisallowedInterfaceExercise(_, _, _, _) =>
         submitErrors.DevError(
           e.getClass.getSimpleName,
           Pretty.prettyDamlException(e).renderWideStream.mkString,

--- a/sdk/ledger/ledger-api-client/BUILD.bazel
+++ b/sdk/ledger/ledger-api-client/BUILD.bazel
@@ -7,6 +7,7 @@ load(
     "da_scala_test_suite",
 )
 load("@scala_version//:index.bzl", "scala_major_version")
+load("//rules_daml:daml.bzl", "daml_compile")
 
 da_scala_library(
     name = "ledger-api-client",
@@ -83,6 +84,7 @@ da_scala_test_suite(
     name = "ledger-api-client-integration-tests",
     srcs = glob(["src/it/**/*.scala"]),
     data = [
+        ":template17.dar",
         "//test-common:dar-files-default",
     ],
     resources = [
@@ -121,4 +123,17 @@ da_scala_test_suite(
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:io_netty_netty_handler",
     ],
+)
+
+daml_compile(
+    name = "iface15",
+    srcs = ["src/daml/Interface15.daml"],
+    target = "1.15",
+)
+
+daml_compile(
+    name = "template17",
+    srcs = ["src/daml/Template17.daml"],
+    data_dependencies = ["//ledger/ledger-api-client:iface15.dar"],
+    target = "1.17",
 )

--- a/sdk/ledger/ledger-api-client/src/daml/Interface15.daml
+++ b/sdk/ledger/ledger-api-client/src/daml/Interface15.daml
@@ -1,0 +1,15 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Interface15 where  
+  
+data V = V {}
+
+interface I where
+  viewtype V
+  owner: Party
+
+  nonconsuming choice C: ()
+    controller (owner this)
+    do
+      pure ()

--- a/sdk/ledger/ledger-api-client/src/daml/Template17.daml
+++ b/sdk/ledger/ledger-api-client/src/daml/Template17.daml
@@ -1,0 +1,20 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Template17 where 
+
+import Interface15
+
+template T with 
+    p: Party
+  where 
+    signatory p
+    interface instance I for T where
+      view = V {}
+      owner = p
+
+    nonconsuming choice D: ()
+        controller p
+        do
+          exercise (coerceContractId @T @I self) C
+

--- a/sdk/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/CommandClientIT.scala
+++ b/sdk/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/CommandClientIT.scala
@@ -582,7 +582,7 @@ final class CommandClientIT
             )
           r <- assertCommandFailsWithCode(
             command,
-            Code.RESOURCE_EXHAUSTED,
+            Code.FAILED_PRECONDITION,
             "DISALLOWED_INTERFACE_EXERCISE",
           )
         } yield r

--- a/sdk/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/CommandClientIT.scala
+++ b/sdk/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/CommandClientIT.scala
@@ -17,12 +17,17 @@ import com.daml.ledger.api.v1.command_submission_service.{
   CommandSubmissionServiceGrpc,
   SubmitRequest,
 }
-import com.daml.ledger.api.v1.commands.{Command, CreateCommand, ExerciseCommand}
+import com.daml.ledger.api.v1.commands.{
+  Command,
+  CreateCommand,
+  CreateAndExerciseCommand,
+  ExerciseCommand,
+}
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset.LedgerBoundary.LEDGER_BEGIN
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset.Value.Boundary
 import com.daml.ledger.api.v1.testing.time_service.TimeServiceGrpc
-import com.daml.ledger.api.v1.value.{Record, RecordField}
+import com.daml.ledger.api.v1.value.{Identifier, Record, RecordField}
 import com.daml.ledger.client.configuration.CommandClientConfiguration
 import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
   CompletionFailure,
@@ -68,9 +73,13 @@ final class CommandClientIT
     with TryValues
     with Inside {
 
-  protected def darFile = Paths.get(BazelRunfiles.rlocation(ModelTestDar.path))
+  override protected val cantonFixtureDebugMode: CantonFixtureDebugMode =
+    CantonFixtureDebugKeepTmpFiles
 
-  override protected lazy val darFiles: List[java.nio.file.Path] = List(darFile)
+  protected def darFile = Paths.get(BazelRunfiles.rlocation(ModelTestDar.path))
+  def darFile0 = Paths.get(BazelRunfiles.rlocation("ledger/ledger-api-client/template17.dar"))
+
+  override protected lazy val darFiles: List[java.nio.file.Path] = List(darFile, darFile0)
 
   private val defaultCommandClientConfiguration =
     CommandClientConfiguration(
@@ -553,6 +562,30 @@ final class CommandClientIT
           a <- assertCommandFailsWithCode(command, Code.NOT_FOUND, "CONTRACT_NOT_FOUND")
         } yield a
 
+      }
+
+      "not accept exercise 1.15 interface implemented by 1.17 template" in {
+        for {
+          party <- freshParty()
+          command =
+            submitRequest(
+              "Exercise_15_interface_with_17_template",
+              List(
+                CreateAndExerciseCommand(
+                  Some(Identifier("#template17", "Template17", "T")),
+                  Some(List("" -> party.asParty).asRecord),
+                  "D",
+                  Some(Nil.asRecordValue),
+                ).wrap
+              ),
+              party,
+            )
+          r <- assertCommandFailsWithCode(
+            command,
+            Code.RESOURCE_EXHAUSTED,
+            "DISALLOWED_INTERFACE_EXERCISE",
+          )
+        } yield r
       }
     }
   }

--- a/sdk/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/ValueConversions.scala
+++ b/sdk/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/ValueConversions.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit
 
 import com.daml.ledger.api.v1.commands.{
   Command,
+  CreateAndExerciseCommand,
   CreateCommand,
   ExerciseByKeyCommand,
   ExerciseCommand,
@@ -75,6 +76,11 @@ object ValueConversions {
   }
 
   implicit def value2Optional(value: Value): Option[Value] = Some(value)
+
+  implicit class CreateAndExerciseCommands(val createAndExercise: CreateAndExerciseCommand)
+      extends AnyVal {
+    def wrap = Command.of(Command.Command.CreateAndExercise(createAndExercise))
+  }
 
   implicit class ExerciseCommands(val exercise: ExerciseCommand) extends AnyVal {
     def wrap = Command.of(Command.Command.Exercise(exercise))


### PR DESCRIPTION
part of DACH-NY/canton/issues/25471 fix

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
