### PR TITLE
Forward port from 3.3: Add banner for contract keys reference page (#21371)

### DIFF
--- a/sdk/docs/manually-written/sdk/reference/daml/contract-keys.rst
+++ b/sdk/docs/manually-written/sdk/reference/daml/contract-keys.rst
@@ -6,6 +6,20 @@
 Reference: Contract Keys
 ########################
 
+
+.. important::
+  Contract keys are not supported in this release of Canton 3.x.
+  Support for **non-unique contract keys** will come in a future release of Canton 3.x.
+  Unique contract keys are not planned be supported in Canton 3.x, as
+  there are no known good solutions for enforcing uniqueness constraints at the
+  infrastructure level when there are multiple independent subnetworks that can
+  be (dis)connected at any point in time.
+
+  The documentation below is kept for completeness, but can be ignored for this release of Canton 3.x.
+
+Unsupported feature
+*******************
+
 Contract keys are an optional addition to templates. They let you specify a way of uniquely identifying contracts, using the parameters to the template - similar to a primary key for a database.
 
 Contract keys do not change and can be used to refer to a contract even when the contract id changes.

--- a/sdk/docs/sharable/sdk/reference/daml/contract-keys.rst
+++ b/sdk/docs/sharable/sdk/reference/daml/contract-keys.rst
@@ -6,6 +6,20 @@
 Reference: Contract Keys
 ########################
 
+
+.. important::
+  Contract keys are not supported in this release of Canton 3.x.
+  Support for **non-unique contract keys** will come in a future release of Canton 3.x.
+  Unique contract keys are not planned be supported in Canton 3.x, as
+  there are no known good solutions for enforcing uniqueness constraints at the
+  infrastructure level when there are multiple independent subnetworks that can
+  be (dis)connected at any point in time.
+
+  The documentation below is kept for completeness, but can be ignored for this release of Canton 3.x.
+
+Unsupported feature
+*******************
+
 Contract keys are an optional addition to templates. They let you specify a way of uniquely identifying contracts, using the parameters to the template - similar to a primary key for a database.
 
 Contract keys do not change and can be used to refer to a contract even when the contract id changes.


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/docs-website/issues/530

I opted for a banner as there are many references outside of that page to "contract keys". A banner ensures that people learn that contract keys will come later.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
