### PR TITLE
Integrate vale in CI scripts

### DIFF
--- a/sdk/.vale-ci.ini
+++ b/sdk/.vale-ci.ini
@@ -3,16 +3,25 @@ StylesPath = ./docs/styles
 # Vocab = DA
 
 [*.rst]
-TokenIgnores = (:ref:`[^`]+`)
-TokenIgnores = (:brokenref:`[^`]+`)
-TokenIgnores = (:subsiteref:`[^`]+`)
-TokenIgnores = (:externalref:`[^`]+`)
-
+# Separately ignore things between < and >, meant to ignore the some-id part of
+# :whichever-ref:Blablabla<some-id>`
+#
+# Somehow this must be before the :ref:, :brokenref:, :subsituteref: and
+# :externalref: ignores
+TokenIgnores = (<[a-zA-Z0-9-_./]+>)
+# Ignore any of these refs that do not have an accompanying text (i.e. those of
+# shape :whichever-ref:`some-id` and not :whichever-ref:Blablabla<some-id>`)
+TokenIgnores = (:ref:`[^`<>]+`)
+TokenIgnores = (:brokenref:`[^`<>]+`)
+TokenIgnores = (:subsiteref:`[^`<>]+`)
+TokenIgnores = (:externalref:`[^`<>]+`)
+# ignore direct links of shape .. _some-link
 BlockIgnores = ([ \t]*\.\. _[^:]+:)
+
+# TODO: enable all styles as per .vale.ini
+# BasedOnStyles = Vale, Google, DigitalAsset, CiEnforced
 BasedOnStyles = CiEnforced
 Vale.Spelling = NO
 Vale.Repetition = NO
 Google.Contractions = NO
 Google.Headings = NO
-# ignore the contents of (broken)references
-# ignore the contents of explicit hyperlink targets

--- a/sdk/.vale-ci.ini
+++ b/sdk/.vale-ci.ini
@@ -1,10 +1,10 @@
-StylesPath = docs/styles
+StylesPath = ./docs/styles
 
-# Vocab = DA
+#Vocab = DA
 
 [*.rst]
 
-#BasedOnStyles = Vale, Google, DigitalAsset
+BasedOnStyles = CiEnforced
 Vale.Spelling = NO
 Vale.Repetition = NO
 Google.Contractions = NO

--- a/sdk/.vale-ci.ini
+++ b/sdk/.vale-ci.ini
@@ -1,11 +1,18 @@
 StylesPath = ./docs/styles
 
-#Vocab = DA
+# Vocab = DA
 
 [*.rst]
+TokenIgnores = (:ref:`[^`]+`)
+TokenIgnores = (:brokenref:`[^`]+`)
+TokenIgnores = (:subsiteref:`[^`]+`)
+TokenIgnores = (:externalref:`[^`]+`)
 
+BlockIgnores = ([ \t]*\.\. _[^:]+:)
 BasedOnStyles = CiEnforced
 Vale.Spelling = NO
 Vale.Repetition = NO
 Google.Contractions = NO
 Google.Headings = NO
+# ignore the contents of (broken)references
+# ignore the contents of explicit hyperlink targets

--- a/sdk/.vale.ini
+++ b/sdk/.vale.ini
@@ -1,13 +1,23 @@
-StylesPath = docs/styles
+StylesPath = ./docs/styles
 
 # Vocab = DA
 
 [*.rst]
-TokenIgnores = (:ref:`[^`]+`)
-TokenIgnores = (:brokenref:`[^`]+`)
-TokenIgnores = (:subsiteref:`[^`]+`)
-TokenIgnores = (:externalref:`[^`]+`)
+# Separately ignore things between < and >, meant to ignore the some-id part of
+# :whichever-ref:Blablabla<some-id>`
+#
+# Somehow this must be before the :ref:, :brokenref:, :subsituteref: and
+# :externalref: ignores
+TokenIgnores = (<[a-zA-Z0-9-_./]+>)
+# Ignore any of these refs that do not have an accompanying text (i.e. those of
+# shape :whichever-ref:`some-id` and not :whichever-ref:Blablabla<some-id>`)
+TokenIgnores = (:ref:`[^`<>]+`)
+TokenIgnores = (:brokenref:`[^`<>]+`)
+TokenIgnores = (:subsiteref:`[^`<>]+`)
+TokenIgnores = (:externalref:`[^`<>]+`)
+# ignore direct links of shape .. _some-link
 BlockIgnores = ([ \t]*\.\. _[^:]+:)
+
 BasedOnStyles = Vale, Google, DigitalAsset, CiEnforced
 Vale.Spelling = NO
 Vale.Repetition = NO

--- a/sdk/.vale.ini
+++ b/sdk/.vale.ini
@@ -4,7 +4,7 @@ StylesPath = docs/styles
 
 [*.rst]
 
-#BasedOnStyles = Vale, Google, DigitalAsset
+BasedOnStyles = Vale, Google, DigitalAsset
 Vale.Spelling = NO
 Vale.Repetition = NO
 Google.Contractions = NO

--- a/sdk/.vale.ini
+++ b/sdk/.vale.ini
@@ -3,8 +3,12 @@ StylesPath = docs/styles
 # Vocab = DA
 
 [*.rst]
-
-BasedOnStyles = Vale, Google, DigitalAsset
+TokenIgnores = (:ref:`[^`]+`)
+TokenIgnores = (:brokenref:`[^`]+`)
+TokenIgnores = (:subsiteref:`[^`]+`)
+TokenIgnores = (:externalref:`[^`]+`)
+BlockIgnores = ([ \t]*\.\. _[^:]+:)
+BasedOnStyles = Vale, Google, DigitalAsset, CiEnforced
 Vale.Spelling = NO
 Vale.Repetition = NO
 Google.Contractions = NO

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -255,6 +255,22 @@ To see only errors when running Vale, use the `--minAlertLevel` flag. For instan
 ```bash
 vale --minAlertLevel=error docs/manually-written/overview/howtos/index.rst 
 ```
+
+#### Run Vale on entire project
+You can pass a folder to `vale` and it will recursively check all subfolders. The scripts check the `docs/sharable` folder by executing (from `/daml/sdk`):
+
+``` bash
+  vale ./docs/sharable --minAlertLevel=suggestion
+```
+
+Please note that vale's recursive search on the `/daml/sdk` folder is broken. If for some reason you want to run it on directories higher than `/doc`, use find to collect all `*.rst*` files:
+
+``` bash
+find . -type f -name "*.rst" -exec vale {} +
+```
+
+#### Further info
+
 For more information, refer to the official [Vale doc][vale_doc]. 
 
 [vale_official]: https://vale.sh/

--- a/sdk/dev-env/bin/rst2html
+++ b/sdk/dev-env/bin/rst2html
@@ -1,0 +1,1 @@
+../lib/dade-exec-nix-tool

--- a/sdk/docs/manually-written/sdk/component-howtos/application-development/daml-sandbox.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/application-development/daml-sandbox.rst
@@ -116,7 +116,7 @@ There are two ways to run the Daml Sandbox:
    **Note**: To forward an option to the underlying ``daml sandbox`` call, use
    the ``--sandbox-option`` flag.
 
-   For example, to change the sandbox's ledger-api port, the normal command would be
+   For example, to change the sandbox's Ledger API port, the normal command would be
 
    .. code-block:: none
 

--- a/sdk/docs/sharable/sdk/component-howtos/application-development/daml-sandbox.rst
+++ b/sdk/docs/sharable/sdk/component-howtos/application-development/daml-sandbox.rst
@@ -116,7 +116,7 @@ There are two ways to run the Daml Sandbox:
    **Note**: To forward an option to the underlying ``daml sandbox`` call, use
    the ``--sandbox-option`` flag.
 
-   For example, to change the sandbox's ledger-api port, the normal command would be
+   For example, to change the sandbox's Ledger API port, the normal command would be
 
    .. code-block:: none
 

--- a/sdk/docs/styles/CiEnforced/Terms.yml
+++ b/sdk/docs/styles/CiEnforced/Terms.yml
@@ -15,3 +15,5 @@ action:
 swap:
   #(?i)=case insensitive
   '(?i)JSON API|HTTP API|JSON API v2|HTTP JSON Ledger API': JSON Ledger API
+  'http': HTTP
+  'api': API

--- a/sdk/docs/styles/CiEnforced/Terms.yml
+++ b/sdk/docs/styles/CiEnforced/Terms.yml
@@ -1,0 +1,17 @@
+# Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# cspell: disable
+# Note: A copy of this file is also available in the Canton repository
+# https://github.com/DACH-NY/canton/blob/release-line-3.3/docs-open/styles/DigitalAsset/Terms.yml
+# TODO: Share vale styles in a public repo for reuse
+# https://github.com/DACH-NY/docs-website/issues/365
+extends: substitution
+message: "Use '%s' instead of '%s'."
+level: error
+ignorecase: false
+action:
+  name: replace
+swap:
+  #(?i)=case insensitive
+  '(?i)JSON API|HTTP API|JSON API v2|HTTP JSON Ledger API': JSON Ledger API

--- a/sdk/fmt.sh
+++ b/sdk/fmt.sh
@@ -182,3 +182,15 @@ for f in $(ls *_install*.json | egrep -v "deprecated"); do
     exit 1
   fi
 done
+
+
+# manually use find to locate all .rst files vale supports recursive search but
+# it seems broken, it does not seem to handle basel symlinks well and config to
+# ignore paths and/or extensions did not seem to work
+if [[ $is_test = 1 ]]; then
+  echo "Checking .rst with vale, is_test=TRUE so --minAlertLevel=warning"
+  vale ./docs/sharable --minAlertLevel=warning
+else
+  echo "Checking .rst with vale, is_test=FALSE so --minAlertLevel=suggestion"
+  vale ./docs/sharable --minAlertLevel=suggestion
+fi

--- a/sdk/fmt.sh
+++ b/sdk/fmt.sh
@@ -183,10 +183,6 @@ for f in $(ls *_install*.json | egrep -v "deprecated"); do
   fi
 done
 
-
-# manually use find to locate all .rst files vale supports recursive search but
-# it seems broken, it does not seem to handle bazel symlinks well and config to
-# ignore paths and/or extensions did not seem to work
 if [[ $is_test = 1 ]]; then
   echo "Checking .rst with vale, is_test=TRUE so --minAlertLevel=warning"
   vale ./docs/sharable --config ./.vale-ci.ini --minAlertLevel=warning

--- a/sdk/fmt.sh
+++ b/sdk/fmt.sh
@@ -188,5 +188,10 @@ if [[ $is_test = 1 ]]; then
   vale ./docs/sharable --config ./.vale-ci.ini --minAlertLevel=warning
 else
   echo "Checking .rst with vale, is_test=FALSE so --minAlertLevel=suggestion"
-  vale ./docs/sharable --config ./.vale-ci.ini --minAlertLevel=suggestion
+  if [ "$diff_mode" = "true" ]; then
+    echo "--diff, so only linting diff"
+    check_diff $merge_base '\.rst$' vale --config ./.vale-ci.ini --minAlertLevel=suggestion
+  else
+    vale ./docs/sharable --config ./.vale-ci.ini --minAlertLevel=suggestion
+  fi
 fi

--- a/sdk/fmt.sh
+++ b/sdk/fmt.sh
@@ -185,7 +185,7 @@ done
 
 
 # manually use find to locate all .rst files vale supports recursive search but
-# it seems broken, it does not seem to handle basel symlinks well and config to
+# it seems broken, it does not seem to handle bazel symlinks well and config to
 # ignore paths and/or extensions did not seem to work
 if [[ $is_test = 1 ]]; then
   echo "Checking .rst with vale, is_test=TRUE so --minAlertLevel=warning"

--- a/sdk/fmt.sh
+++ b/sdk/fmt.sh
@@ -189,8 +189,8 @@ done
 # ignore paths and/or extensions did not seem to work
 if [[ $is_test = 1 ]]; then
   echo "Checking .rst with vale, is_test=TRUE so --minAlertLevel=warning"
-  vale ./docs/sharable --minAlertLevel=warning
+  vale ./docs/sharable --config ./.vale-ci.ini --minAlertLevel=warning
 else
   echo "Checking .rst with vale, is_test=FALSE so --minAlertLevel=suggestion"
-  vale ./docs/sharable --minAlertLevel=suggestion
+  vale ./docs/sharable --config ./.vale-ci.ini --minAlertLevel=suggestion
 fi

--- a/sdk/nix/default.nix
+++ b/sdk/nix/default.nix
@@ -182,6 +182,7 @@ in rec {
 
     # Vale (TODO: use `vale.withStyles` once the nixpkgs snapshot is recent enough)
     vale = pkgs.vale;
+    # indirect dependency of vale (needed to lint reStructurexText.rst files)
     rst2html = python3.pkgs.docutils;
 
     # Cryptography tooling

--- a/sdk/nix/default.nix
+++ b/sdk/nix/default.nix
@@ -182,6 +182,7 @@ in rec {
 
     # Vale (TODO: use `vale.withStyles` once the nixpkgs snapshot is recent enough)
     vale = pkgs.vale;
+    rst2html = python3.pkgs.docutils;
 
     # Cryptography tooling
     gnupg = pkgs.gnupg;


### PR DESCRIPTION
- integrated vale into the CI and created a separate ci-enforced config (since the regular .vale.ini gives 1141 errors), checked as part of `fmt.sh` script which is run during the Platform-agnostic lints and checks step of Linux Intel
- added replacement rule for JSON Ledger API
- added _temporary_ replacement rules for API and HTTP spelling, this should be replaced by utilizing the Vocab functionality when it works
- added ignore statements to not trigger on various kinds of references and links