### PR TITLE
Add lock to .daml folder for package db

### DIFF
--- a/sdk/compiler/damlc/BUILD.bazel
+++ b/sdk/compiler/damlc/BUILD.bazel
@@ -186,6 +186,7 @@ da_haskell_library(
         "either",
         "extra",
         "file-embed",
+        "filelock",
         "filepath",
         "ghcide",
         "ghc-lib",

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -71,8 +71,7 @@ import DA.Cli.Damlc.Command.MultiIde (runMultiIde)
 import DA.Cli.Damlc.Command.UpgradeCheck (runUpgradeCheck)
 import qualified DA.Daml.Dar.Reader as InspectDar
 import qualified DA.Cli.Damlc.Command.Damldoc as Damldoc
-import DA.Cli.Damlc.Packaging (createProjectPackageDb, mbErr)
-import DA.Cli.Damlc.DependencyDb (installDependencies)
+import DA.Cli.Damlc.Packaging (setupPackageDb, setupPackageDbFromPackageConfig, mbErr)
 import DA.Cli.Damlc.Test (CoveragePaths(..),
                           LoadCoverageOnly(..),
                           RunAllTests(..),
@@ -982,22 +981,8 @@ installDepsAndInitPackageDb opts (InitPkgDb shouldInit) =
         isProject <- withPackageConfig defaultProjectPath (const $ pure True) `catch` (\(_ :: ConfigError) -> pure False)
         when isProject $ do
             projRoot <- getCurrentDirectory
-            withPackageConfig defaultProjectPath $ \PackageConfigFields {..} -> do
-              damlAssistantIsSet <- damlAssistantIsSet
-              releaseVersion <- if damlAssistantIsSet
-                  then do
-                    damlPath <- getDamlPath
-                    damlEnv <- getDamlEnv damlPath (LookForProjectPath False)
-                    wrapErr "installing dependencies and initializing package database" $
-                      resolveReleaseVersionUnsafe (envUseCache damlEnv) pSdkVersion
-                  else pure (unsafeResolveReleaseVersion pSdkVersion)
-              installDependencies
-                  (toNormalizedFilePath' projRoot)
-                  opts
-                  releaseVersion
-                  pDependencies
-                  pDataDependencies
-              createProjectPackageDb (toNormalizedFilePath' projRoot) opts pModulePrefixes
+            withPackageConfig defaultProjectPath $
+              setupPackageDbFromPackageConfig (toNormalizedFilePath' projRoot) opts
 
 getMultiPackagePath :: MultiPackageLocation -> IO (Maybe ProjectPath)
 getMultiPackagePath multiPackageLocation =
@@ -1739,8 +1724,7 @@ execDocTest opts scriptDar (ImportSource importSource) files =
             wrapErr "running doc test" $
               resolveReleaseVersionUnsafe (envUseCache damlEnv) SdkVersion.Class.unresolvedBuiltinSdkVersion
           else pure (unsafeResolveReleaseVersion SdkVersion.Class.unresolvedBuiltinSdkVersion)
-      installDependencies "." opts releaseVersion [] [scriptDar]
-      createProjectPackageDb "." opts mempty
+      setupPackageDb "." opts releaseVersion [] [scriptDar] mempty
 
       opts <- pure opts
         { optPackageDbs = projectPackageDatabase : optPackageDbs opts

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/DependencyDb.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/DependencyDb.hs
@@ -8,6 +8,7 @@ module DA.Cli.Damlc.DependencyDb
     , mainMarker
     , depMarker
     , dataDepMarker
+    , packageDbLockPath
     ) where
 
 import qualified "zip-archive" Codec.Archive.Zip as ZipArchive
@@ -94,8 +95,11 @@ dependenciesDir opts projRoot =
     fromNormalizedFilePath projRoot </> projectDependenciesDatabase </>
     lfVersionString (optDamlLfVersion opts)
 
-lockFile :: FilePath
-lockFile = "daml.lock"
+packageDbLockPath :: NormalizedFilePath -> FilePath
+packageDbLockPath projRoot = fromNormalizedFilePath projRoot </> damlArtifactDir </> "setup-package-db.lock"
+
+remotePackagesLockFile :: FilePath
+remotePackagesLockFile = "daml.lock"
 
 fingerprintFile :: FilePath
 fingerprintFile = "fingerprint.json"
@@ -339,11 +343,11 @@ resolvePkgs projRoot opts pkgs
                 | FullPkgName {pkgName, pkgVersion} <- missing
                 ]
             Right result -> do
-              writeLockFile lockFile result
+              writeLockFile remotePackagesLockFile result
               pure result
   where
     depsDir = dependenciesDir opts projRoot
-    lockFp = fromNormalizedFilePath projRoot </> lockFile
+    lockFp = fromNormalizedFilePath projRoot </> remotePackagesLockFile
 
 writeLockFile :: FilePath -> M.Map FullPkgName LF.PackageId -> IO ()
 writeLockFile lockFp resolvedPkgs = do

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -5,6 +5,8 @@
 
 module DA.Cli.Damlc.Packaging
   ( createProjectPackageDb
+  , setupPackageDb
+  , setupPackageDbFromPackageConfig
   , mbErr
   , getUnitId
 
@@ -43,6 +45,7 @@ import qualified Module as GHC
 import qualified "ghc-lib-parser" Packages as GHC
 import System.Directory.Extra (copyFile, createDirectoryIfMissing, listFilesRecursive, removePathForcibly)
 import System.Exit
+import System.FileLock
 import System.FilePath
 import System.IO.Extra (hFlush, hPutStrLn, stderr, writeFileUTF8)
 import System.Info.Extra
@@ -50,20 +53,27 @@ import System.Process (callProcess)
 import "ghc-lib-parser" UniqSet
 
 import DA.Bazel.Runfiles
+import DA.Cli.Damlc.DependencyDb
+import DA.Daml.Assistant.Env (getDamlEnv, getDamlPath, envUseCache)
+import DA.Daml.Assistant.Types (LookForProjectPath (..))
+import DA.Daml.Assistant.Util (wrapErr)
+import DA.Daml.Assistant.Version (resolveReleaseVersionUnsafe)
 import DA.Daml.Compiler.Dar
 import DA.Daml.Compiler.DataDependencies as DataDeps
 import DA.Daml.Compiler.DecodeDar (DecodedDalf(..), decodeDalf)
 import DA.Daml.Compiler.Output
-import qualified DA.Daml.LF.Ast as LF
 import DA.Daml.LF.Ast.Optics (packageRefs)
-import qualified DA.Daml.LFConversion.MetadataEncoding as LFC
 import DA.Daml.Options.Packaging.Metadata
 import DA.Daml.Options.Types
-import DA.Cli.Damlc.DependencyDb
-import qualified DA.Pretty
-import qualified DA.Service.Logger as Logger
+import DA.Daml.Package.Config (PackageConfigFields (..))
+import DA.Daml.Project.Consts (damlAssistantIsSet)
+import DA.Daml.Project.Types (ReleaseVersion, unsafeResolveReleaseVersion)
 import Development.IDE.Core.IdeState.Daml
 import Development.IDE.Core.RuleTypes.Daml
+import qualified DA.Daml.LF.Ast as LF
+import qualified DA.Daml.LFConversion.MetadataEncoding as LFC
+import qualified DA.Pretty
+import qualified DA.Service.Logger as Logger
 import SdkVersion.Class (SdkVersioned, damlStdlib)
 
 -- | Create the project package database containing the given dar packages.
@@ -922,3 +932,42 @@ prefixModules prefixes dalfs = do
                 ( prefix
                 , NM.names . LF.packageModules . LF.extPackagePkg $ LF.dalfPackagePkg pkg
                 )
+
+-- Installs dependencies and creates package Db ready to be used
+setupPackageDb
+    :: SdkVersioned
+    => NormalizedFilePath
+    -> Options
+    -> ReleaseVersion
+    -> [String] -- Package dependencies. Can be base-packages, sdk-packages or filepath.
+    -> [FilePath] -- Data Dependencies. Can be filepath to dars/dalfs.
+    -> MS.Map UnitId GHC.ModuleName
+    -> IO ()
+setupPackageDb projRoot opts releaseVersion pDependencies pDataDependencies pModulePrefixes = do
+    let packageDbLockFile = packageDbLockPath projRoot
+    createDirectoryIfMissing True $ takeDirectory packageDbLockFile
+    withFileLock packageDbLockFile Exclusive $ const $ do
+        installDependencies
+            projRoot
+            opts
+            releaseVersion
+            pDependencies
+            pDataDependencies
+        createProjectPackageDb projRoot opts pModulePrefixes
+
+setupPackageDbFromPackageConfig
+    :: SdkVersioned
+    => NormalizedFilePath
+    -> Options
+    -> PackageConfigFields
+    -> IO ()
+setupPackageDbFromPackageConfig projRoot opts PackageConfigFields {..} = do
+    damlAssistantIsSet <- damlAssistantIsSet
+    releaseVersion <- if damlAssistantIsSet
+        then do
+          damlPath <- getDamlPath
+          damlEnv <- getDamlEnv damlPath (LookForProjectPath False)
+          wrapErr "installing dependencies and initializing package database" $
+            resolveReleaseVersionUnsafe (envUseCache damlEnv) pSdkVersion
+        else pure (unsafeResolveReleaseVersion pSdkVersion)
+    setupPackageDb projRoot opts releaseVersion pDependencies pDataDependencies pModulePrefixes

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -93,7 +93,7 @@ import Test.Tasty.Options
 import Test.Tasty.Providers
 import Test.Tasty.Runners (Result(..))
 
-import DA.Cli.Damlc.DependencyDb (installDependencies)
+import DA.Cli.Damlc.DependencyDb (setupPackageDbFromPackageConfig)
 import DA.Cli.Damlc.Packaging (createProjectPackageDb)
 import Module (stringToUnitId)
 import SdkVersion (SdkVersioned, withSdkVersions, sdkVersion, sdkPackageVersion)
@@ -172,15 +172,12 @@ withVersionedDamlScriptDep packageFlagName darPath mLfVer extraPackages cont = d
 
       extraDars <- traverse (\(name, _) -> locateRunfiles $ mainWorkspace </> "compiler" </> "damlc" </> "tests" </> name <> ".dar") extraPackages
 
-      installDependencies
+      setupPackageDb
         projDir
         (defaultOptions mLfVer)
         (unsafeResolveReleaseVersion (either throw id (parseUnresolvedVersion (T.pack sdkVersion))))
         ["daml-prim", "daml-stdlib"]
         (scriptDar : extraDars)
-      createProjectPackageDb
-        projDir
-        (defaultOptions mLfVer)
         mempty
 
       cont (dir </> projectPackageDatabase, packageFlags)

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -93,8 +93,7 @@ import Test.Tasty.Options
 import Test.Tasty.Providers
 import Test.Tasty.Runners (Result(..))
 
-import DA.Cli.Damlc.DependencyDb (setupPackageDbFromPackageConfig)
-import DA.Cli.Damlc.Packaging (createProjectPackageDb)
+import DA.Cli.Damlc.Packaging (setupPackageDb)
 import Module (stringToUnitId)
 import SdkVersion (SdkVersioned, withSdkVersions, sdkVersion, sdkPackageVersion)
 

--- a/sdk/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -141,15 +141,9 @@ initPackageConfig options scriptDar dars = do
         , "data-dependencies:"
         , "- " <> show scriptDar
         ] ++ ["- " <> show dar | dar <- dars]
-    withPackageConfig (ProjectPath ".") $ \PackageConfigFields {..} -> do
-        dir <- getCurrentDirectory
-        installDependencies
-            (toNormalizedFilePath' dir)
-            options
-            (unsafeResolveReleaseVersion pSdkVersion)
-            pDependencies
-            pDataDependencies
-        createProjectPackageDb (toNormalizedFilePath' dir) options pModulePrefixes
+    dir <- getCurrentDirectory
+    withPackageConfig (ProjectPath ".") $
+        setupPackageDbFromPackageConfig (toNormalizedFilePath' dir) options
 
 drainHandle :: Handle -> Chan String -> IO ()
 drainHandle handle chan = forever $ do

--- a/sdk/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -10,7 +10,6 @@ import Control.Exception
 import Control.Monad.Extra
 import DA.Bazel.Runfiles
 import DA.Cli.Damlc.Packaging
-import DA.Cli.Damlc.DependencyDb
 import DA.Daml.Compiler.Repl
 import qualified DA.Daml.LF.Ast as LF
 import qualified DA.Daml.LF.ReplClient as ReplClient

--- a/sdk/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -76,19 +76,8 @@ withScriptService lfVersion action =
             "data-dependencies:",
             "- " <> show scriptDar
           ]
-      withPackageConfig (ProjectPath ".") $ \PackageConfigFields {..} -> do
-        let projDir = toNormalizedFilePath' dir
-        installDependencies
-            projDir
-            (options lfVersion)
-            (unsafeResolveReleaseVersion pSdkVersion)
-            pDependencies
-            pDataDependencies
-        createProjectPackageDb
-          projDir
-          (options lfVersion)
-          pModulePrefixes
-
+      withPackageConfig (ProjectPath ".") $
+        setupPackageDbFromPackageConfig (toNormalizedFilePath' dir) $ options lfVersion
       logger <- Logger.newStderrLogger Logger.Debug "script-service"
 
       -- Spinning up the scenario service is expensive so we do it once at the beginning.

--- a/sdk/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -9,7 +9,6 @@ import Control.Exception
 import Control.Monad
 import DA.Bazel.Runfiles
 import DA.Cli.Damlc.Packaging
-import DA.Cli.Damlc.DependencyDb
 import qualified DA.Daml.LF.Ast.Version as LF
 import DA.Daml.LF.PrettyScenario (prettyScenarioError, prettyScenarioResult)
 import qualified DA.Daml.LF.ScenarioServiceClient as SS

--- a/sdk/compiler/damlc/tests/src/DA/Test/ScriptService_1_17.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/ScriptService_1_17.hs
@@ -68,18 +68,8 @@ main = withSdkVersions $ do
             "data-dependencies:",
             "- " <> show scriptDar
           ]
-      withPackageConfig (ProjectPath ".") $ \PackageConfigFields {..} -> do
-        let projDir = toNormalizedFilePath' dir
-        installDependencies
-            projDir
-            options
-            (unsafeResolveReleaseVersion pSdkVersion)
-            pDependencies
-            pDataDependencies
-        createProjectPackageDb
-          projDir
-          options
-          pModulePrefixes
+      withPackageConfig (ProjectPath ".") $
+        setupPackageDbFromPackageConfig (toNormalizedFilePath' dir) options
 
       logger <- Logger.newStderrLogger Logger.Debug "script-service"
 

--- a/sdk/compiler/damlc/tests/src/DA/Test/ScriptService_1_17.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/ScriptService_1_17.hs
@@ -9,7 +9,6 @@ import Control.Exception
 import Control.Monad
 import DA.Bazel.Runfiles
 import DA.Cli.Damlc.Packaging
-import DA.Cli.Damlc.DependencyDb
 import qualified DA.Daml.LF.Ast.Version as LF
 import DA.Daml.LF.PrettyScenario (prettyScenarioError, prettyScenarioResult)
 import qualified DA.Daml.LF.ScenarioServiceClient as SS

--- a/sdk/dev-env/bin/daml-sdk-head
+++ b/sdk/dev-env/bin/daml-sdk-head
@@ -109,7 +109,7 @@ sha_version() {
     echo "0.0.0-head.${date}.${nr}.${sha8}${dirty}"
 }
 if [ $SHA = 0 ]; then
-    export DAML_SDK_RELEASE_VERSION=0.0.0
+    export DAML_SDK_RELEASE_VERSION=2.10.0
 else
     export DAML_SDK_RELEASE_VERSION=$(sha_version)
 fi


### PR DESCRIPTION
We've had issues with the multi-IDE spinning up processes that create a package db while multi-build is running, these collisions corrupt the package db, sometimes recoverable, sometimes not.
I've added a lock to the full "installDependencies + createPackageDb" process, which appears to fix this.

In a future PR, I would like to add a lock to the full multi-build process, to prevent the IDE spinning up any processes while a multi build is happening, else we get wasted time.
e.g.
Package A depends on B and C.
We multi-build packages in the order C, B, A
Each package rebuilt will cause the multi-ide to reboot the environment for package A, as it detects changes to its deps.
Ideally we would instead wait for the build to finish before the IDE can open any new environments.

I tried to do this for this PR, but it proves a little more complex as the Multi-IDE needs to share more state regarding already disabled environments for error/sdk install reasons.

This PR is enough to fix the issues equilend is facing.