### PR TITLE
Fix previously broken Ledger API references

### DIFF
--- a/sdk/docs/manually-written/sdk/explanations/ledger-api-services.rst
+++ b/sdk/docs/manually-written/sdk/explanations/ledger-api-services.rst
@@ -68,18 +68,18 @@ Each intended ledger change is identified by its **change ID**, consisting of th
 
 - The submitting parties, i.e., the union of :brokenref:`party <com.daml.ledger.api.v1.Commands.party>` and :brokenref:`act_as <com.daml.ledger.api.v1.Commands.act_as>`
 - the :brokenref:`application ID <com.daml.ledger.api.v1.Commands.application_id>`
-- The :brokenref:`command ID <com.daml.ledger.api.v1.Commands.command_id>`
+- The :subsiteref:`command ID <com.daml.ledger.api.v2.Commands.command_id>`
 
 Application-specific IDs
 ------------------------
 
 The following application-specific IDs, all of which are included in completion events, can be set in commands:
 
-- A :brokenref:`submission ID <com.daml.ledger.api.v1.Commands.submission_id>`, returned to the submitting application only. It may be used to correlate specific submissions to specific completions.
-- A :brokenref:`command ID <com.daml.ledger.api.v1.Commands.command_id>`, returned to the submitting application only; it can be used to correlate commands to completions.
-- A :brokenref:`workflow ID <com.daml.ledger.api.v1.Commands.workflow_id>`, returned as part of the resulting transaction to all applications receiving it. It can be used to track workflows between parties, consisting of several transactions.
+- A :subsiteref:`submission ID <com.daml.ledger.api.v2.Commands.submission_id>`, returned to the submitting application only. It may be used to correlate specific submissions to specific completions.
+- A :subsiteref:`command ID <com.daml.ledger.api.v2.Commands.command_id>`, returned to the submitting application only; it can be used to correlate commands to completions.
+- A :subsiteref:`workflow ID <com.daml.ledger.api.v2.Commands.workflow_id>`, returned as part of the resulting transaction to all applications receiving it. It can be used to track workflows between parties, consisting of several transactions.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.CommandSubmissionService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.CommandSubmissionService>`.
 
 .. _command-submission-service-deduplication:
 
@@ -111,9 +111,9 @@ Command Completion Service
 
 Use the **command completion service** to find out the completion status of commands you have submitted.
 
-Completions contain the :brokenref:`command ID <com.daml.ledger.api.v1.Commands.command_id>` of the completed command, and the completion status of the command. This status indicates failure or success, and your application should use it to update what it knows about commands in flight, and implement any application-specific error recovery.
+Completions contain the :subsiteref:`command ID <com.daml.ledger.api.v2.Commands.command_id>` of the completed command, and the completion status of the command. This status indicates failure or success, and your application should use it to update what it knows about commands in flight, and implement any application-specific error recovery.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.CommandCompletionService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.CommandCompletionService>`.
 
 .. _command-service:
 
@@ -124,7 +124,7 @@ Use the **command service** when you want to submit a command and wait for it to
 
 You can use either the command or command submission services to submit commands to effect a ledger change. The command service is useful for simple applications, as it handles a basic form of coordination between command submission and completion, correlating submissions with completions, and returning a success or failure status. This allow simple applications to be completely stateless, and alleviates the need for them to track command submissions.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.CommandService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.CommandService>`.
 
 Read From the Ledger
 ********************
@@ -166,13 +166,13 @@ You can get these included in requests related to Transactions by setting the ``
 
 Transaction Filter
 ------------------
-``TransactionService`` offers transaction subscriptions filtered by templates and interfaces using ``GetTransactions`` calls. A :brokenref:`transaction filter <com.daml.ledger.api.v1.TransactionFilter>` in ``GetTransactionsRequest`` allows:
+``TransactionService`` offers transaction subscriptions filtered by templates and interfaces using ``GetTransactions`` calls. A :subsiteref:`transaction filter <com.daml.ledger.api.v2.TransactionFilter>` in ``GetTransactionsRequest`` allows:
 
 - filtering by a party, when the :brokenref:`inclusive <com.daml.ledger.api.v1.Filters.inclusive>` field is left empty
 - filtering by a party and :brokenref:`template ID <com.daml.ledger.api.v1.InclusiveFilters.template_filters>`
 - filtering by a party and :brokenref:`interface ID <com.daml.ledger.api.v1.InclusiveFilters.interface_filters>`
-- exposing an interface view, when the :brokenref:`include_interface_view <com.daml.ledger.api.v1.InterfaceFilter.include_interface_view>` is set to ``true``
-- exposing a created event blob to be used for a disclosed contract in command submission when ``include_created_event_blob`` is set to ``true`` in either :brokenref:`TemplateFilter <com.daml.ledger.api.v1.TemplateFilter>` or :brokenref:`InterfaceFilter <com.daml.ledger.api.v1.InterfaceFilter>`
+- exposing an interface view, when the :subsiteref:`include_interface_view <com.daml.ledger.api.v2.InterfaceFilter.include_interface_view>` is set to ``true``
+- exposing a created event blob to be used for a disclosed contract in command submission when ``include_created_event_blob`` is set to ``true`` in either :subsiteref:`TemplateFilter <com.daml.ledger.api.v2.TemplateFilter>` or :subsiteref:`InterfaceFilter <com.daml.ledger.api.v2.InterfaceFilter>`
 
 .. note::
 
@@ -232,7 +232,7 @@ If no events match the request criteria or the requested events are not visible 
 
   When querying by contract key, the key value must be structured in the same way as the key returned in the create event.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.EventQueryService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.EventQueryService>`.
 
 .. _ledger-api-utility-services:
 
@@ -250,7 +250,7 @@ Parties govern on-ledger access control as per :externalref:`Daml's privacy mode
 and :externalref:`authorization rules <da-ledgers-authorization-rules>`.
 Applications and their operators are expected to allocate and use parties to manage on-ledger access control as per their business requirements.
 
-For more information, refer to the pages on :brokenref:`Identity Management</concepts/identity-and-package-management>` and :brokenref:`the API reference documentation <com.daml.ledger.api.v1.admin.PartyManagementService>`.
+For more information, refer to the pages on :brokenref:`Identity Management</concepts/identity-and-package-management>` and :subsiteref:`the API reference documentation <com.daml.ledger.api.v2.admin.PartyManagementService>`.
 
 .. _user-management-service:
 
@@ -265,8 +265,8 @@ Daml 2.0 introduced the concept of the user in Daml. While a party represents a 
 
 The relation between a participant node's users and Daml parties is best understood by analogy to classical databases: a participant node's users are analogous to database users while Daml parties are analogous to database roles. Further, the rights granted to a user are analogous to the user's assigned database roles.
 
-For more information, consult the :brokenref:`the API reference documentation <com.daml.ledger.api.v1.admin.UserManagementService>` for how to list, create, update, and delete users and their rights.
-See the :brokenref:`UserManagementFeature descriptor <com.daml.ledger.api.v1.UserManagementFeature>` to learn about the limits of the user management service, e.g., the maximum number of rights per user.
+For more information, consult the :subsiteref:`the API reference documentation <com.daml.ledger.api.v2.admin.UserManagementService>` for how to list, create, update, and delete users and their rights.
+See the :subsiteref:`UserManagementFeature descriptor <com.daml.ledger.api.v2.UserManagementFeature>` to learn about the limits of the user management service, e.g., the maximum number of rights per user.
 The feature descriptor can be retrieved using the :ref:`Version service <version-service>`.
 
 With user management enabled you can use both new user-based and old custom Daml authorization tokens.
@@ -286,7 +286,7 @@ The **identity provider config service** makes it possible for participant node 
 
 Such parties and users have a matching identity_provider_id defined and are inaccessible to administrators from other identity providers. A user will only be authenticated if the corresponding JWT token is issued by the appropriate identity provider. Users and parties without identity_provider_id defined are assumed to be using the default identity provider, which is configured statically when the participant node is deployed.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.admin.IdentityProviderConfigService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.admin.IdentityProviderConfigService>`.
 
 .. _package-service:
 
@@ -297,7 +297,7 @@ Use the **package service** to obtain information about Daml packages available 
 
 This is useful for obtaining type and metadata information that allow you to interpret event data in a more useful way.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.PackageService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.PackageService>`.
 
 .. _ledger-identity-service:
 
@@ -329,7 +329,7 @@ Version Service
 
 Use the **version service** to retrieve information about the Ledger API version and what optional features are supported by the ledger server.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.VersionService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.VersionService>`.
 
 .. _pruning-service:
 
@@ -338,7 +338,7 @@ Pruning Service
 
 Use the **pruning service** to prune archived contracts and transactions before or at a given offset.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.admin.ParticipantPruningService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.admin.ParticipantPruningService>`.
 
 .. _metering-report-service:
 
@@ -363,4 +363,4 @@ Time Service
 
 Use the **time service** to obtain the time as known by the ledger server.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.testing.TimeService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.testing.TimeService>`.

--- a/sdk/docs/manually-written/sdk/sdlc-howtos/applications/develop/command-deduplication.rst
+++ b/sdk/docs/manually-written/sdk/sdlc-howtos/applications/develop/command-deduplication.rst
@@ -33,13 +33,13 @@ The first three form the :ref:`change ID <change-id>` that identifies the intend
 
 - The :brokenref:`application ID <com.daml.ledger.api.v1.Commands.application_id>` identifies the application that submits the command.
 
-- The :brokenref:`command ID <com.daml.ledger.api.v1.Commands.command_id>` is chosen by the application to identify the intended ledger change.
+- The :subsiteref:`command ID <com.daml.ledger.api.v2.Commands.command_id>` is chosen by the application to identify the intended ledger change.
 
 - The deduplication period specifies the period for which no earlier submissions with the same change ID should have been accepted, as witnessed by a completion event on the :ref:`command completion service <command-completion-service>`.
   If such a change has been accepted in that period, the current submission shall be rejected.
   The period is specified either as a :brokenref:`deduplication duration <com.daml.ledger.api.v1.Commands.deduplication_period.deduplication_duration>` or as a :brokenref:`deduplication offset <com.daml.ledger.api.v1.Commands.deduplication_period.deduplication_offset>` (inclusive).
 
-- The :brokenref:`submission ID <com.daml.ledger.api.v1.Commands.submission_id>` is chosen by the application to identify a specific submission.
+- The :subsiteref:`submission ID <com.daml.ledger.api.v2.Commands.submission_id>` is chosen by the application to identify a specific submission.
   It is included in the corresponding completion event so that the application can correlate specific submissions to specific completions.
   An application should never reuse a submission ID.
 
@@ -50,7 +50,7 @@ The ledger may arbitrarily extend the deduplication period specified in the subm
 
 The deduplication period chosen by the ledger is the *effective deduplication period*.
 The ledger may also convert a requested deduplication duration into an effective deduplication offset or vice versa.
-The effective deduplication period is reported in the command completion event in the :brokenref:`deduplication duration <com.daml.ledger.api.v1.Completion.deduplication_period.deduplication_duration>` or :brokenref:`deduplication offset <com.daml.ledger.api.v1.Completion.deduplication_period.deduplication_offset>` fields.
+The effective deduplication period is reported in the command completion event in the :subsiteref:`deduplication duration <com.daml.ledger.api.v2.Completion.deduplication_period.deduplication_duration>` or :subsiteref:`deduplication offset <com.daml.ledger.api.v2.Completion.deduplication_period.deduplication_offset>` fields.
 
 A command submission is considered a **duplicate submission** if at least one of the following holds:
 
@@ -104,8 +104,8 @@ Some ledger changes can be executed at most once, so no command deduplication is
 For example, if the submitted command exercises a consuming choice on a given contract ID, this command can be accepted at most once because every contract can be archived at most once.
 All duplicate submissions of such a change will be rejected with :brokenref:`CONTRACT_NOT_ACTIVE <error_code_CONTRACT_NOT_ACTIVE>`.
 
-In contrast, a :brokenref:`Create command <com.daml.ledger.api.v1.CreateCommand>` would create a fresh contract instance of the given :brokenref:`template <com.daml.ledger.api.v1.CreateCommand.template_id>` for each submission that reaches the ledger (unless other constraints such as the :ref:`template preconditions <daml-ref-preconditions>` or contract key uniqueness are violated).
-Similarly, an :brokenref:`Exercise command <com.daml.ledger.api.v1.ExerciseCommand>` on a non-consuming choice or an :brokenref:`Exercise-By-Key command <com.daml.ledger.api.v1.ExercisebyKeyCommand>` may be executed multiple times if submitted multiple times.
+In contrast, a :subsiteref:`Create command <com.daml.ledger.api.v2.CreateCommand>` would create a fresh contract instance of the given :subsiteref:`template <com.daml.ledger.api.v2.CreateCommand.template_id>` for each submission that reaches the ledger (unless other constraints such as the :ref:`template preconditions <daml-ref-preconditions>` or contract key uniqueness are violated).
+Similarly, an :subsiteref:`Exercise command <com.daml.ledger.api.v2.ExerciseCommand>` on a non-consuming choice or an :subsiteref:`Exercise-By-Key command <com.daml.ledger.api.v2.ExercisebyKeyCommand>` may be executed multiple times if submitted multiple times.
 With command deduplication, applications can ensure such intended ledger changes are executed only once within the deduplication period, even if the application resubmits, say because it considers the earlier submissions to be lost or forgot during a crash that it had already submitted the command.
 
 
@@ -141,9 +141,9 @@ Under this caveat, the following strategy works for applications that use the :r
 
 #. Submit the command with the following parameters:
 
-   - Set the :brokenref:`command ID <com.daml.ledger.api.v1.Commands.command_id>` to the chosen command ID from :ref:`Step 1 <dedup-bounded-step-command-id>`.
+   - Set the :subsiteref:`command ID <com.daml.ledger.api.v2.Commands.command_id>` to the chosen command ID from :ref:`Step 1 <dedup-bounded-step-command-id>`.
 
-   - Set the :brokenref:`deduplication duration <com.daml.ledger.api.v1.Commands.deduplication_period.deduplication_duration>` to the bound ``B``.
+   - Set the :subsiteref:`deduplication duration <com.daml.ledger.api.v2.Commands.deduplication_period.deduplication_duration>` to the bound ``B``.
 
      .. note::
         It is prudent to explicitly set the deduplication duration to the desired bound ``B``,
@@ -154,7 +154,7 @@ Under this caveat, the following strategy works for applications that use the :r
 	If you omitted the deduplication period, the currently valid maximum deduplication duration would be used.
 	In this case, a ledger configuration update could silently shorten the deduplication period and thus invalidate your deduplication analysis.
 
-   - Set the :brokenref:`submission ID <com.daml.ledger.api.v1.Commands.submission_id>` to a fresh value, e.g., a random UUID.
+   - Set the :subsiteref:`submission ID <com.daml.ledger.api.v2.Commands.submission_id>` to a fresh value, e.g., a random UUID.
 
    - Set the timeout (gRPC deadline) to the expected submission processing time (Command Service) or submission hand-off time (Command Submission Service).
 
@@ -185,7 +185,7 @@ Under this caveat, the following strategy works for applications that use the :r
 Error Handling
 --------------
 
-Error handling is needed when the status code of the command submission RPC call or in the :brokenref:`completion event <com.daml.ledger.api.v1.Completion.status>` is not ``OK``.
+Error handling is needed when the status code of the command submission RPC call or in the :subsiteref:`completion event <com.daml.ledger.api.v2.Completion.status>` is not ``OK``.
 The following table lists appropriate reactions by status code (written as ``STATUS_CODE``) and error code (written in capital letters with a link to the error code documentation).
 Fields in the error metadata are written as ``field`` in lowercase letters.
 
@@ -236,7 +236,7 @@ Fields in the error metadata are written as ``field`` in lowercase letters.
      * The specified deduplication offset has been pruned by the participant.
        ``earliest_offset`` contains the last pruned offset.
 
-        Use the :ref:`Command Completion Service <command-completion-service>` by asking for the :brokenref:`completions <com.daml.ledger.api.v1.CompletionStreamRequest>`, starting from the last pruned offset by setting :brokenref:`offset <com.daml.ledger.api.v1.CompletionStreamRequest.offset>` to the value of
+        Use the :ref:`Command Completion Service <command-completion-service>` by asking for the :subsiteref:`completions <com.daml.ledger.api.v2.CompletionStreamRequest>`, starting from the last pruned offset by setting :brokenref:`offset <com.daml.ledger.api.v1.CompletionStreamRequest.offset>` to the value of
         ``earliest_offset``, and use the first received :brokenref:`offset <com.daml.ledger.api.v1.Checkpoint.offset>` as a deduplication offset.
 
 
@@ -321,7 +321,7 @@ We recommend the following strategy for using deduplication offsets:
 	In general, the ledger end need not identify a command completion that is visible to the submitting parties.
 	When running on such a ledger, use the Command Service approach described next.
 
-   - Use the :ref:`Command Service <command-service>` to obtain a recent offset by repeatedly submitting a dummy command, e.g., a :brokenref:`Create-And-Exercise command <com.daml.ledger.api.v1.CreateAndExerciseCommand>` of some single-signatory template with the :ref:`Archive <function-da-internal-template-functions-archive-2977>` choice, until you get a successful response.
+   - Use the :ref:`Command Service <command-service>` to obtain a recent offset by repeatedly submitting a dummy command, e.g., a :subsiteref:`Create-And-Exercise command <com.daml.ledger.api.v2.CreateAndExerciseCommand>` of some single-signatory template with the :ref:`Archive <function-da-internal-template-functions-archive-2977>` choice, until you get a successful response.
      The response contains the :brokenref:`completion offset <com.daml.ledger.api.v1.SubmitAndWaitForTransactionIdResponse.completion_offset>`.
 
 
@@ -336,11 +336,11 @@ We recommend the following strategy for using deduplication offsets:
 
 #. Submit the command with the following parameters (analogous to :ref:`Step 3 above <dedup-bounded-step-submit>` except for the deduplication period):
 
-   - Set the :brokenref:`command ID <com.daml.ledger.api.v1.Commands.command_id>` to the chosen command ID from :ref:`Step 1 <dedup-bounded-step-command-id>`.
+   - Set the :subsiteref:`command ID <com.daml.ledger.api.v2.Commands.command_id>` to the chosen command ID from :ref:`Step 1 <dedup-bounded-step-command-id>`.
 
-   - Set the :brokenref:`deduplication offset <com.daml.ledger.api.v1.Commands.deduplication_period.deduplication_offset>` to ``OFF0``.
+   - Set the :subsiteref:`deduplication offset <com.daml.ledger.api.v2.Commands.deduplication_period.deduplication_offset>` to ``OFF0``.
 
-   - Set the :brokenref:`submission ID <com.daml.ledger.api.v1.Commands.submission_id>` to a fresh value, e.g., a random UUID.
+   - Set the :subsiteref:`submission ID <com.daml.ledger.api.v2.Commands.submission_id>` to a fresh value, e.g., a random UUID.
 
    - Set the timeout (gRPC deadline) to the expected submission processing time (Command Service) or submission hand-off time (Command Submission Service).
 

--- a/sdk/docs/manually-written/sdk/sdlc-howtos/applications/develop/explicit-contract-disclosure.rst
+++ b/sdk/docs/manually-written/sdk/sdlc-howtos/applications/develop/explicit-contract-disclosure.rst
@@ -211,16 +211,16 @@ How do stakeholders disclose contracts to submitters?
 -----------------------------------------------------
 
 The disclosed contract's details can be fetched by the contract's stakeholder from the contract's
-associated :brokenref:`CreatedEvent <com.daml.ledger.api.v1.CreatedEvent>`,
+associated :subsiteref:`CreatedEvent <com.daml.ledger.api.v2.CreatedEvent>`,
 which can be read from the Ledger API via the active contracts and transactions queries
 (see :ref:`Reading from the ledger <reading-from-the-ledger>`).
 
 The stakeholder can then share the disclosed contract details to the submitter off-ledger (outside of Daml)
-by conventional means, such as HTTPS, SFTP, or e-mail. A :brokenref:`DisclosedContract <com.daml.ledger.api.v1.DisclosedContract>` can
+by conventional means, such as HTTPS, SFTP, or e-mail. A :subsiteref:`DisclosedContract <com.daml.ledger.api.v2.DisclosedContract>` can
 be constructed from the fields of the same name from the original contract's ``CreatedEvent``.
 
 .. note::
-  The ``created_event_blob`` field in ``CreatedEvent`` (used to construct the :brokenref:`DisclosedContract <com.daml.ledger.api.v1.DisclosedContract>`)
+  The ``created_event_blob`` field in ``CreatedEvent`` (used to construct the :subsiteref:`DisclosedContract <com.daml.ledger.api.v2.DisclosedContract>`)
   is populated **only** on demand for ``GetTransactions``, ``GetTransactionTrees``, and ``GetActiveContracts`` streams.
   To learn more, see :ref:`configuring transaction filters <transaction-filter>`.
 
@@ -229,8 +229,8 @@ be constructed from the fields of the same name from the original contract's ``C
 Attaching a disclosed contract to a command submission
 ------------------------------------------------------
 
-A disclosed contract can be attached as part of the ``Command``'s :brokenref:`disclosed_contracts <com.daml.ledger.api.v1.Commands.disclosed_contracts>`
-and requires the following fields (see :brokenref:`DisclosedContract <com.daml.ledger.api.v1.DisclosedContract>` for content details) to be populated from
+A disclosed contract can be attached as part of the ``Command``'s :subsiteref:`disclosed_contracts <com.daml.ledger.api.v2.Commands.disclosed_contracts>`
+and requires the following fields (see :subsiteref:`DisclosedContract <com.daml.ledger.api.v2.DisclosedContract>` for content details) to be populated from
 the original `CreatedEvent` (see above):
 
 - **template_id** - The contract's template id.

--- a/sdk/docs/manually-written/sdk/sdlc-howtos/applications/harden/pruning.rst
+++ b/sdk/docs/manually-written/sdk/sdlc-howtos/applications/harden/pruning.rst
@@ -8,7 +8,7 @@ The Daml Ledger API exposes an append-only ledger model; on the other hand, Daml
 
 In addition, privacy demands [1]_ may require removing Personally Identifiable Information (PII) upon request.
 
-To satisfy these requirements, the :brokenref:`Pruning Service <com.daml.ledger.api.v1.admin.ParticipantPruningService>` Ledger API endpoint [2]_ allows Daml Participants to support pruning of Daml contracts and transactions that were respectively archived and submitted before or at a given ledger offset.
+To satisfy these requirements, the :subsiteref:`Pruning Service <com.daml.ledger.api.v2.admin.ParticipantPruningService>` Ledger API endpoint [2]_ allows Daml Participants to support pruning of Daml contracts and transactions that were respectively archived and submitted before or at a given ledger offset.
 
 Please refer to the specific Daml driver information for details about its pruning support.
 
@@ -27,7 +27,7 @@ Still, Daml applications may be affected in the following ways:
 - Pruning may degrade the behavior of or abort in-progress requests if the pruning offset is too recent. In particular, the system might misbehave if command completions are pruned before the command trackers are able to process the completions.
 - Command deduplication and command tracker retention should always be configured so that the associated windows don't overlap with the pruning window to ensure that their operation is unaffected by pruning.
 - Pruning may affect the behavior of Ledger API calls that allow to read data from the ledger: see the next sub-section for more information about API impacts.
-- Pruning of all divulged contracts (see :brokenref:`Prune Request <com.daml.ledger.api.v1.admin.PruneRequest>`) does not preserve application visibility over contracts divulged up to the pruning offset, hence applications making use of pruned divulged contracts might start experiencing failed command submissions: see the section below for determining a suitable pruning offset.
+- Pruning of all divulged contracts (see :subsiteref:`Prune Request <com.daml.ledger.api.v2.admin.PruneRequest>`) does not preserve application visibility over contracts divulged up to the pruning offset, hence applications making use of pruned divulged contracts might start experiencing failed command submissions: see the section below for determining a suitable pruning offset.
 
 .. warning::
   Participants may know of contracts for which they don't know the current activeness status. This happens through :externalref:`divulgence <da-model-divulgence>` where a party learns of the existence of a contract without being guaranteed to ever see its archival. Such contracts are pruned by the feature described on this page as not doing so could easily lead to an ever growing participant state.

--- a/sdk/docs/manually-written/sdk/sdlc-howtos/smart-contracts/upgrade/smart-contract-upgrades.rst
+++ b/sdk/docs/manually-written/sdk/sdlc-howtos/smart-contracts/upgrade/smart-contract-upgrades.rst
@@ -1839,13 +1839,13 @@ The package preference is needed at each command submission time and is assemble
   version is used.
 
 - The package-id selection preference list specified in the submitted command's
-  :brokenref:`package_id_selection_preference <com.daml.ledger.api.v1.Commands.package_id_selection_preference>` in a command submission.
+  :subsiteref:`package_id_selection_preference <com.daml.ledger.api.v2.Commands.package_id_selection_preference>` in a command submission.
   This is package-id resolution list explicitly provided by the client to
   override the default package preference mentioned above.
 
    - See :ref:`here <daml-script-package-preference>` for how to provide this in Daml-Script
 
-   -  **Note:** The :brokenref:`package_id_selection_preference <com.daml.ledger.api.v1.Commands.package_id_selection_preference>`
+   -  **Note:** The :subsiteref:`package_id_selection_preference <com.daml.ledger.api.v2.Commands.package_id_selection_preference>`
       must not lead to ambiguous resolutions for package-names,
       meaning that it must not contain two package-ids pointing to
       packages with the same package-name, as otherwise the submission will fail with
@@ -1867,7 +1867,7 @@ Dynamic package resolution can happen in two cases during command submission:
 
 -  For command submissions that use a `by-package-name template ID`
    in the command’s templateId field (e.g. in a
-   create command :brokenref:`here <com.daml.ledger.api.v1.CreateCommand>`)
+   create command :subsiteref:`here <com.daml.ledger.api.v2.CreateCommand>`)
 
 -  For command submissions whose Daml interpretation requires the execution of
    interface choices or fetch-by-interface actions.
@@ -1881,7 +1881,7 @@ Dynamic Package Resolution in Ledger API Queries
 When subscribing for :brokenref:`transaction <transaction-trees>`
 or :ref:`active contract streams <active-contract-service>`,
 users can now use the `by-package-name template ID` format
-in the :brokenref:`template-id request filter field <com.daml.ledger.api.v1.TemplateFilter.template_id>`.
+in the :subsiteref:`template-id request filter field <com.daml.ledger.api.v2.TemplateFilter.template_id>`.
 to specify that they’re interested in fetching events for all templates
 pertaining to the specified package-name. This template selection set is
 dynamic and it widens with each uploaded template/package.

--- a/sdk/docs/sharable/sdk/explanations/ledger-api-services.rst
+++ b/sdk/docs/sharable/sdk/explanations/ledger-api-services.rst
@@ -68,18 +68,18 @@ Each intended ledger change is identified by its **change ID**, consisting of th
 
 - The submitting parties, i.e., the union of :brokenref:`party <com.daml.ledger.api.v1.Commands.party>` and :brokenref:`act_as <com.daml.ledger.api.v1.Commands.act_as>`
 - the :brokenref:`application ID <com.daml.ledger.api.v1.Commands.application_id>`
-- The :brokenref:`command ID <com.daml.ledger.api.v1.Commands.command_id>`
+- The :subsiteref:`command ID <com.daml.ledger.api.v2.Commands.command_id>`
 
 Application-specific IDs
 ------------------------
 
 The following application-specific IDs, all of which are included in completion events, can be set in commands:
 
-- A :brokenref:`submission ID <com.daml.ledger.api.v1.Commands.submission_id>`, returned to the submitting application only. It may be used to correlate specific submissions to specific completions.
-- A :brokenref:`command ID <com.daml.ledger.api.v1.Commands.command_id>`, returned to the submitting application only; it can be used to correlate commands to completions.
-- A :brokenref:`workflow ID <com.daml.ledger.api.v1.Commands.workflow_id>`, returned as part of the resulting transaction to all applications receiving it. It can be used to track workflows between parties, consisting of several transactions.
+- A :subsiteref:`submission ID <com.daml.ledger.api.v2.Commands.submission_id>`, returned to the submitting application only. It may be used to correlate specific submissions to specific completions.
+- A :subsiteref:`command ID <com.daml.ledger.api.v2.Commands.command_id>`, returned to the submitting application only; it can be used to correlate commands to completions.
+- A :subsiteref:`workflow ID <com.daml.ledger.api.v2.Commands.workflow_id>`, returned as part of the resulting transaction to all applications receiving it. It can be used to track workflows between parties, consisting of several transactions.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.CommandSubmissionService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.CommandSubmissionService>`.
 
 .. _command-submission-service-deduplication:
 
@@ -111,9 +111,9 @@ Command Completion Service
 
 Use the **command completion service** to find out the completion status of commands you have submitted.
 
-Completions contain the :brokenref:`command ID <com.daml.ledger.api.v1.Commands.command_id>` of the completed command, and the completion status of the command. This status indicates failure or success, and your application should use it to update what it knows about commands in flight, and implement any application-specific error recovery.
+Completions contain the :subsiteref:`command ID <com.daml.ledger.api.v2.Commands.command_id>` of the completed command, and the completion status of the command. This status indicates failure or success, and your application should use it to update what it knows about commands in flight, and implement any application-specific error recovery.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.CommandCompletionService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.CommandCompletionService>`.
 
 .. _command-service:
 
@@ -124,7 +124,7 @@ Use the **command service** when you want to submit a command and wait for it to
 
 You can use either the command or command submission services to submit commands to effect a ledger change. The command service is useful for simple applications, as it handles a basic form of coordination between command submission and completion, correlating submissions with completions, and returning a success or failure status. This allow simple applications to be completely stateless, and alleviates the need for them to track command submissions.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.CommandService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.CommandService>`.
 
 Read From the Ledger
 ********************
@@ -166,13 +166,13 @@ You can get these included in requests related to Transactions by setting the ``
 
 Transaction Filter
 ------------------
-``TransactionService`` offers transaction subscriptions filtered by templates and interfaces using ``GetTransactions`` calls. A :brokenref:`transaction filter <com.daml.ledger.api.v1.TransactionFilter>` in ``GetTransactionsRequest`` allows:
+``TransactionService`` offers transaction subscriptions filtered by templates and interfaces using ``GetTransactions`` calls. A :subsiteref:`transaction filter <com.daml.ledger.api.v2.TransactionFilter>` in ``GetTransactionsRequest`` allows:
 
 - filtering by a party, when the :brokenref:`inclusive <com.daml.ledger.api.v1.Filters.inclusive>` field is left empty
 - filtering by a party and :brokenref:`template ID <com.daml.ledger.api.v1.InclusiveFilters.template_filters>`
 - filtering by a party and :brokenref:`interface ID <com.daml.ledger.api.v1.InclusiveFilters.interface_filters>`
-- exposing an interface view, when the :brokenref:`include_interface_view <com.daml.ledger.api.v1.InterfaceFilter.include_interface_view>` is set to ``true``
-- exposing a created event blob to be used for a disclosed contract in command submission when ``include_created_event_blob`` is set to ``true`` in either :brokenref:`TemplateFilter <com.daml.ledger.api.v1.TemplateFilter>` or :brokenref:`InterfaceFilter <com.daml.ledger.api.v1.InterfaceFilter>`
+- exposing an interface view, when the :subsiteref:`include_interface_view <com.daml.ledger.api.v2.InterfaceFilter.include_interface_view>` is set to ``true``
+- exposing a created event blob to be used for a disclosed contract in command submission when ``include_created_event_blob`` is set to ``true`` in either :subsiteref:`TemplateFilter <com.daml.ledger.api.v2.TemplateFilter>` or :subsiteref:`InterfaceFilter <com.daml.ledger.api.v2.InterfaceFilter>`
 
 .. note::
 
@@ -232,7 +232,7 @@ If no events match the request criteria or the requested events are not visible 
 
   When querying by contract key, the key value must be structured in the same way as the key returned in the create event.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.EventQueryService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.EventQueryService>`.
 
 .. _ledger-api-utility-services:
 
@@ -250,7 +250,7 @@ Parties govern on-ledger access control as per :externalref:`Daml's privacy mode
 and :externalref:`authorization rules <da-ledgers-authorization-rules>`.
 Applications and their operators are expected to allocate and use parties to manage on-ledger access control as per their business requirements.
 
-For more information, refer to the pages on :brokenref:`Identity Management</concepts/identity-and-package-management>` and :brokenref:`the API reference documentation <com.daml.ledger.api.v1.admin.PartyManagementService>`.
+For more information, refer to the pages on :brokenref:`Identity Management</concepts/identity-and-package-management>` and :subsiteref:`the API reference documentation <com.daml.ledger.api.v2.admin.PartyManagementService>`.
 
 .. _user-management-service:
 
@@ -265,8 +265,8 @@ Daml 2.0 introduced the concept of the user in Daml. While a party represents a 
 
 The relation between a participant node's users and Daml parties is best understood by analogy to classical databases: a participant node's users are analogous to database users while Daml parties are analogous to database roles. Further, the rights granted to a user are analogous to the user's assigned database roles.
 
-For more information, consult the :brokenref:`the API reference documentation <com.daml.ledger.api.v1.admin.UserManagementService>` for how to list, create, update, and delete users and their rights.
-See the :brokenref:`UserManagementFeature descriptor <com.daml.ledger.api.v1.UserManagementFeature>` to learn about the limits of the user management service, e.g., the maximum number of rights per user.
+For more information, consult the :subsiteref:`the API reference documentation <com.daml.ledger.api.v2.admin.UserManagementService>` for how to list, create, update, and delete users and their rights.
+See the :subsiteref:`UserManagementFeature descriptor <com.daml.ledger.api.v2.UserManagementFeature>` to learn about the limits of the user management service, e.g., the maximum number of rights per user.
 The feature descriptor can be retrieved using the :ref:`Version service <version-service>`.
 
 With user management enabled you can use both new user-based and old custom Daml authorization tokens.
@@ -286,7 +286,7 @@ The **identity provider config service** makes it possible for participant node 
 
 Such parties and users have a matching identity_provider_id defined and are inaccessible to administrators from other identity providers. A user will only be authenticated if the corresponding JWT token is issued by the appropriate identity provider. Users and parties without identity_provider_id defined are assumed to be using the default identity provider, which is configured statically when the participant node is deployed.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.admin.IdentityProviderConfigService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.admin.IdentityProviderConfigService>`.
 
 .. _package-service:
 
@@ -297,7 +297,7 @@ Use the **package service** to obtain information about Daml packages available 
 
 This is useful for obtaining type and metadata information that allow you to interpret event data in a more useful way.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.PackageService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.PackageService>`.
 
 .. _ledger-identity-service:
 
@@ -329,7 +329,7 @@ Version Service
 
 Use the **version service** to retrieve information about the Ledger API version and what optional features are supported by the ledger server.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.VersionService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.VersionService>`.
 
 .. _pruning-service:
 
@@ -338,7 +338,7 @@ Pruning Service
 
 Use the **pruning service** to prune archived contracts and transactions before or at a given offset.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.admin.ParticipantPruningService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.admin.ParticipantPruningService>`.
 
 .. _metering-report-service:
 
@@ -363,4 +363,4 @@ Time Service
 
 Use the **time service** to obtain the time as known by the ledger server.
 
-For full details, see :brokenref:`the proto documentation for the service <com.daml.ledger.api.v1.testing.TimeService>`.
+For full details, see :subsiteref:`the proto documentation for the service <com.daml.ledger.api.v2.testing.TimeService>`.

--- a/sdk/docs/sharable/sdk/sdlc-howtos/applications/develop/command-deduplication.rst
+++ b/sdk/docs/sharable/sdk/sdlc-howtos/applications/develop/command-deduplication.rst
@@ -33,13 +33,13 @@ The first three form the :ref:`change ID <change-id>` that identifies the intend
 
 - The :brokenref:`application ID <com.daml.ledger.api.v1.Commands.application_id>` identifies the application that submits the command.
 
-- The :brokenref:`command ID <com.daml.ledger.api.v1.Commands.command_id>` is chosen by the application to identify the intended ledger change.
+- The :subsiteref:`command ID <com.daml.ledger.api.v2.Commands.command_id>` is chosen by the application to identify the intended ledger change.
 
 - The deduplication period specifies the period for which no earlier submissions with the same change ID should have been accepted, as witnessed by a completion event on the :ref:`command completion service <command-completion-service>`.
   If such a change has been accepted in that period, the current submission shall be rejected.
   The period is specified either as a :brokenref:`deduplication duration <com.daml.ledger.api.v1.Commands.deduplication_period.deduplication_duration>` or as a :brokenref:`deduplication offset <com.daml.ledger.api.v1.Commands.deduplication_period.deduplication_offset>` (inclusive).
 
-- The :brokenref:`submission ID <com.daml.ledger.api.v1.Commands.submission_id>` is chosen by the application to identify a specific submission.
+- The :subsiteref:`submission ID <com.daml.ledger.api.v2.Commands.submission_id>` is chosen by the application to identify a specific submission.
   It is included in the corresponding completion event so that the application can correlate specific submissions to specific completions.
   An application should never reuse a submission ID.
 
@@ -50,7 +50,7 @@ The ledger may arbitrarily extend the deduplication period specified in the subm
 
 The deduplication period chosen by the ledger is the *effective deduplication period*.
 The ledger may also convert a requested deduplication duration into an effective deduplication offset or vice versa.
-The effective deduplication period is reported in the command completion event in the :brokenref:`deduplication duration <com.daml.ledger.api.v1.Completion.deduplication_period.deduplication_duration>` or :brokenref:`deduplication offset <com.daml.ledger.api.v1.Completion.deduplication_period.deduplication_offset>` fields.
+The effective deduplication period is reported in the command completion event in the :subsiteref:`deduplication duration <com.daml.ledger.api.v2.Completion.deduplication_period.deduplication_duration>` or :subsiteref:`deduplication offset <com.daml.ledger.api.v2.Completion.deduplication_period.deduplication_offset>` fields.
 
 A command submission is considered a **duplicate submission** if at least one of the following holds:
 
@@ -104,8 +104,8 @@ Some ledger changes can be executed at most once, so no command deduplication is
 For example, if the submitted command exercises a consuming choice on a given contract ID, this command can be accepted at most once because every contract can be archived at most once.
 All duplicate submissions of such a change will be rejected with :brokenref:`CONTRACT_NOT_ACTIVE <error_code_CONTRACT_NOT_ACTIVE>`.
 
-In contrast, a :brokenref:`Create command <com.daml.ledger.api.v1.CreateCommand>` would create a fresh contract instance of the given :brokenref:`template <com.daml.ledger.api.v1.CreateCommand.template_id>` for each submission that reaches the ledger (unless other constraints such as the :ref:`template preconditions <daml-ref-preconditions>` or contract key uniqueness are violated).
-Similarly, an :brokenref:`Exercise command <com.daml.ledger.api.v1.ExerciseCommand>` on a non-consuming choice or an :brokenref:`Exercise-By-Key command <com.daml.ledger.api.v1.ExercisebyKeyCommand>` may be executed multiple times if submitted multiple times.
+In contrast, a :subsiteref:`Create command <com.daml.ledger.api.v2.CreateCommand>` would create a fresh contract instance of the given :subsiteref:`template <com.daml.ledger.api.v2.CreateCommand.template_id>` for each submission that reaches the ledger (unless other constraints such as the :ref:`template preconditions <daml-ref-preconditions>` or contract key uniqueness are violated).
+Similarly, an :subsiteref:`Exercise command <com.daml.ledger.api.v2.ExerciseCommand>` on a non-consuming choice or an :subsiteref:`Exercise-By-Key command <com.daml.ledger.api.v2.ExercisebyKeyCommand>` may be executed multiple times if submitted multiple times.
 With command deduplication, applications can ensure such intended ledger changes are executed only once within the deduplication period, even if the application resubmits, say because it considers the earlier submissions to be lost or forgot during a crash that it had already submitted the command.
 
 
@@ -141,9 +141,9 @@ Under this caveat, the following strategy works for applications that use the :r
 
 #. Submit the command with the following parameters:
 
-   - Set the :brokenref:`command ID <com.daml.ledger.api.v1.Commands.command_id>` to the chosen command ID from :ref:`Step 1 <dedup-bounded-step-command-id>`.
+   - Set the :subsiteref:`command ID <com.daml.ledger.api.v2.Commands.command_id>` to the chosen command ID from :ref:`Step 1 <dedup-bounded-step-command-id>`.
 
-   - Set the :brokenref:`deduplication duration <com.daml.ledger.api.v1.Commands.deduplication_period.deduplication_duration>` to the bound ``B``.
+   - Set the :subsiteref:`deduplication duration <com.daml.ledger.api.v2.Commands.deduplication_period.deduplication_duration>` to the bound ``B``.
 
      .. note::
         It is prudent to explicitly set the deduplication duration to the desired bound ``B``,
@@ -154,7 +154,7 @@ Under this caveat, the following strategy works for applications that use the :r
 	If you omitted the deduplication period, the currently valid maximum deduplication duration would be used.
 	In this case, a ledger configuration update could silently shorten the deduplication period and thus invalidate your deduplication analysis.
 
-   - Set the :brokenref:`submission ID <com.daml.ledger.api.v1.Commands.submission_id>` to a fresh value, e.g., a random UUID.
+   - Set the :subsiteref:`submission ID <com.daml.ledger.api.v2.Commands.submission_id>` to a fresh value, e.g., a random UUID.
 
    - Set the timeout (gRPC deadline) to the expected submission processing time (Command Service) or submission hand-off time (Command Submission Service).
 
@@ -185,7 +185,7 @@ Under this caveat, the following strategy works for applications that use the :r
 Error Handling
 --------------
 
-Error handling is needed when the status code of the command submission RPC call or in the :brokenref:`completion event <com.daml.ledger.api.v1.Completion.status>` is not ``OK``.
+Error handling is needed when the status code of the command submission RPC call or in the :subsiteref:`completion event <com.daml.ledger.api.v2.Completion.status>` is not ``OK``.
 The following table lists appropriate reactions by status code (written as ``STATUS_CODE``) and error code (written in capital letters with a link to the error code documentation).
 Fields in the error metadata are written as ``field`` in lowercase letters.
 
@@ -236,7 +236,7 @@ Fields in the error metadata are written as ``field`` in lowercase letters.
      * The specified deduplication offset has been pruned by the participant.
        ``earliest_offset`` contains the last pruned offset.
 
-        Use the :ref:`Command Completion Service <command-completion-service>` by asking for the :brokenref:`completions <com.daml.ledger.api.v1.CompletionStreamRequest>`, starting from the last pruned offset by setting :brokenref:`offset <com.daml.ledger.api.v1.CompletionStreamRequest.offset>` to the value of
+        Use the :ref:`Command Completion Service <command-completion-service>` by asking for the :subsiteref:`completions <com.daml.ledger.api.v2.CompletionStreamRequest>`, starting from the last pruned offset by setting :brokenref:`offset <com.daml.ledger.api.v1.CompletionStreamRequest.offset>` to the value of
         ``earliest_offset``, and use the first received :brokenref:`offset <com.daml.ledger.api.v1.Checkpoint.offset>` as a deduplication offset.
 
 
@@ -321,7 +321,7 @@ We recommend the following strategy for using deduplication offsets:
 	In general, the ledger end need not identify a command completion that is visible to the submitting parties.
 	When running on such a ledger, use the Command Service approach described next.
 
-   - Use the :ref:`Command Service <command-service>` to obtain a recent offset by repeatedly submitting a dummy command, e.g., a :brokenref:`Create-And-Exercise command <com.daml.ledger.api.v1.CreateAndExerciseCommand>` of some single-signatory template with the :ref:`Archive <function-da-internal-template-functions-archive-2977>` choice, until you get a successful response.
+   - Use the :ref:`Command Service <command-service>` to obtain a recent offset by repeatedly submitting a dummy command, e.g., a :subsiteref:`Create-And-Exercise command <com.daml.ledger.api.v2.CreateAndExerciseCommand>` of some single-signatory template with the :ref:`Archive <function-da-internal-template-functions-archive-2977>` choice, until you get a successful response.
      The response contains the :brokenref:`completion offset <com.daml.ledger.api.v1.SubmitAndWaitForTransactionIdResponse.completion_offset>`.
 
 
@@ -336,11 +336,11 @@ We recommend the following strategy for using deduplication offsets:
 
 #. Submit the command with the following parameters (analogous to :ref:`Step 3 above <dedup-bounded-step-submit>` except for the deduplication period):
 
-   - Set the :brokenref:`command ID <com.daml.ledger.api.v1.Commands.command_id>` to the chosen command ID from :ref:`Step 1 <dedup-bounded-step-command-id>`.
+   - Set the :subsiteref:`command ID <com.daml.ledger.api.v2.Commands.command_id>` to the chosen command ID from :ref:`Step 1 <dedup-bounded-step-command-id>`.
 
-   - Set the :brokenref:`deduplication offset <com.daml.ledger.api.v1.Commands.deduplication_period.deduplication_offset>` to ``OFF0``.
+   - Set the :subsiteref:`deduplication offset <com.daml.ledger.api.v2.Commands.deduplication_period.deduplication_offset>` to ``OFF0``.
 
-   - Set the :brokenref:`submission ID <com.daml.ledger.api.v1.Commands.submission_id>` to a fresh value, e.g., a random UUID.
+   - Set the :subsiteref:`submission ID <com.daml.ledger.api.v2.Commands.submission_id>` to a fresh value, e.g., a random UUID.
 
    - Set the timeout (gRPC deadline) to the expected submission processing time (Command Service) or submission hand-off time (Command Submission Service).
 

--- a/sdk/docs/sharable/sdk/sdlc-howtos/applications/develop/explicit-contract-disclosure.rst
+++ b/sdk/docs/sharable/sdk/sdlc-howtos/applications/develop/explicit-contract-disclosure.rst
@@ -211,16 +211,16 @@ How do stakeholders disclose contracts to submitters?
 -----------------------------------------------------
 
 The disclosed contract's details can be fetched by the contract's stakeholder from the contract's
-associated :brokenref:`CreatedEvent <com.daml.ledger.api.v1.CreatedEvent>`,
+associated :subsiteref:`CreatedEvent <com.daml.ledger.api.v2.CreatedEvent>`,
 which can be read from the Ledger API via the active contracts and transactions queries
 (see :ref:`Reading from the ledger <reading-from-the-ledger>`).
 
 The stakeholder can then share the disclosed contract details to the submitter off-ledger (outside of Daml)
-by conventional means, such as HTTPS, SFTP, or e-mail. A :brokenref:`DisclosedContract <com.daml.ledger.api.v1.DisclosedContract>` can
+by conventional means, such as HTTPS, SFTP, or e-mail. A :subsiteref:`DisclosedContract <com.daml.ledger.api.v2.DisclosedContract>` can
 be constructed from the fields of the same name from the original contract's ``CreatedEvent``.
 
 .. note::
-  The ``created_event_blob`` field in ``CreatedEvent`` (used to construct the :brokenref:`DisclosedContract <com.daml.ledger.api.v1.DisclosedContract>`)
+  The ``created_event_blob`` field in ``CreatedEvent`` (used to construct the :subsiteref:`DisclosedContract <com.daml.ledger.api.v2.DisclosedContract>`)
   is populated **only** on demand for ``GetTransactions``, ``GetTransactionTrees``, and ``GetActiveContracts`` streams.
   To learn more, see :ref:`configuring transaction filters <transaction-filter>`.
 
@@ -229,8 +229,8 @@ be constructed from the fields of the same name from the original contract's ``C
 Attaching a disclosed contract to a command submission
 ------------------------------------------------------
 
-A disclosed contract can be attached as part of the ``Command``'s :brokenref:`disclosed_contracts <com.daml.ledger.api.v1.Commands.disclosed_contracts>`
-and requires the following fields (see :brokenref:`DisclosedContract <com.daml.ledger.api.v1.DisclosedContract>` for content details) to be populated from
+A disclosed contract can be attached as part of the ``Command``'s :subsiteref:`disclosed_contracts <com.daml.ledger.api.v2.Commands.disclosed_contracts>`
+and requires the following fields (see :subsiteref:`DisclosedContract <com.daml.ledger.api.v2.DisclosedContract>` for content details) to be populated from
 the original `CreatedEvent` (see above):
 
 - **template_id** - The contract's template id.

--- a/sdk/docs/sharable/sdk/sdlc-howtos/applications/harden/pruning.rst
+++ b/sdk/docs/sharable/sdk/sdlc-howtos/applications/harden/pruning.rst
@@ -8,7 +8,7 @@ The Daml Ledger API exposes an append-only ledger model; on the other hand, Daml
 
 In addition, privacy demands [1]_ may require removing Personally Identifiable Information (PII) upon request.
 
-To satisfy these requirements, the :brokenref:`Pruning Service <com.daml.ledger.api.v1.admin.ParticipantPruningService>` Ledger API endpoint [2]_ allows Daml Participants to support pruning of Daml contracts and transactions that were respectively archived and submitted before or at a given ledger offset.
+To satisfy these requirements, the :subsiteref:`Pruning Service <com.daml.ledger.api.v2.admin.ParticipantPruningService>` Ledger API endpoint [2]_ allows Daml Participants to support pruning of Daml contracts and transactions that were respectively archived and submitted before or at a given ledger offset.
 
 Please refer to the specific Daml driver information for details about its pruning support.
 
@@ -27,7 +27,7 @@ Still, Daml applications may be affected in the following ways:
 - Pruning may degrade the behavior of or abort in-progress requests if the pruning offset is too recent. In particular, the system might misbehave if command completions are pruned before the command trackers are able to process the completions.
 - Command deduplication and command tracker retention should always be configured so that the associated windows don't overlap with the pruning window to ensure that their operation is unaffected by pruning.
 - Pruning may affect the behavior of Ledger API calls that allow to read data from the ledger: see the next sub-section for more information about API impacts.
-- Pruning of all divulged contracts (see :brokenref:`Prune Request <com.daml.ledger.api.v1.admin.PruneRequest>`) does not preserve application visibility over contracts divulged up to the pruning offset, hence applications making use of pruned divulged contracts might start experiencing failed command submissions: see the section below for determining a suitable pruning offset.
+- Pruning of all divulged contracts (see :subsiteref:`Prune Request <com.daml.ledger.api.v2.admin.PruneRequest>`) does not preserve application visibility over contracts divulged up to the pruning offset, hence applications making use of pruned divulged contracts might start experiencing failed command submissions: see the section below for determining a suitable pruning offset.
 
 .. warning::
   Participants may know of contracts for which they don't know the current activeness status. This happens through :externalref:`divulgence <da-model-divulgence>` where a party learns of the existence of a contract without being guaranteed to ever see its archival. Such contracts are pruned by the feature described on this page as not doing so could easily lead to an ever growing participant state.

--- a/sdk/docs/sharable/sdk/sdlc-howtos/smart-contracts/upgrade/smart-contract-upgrades.rst
+++ b/sdk/docs/sharable/sdk/sdlc-howtos/smart-contracts/upgrade/smart-contract-upgrades.rst
@@ -1839,13 +1839,13 @@ The package preference is needed at each command submission time and is assemble
   version is used.
 
 - The package-id selection preference list specified in the submitted command's
-  :brokenref:`package_id_selection_preference <com.daml.ledger.api.v1.Commands.package_id_selection_preference>` in a command submission.
+  :subsiteref:`package_id_selection_preference <com.daml.ledger.api.v2.Commands.package_id_selection_preference>` in a command submission.
   This is package-id resolution list explicitly provided by the client to
   override the default package preference mentioned above.
 
    - See :ref:`here <daml-script-package-preference>` for how to provide this in Daml-Script
 
-   -  **Note:** The :brokenref:`package_id_selection_preference <com.daml.ledger.api.v1.Commands.package_id_selection_preference>`
+   -  **Note:** The :subsiteref:`package_id_selection_preference <com.daml.ledger.api.v2.Commands.package_id_selection_preference>`
       must not lead to ambiguous resolutions for package-names,
       meaning that it must not contain two package-ids pointing to
       packages with the same package-name, as otherwise the submission will fail with
@@ -1867,7 +1867,7 @@ Dynamic package resolution can happen in two cases during command submission:
 
 -  For command submissions that use a `by-package-name template ID`
    in the command’s templateId field (e.g. in a
-   create command :brokenref:`here <com.daml.ledger.api.v1.CreateCommand>`)
+   create command :subsiteref:`here <com.daml.ledger.api.v2.CreateCommand>`)
 
 -  For command submissions whose Daml interpretation requires the execution of
    interface choices or fetch-by-interface actions.
@@ -1881,7 +1881,7 @@ Dynamic Package Resolution in Ledger API Queries
 When subscribing for :brokenref:`transaction <transaction-trees>`
 or :ref:`active contract streams <active-contract-service>`,
 users can now use the `by-package-name template ID` format
-in the :brokenref:`template-id request filter field <com.daml.ledger.api.v1.TemplateFilter.template_id>`.
+in the :subsiteref:`template-id request filter field <com.daml.ledger.api.v2.TemplateFilter.template_id>`.
 to specify that they’re interested in fetching events for all templates
 pertaining to the specified package-name. This template selection set is
 dynamic and it widens with each uploaded template/package.


### PR DESCRIPTION
Changed the references from `v1` to `v2` where they are valid (and also changed `:brokenref:` to `:subsiteref:`).

I left some of the broken refs, where there are no obvious corresponding refs to `v2`.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
