### PR TITLE
Fix expression warning for utility deps

### DIFF
--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -950,7 +950,7 @@ checkQualName deps name =
                   if udPkgName (_present upgradingDep) `elem` [PackageName "daml-stdlib", PackageName "daml-prim"]
                   then []
                   else case udMbPackageVersion `traverse` upgradingDep of
-                    Just version -> ifMismatch (_past version > _present version) (PastPackageHasHigherVersion upgradingDep)
+                    Just version -> ifMismatch (_past version < _present version) (PastPackageHasHigherVersion upgradingDep)
                     _ -> [] -- This case should not be possible
                 Upgrading False False ->
                   case udMbPackageVersion <$> upgradingDep of

--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Upgrade.hs
@@ -927,6 +927,7 @@ checkQualName deps name =
     prioritizeMismatches (namesAreSame `Alpha.andMismatches` qualificationIsSameOrUpgraded)
   where
     nameMismatch' reason = foldU Alpha.nameMismatch name (Just reason)
+    -- if b is False, we emit the mismatch on the right
     ifMismatch b reason = [nameMismatch' reason | not b]
     tryGetPkgId :: LF.PackageId -> Either PackageId UpgradingDep
     tryGetPkgId pkgId =

--- a/sdk/compiler/damlc/tests/BUILD.bazel
+++ b/sdk/compiler/damlc/tests/BUILD.bazel
@@ -596,6 +596,10 @@ da_haskell_test(
         "//test-common:upgrades-FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage-v2.dar",
         "//test-common:upgrades-FailsWhenAnInstanceIsReplacedWithADifferentInstanceOfAnIdenticallyNamedInterface-v1.dar",
         "//test-common:upgrades-FailsWhenAnInstanceIsReplacedWithADifferentInstanceOfAnIdenticallyNamedInterface-v2.dar",
+        "//test-common:upgrades-DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifierDep-v1.dar",
+        "//test-common:upgrades-DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifierDep-v2.dar",
+        "//test-common:upgrades-DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifier-v1.dar",
+        "//test-common:upgrades-DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifier-v2.dar",
     ],
     hackage_deps = [
         "base",

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcUpgrades.hs
@@ -447,6 +447,9 @@ tests damlc =
             , testUpgradeCheck
                   "FailsWhenAnExceptionIsDefinedInAnUpgradingPackageWhenItWasAlreadyInThePriorPackage"
                   (FailWithError "error type checking exception Main.E:\n  Tried to upgrade exception E, but exceptions cannot be upgraded. They should be removed in any upgrading package.")
+            , testUpgradeCheck
+                  "DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifier"
+                  (SucceedWithoutWarning "*.warning while type checking template Main.Foo signatories:\n  The upgraded template Foo has changed the definition of its signatories.\n  There is 1 difference in the expression:\n    Name .*:Dep:duplicateParty and name .*:Dep:duplicateParty differ for the following reason: Just Name came from package .* and now comes from package .* Both packages support upgrades, but the previous package had a higher version than the current one..*")
             ]
        )
   where
@@ -710,7 +713,7 @@ data Expectation
   = Succeed
   | FailWithError T.Text
   | SucceedWithWarning T.Text
-  | SucceedWithoutWarning T.Text
+  | SucceedWithoutWarning T.Text -- fails if warning equals passed Text
   deriving (Show, Eq, Ord)
 
 data Dependency

--- a/sdk/test-common/BUILD.bazel
+++ b/sdk/test-common/BUILD.bazel
@@ -292,6 +292,12 @@ da_scala_dar_resources_library(
                 "module_prefixes": {"upgrades-example-SucceedsWhenDepIsValidPreviousVersionOfSelf-1.0.0": "V1"},
             },
         ),
+        ("DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifierDep", {}, {}),
+        (
+            "DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifier",
+            {"data_dependencies": ["//test-common:upgrades-DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifierDep-v1.dar"]},
+            {"data_dependencies": ["//test-common:upgrades-DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifierDep-v2.dar"]},
+        ),
 
         # Ported from DamlcUpgrades.hs
         ("FailsWhenExistingFieldInTemplateChoiceIsChanged", {}, {}),

--- a/sdk/test-common/src/main/daml/upgrades/DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifier/v1/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifier/v1/Main.daml
@@ -1,0 +1,16 @@
+-- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+import Dep
+
+data DummyUser = DummyUser with
+--  dummy : Dummy
+  dummy : Bool
+
+template Foo with
+    p : Party
+  where
+    signatory (duplicateParty p)
+

--- a/sdk/test-common/src/main/daml/upgrades/DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifier/v2/Main.daml
+++ b/sdk/test-common/src/main/daml/upgrades/DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifier/v2/Main.daml
@@ -1,0 +1,16 @@
+-- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+import Dep
+
+data DummyUser = DummyUser with
+--  dummy : Dummy
+  dummy : Bool
+
+template Foo with
+    p : Party
+  where
+    signatory (duplicateParty p)
+

--- a/sdk/test-common/src/main/daml/upgrades/DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifierDep/v1/Dep.daml
+++ b/sdk/test-common/src/main/daml/upgrades/DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifierDep/v1/Dep.daml
@@ -1,0 +1,11 @@
+-- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Dep where
+
+-- data Dummy = Dummy with
+--     foo : Bool
+
+duplicateParty : Party -> [Party]
+duplicateParty x = [x,x]
+

--- a/sdk/test-common/src/main/daml/upgrades/DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifierDep/v2/Dep.daml
+++ b/sdk/test-common/src/main/daml/upgrades/DoesNotWarnWhenExpressionUpgradesUtilityDependencyIdentifierDep/v2/Dep.daml
@@ -1,0 +1,11 @@
+-- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Dep where
+
+-- data Dummy = Dummy with
+--     foo : Bool
+
+duplicateParty : Party -> [Party]
+duplicateParty x = [x,x]
+


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->

closes #21156

Added test for scenario (that failed on then-current main), flipped the > into a <, test now succeeds
