### PR TITLE
Added empty interned kinds in proto archive

### DIFF
--- a/sdk/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/DecodeV2.hs
+++ b/sdk/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/DecodeV2.hs
@@ -36,6 +36,7 @@ data DecodeEnv = DecodeEnv
     { internedStrings :: !(V.Vector (T.Text, Either String UnmangledIdentifier))
     , internedDottedNames :: !(V.Vector ([T.Text], Either String [UnmangledIdentifier]))
     , internedTypes :: !(V.Vector Type)
+    , internedKinds :: !(V.Vector Kind)
     , selfPackageRef :: SelfOrImportedPackageId
     }
 
@@ -142,13 +143,16 @@ decodeInternedDottedName (LF2.InternedDottedName ids) = do
     pure (mangled, sequence unmangledOrErr)
 
 decodePackage :: LF.Version -> LF.SelfOrImportedPackageId -> LF2.Package -> Either Error Package
-decodePackage version selfPackageRef (LF2.Package mods internedStringsV internedDottedNamesV mMetadata internedTypesV)
+decodePackage version selfPackageRef (LF2.Package mods internedStringsV internedDottedNamesV mMetadata internedTypesV _internedKindsV)
   | Nothing <- mMetadata  =
       throwError (ParseError "missing package metadata")
   | Just metadata <- mMetadata = do
       let internedStrings = V.map decodeMangledString internedStringsV
       let internedDottedNames = V.empty
       let internedTypes = V.empty
+      -- for internedTypes we do something with the matched internedTypesV but
+      -- for kinds this is not yet needed as, for now, they are always empty
+      let internedKinds = V.empty
       let env0 = DecodeEnv{..}
       internedDottedNames <- runDecode env0 $ mapM decodeInternedDottedName internedDottedNamesV
       let env1 = env0{internedDottedNames}
@@ -739,6 +743,7 @@ decodeKind LF2.Kind{..} = mayDecode "kindSum" kindSum $ \case
   LF2.KindSumArrow (LF2.Kind_Arrow params mbResult) -> do
     result <- mayDecode "kind_ArrowResult" mbResult decodeKind
     foldr KArrow result <$> traverse decodeKind (V.toList params)
+  LF2.KindSumInterned _ -> error "Should not be populated"
 
 decodeBuiltin :: LF2.BuiltinType -> Decode BuiltinType
 decodeBuiltin = \case

--- a/sdk/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/DecodeV2.hs
+++ b/sdk/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/DecodeV2.hs
@@ -150,6 +150,7 @@ decodePackage version selfPackageRef (LF2.Package mods internedStringsV interned
       let internedStrings = V.map decodeMangledString internedStringsV
       let internedDottedNames = V.empty
       let internedTypes = V.empty
+      -- TODO https://github.com/digital-asset/daml/issues/21155
       -- for internedTypes we do something with the matched internedTypesV but
       -- for kinds this is not yet needed as, for now, they are always empty
       let internedKinds = V.empty

--- a/sdk/compiler/daml-lf-proto-encode/src/DA/Daml/LF/Proto3/EncodeV2.hs
+++ b/sdk/compiler/daml-lf-proto-encode/src/DA/Daml/LF/Proto3/EncodeV2.hs
@@ -965,6 +965,7 @@ encodePackage (Package version mods metadata) =
             V.fromList $ map (P.InternedDottedName . V.fromList . fst) $ L.sortOn snd $ HMS.toList internedDottedNames
         packageInternedTypes =
             V.fromList $ map (P.Type . Just . fst) $ L.sortOn snd $ Map.toList internedTypes
+        packageInternedKinds = V.empty
     in
     P.Package{..}
 

--- a/sdk/compiler/damlc/tests/src/package-pattern-match-perf.sh
+++ b/sdk/compiler/damlc/tests/src/package-pattern-match-perf.sh
@@ -28,4 +28,4 @@ $DAMLC build --project-root $DIR/dep
 # does not come with larger memomry or stack usage.  However, the slow
 # down is so big that this times out the 300s Bazel timeout whereas
 # the fixed version runs in about 30s.
-$DAMLC build --project-root $DIR/main +RTS -s -M150M -K1M -N1
+$DAMLC build --project-root $DIR/main +RTS -s -M200M -K1M -N1

--- a/sdk/daml-lf/archive/src/main/protobuf/com/digitalasset/daml/lf/archive/daml_lf2.proto
+++ b/sdk/daml-lf/archive/src/main/protobuf/com/digitalasset/daml/lf/archive/daml_lf2.proto
@@ -142,7 +142,7 @@ message Kind {
     // kind of TNat type;
     Unit nat = 3;
     // interned kinds
-    uint32 interned = 4;
+    uint32 interned = 4; // *Available in versions >= 2.dev*
   }
 }
 
@@ -1390,5 +1390,5 @@ message Package {
   // Types in the interning table are only allowed to refer to interned types
   // at smaller indices.
   repeated Type interned_types = 5;
-  repeated Kind interned_kinds = 6;
+  repeated Kind interned_kinds = 6; // *Available in versions >= 2.dev*
 }

--- a/sdk/daml-lf/archive/src/main/protobuf/com/digitalasset/daml/lf/archive/daml_lf2.proto
+++ b/sdk/daml-lf/archive/src/main/protobuf/com/digitalasset/daml/lf/archive/daml_lf2.proto
@@ -141,6 +141,8 @@ message Kind {
     Arrow arrow = 2;
     // kind of TNat type;
     Unit nat = 3;
+    // interned kinds
+    uint32 interned = 4;
   }
 }
 
@@ -1388,4 +1390,5 @@ message Package {
   // Types in the interning table are only allowed to refer to interned types
   // at smaller indices.
   repeated Type interned_types = 5;
+  repeated Kind interned_kinds = 6;
 }

--- a/sdk/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV2.scala
+++ b/sdk/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV2.scala
@@ -648,6 +648,8 @@ private[archive] class DecodeV2(minor: LV.Minor) {
                 Ret((kinds foldRight base)(KArrow))
               }
             }
+          case PLF.Kind.SumCase.INTERNED =>
+            throw Error.Parsing(s"Unexpected filed result_interned_kind")
           case PLF.Kind.SumCase.SUM_NOT_SET =>
             throw Error.Parsing("Kind.SUM_NOT_SET")
         }

--- a/sdk/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV2Spec.scala
+++ b/sdk/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV2Spec.scala
@@ -104,6 +104,18 @@ class DecodeV2Spec
         moduleDecoder(version).decodeKindForTest(input) shouldBe Ast.KNat
       }
     }
+
+    "reject Arrow if result_interned_kind is set" in {
+      val input = DamlLf2.Kind
+        .newBuilder()
+        .setInterned(32)
+        .build()
+
+      forEveryVersion { version =>
+        an[Error.Parsing] shouldBe thrownBy(moduleDecoder(version).decodeKindForTest(input))
+      }
+    }
+
   }
 
   "uncheckedDecodeType" should {


### PR DESCRIPTION
First steps of https://github.com/digital-asset/daml/issues/21347:

- [x] Extend the protobuf in backwards-compatible fashion
- [x] Fix (de)coding such that compilation succeeds and usage of the new fields is rejected
  - [x] Haskell
  - [x] Scala