### PR TITLE
Remove the docs team as codeowners of the docs.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,13 +43,6 @@ sdk/release.sh         @digital-asset/daml-language
 /sdk/ledger-service/
 /sdk/runtime-components/ 
 
-# Technical writers should review the docs
-/sdk/docs/manually-written @digital-asset/daml-docs
-
-# Even though some docs in this folder are auto-generated, it wouldn't hurt to review them too
-# And it's not obvious to separate them
-/sdk/docs/sharable         @digital-asset/daml-docs
-
 # Misc
 /sdk/docs/ 
 /sdk/libs-scala/


### PR DESCRIPTION
The docs team has dramatically scaled down since this was added, and unfortunately it's not possible for the much smaller team to keep up with the volume of PRs.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
