### PR TITLE
Improve debugging in check-for-release-job

### DIFF
--- a/ci/check-for-release-job.yml
+++ b/ci/check-for-release-job.yml
@@ -17,7 +17,11 @@ jobs:
         var_name: bash-lib
     - bash: |
         set -euo pipefail
-        
+                
+        cd sdk
+        eval "$(./dev-env/bin/dade-assist)"
+        source $(bash-lib)
+
         error_handler() {
           local exit_code="$1"
           local line_number="$2"
@@ -25,10 +29,6 @@ jobs:
           echo "Error: Command '$command' on line $line_number exited with status $exit_code" >&2
         }
         trap 'error_handler $? $LINENO "$BASH_COMMAND"' ERR 
-        
-        cd sdk
-        eval "$(./dev-env/bin/dade-assist)"
-        source $(bash-lib)
 
         ./release.sh check
 


### PR DESCRIPTION
The error trap [didn't trigger](https://dev.azure.com/digitalasset/daml/_build/results?buildId=192354&view=logs&j=e74c1ec1-54ae-5943-cedf-e785163662c7&t=68519945-eab9-5f94-7ad3-9048857f8c49) in the nightly. I suspect that's because dade-init, which is eventually sourced from dade-assist, unsets it. So I'm moving it further down.