### PR TITLE
Fix the daily snapshot

### DIFF
--- a/ci/daily-snapshot.yml
+++ b/ci/daily-snapshot.yml
@@ -27,25 +27,14 @@ jobs:
         eval "$(./dev-env/bin/dade-assist)"
         source $(bash-lib)
 
-        error_handler() {
-          local exit_code="$1"
-          local line_number="$2"
-          local command="$3"
-          echo "Error: Command '$command' on line $line_number exited with status $exit_code" >&2
-        }
-        trap 'error_handler $? $LINENO "$BASH_COMMAND"' ERR
-
         prefix=$(git show ${{ parameters.commit }}:sdk/NIGHTLY_PREFIX)
         if [ "${{ parameters.version }}" = "snapshot" ]; then
-            release=$(./release.sh snapshot ${{ parameters.commit }} $prefix | awk '{print $2}')
+            release=$(./release.sh snapshot ${{ parameters.commit }} $prefix 2>/dev/null | awk '{print $2}')
         else
             release=${{ parameters.version }}
         fi
 
         ERR=$(mktemp)
-        ip a
-        ping -c 10 google.com
-        ping -c 10 digitalasset.jfrog.io
         OUT=$(curl https://digitalasset.jfrog.io/artifactory/api/storage/assembly/daml/$release \
                    -u $AUTH \
                    -I \

--- a/sdk/release.sh
+++ b/sdk/release.sh
@@ -220,21 +220,21 @@ case $1 in
             sha="$(git rev-parse "$commit")"
             case $(check_new_version_and_commit "$version" "$commit") in
               exact)
-                echo "add the following line to LATEST in order to preserve semver ordering:"
+                >&2 echo "add the following line to LATEST in order to preserve semver ordering:"
                 make_snapshot snapshot $sha "$version"
-                echo "and commit with the following (2 lines) message:"
-                echo "$branch_name Snapshot"
-                echo "Create a snapshot for [$branch_name](https://github.com/digital-asset/daml/commits/$branch_name/) at commit $sha"
+                >&2 echo "and commit with the following (2 lines) message:"
+                >&2 echo "$branch_name Snapshot"
+                >&2 echo "Create a snapshot for [$branch_name](https://github.com/digital-asset/daml/commits/$branch_name/) at commit $sha"
                 ;;
               adhoc)
-                echo "add the following line to LATEST in order to preserve semver ordering:"
+                >&2 echo "add the following line to LATEST in order to preserve semver ordering:"
                 make_snapshot adhoc $sha "$version"
-                echo "WARNING: The expected release branch for version $version is '$target_branch', but commit $commit is not on any release branch. Generating an adhoc release name..." >&2
-                echo "and commit with the following message:"
-                echo "$branch_name adhoc Snapshot"
+                >&2 echo "WARNING: The expected release branch for version $version is '$target_branch', but commit $commit is not on any release branch. Generating an adhoc release name..." >&2
+                >&2 echo "and commit with the following message:"
+                >&2 echo "$branch_name adhoc Snapshot"
                 ;;
               failure)
-                echo "ERROR: The expected release branch for version $version is '$target_branch', but commit $commit belongs to a different release branch: $(find_release_branches_for_commit "$commit" | tr '\n' ' ')" >&2
+                >&2 echo "ERROR: The expected release branch for version $version is '$target_branch', but commit $commit belongs to a different release branch: $(find_release_branches_for_commit "$commit" | tr '\n' ' ')" >&2
                 exit 1
                 ;;
             esac


### PR DESCRIPTION
In
https://github.com/digital-asset/daml/blob/9be6094cdf4939e3f591e7b6770c11be521f107d/ci/daily-snapshot.yml#L40 we read the output of release.sh to extract the release version. But in https://github.com/digital-asset/daml/pull/21169 we added help messages to the standard output. So I change release.sh to display the help messages on stderr instead, and I revert the debugging code in the daily-snapshot pipeline.

I've already tested that the following works as intended locally now:
```
release=$(./release.sh snapshot cf9f07e6398e6f91de57e13328dc32e3d67b508f 3.4.0 2>/dev/null | awk '{print $2}')
echo $release
```

When this is merged, I'll trigger the pipeline manually to check this is fixed for good (and to produce a snapshot).