### PR TITLE
make createdAt optional in FatContractInstance

### DIFF
--- a/sdk/canton/community/base/src/main/scala/com/digitalasset/canton/crypto/InteractiveSubmission.scala
+++ b/sdk/canton/community/base/src/main/scala/com/digitalasset/canton/crypto/InteractiveSubmission.scala
@@ -13,17 +13,13 @@ import com.digitalasset.canton.data.LedgerTimeBoundaries
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.logging.TracedLogger
 import com.digitalasset.canton.protocol.hash.TransactionHash.NodeHashingError
-import com.digitalasset.canton.protocol.hash.{
-  HashTracer,
-  TransactionHash,
-  TransactionMetadataHashBuilder,
-}
+import com.digitalasset.canton.protocol.hash.{HashTracer, TransactionHash, TransactionMetadataHashBuilder}
 import com.digitalasset.canton.protocol.{LfContractId, LfHash, SerializableContract}
 import com.digitalasset.canton.topology.{PartyId, SynchronizerId}
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.version.{HashingSchemeVersion, ProtocolVersion}
 import com.digitalasset.daml.lf.data.{Bytes, Ref, Time}
-import com.digitalasset.daml.lf.transaction.{FatContractInstance, NodeId, VersionedTransaction}
+import com.digitalasset.daml.lf.transaction.{CreationTime, FatContractInstance, NodeId, VersionedTransaction}
 import com.digitalasset.daml.lf.value.Value.ContractId
 
 import java.util.UUID
@@ -89,7 +85,7 @@ object InteractiveSubmission {
         .map { case (contractId, serializedNode) =>
           contractId -> FatContractInstance.fromCreateNode(
             serializedNode.toLf,
-            serializedNode.ledgerCreateTime.toLf,
+            CreationTime.CreatedAt(serializedNode.ledgerCreateTime.toLf),
             saltFromSerializedContract(serializedNode),
           )
         }

--- a/sdk/canton/community/base/src/main/scala/com/digitalasset/canton/protocol/SerializableContract.scala
+++ b/sdk/canton/community/base/src/main/scala/com/digitalasset/canton/protocol/SerializableContract.scala
@@ -14,7 +14,7 @@ import com.digitalasset.canton.serialization.ProtoConverter
 import com.digitalasset.canton.serialization.ProtoConverter.ParsingResult
 import com.digitalasset.canton.version.*
 import com.digitalasset.canton.{LfTimestamp, admin, crypto, protocol}
-import com.digitalasset.daml.lf.transaction.{FatContractInstance, Versioned}
+import com.digitalasset.daml.lf.transaction.{CreationTime, FatContractInstance, Versioned}
 import com.digitalasset.daml.lf.value.ValueCoder
 import com.google.protobuf.ByteString
 import com.google.protobuf.timestamp.Timestamp
@@ -103,7 +103,7 @@ case class SerializableContract(
   def tryFatContractInstance: FatContractInstance =
     FatContractInstance.fromCreateNode(
       toLf,
-      ledgerCreateTime.toLf,
+      CreationTime.CreatedAt(ledgerCreateTime.toLf),
       DriverContractMetadata(contractSalt).toLfBytes(
         CantonContractIdVersion.tryCantonContractIdVersion(contractId)
       ),
@@ -153,9 +153,12 @@ object SerializableContract
   def fromFatContract(
       fat: FatContractInstance
   ): Either[String, SerializableContract] = {
-    val ledgerTime = CantonTimestamp(fat.createdAt)
     val driverContractMetadataBytes = fat.cantonData.toByteArray
     for {
+      ledgerTime <- fat.createdAt match {
+        case CreationTime.Now => Left("Invalid createdAt timestamp")
+        case CreationTime.CreatedAt(ts) => Right(CantonTimestamp(ts))
+      }
       _disclosedContractIdVersion <- CantonContractIdVersion
         .extractCantonContractIdVersion(fat.contractId)
         .leftMap(err => s"Invalid disclosed contract id: ${err.toString}")

--- a/sdk/canton/community/base/src/main/scala/com/digitalasset/canton/protocol/hash/TransactionMetadataHashBuilder.scala
+++ b/sdk/canton/community/base/src/main/scala/com/digitalasset/canton/protocol/hash/TransactionMetadataHashBuilder.scala
@@ -9,7 +9,7 @@ import com.digitalasset.canton.protocol.LfHash
 import com.digitalasset.canton.protocol.hash.HashTracer
 import com.digitalasset.canton.protocol.hash.TransactionHash.NodeHashingError
 import com.digitalasset.daml.lf.data.{Ref, Time}
-import com.digitalasset.daml.lf.transaction.FatContractInstance
+import com.digitalasset.daml.lf.transaction.{CreationTime, FatContractInstance}
 import com.digitalasset.daml.lf.value.Value.ContractId
 
 import java.util.UUID
@@ -65,7 +65,7 @@ object TransactionMetadataHashBuilder {
         _.iterateOver(metadata.disclosedContracts.valuesIterator, metadata.disclosedContracts.size)(
           (builder, fatInstance) =>
             builder
-              .withContext("Created At")(_.add(fatInstance.createdAt.micros))
+              .withContext("Created At")(_.add(CreationTime.encode(fatInstance.createdAt)))
               .withContext("Create Contract")(builder =>
                 builder.addHash(
                   builder.hashNode(

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/execution/ResolveMaximumLedgerTime.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/execution/ResolveMaximumLedgerTime.scala
@@ -4,15 +4,12 @@
 package com.digitalasset.canton.platform.apiserver.execution
 
 import com.digitalasset.canton.concurrent.DirectExecutionContext
-import com.digitalasset.canton.ledger.participant.state.index.{
-  MaximumLedgerTime,
-  MaximumLedgerTimeService,
-}
+import com.digitalasset.canton.ledger.participant.state.index.{MaximumLedgerTime, MaximumLedgerTimeService}
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.logging.{LoggingContextWithTrace, NamedLoggerFactory, NamedLogging}
 import com.digitalasset.daml.lf.data.ImmArray
 import com.digitalasset.daml.lf.data.Time.Timestamp
-import com.digitalasset.daml.lf.transaction.FatContractInstance
+import com.digitalasset.daml.lf.transaction.{CreationTime, FatContractInstance}
 import com.digitalasset.daml.lf.value.Value.ContractId
 
 import scala.concurrent.ExecutionContext
@@ -53,6 +50,7 @@ class ResolveMaximumLedgerTime(
   ): MaximumLedgerTime =
     processedDisclosedContracts.iterator
       .map(_.createdAt)
+      .collect { case CreationTime.CreatedAt(time) => time }
       .maxOption
       .fold(lookupMaximumLet)(adjust(lookupMaximumLet, _))
 

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/PreparedTransactionDecoder.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/PreparedTransactionDecoder.scala
@@ -40,7 +40,7 @@ import com.digitalasset.daml.lf
 import com.digitalasset.daml.lf.data.Ref.TypeConId
 import com.digitalasset.daml.lf.data.{Bytes, ImmArray, Ref, Time}
 import com.digitalasset.daml.lf.language.LanguageVersion
-import com.digitalasset.daml.lf.transaction.{FatContractInstance, NodeId}
+import com.digitalasset.daml.lf.transaction.{CreationTime, FatContractInstance, NodeId}
 import com.digitalasset.daml.lf.value.Value
 import com.google.common.annotations.VisibleForTesting
 import com.google.protobuf.ByteString
@@ -369,7 +369,7 @@ final class PreparedTransactionDecoder(override val loggerFactory: NamedLoggerFa
         createTime <- src.createdAt.transformIntoPartial[Time.Timestamp]
       } yield FatContractInstance.fromCreateNode(
         createNode,
-        createTime,
+        CreationTime.CreatedAt(createTime),
         src.driverMetadata.transformInto[Bytes],
       )
     }

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/PreparedTransactionEncoder.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/PreparedTransactionEncoder.scala
@@ -29,6 +29,7 @@ import com.digitalasset.daml.lf.crypto
 import com.digitalasset.daml.lf.data.{Bytes, ImmArray}
 import com.digitalasset.daml.lf.language.LanguageVersion
 import com.digitalasset.daml.lf.transaction.{
+  CreationTime,
   FatContractInstance,
   GlobalKey,
   Node,
@@ -293,7 +294,7 @@ final class PreparedTransactionEncoder(
             }
         },
       )
-      .withFieldComputed(_.createdAt, _.createdAt.transformInto[Long])
+      .withFieldComputed(_.createdAt, fci => CreationTime.encode(fci.createdAt))
       .withFieldComputed(_.driverMetadata, _.cantonData.transformInto[ByteString])
       .buildTransformer
 

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/index/ContractStoreBasedMaximumLedgerTimeService.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/index/ContractStoreBasedMaximumLedgerTimeService.scala
@@ -4,14 +4,10 @@
 package com.digitalasset.canton.platform.index
 
 import com.digitalasset.canton.concurrent.DirectExecutionContext
-import com.digitalasset.canton.ledger.participant.state.index.{
-  ContractState,
-  ContractStore,
-  MaximumLedgerTime,
-  MaximumLedgerTimeService,
-}
+import com.digitalasset.canton.ledger.participant.state.index.{ContractState, ContractStore, MaximumLedgerTime, MaximumLedgerTimeService}
 import com.digitalasset.canton.logging.{LoggingContextWithTrace, NamedLoggerFactory, NamedLogging}
 import com.digitalasset.daml.lf.data.Time.Timestamp
+import com.digitalasset.daml.lf.transaction.CreationTime
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.ContractId
 
@@ -46,10 +42,11 @@ class ContractStoreBasedMaximumLedgerTimeService(
                 Future.successful(MaximumLedgerTime.Archived(Set(contractId)))
 
               case active: ContractState.Active =>
-                val newMaximumLedgerTime = resultSoFar
-                  .getOrElse(Timestamp.MinValue)
-                  .pipe(Ordering[Timestamp].max(_, active.contractInstance.createdAt))
-                  .pipe(Some(_))
+                val createdAt = active.contractInstance.createdAt match {
+                  case CreationTime.CreatedAt(time) => Some(time)
+                  case CreationTime.Now => None
+                }
+                val newMaximumLedgerTime = Ordering[Option[Timestamp]].max(resultSoFar, createdAt)
                 goAsync(newMaximumLedgerTime, otherContractIds)
             }(directEc)
       }

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/index/InMemoryStateUpdater.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/index/InMemoryStateUpdater.scala
@@ -30,6 +30,7 @@ import com.digitalasset.canton.platform.store.interfaces.TransactionLogUpdate
 import com.digitalasset.canton.platform.{FatContract, InMemoryState, Key, KeyWithMaintainers, Party}
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.daml.lf.transaction.CreationTime
 import com.digitalasset.daml.lf.transaction.Node.{Create, Exercise}
 import org.apache.pekko.NotUsed
 import org.apache.pekko.stream.FlowShape
@@ -387,7 +388,7 @@ private[platform] object InMemoryStateUpdater {
             },
             version = createdEvent.createArgument.version,
           ),
-          createTime = createdEvent.ledgerEffectiveTime,
+          createTime = CreationTime.CreatedAt(createdEvent.ledgerEffectiveTime),
           cantonData = createdEvent.driverMetadata,
         ),
         eventOffset = createdEvent.eventOffset,

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/ContractsReader.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/ContractsReader.scala
@@ -10,10 +10,7 @@ import com.digitalasset.canton.logging.{LoggingContextWithTrace, NamedLoggerFact
 import com.digitalasset.canton.metrics.LedgerApiServerMetrics
 import com.digitalasset.canton.platform.*
 import com.digitalasset.canton.platform.store.backend.ContractStorageBackend
-import com.digitalasset.canton.platform.store.backend.ContractStorageBackend.{
-  RawArchivedContract,
-  RawCreatedContract,
-}
+import com.digitalasset.canton.platform.store.backend.ContractStorageBackend.{RawArchivedContract, RawCreatedContract}
 import com.digitalasset.canton.platform.store.dao.DbDispatcher
 import com.digitalasset.canton.platform.store.dao.events.ContractsReader.*
 import com.digitalasset.canton.platform.store.interfaces.LedgerDaoContractsReader
@@ -21,7 +18,7 @@ import com.digitalasset.canton.platform.store.interfaces.LedgerDaoContractsReade
 import com.digitalasset.canton.platform.store.serialization.{Compression, ValueSerializer}
 import com.digitalasset.daml.lf.data.Bytes
 import com.digitalasset.daml.lf.data.Ref.PackageName
-import com.digitalasset.daml.lf.transaction.{GlobalKeyWithMaintainers, Node}
+import com.digitalasset.daml.lf.transaction.{CreationTime, GlobalKeyWithMaintainers, Node}
 import com.digitalasset.daml.lf.value.Value.VersionedValue
 
 import java.io.{ByteArrayInputStream, InputStream}
@@ -140,7 +137,7 @@ private[dao] sealed class ContractsReader(
                   keyOpt = keyOpt,
                   version = createArg.version,
                 ),
-                createTime = raw.ledgerEffectiveTime,
+                createTime = CreationTime.CreatedAt(raw.ledgerEffectiveTime),
                 cantonData = Bytes.fromByteArray(raw.driverMetadata),
               )
             )

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/LfValueTranslation.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/LfValueTranslation.scala
@@ -369,7 +369,7 @@ final class LfValueTranslation(
           keyOpt = globalKey.map(GlobalKeyWithMaintainers(_, maintainers)),
           version = createArgument.version,
         ),
-        createTime = rawCreatedEvent.ledgerEffectiveTime,
+        createTime = CreationTime.CreatedAt(rawCreatedEvent.ledgerEffectiveTime),
         cantonData = Bytes.fromByteArray(rawCreatedEvent.driverMetadata),
       )
 

--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/TransactionLogUpdatesConversions.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/TransactionLogUpdatesConversions.scala
@@ -56,6 +56,7 @@ import com.digitalasset.daml.lf.data.Ref.Party
 import com.digitalasset.daml.lf.data.Time.Timestamp
 import com.digitalasset.daml.lf.data.{Bytes, Ref}
 import com.digitalasset.daml.lf.transaction.{
+  CreationTime,
   FatContractInstance,
   GlobalKeyWithMaintainers,
   Node,
@@ -794,7 +795,7 @@ private[events] object TransactionLogUpdatesConversions {
   ): Future[apiEvent.CreatedEvent] = {
 
     def getFatContractInstance: Right[Nothing, FatContractInstance] =
-      Right(FatContractInstance.fromCreateNode(create, ledgerEffectiveTime, driverMetadata))
+      Right(FatContractInstance.fromCreateNode(create, CreationTime.CreatedAt(ledgerEffectiveTime), driverMetadata))
 
     val witnesses = requestingPartiesO
       .fold(createdEventWitnesses)(_.view.filter(createdEventWitnesses).toSet)

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/admin/data/RepairContract.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/admin/data/RepairContract.scala
@@ -12,7 +12,7 @@ import com.digitalasset.canton.topology.SynchronizerId
 import com.digitalasset.canton.util.{ByteStringUtil, GrpcStreamingUtils, ResourceUtil}
 import com.digitalasset.canton.{LfVersioned, ReassignmentCounter}
 import com.digitalasset.daml.lf.transaction
-import com.digitalasset.daml.lf.transaction.TransactionCoder
+import com.digitalasset.daml.lf.transaction.{CreationTime, TransactionCoder}
 import com.google.protobuf.ByteString
 
 import java.io.ByteArrayInputStream
@@ -95,7 +95,10 @@ object RepairContract {
         maybeKeyWithMaintainersVersioned,
       )
 
-      ledgerCreateTime = LedgerCreateTime(CantonTimestamp(fattyContract.createdAt))
+      ledgerCreateTime <- fattyContract.createdAt match {
+        case CreationTime.CreatedAt(time) => Right(LedgerCreateTime(CantonTimestamp(time)))
+        case CreationTime.Now => Left("Unable to determine create time.")
+      }
 
       driverContractMetadata <-
         DriverContractMetadata

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/ContractAuthenticatorImpl.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/ContractAuthenticatorImpl.scala
@@ -8,7 +8,7 @@ import com.digitalasset.canton.crypto.{HashOps, HmacOps, Salt}
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.protocol.*
 import com.digitalasset.canton.protocol.SerializableContract.LedgerCreateTime
-import com.digitalasset.daml.lf.transaction.{FatContractInstance, Versioned}
+import com.digitalasset.daml.lf.transaction.{CreationTime, FatContractInstance, Versioned}
 import com.digitalasset.daml.lf.value.Value.{ContractId, ThinContractInstance}
 
 trait ContractAuthenticator {
@@ -64,7 +64,10 @@ class ContractAuthenticatorImpl(unicumGenerator: UnicumGenerator) extends Contra
       driverMetadata <- DriverContractMetadata
         .fromLfBytes(contract.cantonData.toByteArray)
         .leftMap(_.toString)
-      createTime <- CantonTimestamp.fromInstant(contract.createdAt.toInstant)
+      createTime <- contract.createdAt match {
+        case CreationTime.CreatedAt(time) => Right(CantonTimestamp(time))
+        case CreationTime.Now => Left(s"Cannot determine creation time for contract ${contract.contractId}.")
+      }
       contractInstance <- SerializableRawContractInstance
         .create(
           Versioned(

--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ModelConformanceChecker.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ModelConformanceChecker.scala
@@ -49,7 +49,7 @@ import com.digitalasset.canton.version.{HashingSchemeVersion, ProtocolVersion}
 import com.digitalasset.canton.{LfCreateCommand, LfKeyResolver, LfPartyId, LfValue, checked}
 import com.digitalasset.daml.lf
 import com.digitalasset.daml.lf.data.Ref.{CommandId, Identifier, PackageId, PackageName}
-import com.digitalasset.daml.lf.transaction.FatContractInstance
+import com.digitalasset.daml.lf.transaction.{CreationTime, FatContractInstance}
 
 import java.util.UUID
 import scala.concurrent.ExecutionContext
@@ -478,7 +478,7 @@ object ModelConformanceChecker {
             createNodeEnricher(storedContract.toLf)(traceContext).map { enrichedNode =>
               cid -> FatContractInstance.fromCreateNode(
                 enrichedNode,
-                storedContract.ledgerCreateTime.toLf,
+                CreationTime.CreatedAt(storedContract.ledgerCreateTime.toLf),
                 saltFromSerializedContract(storedContract),
               )
             }

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -11,6 +11,7 @@ import com.digitalasset.daml.lf.data._
 import com.digitalasset.daml.lf.language.Ast._
 import com.digitalasset.daml.lf.language.Util._
 import com.digitalasset.daml.lf.transaction.{
+  CreationTime,
   FatContractInstance,
   GlobalKey,
   GlobalKeyWithMaintainers,
@@ -195,7 +196,7 @@ class EngineTest(majorLanguageVersion: LanguageMajorVersion, contractIdVersion: 
             keyOpt = None,
             version = basicTestsPkg.languageVersion,
           ),
-          Time.Timestamp.now(),
+          CreationTime.CreatedAt(Time.Timestamp.now()),
           Bytes.Empty,
         )
 
@@ -257,7 +258,7 @@ class EngineTest(majorLanguageVersion: LanguageMajorVersion, contractIdVersion: 
             keyOpt = None,
             version = basicTestsPkg.languageVersion,
           ),
-          Time.Timestamp.now(),
+          CreationTime.CreatedAt(Time.Timestamp.now()),
           Bytes.Empty,
         )
 
@@ -2946,7 +2947,8 @@ class EngineTestHelpers(
           (
             contracts.updated(
               create.coid,
-              FatContractInstance.fromCreateNode(create, meta.submissionTime, Bytes.Empty),
+              FatContractInstance
+                .fromCreateNode(create, CreationTime.CreatedAt(meta.submissionTime), Bytes.Empty),
             ),
             create.keyOpt.fold(keys)(k => keys.updated(k, create.coid)),
           )
@@ -2989,7 +2991,7 @@ class EngineTestHelpers(
           ),
           version = version,
         ),
-        Time.Timestamp.now(),
+        CreationTime.CreatedAt(Time.Timestamp.now()),
         Bytes.Empty,
       ),
       arg,

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/PreprocessorSpec.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/PreprocessorSpec.scala
@@ -29,6 +29,7 @@ import com.digitalasset.daml.lf.transaction.test.TransactionBuilder.Implicits.{
   _,
 }
 import com.digitalasset.daml.lf.transaction.{
+  CreationTime,
   FatContractInstanceImpl,
   GlobalKey,
   GlobalKeyWithMaintainers,
@@ -628,7 +629,7 @@ final class PreprocessorSpecHelpers(majorLanguageVersion: LanguageMajorVersion) 
       stakeholders = signatories,
       contractKeyWithMaintainers =
         key.map(k => GlobalKeyWithMaintainers.assertBuild(templateId, k, signatories, pkgName)),
-      createdAt = data.Time.Timestamp.Epoch,
+      createdAt = CreationTime.CreatedAt(data.Time.Timestamp.Epoch),
       cantonData = Bytes.Empty,
     )
   }

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/UpgradeTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/UpgradeTest.scala
@@ -1819,7 +1819,7 @@ object UpgradeTest {
       signatories = immutable.TreeSet(alice),
       stakeholders = immutable.TreeSet(alice),
       contractKeyWithMaintainers = Some(globalContractKeyWithMaintainers),
-      createdAt = Time.Timestamp.Epoch,
+      createdAt = CreationTime.CreatedAt(Time.Timestamp.Epoch),
       cantonData = Bytes.assertFromString("00"),
     )
 

--- a/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/CompilerTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/CompilerTest.scala
@@ -15,6 +15,7 @@ import com.digitalasset.daml.lf.speedy.Speedy.ContractInfo
 import com.digitalasset.daml.lf.testing.parser.Implicits.SyntaxHelper
 import com.digitalasset.daml.lf.testing.parser.ParserParameters
 import com.digitalasset.daml.lf.transaction.{
+  CreationTime,
   FatContractInstance,
   GlobalKeyWithMaintainers,
   Node,
@@ -627,7 +628,7 @@ final class CompilerTestHelpers(majorLanguageVersion: LanguageMajorVersion) {
               None,
           version = txVersion,
         ),
-        Time.Timestamp.now(),
+        CreationTime.CreatedAt(Time.Timestamp.now()),
         Bytes.Empty,
       ),
       payload,

--- a/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -2404,7 +2404,7 @@ final class SBuiltinTestHelpers(majorLanguageVersion: LanguageMajorVersion) {
           keyOpt = keyOpt,
           version = txVersion,
         ),
-        createTime = Time.Timestamp.now(),
+        createTime = CreationTime.CreatedAt(Time.Timestamp.now()),
         cantonData = Bytes.Empty,
       ),
       sarg,

--- a/sdk/daml-lf/snapshot/src/main/scala/com/digitalasset/daml/lf/testing/snapshot/TransactionSnapshot.scala
+++ b/sdk/daml-lf/snapshot/src/main/scala/com/digitalasset/daml/lf/testing/snapshot/TransactionSnapshot.scala
@@ -11,6 +11,7 @@ import com.digitalasset.daml.lf.language.{Ast, LanguageVersion, Util => AstUtil}
 import com.digitalasset.daml.lf.testing.snapshot.Snapshot.SubmissionEntry.EntryCase
 import com.digitalasset.daml.lf.transaction.Transaction.ChildrenRecursion
 import com.digitalasset.daml.lf.transaction.{
+  CreationTime,
   FatContractInstance,
   GlobalKeyWithMaintainers,
   Node,
@@ -169,7 +170,11 @@ private[snapshot] object TransactionSnapshot {
       val relevantCreateNodes = activeCreates.view.filterKeys(tx.inputContracts).toList
       val contracts = relevantCreateNodes.view.map { case (cid, create) =>
         val ledgerTime = Time.Timestamp.assertFromLong(txEntry.getLedgerTime)
-        cid -> FatContractInstance.fromCreateNode(create, ledgerTime, Bytes.Empty)
+        cid -> FatContractInstance.fromCreateNode(
+          create,
+          CreationTime.CreatedAt(ledgerTime),
+          Bytes.Empty,
+        )
       }.toMap
       val contractKeys = relevantCreateNodes.view.flatMap { case (cid, create) =>
         create.keyOpt.map(_ -> cid).toList

--- a/sdk/daml-lf/transaction/src/main/protobuf/com/digitalasset/daml/lf/transaction.proto
+++ b/sdk/daml-lf/transaction/src/main/protobuf/com/digitalasset/daml/lf/transaction.proto
@@ -96,15 +96,17 @@ message Versioned {
   bytes payload = 2;
 }
 
-// A self contains representation of a committed contract.
+// A self contained representation of a committed contract.
 message FatContractInstance {
   bytes contract_id = 1;
   string package_name = 2;
-  repeated int32 package_version = 9; // required *since dev(
+  repeated int32 package_version = 9; // required *since dev*
   com.digitalasset.daml.lf.value.Identifier template_id = 3;
   bytes create_arg = 4;
   repeated string non_maintainer_signatories = 5;
   repeated string non_signatory_stakeholders = 6;
+  // Long.MinValue denotes that the creation time is unknown and should be derived from the context
+  // For Create nodes, this must be set to 0.
   sfixed64 created_at = 7;
   bytes canton_data = 8;
   KeyWithMaintainers contract_key_with_maintainers = 1001; // optional *since dev*

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -264,7 +264,7 @@ object Hash {
         _.iterateOver(metadata.disclosedContracts.valuesIterator, metadata.disclosedContracts.size)(
           (builder, fatInstance) =>
             builder
-              .withContext("Created At")(_.addLong(fatInstance.createdAt.micros))
+              .withContext("Created At")(_.addLong(CreationTime.encode(fatInstance.createdAt)))
               .withContext("Create Contract")(builder =>
                 builder.addHash(
                   builder.hashNode(

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/FatContractInstance.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/FatContractInstance.scala
@@ -164,7 +164,9 @@ object CreationTime {
   def encode(creationTime: CreationTime): Long =
     creationTime match {
       case CreatedAt(time) => time.micros
-      case Now => Long.MinValue
+      case Now =>
+        // Long.MinValue is outside of the range of valid micros for Timestamps
+        Long.MinValue
     }
 
   def decode(encoded: Long): Either[String, CreationTime] =

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.daml.lf
 package transaction
 
-import com.digitalasset.daml.lf.data.{BackStack, ImmArray, Ref}
+import com.digitalasset.daml.lf.data.{BackStack, ImmArray, Ref, Time}
 import com.digitalasset.daml.lf.transaction.TransactionOuterClass.Node.NodeTypeCase
 import com.digitalasset.daml.lf.data.Ref.{Name, Party}
 import com.digitalasset.daml.lf.value.ValueCoder.decodeCoid
@@ -165,7 +165,7 @@ object TransactionCoder {
             case nc: Node.Create =>
               val fatContractInstance = FatContractInstance.fromCreateNode(
                 create = nc,
-                createTime = data.Time.Timestamp.Epoch,
+                createTime = CreationTime.CreatedAt(data.Time.Timestamp.Epoch),
                 cantonData = data.Bytes.Empty,
               )
               for {
@@ -396,7 +396,8 @@ object TransactionCoder {
       nodeVersion <- decodeActionNodeVersion(txVersion, nodeVersionStr)
       contract <- decodeFatContractInstance(nodeVersion, msg)
       _ <- Either.cond(
-        contract.createdAt.micros == 0L,
+        // TODO Discuss with Remy whether it would make sense to encode create nodes with CreationTime.Now instead of 0
+        contract.createdAt == CreationTime.CreatedAt(Time.Timestamp.Epoch),
         (),
         DecodeError("unexpected created_at field in create node"),
       )
@@ -742,7 +743,7 @@ object TransactionCoder {
       encodedKeyOpt.foreach(builder.setContractKeyWithMaintainers)
       nonMaintainerSignatories.foreach(builder.addNonMaintainerSignatories)
       nonSignatoryStakeholders.foreach(builder.addNonSignatoryStakeholders)
-      discard(builder.setCreatedAt(createdAt.micros))
+      discard(builder.setCreatedAt(CreationTime.encode(createdAt)))
       discard(builder.setCantonData(cantonData.toByteString))
       builder.build()
     }
@@ -802,7 +803,7 @@ object TransactionCoder {
           Left(DecodeError(s"party $p is declared as signatory and nonSignatoryStakeholder"))
         case None => Right(signatories | nonSignatoryStakeholders)
       }
-      createdAt <- data.Time.Timestamp.fromLong(msg.getCreatedAt).left.map(DecodeError)
+      createdAt <- CreationTime.decode(msg.getCreatedAt).left.map(DecodeError)
       cantonData = msg.getCantonData
     } yield FatContractInstanceImpl(
       version = txVersion,

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -396,7 +396,6 @@ object TransactionCoder {
       nodeVersion <- decodeActionNodeVersion(txVersion, nodeVersionStr)
       contract <- decodeFatContractInstance(nodeVersion, msg)
       _ <- Either.cond(
-        // TODO Discuss with Remy whether it would make sense to encode create nodes with CreationTime.Now instead of 0
         contract.createdAt == CreationTime.CreatedAt(Time.Timestamp.Epoch),
         (),
         DecodeError("unexpected created_at field in create node"),

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -190,6 +190,7 @@ object Value {
     def toBytes: Bytes
     def version: ContractIdVersion
     def isAbsolute: Boolean
+    def isLocal: Boolean
 
     final override def mapCid(f: ContractId => ContractId): ContractId = f(this)
   }
@@ -203,6 +204,7 @@ object Value {
       override def toString: String = s"ContractId($coid)"
       override def version: ContractIdVersion = ContractIdVersion.V1
       override def isAbsolute: Boolean = suffix.nonEmpty
+      override def isLocal: Boolean = suffix.isEmpty
     }
 
     object V1 {
@@ -256,6 +258,7 @@ object Value {
 
       def isRelative: Boolean = suffix.nonEmpty && suffix.toByteString.byteAt(0) >= 0
       override def isAbsolute: Boolean = suffix.nonEmpty && suffix.toByteString.byteAt(0) < 0
+      override def isLocal: Boolean = suffix.isEmpty
     }
 
     object V2 {

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -204,7 +204,7 @@ object Value {
       override def toString: String = s"ContractId($coid)"
       override def version: ContractIdVersion = ContractIdVersion.V1
       override def isAbsolute: Boolean = suffix.nonEmpty
-      override def isLocal: Boolean = suffix.isEmpty
+      override def isLocal: Boolean = !isAbsolute
     }
 
     object V1 {

--- a/sdk/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/MetadataHashV1Spec.scala
+++ b/sdk/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/MetadataHashV1Spec.scala
@@ -6,7 +6,7 @@ package com.digitalasset.daml.lf
 import com.digitalasset.daml.lf.crypto.Hash
 import com.digitalasset.daml.lf.crypto.HashUtils.HashTracer
 import com.digitalasset.daml.lf.data.{Bytes, Ref, Time}
-import com.digitalasset.daml.lf.transaction.{FatContractInstance, TransactionSpec}
+import com.digitalasset.daml.lf.transaction.{CreationTime, FatContractInstance, TransactionSpec}
 import com.digitalasset.daml.lf.value.Value
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -29,12 +29,12 @@ class MetadataHashV1Spec extends AnyWordSpec with Matchers with HashUtils {
   private val bob = Ref.Party.assertFromString("bob")
   private val node1 = FatContractInstance.fromCreateNode(
     TransactionSpec.dummyCreateNode(cid1, Set(alice), Set(alice)),
-    Time.Timestamp.Epoch.add(Duration.ofDays(10)),
+    CreationTime.CreatedAt(Time.Timestamp.Epoch.add(Duration.ofDays(10))),
     Bytes.assertFromString("0010"),
   )
   private val node2 = FatContractInstance.fromCreateNode(
     TransactionSpec.dummyCreateNode(cid2, Set(bob), Set(bob)),
-    Time.Timestamp.Epoch.add(Duration.ofDays(20)),
+    CreationTime.CreatedAt(Time.Timestamp.Epoch.add(Duration.ofDays(20))),
     Bytes.assertFromString("0050"),
   )
   private val metadata = Hash.TransactionMetadataBuilderV1.Metadata(

--- a/sdk/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/sdk/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -339,7 +339,7 @@ class TransactionCoderSpec
         val normalizedCreate = adjustStakeholders(normalizeCreate(create))
         val instance = FatContractInstance.fromCreateNode(
           normalizedCreate,
-          time,
+          CreationTime.CreatedAt(time),
           data.Bytes.fromByteString(salt),
         )
         val Right(encoded) = TransactionCoder.encodeFatContractInstance(instance)
@@ -371,7 +371,7 @@ class TransactionCoderSpec
         val normalizedCreate = adjustStakeholders(normalizeCreate(create))
         val instance = FatContractInstance.fromCreateNode(
           normalizedCreate,
-          time,
+          CreationTime.CreatedAt(time),
           data.Bytes.fromByteString(salt),
         )
         val bytes = hackProto(instance, addUnknownField(_, i, extraBytes))
@@ -396,7 +396,7 @@ class TransactionCoderSpec
           val normalizedCreate = adjustStakeholders(normalizeCreate(create))
           val instance = FatContractInstance.fromCreateNode(
             normalizedCreate,
-            time,
+            CreationTime.CreatedAt(time),
             data.Bytes.fromByteString(salt),
           )
           val Right(protoKey) = TransactionCoder.encodeKeyWithMaintainers(create.version, key)
@@ -422,7 +422,7 @@ class TransactionCoderSpec
         val normalizedCreate = adjustStakeholders(normalizeCreate(create))
         val instance = FatContractInstance.fromCreateNode(
           normalizedCreate,
-          time,
+          CreationTime.CreatedAt(time),
           data.Bytes.fromByteString(salt),
         )
         val bytes =
@@ -463,7 +463,7 @@ class TransactionCoderSpec
           val normalizedCreate = adjustStakeholders(normalizeCreate(create))
           val instance = FatContractInstance.fromCreateNode(
             normalizedCreate,
-            time,
+            CreationTime.CreatedAt(time),
             data.Bytes.fromByteString(salt),
           )
           val nonMaintainerSignatories = (instance.nonMaintainerSignatories + party)
@@ -510,7 +510,7 @@ class TransactionCoderSpec
           val normalizedCreate = adjustStakeholders(normalizeCreate(create))
           val instance = FatContractInstance.fromCreateNode(
             normalizedCreate,
-            time,
+            CreationTime.CreatedAt(time),
             data.Bytes.fromByteString(salt),
           )
           val maintainers = TreeSet.from(key.maintainers + party)
@@ -558,7 +558,7 @@ class TransactionCoderSpec
         val normalizedCreate = adjustStakeholders(normalizeCreate(create))
         val instance = FatContractInstance.fromCreateNode(
           normalizedCreate,
-          time,
+          CreationTime.CreatedAt(time),
           data.Bytes.fromByteString(salt),
         )
         val party_ = makePartyFresh(party, create)

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -29,6 +29,7 @@ import com.digitalasset.daml.lf.script
 import com.digitalasset.daml.lf.speedy.Speedy.Machine
 import com.digitalasset.daml.lf.speedy.{Pretty, SError, SValue, TraceLog, WarningLog}
 import com.digitalasset.daml.lf.transaction.{
+  CreationTime,
   FatContractInstance,
   GlobalKey,
   IncompleteTransaction,
@@ -40,7 +41,6 @@ import com.digitalasset.daml.lf.transaction.{
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.ContractId
 import com.daml.nonempty.NonEmpty
-
 import com.digitalasset.canton.logging.{LoggingContextWithTrace, NamedLoggerFactory}
 import com.digitalasset.canton.ledger.localstore.InMemoryUserManagementStore
 import scalaz.OneAnd
@@ -124,7 +124,7 @@ class IdeLedgerClient(
     Bytes.fromByteString(TransactionCoder.encodeFatContractInstance(contract).toOption.get)
 
   private[this] def blob(create: Node.Create, createAt: Time.Timestamp): Bytes =
-    blob(FatContractInstance.fromCreateNode(create, createAt, Bytes.Empty))
+    blob(FatContractInstance.fromCreateNode(create, CreationTime.CreatedAt(createAt), Bytes.Empty))
 
   override def query(
       parties: OneAnd[Set, Ref.Party],

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -138,7 +138,7 @@
 - Evaluation order of successful lookup_by_key of a local contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3183)
 - Evaluation order of successful lookup_by_key of a non-cached global contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3050)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L34)
-- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2284)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2304)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/stable/Exceptions.daml#L262)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version, where one is new to V2 within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/stable/Exceptions.daml#L266)
 - Smart Contract Upgrade: Can catch same errors thrown by different choice versions within Update: [Exceptions.daml](daml-script/test/daml/upgrades/stable/Exceptions.daml#L258)

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -138,7 +138,7 @@
 - Evaluation order of successful lookup_by_key of a local contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3183)
 - Evaluation order of successful lookup_by_key of a non-cached global contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3050)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L34)
-- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2303)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2284)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/stable/Exceptions.daml#L262)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version, where one is new to V2 within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/stable/Exceptions.daml#L266)
 - Smart Contract Upgrade: Can catch same errors thrown by different choice versions within Update: [Exceptions.daml](daml-script/test/daml/upgrades/stable/Exceptions.daml#L258)


### PR DESCRIPTION
Generalizes the `createdAt` field of the `FatContractInstance` so that it can specify "now" instead of a concrete timestamp. "now" means that the contract is created in the same time as the context processing it. This is useful for relative contract instances, i.e., contracts created in the same transaction, but where the creation happens outside of the current focus (e.g., a projection).

This PR does not yet make use of this symbolic timestamp, as the counterpart `SerializableContract` must be generalized in the same way. Therefore, all the changes in the Canton codedrop are merely preliminary in this PR.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
