### PR TITLE
private rather than oci-private

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,7 +140,7 @@ jobs:
       name: publish_to_oci
       env:
         GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
-        REGISTRY: "europe-docker.pkg.dev/da-images-dev/oci-private"
+        REGISTRY: "europe-docker.pkg.dev/da-images-dev/private"
       condition: and(succeeded(), not(eq(variables['skip-github'], 'TRUE')))
     - bash: |
         set -euo pipefail

--- a/ci/get-unifi.sh
+++ b/ci/get-unifi.sh
@@ -6,7 +6,7 @@ TEMP_DIR="$(mktemp -d)"
 ORAS_VERSION="1.2.2"
 ORAS="oras"
 # Unifi latest url
-UNIFI_URL="${1:-europe-docker.pkg.dev/da-images-dev/oci-private/components/assistant:latest}"
+UNIFI_URL="${1:-europe-docker.pkg.dev/da-images-dev/private/components/assistant:latest}"
 # Get current machine OS type and ARCH
 OS_TYPE="$(uname -s | tr A-Z a-z)"
 if [[ $(uname -m) == 'x86_64' ]]; then

--- a/ci/split-release-job.yml
+++ b/ci/split-release-job.yml
@@ -126,7 +126,7 @@ jobs:
       name: publish_to_oci
       env:
         GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
-        REGISTRY: "europe-docker.pkg.dev/da-images-dev/oci-private"
+        REGISTRY: "europe-docker.pkg.dev/da-images-dev/private"
     - bash: |
         set -euo pipefail
         # Note: this gets dev-env from the release commit, not the trigger commit


### PR DESCRIPTION
Since `oci://` is already in the protocol name, call the registry `private` rather than `oci-private`

affects the damlc and daml-script components published to the OCI repo via unifi assistant
• ensure new version of unifi picked up with breaking change to assembly schema
• publish to `private` repository instead of `oci-private` with redundant oci in name