### PR TITLE
Ensure key template cannot differ from contract template

### DIFF
--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/FatContractInstance.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/FatContractInstance.scala
@@ -89,6 +89,10 @@ private[lf] final case class FatContractInstanceImpl[Time <: CreationTime](
     createdAt != CreationTime.Now || (!contractId.isAbsolute && !contractId.isLocal),
     "Creation time 'now' is not allowed for local and absolute contract ids",
   )
+  require(
+    contractKeyWithMaintainers.forall(_.globalKey.templateId == templateId),
+    "template ID of the contract key must match the template ID of the contract",
+  )
 
   override def mapCid(f: Value.ContractId => Value.ContractId): FatContractInstanceImpl[Time] = {
     copy(

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -100,7 +100,7 @@ object TransactionCoder {
   ): Either[EncodeError, TransactionOuterClass.KeyWithMaintainers] =
     if (version >= TransactionVersion.minVersion) {
       val builder = TransactionOuterClass.KeyWithMaintainers.newBuilder()
-      key.maintainers.foreach(builder.addMaintainers(_))
+      TreeSet.from(key.maintainers).foreach(builder.addMaintainers(_))
       ValueCoder
         .encodeValue(valueVersion = version, v0 = key.value)
         .map(builder.setKey(_).build())


### PR DESCRIPTION
This PR fixes the following issues detected when testing with canton:

- Do not allow a `FatContactinstance` to be created with a key template different from the contract template. Currently if this is done it is ignored on encoding and the contract template will be used for the key on decoding.

- Ensure that the maintainers are sorted prior to encoding so the same encoded form is generated in all cases. Prior to the change different serializations were observed for the same contract details.