### PR TITLE
add a live docs preview command

### DIFF
--- a/sdk/ci/live-docs-preview.sh
+++ b/sdk/ci/live-docs-preview.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+watchexec --restart --watch $DIR/../docs/manually-written/ -- "$DIR/../ci/synchronize-docs.sh && $DIR/../ci/docs-sphinx-build.sh --with-preview"

--- a/sdk/dev-env/bin/watchexec
+++ b/sdk/dev-env/bin/watchexec
@@ -1,0 +1,1 @@
+../lib/dade-exec-nix-tool

--- a/sdk/nix/default.nix
+++ b/sdk/nix/default.nix
@@ -196,10 +196,9 @@ in rec {
 
     # Sphinx
     sphinx-build = pkgs.sphinx;
-
     semver = pkgs.semver-tool;
-
     undmg = pkgs.undmg;
+    watchexec = pkgs.watchexec;
 
     # Cloud tools
     aws = pkgs.awscli;


### PR DESCRIPTION
Adds a `ci/live-docs-preview.sh` that re-synchronizes and re-run sphinx on the result every time some file is changed.