### PR TITLE
Use real package metadata in script service

### DIFF
--- a/sdk/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/sdk/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -870,6 +870,7 @@ contextForFile file = do
         { ctxModules = Map.fromList encodedModules
         , ctxPackages = [(LF.dalfPackageId pkg, LF.dalfPackageBytes pkg) | pkg <- Map.elems pkgMap ++ Map.elems stablePackages]
         , ctxSkipValidation = SS.SkipValidation (getSkipScriptValidation envSkipScriptValidation)
+        , ctxPackageMetadata = LF.packageMetadata pkg
         }
 
 contextForPackage :: NormalizedFilePath -> LF.Package -> Action SS.Context
@@ -888,6 +889,7 @@ contextForPackage file pkg = do
                   | pkg <- Map.elems pkgMap ++ Map.elems stablePackages
                   ]
             , ctxSkipValidation = SS.SkipValidation True -- no validation for external packages
+            , ctxPackageMetadata = LF.packageMetadata pkg
             }
 
 worldForFile :: NormalizedFilePath -> Action LF.World

--- a/sdk/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/CodeLens.hs
+++ b/sdk/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/CodeLens.hs
@@ -39,8 +39,8 @@ handle ide CodeLensParams{_textDocument=TextDocumentIdentifier uri} = liftIO $ R
               Just (mod, mapping) ->
                   pure
                       [ virtualResourceToCodeLens (range, name, vr)
-                      | (valRef, Just loc) <- scriptsInModule mod
-                      , let name = LF.unExprValName (LF.qualObject valRef)
+                      | (valName, Just loc) <- scriptsInModule mod
+                      , let name = LF.unExprValName valName
                       , let vr = VRScript filePath name
                       , Just range <- [toCurrentRange mapping $ sourceLocToRange loc]
                       ]

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -497,19 +497,22 @@ runTestsInProjectOrFiles projectOpts Nothing allTests _ coverage color mbJUnitOu
   where effect = withExpectProjectRoot (projectRoot projectOpts) "daml test" $ \pPath relativize -> do
         installDepsAndInitPackageDb cliOptions initPkgDb
         mbJUnitOutput <- traverse relativize mbJUnitOutput
-        withPackageConfig (ProjectPath pPath) $ \PackageConfigFields{..} -> do
+        withPackageConfig (ProjectPath pPath) $ \pkgConfig@PackageConfigFields{..} -> do
             -- TODO: We set up one script service context per file that
             -- we pass to execTest and script contexts are quite expensive.
             -- Therefore we keep the behavior of only passing the root file
             -- if source points to a specific file.
             files <- getDamlRootFiles pSrc
-            execTest files allTests coverage color mbJUnitOutput cliOptions tableOutputPath transactionsOutputPath coveragePaths coverageFilters
+            execTest files allTests coverage color mbJUnitOutput (Just pkgConfig) cliOptions tableOutputPath transactionsOutputPath coveragePaths coverageFilters
 runTestsInProjectOrFiles projectOpts (Just inFiles) allTests _ coverage color mbJUnitOutput cliOptions initPkgDb tableOutputPath transactionsOutputPath coveragePaths coverageFilters = Command Test (Just projectOpts) effect
-  where effect = withProjectRoot' projectOpts $ \relativize -> do
+  where effect = withProjectRoot (projectRoot projectOpts) (projectCheck projectOpts) $ \mProjectPath relativize -> do
         installDepsAndInitPackageDb cliOptions initPkgDb
         mbJUnitOutput <- traverse relativize mbJUnitOutput
+        mPkgConfig <- case mProjectPath of
+            Just projectPath -> withMaybeConfig (withPackageConfig (ProjectPath projectPath)) pure
+            Nothing -> pure Nothing
         inFiles' <- mapM (fmap toNormalizedFilePath' . relativize) inFiles
-        execTest inFiles' allTests coverage color mbJUnitOutput cliOptions tableOutputPath transactionsOutputPath coveragePaths coverageFilters
+        execTest inFiles' allTests coverage color mbJUnitOutput mPkgConfig cliOptions tableOutputPath transactionsOutputPath coveragePaths coverageFilters
 
 cmdInspect :: Mod CommandFields Command
 cmdInspect =

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -22,6 +22,7 @@ import Control.Exception
 import Control.Monad.Except
 import Control.Monad.Extra
 import DA.Daml.Compiler.Output
+import DA.Daml.Package.Config
 import qualified DA.Daml.LF.Ast as LF
 import qualified DA.Daml.LF.PrettyScript as SS
 import qualified DA.Daml.LF.ScriptServiceClient as SSC
@@ -76,10 +77,24 @@ data CoveragePaths = CoveragePaths
 newtype LoadCoverageOnly = LoadCoverageOnly {getLoadCoverageOnly :: Bool}
 
 -- | Test a Daml file.
-execTest :: SdkVersioned => [NormalizedFilePath] -> RunAllTests -> ShowCoverage -> UseColor -> Maybe FilePath -> Options -> TableOutputPath -> TransactionsOutputPath -> CoveragePaths -> [CoverageFilter] -> IO ()
-execTest inFiles runAllTests coverage color mbJUnitOutput opts tableOutputPath transactionsOutputPath resultsIO coverageFilters = do
+execTest
+    :: SdkVersioned
+    => [NormalizedFilePath]
+    -> RunAllTests
+    -> ShowCoverage
+    -> UseColor
+    -> Maybe FilePath
+    -> Maybe PackageConfigFields
+    -> Options
+    -> TableOutputPath
+    -> TransactionsOutputPath
+    -> CoveragePaths
+    -> [CoverageFilter]
+    -> IO ()
+execTest inFiles runAllTests coverage color mbJUnitOutput mPkgConfig opts tableOutputPath transactionsOutputPath resultsIO coverageFilters = do
     loggerH <- getLogger opts "test"
-    withDamlIdeState opts loggerH diagnosticsLogger $ \h -> do
+    let optsWithPkg = maybe opts (\PackageConfigFields{..} -> opts { optMbPackageName = Just pName, optMbPackageVersion = pVersion }) mPkgConfig
+    withDamlIdeState optsWithPkg loggerH diagnosticsLogger $ \h -> do
         testRun h inFiles (optDetailLevel opts) (optDamlLfVersion opts) runAllTests coverage color mbJUnitOutput tableOutputPath transactionsOutputPath resultsIO coverageFilters
         diags <- getDiagnostics h
         when (any (\(_, _, diag) -> Just DsError == _severity diag) diags) exitFailure
@@ -141,12 +156,12 @@ testRun h inFiles lvl lfVersion (RunAllTests runAllTests) coverage color mbJUnit
     extResults <-
         if runAllTests
         then case headMay inFiles of
-                 Nothing -> pure [] -- nothing to test
-                 Just file ->
-                     runActionSync h $
-                     forM extPkgs $ \pkg -> do
-                         (_fileDiagnostics, mbResults) <- runScriptsPkg file pkg extPkgs
-                         pure (pkg, mbResults)
+                Nothing -> pure [] -- nothing to test
+                Just file ->
+                    runActionSync h $
+                    forM extPkgs $ \pkg -> do
+                        (_fileDiagnostics, mbResults) <- runScriptsPkg file pkg extPkgs
+                        pure (pkg, mbResults)
         else pure []
 
     let -- All Packages / Modules mentioned somehow

--- a/sdk/compiler/script-service/client/src/DA/Daml/LF/ScriptServiceClient.hs
+++ b/sdk/compiler/script-service/client/src/DA/Daml/LF/ScriptServiceClient.hs
@@ -188,6 +188,7 @@ data Context = Context
   { ctxModules :: MS.Map Hash (LF.ModuleName, BS.ByteString)
   , ctxPackages :: [(LF.PackageId, BS.ByteString)]
   , ctxSkipValidation :: LowLevel.SkipValidation
+  , ctxPackageMetadata :: LF.PackageMetadata
   }
 
 getNewCtx :: Handle -> Context -> IO (Either LowLevel.BackendError LowLevel.ContextId)
@@ -210,6 +211,7 @@ getNewCtx Handle{..} Context{..} = withLock hContextLock $ withSem hConcurrencyS
       loadPackages
       (S.toList unloadPackages)
       ctxSkipValidation
+      ctxPackageMetadata
   rootCtxId <- readIORef hContextId
   runExceptT $ do
       clonedRootCtxId <- ExceptT $ LowLevel.cloneCtx hLowLevelHandle rootCtxId

--- a/sdk/compiler/script-service/client/src/DA/Daml/LF/ScriptServiceClient.hs
+++ b/sdk/compiler/script-service/client/src/DA/Daml/LF/ScriptServiceClient.hs
@@ -17,7 +17,6 @@ module DA.Daml.LF.ScriptServiceClient
   , getNewCtx
   , deleteCtx
   , gcCtxs
-  , runScript
   , runLiveScript
   , LowLevel.BackendError(..)
   , LowLevel.Error(..)
@@ -85,9 +84,9 @@ data Handle = Handle
   , hContextId :: IORef LowLevel.ContextId
   -- ^ The root context id, this is mutable so that rather than mutating the context
   -- we can clone it and update the clone which allows us to safely interrupt a context update.
-  , hRunningHandlers :: MVar (MS.Map RunOptions RunInfo)
-  -- ^ Track running scripts as a map between the RunOptions that triggered
-  -- them and all information required to cancel them or to resume from them
+  , hRunningHandlers :: MVar (MS.Map (LF.ModuleName, LF.ExprValName) RunInfo)
+  -- ^ Track running scripts as a map between the script and all information
+  -- required to cancel them or to resume from them
   -- ContextId for determining ThreadId for cancelling via asynchronous exception
   }
 
@@ -241,30 +240,10 @@ encodeModule :: LF.Version -> LF.Module -> (Hash, BS.ByteString)
 encodeModule v m = (Hash $ hash m', m')
   where m' = LowLevel.encodeSinglePackageModule v m
 
--- Reify name * live/unlive
-data RunOptions = RunOptions
-  { scriptModuleName :: LF.ModuleName
-  , scriptValName :: LF.ExprValName
-  , live :: Maybe LiveHandler
-  }
-  deriving (Show, Eq, Ord)
-newtype LiveHandler = LiveHandler (LowLevel.ScriptStatus -> IO ())
-instance Show LiveHandler where
-  show _ = "LiveHandler"
-instance Eq LiveHandler where
-  (==) _ _ = True
-instance Ord LiveHandler where
-  compare _ _ = EQ
+type LiveHandler = LowLevel.ScriptStatus -> IO ()
 
-runScript :: Handle -> LowLevel.ContextId -> IDELogger.Logger -> LF.ModuleName -> LF.ExprValName -> IO (Either LowLevel.Error LowLevel.ScriptResult)
-runScript h ctxId logger moduleName scriptName = runWithOptions (RunOptions moduleName scriptName Nothing) h ctxId logger
-
-runLiveScript :: Handle -> LowLevel.ContextId -> IDELogger.Logger -> LF.ModuleName -> LF.ExprValName -> (LowLevel.ScriptStatus -> IO ()) -> IO (Either LowLevel.Error LowLevel.ScriptResult)
-runLiveScript h ctxId logger moduleName scriptName statusUpdateHandler =
-  runWithOptions (RunOptions moduleName scriptName (Just (LiveHandler statusUpdateHandler))) h ctxId logger
-
-runWithOptions :: RunOptions -> Handle -> LowLevel.ContextId -> IDELogger.Logger -> IO (Either LowLevel.Error LowLevel.ScriptResult)
-runWithOptions options Handle{..} ctxId logger = do
+runLiveScript :: Handle -> LowLevel.ContextId -> IDELogger.Logger -> LF.ModuleName -> LF.ExprValName -> LiveHandler -> IO (Either LowLevel.Error LowLevel.ScriptResult)
+runLiveScript Handle{..} ctxId logger moduleName scriptName handler = do
   resBarrier <- newBarrier
   stopSemaphore <- newEmptyMVar
 
@@ -272,7 +251,7 @@ runWithOptions options Handle{..} ctxId logger = do
   modifyMVar_ hRunningHandlers $ \runningHandlers -> do
     -- If there was an old thread handling the same script in the same
     -- way, under a different context, send a cancellation to its semaphore
-    let mbOldRunInfo = MS.lookup options runningHandlers
+    let mbOldRunInfo = MS.lookup (moduleName, scriptName) runningHandlers
     case mbOldRunInfo of
       Just oldRunInfo
         | context oldRunInfo == ctxId -> pure ()
@@ -295,7 +274,7 @@ runWithOptions options Handle{..} ctxId logger = do
           pure runningHandlers
       _ -> do
         handlerThread <- forkIO $ withSem hConcurrencySem $ do
-          r <- try $ optionsToLowLevel options hLowLevelHandle ctxId logger stopSemaphore
+          r <- try $ LowLevel.runLiveScript hLowLevelHandle ctxId moduleName scriptName logger stopSemaphore handler
           signalBarrier resBarrier $
             case r of
               Left ex -> Left $ LowLevel.ExceptionError ex
@@ -308,15 +287,9 @@ runWithOptions options Handle{..} ctxId logger = do
                 , stop = stopSemaphore
                 , result = resBarrier
                 }
-        let newRunningHandlers = MS.insert options selfInfo runningHandlers
+        let newRunningHandlers = MS.insert (moduleName, scriptName) selfInfo runningHandlers
         pure newRunningHandlers
   waitBarrier resBarrier
-
-optionsToLowLevel :: RunOptions -> LowLevel.Handle -> LowLevel.ContextId -> IDELogger.Logger -> MVar Bool -> IO (Either LowLevel.Error LowLevel.ScriptResult)
-optionsToLowLevel RunOptions{..} h ctxId logger mask =
-  case live of
-    Just (LiveHandler handler) -> LowLevel.runLiveScript h ctxId scriptModuleName scriptValName logger mask handler
-    Nothing                    -> LowLevel.runScript h ctxId scriptModuleName scriptValName
 
 newtype Hash = Hash Int deriving (Eq, Ord, NFData, Show)
 

--- a/sdk/compiler/script-service/client/src/DA/Daml/LF/ScriptServiceClient/LowLevel.hs
+++ b/sdk/compiler/script-service/client/src/DA/Daml/LF/ScriptServiceClient/LowLevel.hs
@@ -107,6 +107,7 @@ data ContextUpdate = ContextUpdate
   , updLoadPackages :: ![(LF.PackageId, BS.ByteString)]
   , updUnloadPackages :: ![LF.PackageId]
   , updSkipValidation :: SkipValidation
+  , updPackageMetadata :: LF.PackageMetadata 
   }
 
 encodeSinglePackageModule :: LF.Version -> LF.Module -> BS.ByteString
@@ -327,6 +328,7 @@ updateCtx Handle{..} (ContextId ctxId) ContextUpdate{..} = do
           (Just updModules)
           (Just updPackages)
           (getSkipValidation updSkipValidation)
+          (Just $ convPackageMetadata updPackageMetadata)
   pure (void res)
   where
     updModules =
@@ -340,6 +342,10 @@ updateCtx Handle{..} (ContextId ctxId) ContextUpdate{..} = do
     encodeName = TL.fromStrict . mangleModuleName
     convModule :: (LF.ModuleName, BS.ByteString) -> SS.ScriptModule
     convModule (_, bytes) = SS.ScriptModule bytes
+    convPackageMetadata m =
+      SS.PackageMetadata
+        (TL.fromStrict $ LF.unPackageName $ LF.packageName m)
+        (TL.fromStrict $ LF.unPackageVersion $ LF.packageVersion m)
 
 mangleModuleName :: LF.ModuleName -> T.Text
 mangleModuleName (LF.ModuleName modName) =

--- a/sdk/compiler/script-service/protos/script_service.proto
+++ b/sdk/compiler/script-service/protos/script_service.proto
@@ -106,7 +106,8 @@ message UpdateContextRequest {
   UpdateModules update_modules = 2;
   UpdatePackages update_packages = 3;
   bool noValidation = 4; // if true, does not run the package validations
-  PackageMetadata self_package_metadata = 5;
+   // the metadata of the package that contains the scripts to run
+  PackageMetadata package_metadata = 5;
 }
 
 message UpdateContextResponse {
@@ -125,7 +126,7 @@ message RunScriptRequest {
 
 message RunScriptStart {
   int64 context_id = 1;
-  Identifier script_id = 2;
+  string script_name = 3;
 }
 
 message RunScriptCancel {

--- a/sdk/compiler/script-service/protos/script_service.proto
+++ b/sdk/compiler/script-service/protos/script_service.proto
@@ -106,6 +106,7 @@ message UpdateContextRequest {
   UpdateModules update_modules = 2;
   UpdatePackages update_packages = 3;
   bool noValidation = 4; // if true, does not run the package validations
+  PackageMetadata self_package_metadata = 5;
 }
 
 message UpdateContextResponse {

--- a/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/ScriptServiceMain.scala
+++ b/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/ScriptServiceMain.scala
@@ -16,6 +16,7 @@ import com.digitalasset.daml.lf.archive
 import com.digitalasset.daml.lf.data.ImmArray
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.data.Ref.ModuleName
+import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml.lf.language.LanguageVersion
 import com.digitalasset.daml.lf.script.api.v1.{Map => _, _}
 import com.daml.logging.LoggingContext
@@ -423,12 +424,22 @@ class ScriptService(implicit
             else
               Seq.empty
 
+          val selfPackageMetadata = Option.when(req.hasSelfPackageMetadata) {
+            val proto = req.getSelfPackageMetadata
+            Ast.PackageMetadata(
+              Ref.PackageName.assertFromString(proto.getPackageName),
+              Ref.PackageVersion.assertFromString(proto.getPackageVersion),
+              None,
+            )
+          }
+
           ctx.update(
             unloadModules,
             loadModules,
             unloadPackages,
             loadPackages,
             req.getNoValidation,
+            selfPackageMetadata,
           )
 
           resp.addAllLoadedModules(ctx.loadedModules().map(_.toString).asJava)

--- a/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/ScriptServiceMain.scala
+++ b/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/ScriptServiceMain.scala
@@ -193,11 +193,7 @@ class ScriptService(implicit
       respObs: StreamObserver[RunScriptResponse],
   ): Unit =
     if (req.hasStart) {
-      runLive(
-        req.getStart,
-        ScriptStream.WithoutStatus(respObs),
-        { case (ctx, pkgId, name) => ctx.interpretScript(pkgId, name) },
-      )
+      runLive(req.getStart, ScriptStream.WithoutStatus(respObs), () => false)
     }
 
   override def runLiveScript(
@@ -212,11 +208,7 @@ class ScriptService(implicit
           cancelled = true
         } else if (req.hasStart) {
           println(f"Script started.")
-          runLive(
-            req.getStart,
-            ScriptStream.WithStatus(respObs),
-            { case (ctx, pkgId, name) => ctx.interpretScript(pkgId, name, () => cancelled) },
-          )
+          runLive(req.getStart, ScriptStream.WithStatus(respObs), () => cancelled)
         }
       }
 
@@ -231,57 +223,45 @@ class ScriptService(implicit
   private def runLive(
       req: RunScriptStart,
       respStream: ScriptStream,
-      interpret: (Context, String, String) => Future[Option[IdeLedgerRunner.ScriptResult]],
+      canceledByRequest: () => Boolean,
   ): Unit = {
-    val scriptId = req.getScriptId
+    val scriptName = req.getScriptName
     val contextId = req.getContextId
     val response: Future[Option[Either[ScriptError, ScriptResult]]] =
       contexts
         .get(contextId)
         .traverse { context =>
-          val packageId = scriptId.getPackage.getSumCase match {
-            case PackageIdentifier.SumCase.SELF =>
-              context.homePackageId
-            case PackageIdentifier.SumCase.PACKAGE_ID =>
-              scriptId.getPackage.getPackageId
-            case PackageIdentifier.SumCase.SUM_NOT_SET =>
-              throw new RuntimeException(
-                s"Package id not set when running script, context id $contextId"
+          context.interpretScript(scriptName, canceledByRequest).map {
+            case error: IdeLedgerRunner.ScriptError =>
+              Left(
+                new Conversions(
+                  context.homePackageId,
+                  error.ledger,
+                  error.currentSubmission.map(_.ptx),
+                  error.traceLog,
+                  error.warningLog,
+                  error.currentSubmission.flatMap(_.commitLocation),
+                  error.stackTrace,
+                  context.devMode,
+                )
+                  .convertScriptError(error.error)
+              )
+            case success: IdeLedgerRunner.ScriptSuccess =>
+              Right(
+                new Conversions(
+                  context.homePackageId,
+                  success.ledger,
+                  None,
+                  success.traceLog,
+                  success.warningLog,
+                  None,
+                  ImmArray.Empty,
+                  context.devMode,
+                )
+                  .convertScriptResult(success.resultValue)
               )
           }
-          interpret(context, packageId, scriptId.getName)
-            .map(_.map {
-              case error: IdeLedgerRunner.ScriptError =>
-                Left(
-                  new Conversions(
-                    context.homePackageId,
-                    error.ledger,
-                    error.currentSubmission.map(_.ptx),
-                    error.traceLog,
-                    error.warningLog,
-                    error.currentSubmission.flatMap(_.commitLocation),
-                    error.stackTrace,
-                    context.devMode,
-                  )
-                    .convertScriptError(error.error)
-                )
-              case success: IdeLedgerRunner.ScriptSuccess =>
-                Right(
-                  new Conversions(
-                    context.homePackageId,
-                    success.ledger,
-                    None,
-                    success.traceLog,
-                    success.warningLog,
-                    None,
-                    ImmArray.Empty,
-                    context.devMode,
-                  )
-                    .convertScriptResult(success.resultValue)
-                )
-            })
         }
-        .map(_.flatten)
 
     Future {
       val startedAt = Instant.now.toEpochMilli
@@ -307,7 +287,7 @@ class ScriptService(implicit
 
     response.onComplete {
       case Success(None) =>
-        log(s"runScript[$contextId]: $scriptId not found")
+        log(s"runScript: $contextId not found")
         respStream.sendError(notFoundContextError(req.getContextId))
       case Success(Some(resp)) =>
         respStream.sendFinalResponse(resp)
@@ -424,14 +404,12 @@ class ScriptService(implicit
             else
               Seq.empty
 
-          val selfPackageMetadata = Option.when(req.hasSelfPackageMetadata) {
-            val proto = req.getSelfPackageMetadata
-            Ast.PackageMetadata(
-              Ref.PackageName.assertFromString(proto.getPackageName),
-              Ref.PackageVersion.assertFromString(proto.getPackageVersion),
-              None,
-            )
-          }
+          val pkgMetadataProto = req.getPackageMetadata
+          val pkgMetadata = Ast.PackageMetadata(
+            Ref.PackageName.assertFromString(pkgMetadataProto.getPackageName),
+            Ref.PackageVersion.assertFromString(pkgMetadataProto.getPackageVersion),
+            None,
+          )
 
           ctx.update(
             unloadModules,
@@ -439,7 +417,7 @@ class ScriptService(implicit
             unloadPackages,
             loadPackages,
             req.getNoValidation,
-            selfPackageMetadata,
+            pkgMetadata,
           )
 
           resp.addAllLoadedModules(ctx.loadedModules().map(_.toString).asJava)


### PR DESCRIPTION
This PR is a follow-up of #21351, to fix the bug described in https://github.com/digital-asset/daml/issues/21324#issuecomment-2959739048.

In the script service we used to create a dummy package metadata for the self package. This causes the `queryInterface` to fail resolving the interface view of an upgraded template in the self package. To fix it, the `daml` assistant reads the real package metadata from the `daml.yaml` and sends it to the script service through the `UpdatePackages` request.

As a side improvement, when we create the context of an external package, to run the scripts in that package, we reuse the loaded package, instead of loading its modules separatly. This ensures we don't create two packages with the same signature but different package ids. The package metadata is used to determine the real package id of the loaded package that contains the scripts to run.