### PR TITLE
docs: tiny typo fix – "ocnfiguration" → "configuration"

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 We run our CI on Azure Pipelines. Azure Pipelines uses its own variant of YAML
-for its ocnfiguration; it's worth getting familiar with their [YAML
+for its configuration; it's worth getting familiar with their [YAML
 documentation][YAML], as well as with their [expression syntax].
 
 [YAML]: https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/?view=azure-pipelines


### PR DESCRIPTION
spotted a quick typo in the Azure Pipelines bit – just cleaned up "ocnfiguration" to the correct "configuration"

<img width="922" alt="Снимок экрана 2025-07-07 в 13 32 36" src="https://github.com/user-attachments/assets/17b3c50a-d6f3-417b-967c-d134f8966644" />

