### PR TITLE
Revert "Temporarily disable windows on CI as windows machines fail to register"

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -135,8 +135,6 @@ jobs:
 - template: blackduck.yml
 
 - job: Windows
-  # Temporarily disable windows as windows machines fail to register
-  condition: false
   dependsOn:
     - check_for_release
   variables:


### PR DESCRIPTION
Reverts digital-asset/daml#21354

Windows machines are so back. :window: 