### PR TITLE
Fix docs around interface instance clauses

### DIFF
--- a/sdk/docs/manually-written/sdk/reference/daml/interfaces.rst
+++ b/sdk/docs/manually-written/sdk/reference/daml/interfaces.rst
@@ -198,27 +198,6 @@ For context, a simple template definition:
 - The implementation of the special ``view`` method must return the type
   specified as the ``viewtype`` in the interface declaration.
 
-``interface instance`` clause in the interface
-----------------------------------------------
-
-.. todo:: Fix or remove this literal include
-
-.. INTERFACE_INSTANCE_IN_INTERFACE_BEGIN no longer exists in the daml file
-    .. literalinclude:: code-snippets-dev/Interfaces.daml
-       :language: daml
-       :start-after: -- INTERFACE_INSTANCE_IN_INTERFACE_BEGIN
-       :end-before: -- INTERFACE_INSTANCE_IN_INTERFACE_END
-
-- To make an *existing* template an instance of a new interface, the
-  ``interface instance`` clause must be defined in the *interface* declaration.
-- In this case, the *interface* of the clause must match the enclosing
-  declaration. In other words, an interface ``I`` declaration can only contain
-  ``interface instance`` clauses where the interface is ``I``.
-- All other rules for ``interface instance`` clauses are the same whether the
-  enclosing declaration is a template or an interface. In particular, the
-  implicit local binding ``this`` always has the type of the *template*'s
-  record.
-
 Empty ``interface instance`` clause
 -----------------------------------
 

--- a/sdk/docs/manually-written/sdk/sdlc-howtos/smart-contracts/upgrade/smart-contract-upgrades.rst
+++ b/sdk/docs/manually-written/sdk/sdlc-howtos/smart-contracts/upgrade/smart-contract-upgrades.rst
@@ -2,7 +2,7 @@
 .. SPDX-License-Identifier: Apache-2.0
 
 .. wip::
-    Turn into a proper how-to guide, remove mentions to contract keys.
+    Turn into a proper how-to guide.
 
 .. _smart-contract-upgrades:
 
@@ -305,7 +305,7 @@ data transformations that cannot be made using SCU upgrades:
 
 -  Upgrading interface and exception definitions
 
--  Adding/removing an interface instance on a template
+-  Removing an interface instance from a template
 
 These restrictions are required to give a simple model of runtime
 upgrades, avoiding ambiguity and non-obvious side effects. If you
@@ -315,10 +315,6 @@ redeployment with downtime, either using the approach suggested in
 
 In this version of SCU, the following functionality has not yet
 been implemented, but may be implemented in future releases.
-
--  Retroactive interface instances are not compatible with SCU upgrades.
-   SCU allows instances to be changed in an upgrade. However, a new interface
-   instance cannot be added to a template in an upgrade; it requires an offline migration.
 
 -  Daml Script does not support SCU or LF1.17, you must use Daml Script LTS.
 
@@ -1611,8 +1607,7 @@ reupload the two versions:
   Uploading .daml/dist/my-pkg-2.0.0.dar to localhost:6865
   upload-dar did not succeed: ... Implementation of interface ...:MyIface:HasValue by template IOU appears in package that is being upgraded, but does not appear in this package.
 
-Packages with new versions can however add an interface instance to an existing
-template. For example, restore the instance deleted in the previous step
+As another example, restore the instance deleted in the previous step
 and remove the ``HasValue`` interface from ``v2/my-pkg/daml/Main.daml`` instead.
 Then restart the sandbox and try to reupload the two versions.
 

--- a/sdk/docs/manually-written/sdk/sdlc-howtos/smart-contracts/upgrade/upgrade-scopes.csv
+++ b/sdk/docs/manually-written/sdk/sdlc-howtos/smart-contracts/upgrade/upgrade-scopes.csv
@@ -27,6 +27,6 @@ Change of Choice Return Type,Choice,"Yes, except for Tuple or scalar types","| Y
 |
 | In particular: you cannot change a collection, Optional, List, or Map; you can change Tuple, (to a triple) if you define your own type."
 Change of Interface Definition,Interface Definition,No,Interfaces are static and cannot be changed. Separate interface definition and keep the implementation in the template code.
-Addition of Interface Implementations (Retroactive Interfaces),Interface Definition,No,
-Adding or Removing Interfaces from Templates,Template Definition,No,Interfaces cannot be changed.
+Adding Interfaces to Templates,Template Definition,Yes,
+Removing Interfaces from Templates,Template Definition,No,Though the implementation can be changed.
 Change or Deletion of Exception,Exception Definition,No,Keep the exception definition separate. Exceptions cannot be upgraded.

--- a/sdk/docs/sharable/sdk/reference/daml/interfaces.rst
+++ b/sdk/docs/sharable/sdk/reference/daml/interfaces.rst
@@ -198,27 +198,6 @@ For context, a simple template definition:
 - The implementation of the special ``view`` method must return the type
   specified as the ``viewtype`` in the interface declaration.
 
-``interface instance`` clause in the interface
-----------------------------------------------
-
-.. todo:: Fix or remove this literal include
-
-.. INTERFACE_INSTANCE_IN_INTERFACE_BEGIN no longer exists in the daml file
-    .. literalinclude:: code-snippets-dev/Interfaces.daml
-       :language: daml
-       :start-after: -- INTERFACE_INSTANCE_IN_INTERFACE_BEGIN
-       :end-before: -- INTERFACE_INSTANCE_IN_INTERFACE_END
-
-- To make an *existing* template an instance of a new interface, the
-  ``interface instance`` clause must be defined in the *interface* declaration.
-- In this case, the *interface* of the clause must match the enclosing
-  declaration. In other words, an interface ``I`` declaration can only contain
-  ``interface instance`` clauses where the interface is ``I``.
-- All other rules for ``interface instance`` clauses are the same whether the
-  enclosing declaration is a template or an interface. In particular, the
-  implicit local binding ``this`` always has the type of the *template*'s
-  record.
-
 Empty ``interface instance`` clause
 -----------------------------------
 

--- a/sdk/docs/sharable/sdk/sdlc-howtos/smart-contracts/upgrade/smart-contract-upgrades.rst
+++ b/sdk/docs/sharable/sdk/sdlc-howtos/smart-contracts/upgrade/smart-contract-upgrades.rst
@@ -2,7 +2,7 @@
 .. SPDX-License-Identifier: Apache-2.0
 
 .. wip::
-    Turn into a proper how-to guide, remove mentions to contract keys.
+    Turn into a proper how-to guide.
 
 .. _smart-contract-upgrades:
 
@@ -305,7 +305,7 @@ data transformations that cannot be made using SCU upgrades:
 
 -  Upgrading interface and exception definitions
 
--  Adding/removing an interface instance on a template
+-  Removing an interface instance from a template
 
 These restrictions are required to give a simple model of runtime
 upgrades, avoiding ambiguity and non-obvious side effects. If you
@@ -315,10 +315,6 @@ redeployment with downtime, either using the approach suggested in
 
 In this version of SCU, the following functionality has not yet
 been implemented, but may be implemented in future releases.
-
--  Retroactive interface instances are not compatible with SCU upgrades.
-   SCU allows instances to be changed in an upgrade. However, a new interface
-   instance cannot be added to a template in an upgrade; it requires an offline migration.
 
 -  Daml Script does not support SCU or LF1.17, you must use Daml Script LTS.
 
@@ -1611,8 +1607,7 @@ reupload the two versions:
   Uploading .daml/dist/my-pkg-2.0.0.dar to localhost:6865
   upload-dar did not succeed: ... Implementation of interface ...:MyIface:HasValue by template IOU appears in package that is being upgraded, but does not appear in this package.
 
-Packages with new versions can however add an interface instance to an existing
-template. For example, restore the instance deleted in the previous step
+As another example, restore the instance deleted in the previous step
 and remove the ``HasValue`` interface from ``v2/my-pkg/daml/Main.daml`` instead.
 Then restart the sandbox and try to reupload the two versions.
 

--- a/sdk/docs/sharable/sdk/sdlc-howtos/smart-contracts/upgrade/upgrade-scopes.csv
+++ b/sdk/docs/sharable/sdk/sdlc-howtos/smart-contracts/upgrade/upgrade-scopes.csv
@@ -27,6 +27,6 @@ Change of Choice Return Type,Choice,"Yes, except for Tuple or scalar types","| Y
 |
 | In particular: you cannot change a collection, Optional, List, or Map; you can change Tuple, (to a triple) if you define your own type."
 Change of Interface Definition,Interface Definition,No,Interfaces are static and cannot be changed. Separate interface definition and keep the implementation in the template code.
-Addition of Interface Implementations (Retroactive Interfaces),Interface Definition,No,
-Adding or Removing Interfaces from Templates,Template Definition,No,Interfaces cannot be changed.
+Adding Interfaces to Templates,Template Definition,Yes,
+Removing Interfaces from Templates,Template Definition,No,Though the implementation can be changed.
 Change or Deletion of Exception,Exception Definition,No,Keep the exception definition separate. Exceptions cannot be upgraded.


### PR DESCRIPTION
This PR makes two edits:

* Removes discussion of "retroactive interfaces," which were deprecated with the introduction of Smart Contract Upgrades.
* Mentions support for SCU-compatibility of adding interfaces to a previously defined template.

See [this recent forums post](https://discuss.daml.com/t/interfaces-in-daml-3/8093/2?u=wallacekelly).