### PR TITLE
[WIP] Configure haskell-language-server in nix

### DIFF
--- a/sdk/dev-env/bin/haskell-language-server
+++ b/sdk/dev-env/bin/haskell-language-server
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Meant to be linked to from `dev-env/bin`, symlink should be named after the
+# tool. Execute a Nix tool from a derivation that creates a `result` directory.
+
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
+source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
+base=$(basename $0)
+execTool $base out haskell-language-server-wrapper "$@"

--- a/sdk/dev-env/bin/haskell-language-server-9.0.2
+++ b/sdk/dev-env/bin/haskell-language-server-9.0.2
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Meant to be linked to from `dev-env/bin`, symlink should be named after the
+# tool. Execute a Nix tool from a derivation that creates a `result` directory.
+
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
+source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
+base=$(basename $0)
+execTool haskell-language-server out $base "$@"

--- a/sdk/hie.yaml
+++ b/sdk/hie.yaml
@@ -1,0 +1,3 @@
+cradle:
+  bios:
+    program: ".hie-bios"

--- a/sdk/nix/default.nix
+++ b/sdk/nix/default.nix
@@ -22,6 +22,14 @@ let
   # Add all packages that are used by Bazel builds here
   bazel_dependencies = import ./bazel.nix { inherit system pkgs; };
 
+  hls_pkgs = (let
+                spec = builtins.fromJSON (builtins.readFile ./nixpkgs/hls.src.json);
+              in
+                import (builtins.fetchTarball {
+                  url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
+                  sha256 = spec.sha256;
+              }) {});
+
 in rec {
   inherit pkgs;
 
@@ -62,6 +70,7 @@ in rec {
                        }) {}).haskellPackages.ghcid;
     hlint           = bazel_dependencies.hlint;
     ghci            = bazel_dependencies.ghc;
+    haskell-language-server = hls_pkgs.haskell.packages.native-bignum.ghc902.haskell-language-server;
 
     # Hazel’s configure step currently searches for the C compiler in
     # PATH instead of taking it from our cc toolchain so we have to add

--- a/sdk/nix/nixpkgs/hls.src.json
+++ b/sdk/nix/nixpkgs/hls.src.json
@@ -1,0 +1,7 @@
+{
+  "owner": "NixOS",
+  "repo": "nixpkgs",
+  "branch": "nixpkgs-unstable",
+  "rev": "18a01f3fd956de7fc6d32e5e241e949671e7e8bf",
+  "sha256": "067d4i91ymg7jnsxr6gkc0dm9s4qymxys3h0i2nacj41pbq5qbpv"
+}


### PR DESCRIPTION
This is an attempt to configure `haskell-language-server` in nix. Unfortunately it does not work because of:

```
$ haskell-language-server --debug compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs

...

2025-07-17T11:41:44.932218Z | Info | updateFileDiagnostics published different from new diagnostics - file diagnostics: File:     /home/adrien/daml2/sdk/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
Hidden:   no
Range:    1:1-2:1
Source:   typecheck
Severity: DiagnosticSeverity_Error
Message: 
  Unexpected usage error
  /nix/store/pf5avvvl4ssd6kylcvg2g23hcjp71h19-glibc-2.39-52/lib/libc.so.6: undefined symbol:
  __tunable_is_initialized, version GLIBC_PRIVATE

...
```
