### PR TITLE
retry 10 times to build on m1

### DIFF
--- a/sdk/build.sh
+++ b/sdk/build.sh
@@ -94,15 +94,40 @@ if has_regenerate_stackage_trailer; then
   exit 1
 fi
 
-echo "Running 'bazel build //...'"
 # Bazel test only builds targets that are dependencies of a test suite so do a full build first.
-$bazel build //... \
-  --build_tag_filters "${tag_filter}" \
-  --profile build-profile.json \
-  --experimental_profile_include_target_label \
-  --build_event_json_file build-events.json \
-  --build_event_publish_all_actions \
-  --execution_log_json_file "$ARTIFACT_DIRS/logs/build_execution${execution_log_postfix}.json.gz"
+run_build() {
+  bazel build "$@" //... \
+    --build_tag_filters "${tag_filter}" \
+    --profile build-profile.json \
+    --experimental_profile_include_target_label \
+    --build_event_json_file build-events.json \
+    --build_event_publish_all_actions \
+    --execution_log_json_file "$ARTIFACT_DIRS/logs/build_execution${execution_log_postfix}.json.gz"
+}
+
+if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
+  echo "Running on Apple Silicon (arm64). Building with --keep-going and retry on fail."
+
+  max_tries=10
+  build_succeeded=false
+
+  for i in $(seq 1 $max_tries); do
+    echo "Build attempt ${i}/${max_tries}..."
+    if run_build -k; then
+      build_succeeded=true
+      break
+    fi
+  done
+
+  if [ "$build_succeeded" = false ]; then
+    echo "Build failed after ${max_tries} attempts. Exiting."
+    exit 1
+  fi
+
+else
+  echo "Running on linux or non-arm Apple. Building without retry logic."
+  run_build
+fi
 
 # Set up a shared PostgreSQL instance.
 export POSTGRESQL_ROOT_DIR="${POSTGRESQL_TMP_ROOT_DIR:-$DIR/.tmp-pg}/daml/postgresql"


### PR DESCRIPTION
M1 builds are currently flaky because of a non-deterministic linker error that will only be solved when we migrate to GHC 9.2.7. For that reason they are disabled on PRs but enabled on main. As a result, main is always red, which hides other serious errors like maven refusing our uploads.

To circumvent that problem, on m1 we run the build in a loop with the --keep-going flag on. It shouldn't be very expensive as it will resume work where it left off at the previous iteration. In case of a real build failure, it will fail 10 times in a row, which is ok as compilation errors don't usually take long to get reported.