### PR TITLE
Temporarily disable windows on CI as windows machines fail to register

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -129,6 +129,8 @@ jobs:
 - template: blackduck.yml
 
 - job: Windows
+  # Temporarily disable windows as windows machines fail to register
+  condition: false
   dependsOn:
     - check_for_release
   variables:


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
