### PR TITLE
Backport "Fix minimatch version bound (#21459)" to 2.3

### DIFF
--- a/sdk/compatibility/bazel_tools/create-daml-app/Main.hs
+++ b/sdk/compatibility/bazel_tools/create-daml-app/Main.hs
@@ -283,15 +283,15 @@ patchNestedKey packageJsonFile allowMissing key f = do
         _ -> error $ "malformed json file while patching '" <> packageJsonFile <> "':" <> show obj
 
 patchMinimatch :: FilePath -> IO ()
-patchMinimatch packageJsonFile = patchNestedKey packageJsonFile "devDependencies" False $ KM.insert "@types/minimatch" (Aeson.String "5.1.2")
+patchMinimatch packageJsonFile = patchNestedKey packageJsonFile False "devDependencies" $ KM.insert "@types/minimatch" (Aeson.String "5.1.2")
 
 patchTsDependencies :: FilePath -> FilePath -> IO ()
 patchTsDependencies uiDir packageJsonFile = do
-  patchNestedKey packageJsonFile "dependencies" False patchDeps
-  patchNestedKey packageJsonFile "scripts" True patchScripts
+  patchNestedKey packageJsonFile False "dependencies" patchDeps
+  patchNestedKey packageJsonFile True "scripts" patchScripts
   where
   patchScripts scripts =
-    KM.insert "start" "react-scripts start" . KM.insert "build" "react-scripts build"
+    KM.insert "start" "react-scripts start" $ KM.insert "build" "react-scripts build" scripts
   patchDeps dependencies =
     let depNames = KM.keys dependencies
     in

--- a/sdk/compatibility/bazel_tools/create-daml-app/Main.hs
+++ b/sdk/compatibility/bazel_tools/create-daml-app/Main.hs
@@ -261,7 +261,7 @@ setupNpmEnv uiDir libs = do
 
 -- | Overwrite dependencies to our TypeScript libraries to point to local file dependencies in the
 -- 'ui' directory in the specified package.json file.
-patchNestedKey :: FilePath -> Boolean -> AK.Key -> (Aeson.Object -> Aeson.Object) -> IO ()
+patchNestedKey :: FilePath -> Bool -> AK.Key -> (Aeson.Object -> Aeson.Object) -> IO ()
 patchNestedKey packageJsonFile allowMissing key f = do
   packageJson0 <- readJsonFile packageJsonFile
   let newPackageJson = updateNestedKey key f packageJson0

--- a/sdk/templates/create-daml-app/ui/package.json.template
+++ b/sdk/templates/create-daml-app/ui/package.json.template
@@ -38,6 +38,7 @@
     ]
   },
   "devDependencies": {
+    "@types/minimatch": "5.1.2",
     "@types/jwt-simple": "^0.5.33",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",


### PR DESCRIPTION
This has to differ a bit from changes in https://github.com/digital-asset/daml/pull/21459 and https://github.com/digital-asset/daml/pull/21462 to accomodate patches to `scripts`.