### PR TITLE
Try to fix vscode marketplace

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -183,7 +183,7 @@ jobs:
             # This produces out/src/extension.js
             bazel run --run_under="cd $PWD &&" @yarn//:yarn install
             bazel run --run_under="cd $PWD &&" @yarn//:yarn compile
-            bazel run --run_under="cd $PWD && " @daml_extension_deps//vsce/bin:vsce -- publish --yarn $GITHUB -p $MARKETPLACE_TOKEN
+            bazel run --run_under="cd $PWD && "@daml_extension_deps//vsce/bin:vsce -- publish --yarn $GITHUB -p $MARKETPLACE_TOKEN
             )
           else
             if [[ "$GITHUB" == "$MARKET" ]]; then

--- a/sdk/WORKSPACE
+++ b/sdk/WORKSPACE
@@ -708,6 +708,7 @@ yarn_install(
     args = ["--frozen-lockfile"],
     package_json = "//compiler/daml-extension:package.json",
     symlink_node_modules = False,
+    use_global_yarn_cache = False,
     yarn_lock = "//compiler/daml-extension:yarn.lock",
 )
 


### PR DESCRIPTION
vscode_marketplace is failing for reasons I don't see locally. I assume its some kind of cache poisoning. I want to see if disabling the "use_global_yarn_cache" option helps at all.