### PR TITLE
Log commands in the check-for-release step

### DIFF
--- a/ci/check-for-release-job.yml
+++ b/ci/check-for-release-job.yml
@@ -17,7 +17,7 @@ jobs:
         var_name: bash-lib
     - bash: |
         set -euo pipefail
-        set -x
+        #set -x
         cd sdk
         eval "$(./dev-env/bin/dade-assist)"
         source $(bash-lib)

--- a/ci/check-for-release-job.yml
+++ b/ci/check-for-release-job.yml
@@ -17,6 +17,7 @@ jobs:
         var_name: bash-lib
     - bash: |
         set -euo pipefail
+        set -x
         cd sdk
         eval "$(./dev-env/bin/dade-assist)"
         source $(bash-lib)

--- a/ci/check-for-release-job.yml
+++ b/ci/check-for-release-job.yml
@@ -17,7 +17,8 @@ jobs:
         var_name: bash-lib
     - bash: |
         set -euo pipefail
-        #set -x
+        export BASH_XTRACEFD=1
+        set -x
         cd sdk
         eval "$(./dev-env/bin/dade-assist)"
         source $(bash-lib)

--- a/ci/check-for-release-job.yml
+++ b/ci/check-for-release-job.yml
@@ -18,16 +18,13 @@ jobs:
     - bash: |
         set -euo pipefail
         
-        # Log commands to some temp logfile and display it on stdout at the end
-        LOGFILE=$(mktemp)
-        function display_debug_log() {
-          echo "LOG FILE:"
-          cat "$LOGFILE"
+        error_handler() {
+          local exit_code="$1"
+          local line_number="$2"
+          local command="$3"
+          echo "Error: Command '$command' on line $line_number exited with status $exit_code" >&2
         }
-        trap display_debug_log EXIT
-        exec 7>"$LOGFILE"
-        export BASH_XTRACEFD=7
-        set -x
+        trap 'error_handler $? $LINENO "$BASH_COMMAND"' ERR 
         
         cd sdk
         eval "$(./dev-env/bin/dade-assist)"
@@ -82,8 +79,5 @@ jobs:
         else
             setvar scala_2_13 false
         fi
-
-        # close the file descriptor
-        exec 7>&-
       name: out
 

--- a/ci/check-for-release-job.yml
+++ b/ci/check-for-release-job.yml
@@ -17,8 +17,18 @@ jobs:
         var_name: bash-lib
     - bash: |
         set -euo pipefail
-        export BASH_XTRACEFD=1
+        
+        # Log commands to some temp logfile and display it on stdout at the end
+        LOGFILE=$(mktemp)
+        function display_debug_log() {
+          echo "LOG FILE:"
+          cat "$LOGFILE"
+        }
+        trap display_debug_log EXIT
+        exec 7>"$LOGFILE"
+        export BASH_XTRACEFD=7
         set -x
+        
         cd sdk
         eval "$(./dev-env/bin/dade-assist)"
         source $(bash-lib)
@@ -72,5 +82,8 @@ jobs:
         else
             setvar scala_2_13 false
         fi
+
+        # close the file descriptor
+        exec 7>&-
       name: out
 


### PR DESCRIPTION
The check-for-release step of the CI is [currently failing](https://dev.azure.com/digitalasset/daml/_build/results?buildId=192263&view=logs&j=4c01d40f-9a3f-59f7-c19b-4b567a7164bf&t=201826b8-3fe0-5b7d-114c-fdd1bfe7ff94) when a snapshot should be created. Adding more logging to that step in this PR and then will create another PR that modifies LATEST in order to create a snapshot.