### PR TITLE
Fix Vale output directory in dev-env

### DIFF
--- a/sdk/dev-env/bin/vale
+++ b/sdk/dev-env/bin/vale
@@ -1,1 +1,1 @@
-../lib/dade-exec-nix-bin-tool
+../lib/dade-exec-nix-tool


### PR DESCRIPTION
I tried running Vale on my Macbook and it failed:
```
vale --version
[dev-env] Building tools.vale...
[dev-env] Built tools.vale in /nix/store/62k5dvd3728wsrv3w6wmp5k1ma9gkxdy-vale-2.21.3 and linked to /Users/adrienpiquerez/github/digital-asset/daml/sdk/dev-env/var/gc-roots/vale-bin
/Users/adrienpiquerez/github/digital-asset/daml/sdk/dev-env/lib/../lib/dade-common: line 143: /bin/vale: No such file or directory
```

This PR fixes the issue for me, hopefully it works on other systems as well.