### PR TITLE
ping google and jfrog 10 times, also run 'ip a'

### DIFF
--- a/ci/daily-snapshot.yml
+++ b/ci/daily-snapshot.yml
@@ -43,8 +43,9 @@ jobs:
         fi
 
         ERR=$(mktemp)
-        ping -c 1 google.com
-        ping -c 1 digitalasset.jfrog.io
+        ip a
+        ping -c 10 google.com
+        ping -c 10 digitalasset.jfrog.io
         OUT=$(curl https://digitalasset.jfrog.io/artifactory/api/storage/assembly/daml/$release \
                    -u $AUTH \
                    -I \


### PR DESCRIPTION
 - we see that google.com is resolved but the first ping has a 100% packet loss, trying more than 1 ping
- https://learn.microsoft.com/en-us/answers/questions/2276997/azure-vm-unable-to-see-the-internet-(or-its-own-ga recommends to run `ip a` to check the status of the network adapters
