### PR TITLE
Fix HLS integration

### DIFF
--- a/sdk/.hie-bios
+++ b/sdk/.hie-bios
@@ -2,7 +2,7 @@
 set -euo pipefail
 hie_bios_flags() {
   bazel run //compiler/damlc:damlc@ghci@bios \
-    | awk '
+    | awk -v execroot="$(bazel info execution_root)" '
       BEGIN { rts_opts = false }
       {
         if (rts_opts) {
@@ -16,6 +16,9 @@ hie_bios_flags() {
         } else if (match($0, "grpc_haskell_core_cbits")) {
         } else if (match($0, "-lmerged_cbits")) {
         } else {
+          # Temporary fix for https://github.com/tweag/rules_haskell/issues/2325
+          # Remove when upstream is patched.
+          sub(execroot "/", "", $0)
           print $0
         }
       }'

--- a/sdk/hie.yaml
+++ b/sdk/hie.yaml
@@ -1,0 +1,7 @@
+# Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cradle:
+  bios:
+    program: .hie-bios
+


### PR DESCRIPTION
HLS integration is mostly broken since we upgraded to Bazel 7 (#21041) and haskell_rules 1.0. The main issue is that the new `@bios` target imports the source files from the Bazel sandbox, instead of the source files from the workspace. It confuses HLS and VSCode: code navigation brings the user to the sandboxed files, and similarly, errors are sometimes reported in the sandboxed files. The user (me) ends up having two copies of the same files opened in the IDE, potentially with different unsaved edits, and stalled compiler errors. This issue was reported upstream in https://github.com/tweag/rules_haskell/issues/2325.

This PR contains a workaround, which is to strip out the Bazel `execroot` prefix to get relative paths from the workspace. This workaround should be reverted after https://github.com/tweag/rules_haskell/issues/2325 is fixed.

I tested it locally (on MacOS) and it was working fine, much better than before. `.hie-bios` is still slow to run (because of the  hundreds of `rlocation` resolutions, but hopefully it is only called once every time we run HLS.