### PR TITLE
Introduce release notes process to the daml repo

### DIFF
--- a/sdk/UNRELEASED.md
+++ b/sdk/UNRELEASED.md
@@ -4,12 +4,10 @@ Daml SDK DAML_VERSION has been released on RELEASE_DATE. You can download the Da
 Please also consult the [full documentation of this release](https://docs.daml.com/CANTON_VERSION/canton/about.html).
 
 INFO: Note that the **"## Until YYYY-MM-DD (Exclusive)" headers**
-below should all be Wednesdays to align with the weekly release
+below should all be Tuesdays to align with the weekly release
 schedule, i.e. if you add an entry effective at or after the first
 header, prepend the new date header that corresponds to the
 Wednesday after your change.
 
 ## Until YYYY-MM-DD (Exclusive)
-
-## Until 2025-05-14 (Exclusive)
 

--- a/sdk/UNRELEASED.md
+++ b/sdk/UNRELEASED.md
@@ -1,68 +1,15 @@
-# Release of Daml DAML_VERSION
-Use one of the following topics to capture your release notes. Duplicate this file if necessary.
-Add [links to the documentation too](https://docs.daml.com/DAML_VERSION/about.html).
+# Release of Daml SDK DAML_VERSION
 
-You text does not need to be perfect. Leave good information here such that we can build release notes from your hints.
-Of course, perfect write-ups are very welcome.
+Daml SDK DAML_VERSION has been released on RELEASE_DATE. You can download the Daml Open Source edition from the Daml Connect [Github Release Section](https://github.com/digital-asset/daml/releases/tag/vCANTON_VERSION). The Enterprise edition is available on [Artifactory](https://digitalasset.jfrog.io/artifactory/canton-enterprise/canton-enterprise-CANTON_VERSION.zip).
+Please also consult the [full documentation of this release](https://docs.daml.com/CANTON_VERSION/canton/about.html).
 
-You need to update this file whenever you commit something of significance. Reviewers need to check your PR
-and ensure that the release notes and documentation has been included as part of the PR.
+INFO: Note that the **"## Until YYYY-MM-DD (Exclusive)" headers**
+below should all be Wednesdays to align with the weekly release
+schedule, i.e. if you add an entry effective at or after the first
+header, prepend the new date header that corresponds to the
+Wednesday after your change.
 
-## Bugfixes
+## Until YYYY-MM-DD (Exclusive)
 
-## What’s New
+## Until 2025-05-14 (Exclusive)
 
-# Release of Daml 2.8.1
-
-## Bugfixes
-
-## What’s New
-
-# Release of Daml 2.9.0
-
-## Bugfixes
-
-## What’s New
-
-# Release of Daml 3.0.0
-
-## Bugfixes
-
-## What’s New
-
-* The type class `HasField` (methods `getField` and `setField`) has been split
-  in two: `GetField` and `SetField`, each one with the correspondingly named
-  method. `HasField` is now defined as a type synonym for the conjunction of
-  `GetField` and `SetField`. This means that functions with `HasField`
-  constraints will continue to work without any changes.
-
-  No action should be necessary for migrating the compiler-generated instances
-  for record types. For user-defined instances of the `HasField` class,
-  migration is a matter of replacing one instance declaration with two, for
-  example,
-
-  ```daml
-  instance HasField "field_name" RecType FieldType where
-    getField = <getFieldImpl>
-    setField = <setFieldImpl>
-  ```
-
-  would have to be rewritten as
-
-  ```daml
-  instance GetField "field_name" RecType FieldType where
-    getField = <getFieldImpl>
-
-  instance SetField "field_name" RecType FieldType where
-    setField = <setFieldImpl>
-  ```
-
-* User-defined instances of the class `GetField` enable the use of dot-syntax
-  for field access, i.e. `rec.field`
-
-* User-defined instances of the class `SetField` enable the use of with-syntax
-  for field update, i.e. `rec with field = newValue`
-
-* Removed support for "template-let" syntax, previously deprecated in Daml 2.8.0.
-  See [Template-local Definitions (Deprecated)](https://docs.daml.com/daml/reference/templates.html#template-local-definitions-deprecated)
-  for migration guidance.

--- a/sdk/release-notes/3.3.0.md
+++ b/sdk/release-notes/3.3.0.md
@@ -1,0 +1,97 @@
+# Release of Daml SDK 3.3.0
+
+## What’s New
+
+### Smart Contract Upgrading
+
+The Smart Contract Upgrade feature enables fixing application bugs or extending Daml models is possible without downtime
+or breaking Daml clients. It was introduced in Daml v2.9.1 and is now available in Daml and Canton 3.3.
+
+This feature is well-suited for developing and rolling out incremental template updates. There are guidelines to ensure
+upgrade compatibility between DAR files. The compatibility is checked at compile time, DAR upload time, and runtime.
+This is to ensure data backwards compatibility and forward compatibility (subject to the guidelines being followed)
+so that DARs can be safely upgraded to new versions. It also prevents unexpected data loss if a runtime downgrade occurs
+(e.g., a ledger client is using template version 1.0.0 while the participant node has the newer version 1.1.0).
+
+### Time boundaries functions
+
+Time boundaries functions allow constructing time assertions in Daml that are valid over a long period of time.
+- Ledger time bound checking predicates: ``isLedgerTimeLT``, ``isLedgerTimeLE``, ``isLedgerTimeGT`` and ``isLedgerTimeGE``
+- Ledger time deadline assertions: ``assertWithinDeadline`` and ``assertDeadlineExceeded``.
+
+### Crypto primitives
+
+New crypto primitives simplify manipulation of data encoded into hex strings and introduce routines to calculate
+hashes and validate signatures over a block of encoded data.
+- Introduced Daml data type ``BytesHex`` supported via type classes ``HasToHex`` and ``HasFromHex``.
+- ``BytesHex`` support for base 16 encoded byte strings: ``isHex``, ``byteCount``, ``packHexBytes`` and ``sliceHexBytes``
+- ``Bytes32Hex`` support for base 16 encoded byte strings of length 32: ``isBytes32Hex``, ``minBytes32Hex`` and 
+``maxBytes32Hex``.
+- ``UInt32Hex`` support for base 16 encoded byte strings representing UInt32: ``isUInt32Hex``, ``minUInt32Hex`` and
+``maxUInt32Hex``.
+- ``UInt64Hex`` support for base 16 encoded byte strings representing UInt64: ``isUInt64Hex``, ``minUInt64Hex`` and
+``maxUInt64Hex``.
+- ``UInt256Hex`` support for base 16 encoded byte strings representing UInt256: ``isUInt256Hex``, ``minUInt256Hex`` and
+``maxUInt256Hex``.
+- ``keccak256`` support creation of KECCAK256 hash of the UTF8 bytes.
+- ``secp256k1`` support validation the SECP256K1 signature given a hex encoded message and a hex encoded DER formatted
+public key.
+
+## Breaking Changes
+
+## Functional Changes
+
+### Daml Script
+
+- ``allocatePartyWithHint`` has been deprecated and replaced with ``allocatePartyByHint``. Parties can no longer have
+a display name that differs from the ``PartyHint``.  
+- ``daml-script`` is now a utility package: the datatypes it defines
+cannot be used as template or choice parameters, and it is transparent to upgrades. It is strongly discouraged to upload
+``daml-script`` to a production ledger but this change ensures that it is harmless. 
+- The ``daml-script`` library in Daml 3.3 is Daml 3’s name for ``daml-script-lts`` in Canton 2.10 (renamed from
+``daml3-script`` in 3.2). The old ``daml-script`` library of Canton 3.2 no longer exists.
+- ``daml-script`` exposes a new
+``prefetchKey`` option for submissions. See here.
+
+### Standard library changes
+
+- New ``Bounded`` instances for ``Numeric`` and ``Time``.
+- ``TextMap`` is no longer deprecated
+- Added ``Map.singleton`` and ``TextMap.singleton`` functions.
+- Added ``List.mapWithIndex``.
+- Added ``Functor.<$$>``.
+- Added ``Text.isNotEmpty``.
+
+### Language changes
+
+- New alternative syntax for implementing interfaces: one can now write implements ``I where ...``
+instead of ``interface instance I for T where ...``
+
+
+### Daml assistant changes
+
+- Fixed an issue with ``daml build –all`` failing to find ``multi-package.yaml`` when in a directory below a ``daml.yaml``
+- The ``daml package`` and ``daml merge-dars`` commands no longer exist.
+- The ``daml start`` command no longer supports hot reload as this feature is incompatible with Smart Contract Upgrades.
+- Added a new multi-package project template called ``multi-package-example`` to the daml assistant.
+
+### Daml compiler changes
+
+- The compiler now emits warnings for unused dependencies.
+- Added flags for turning warnings about expressions into errors.
+- The ``bad-{exceptions,interface-instances}`` and ``warn-large-tuples`` flags no longer exist.
+
+### Code generation changes
+
+- In typescript-generated code, ``undefined`` is now accepted by functions expecting an optional value and is understood
+to mean ``None``.
+- Typescript code generation no longer emits code for utility packages: these packages don’t expose any serializable
+type and thus will never be interacted with through the ledger API.
+- Java codegen now exposes additional fields in the class representing an interface. Next to ``TEMPLATE_ID`` there is
+``INTERFACE_ID`` and next to ``TEMPLATE_ID_WITH_PACKAGE_ID`` there is ``INTERFACE_ID_WITH_PACKAGE_ID``. Both field pairs
+contain the same value.
+
+### Miscellaneous
+
+- The Daml SDK is now compiled against open JDK 17
+- Added transaction traces


### PR DESCRIPTION
Using the template of the canton arepo we introduce the process of documenting the changes going into a release. It is composed of 2 elements
- an UNRELEASED.md file where incremental changes are documented in a development phase of a release,
- a curated release.note document that is edited from the UNRELEASED.md at the end of the release cycle.