### PR TITLE
make ContractId implement CidContainer

### DIFF
--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/FatContractInstance.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/FatContractInstance.scala
@@ -80,8 +80,6 @@ private[lf] final case class FatContractInstanceImpl(
   require(signatories.nonEmpty, "signatories should be non empty")
   require(signatories.subsetOf(stakeholders), "signatories should be a subset of stakeholders")
 
-  override protected def self: FatContractInstanceImpl = this
-
   override def mapCid(f: Value.ContractId => Value.ContractId): FatContractInstanceImpl = {
     copy(
       contractId = f(contractId),

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -22,8 +22,6 @@ final case class VersionedTransaction private[lf] (
     with value.CidContainer[VersionedTransaction]
     with NoCopy {
 
-  override protected def self: this.type = this
-
   override def mapCid(f: ContractId => ContractId): VersionedTransaction =
     VersionedTransaction(
       version,
@@ -64,7 +62,6 @@ final case class Transaction(
 
   import Transaction._
 
-  override protected def self: this.type = this
   override def mapCid(f: ContractId => ContractId): Transaction =
     copy(nodes = nodes.map { case (nodeId, node) => nodeId -> node.mapCid(f) })
   def mapNodeId(f: NodeId => NodeId): Transaction =

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
@@ -12,8 +12,6 @@ import scala.util.control.NoStackTrace
 
 trait CidContainer[+A] {
 
-  protected def self: A
-
   def mapCid(f: ContractId => ContractId): A
 
   def foreachCid(f: ContractId => Unit) = {


### PR DESCRIPTION
A contract ID is a trivial container for contract IDs, so it makes sense to be able to call the functions from `CidContainer` on it.

Additionally, this PR fully pulls through the pattern of extending `CidContainer[subclass]` for all `subclass` implementations even if the parent already extends `CidContainer` for a supertype. This ensures that if a call to something like `valueTextMap.suffixCid` actually returns a `ValueTextMap` and not just a generic `Value`.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
