### PR TITLE
Engine.validateDar function

### DIFF
--- a/sdk/daml-lf/engine/BUILD.bazel
+++ b/sdk/daml-lf/engine/BUILD.bazel
@@ -32,6 +32,7 @@ da_scala_library(
     tags = ["maven_coordinates=com.daml:daml-lf-engine:__VERSION__"],
     visibility = ["//visibility:public"],
     deps = [
+        "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/data",
         "//daml-lf/interpreter",
         "//daml-lf/language",

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -691,7 +691,7 @@ class Engine(val config: EngineConfig) {
         val knownDeps = knownPkgIds.map(id => id -> DependentPackage(id)).toMap
         // There is no point in searching through missing package Ids!
         val directDeps =
-          knownDeps.flatMap(id => pkgClassification(id).asInstanceOf[ExtraPackage].pkg.directDeps)
+          knownPkgIds.flatMap(id => pkgClassification(id).asInstanceOf[ExtraPackage].pkg.directDeps)
 
         calculateDependencyInformation(directDeps, pkgClassification ++ knownDeps ++ missingDeps)
       }
@@ -713,7 +713,7 @@ class Engine(val config: EngineConfig) {
       // missingDeps are transitive dependencies (of the Dar main package) that are missing from the Dar manifest
       (transitiveDeps, missingDeps, unusedDeps) = calculateDependencyInformation(
         mainPackageDependencies,
-        darPackages.map((id, pkg) => ExtraPackage(id, pkg)),
+        darPackages.map { case (id, pkg) => id -> ExtraPackage(id, pkg) },
       )
       // extraDeps are unused Dar manifest package IDs that are not stable packages
       extraDeps = unusedDeps.diff(stablePackageIds)

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -703,12 +703,8 @@ class Engine(val config: EngineConfig) {
         Set.empty,
         Set.empty,
       )
-      extraDeps = darManifest.keySet
-        .diff(
-          Set(
-            mainPackageId
-          ) ++ transitiveDeps ++ missingDeps ++ stablePackageIds
-        )
+      knownDeps = Set(mainPackageId) ++ transitiveDeps ++ missingDeps ++ stablePackageIds
+      extraDeps = darManifest.keySet.diff(knownDeps)
       _ <- Either.cond(
         missingDeps.isEmpty && extraDeps.isEmpty,
         (),

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -715,8 +715,8 @@ class Engine(val config: EngineConfig) {
         mainPackageDependencies,
         darPackages.map { case (id, pkg) => id -> ExtraPackage(id, pkg) },
       )
-      // extraDeps are unused Dar manifest package IDs that are not stable packages
-      extraDeps = unusedDeps.diff(stablePackageIds)
+      // extraDeps are unused Dar manifest package IDs that are not stable packages and not the main package ID
+      extraDeps = unusedDeps.diff(Set(mainPackageId) union stablePackageIds)
       _ <- Either.cond(
         missingDeps.isEmpty && extraDeps.isEmpty,
         (),

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
@@ -26,6 +26,10 @@ object Error {
       def message: String
     }
 
+    trait OptionalLogReporting {
+      def logReportingEnabled: Boolean
+    }
+
     final case class Internal(
         location: String,
         override val message: String,
@@ -76,7 +80,8 @@ object Error {
         transitiveDependencies: Set[Ref.PackageId],
         missingDependencies: Set[Ref.PackageId],
         extraDependencies: Set[Ref.PackageId],
-    ) extends Error {
+    ) extends Error
+        with OptionalLogReporting {
       def message: String =
         s"For package $mainPackageId, the set of package dependencies ${transitiveDependencies
             .mkString("{'", "', '", "'}")} is not self consistent, " +
@@ -87,6 +92,9 @@ object Error {
           (if (extraDependencies.nonEmpty)
              s"the extra dependencies are ${extraDependencies.mkString("{'", "', '", "'}")}"
            else "")
+
+      override def logReportingEnabled: Boolean =
+        missingDependencies.isEmpty && extraDependencies.nonEmpty
     }
   }
 

--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
@@ -71,6 +71,23 @@ object Error {
           s"the missing dependencies are ${missingDependencies.mkString("{'", "', '", "'}")}."
     }
 
+    final case class DarSelfConsistency(
+        mainPackageId: Ref.PackageId,
+        transitiveDependencies: Set[Ref.PackageId],
+        missingDependencies: Set[Ref.PackageId],
+        extraDependencies: Set[Ref.PackageId],
+    ) extends Error {
+      def message: String =
+        s"For package $mainPackageId, the set of package dependencies ${transitiveDependencies
+            .mkString("{'", "', '", "'}")} is not self consistent, " +
+          (if (missingDependencies.nonEmpty)
+             s"the missing dependencies are ${missingDependencies.mkString("{'", "', '", "'}")} "
+           else "") +
+          (if (missingDependencies.nonEmpty && extraDependencies.nonEmpty) "and " else "") +
+          (if (extraDependencies.nonEmpty)
+             s"the extra dependencies are ${extraDependencies.mkString("{'", "', '", "'}")}"
+           else "")
+    }
   }
 
   // Error happening during command/transaction preprocessing

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineValidatePackagesTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineValidatePackagesTest.scala
@@ -4,8 +4,11 @@
 package com.digitalasset.daml.lf
 package engine
 
+import com.digitalasset.daml.lf.archive.Dar
 import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.daml.lf.language.Ast.Package
 import com.digitalasset.daml.lf.language.{LanguageMajorVersion, LanguageVersion}
+import com.digitalasset.daml.lf.stablepackages.StablePackages
 import com.digitalasset.daml.lf.testing.parser
 import com.digitalasset.daml.lf.testing.parser.Implicits.SyntaxHelper
 import org.scalatest.Inside
@@ -19,16 +22,60 @@ class EngineValidatePackagesTest(majorLanguageVersion: LanguageMajorVersion)
     with Matchers
     with Inside {
 
-  val pkgId = Ref.PackageId.assertFromString("-pkg-")
-
   val langVersion = LanguageVersion.defaultOrLatestStable(majorLanguageVersion)
+
+  val pkgId = Ref.PackageId.assertFromString("-pkg-")
+  val extraPkgId = Ref.PackageId.assertFromString("-extra-")
+  val missingPkgId = Ref.PackageId.assertFromString("-missing-")
+  val utilityPkgId = Ref.PackageId.assertFromString("-utility-")
+  val altUtilityPkgId = Ref.PackageId.assertFromString("-alt-utility-")
+  val (stablePkgId, stablePkg) = StablePackages(majorLanguageVersion).packagesMap.head
 
   implicit val parserParameters: parser.ParserParameters[this.type] =
     parser.ParserParameters(pkgId, langVersion)
 
+  val fakeDamlPrimPkg =
+    p"""
+      metadata ( 'daml-prim' : '1.0.0' )
+      module Mod {
+        val string: Text = "fake-daml-prim";
+      }
+    """
+  val fakeDamlStdlibPkg =
+    p"""
+      metadata ( 'daml-stdlib' : '1.0.0' )
+      module Mod {
+        val string: Text = "fake-daml-stdlib";
+      }
+    """
+  val utilityPkgChoices = Seq(
+    ("no utility packages", Set.empty, Seq.empty),
+    ("daml-prim utility package", Set(utilityPkgId), Seq(utilityPkgId -> fakeDamlPrimPkg)),
+    (
+      "daml-stdlib utility package",
+      Set(altUtilityPkgId),
+      Seq(altUtilityPkgId -> fakeDamlStdlibPkg),
+    ),
+    (
+      "daml-prim and daml-stdlib utility package",
+      Set(utilityPkgId, altUtilityPkgId),
+      Seq(utilityPkgId -> fakeDamlPrimPkg, altUtilityPkgId -> fakeDamlStdlibPkg),
+    ),
+  )
+  val stablePkgChoices = Seq(
+    ("no stable packages", Set.empty, Seq.empty),
+    ("stable package", Set(stablePkgId), Seq(stablePkgId -> stablePkg)),
+  )
+
   private def newEngine = new Engine(
     EngineConfig(LanguageVersion.AllVersions(majorLanguageVersion))
   )
+
+  private def darFromPackageMap(
+      mainPkg: (Ref.PackageId, Package),
+      dependentPkgs: (Ref.PackageId, Package)*
+  ): Dar[(Ref.PackageId, Package)] =
+    Dar(mainPkg, dependentPkgs.toList)
 
   "Engine.validatePackages" should {
 
@@ -87,4 +134,184 @@ class EngineValidatePackagesTest(majorLanguageVersion: LanguageMajorVersion)
 
   }
 
+  "Engine.validateDar" should {
+    val pkg =
+      p"""
+        metadata ( 'pkg' : '1.0.0' )
+        module Mod {
+          val string: Text = "pkg";
+        }
+      """
+
+    "accept valid package" should {
+      utilityPkgChoices.foreach { case (utilityLabel, utilityDirectDeps, utilityDependencies) =>
+        stablePkgChoices.foreach { case (stableLabel, stableDirectDeps, stableDependencies) =>
+          s"with $utilityLabel and $stableLabel" in {
+            newEngine.validateDar(
+              darFromPackageMap(
+                pkgId -> pkg.copy(directDeps = utilityDirectDeps ++ stableDirectDeps),
+                utilityDependencies ++ stableDependencies: _*
+              )
+            ) shouldBe Right(())
+          }
+        }
+      }
+    }
+
+    "reject ill-typed packages" should {
+      val illTypedPackage =
+        p"""
+        metadata ( 'pkg' : '1.0.0' )
+        module Mod {
+          val string: Text = 1;
+        }
+      """
+
+      utilityPkgChoices.foreach { case (utilityLabel, utilityDirectDeps, utilityDependencies) =>
+        stablePkgChoices.foreach { case (stableLabel, stableDirectDeps, stableDependencies) =>
+          s"with $utilityLabel and $stableLabel" in {
+            inside(
+              newEngine.validateDar(
+                darFromPackageMap(
+                  pkgId -> illTypedPackage.copy(directDeps = utilityDirectDeps ++ stableDirectDeps),
+                  utilityDependencies ++ stableDependencies: _*
+                )
+              )
+            ) { case Left(_: Error.Package.Validation) =>
+            }
+          }
+        }
+      }
+    }
+
+    "reject non self-consistent sets of packages" should {
+      val extraPkg =
+        p"""
+           metadata ( 'extra' : '1.0.0' )
+           module Mod {
+             val string: Text = "e";
+           }
+         """
+
+      "with missing dependencies only" should {
+        val dependentPackage =
+          p"""
+              metadata ( 'pkg' : '1.0.0' )
+              module Mod {
+                val string: Text = '-missing-':Mod:Text;
+              }
+            """
+
+        utilityPkgChoices.foreach { case (utilityLabel, utilityDirectDeps, utilityDependencies) =>
+          stablePkgChoices.foreach { case (stableLabel, stableDirectDeps, stableDependencies) =>
+            s"with $utilityLabel and $stableLabel" in {
+              inside(
+                newEngine.validateDar(
+                  darFromPackageMap(
+                    pkgId -> dependentPackage.copy(directDeps =
+                      Set(missingPkgId) ++ utilityDirectDeps ++ stableDirectDeps
+                    ),
+                    utilityDependencies ++ stableDependencies: _*
+                  )
+                )
+              ) {
+                case Left(
+                      Error.Package.DarSelfConsistency(
+                        mainPkgId,
+                        transitiveDeps,
+                        missingDeps,
+                        extraDeps,
+                      )
+                    ) =>
+                  mainPkgId shouldBe pkgId
+                  transitiveDeps shouldBe utilityDirectDeps ++ stableDirectDeps
+                  missingDeps shouldBe Set(missingPkgId)
+                  extraDeps shouldBe Set.empty
+              }
+            }
+          }
+        }
+      }
+
+      "with extra dependencies only" should {
+        val dependentPackage =
+          p"""
+              metadata ( 'pkg' : '1.0.0' )
+              module Mod {
+                val string: Text = "t";
+              }
+            """
+
+        utilityPkgChoices.foreach { case (utilityLabel, utilityDirectDeps, utilityDependencies) =>
+          stablePkgChoices.foreach { case (stableLabel, stableDirectDeps, stableDependencies) =>
+            s"with $utilityLabel and $stableLabel" in {
+              inside(
+                newEngine.validateDar(
+                  darFromPackageMap(
+                    pkgId -> dependentPackage.copy(directDeps =
+                      utilityDirectDeps ++ stableDirectDeps
+                    ),
+                    Seq(extraPkgId -> extraPkg) ++ utilityDependencies ++ stableDependencies: _*
+                  )
+                )
+              ) {
+                case Left(
+                      Error.Package.DarSelfConsistency(
+                        mainPkgId,
+                        transitiveDeps,
+                        missingDeps,
+                        extraDeps,
+                      )
+                    ) =>
+                  mainPkgId shouldBe pkgId
+                  transitiveDeps shouldBe utilityDirectDeps ++ stableDirectDeps
+                  missingDeps shouldBe Set.empty
+                  extraDeps shouldBe Set(extraPkgId)
+              }
+            }
+          }
+        }
+      }
+
+      "with both missing dependencies and extra dependencies" should {
+        val dependentPackage =
+          p"""
+              metadata ( 'pkg' : '1.0.0' )
+              module Mod {
+                val string: Text = '-missing-':Mod:Text;
+              }
+            """
+
+        utilityPkgChoices.foreach { case (utilityLabel, utilityDirectDeps, utilityDependencies) =>
+          stablePkgChoices.foreach { case (stableLabel, stableDirectDeps, stableDependencies) =>
+            s"with $utilityLabel and $stableLabel" in {
+              inside(
+                newEngine.validateDar(
+                  darFromPackageMap(
+                    pkgId -> dependentPackage.copy(directDeps =
+                      Set(missingPkgId) ++ utilityDirectDeps ++ stableDirectDeps
+                    ),
+                    Seq(extraPkgId -> extraPkg) ++ utilityDependencies ++ stableDependencies: _*
+                  )
+                )
+              ) {
+                case Left(
+                      Error.Package.DarSelfConsistency(
+                        mainPkgId,
+                        transitiveDeps,
+                        missingDeps,
+                        extraDeps,
+                      )
+                    ) =>
+                  mainPkgId shouldBe pkgId
+                  transitiveDeps shouldBe utilityDirectDeps ++ stableDirectDeps
+                  missingDeps shouldBe Set(missingPkgId)
+                  extraDeps shouldBe Set(extraPkgId)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Part of resolving https://github.com/digital-asset/daml/issues/21385 - introduce an Engine.validateDar function

- [x] Engine.validateDar function (to replace Engine.validatePackages on a future PR)
- [x] Define a DarSelfConsistency error value (to replace SelfConsistency on a future PR)
- [x] Add in testing for Engine.validateDar

Next step is to integrate this work into the package uploader (on the Canton side) - https://github.com/DACH-NY/canton/pull/26598.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
