### PR TITLE
Libs: fix NonEmpty::reverse to return a NonEmpty

### DIFF
--- a/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/RecipientsValidator.scala
+++ b/sdk/canton/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/RecipientsValidator.scala
@@ -6,6 +6,7 @@ package com.digitalasset.canton.participant.protocol.validation
 import cats.data.OptionT
 import cats.syntax.functorFilter.*
 import cats.syntax.parallel.*
+import com.daml.nonempty.NonEmpty
 import com.digitalasset.canton.LfPartyId
 import com.digitalasset.canton.data.ViewPosition.MerklePathElement
 import com.digitalasset.canton.data.{ViewPosition, ViewTree}
@@ -359,7 +360,7 @@ class RecipientsValidator[I](
       context: Context,
       mainRecipients: Recipients,
       mainViewPosition: List[MerklePathElement],
-      recipientsPathViewToRoot: Seq[Set[Recipient]],
+      recipientsPathViewToRoot: NonEmpty[Seq[NonEmpty[Set[Recipient]]]],
       errorBuilder: mutable.Builder[Error, Seq[Error]],
   )(implicit traceContext: TraceContext): Option[BadViewPosition] = {
     val Context(requestId, informeeParticipantsOfPositionAndParty) =

--- a/sdk/libs-scala/nonempty/src/main/scala/com/daml/nonempty/NonEmpty.scala
+++ b/sdk/libs-scala/nonempty/src/main/scala/com/daml/nonempty/NonEmpty.scala
@@ -203,6 +203,7 @@ object NonEmptyColl extends NonEmptyCollInstances {
       un((self: ESelf).sortBy(f))
     def sorted[B >: A](implicit ord: Ordering[B]): NonEmpty[C] =
       un((self: ESelf).sorted[B])
+    def reverse: NonEmpty[C] = un((self: ESelf).reverse)
   }
 
   implicit final class `Seq Ops`[A, CC[_], C](

--- a/sdk/libs-scala/nonempty/src/main/scala/com/daml/nonempty/NonEmptyReturningOps.scala
+++ b/sdk/libs-scala/nonempty/src/main/scala/com/daml/nonempty/NonEmptyReturningOps.scala
@@ -30,7 +30,6 @@ object NonEmptyReturningOps {
 
     def +-:(elem: A): NonEmpty[CC[A]] = un(elem +: self)
     def :-+(elem: A): NonEmpty[CC[A]] = un(self :+ elem)
-    def reverse: NonEmpty[C] = un(self.reverse)
   }
 
   implicit final class `NE Set Ops`[A](private val self: Set[A]) extends AnyVal {

--- a/sdk/libs-scala/nonempty/src/test/scala/com/daml/nonempty/NonEmptySpec.scala
+++ b/sdk/libs-scala/nonempty/src/test/scala/com/daml/nonempty/NonEmptySpec.scala
@@ -292,7 +292,8 @@ class NonEmptySpec extends AnyWordSpec with Matchers with WordSpecCheckLaws {
 
   "reverse" should {
     "work" in {
-      NonEmpty(Seq, 1, 3, 2).reverse should ===(NonEmpty(Seq, 2, 3, 1))
+      val reversed: NonEmpty[Seq[Int]] = NonEmpty(Seq, 1, 3, 2).reverse
+      reversed should ===(NonEmpty(Seq, 2, 3, 1))
     }
   }
 


### PR DESCRIPTION
`reverse` was previously being put into an implicit which wrapped a `SeqOps`, so wasn't even being applied to `NonEmpty`s.

The implementation of `reverse` in the test was being found via the `widen` trait, so it didn't preserve `NonEmpty`-ness. Now it does.