### PR TITLE
Add `-hide-all-packages` to fix hls import

### DIFF
--- a/sdk/WORKSPACE
+++ b/sdk/WORKSPACE
@@ -391,8 +391,7 @@ common_ghc_flags = [
     # We default to -c opt but we also want -O1 in -c dbg builds
     # since we use them for profiling.
     "-O1",
-    "-hide-package=ghc-boot-th",
-    "-hide-package=ghc-boot",
+    "-hide-all-packages",
 ]
 
 # Used by Darwin and Linux


### PR DESCRIPTION
I was told by @aherrmann-da that `-hide-all-packages` flag could fix the import of `attoparsec` in hls, and indeed it does.

What's more, it seems that flag is a good thing to have. Quoting the [ghc documentation](https://downloads.haskell.org/ghc/latest/docs/users_guide/packages.html#ghc-flag-hide-all-packages), :
> This is a good way to insulate your program from differences in the globally exposed packages, and being explicit about package dependencies is a Good Thing. Cabal always passes the -hide-all-packages flag to GHC, for exactly this reason.