### PR TITLE
Fix vscode_marketplace job

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -181,8 +181,8 @@ jobs:
             cd compiler/daml-extension
             sed -i "s/__VERSION__/$GITHUB/" package.json
             # This produces out/src/extension.js
-            bazel run --run_under="cd $PWD &&" @nodejs//:yarn install
-            bazel run --run_under="cd $PWD &&" @nodejs//:yarn compile
+            bazel run --run_under="cd $PWD &&" @yarn//:yarn install
+            bazel run --run_under="cd $PWD &&" @yarn//:yarn compile
             bazel run --run_under="cd $PWD && " @daml_extension_deps//vsce/bin:vsce -- publish --yarn $GITHUB -p $MARKETPLACE_TOKEN
             )
           else


### PR DESCRIPTION
vscode_marketplace job on main is failing.
This is because yarn was moved from @nodejs to @yarn, and this job invokes bazel in a shell job, so non-main CI wouldn't catch it.