### PR TITLE
replace deprecated bazel log format with new one

### DIFF
--- a/sdk/compatibility/build-release-artifacts-windows.ps1
+++ b/sdk/compatibility/build-release-artifacts-windows.ps1
@@ -37,7 +37,8 @@ function bazel() {
 
 bazel shutdown
 bazel build `
-  `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/build_execution_windows.log `
+  `-`-execution_log_binary_file ${ARTIFACT_DIRS}/build_execution_windows.log `
+  `-`-noexecution_log_sort `
   //release:sdk-release-tarball `
   //daml-assistant:daml
 


### PR DESCRIPTION
On windows we're logging stats about bazel execution and saving them to gcp in order to someday maybe debug performance. The log format we were using is deprecated in bazel 7 so I'm switching to the new recommended set of flags in the bazel release notes.