### PR TITLE
display git status when checkout fails

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -54,11 +54,20 @@ jobs:
     name: 'ubuntu_20_04'
     demands: assignment -equals default
   steps:
+    - checkout: self
+    - bash: |
+        echo "The checkout step failed. Displaying Git status to identify unstaged changes:"
+        set -euo pipefail
+        cd sdk
+        git status
+      displayName: 'Show Git Status on Checkout Failure'
+      condition: failed()
     - bash: |
         set -euo pipefail
         cd sdk
         eval "$(./dev-env/bin/dade-assist)"
         ./ci/docs-sphinx-build.sh
+      condition: succeeded()
 
 - job: Linux
   dependsOn:


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
