### PR TITLE
Document DARs and DALFs, and decoding thereof

### DIFF
--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -10,6 +10,8 @@ When a Daml project is compiled, it produces a DAR (extension ``.dar``), short
 for Daml Archive. The Daml compiler exposes commands for inspecting this
 archive.
 
+.. _inspecting_dars:
+
 Inspecting a DAR file
 *********************
 
@@ -189,15 +191,19 @@ depending on what is needed.
   In this case, ``PackageId`` comes from ``com.digitalasset.daml.lf.language.Ref``
   in the ``com.daml:daml-lf-data`` package, and ``Package`` comes from
   ``com.digitalasset.daml.lf.language.Ast``, in the ``com.daml:daml-lf-language``
-  `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-language>`_.
+  `library on Maven`__.
+
+  __ https://mvnrepository.com/artifact/com.daml/daml-lf-language
 
   Because fully decoding the package takes more processing time than the next
   two examples, only use it when the full package code is needed.
 * When only the simplest representation of the protobuf of the package is
   needed, pick a decoder returning a ``com.digitalasset.daml.lf.DamlLf.ArchivePayload``
-  (from the ``com-daml:daml-lf-archive-proto`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-archive-proto>`).
+  (from the ``com-daml:daml-lf-archive-proto`` `library on Maven`__).
   This should only be needed when working with internal protobuf representations
   of a package.
+
+  __ https://mvnrepository.com/artifact/com.daml/daml-lf-archive-proto
 * When only the package's byte representation and hash is needed, use a
   decoder that returns ``Archive`` (also from the ``com-daml:daml-lf-archive-proto``
   library). When using this, the decoder will not spend time decoding any of the

--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -131,13 +131,12 @@ Parsing DAR and DALF files
 **************************
 
 To parse a DAR or DALF file from within Scala code, the
-``com-daml:daml-lf-archive-reader`` library `on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-archive-reader>`_
+``com-daml:daml-lf-archive-reader`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-archive-reader>`_
 provides a Scala package object ``com.digitalasset.daml.lf.archive`` with
-several decoders.
-
-There are three different types of outputs a decoder can have, and three
-possible inputs that a decoder accepts - the ``archive`` package object
-defines decoders for 8 of the 9 possible combinations
+several decoders. Below are the common types of inputs and outputs a decoder can
+have, and which decoders to use depending on the input and output that is
+desired. For more details on inputs, outputs, and decoders, please refer to
+Maven to find the source code for the associated libraries.
 
 Output types
 """"""""""""
@@ -151,14 +150,15 @@ depending on what is needed.
   In this case, ``PackageId`` comes from ``com.digitalasset.daml.lf.language.Ref``
   in the ``com.daml:daml-lf-data`` package, and ``Package`` comes from
   ``com.digitalasset.daml.lf.language.Ast``, in the ``com.daml:daml-lf-language``
-  library.
+  `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-language>`_.
 
   Because fully decoding the package takes more processing time than the next
   two examples, only use it when the full package code is needed.
 * When only the simplest representation of the protobuf of the package is
   needed, pick a decoder returning a ``com.digitalasset.daml.lf.DamlLf.ArchivePayload``
-  (from the ``com-daml:daml-lf-archive-proto`` library). This should only be
-  needed when working with internal protobuf representations of a package.
+  (from the ``com-daml:daml-lf-archive-proto`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-archive-proto>`).
+  This should only be needed when working with internal protobuf representations
+  of a package.
 * When only the package's byte representation and hash is needed, use a
   decoder that returns ``Archive`` (also from the ``com-daml:daml-lf-archive-proto``
   library). When using this, the decoder will not spend time decoding any of the

--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -115,7 +115,8 @@ Inspecting the main package of a DAR file
 
 If you'd like to inspect the code inside the main package of a DAR, the Daml
 compiler provides the ``inspect`` tool; running ``daml damlc inspect <path-to-dar-file>``
-prints all of the code in that DALF file in a human-readable format.
+prints all of the code in the main package of that DAR file in a human-readable
+format.
 
 For example, run the ``inspect`` tool on the DAR produced in the previous
 section:

--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -131,8 +131,9 @@ Parsing DAR and DALF files
 **************************
 
 To parse a DAR or DALF file from within Scala code, the
-``com-daml:daml-lf-archive-reader`` library on Maven provides a Scala package
-object ``com.digitalasset.daml.lf.archive`` with several decoders.
+``com-daml:daml-lf-archive-reader`` library `on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-archive-reader>`_
+provides a Scala package object ``com.digitalasset.daml.lf.archive`` with
+several decoders.
 
 There are three different types of outputs a decoder can have, and three
 possible inputs that the a decoder accepts - the ``archive`` package object

--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -202,8 +202,8 @@ depending on what is needed.
   For example, the ``com.digitalasset.daml.lf.typesig.reader.SignatureReader`` class
   from the ``com-daml:daml-lf-api-type-signature`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-api-type-signature>`
   takes a ``(PackageId, Package)`` pair to produce a ``com.digitalasset.daml.lf.typesig.PackageSignature``
-  (also from the ``api-type-signature``) package, which quickly specifies all of
-  the templates, datatypes, and interfaces in a package.
+  (also from the ``api-type-signature``) package, which specifies all of the
+  templates, datatypes, and interfaces in a package.
 
 * When only the simplest representation of the protobuf of the package is
   needed, pick a decoder returning a ``com.digitalasset.daml.lf.ArchivePayload``

--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -13,11 +13,9 @@ archive.
 Inspecting a DAR file
 *********************
 
-A DAR is actually a zip file which contains many ``.dalf`` files - each
-``.dalf`` file contains the compiled code for a specific package. A metadata
-file called ``MANIFEST`` records which package is the "main" or "primary"
-package of the DAR -- the rest of the packages are dependencies of that "main"
-package.
+A DAR is actually a zip file containing multiple packages, one of which is the
+"main" package; more information on the exact structure of the zip file is
+:ref:`available the explanation on Daml packages and archive files <structure-of-an-archive-file>`.
 
 Running ``daml damlc inspect-dar <darfile>`` reports all of the files and
 packages in a DAR file. For example, consider a package ``mypkg`` which depends
@@ -46,6 +44,10 @@ it contains both the ``mypkg`` package and its dependency ``dep``:
 
 .. code-block:: none
 
+   > daml build
+   ...
+   Created .daml/dist/mypkg-1.0.0.dar
+
    > daml damlc inspect-dar .daml/dist/mypkg-1.0.0.dar
 
    DAR archive contains the following files:
@@ -64,13 +66,8 @@ it contains both the ``mypkg`` package and its dependency ``dep``:
    dep-1.0.0-<dep-package-id> "<dep-package-id>"
    mypkg-1.0.0-<mypkg-package-id> "<mypkg-package-id>"
 
-The first section reports all of the files in DAR, including the DAR's MANIFEST
-file, which keeps metadata about which DALF file is the "main". The second section
-reports the package name and package ID for every dalf in the archive.
-
-In every DAR, there will be many additional ``.dalf`` files for the standard
-library and primitive libraries - these are necessary for running any Daml code,
-so they are automatically included.
+The first section reports all of the files in DAR, and the second section
+reports the package name and package ID for every DALF in the archive.
 
 Inspecting a DALF file
 **********************

--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -199,16 +199,17 @@ depending on what is needed.
   Because fully decoding the package takes more processing time than the next
   two examples, only use it when the full package code is needed.
 * When only the simplest representation of the protobuf of the package is
-  needed, pick a decoder returning a ``com.digitalasset.daml.lf.DamlLf.ArchivePayload``
-  (from the ``com-daml:daml-lf-archive-proto`` `library on Maven`__).
-  This should only be needed when working with internal protobuf representations
-  of a package.
+  needed, pick a decoder returning a ``com.digitalasset.daml.lf.ArchivePayload``
+  (from the ``com-daml:daml-lf-archive`` `library on Maven`__).
+
+  __ https://mvnrepository.com/artifact/com.daml/daml-lf-archive
+
+* When only the package's byte representation and hash is needed, use a
+  decoder that returns ``Archive`` (from the ``com-daml:daml-lf-archive-proto``
+  `library on Maven`__). When using this, the decoder will not spend time decoding any of the
+  package's actual content, such as its metadata or its code.
 
   __ https://mvnrepository.com/artifact/com.daml/daml-lf-archive-proto
-* When only the package's byte representation and hash is needed, use a
-  decoder that returns ``Archive`` (also from the ``com-daml:daml-lf-archive-proto``
-  library). When using this, the decoder will not spend time decoding any of the
-  package's actual content, such as its metadata or its code.
 
 Input types
 """""""""""

--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -136,7 +136,7 @@ provides a Scala package object ``com.digitalasset.daml.lf.archive`` with
 several decoders.
 
 There are three different types of outputs a decoder can have, and three
-possible inputs that the a decoder accepts - the ``archive`` package object
+possible inputs that a decoder accepts - the ``archive`` package object
 defines decoders for 8 of the 9 possible combinations
 
 Output types

--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -151,7 +151,7 @@ depending on what is needed.
   In this case, ``PackageId`` comes from ``com.digitalasset.daml.lf.language.Ref``
   in the ``com.daml:daml-lf-data`` package, and ``Package`` comes from
   ``com.digitalasset.daml.lf.language.Ast``, in the ``com.daml:daml-lf-language``
-  package.
+  library.
 
   Because fully decoding the package takes more processing time than the next
   two examples, only use it when the full package code is needed.

--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -199,11 +199,15 @@ depending on what is needed.
   Because fully decoding the package takes more processing time than the next
   two examples, only use it when the full package code is needed.
 
+  .. vale CiEnforced.Terms = NO
+
   For example, the ``com.digitalasset.daml.lf.typesig.reader.SignatureReader`` class
   from the ``com-daml:daml-lf-api-type-signature`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-api-type-signature>`
   takes a ``(PackageId, Package)`` pair to produce a ``com.digitalasset.daml.lf.typesig.PackageSignature``
   (also from the ``api-type-signature``) package, which specifies all of the
   templates, datatypes, and interfaces in a package.
+
+  .. vale CiEnforced.Terms = YES
 
 * When only the simplest representation of the protobuf of the package is
   needed, pick a decoder returning a ``com.digitalasset.daml.lf.ArchivePayload``

--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -13,10 +13,6 @@ archive.
 Inspecting a DAR file
 *********************
 
-A DAR is actually a zip file containing multiple packages, one of which is the
-"main" package; more information on the exact structure of the zip file is
-:ref:`available the explanation on Daml packages and archive files <structure-of-an-archive-file>`.
-
 Running ``daml damlc inspect-dar <darfile>`` reports all of the files and
 packages in a DAR file. For example, consider a package ``mypkg`` which depends
 on a package ``dep``:
@@ -68,6 +64,8 @@ it contains both the ``mypkg`` package and its dependency ``dep``:
 
 The first section reports all of the files in DAR, and the second section
 reports the package name and package ID for every DALF in the archive.
+
+More information on the exact structure of the zip file is :ref:`available in the explanation on Daml packages and archive files <structure-of-an-archive-file>`.
 
 Inspecting the main package of a DAR file
 *****************************************

--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -1,0 +1,244 @@
+.. Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. _how-to-parse-daml-archive-files:
+
+How to parse Daml archive files
+###############################
+
+When a Daml project is compiled, it produces a DAR (extension ``.dar``), short
+for Daml Archive. The Daml compiler exposes commands for inspecting this
+archive.
+
+Inspecting a DAR file
+*********************
+
+A DAR is actually a zip file which contains many ``.dalf`` files - each
+``.dalf`` file contains the compiled code for a specific package. A metadata
+file called ``MANIFEST`` records which package is the "main" or "primary"
+package of the DAR -- the rest of the packages are dependencies of that "main"
+package.
+
+Running ``daml damlc inspect-dar <darfile>`` reports all of the files and
+packages in a DAR file. For example, consider a package ``mypkg`` which depends
+on a package ``dep``:
+
+.. code-block:: yaml
+   :caption: mypkg/daml.yaml
+
+   name: mypkg
+   version: 1.0.0
+   source: daml
+   ...
+   data-dependencies:
+   - ../dep/.daml/dist/dep-1.0.0.dar
+
+.. code-block:: yaml
+   :caption: dep/daml.yaml
+
+   name: dep
+   version: 1.0.0
+   source: daml
+   ...
+
+When ``mypkg-1.0.0`` is compiled to a DAR, we can inspect that DAR to ensure that
+it contains both the ``mypkg`` package and its dependency ``dep``:
+
+.. code-block:: none
+
+   > daml damlc inspect-dar .daml/dist/mypkg-1.0.0.dar
+
+   DAR archive contains the following files:
+
+   ...
+   mypkg-1.0.0-<mypkg-package-id>/dep-1.0.0-<dep-package-id>.dalf
+   mypkg-1.0.0-<mypkg-package-id>/mypkg-1.0.0-<mypkg-package-id>.dalf
+   mypkg-1.0.0-<mypkg-package-id>/MyPkg.daml
+   mypkg-1.0.0-<mypkg-package-id>/MyPkg.hi
+   mypkg-1.0.0-<mypkg-package-id>/MyPkg.hie
+   META-INF/MANIFEST.MF
+
+   DAR archive contains the following packages:
+
+   ...
+   dep-1.0.0-<dep-package-id> "<dep-package-id>"
+   mypkg-1.0.0-<mypkg-package-id> "<mypkg-package-id>"
+
+The first section reports all of the files in DAR, including the DAR's MANIFEST
+file, which keeps metadata about which DALF file is the "main". The second section
+reports the package name and package ID for every dalf in the archive.
+
+In every DAR, there will be many additional ``.dalf`` files for the standard
+library and primitive libraries - these are necessary for running any Daml code,
+so they are automatically included.
+
+Inspecting a DALF file
+**********************
+
+If you'd like to inspect the code inside a .dalf, the Daml compiler provides the
+``inspect`` tool; running ``daml damlc inspect <path-to-dalf-file>`` on a DALF
+file prints all of the code in that DALF file in a human-readable format.
+
+We can unzip a DAR to access its dalfs and inspect them, for example with the
+DAR from the previous section:
+
+.. code-block:: sh
+
+   > unzip .daml/dist/mypkg-1.0.0.dar
+   > daml damlc inspect mypkg-1.0.0-<mypkg-package-id>/mypkg-1.0.0-<mypkg-package-id>.dalf
+   ...
+   # Human-readable dump of code in mypkg
+   ...
+   > daml damlc inspect mypkg-1.0.0-<mypkg-package-id>/dep-1.0.0-<dep-package-id>.dalf
+   ...
+   # Human-readable dump of code in dep
+   ...
+
+Running ``inspect`` on a DAR will extract only its "main" package's ``.dalf``,
+and then run ``inspect`` on that ``.dalf``:
+
+.. code-block:: sh
+
+   # Same as the first two lines in the code block above
+   > daml damlc inspect .daml/dist/mypkg-1.0.0.dar
+   ...
+   # Human-readable dump of code in mypkg
+   ...
+
+Parsing DAR and DALF files
+**************************
+
+To parse a DAR or DALF file from within Scala code, the
+``com-daml:daml-lf-archive-reader`` library on Maven provides a Scala package
+object ``com.digitalasset.daml.lf.archive`` with several decoders.
+
+There are three different types of outputs a decoder can have, and three
+possible inputs that the a decoder accepts - the ``archive`` package object
+defines decoders for 8 of the 9 possible combinations
+
+Output types
+""""""""""""
+
+When decoding a package, a decoder can have one of several possible outputs,
+depending on what is needed.
+
+* When the full code of the package is needed, pick a decoder returning tuples
+  ``(PackageId, Package)``.
+
+  In this case, ``PackageId`` comes from ``com.digitalasset.daml.lf.language.Ref``
+  in the ``com.daml:daml-lf-data`` package, and ``Package`` comes from
+  ``com.digitalasset.daml.lf.language.Ast``, in the ``com.daml:daml-lf-language``
+  package.
+
+  Because fully decoding the package takes more processing time than the next
+  two examples, only use it when the full package code is needed.
+* When only the simplest representation of the protobuf of the package is
+  needed, pick a decoder returning a ``com.digitalasset.daml.lf.DamlLf.ArchivePayload``
+  (from the ``com-daml:daml-lf-archive-proto`` library). This should only be
+  needed when working with internal protobuf representations of a package.
+* When only the package's byte representation and hash is needed, use a
+  decoder that returns ``Archive`` (also from the ``com-daml:daml-lf-archive-proto``
+  library). When using this, the decoder will not spend time decoding any of the
+  package's actual content, such as its metadata or its code.
+
+Input types
+"""""""""""
+
+A decoder can either accept DALF files, DAR files, or it can accept both.
+
+* If a decoder accepts DALF files, it will parse the single package in that DALF
+  file to its output type (one of the three specified above).
+* If a decoder accepts DAR files, it will parse multiple packages
+  from a DAR file to a struct ``Dar[X]``, which is a case class that encodes a DAR
+  as two public fields, ``main: X`` and ``dependencies: List[X]``.
+* If a decoder accepts both, it will always produce a ``Dar[X]``. When given a
+  DAR, the decoder will run as a normal DAR decoder would. When given a DALF,
+  the decoder will decode the DALF as a single package and return a ``Dar[X]``
+  with a ``main`` package and an empty list of dependencies.
+
+Decoders
+""""""""
+
+Decoders for reading DALFs are instances of ``GenReader[X]``, which provides the
+method ``readArchiveFromFile(file: java.io.File): Either[Error, X]``.
+
+* ``val ArchiveReader: GenReader[ArchivePayload]``
+
+  Run ``ArchiveReader.readArchiveFromFile(new java.io.File("<path-to-dalf>"))`` to parse
+  out the ``ArchivePayload`` of a dalf file.
+* ``val ArchiveDecoder: GenReader[(PackageId, Ast.Package)]``
+
+  Run ``ArchiveDecoder.readArchiveFromFile(new java.io.File("<path-to-dalf>"))`` to parse
+  out the ``(Ref.PackageId, Ast.Package)`` of a dalf file.
+* ``val ArchiveParser: GenReader[DamlLf.Archive]``
+
+  Run ``ArchiveParser.readArchiveFromFile(new java.io.File("<path-to-dalf>"))`` to parse
+  out the ``DamlLf.Archive`` of a dalf file.
+
+Decoders for reading DARs are instances of ``GenDarReader``, which provides the
+method ``readArchiveFromFile(file: java.io.File): Either[Error, Dar[X]]``.
+
+* ``val DarReader: GenDarReader[ArchivePayload]``
+
+  Run ``DarReader.readArchiveFromFile(new java.io.File("<path-to-dar>"))`` to parse
+  out the ``Dar[ArchivePayload]`` of a dar file.
+* ``val DarDecoder: GenDarReader[(PackageId, Ast.Package)]``
+
+  Run ``DarDecoder.readArchiveFromFile(new java.io.File("<path-to-dar>"))`` to parse
+  out the ``Dar[(Ref.PackageId, Ast.Package)]`` of a dar file.
+* ``val DarParser: GenDarReader[DamlLf.Archive]``
+
+  Run ``DarParser.readArchiveFromFile(new java.io.File("<path-to-dar>"))`` to parse
+  out the ``Dar[DamlLf.Archive]`` of a dar file.
+
+Decoders for reading DARs are instances of ``GenUniversalArchiveReader``, which
+provides the method ``readFile(file: java.io.File): Either[Error, Dar[X]]``.
+
+* ``val UniversalArchiveReader: GenUniversalArchiveReader[ArchivePayload]``
+
+  Run ``UniversalArchiveReader.readFile(new java.io.File("<path-to-dar-or-dalf>"))``
+  to parse out the ``Dar[ArchivePayload]`` of a dar file.
+* ``val UniversalArchiveDecoder: GenUniversalArchiveReader[(PackageId, Ast.Package)]``
+
+  Run ``UniversalArchiveDecoder.readFile(new java.io.File("<path-to-dar-or-dalf>"))``
+  to parse out the ``Dar[(Ref.PackageId, Ast.Package)]`` of a dar file.
+
+Example
+"""""""
+
+We can load up a Scala REPL with the ``daml-lf-archive-reader`` library to
+interactively parse our ``mypkg`` DAR:
+
+.. code-block:: scala
+
+   scala> // Start a REPL
+   scala> val darEither = DarDecoder.readArchiveFromFile(".daml/dist/mypkg-1.0.0.dar")
+   val dar: Either[Error, Dar[(Ref.PackageId, Ast.Package)]]
+   Right(Dar((..., GenPackage(Map(Main -> ...
+   ...
+
+   scala> // Extract the resulting value
+   scala> val dar = darEither.toOption.get
+
+   scala> :t dar.main
+   (Ref.PackageId, Ast.Package)
+
+   scala> :t dar.dependencies
+   List[(Ref.PackageId, Ast.Package)]
+
+The Dar datatype also has a method ``.all`` which returns the main package and
+dependencies as a single list. Mapping ``_1`` over this gets all of the package
+IDs in the DAR:
+
+.. code-block:: scala
+
+   scala> dar.all.map(_._1)
+   val res1: List[Ref.PackageId] = List(224..., 54f..., ...)
+
+Get the names of all the dependency packages in the DAR by using the
+``.metadata.name`` field in the ``Ast.Package`` datatype:
+
+.. code-block:: scala
+
+   scala> dar.dependencies.map(_._2.metadata.name)
+   val res2: List[com.digitalasset.daml.lf.data.Ref.PackageName] = List(daml-prim, daml-prim-DA-Exception-ArithmeticError, ...

--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -173,7 +173,7 @@ Parsing DAR and DALF files
 **************************
 
 To parse a DAR or DALF file from within Scala code, the
-``com-daml:daml-lf-archive-reader`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-archive-reader>`_
+``com-daml:daml-lf-archive-reader`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-archive-reader>`
 provides a Scala package object ``com.digitalasset.daml.lf.archive`` with
 several decoders. Below are the common types of inputs and outputs a decoder can
 have, and which decoders to use depending on the input and output that is
@@ -189,27 +189,27 @@ depending on what is needed.
 * When the full code of the package is needed, pick a decoder returning tuples
   ``(PackageId, Package)``.
 
-  In this case, ``PackageId`` comes from ``com.digitalasset.daml.lf.language.Ref``
-  in the ``com.daml:daml-lf-data`` package, and ``Package`` comes from
-  ``com.digitalasset.daml.lf.language.Ast``, in the ``com.daml:daml-lf-language``
-  `library on Maven`__.
-
-  __ https://mvnrepository.com/artifact/com.daml/daml-lf-language
+  In this case, ``PackageId`` is a string-like type that comes from
+  ``com.digitalasset.daml.lf.language.Ref`` in the ``com.daml:daml-lf-data``
+  `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-data>`.
+  ``Package`` represents the full structure of a package, and comes
+  from ``com.digitalasset.daml.lf.language.Ast``, in the ``com.daml:daml-lf-language``
+  `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-language>`.
 
   Because fully decoding the package takes more processing time than the next
   two examples, only use it when the full package code is needed.
+
 * When only the simplest representation of the protobuf of the package is
   needed, pick a decoder returning a ``com.digitalasset.daml.lf.ArchivePayload``
-  (from the ``com-daml:daml-lf-archive`` `library on Maven`__).
-
-  __ https://mvnrepository.com/artifact/com.daml/daml-lf-archive
+  (from the ``com-daml:daml-lf-archive`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-archive>`).
+  This should only be needed when working with internal protobuf representations
+  of a package.
 
 * When only the package's byte representation and hash is needed, use a
   decoder that returns ``Archive`` (from the ``com-daml:daml-lf-archive-proto``
-  `library on Maven`__). When using this, the decoder will not spend time decoding any of the
-  package's actual content, such as its metadata or its code.
-
-  __ https://mvnrepository.com/artifact/com.daml/daml-lf-archive-proto
+  `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-archive-proto>`).
+  When using this, the decoder will not spend time decoding any of the package's
+  actual content, such as its metadata or its code.
 
 Input types
 """""""""""

--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -22,7 +22,7 @@ on a package ``dep``:
 
    name: mypkg
    version: 1.0.0
-   source: daml
+   source: daml/Main.daml
    ...
    data-dependencies:
    - ../dep/.daml/dist/dep-1.0.0.dar
@@ -32,7 +32,7 @@ on a package ``dep``:
 
    name: dep
    version: 1.0.0
-   source: daml
+   source: daml/Dep.daml
    ...
 
 When ``mypkg-1.0.0`` is compiled to a DAR, we can inspect that DAR to ensure that

--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -199,6 +199,12 @@ depending on what is needed.
   Because fully decoding the package takes more processing time than the next
   two examples, only use it when the full package code is needed.
 
+  For example, the ``com.digitalasset.daml.lf.typesig.reader.SignatureReader`` class
+  from the ``com-daml:daml-lf-api-type-signature`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-api-type-signature>`
+  takes a ``(PackageId, Package)`` pair to produce a ``com.digitalasset.daml.lf.typesig.PackageSignature``
+  (also from the ``api-type-signature``) package, which quickly specifies all of
+  the templates, datatypes, and interfaces in a package.
+
 * When only the simplest representation of the protobuf of the package is
   needed, pick a decoder returning a ``com.digitalasset.daml.lf.ArchivePayload``
   (from the ``com-daml:daml-lf-archive`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-archive>`).

--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -69,37 +69,62 @@ it contains both the ``mypkg`` package and its dependency ``dep``:
 The first section reports all of the files in DAR, and the second section
 reports the package name and package ID for every DALF in the archive.
 
+Inspecting the main package of a DAR file
+*****************************************
+
+If you'd like to inspect the code inside the main package of a DAR, the Daml
+compiler provides the ``inspect`` tool; running ``daml damlc inspect <path-to-dar-file>``
+prints all of the code in that DALF file in a human-readable format.
+
+For example, run the ``inspect`` tool on the DAR produced in the previous
+section:
+
+.. code-block:: sh
+
+   # Human-readable dump of code in "mypkg" package inside of "mypkg" DAR
+   > daml damlc inspect .daml/dist/mypkg-1.0.0.dar
+   package <mypkg-package-id>
+   daml-lf 2.1
+   metadata mypkg-1.0.0
+
+   module Main where
+   ...
+
 Inspecting a DALF file
 **********************
 
-If you'd like to inspect the code inside a .dalf, the Daml compiler provides the
-``inspect`` tool; running ``daml damlc inspect <path-to-dalf-file>`` on a DALF
-file prints all of the code in that DALF file in a human-readable format.
+The ``inspect`` tool also accepts DALF files; running ``daml damlc inspect <path-to-dalf-file>``
+on a DALF file prints all of the code in that DALF file.
 
 We can unzip a DAR to access its dalfs and inspect them, for example with the
 DAR from the previous section:
 
 .. code-block:: sh
 
+   # Unzip the DAR to get its DALFs
    > unzip .daml/dist/mypkg-1.0.0.dar
-   > daml damlc inspect mypkg-1.0.0-<mypkg-package-id>/mypkg-1.0.0-<mypkg-package-id>.dalf
-   ...
-   # Human-readable dump of code in mypkg
-   ...
-   > daml damlc inspect mypkg-1.0.0-<mypkg-package-id>/dep-1.0.0-<dep-package-id>.dalf
-   ...
+
    # Human-readable dump of code in dep
+   > daml damlc inspect mypkg-1.0.0-<mypkg-package-id>/dep-1.0.0-<dep-package-id>.dalf
+   package <dep-package-id>
+   daml-lf 2.1
+   metadata dep-1.0.0
+
+   module Dep where
    ...
 
-Running ``inspect`` on a DAR will extract only its "main" package's ``.dalf``,
-and then run ``inspect`` on that ``.dalf``:
+We can even inspect the main package of a DAR this way, even though running
+``inspect`` directly on the DAR file would require fewer steps.
 
 .. code-block:: sh
 
-   # Same as the first two lines in the code block above
-   > daml damlc inspect .daml/dist/mypkg-1.0.0.dar
-   ...
-   # Human-readable dump of code in mypkg
+   # Identical to dump from `daml damlc inspect .daml/dist/mypkg-1.0.0.dar`
+   > daml damlc inspect mypkg-1.0.0-<mypkg-package-id>/mypkg-1.0.0-<mypkg-package-id>.dalf
+   package <mypkg-package-id>
+   daml-lf 2.1
+   metadata mypkg-1.0.0
+
+   module Main where
    ...
 
 Parsing DAR and DALF files

--- a/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -13,9 +13,12 @@ archive.
 Inspecting a DAR file
 *********************
 
-Running ``daml damlc inspect-dar <darfile>`` reports all of the files and
-packages in a DAR file. For example, consider a package ``mypkg`` which depends
-on a package ``dep``:
+You can run ``daml damlc inspect-dar /path/to/your.dar`` to get a
+human-readable listing of the files inside it and a list of packages
+and their package ids. This is often useful to find the package id of the
+project you just built.
+
+For example, consider a package ``mypkg`` which depends on a package ``dep``:
 
 .. code-block:: yaml
    :caption: mypkg/daml.yaml
@@ -38,7 +41,7 @@ on a package ``dep``:
 When ``mypkg-1.0.0`` is compiled to a DAR, we can inspect that DAR to ensure that
 it contains both the ``mypkg`` package and its dependency ``dep``:
 
-.. code-block:: none
+.. code-block:: sh
 
    > daml build
    ...
@@ -66,6 +69,44 @@ The first section reports all of the files in DAR, and the second section
 reports the package name and package ID for every DALF in the archive.
 
 More information on the exact structure of the zip file is :ref:`available in the explanation on Daml packages and archive files <structure-of-an-archive-file>`.
+
+Inspecting a DAR file as JSON
+*****************************
+
+In addition to the human-readable output, you can also get the output
+as JSON. This is easier to consume programmatically and it is more
+robust to changes across SDK versions:
+
+.. code-block:: sh
+
+  > daml damlc inspect-dar --json .daml/dist/mypkg-1.0.0.dar
+  {
+      "files": [
+          "mypkg-1.0.0-<mypkg-package-id>/dep-1.0.0-<dep-package-id>.dalf",
+          "mypkg-1.0.0-<mypkg-package-id>/mypkg-1.0.0-<mypkg-package-id>.dalf",
+          "mypkg-1.0.0-<mypkg-package-id>/Main.daml",
+          "mypkg-1.0.0-<mypkg-package-id>/Main.hi",
+          "mypkg-1.0.0-<mypkg-package-id>/Main.hie",
+          "META-INF/MANIFEST.MF"
+      ],
+      "main_package_id": "<mypkg-package-id>",
+      "packages": {
+          "<mypkg-package-id>": {
+              "name": "mypkg",
+              "path":
+                "mypkg-1.0.0-<mypkg-package-id>/mypkg-1.0.0-<mypkg-package-id>.dalf",
+              "version": "1.0.0"
+          },
+          "<dep-package-id>": {
+              "name": "dep",
+              "path": "mypkg-1.0.0-<mypkg-package-id>/dep-1.0.0-<dep-package-id>.dalf",
+              "version": "1.0.0"
+          }
+      }
+  }
+
+
+Note that ``name`` and ``version`` will be ``null`` for packages in Daml-LF < 1.8.
 
 Inspecting the main package of a DAR file
 *****************************************

--- a/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
@@ -108,8 +108,8 @@ and DALF files:
 * DALF files, on the other hand contain a compact, binary-encoded representation
   of Daml-LF. Daml-LF is very restricted, comparatively simple
   computer-executable programming language. Daml-LF is not intended to be
-  human-readable nor human-writable, it is intended to be fast to
-  execute and secure.
+  human-readable nor human-writable, it is intended to be deterministic, fast to
+  execute, and secure.
 
 Because DAR files are intended to be executed and passed around, they primarily
 contain Daml-LF, which can be executed directly -- they do not need to store the

--- a/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
@@ -90,7 +90,7 @@ Aside from these files, there will be:
   is also used by Daml Studio to provide jump-to-definition.
 
 Both the source code and interface files are not required by any other tool than
-``Daml Studio`` - they can be safely removed from the DAR by consumers such as
+Daml Studio - they can be safely removed from the DAR by consumers such as
 participant runners.
 
 Difference between DALF files and Daml files

--- a/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
@@ -112,10 +112,8 @@ and DALF files:
   execute and secure.
 
 Because DAR files are intended to be executed and passed around, they primarily
-contain Daml-LF, which can be executed directly when it is uploaded to a
-participant and run. In general, DAR files only need to keep the executable
-Daml-LF for the whole package around, so they do not need to store the Daml code
-from which it was compiled.
+contain Daml-LF, which can be executed directly -- they do not need to store the
+Daml code from which it was compiled.
 
 DARs as dependencies
 ********************

--- a/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
@@ -8,7 +8,7 @@ When a Daml package is compiled, it is packed into a final artifact called a DAR
 code and logic to run the package's templates, without requiring any other
 files.
 
-For example, assume a simple package with the following definition:
+For example, assume a simple package ``mypkg`` with a single dependency ``dep``:
 
 .. code:: yaml
 
@@ -19,6 +19,8 @@ For example, assume a simple package with the following definition:
    dependencies:
    - daml-prim
    - daml-stdlib
+   data-dependencies:
+   - /path/to/dep-1.0.0.dar
 
 The command ``daml build`` compiles it and reports the path of the resulting DAR
 as the last line:
@@ -36,21 +38,53 @@ as the last line:
 This DAR will contain all of the code for the package, as well as all of the
 code for its dependencies.
 
-Contents of an archive file
-***************************
+.. _structure-of-an-archive-file:
 
-A DAR file contains:
+Structure of an archive file
+****************************
 
-* A ``MANIFEST`` file which contains the name of the package that was compiled
-  into the DAR, contains some more metadata about the package, and lists all of
-  the dependencies of that package.
-* The entire compiled representation of the DAR's primary package, encoded via
-  protobuf into a single DALF file (``.dalf``).
-* For each dependency of the primary package, another DALF file is listed. This
-  includes depdencies like daml-prim and daml-stdlib.
-* Optionally, the source code and interface files for the primary package. This
-  is used by Daml Studio to provide jump-to-definition and similar functionality
-  when the DAR is included as a dependency of another project.
+A DAR is actually a zip file which contains many different files, all of which
+work together to provide a ledger everything it needs to know in order to run
+the code it was compiled from.
+
+.. code:: sh
+
+   > unzip -Z1 .daml/dist/mypkg-1.0.0.dar
+
+   META-INF/MANIFEST.MF
+   ...
+   mypkg-1.0.0-<mypkg-package-id>/dep-1.0.0-....dalf
+   mypkg-1.0.0-<mypkg-package-id>/Main.daml
+   mypkg-1.0.0-<mypkg-package-id>/Main.hi
+   mypkg-1.0.0-<mypkg-package-id>/Main.hie
+   mypkg-1.0.0-<mypkg-package-id>/mypkg-1.0.0-....dalf
+
+
+The majority of the files in a given DAR will be DALF files (``.dalf``). Each
+``.dalf`` file contains the entire compiled code for a specific package.
+
+One of the DALF files will be the "main" or "primary" package that the DAR was
+compiled from - this DALF will contain the definitions of templates, interfaces,
+datatypes, and functions that were originally described in the Daml code that
+the DAR was compiled from. In this case, that is the ``mypkg-1.0.0-....dalf``
+file listed above.
+
+All of the other DALF files will be for dependency packages of that "main"
+package, which are required to run the package. This includes the ``dep-1.0.0....dalf``
+file, as well as many DALF files for the ``daml-prim`` and ``daml-stdlib``
+libraries.
+
+Aside from these files, there will be:
+
+* A ``MANIFEST.MF`` file, which contains metadata about the rest of the
+  artifacts in the DAR.
+  * the name of the "main" package that was compiled into the DAR
+  * a list of all of the dependencies of the main package
+  * some more metadata about the package
+* Optionally, the source code (``.daml``) and interface files (``.hi``,
+  ``.hie``, ``.conf``) for the primary package. This is used by Daml Studio to
+  provide jump-to-definition and similar functionality when the DAR is included
+  as a dependency of another project.
 
 Difference between DALF files and Daml files
 ********************************************

--- a/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
@@ -96,8 +96,8 @@ participant runners.
 Difference between DALF files and Daml files
 ********************************************
 
-A common question at this stage is why DAR files contain DALF files - why don't
-they just contain all of the source code for all of the packages directly?
+A common question is why DAR files contain DALF files - why don't they just
+contain all of the source code for all of the packages directly?
 
 To understand why, it is important to understand the distinction between Daml
 and DALF files:

--- a/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
@@ -81,11 +81,17 @@ Aside from these files, there will be:
   * the name of the "main" package that was compiled into the DAR
   * a list of all of the dependencies of the main package
   * some more metadata about the package
-* The source code (``.daml``) and interface files (``.hi``, ``.hie``, ``.conf``)
-  for the primary package. This is used by Daml Studio to provide
-  jump-to-definition and similar functionality when the DAR is included as a
-  dependency of another project. It is not required by any other tool and can be
-  safely removed from the DAR.
+* The source code (``.daml``) for the primary package. This can be used by
+  consumers of the DAR to verify that the DALF they're running corresponds to
+  the code inside of it. It is also used by Daml Studio for code intelligence
+  such as jump-to-definition when the DAR is included as a dependency of another
+  project.
+* Interface files (``.hi``, ``.hie``, ``.conf``) for the primary package. This
+  is also used by Daml Studio to provide jump-to-definition.
+
+Both the source code and interface files are not required by any other tool than
+``Daml Studio`` - they can be safely removed from the DAR by consumers such as
+participant runners.
 
 Difference between DALF files and Daml files
 ********************************************
@@ -110,11 +116,6 @@ contain Daml-LF, which can be executed directly when it is uploaded to a
 participant and run. In general, DAR files only need to keep the executable
 Daml-LF for the whole package around, so they do not need to store the Daml code
 from which it was compiled.
-
-There is one exception: so that Daml Studio can provide useful functions such as
-goto-definition, a DAR file can store the Daml code for its primary package.
-However, the DAR does not store the Daml code for any other package because Daml
-Studio does not provide jump-to-definition for transitive dependencies.
 
 DARs as dependencies
 ********************

--- a/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
@@ -81,10 +81,11 @@ Aside from these files, there will be:
   * the name of the "main" package that was compiled into the DAR
   * a list of all of the dependencies of the main package
   * some more metadata about the package
-* Optionally, the source code (``.daml``) and interface files (``.hi``,
-  ``.hie``, ``.conf``) for the primary package. This is used by Daml Studio to
-  provide jump-to-definition and similar functionality when the DAR is included
-  as a dependency of another project.
+* The source code (``.daml``) and interface files (``.hi``, ``.hie``, ``.conf``)
+  for the primary package. This is used by Daml Studio to provide
+  jump-to-definition and similar functionality when the DAR is included as a
+  dependency of another project. It is not required by any other tool and can be
+  safely removed from the DAR.
 
 Difference between DALF files and Daml files
 ********************************************

--- a/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
@@ -53,11 +53,11 @@ the code it was compiled from.
 
    META-INF/MANIFEST.MF
    ...
-   mypkg-1.0.0-<mypkg-package-id>/dep-1.0.0-....dalf
+   mypkg-1.0.0-<mypkg-package-id>/dep-1.0.0-<dep-package-id>.dalf
    mypkg-1.0.0-<mypkg-package-id>/Main.daml
    mypkg-1.0.0-<mypkg-package-id>/Main.hi
    mypkg-1.0.0-<mypkg-package-id>/Main.hie
-   mypkg-1.0.0-<mypkg-package-id>/mypkg-1.0.0-....dalf
+   mypkg-1.0.0-<mypkg-package-id>/mypkg-1.0.0-<mypkg-package-id>.dalf
 
 
 The majority of the files in a given DAR will be DALF files (``.dalf``). Each
@@ -66,11 +66,11 @@ The majority of the files in a given DAR will be DALF files (``.dalf``). Each
 One of the DALF files will be the "main" or "primary" package that the DAR was
 compiled from - this DALF will contain the definitions of templates, interfaces,
 datatypes, and functions that were originally described in the Daml code that
-the DAR was compiled from. In this case, that is the ``mypkg-1.0.0-....dalf``
+the DAR was compiled from. In this case, that is the ``mypkg-1.0.0-<mypkg-package-id>.dalf``
 file listed above.
 
 All of the other DALF files will be for dependency packages of that "main"
-package, which are required to run the package. This includes the ``dep-1.0.0....dalf``
+package, which are required to run the package. This includes the ``dep-1.0.0-<dep-package-id>.dalf``
 file, as well as many DALF files for the ``daml-prim`` and ``daml-stdlib``
 libraries.
 

--- a/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
@@ -136,10 +136,10 @@ package as a dependency:
    data-dependencies:
    - ../mypkg/.daml/dist/mypkg-1.0.0.dar
 
-In this case, the compilation process unpacks the DAR, finds its primary
-package, and exposes that as a dependency to code inside ``next-project``. When
-``next-project`` is compiled, it retains all of the DALF files inside the
-``mypkg`` DAR, including the ``mypkg`` package's dependencies.
+In this case, the compilation process unpacks the ``mypkg-1.0.0`` DAR, finds its
+primary package, and exposes that as a dependency to code inside
+``next-project``. When ``next-project`` is compiled, it retains all of the DALF
+files inside the ``mypkg`` DAR, including the ``mypkg`` package's dependencies.
 
 In general, any time a DAR is compiled for a package that has further DAR
 dependencies, those DAR dependencies are unpacked and all of their DALF files

--- a/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
+++ b/sdk/docs/manually-written/sdk/explanations/daml-packages-and-archive-files.rst
@@ -119,7 +119,7 @@ DARs as dependencies
 ********************
 
 When a new project needs to depend on a different package, the DAR that the
-package was compiled to is supplied a data-dependency in the new project's
+package was compiled to is supplied as a data-dependency in the new project's
 ``daml.yaml``.
 
 For example, suppose a new package ``next-project`` that uses the ``mypkg``

--- a/sdk/docs/manually-written/sdk/reference/daml/packages.rst
+++ b/sdk/docs/manually-written/sdk/reference/daml/packages.rst
@@ -23,86 +23,10 @@ You can specify a different path for the Daml archive by using the ``-o`` flag:
 
  The rest of this page will focus on how to import a Daml package in other Daml projects.
 
-.. _inspecting_dars:
-
 Inspecting DARs
 ***************
 
-To inspect a DAR and get information about the packages inside it, you
-can use the ``daml damlc inspect-dar`` command. This is often useful
-to find the package id of the project you just built.
-
-You can run ``daml damlc inspect-dar /path/to/your.dar`` to get a
-human-readable listing of the files inside it and a list of packages
-and their package ids. Here is a (shortened) example output:
-
-.. code-block:: sh
-
-  $ daml damlc inspect-dar .daml/dist/create-daml-app-0.1.0.dar
-  DAR archive contains the following files:
-
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d.dalf
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-prim-75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15.dalf
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-0.0.0-a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a.dalf
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-DA-Internal-Template-d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662.dalf
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/data/create-daml-app-0.1.0.conf
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.daml
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.hi
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.hie
-  META-INF/MANIFEST.MF
-
-  DAR archive contains the following packages:
-
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d "29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d"
-  daml-stdlib-DA-Internal-Template-d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662 "d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662"
-  daml-prim-75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15 "75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15"
-  daml-stdlib-0.0.0-a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a "a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a"
-
-In addition to the human-readable output, you can also get the output
-as JSON. This is easier to consume programmatically and it is more
-robust to changes across SDK versions:
-
-.. code-block:: sh
-
-  $ daml damlc inspect-dar --json .daml/dist/create-daml-app-0.1.0.dar
-  {
-      "packages": {
-          "29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d": {
-              "path": "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d.dalf",
-              "name": "create-daml-app",
-              "version": "0.1.0"
-          },
-          "d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662": {
-              "path": "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-DA-Internal-Template-d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662.dalf",
-              "name": null,
-              "version": null
-          },
-          "75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15": {
-              "path": "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-prim-75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15.dalf",
-              "name": "daml-prim",
-              "version": "0.0.0"
-          },
-          "a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a": {
-              "path": "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-0.0.0-a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a.dalf",
-              "name": "daml-stdlib",
-              "version": "0.0.0"
-          }
-      },
-      "main_package_id": "29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d",
-      "files": [
-          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d.dalf",
-          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-prim-75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15.dalf",
-          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-0.0.0-a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a.dalf",
-          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-DA-Internal-Template-d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662.dalf",
-          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/data/create-daml-app-0.1.0.conf",
-          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.daml",
-          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.hi",
-          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.hie",
-          "META-INF/MANIFEST.MF"
-      ]
-  }
-
-Note that ``name`` and ``version`` will be ``null`` for packages in Daml-LF < 1.8.
+Refer to the :ref:`section on decoding DARs and DALF files <inspecting_dars>`.
 
 Import Daml Packages
 ********************

--- a/sdk/docs/sharable/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/sharable/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -10,6 +10,8 @@ When a Daml project is compiled, it produces a DAR (extension ``.dar``), short
 for Daml Archive. The Daml compiler exposes commands for inspecting this
 archive.
 
+.. _inspecting_dars:
+
 Inspecting a DAR file
 *********************
 
@@ -189,15 +191,19 @@ depending on what is needed.
   In this case, ``PackageId`` comes from ``com.digitalasset.daml.lf.language.Ref``
   in the ``com.daml:daml-lf-data`` package, and ``Package`` comes from
   ``com.digitalasset.daml.lf.language.Ast``, in the ``com.daml:daml-lf-language``
-  `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-language>`_.
+  `library on Maven`__.
+
+  __ https://mvnrepository.com/artifact/com.daml/daml-lf-language
 
   Because fully decoding the package takes more processing time than the next
   two examples, only use it when the full package code is needed.
 * When only the simplest representation of the protobuf of the package is
   needed, pick a decoder returning a ``com.digitalasset.daml.lf.DamlLf.ArchivePayload``
-  (from the ``com-daml:daml-lf-archive-proto`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-archive-proto>`).
+  (from the ``com-daml:daml-lf-archive-proto`` `library on Maven`__).
   This should only be needed when working with internal protobuf representations
   of a package.
+
+  __ https://mvnrepository.com/artifact/com.daml/daml-lf-archive-proto
 * When only the package's byte representation and hash is needed, use a
   decoder that returns ``Archive`` (also from the ``com-daml:daml-lf-archive-proto``
   library). When using this, the decoder will not spend time decoding any of the

--- a/sdk/docs/sharable/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/sharable/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -13,20 +13,19 @@ archive.
 Inspecting a DAR file
 *********************
 
-A DAR is actually a zip file containing multiple packages, one of which is the
-"main" package; more information on the exact structure of the zip file is
-:ref:`available the explanation on Daml packages and archive files <structure-of-an-archive-file>`.
+You can run ``daml damlc inspect-dar /path/to/your.dar`` to get a
+human-readable listing of the files inside it and a list of packages
+and their package ids. This is often useful to find the package id of the
+project you just built.
 
-Running ``daml damlc inspect-dar <darfile>`` reports all of the files and
-packages in a DAR file. For example, consider a package ``mypkg`` which depends
-on a package ``dep``:
+For example, consider a package ``mypkg`` which depends on a package ``dep``:
 
 .. code-block:: yaml
    :caption: mypkg/daml.yaml
 
    name: mypkg
    version: 1.0.0
-   source: daml
+   source: daml/Main.daml
    ...
    data-dependencies:
    - ../dep/.daml/dist/dep-1.0.0.dar
@@ -36,13 +35,13 @@ on a package ``dep``:
 
    name: dep
    version: 1.0.0
-   source: daml
+   source: daml/Dep.daml
    ...
 
 When ``mypkg-1.0.0`` is compiled to a DAR, we can inspect that DAR to ensure that
 it contains both the ``mypkg`` package and its dependency ``dep``:
 
-.. code-block:: none
+.. code-block:: sh
 
    > daml build
    ...
@@ -68,6 +67,46 @@ it contains both the ``mypkg`` package and its dependency ``dep``:
 
 The first section reports all of the files in DAR, and the second section
 reports the package name and package ID for every DALF in the archive.
+
+More information on the exact structure of the zip file is :ref:`available in the explanation on Daml packages and archive files <structure-of-an-archive-file>`.
+
+Inspecting a DAR file as JSON
+*****************************
+
+In addition to the human-readable output, you can also get the output
+as JSON. This is easier to consume programmatically and it is more
+robust to changes across SDK versions:
+
+.. code-block:: sh
+
+  > daml damlc inspect-dar --json .daml/dist/mypkg-1.0.0.dar
+  {
+      "files": [
+          "mypkg-1.0.0-<mypkg-package-id>/dep-1.0.0-<dep-package-id>.dalf",
+          "mypkg-1.0.0-<mypkg-package-id>/mypkg-1.0.0-<mypkg-package-id>.dalf",
+          "mypkg-1.0.0-<mypkg-package-id>/Main.daml",
+          "mypkg-1.0.0-<mypkg-package-id>/Main.hi",
+          "mypkg-1.0.0-<mypkg-package-id>/Main.hie",
+          "META-INF/MANIFEST.MF"
+      ],
+      "main_package_id": "<mypkg-package-id>",
+      "packages": {
+          "<mypkg-package-id>": {
+              "name": "mypkg",
+              "path":
+                "mypkg-1.0.0-<mypkg-package-id>/mypkg-1.0.0-<mypkg-package-id>.dalf",
+              "version": "1.0.0"
+          },
+          "<dep-package-id>": {
+              "name": "dep",
+              "path": "mypkg-1.0.0-<mypkg-package-id>/dep-1.0.0-<dep-package-id>.dalf",
+              "version": "1.0.0"
+          }
+      }
+  }
+
+
+Note that ``name`` and ``version`` will be ``null`` for packages in Daml-LF < 1.8.
 
 Inspecting the main package of a DAR file
 *****************************************

--- a/sdk/docs/sharable/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/sharable/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -202,8 +202,8 @@ depending on what is needed.
   For example, the ``com.digitalasset.daml.lf.typesig.reader.SignatureReader`` class
   from the ``com-daml:daml-lf-api-type-signature`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-api-type-signature>`
   takes a ``(PackageId, Package)`` pair to produce a ``com.digitalasset.daml.lf.typesig.PackageSignature``
-  (also from the ``api-type-signature``) package, which quickly specifies all of
-  the templates, datatypes, and interfaces in a package.
+  (also from the ``api-type-signature``) package, which specifies all of the
+  templates, datatypes, and interfaces in a package.
 
 * When only the simplest representation of the protobuf of the package is
   needed, pick a decoder returning a ``com.digitalasset.daml.lf.ArchivePayload``

--- a/sdk/docs/sharable/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/sharable/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -199,11 +199,15 @@ depending on what is needed.
   Because fully decoding the package takes more processing time than the next
   two examples, only use it when the full package code is needed.
 
+  .. vale CiEnforced.Terms = NO
+
   For example, the ``com.digitalasset.daml.lf.typesig.reader.SignatureReader`` class
   from the ``com-daml:daml-lf-api-type-signature`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-api-type-signature>`
   takes a ``(PackageId, Package)`` pair to produce a ``com.digitalasset.daml.lf.typesig.PackageSignature``
   (also from the ``api-type-signature``) package, which specifies all of the
   templates, datatypes, and interfaces in a package.
+
+  .. vale CiEnforced.Terms = YES
 
 * When only the simplest representation of the protobuf of the package is
   needed, pick a decoder returning a ``com.digitalasset.daml.lf.ArchivePayload``

--- a/sdk/docs/sharable/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/sharable/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -1,0 +1,244 @@
+.. Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. _how-to-parse-daml-archive-files:
+
+How to parse Daml archive files
+###############################
+
+When a Daml project is compiled, it produces a DAR (extension ``.dar``), short
+for Daml Archive. The Daml compiler exposes commands for inspecting this
+archive.
+
+Inspecting a DAR file
+*********************
+
+A DAR is actually a zip file which contains many ``.dalf`` files - each
+``.dalf`` file contains the compiled code for a specific package. A metadata
+file called ``MANIFEST`` records which package is the "main" or "primary"
+package of the DAR -- the rest of the packages are dependencies of that "main"
+package.
+
+Running ``daml damlc inspect-dar <darfile>`` reports all of the files and
+packages in a DAR file. For example, consider a package ``mypkg`` which depends
+on a package ``dep``:
+
+.. code-block:: yaml
+   :caption: mypkg/daml.yaml
+
+   name: mypkg
+   version: 1.0.0
+   source: daml
+   ...
+   data-dependencies:
+   - ../dep/.daml/dist/dep-1.0.0.dar
+
+.. code-block:: yaml
+   :caption: dep/daml.yaml
+
+   name: dep
+   version: 1.0.0
+   source: daml
+   ...
+
+When ``mypkg-1.0.0`` is compiled to a DAR, we can inspect that DAR to ensure that
+it contains both the ``mypkg`` package and its dependency ``dep``:
+
+.. code-block:: none
+
+   > daml damlc inspect-dar .daml/dist/mypkg-1.0.0.dar
+
+   DAR archive contains the following files:
+
+   ...
+   mypkg-1.0.0-<mypkg-package-id>/dep-1.0.0-<dep-package-id>.dalf
+   mypkg-1.0.0-<mypkg-package-id>/mypkg-1.0.0-<mypkg-package-id>.dalf
+   mypkg-1.0.0-<mypkg-package-id>/MyPkg.daml
+   mypkg-1.0.0-<mypkg-package-id>/MyPkg.hi
+   mypkg-1.0.0-<mypkg-package-id>/MyPkg.hie
+   META-INF/MANIFEST.MF
+
+   DAR archive contains the following packages:
+
+   ...
+   dep-1.0.0-<dep-package-id> "<dep-package-id>"
+   mypkg-1.0.0-<mypkg-package-id> "<mypkg-package-id>"
+
+The first section reports all of the files in DAR, including the DAR's MANIFEST
+file, which keeps metadata about which DALF file is the "main". The second section
+reports the package name and package ID for every dalf in the archive.
+
+In every DAR, there will be many additional ``.dalf`` files for the standard
+library and primitive libraries - these are necessary for running any Daml code,
+so they are automatically included.
+
+Inspecting a DALF file
+**********************
+
+If you'd like to inspect the code inside a .dalf, the Daml compiler provides the
+``inspect`` tool; running ``daml damlc inspect <path-to-dalf-file>`` on a DALF
+file prints all of the code in that DALF file in a human-readable format.
+
+We can unzip a DAR to access its dalfs and inspect them, for example with the
+DAR from the previous section:
+
+.. code-block:: sh
+
+   > unzip .daml/dist/mypkg-1.0.0.dar
+   > daml damlc inspect mypkg-1.0.0-<mypkg-package-id>/mypkg-1.0.0-<mypkg-package-id>.dalf
+   ...
+   # Human-readable dump of code in mypkg
+   ...
+   > daml damlc inspect mypkg-1.0.0-<mypkg-package-id>/dep-1.0.0-<dep-package-id>.dalf
+   ...
+   # Human-readable dump of code in dep
+   ...
+
+Running ``inspect`` on a DAR will extract only its "main" package's ``.dalf``,
+and then run ``inspect`` on that ``.dalf``:
+
+.. code-block:: sh
+
+   # Same as the first two lines in the code block above
+   > daml damlc inspect .daml/dist/mypkg-1.0.0.dar
+   ...
+   # Human-readable dump of code in mypkg
+   ...
+
+Parsing DAR and DALF files
+**************************
+
+To parse a DAR or DALF file from within Scala code, the
+``com-daml:daml-lf-archive-reader`` library on Maven provides a Scala package
+object ``com.digitalasset.daml.lf.archive`` with several decoders.
+
+There are three different types of outputs a decoder can have, and three
+possible inputs that the a decoder accepts - the ``archive`` package object
+defines decoders for 8 of the 9 possible combinations
+
+Output types
+""""""""""""
+
+When decoding a package, a decoder can have one of several possible outputs,
+depending on what is needed.
+
+* When the full code of the package is needed, pick a decoder returning tuples
+  ``(PackageId, Package)``.
+
+  In this case, ``PackageId`` comes from ``com.digitalasset.daml.lf.language.Ref``
+  in the ``com.daml:daml-lf-data`` package, and ``Package`` comes from
+  ``com.digitalasset.daml.lf.language.Ast``, in the ``com.daml:daml-lf-language``
+  package.
+
+  Because fully decoding the package takes more processing time than the next
+  two examples, only use it when the full package code is needed.
+* When only the simplest representation of the protobuf of the package is
+  needed, pick a decoder returning a ``com.digitalasset.daml.lf.DamlLf.ArchivePayload``
+  (from the ``com-daml:daml-lf-archive-proto`` library). This should only be
+  needed when working with internal protobuf representations of a package.
+* When only the package's byte representation and hash is needed, use a
+  decoder that returns ``Archive`` (also from the ``com-daml:daml-lf-archive-proto``
+  library). When using this, the decoder will not spend time decoding any of the
+  package's actual content, such as its metadata or its code.
+
+Input types
+"""""""""""
+
+A decoder can either accept DALF files, DAR files, or it can accept both.
+
+* If a decoder accepts DALF files, it will parse the single package in that DALF
+  file to its output type (one of the three specified above).
+* If a decoder accepts DAR files, it will parse multiple packages
+  from a DAR file to a struct ``Dar[X]``, which is a case class that encodes a DAR
+  as two public fields, ``main: X`` and ``dependencies: List[X]``.
+* If a decoder accepts both, it will always produce a ``Dar[X]``. When given a
+  DAR, the decoder will run as a normal DAR decoder would. When given a DALF,
+  the decoder will decode the DALF as a single package and return a ``Dar[X]``
+  with a ``main`` package and an empty list of dependencies.
+
+Decoders
+""""""""
+
+Decoders for reading DALFs are instances of ``GenReader[X]``, which provides the
+method ``readArchiveFromFile(file: java.io.File): Either[Error, X]``.
+
+* ``val ArchiveReader: GenReader[ArchivePayload]``
+
+  Run ``ArchiveReader.readArchiveFromFile(new java.io.File("<path-to-dalf>"))`` to parse
+  out the ``ArchivePayload`` of a dalf file.
+* ``val ArchiveDecoder: GenReader[(PackageId, Ast.Package)]``
+
+  Run ``ArchiveDecoder.readArchiveFromFile(new java.io.File("<path-to-dalf>"))`` to parse
+  out the ``(Ref.PackageId, Ast.Package)`` of a dalf file.
+* ``val ArchiveParser: GenReader[DamlLf.Archive]``
+
+  Run ``ArchiveParser.readArchiveFromFile(new java.io.File("<path-to-dalf>"))`` to parse
+  out the ``DamlLf.Archive`` of a dalf file.
+
+Decoders for reading DARs are instances of ``GenDarReader``, which provides the
+method ``readArchiveFromFile(file: java.io.File): Either[Error, Dar[X]]``.
+
+* ``val DarReader: GenDarReader[ArchivePayload]``
+
+  Run ``DarReader.readArchiveFromFile(new java.io.File("<path-to-dar>"))`` to parse
+  out the ``Dar[ArchivePayload]`` of a dar file.
+* ``val DarDecoder: GenDarReader[(PackageId, Ast.Package)]``
+
+  Run ``DarDecoder.readArchiveFromFile(new java.io.File("<path-to-dar>"))`` to parse
+  out the ``Dar[(Ref.PackageId, Ast.Package)]`` of a dar file.
+* ``val DarParser: GenDarReader[DamlLf.Archive]``
+
+  Run ``DarParser.readArchiveFromFile(new java.io.File("<path-to-dar>"))`` to parse
+  out the ``Dar[DamlLf.Archive]`` of a dar file.
+
+Decoders for reading DARs are instances of ``GenUniversalArchiveReader``, which
+provides the method ``readFile(file: java.io.File): Either[Error, Dar[X]]``.
+
+* ``val UniversalArchiveReader: GenUniversalArchiveReader[ArchivePayload]``
+
+  Run ``UniversalArchiveReader.readFile(new java.io.File("<path-to-dar-or-dalf>"))``
+  to parse out the ``Dar[ArchivePayload]`` of a dar file.
+* ``val UniversalArchiveDecoder: GenUniversalArchiveReader[(PackageId, Ast.Package)]``
+
+  Run ``UniversalArchiveDecoder.readFile(new java.io.File("<path-to-dar-or-dalf>"))``
+  to parse out the ``Dar[(Ref.PackageId, Ast.Package)]`` of a dar file.
+
+Example
+"""""""
+
+We can load up a Scala REPL with the ``daml-lf-archive-reader`` library to
+interactively parse our ``mypkg`` DAR:
+
+.. code-block:: scala
+
+   scala> // Start a REPL
+   scala> val darEither = DarDecoder.readArchiveFromFile(".daml/dist/mypkg-1.0.0.dar")
+   val dar: Either[Error, Dar[(Ref.PackageId, Ast.Package)]]
+   Right(Dar((..., GenPackage(Map(Main -> ...
+   ...
+
+   scala> // Extract the resulting value
+   scala> val dar = darEither.toOption.get
+
+   scala> :t dar.main
+   (Ref.PackageId, Ast.Package)
+
+   scala> :t dar.dependencies
+   List[(Ref.PackageId, Ast.Package)]
+
+The Dar datatype also has a method ``.all`` which returns the main package and
+dependencies as a single list. Mapping ``_1`` over this gets all of the package
+IDs in the DAR:
+
+.. code-block:: scala
+
+   scala> dar.all.map(_._1)
+   val res1: List[Ref.PackageId] = List(224..., 54f..., ...)
+
+Get the names of all the dependency packages in the DAR by using the
+``.metadata.name`` field in the ``Ast.Package`` datatype:
+
+.. code-block:: scala
+
+   scala> dar.dependencies.map(_._2.metadata.name)
+   val res2: List[com.digitalasset.daml.lf.data.Ref.PackageName] = List(daml-prim, daml-prim-DA-Exception-ArithmeticError, ...

--- a/sdk/docs/sharable/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
+++ b/sdk/docs/sharable/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst
@@ -115,7 +115,8 @@ Inspecting the main package of a DAR file
 
 If you'd like to inspect the code inside the main package of a DAR, the Daml
 compiler provides the ``inspect`` tool; running ``daml damlc inspect <path-to-dar-file>``
-prints all of the code in that DALF file in a human-readable format.
+prints all of the code in the main package of that DAR file in a human-readable
+format.
 
 For example, run the ``inspect`` tool on the DAR produced in the previous
 section:
@@ -172,7 +173,7 @@ Parsing DAR and DALF files
 **************************
 
 To parse a DAR or DALF file from within Scala code, the
-``com-daml:daml-lf-archive-reader`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-archive-reader>`_
+``com-daml:daml-lf-archive-reader`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-archive-reader>`
 provides a Scala package object ``com.digitalasset.daml.lf.archive`` with
 several decoders. Below are the common types of inputs and outputs a decoder can
 have, and which decoders to use depending on the input and output that is
@@ -188,26 +189,33 @@ depending on what is needed.
 * When the full code of the package is needed, pick a decoder returning tuples
   ``(PackageId, Package)``.
 
-  In this case, ``PackageId`` comes from ``com.digitalasset.daml.lf.language.Ref``
-  in the ``com.daml:daml-lf-data`` package, and ``Package`` comes from
-  ``com.digitalasset.daml.lf.language.Ast``, in the ``com.daml:daml-lf-language``
-  `library on Maven`__.
-
-  __ https://mvnrepository.com/artifact/com.daml/daml-lf-language
+  In this case, ``PackageId`` is a string-like type that comes from
+  ``com.digitalasset.daml.lf.language.Ref`` in the ``com.daml:daml-lf-data``
+  `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-data>`.
+  ``Package`` represents the full structure of a package, and comes
+  from ``com.digitalasset.daml.lf.language.Ast``, in the ``com.daml:daml-lf-language``
+  `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-language>`.
 
   Because fully decoding the package takes more processing time than the next
   two examples, only use it when the full package code is needed.
+
+  For example, the ``com.digitalasset.daml.lf.typesig.reader.SignatureReader`` class
+  from the ``com-daml:daml-lf-api-type-signature`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-api-type-signature>`
+  takes a ``(PackageId, Package)`` pair to produce a ``com.digitalasset.daml.lf.typesig.PackageSignature``
+  (also from the ``api-type-signature``) package, which quickly specifies all of
+  the templates, datatypes, and interfaces in a package.
+
 * When only the simplest representation of the protobuf of the package is
-  needed, pick a decoder returning a ``com.digitalasset.daml.lf.DamlLf.ArchivePayload``
-  (from the ``com-daml:daml-lf-archive-proto`` `library on Maven`__).
+  needed, pick a decoder returning a ``com.digitalasset.daml.lf.ArchivePayload``
+  (from the ``com-daml:daml-lf-archive`` `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-archive>`).
   This should only be needed when working with internal protobuf representations
   of a package.
 
-  __ https://mvnrepository.com/artifact/com.daml/daml-lf-archive-proto
 * When only the package's byte representation and hash is needed, use a
-  decoder that returns ``Archive`` (also from the ``com-daml:daml-lf-archive-proto``
-  library). When using this, the decoder will not spend time decoding any of the
-  package's actual content, such as its metadata or its code.
+  decoder that returns ``Archive`` (from the ``com-daml:daml-lf-archive-proto``
+  `library on Maven <https://mvnrepository.com/artifact/com.daml/daml-lf-archive-proto>`).
+  When using this, the decoder will not spend time decoding any of the package's
+  actual content, such as its metadata or its code.
 
 Input types
 """""""""""

--- a/sdk/docs/sharable/sdk/explanations/daml-packages-and-archive-files.rst
+++ b/sdk/docs/sharable/sdk/explanations/daml-packages-and-archive-files.rst
@@ -53,11 +53,11 @@ the code it was compiled from.
 
    META-INF/MANIFEST.MF
    ...
-   mypkg-1.0.0-<mypkg-package-id>/dep-1.0.0-....dalf
+   mypkg-1.0.0-<mypkg-package-id>/dep-1.0.0-<dep-package-id>.dalf
    mypkg-1.0.0-<mypkg-package-id>/Main.daml
    mypkg-1.0.0-<mypkg-package-id>/Main.hi
    mypkg-1.0.0-<mypkg-package-id>/Main.hie
-   mypkg-1.0.0-<mypkg-package-id>/mypkg-1.0.0-....dalf
+   mypkg-1.0.0-<mypkg-package-id>/mypkg-1.0.0-<mypkg-package-id>.dalf
 
 
 The majority of the files in a given DAR will be DALF files (``.dalf``). Each
@@ -66,11 +66,11 @@ The majority of the files in a given DAR will be DALF files (``.dalf``). Each
 One of the DALF files will be the "main" or "primary" package that the DAR was
 compiled from - this DALF will contain the definitions of templates, interfaces,
 datatypes, and functions that were originally described in the Daml code that
-the DAR was compiled from. In this case, that is the ``mypkg-1.0.0-....dalf``
+the DAR was compiled from. In this case, that is the ``mypkg-1.0.0-<mypkg-package-id>.dalf``
 file listed above.
 
 All of the other DALF files will be for dependency packages of that "main"
-package, which are required to run the package. This includes the ``dep-1.0.0....dalf``
+package, which are required to run the package. This includes the ``dep-1.0.0-<dep-package-id>.dalf``
 file, as well as many DALF files for the ``daml-prim`` and ``daml-stdlib``
 libraries.
 
@@ -136,10 +136,10 @@ package as a dependency:
    data-dependencies:
    - ../mypkg/.daml/dist/mypkg-1.0.0.dar
 
-In this case, the compilation process unpacks the DAR, finds its primary
-package, and exposes that as a dependency to code inside ``next-project``. When
-``next-project`` is compiled, it retains all of the DALF files inside the
-``mypkg`` DAR, including the ``mypkg`` package's dependencies.
+In this case, the compilation process unpacks the ``mypkg-1.0.0`` DAR, finds its
+primary package, and exposes that as a dependency to code inside
+``next-project``. When ``next-project`` is compiled, it retains all of the DALF
+files inside the ``mypkg`` DAR, including the ``mypkg`` package's dependencies.
 
 In general, any time a DAR is compiled for a package that has further DAR
 dependencies, those DAR dependencies are unpacked and all of their DALF files

--- a/sdk/docs/sharable/sdk/explanations/daml-packages-and-archive-files.rst
+++ b/sdk/docs/sharable/sdk/explanations/daml-packages-and-archive-files.rst
@@ -119,7 +119,7 @@ DARs as dependencies
 ********************
 
 When a new project needs to depend on a different package, the DAR that the
-package was compiled to is supplied a data-dependency in the new project's
+package was compiled to is supplied as a data-dependency in the new project's
 ``daml.yaml``.
 
 For example, suppose a new package ``next-project`` that uses the ``mypkg``

--- a/sdk/docs/sharable/sdk/reference/daml/packages.rst
+++ b/sdk/docs/sharable/sdk/reference/daml/packages.rst
@@ -23,86 +23,10 @@ You can specify a different path for the Daml archive by using the ``-o`` flag:
 
  The rest of this page will focus on how to import a Daml package in other Daml projects.
 
-.. _inspecting_dars:
-
 Inspecting DARs
 ***************
 
-To inspect a DAR and get information about the packages inside it, you
-can use the ``daml damlc inspect-dar`` command. This is often useful
-to find the package id of the project you just built.
-
-You can run ``daml damlc inspect-dar /path/to/your.dar`` to get a
-human-readable listing of the files inside it and a list of packages
-and their package ids. Here is a (shortened) example output:
-
-.. code-block:: sh
-
-  $ daml damlc inspect-dar .daml/dist/create-daml-app-0.1.0.dar
-  DAR archive contains the following files:
-
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d.dalf
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-prim-75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15.dalf
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-0.0.0-a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a.dalf
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-DA-Internal-Template-d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662.dalf
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/data/create-daml-app-0.1.0.conf
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.daml
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.hi
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.hie
-  META-INF/MANIFEST.MF
-
-  DAR archive contains the following packages:
-
-  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d "29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d"
-  daml-stdlib-DA-Internal-Template-d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662 "d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662"
-  daml-prim-75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15 "75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15"
-  daml-stdlib-0.0.0-a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a "a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a"
-
-In addition to the human-readable output, you can also get the output
-as JSON. This is easier to consume programmatically and it is more
-robust to changes across SDK versions:
-
-.. code-block:: sh
-
-  $ daml damlc inspect-dar --json .daml/dist/create-daml-app-0.1.0.dar
-  {
-      "packages": {
-          "29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d": {
-              "path": "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d.dalf",
-              "name": "create-daml-app",
-              "version": "0.1.0"
-          },
-          "d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662": {
-              "path": "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-DA-Internal-Template-d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662.dalf",
-              "name": null,
-              "version": null
-          },
-          "75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15": {
-              "path": "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-prim-75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15.dalf",
-              "name": "daml-prim",
-              "version": "0.0.0"
-          },
-          "a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a": {
-              "path": "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-0.0.0-a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a.dalf",
-              "name": "daml-stdlib",
-              "version": "0.0.0"
-          }
-      },
-      "main_package_id": "29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d",
-      "files": [
-          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d.dalf",
-          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-prim-75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15.dalf",
-          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-0.0.0-a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a.dalf",
-          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-DA-Internal-Template-d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662.dalf",
-          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/data/create-daml-app-0.1.0.conf",
-          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.daml",
-          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.hi",
-          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.hie",
-          "META-INF/MANIFEST.MF"
-      ]
-  }
-
-Note that ``name`` and ``version`` will be ``null`` for packages in Daml-LF < 1.8.
+Refer to the :ref:`section on decoding DARs and DALF files <inspecting_dars>`.
 
 Import Daml Packages
 ********************


### PR DESCRIPTION
Builds on top of https://github.com/digital-asset/daml/pull/21303
Change to make this fit into the table of contents are available in https://github.com/DACH-NY/docs-website/tree/dylant-da/document-dar-dalf-decoding