### PR TITLE
report m1 flakes

### DIFF
--- a/ci/macOS.yml
+++ b/ci/macOS.yml
@@ -54,11 +54,9 @@ jobs:
     # Do not upload metrics for m1
     - ${{ if eq(parameters.name, 'macos') }}:
       - template: upload-bazel-metrics.yml
-    # Do not report flakes for m1
-    - ${{ if eq(parameters.name, 'macos') }}:
-      - template: report-flakes.yml
-        parameters:
-          is_release: variables.is_release
+    - template: report-flakes.yml
+      parameters:
+        is_release: variables.is_release
     - template: tell-slack-failed.yml
       parameters:
         trigger_sha: '$(trigger_sha)'


### PR DESCRIPTION
After https://github.com/digital-asset/daml/pull/21474, all m1 failures seem to be flakes, so we can start reporting them. I actually believe we could have reported them from day 1 but I was under the misguided impression that the m1 linker issues were affecting the build and the tests equally.