### PR TITLE
Use real package metadata in script service

### DIFF
--- a/sdk/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/sdk/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -870,6 +870,7 @@ contextForFile file = do
         { ctxModules = Map.fromList encodedModules
         , ctxPackages = [(LF.dalfPackageId pkg, LF.dalfPackageBytes pkg) | pkg <- Map.elems pkgMap ++ Map.elems stablePackages]
         , ctxSkipValidation = SS.SkipValidation (getSkipScriptValidation envSkipScriptValidation)
+        , ctxPackageMetadata = LF.packageMetadata pkg
         }
 
 contextForPackage :: NormalizedFilePath -> LF.Package -> Action SS.Context
@@ -888,6 +889,7 @@ contextForPackage file pkg = do
                   | pkg <- Map.elems pkgMap ++ Map.elems stablePackages
                   ]
             , ctxSkipValidation = SS.SkipValidation True -- no validation for external packages
+            , ctxPackageMetadata = LF.packageMetadata pkg
             }
 
 worldForFile :: NormalizedFilePath -> Action LF.World

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -159,9 +159,9 @@ testRun h inFiles lvl lfVersion (RunAllTests runAllTests) coverage color mbJUnit
                  Nothing -> pure [] -- nothing to test
                  Just file ->
                      runActionSync h $
-                     forM extPkgs $ \pkg -> do
-                         (_fileDiagnostics, mbResults) <- runScriptsPkg file pkg extPkgs
-                         pure (pkg, mbResults)
+                     forM extPkgs $ \extPkg -> do
+                         (_fileDiagnostics, mbResults) <- runScriptsPkg file extPkg extPkgs
+                         pure (extPkg, mbResults)
         else pure []
 
     let -- All Packages / Modules mentioned somehow

--- a/sdk/compiler/script-service/client/src/DA/Daml/LF/ScriptServiceClient.hs
+++ b/sdk/compiler/script-service/client/src/DA/Daml/LF/ScriptServiceClient.hs
@@ -188,6 +188,7 @@ data Context = Context
   { ctxModules :: MS.Map Hash (LF.ModuleName, BS.ByteString)
   , ctxPackages :: [(LF.PackageId, BS.ByteString)]
   , ctxSkipValidation :: LowLevel.SkipValidation
+  , ctxPackageMetadata :: LF.PackageMetadata
   }
 
 getNewCtx :: Handle -> Context -> IO (Either LowLevel.BackendError LowLevel.ContextId)
@@ -210,6 +211,7 @@ getNewCtx Handle{..} Context{..} = withLock hContextLock $ withSem hConcurrencyS
       loadPackages
       (S.toList unloadPackages)
       ctxSkipValidation
+      ctxPackageMetadata
   rootCtxId <- readIORef hContextId
   runExceptT $ do
       clonedRootCtxId <- ExceptT $ LowLevel.cloneCtx hLowLevelHandle rootCtxId

--- a/sdk/compiler/script-service/client/src/DA/Daml/LF/ScriptServiceClient.hs
+++ b/sdk/compiler/script-service/client/src/DA/Daml/LF/ScriptServiceClient.hs
@@ -188,7 +188,11 @@ data Context = Context
   { ctxModules :: MS.Map Hash (LF.ModuleName, BS.ByteString)
   , ctxPackages :: [(LF.PackageId, BS.ByteString)]
   , ctxSkipValidation :: LowLevel.SkipValidation
-  , ctxPackageMetadata :: LF.PackageMetadata
+  , ctxSelfPackageMetadata :: Maybe LF.PackageMetadata
+  -- ^ the self package is the package from which we run the test command,
+  -- and not necessarily the package that contains the script being run.
+  -- This allows to distinguish between internal and external templates
+  -- in the coverage report.
   }
 
 getNewCtx :: Handle -> Context -> IO (Either LowLevel.BackendError LowLevel.ContextId)
@@ -211,7 +215,7 @@ getNewCtx Handle{..} Context{..} = withLock hContextLock $ withSem hConcurrencyS
       loadPackages
       (S.toList unloadPackages)
       ctxSkipValidation
-      ctxPackageMetadata
+      ctxSelfPackageMetadata
   rootCtxId <- readIORef hContextId
   runExceptT $ do
       clonedRootCtxId <- ExceptT $ LowLevel.cloneCtx hLowLevelHandle rootCtxId

--- a/sdk/compiler/script-service/client/src/DA/Daml/LF/ScriptServiceClient/LowLevel.hs
+++ b/sdk/compiler/script-service/client/src/DA/Daml/LF/ScriptServiceClient/LowLevel.hs
@@ -107,6 +107,7 @@ data ContextUpdate = ContextUpdate
   , updLoadPackages :: ![(LF.PackageId, BS.ByteString)]
   , updUnloadPackages :: ![LF.PackageId]
   , updSkipValidation :: SkipValidation
+  , updPackageMetadata :: LF.PackageMetadata 
   }
 
 encodeSinglePackageModule :: LF.Version -> LF.Module -> BS.ByteString
@@ -327,6 +328,7 @@ updateCtx Handle{..} (ContextId ctxId) ContextUpdate{..} = do
           (Just updModules)
           (Just updPackages)
           (getSkipValidation updSkipValidation)
+          (Just $ convPackageMetadata updPackageMetadata)
   pure (void res)
   where
     updModules =
@@ -340,6 +342,10 @@ updateCtx Handle{..} (ContextId ctxId) ContextUpdate{..} = do
     encodeName = TL.fromStrict . mangleModuleName
     convModule :: (LF.ModuleName, BS.ByteString) -> SS.ScriptModule
     convModule (_, bytes) = SS.ScriptModule bytes
+    convPackageMetadata m =
+      SS.PackageMetadata
+        (TL.fromStrict $ LF.unPackageName $ LF.packageName m)
+        (TL.fromStrict $ LF.unPackageVersion $ LF.packageVersion m)
 
 mangleModuleName :: LF.ModuleName -> T.Text
 mangleModuleName (LF.ModuleName modName) =

--- a/sdk/compiler/script-service/client/src/DA/Daml/LF/ScriptServiceClient/LowLevel.hs
+++ b/sdk/compiler/script-service/client/src/DA/Daml/LF/ScriptServiceClient/LowLevel.hs
@@ -107,7 +107,7 @@ data ContextUpdate = ContextUpdate
   , updLoadPackages :: ![(LF.PackageId, BS.ByteString)]
   , updUnloadPackages :: ![LF.PackageId]
   , updSkipValidation :: SkipValidation
-  , updPackageMetadata :: LF.PackageMetadata 
+  , updSelfPackageMetadata :: Maybe LF.PackageMetadata 
   }
 
 encodeSinglePackageModule :: LF.Version -> LF.Module -> BS.ByteString
@@ -328,7 +328,7 @@ updateCtx Handle{..} (ContextId ctxId) ContextUpdate{..} = do
           (Just updModules)
           (Just updPackages)
           (getSkipValidation updSkipValidation)
-          (Just $ convPackageMetadata updPackageMetadata)
+          (fmap convPackageMetadata updSelfPackageMetadata)
   pure (void res)
   where
     updModules =

--- a/sdk/compiler/script-service/protos/script_service.proto
+++ b/sdk/compiler/script-service/protos/script_service.proto
@@ -106,6 +106,7 @@ message UpdateContextRequest {
   UpdateModules update_modules = 2;
   UpdatePackages update_packages = 3;
   bool noValidation = 4; // if true, does not run the package validations
+  PackageMetadata self_package_metadata = 5;
 }
 
 message UpdateContextResponse {

--- a/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/ScriptServiceMain.scala
+++ b/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/ScriptServiceMain.scala
@@ -16,6 +16,7 @@ import com.digitalasset.daml.lf.archive
 import com.digitalasset.daml.lf.data.ImmArray
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.data.Ref.ModuleName
+import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml.lf.language.LanguageVersion
 import com.digitalasset.daml.lf.script.api.v1.{Map => _, _}
 import com.daml.logging.LoggingContext
@@ -423,12 +424,22 @@ class ScriptService(implicit
             else
               Seq.empty
 
+          val selfPackageMetadata = Option.when(req.hasSelfPackageMetadata) {
+            val proto = req.getSelfPackageMetadata
+            Ast.PackageMetadata(
+              Ref.PackageName.assertFromString(proto.getPackageName),
+              Ref.PackageVersion.assertFromString(proto.getPackageVersion),
+              None,
+            )
+          }
+
           ctx.update(
             unloadModules,
             loadModules,
             unloadPackages,
             loadPackages,
             req.getNoValidation,
+            selfPackageMetadata,
           )
 
           resp.addAllLoadedModules(ctx.loadedModules().map(_.toString).asJava)


### PR DESCRIPTION
This PR is a follow-up of #21351, to fix the bug described in https://github.com/digital-asset/daml/issues/21324#issuecomment-2959739048.

In the script service we used to create a dummy package metadata for the self package. This causes the `queryInterface` to fail resolving the interface view of an upgraded template in the self package. To fix it, the `daml` assistant reads the real package metadata from the `daml.yaml` and sends it to the script service through the `UpdatePackages` request.