### PR TITLE
Create .netrc file before running verify_docs_synchronized

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -34,6 +34,13 @@ jobs:
   steps:
     - bash: |
         set -euo pipefail
+        ci/create-dotnetrc.sh
+      displayName: 'Create .netrc file'
+      condition: succeeded()
+      env:
+        GITHUB_TOKEN: $(GH_DAML_READONLY)
+    - bash: |
+        set -euo pipefail
         cd sdk
         eval "$(./dev-env/bin/dade-assist)"
         ./ci/verify-docs-synchronized.sh


### PR DESCRIPTION
We already create a `.netrc` file in `build-unix` and `build-windows` to prevent github rate-limiting and we want to keep this creation there because these builds are run by other pipelines than the PR one. But we also need to create one at the beginning of the PR pipeline because `verify_docs_synchronized` also need to query github.
