### PR TITLE
[Compiler] remove location arround atomic expressions

### DIFF
--- a/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/sdk/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -207,6 +207,16 @@ safetyStep = \case
   EChoiceObserverF _ _ s1 s2 -> s1 <> s2 <> Safe 0
   EExperimentalF _ _ -> Unsafe
 
+isAtomic :: Expr  -> Bool
+isAtomic = \case
+    EVar _ -> True
+    EVal _ -> True
+    EBuiltinFun _ -> True
+    EEnumCon _ _ -> True
+    ENil _ -> True
+    ENone _ -> True
+    _ -> False
+
 isTypeClassDictionary :: DefValue -> Bool
 isTypeClassDictionary DefValue{..}
     = T.isPrefixOf "$f" (unExprValName (fst dvalBinder)) -- generic dictionary
@@ -472,6 +482,8 @@ simplifyExpr = fmap fst . cata go'
           go world $ ELetF (BindingF (x, t) (e1, s1)) (go world $ ETmAppF (e2, s2) e3)
           where
             (s1, s2) = infoUnstepELet x s0
+
+      ELocationF _ e | isAtomic (fst e) -> e
 
       -- e    ==>    e
       e -> (embed (fmap fst e), infoStep world (fmap snd e))


### PR DESCRIPTION
Those are useless for the run time.
Rmove them reduce the dar size by 8%.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
