### PR TITLE
Change the base Daml docs to point to the new docs site [3.3]

### DIFF
--- a/sdk/compiler/damlc/BUILD.bazel
+++ b/sdk/compiler/damlc/BUILD.bazel
@@ -354,7 +354,7 @@ genrule(
             --template=$(location :daml-base-rst-template) \\
             --index-template=$(location :daml-base-rst-index-template) \\
             --hoogle-template=$(location :daml-base-hoogle-template) \\
-            --base-url=https://docs.daml.com/daml/stdlib \\
+            --base-url=https://docs.digitalasset.com/build/3.3/reference/daml/stdlib \\
             --no-input-anchor \\
             --output-hoogle=$(location :daml-base-hoogle.txt) \\
             --output-anchor=$(location :daml-base-anchors.json) \\

--- a/sdk/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.md
+++ b/sdk/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.md
@@ -13,4 +13,4 @@ not present in the class itself.
 >
 > <a name="function-constrainedclassmethod-bar-5816"></a>[bar](#function-constrainedclassmethod-bar-5816)
 >
-> > : [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) t =\> t -\> t
+> > : [Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) t =\> t -\> t

--- a/sdk/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.rst
+++ b/sdk/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.rst
@@ -21,4 +21,4 @@ Typeclasses
   .. _function-constrainedclassmethod-bar-5816:
 
   `bar <function-constrainedclassmethod-bar-5816_>`_
-    \: `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ t \=\> t \-\> t
+    \: `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ t \=\> t \-\> t

--- a/sdk/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.md
+++ b/sdk/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.md
@@ -4,38 +4,38 @@
 
 <a name="type-constrainttuples-eq2-29566"></a>**type** [Eq2](#type-constrainttuples-eq2-29566) a b
 
-> = ([Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) a, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) b)
+> = ([Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) a, [Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) b)
 
 <a name="type-constrainttuples-eq3-18799"></a>**type** [Eq3](#type-constrainttuples-eq3-18799) a b c
 
-> = ([Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) a, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) b, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) c)
+> = ([Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) a, [Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) b, [Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) c)
 
 <a name="type-constrainttuples-eq4-25412"></a>**type** [Eq4](#type-constrainttuples-eq4-25412) a b c d
 
-> = ([Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) a, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) b, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) c, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) d)
+> = ([Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) a, [Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) b, [Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) c, [Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) d)
 
 ## Functions
 
 <a name="function-constrainttuples-eq2-16370"></a>[eq2](#function-constrainttuples-eq2-16370)
 
-> : [Eq2](#type-constrainttuples-eq2-29566) a b =\> a -\> a -\> b -\> b -\> [Bool](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)
+> : [Eq2](#type-constrainttuples-eq2-29566) a b =\> a -\> a -\> b -\> b -\> [Bool](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)
 
 <a name="function-constrainttuples-eq2tick-63686"></a>[eq2'](#function-constrainttuples-eq2tick-63686)
 
-> : ([Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) a, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) b) =\> a -\> a -\> b -\> b -\> [Bool](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)
+> : ([Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) a, [Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) b) =\> a -\> a -\> b -\> b -\> [Bool](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)
 
 <a name="function-constrainttuples-eq3-5603"></a>[eq3](#function-constrainttuples-eq3-5603)
 
-> : [Eq3](#type-constrainttuples-eq3-18799) a b c =\> a -\> a -\> b -\> b -\> c -\> c -\> [Bool](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)
+> : [Eq3](#type-constrainttuples-eq3-18799) a b c =\> a -\> a -\> b -\> b -\> c -\> c -\> [Bool](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)
 
 <a name="function-constrainttuples-eq3tick-36081"></a>[eq3'](#function-constrainttuples-eq3tick-36081)
 
-> : ([Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) a, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) b, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) c) =\> a -\> a -\> b -\> b -\> c -\> c -\> [Bool](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)
+> : ([Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) a, [Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) b, [Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) c) =\> a -\> a -\> b -\> b -\> c -\> c -\> [Bool](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)
 
 <a name="function-constrainttuples-eq4-77456"></a>[eq4](#function-constrainttuples-eq4-77456)
 
-> : [Eq4](#type-constrainttuples-eq4-25412) a b c d =\> a -\> a -\> b -\> b -\> c -\> c -\> d -\> d -\> [Bool](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)
+> : [Eq4](#type-constrainttuples-eq4-25412) a b c d =\> a -\> a -\> b -\> b -\> c -\> c -\> d -\> d -\> [Bool](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)
 
 <a name="function-constrainttuples-eq4tick-59016"></a>[eq4'](#function-constrainttuples-eq4tick-59016)
 
-> : ([Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) a, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) b, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) c, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) d) =\> a -\> a -\> b -\> b -\> c -\> c -\> d -\> d -\> [Bool](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)
+> : ([Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) a, [Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) b, [Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) c, [Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) d) =\> a -\> a -\> b -\> b -\> c -\> c -\> d -\> d -\> [Bool](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)

--- a/sdk/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.rst
+++ b/sdk/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.rst
@@ -9,17 +9,17 @@ Data Types
 .. _type-constrainttuples-eq2-29566:
 
 **type** `Eq2 <type-constrainttuples-eq2-29566_>`_ a b
-  \= (`Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ a, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ b)
+  \= (`Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ a, `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ b)
 
 .. _type-constrainttuples-eq3-18799:
 
 **type** `Eq3 <type-constrainttuples-eq3-18799_>`_ a b c
-  \= (`Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ a, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ b, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ c)
+  \= (`Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ a, `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ b, `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ c)
 
 .. _type-constrainttuples-eq4-25412:
 
 **type** `Eq4 <type-constrainttuples-eq4-25412_>`_ a b c d
-  \= (`Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ a, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ b, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ c, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ d)
+  \= (`Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ a, `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ b, `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ c, `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ d)
 
 Functions
 ^^^^^^^^^
@@ -27,29 +27,29 @@ Functions
 .. _function-constrainttuples-eq2-16370:
 
 `eq2 <function-constrainttuples-eq2-16370_>`_
-  \: `Eq2 <type-constrainttuples-eq2-29566_>`_ a b \=\> a \-\> a \-\> b \-\> b \-\> `Bool <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-66265>`_
+  \: `Eq2 <type-constrainttuples-eq2-29566_>`_ a b \=\> a \-\> a \-\> b \-\> b \-\> `Bool <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-bool-66265>`_
 
 .. _function-constrainttuples-eq2tick-63686:
 
 `eq2' <function-constrainttuples-eq2tick-63686_>`_
-  \: (`Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ a, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ b) \=\> a \-\> a \-\> b \-\> b \-\> `Bool <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-66265>`_
+  \: (`Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ a, `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ b) \=\> a \-\> a \-\> b \-\> b \-\> `Bool <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-bool-66265>`_
 
 .. _function-constrainttuples-eq3-5603:
 
 `eq3 <function-constrainttuples-eq3-5603_>`_
-  \: `Eq3 <type-constrainttuples-eq3-18799_>`_ a b c \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> `Bool <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-66265>`_
+  \: `Eq3 <type-constrainttuples-eq3-18799_>`_ a b c \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> `Bool <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-bool-66265>`_
 
 .. _function-constrainttuples-eq3tick-36081:
 
 `eq3' <function-constrainttuples-eq3tick-36081_>`_
-  \: (`Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ a, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ b, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ c) \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> `Bool <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-66265>`_
+  \: (`Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ a, `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ b, `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ c) \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> `Bool <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-bool-66265>`_
 
 .. _function-constrainttuples-eq4-77456:
 
 `eq4 <function-constrainttuples-eq4-77456_>`_
-  \: `Eq4 <type-constrainttuples-eq4-25412_>`_ a b c d \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> d \-\> d \-\> `Bool <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-66265>`_
+  \: `Eq4 <type-constrainttuples-eq4-25412_>`_ a b c d \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> d \-\> d \-\> `Bool <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-bool-66265>`_
 
 .. _function-constrainttuples-eq4tick-59016:
 
 `eq4' <function-constrainttuples-eq4tick-59016_>`_
-  \: (`Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ a, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ b, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ c, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ d) \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> d \-\> d \-\> `Bool <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-66265>`_
+  \: (`Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ a, `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ b, `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ c, `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ d) \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> d \-\> d \-\> `Bool <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-bool-66265>`_

--- a/sdk/compiler/damlc/tests/daml-test-files/DamlDocFormatting.EXPECTED.md
+++ b/sdk/compiler/damlc/tests/daml-test-files/DamlDocFormatting.EXPECTED.md
@@ -6,16 +6,16 @@
 
 > Signatory: sender, map (\\ r -\> (DA.Internal.Record.getField @"receiver" r)) receiverAmounts
 >
-> | Field                                                                                   | Type                                                                                    | Description |
-> | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
-> | sender                                                                                  | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
-> | receiverAmounts                                                                         | \[[ReceiverAmount](#type-damldocformatting-receiveramount-1032)\]                       |  |
+> | Field                                                                                                               | Type                                                                                                                | Description |
+> | :------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------ | :---------- |
+> | sender                                                                                                              | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> | receiverAmounts                                                                                                     | \[[ReceiverAmount](#type-damldocformatting-receiveramount-1032)\]                                                   |  |
 >
 > * <a name="type-damldocformatting-addreceiver-84828"></a>**Choice** [AddReceiver](#type-damldocformatting-addreceiver-84828)
 >
 >   Controller: undefined : Party
 >
->   Returns: [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Payment](#type-damldocformatting-payment-18108)
+>   Returns: [ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Payment](#type-damldocformatting-payment-18108)
 >
 >   | Field                                                         | Type                                                          | Description |
 >   | :------------------------------------------------------------ | :------------------------------------------------------------ | :---------- |
@@ -35,29 +35,29 @@
 
 > <a name="constr-damldocformatting-receiveramount-87105"></a>[ReceiverAmount](#constr-damldocformatting-receiveramount-87105)
 >
-> > | Field                                                                                   | Type                                                                                    | Description |
-> > | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
-> > | receiver                                                                                | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
-> > | amount                                                                                  | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  |  |
+> > | Field                                                                                                               | Type                                                                                                                | Description |
+> > | :------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------ | :---------- |
+> > | receiver                                                                                                            | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> > | amount                                                                                                              | [Decimal](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  |  |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) [ReceiverAmount](#type-damldocformatting-receiveramount-1032)
+> **instance** [Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) [ReceiverAmount](#type-damldocformatting-receiveramount-1032)
 >
-> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) [ReceiverAmount](#type-damldocformatting-receiveramount-1032)
+> **instance** [Ord](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) [ReceiverAmount](#type-damldocformatting-receiveramount-1032)
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) [ReceiverAmount](#type-damldocformatting-receiveramount-1032)
+> **instance** [Show](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-show-show-65360) [ReceiverAmount](#type-damldocformatting-receiveramount-1032)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "amount" [ReceiverAmount](#type-damldocformatting-receiveramount-1032) [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [GetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "amount" [ReceiverAmount](#type-damldocformatting-receiveramount-1032) [Decimal](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiver" [AddReceiver](#type-damldocformatting-addreceiver-84828) [ReceiverAmount](#type-damldocformatting-receiveramount-1032)
+> **instance** [GetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiver" [AddReceiver](#type-damldocformatting-addreceiver-84828) [ReceiverAmount](#type-damldocformatting-receiveramount-1032)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiver" [ReceiverAmount](#type-damldocformatting-receiveramount-1032) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiver" [ReceiverAmount](#type-damldocformatting-receiveramount-1032) [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiverAmounts" [Payment](#type-damldocformatting-payment-18108) \[[ReceiverAmount](#type-damldocformatting-receiveramount-1032)\]
+> **instance** [GetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiverAmounts" [Payment](#type-damldocformatting-payment-18108) \[[ReceiverAmount](#type-damldocformatting-receiveramount-1032)\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "amount" [ReceiverAmount](#type-damldocformatting-receiveramount-1032) [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [SetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "amount" [ReceiverAmount](#type-damldocformatting-receiveramount-1032) [Decimal](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiver" [AddReceiver](#type-damldocformatting-addreceiver-84828) [ReceiverAmount](#type-damldocformatting-receiveramount-1032)
+> **instance** [SetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiver" [AddReceiver](#type-damldocformatting-addreceiver-84828) [ReceiverAmount](#type-damldocformatting-receiveramount-1032)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiver" [ReceiverAmount](#type-damldocformatting-receiveramount-1032) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiver" [ReceiverAmount](#type-damldocformatting-receiveramount-1032) [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiverAmounts" [Payment](#type-damldocformatting-payment-18108) \[[ReceiverAmount](#type-damldocformatting-receiveramount-1032)\]
+> **instance** [SetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiverAmounts" [Payment](#type-damldocformatting-payment-18108) \[[ReceiverAmount](#type-damldocformatting-receiveramount-1032)\]

--- a/sdk/compiler/damlc/tests/daml-test-files/DamlDocFormatting.EXPECTED.rst
+++ b/sdk/compiler/damlc/tests/daml-test-files/DamlDocFormatting.EXPECTED.rst
@@ -20,7 +20,7 @@ Templates
        - Type
        - Description
      * - sender
-       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
        -
      * - receiverAmounts
        - \[`ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_\]
@@ -32,7 +32,7 @@ Templates
 
     Controller\: undefined \: Party
 
-    Returns\: `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Payment <type-damldocformatting-payment-18108_>`_
+    Returns\: `ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Payment <type-damldocformatting-payment-18108_>`_
 
     .. list-table::
        :widths: 15 10 30
@@ -72,30 +72,30 @@ Data Types
          - Type
          - Description
        * - receiver
-         - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+         - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
          -
        * - amount
-         - `Decimal <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135>`_
+         - `Decimal <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135>`_
          -
 
-  **instance** `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_
+  **instance** `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_
 
-  **instance** `Ord <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395>`_ `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_
+  **instance** `Ord <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395>`_ `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_
 
-  **instance** `Show <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360>`_ `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_
+  **instance** `Show <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-show-show-65360>`_ `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_
 
-  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"amount\" `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_ `Decimal <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135>`_
+  **instance** `GetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"amount\" `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_ `Decimal <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135>`_
 
-  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"receiver\" `AddReceiver <type-damldocformatting-addreceiver-84828_>`_ `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_
+  **instance** `GetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"receiver\" `AddReceiver <type-damldocformatting-addreceiver-84828_>`_ `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_
 
-  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"receiver\" `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_ `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+  **instance** `GetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"receiver\" `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_ `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
 
-  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"receiverAmounts\" `Payment <type-damldocformatting-payment-18108_>`_ \[`ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_\]
+  **instance** `GetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"receiverAmounts\" `Payment <type-damldocformatting-payment-18108_>`_ \[`ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_\]
 
-  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"amount\" `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_ `Decimal <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135>`_
+  **instance** `SetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"amount\" `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_ `Decimal <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135>`_
 
-  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"receiver\" `AddReceiver <type-damldocformatting-addreceiver-84828_>`_ `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_
+  **instance** `SetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"receiver\" `AddReceiver <type-damldocformatting-addreceiver-84828_>`_ `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_
 
-  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"receiver\" `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_ `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+  **instance** `SetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"receiver\" `ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_ `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
 
-  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"receiverAmounts\" `Payment <type-damldocformatting-payment-18108_>`_ \[`ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_\]
+  **instance** `SetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"receiverAmounts\" `Payment <type-damldocformatting-payment-18108_>`_ \[`ReceiverAmount <type-damldocformatting-receiveramount-1032_>`_\]

--- a/sdk/compiler/damlc/tests/daml-test-files/DamlDocHoogle.EXPECTED.md
+++ b/sdk/compiler/damlc/tests/daml-test-files/DamlDocHoogle.EXPECTED.md
@@ -8,9 +8,9 @@
 >
 > Signatory: p
 >
-> | Field                                                                                   | Type                                                                                    | Description |
-> | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
-> | p                                                                                       | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> | Field                                                                                                               | Type                                                                                                                | Description |
+> | :------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------ | :---------- |
+> | p                                                                                                                   | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
 >
 > * **Choice** Archive
 >
@@ -28,9 +28,9 @@
 >
 >   Returns: ()
 >
->   | Field                                                                          | Type                                                                           | Description |
->   | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
->   | i                                                                              | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
+>   | Field                                                                                                      | Type                                                                                                       | Description |
+>   | :--------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------- | :---------- |
+>   | i                                                                                                          | [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
 
 ## Interfaces
 
@@ -54,13 +54,13 @@
 >
 >   Controller: getController this
 >
->   Returns: [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+>   Returns: [Optional](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 >
->   | Field                                                                          | Type                                                                           | Description |
->   | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
->   | i                                                                              | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
+>   | Field                                                                                                      | Type                                                                                                       | Description |
+>   | :--------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------- | :---------- |
+>   | i                                                                                                          | [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
 >
-> * **Method getController :** [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> * **Method getController :** [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
 >
 >   getController docs
 
@@ -74,12 +74,12 @@
 >
 > > (no fields)
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) [I](#type-damldochoogle-i-6172) [View](#type-damldochoogle-view-20961)
+> **instance** [HasFromAnyView](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) [I](#type-damldochoogle-i-6172) [View](#type-damldochoogle-view-20961)
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) [I](#type-damldochoogle-i-6172) [View](#type-damldochoogle-view-20961)
+> **instance** [HasInterfaceView](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) [I](#type-damldochoogle-i-6172) [View](#type-damldochoogle-view-20961)
 
 ## Functions
 
 <a name="function-damldochoogle-getcontroller-29001"></a>[getController](#function-damldochoogle-getcontroller-29001)
 
-> : [I](#type-damldochoogle-i-6172) -\> [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> : [I](#type-damldochoogle-i-6172) -\> [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)

--- a/sdk/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.md
+++ b/sdk/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.md
@@ -18,15 +18,15 @@
 >
 > > : (a -\> b -\> b) -\> b -\> t a -\> b
 
-<a name="class-defaultmethods-traversablex-84604"></a>**class** ([Functor](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-base-functor-31205) t, [FoldableX](#class-defaultmethods-foldablex-43965) t) =\> [TraversableX](#class-defaultmethods-traversablex-84604) t **where**
+<a name="class-defaultmethods-traversablex-84604"></a>**class** ([Functor](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-base-functor-31205) t, [FoldableX](#class-defaultmethods-foldablex-43965) t) =\> [TraversableX](#class-defaultmethods-traversablex-84604) t **where**
 
 > <a name="function-defaultmethods-traversex-89947"></a>[traverseX](#function-defaultmethods-traversex-89947)
 >
-> > : [Applicative](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-prelude-applicative-9257) m =\> (a -\> m b) -\> t a -\> m (t b)
+> > : [Applicative](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-da-internal-prelude-applicative-9257) m =\> (a -\> m b) -\> t a -\> m (t b)
 >
 > <a name="function-defaultmethods-sequencex-92456"></a>[sequenceX](#function-defaultmethods-sequencex-92456)
 >
-> > : [Applicative](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-prelude-applicative-9257) m =\> t (m a) -\> m (t a)
+> > : [Applicative](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-da-internal-prelude-applicative-9257) m =\> t (m a) -\> m (t a)
 
 <a name="class-defaultmethods-id-10050"></a>**class** [Id](#class-defaultmethods-id-10050) a **where**
 
@@ -34,7 +34,7 @@
 >
 > > : a -\> a
 >
-> **instance** [Id](#class-defaultmethods-id-10050) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> **instance** [Id](#class-defaultmethods-id-10050) [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 
 <a name="class-defaultmethods-myshow-63060"></a>**class** [MyShow](#class-defaultmethods-myshow-63060) t **where**
 
@@ -42,12 +42,12 @@
 >
 > <a name="function-defaultmethods-myshow-32065"></a>[myShow](#function-defaultmethods-myshow-32065)
 >
-> > : t -\> [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+> > : t -\> [Text](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
 > >
 > > Doc for method.
 >
 > **default** myShow
 >
-> > : [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) t =\> t -\> [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+> > : [Show](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-show-show-65360) t =\> t -\> [Text](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
 > >
 > > Doc for default.

--- a/sdk/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.rst
+++ b/sdk/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.rst
@@ -31,17 +31,17 @@ Typeclasses
 
 .. _class-defaultmethods-traversablex-84604:
 
-**class** (`Functor <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-base-functor-31205>`_ t, `FoldableX <class-defaultmethods-foldablex-43965_>`_ t) \=\> `TraversableX <class-defaultmethods-traversablex-84604_>`_ t **where**
+**class** (`Functor <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-base-functor-31205>`_ t, `FoldableX <class-defaultmethods-foldablex-43965_>`_ t) \=\> `TraversableX <class-defaultmethods-traversablex-84604_>`_ t **where**
 
   .. _function-defaultmethods-traversex-89947:
 
   `traverseX <function-defaultmethods-traversex-89947_>`_
-    \: `Applicative <https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-prelude-applicative-9257>`_ m \=\> (a \-\> m b) \-\> t a \-\> m (t b)
+    \: `Applicative <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-da-internal-prelude-applicative-9257>`_ m \=\> (a \-\> m b) \-\> t a \-\> m (t b)
 
   .. _function-defaultmethods-sequencex-92456:
 
   `sequenceX <function-defaultmethods-sequencex-92456_>`_
-    \: `Applicative <https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-prelude-applicative-9257>`_ m \=\> t (m a) \-\> m (t a)
+    \: `Applicative <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-da-internal-prelude-applicative-9257>`_ m \=\> t (m a) \-\> m (t a)
 
 .. _class-defaultmethods-id-10050:
 
@@ -52,7 +52,7 @@ Typeclasses
   `id <function-defaultmethods-id-52623_>`_
     \: a \-\> a
 
-  **instance** `Id <class-defaultmethods-id-10050_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  **instance** `Id <class-defaultmethods-id-10050_>`_ `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
 .. _class-defaultmethods-myshow-63060:
 
@@ -63,12 +63,12 @@ Typeclasses
   .. _function-defaultmethods-myshow-32065:
 
   `myShow <function-defaultmethods-myshow-32065_>`_
-    \: t \-\> `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
+    \: t \-\> `Text <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
 
     Doc for method\.
 
   **default** myShow
 
-    \: `Show <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360>`_ t \=\> t \-\> `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
+    \: `Show <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-show-show-65360>`_ t \=\> t \-\> `Text <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
 
     Doc for default\.

--- a/sdk/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.md
+++ b/sdk/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.md
@@ -22,10 +22,10 @@
 > <a name="constr-deriving-disjunction-19371"></a>[Disjunction](#constr-deriving-disjunction-19371) \[[Formula](#type-deriving-formula-60264) t\]
 >
 >
-> **instance** [Functor](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-base-functor-31205) [Formula](#type-deriving-formula-60264)
+> **instance** [Functor](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-base-functor-31205) [Formula](#type-deriving-formula-60264)
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) t =\> [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) ([Formula](#type-deriving-formula-60264) t)
+> **instance** [Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) t =\> [Eq](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) ([Formula](#type-deriving-formula-60264) t)
 >
-> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) t =\> [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) ([Formula](#type-deriving-formula-60264) t)
+> **instance** [Ord](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) t =\> [Ord](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) ([Formula](#type-deriving-formula-60264) t)
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) t =\> [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) ([Formula](#type-deriving-formula-60264) t)
+> **instance** [Show](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-show-show-65360) t =\> [Show](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-show-show-65360) ([Formula](#type-deriving-formula-60264) t)

--- a/sdk/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.rst
+++ b/sdk/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.rst
@@ -40,10 +40,10 @@ Data Types
   `Disjunction <constr-deriving-disjunction-19371_>`_ \[`Formula <type-deriving-formula-60264_>`_ t\]
 
 
-  **instance** `Functor <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-base-functor-31205>`_ `Formula <type-deriving-formula-60264_>`_
+  **instance** `Functor <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-base-functor-31205>`_ `Formula <type-deriving-formula-60264_>`_
 
-  **instance** `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ t \=\> `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ (`Formula <type-deriving-formula-60264_>`_ t)
+  **instance** `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ t \=\> `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ (`Formula <type-deriving-formula-60264_>`_ t)
 
-  **instance** `Ord <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395>`_ t \=\> `Ord <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395>`_ (`Formula <type-deriving-formula-60264_>`_ t)
+  **instance** `Ord <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395>`_ t \=\> `Ord <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395>`_ (`Formula <type-deriving-formula-60264_>`_ t)
 
-  **instance** `Show <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360>`_ t \=\> `Show <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360>`_ (`Formula <type-deriving-formula-60264_>`_ t)
+  **instance** `Show <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-show-show-65360>`_ t \=\> `Show <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-show-show-65360>`_ (`Formula <type-deriving-formula-60264_>`_ t)

--- a/sdk/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
+++ b/sdk/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
@@ -6,10 +6,10 @@
 
 > Signatory: tfield0
 >
-> | Field                                                                                   | Type                                                                                    | Description |
-> | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
-> | tfield0                                                                                 | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
-> | tfield0'                                                                                | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> | Field                                                                                                               | Type                                                                                                                | Description |
+> | :------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------ | :---------- |
+> | tfield0                                                                                                             | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> | tfield0'                                                                                                            | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
 >
 > * **Choice** Archive
 >
@@ -31,10 +31,10 @@
 
 > Signatory: tfield1
 >
-> | Field                                                                                   | Type                                                                                    | Description |
-> | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
-> | tfield1                                                                                 | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
-> | tfield1'                                                                                | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> | Field                                                                                                               | Type                                                                                                                | Description |
+> | :------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------ | :---------- |
+> | tfield1                                                                                                             | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> | tfield1'                                                                                                            | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
 >
 > * **Choice** Archive
 >
@@ -56,10 +56,10 @@
 
 > Signatory: tfield2
 >
-> | Field                                                                                   | Type                                                                                    | Description |
-> | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
-> | tfield2                                                                                 | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
-> | tfield2'                                                                                | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> | Field                                                                                                               | Type                                                                                                                | Description |
+> | :------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------ | :---------- |
+> | tfield2                                                                                                             | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> | tfield2'                                                                                                            | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
 >
 > * **Choice** Archive
 >
@@ -81,10 +81,10 @@
 
 > Signatory: tfield3
 >
-> | Field                                                                                   | Type                                                                                    | Description |
-> | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
-> | tfield3                                                                                 | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
-> | tfield3'                                                                                | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> | Field                                                                                                               | Type                                                                                                                | Description |
+> | :------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------ | :---------- |
+> | tfield3                                                                                                             | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> | tfield3'                                                                                                            | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
 >
 > * **Choice** Archive
 >
@@ -130,15 +130,15 @@
 
 <a name="type-exportlist-data1-71597"></a>**data** [Data1](#type-exportlist-data1-71597)
 
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "field1" [Data1](#type-exportlist-data1-71597) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> **instance** [GetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "field1" [Data1](#type-exportlist-data1-71597) [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "field1" [Data1](#type-exportlist-data1-71597) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> **instance** [SetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "field1" [Data1](#type-exportlist-data1-71597) [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 
 <a name="type-exportlist-data2-35142"></a>**data** [Data2](#type-exportlist-data2-35142)
 
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "field2" [Data2](#type-exportlist-data2-35142) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> **instance** [GetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "field2" [Data2](#type-exportlist-data2-35142) [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "field2" [Data2](#type-exportlist-data2-35142) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> **instance** [SetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "field2" [Data2](#type-exportlist-data2-35142) [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 
 <a name="type-exportlist-data3-37219"></a>**data** [Data3](#type-exportlist-data3-37219)
 
@@ -146,45 +146,45 @@
 >
 > > (no fields)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "field3" [Data3](#type-exportlist-data3-37219) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> **instance** [GetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "field3" [Data3](#type-exportlist-data3-37219) [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "field3" [Data3](#type-exportlist-data3-37219) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> **instance** [SetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "field3" [Data3](#type-exportlist-data3-37219) [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 
 <a name="type-exportlist-data4-52140"></a>**data** [Data4](#type-exportlist-data4-52140)
 
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "field4" [Data4](#type-exportlist-data4-52140) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> **instance** [GetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "field4" [Data4](#type-exportlist-data4-52140) [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "field4" [Data4](#type-exportlist-data4-52140) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> **instance** [SetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "field4" [Data4](#type-exportlist-data4-52140) [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 
 <a name="type-exportlist-data5-28529"></a>**data** [Data5](#type-exportlist-data5-28529)
 
 > <a name="constr-exportlist-constr5-98773"></a>[Constr5](#constr-exportlist-constr5-98773)
 >
-> > | Field                                                                          | Type                                                                           | Description |
-> > | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
-> > | field5                                                                         | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
+> > | Field                                                                                                      | Type                                                                                                       | Description |
+> > | :--------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------- | :---------- |
+> > | field5                                                                                                     | [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "field5" [Data5](#type-exportlist-data5-28529) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> **instance** [GetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "field5" [Data5](#type-exportlist-data5-28529) [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "field5" [Data5](#type-exportlist-data5-28529) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> **instance** [SetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "field5" [Data5](#type-exportlist-data5-28529) [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 
 <a name="type-exportlist-data6-43450"></a>**data** [Data6](#type-exportlist-data6-43450)
 
 > <a name="constr-exportlist-constr6-5386"></a>[Constr6](#constr-exportlist-constr6-5386)
 >
-> > | Field                                                                          | Type                                                                           | Description |
-> > | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
-> > | field6                                                                         | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
+> > | Field                                                                                                      | Type                                                                                                       | Description |
+> > | :--------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------- | :---------- |
+> > | field6                                                                                                     | [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
 >
 > <a name="constr-exportlist-constr6tick-99942"></a>[Constr6'](#constr-exportlist-constr6tick-99942)
 >
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "field6" [Data6](#type-exportlist-data6-43450) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> **instance** [GetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "field6" [Data6](#type-exportlist-data6-43450) [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "field6" [Data6](#type-exportlist-data6-43450) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> **instance** [SetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "field6" [Data6](#type-exportlist-data6-43450) [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 
 ## Functions
 
 <a name="function-exportlist-function1-57949"></a>[function1](#function-exportlist-function1-57949)
 
-> : [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> : [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)

--- a/sdk/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
+++ b/sdk/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
@@ -20,10 +20,10 @@ Templates
        - Type
        - Description
      * - tfield0
-       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
        -
      * - tfield0'
-       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
        -
 
   + **Choice** Archive
@@ -58,10 +58,10 @@ Templates
        - Type
        - Description
      * - tfield1
-       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
        -
      * - tfield1'
-       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
        -
 
   + **Choice** Archive
@@ -96,10 +96,10 @@ Templates
        - Type
        - Description
      * - tfield2
-       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
        -
      * - tfield2'
-       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
        -
 
   + **Choice** Archive
@@ -134,10 +134,10 @@ Templates
        - Type
        - Description
      * - tfield3
-       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
        -
      * - tfield3'
-       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
        -
 
   + **Choice** Archive
@@ -201,17 +201,17 @@ Data Types
 
 **data** `Data1 <type-exportlist-data1-71597_>`_
 
-  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"field1\" `Data1 <type-exportlist-data1-71597_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  **instance** `GetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"field1\" `Data1 <type-exportlist-data1-71597_>`_ `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
-  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"field1\" `Data1 <type-exportlist-data1-71597_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  **instance** `SetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"field1\" `Data1 <type-exportlist-data1-71597_>`_ `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
 .. _type-exportlist-data2-35142:
 
 **data** `Data2 <type-exportlist-data2-35142_>`_
 
-  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"field2\" `Data2 <type-exportlist-data2-35142_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  **instance** `GetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"field2\" `Data2 <type-exportlist-data2-35142_>`_ `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
-  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"field2\" `Data2 <type-exportlist-data2-35142_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  **instance** `SetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"field2\" `Data2 <type-exportlist-data2-35142_>`_ `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
 .. _type-exportlist-data3-37219:
 
@@ -223,17 +223,17 @@ Data Types
 
     (no fields)
 
-  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"field3\" `Data3 <type-exportlist-data3-37219_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  **instance** `GetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"field3\" `Data3 <type-exportlist-data3-37219_>`_ `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
-  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"field3\" `Data3 <type-exportlist-data3-37219_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  **instance** `SetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"field3\" `Data3 <type-exportlist-data3-37219_>`_ `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
 .. _type-exportlist-data4-52140:
 
 **data** `Data4 <type-exportlist-data4-52140_>`_
 
-  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"field4\" `Data4 <type-exportlist-data4-52140_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  **instance** `GetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"field4\" `Data4 <type-exportlist-data4-52140_>`_ `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
-  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"field4\" `Data4 <type-exportlist-data4-52140_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  **instance** `SetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"field4\" `Data4 <type-exportlist-data4-52140_>`_ `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
 .. _type-exportlist-data5-28529:
 
@@ -251,12 +251,12 @@ Data Types
          - Type
          - Description
        * - field5
-         - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+         - `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
          -
 
-  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"field5\" `Data5 <type-exportlist-data5-28529_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  **instance** `GetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"field5\" `Data5 <type-exportlist-data5-28529_>`_ `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
-  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"field5\" `Data5 <type-exportlist-data5-28529_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  **instance** `SetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"field5\" `Data5 <type-exportlist-data5-28529_>`_ `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
 .. _type-exportlist-data6-43450:
 
@@ -274,7 +274,7 @@ Data Types
          - Type
          - Description
        * - field6
-         - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+         - `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
          -
 
   .. _constr-exportlist-constr6tick-99942:
@@ -282,9 +282,9 @@ Data Types
   `Constr6' <constr-exportlist-constr6tick-99942_>`_
 
 
-  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"field6\" `Data6 <type-exportlist-data6-43450_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  **instance** `GetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"field6\" `Data6 <type-exportlist-data6-43450_>`_ `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
-  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"field6\" `Data6 <type-exportlist-data6-43450_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  **instance** `SetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"field6\" `Data6 <type-exportlist-data6-43450_>`_ `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
 Functions
 ^^^^^^^^^
@@ -292,4 +292,4 @@ Functions
 .. _function-exportlist-function1-57949:
 
 `function1 <function-exportlist-function1-57949_>`_
-  \: `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  \: `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_

--- a/sdk/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.md
+++ b/sdk/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.md
@@ -6,11 +6,11 @@
 
 > Signatory: issuer, owner
 >
-> | Field                                                                                   | Type                                                                                    | Description |
-> | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
-> | issuer                                                                                  | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
-> | owner                                                                                   | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
-> | amount                                                                                  | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)          |  |
+> | Field                                                                                                               | Type                                                                                                                | Description |
+> | :------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------ | :---------- |
+> | issuer                                                                                                              | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> | owner                                                                                                               | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> | amount                                                                                                              | [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)          |  |
 >
 > * **Choice** Archive
 >
@@ -42,11 +42,11 @@
 >
 >   Controller: getOwner this
 >
->   Returns: [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651)
+>   Returns: [ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651)
 >
->   | Field                                                                          | Type                                                                           | Description |
->   | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
->   | byHowMuch                                                                      | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
+>   | Field                                                                                                      | Type                                                                                                       | Description |
+>   | :--------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------- | :---------- |
+>   | byHowMuch                                                                                                  | [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
 >
 > * <a name="type-interface-noop-44317"></a>**Choice** [Noop](#type-interface-noop-44317)
 >
@@ -64,35 +64,35 @@
 >
 >   Controller: getOwner this
 >
->   Returns: ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651), [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651))
+>   Returns: ([ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651), [ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651))
 >
->   | Field                                                                          | Type                                                                           | Description |
->   | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
->   | splitAmount                                                                    | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) | A choice field comment. |
+>   | Field                                                                                                      | Type                                                                                                       | Description |
+>   | :--------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------- | :---------- |
+>   | splitAmount                                                                                                | [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261) | A choice field comment. |
 >
 > * <a name="type-interface-transfer-15068"></a>**Choice** [Transfer](#type-interface-transfer-15068)
 >
 >   Controller: getOwner this, newOwner
 >
->   Returns: [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651)
+>   Returns: [ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651)
 >
->   | Field                                                                                   | Type                                                                                    | Description |
->   | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
->   | newOwner                                                                                | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+>   | Field                                                                                                               | Type                                                                                                                | Description |
+>   | :------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------ | :---------- |
+>   | newOwner                                                                                                            | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
 >
-> * **Method getAmount :** [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> * **Method getAmount :** [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 >
-> * **Method getOwner :** [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> * **Method getOwner :** [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
 >
 >   A method comment.
 >
-> * **Method noopImpl :** () -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ()
+> * **Method noopImpl :** () -\> [Update](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ()
 >
-> * **Method setAmount :** [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Token](#type-interface-token-10651)
+> * **Method setAmount :** [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Token](#type-interface-token-10651)
 >
-> * **Method splitImpl :** [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651), [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651))
+> * **Method splitImpl :** [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Update](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651), [ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651))
 >
-> * **Method transferImpl :** [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651))
+> * **Method transferImpl :** [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) -\> [Update](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651))
 
 ## Data Types
 
@@ -102,32 +102,32 @@
 >
 > > (no fields)
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) [Token](#type-interface-token-10651) [EmptyInterfaceView](#type-interface-emptyinterfaceview-28816)
+> **instance** [HasFromAnyView](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) [Token](#type-interface-token-10651) [EmptyInterfaceView](#type-interface-emptyinterfaceview-28816)
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) [Token](#type-interface-token-10651) [EmptyInterfaceView](#type-interface-emptyinterfaceview-28816)
+> **instance** [HasInterfaceView](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) [Token](#type-interface-token-10651) [EmptyInterfaceView](#type-interface-emptyinterfaceview-28816)
 
 ## Functions
 
 <a name="function-interface-getowner-36980"></a>[getOwner](#function-interface-getowner-36980)
 
-> : [Token](#type-interface-token-10651) -\> [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> : [Token](#type-interface-token-10651) -\> [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
 
 <a name="function-interface-getamount-416"></a>[getAmount](#function-interface-getamount-416)
 
-> : [Token](#type-interface-token-10651) -\> [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> : [Token](#type-interface-token-10651) -\> [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 
 <a name="function-interface-setamount-37812"></a>[setAmount](#function-interface-setamount-37812)
 
-> : [Token](#type-interface-token-10651) -\> [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Token](#type-interface-token-10651)
+> : [Token](#type-interface-token-10651) -\> [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Token](#type-interface-token-10651)
 
 <a name="function-interface-splitimpl-93694"></a>[splitImpl](#function-interface-splitimpl-93694)
 
-> : [Token](#type-interface-token-10651) -\> [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651), [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651))
+> : [Token](#type-interface-token-10651) -\> [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Update](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651), [ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651))
 
 <a name="function-interface-transferimpl-36342"></a>[transferImpl](#function-interface-transferimpl-36342)
 
-> : [Token](#type-interface-token-10651) -\> [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651))
+> : [Token](#type-interface-token-10651) -\> [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) -\> [Update](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-interface-token-10651))
 
 <a name="function-interface-noopimpl-41891"></a>[noopImpl](#function-interface-noopimpl-41891)
 
-> : [Token](#type-interface-token-10651) -\> () -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ()
+> : [Token](#type-interface-token-10651) -\> () -\> [Update](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ()

--- a/sdk/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.rst
+++ b/sdk/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.rst
@@ -20,13 +20,13 @@ Templates
        - Type
        - Description
      * - issuer
-       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
        -
      * - owner
-       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
        -
      * - amount
-       - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+       - `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
        -
 
   + **Choice** Archive
@@ -64,7 +64,7 @@ Interfaces
 
     Controller\: getOwner this
 
-    Returns\: `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_
+    Returns\: `ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_
 
     .. list-table::
        :widths: 15 10 30
@@ -74,7 +74,7 @@ Interfaces
          - Type
          - Description
        * - byHowMuch
-         - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+         - `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
          -
 
   + .. _type-interface-noop-44317:
@@ -104,7 +104,7 @@ Interfaces
 
     Controller\: getOwner this
 
-    Returns\: (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_, `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_)
+    Returns\: (`ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_, `ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_)
 
     .. list-table::
        :widths: 15 10 30
@@ -114,7 +114,7 @@ Interfaces
          - Type
          - Description
        * - splitAmount
-         - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+         - `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
          - A choice field comment\.
 
   + .. _type-interface-transfer-15068:
@@ -123,7 +123,7 @@ Interfaces
 
     Controller\: getOwner this, newOwner
 
-    Returns\: `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_
+    Returns\: `ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_
 
     .. list-table::
        :widths: 15 10 30
@@ -133,22 +133,22 @@ Interfaces
          - Type
          - Description
        * - newOwner
-         - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+         - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
          -
 
-  + **Method getAmount \:** `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  + **Method getAmount \:** `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
-  + **Method getOwner \:** `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+  + **Method getOwner \:** `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
 
     A method comment\.
 
-  + **Method noopImpl \:** () \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ ()
+  + **Method noopImpl \:** () \-\> `Update <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ ()
 
-  + **Method setAmount \:** `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Token <type-interface-token-10651_>`_
+  + **Method setAmount \:** `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Token <type-interface-token-10651_>`_
 
-  + **Method splitImpl \:** `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_, `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_)
+  + **Method splitImpl \:** `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Update <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_, `ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_)
 
-  + **Method transferImpl \:** `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_)
+  + **Method transferImpl \:** `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_ \-\> `Update <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_)
 
 Data Types
 ^^^^^^^^^^
@@ -163,9 +163,9 @@ Data Types
 
     (no fields)
 
-  **instance** `HasFromAnyView <https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108>`_ `Token <type-interface-token-10651_>`_ `EmptyInterfaceView <type-interface-emptyinterfaceview-28816_>`_
+  **instance** `HasFromAnyView <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108>`_ `Token <type-interface-token-10651_>`_ `EmptyInterfaceView <type-interface-emptyinterfaceview-28816_>`_
 
-  **instance** `HasInterfaceView <https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492>`_ `Token <type-interface-token-10651_>`_ `EmptyInterfaceView <type-interface-emptyinterfaceview-28816_>`_
+  **instance** `HasInterfaceView <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492>`_ `Token <type-interface-token-10651_>`_ `EmptyInterfaceView <type-interface-emptyinterfaceview-28816_>`_
 
 Functions
 ^^^^^^^^^
@@ -173,29 +173,29 @@ Functions
 .. _function-interface-getowner-36980:
 
 `getOwner <function-interface-getowner-36980_>`_
-  \: `Token <type-interface-token-10651_>`_ \-\> `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+  \: `Token <type-interface-token-10651_>`_ \-\> `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
 
 .. _function-interface-getamount-416:
 
 `getAmount <function-interface-getamount-416_>`_
-  \: `Token <type-interface-token-10651_>`_ \-\> `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  \: `Token <type-interface-token-10651_>`_ \-\> `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
 .. _function-interface-setamount-37812:
 
 `setAmount <function-interface-setamount-37812_>`_
-  \: `Token <type-interface-token-10651_>`_ \-\> `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Token <type-interface-token-10651_>`_
+  \: `Token <type-interface-token-10651_>`_ \-\> `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Token <type-interface-token-10651_>`_
 
 .. _function-interface-splitimpl-93694:
 
 `splitImpl <function-interface-splitimpl-93694_>`_
-  \: `Token <type-interface-token-10651_>`_ \-\> `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_, `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_)
+  \: `Token <type-interface-token-10651_>`_ \-\> `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Update <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_, `ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_)
 
 .. _function-interface-transferimpl-36342:
 
 `transferImpl <function-interface-transferimpl-36342_>`_
-  \: `Token <type-interface-token-10651_>`_ \-\> `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_)
+  \: `Token <type-interface-token-10651_>`_ \-\> `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_ \-\> `Update <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-interface-token-10651_>`_)
 
 .. _function-interface-noopimpl-41891:
 
 `noopImpl <function-interface-noopimpl-41891_>`_
-  \: `Token <type-interface-token-10651_>`_ \-\> () \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ ()
+  \: `Token <type-interface-token-10651_>`_ \-\> () \-\> `Update <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ ()

--- a/sdk/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.md
+++ b/sdk/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.md
@@ -6,13 +6,13 @@
 
 > Signatory: issuer
 >
-> | Field                                                                                       | Type                                                                                        | Description |
-> | :------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------ | :---------- |
-> | issuer                                                                                      | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)     |  |
-> | owner                                                                                       | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)     |  |
-> | currency                                                                                    | [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)            | only 3-letter symbols are allowed |
-> | amount                                                                                      | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)      | must be positive |
-> | regulators                                                                                  | \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\] | `regulators` may observe any use of the `Iou` |
+> | Field                                                                                                                   | Type                                                                                                                    | Description |
+> | :---------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------- | :---------- |
+> | issuer                                                                                                                  | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)     |  |
+> | owner                                                                                                                   | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)     |  |
+> | currency                                                                                                                | [Text](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952)            | only 3-letter symbols are allowed |
+> | amount                                                                                                                  | [Decimal](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)      | must be positive |
+> | regulators                                                                                                              | \[[Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\] | `regulators` may observe any use of the `Iou` |
 >
 > * **Choice** Archive
 >
@@ -36,11 +36,11 @@
 >
 >   Controller: owner
 >
->   Returns: [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962)
+>   Returns: [ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962)
 >
->   | Field                                                                                                                          | Type                                                                                                                           | Description |
->   | :----------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------- | :---------- |
->   | otherCid                                                                                                                       | [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962) | Must have same owner, issuer, and currency. The regulators may differ, and are taken from the original `Iou`. |
+>   | Field                                                                                                                                                      | Type                                                                                                                                                       | Description |
+>   | :--------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------- |
+>   | otherCid                                                                                                                                                   | [ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962) | Must have same owner, issuer, and currency. The regulators may differ, and are taken from the original `Iou`. |
 >
 > * <a name="type-iou12-split-33517"></a>**Choice** [Split](#type-iou12-split-33517)
 >
@@ -48,11 +48,11 @@
 >
 >   Controller: owner
 >
->   Returns: ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962), [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962))
+>   Returns: ([ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962), [ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962))
 >
->   | Field                                                                                  | Type                                                                                   | Description |
->   | :------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------- | :---------- |
->   | splitAmount                                                                            | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135) | must be between zero and original amount |
+>   | Field                                                                                                              | Type                                                                                                               | Description |
+>   | :----------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- | :---------- |
+>   | splitAmount                                                                                                        | [Decimal](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135) | must be between zero and original amount |
 >
 > * <a name="type-iou12-transfer-99339"></a>**Choice** [Transfer](#type-iou12-transfer-99339)
 >
@@ -60,21 +60,21 @@
 >
 >   Controller: owner
 >
->   Returns: [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962)
+>   Returns: [ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962)
 >
->   | Field                                                                                   | Type                                                                                    | Description |
->   | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
->   | newOwner                                                                                | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+>   | Field                                                                                                               | Type                                                                                                                | Description |
+>   | :------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------ | :---------- |
+>   | newOwner                                                                                                            | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
 
 ## Functions
 
 <a name="function-iou12-updateowner-56091"></a>[updateOwner](#function-iou12-updateowner-56091)
 
-> : [Iou](#type-iou12-iou-72962) -\> [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962))
+> : [Iou](#type-iou12-iou-72962) -\> [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) -\> [Update](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962))
 
 <a name="function-iou12-updateamount-41005"></a>[updateAmount](#function-iou12-updateamount-41005)
 
-> : [Iou](#type-iou12-iou-72962) -\> [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962))
+> : [Iou](#type-iou12-iou-72962) -\> [Decimal](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135) -\> [Update](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Iou](#type-iou12-iou-72962))
 
 <a name="function-iou12-main-28537"></a>[main](#function-iou12-main-28537)
 

--- a/sdk/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.rst
+++ b/sdk/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.rst
@@ -20,19 +20,19 @@ Templates
        - Type
        - Description
      * - issuer
-       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
        -
      * - owner
-       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
        -
      * - currency
-       - `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
+       - `Text <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
        - only 3\-letter symbols are allowed
      * - amount
-       - `Decimal <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135>`_
+       - `Decimal <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135>`_
        - must be positive
      * - regulators
-       - \[`Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_\]
+       - \[`Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_\]
        - ``regulators`` may observe any use of the ``Iou``
 
   + **Choice** Archive
@@ -61,7 +61,7 @@ Templates
 
     Controller\: owner
 
-    Returns\: `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_
+    Returns\: `ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_
 
     .. list-table::
        :widths: 15 10 30
@@ -71,7 +71,7 @@ Templates
          - Type
          - Description
        * - otherCid
-         - `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_
+         - `ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_
          - Must have same owner, issuer, and currency\. The regulators may differ, and are taken from the original ``Iou``\.
 
   + .. _type-iou12-split-33517:
@@ -82,7 +82,7 @@ Templates
 
     Controller\: owner
 
-    Returns\: (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_, `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_)
+    Returns\: (`ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_, `ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_)
 
     .. list-table::
        :widths: 15 10 30
@@ -92,7 +92,7 @@ Templates
          - Type
          - Description
        * - splitAmount
-         - `Decimal <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135>`_
+         - `Decimal <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135>`_
          - must be between zero and original amount
 
   + .. _type-iou12-transfer-99339:
@@ -103,7 +103,7 @@ Templates
 
     Controller\: owner
 
-    Returns\: `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_
+    Returns\: `ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_
 
     .. list-table::
        :widths: 15 10 30
@@ -113,7 +113,7 @@ Templates
          - Type
          - Description
        * - newOwner
-         - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+         - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
          -
 
 Functions
@@ -122,12 +122,12 @@ Functions
 .. _function-iou12-updateowner-56091:
 
 `updateOwner <function-iou12-updateowner-56091_>`_
-  \: `Iou <type-iou12-iou-72962_>`_ \-\> `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_)
+  \: `Iou <type-iou12-iou-72962_>`_ \-\> `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_ \-\> `Update <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_)
 
 .. _function-iou12-updateamount-41005:
 
 `updateAmount <function-iou12-updateamount-41005_>`_
-  \: `Iou <type-iou12-iou-72962_>`_ \-\> `Decimal <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_)
+  \: `Iou <type-iou12-iou-72962_>`_ \-\> `Decimal <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135>`_ \-\> `Update <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Iou <type-iou12-iou-72962_>`_)
 
 .. _function-iou12-main-28537:
 

--- a/sdk/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
+++ b/sdk/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
@@ -6,23 +6,23 @@
 
 > <a name="constr-newtype-nat-30825"></a>[Nat](#constr-newtype-nat-30825)
 >
-> > | Field                                                                          | Type                                                                           | Description |
-> > | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
-> > | unNat                                                                          | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
+> > | Field                                                                                                      | Type                                                                                                       | Description |
+> > | :--------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------- | :---------- |
+> > | unNat                                                                                                      | [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "unNat" [Nat](#type-newtype-nat-87202) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> **instance** [GetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "unNat" [Nat](#type-newtype-nat-87202) [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "unNat" [Nat](#type-newtype-nat-87202) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> **instance** [SetField](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "unNat" [Nat](#type-newtype-nat-87202) [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 
 ## Functions
 
 <a name="function-newtype-mknat-18836"></a>[mkNat](#function-newtype-mknat-18836)
 
-> : [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Nat](#type-newtype-nat-87202)
+> : [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Nat](#type-newtype-nat-87202)
 
 <a name="function-newtype-unsafemknat-5876"></a>[unsafeMkNat](#function-newtype-unsafemknat-5876)
 
-> : [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Nat](#type-newtype-nat-87202)
+> : [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Nat](#type-newtype-nat-87202)
 
 <a name="function-newtype-zero0-56775"></a>[zero0](#function-newtype-zero0-56775)
 
@@ -34,12 +34,12 @@
 
 <a name="function-newtype-unnat1-45463"></a>[unNat1](#function-newtype-unnat1-45463)
 
-> : [Nat](#type-newtype-nat-87202) -\> [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> : [Nat](#type-newtype-nat-87202) -\> [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 
 <a name="function-newtype-unnat2-74120"></a>[unNat2](#function-newtype-unnat2-74120)
 
-> : [Nat](#type-newtype-nat-87202) -\> [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> : [Nat](#type-newtype-nat-87202) -\> [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
 
 <a name="function-newtype-unnat3-66997"></a>[unNat3](#function-newtype-unnat3-66997)
 
-> : [Nat](#type-newtype-nat-87202) -\> [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> : [Nat](#type-newtype-nat-87202) -\> [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)

--- a/sdk/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
+++ b/sdk/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
@@ -22,12 +22,12 @@ Data Types
          - Type
          - Description
        * - unNat
-         - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+         - `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
          -
 
-  **instance** `GetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"unNat\" `Nat <type-newtype-nat-87202_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  **instance** `GetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979>`_ \"unNat\" `Nat <type-newtype-nat-87202_>`_ `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
-  **instance** `SetField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"unNat\" `Nat <type-newtype-nat-87202_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  **instance** `SetField <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311>`_ \"unNat\" `Nat <type-newtype-nat-87202_>`_ `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
 Functions
 ^^^^^^^^^
@@ -35,12 +35,12 @@ Functions
 .. _function-newtype-mknat-18836:
 
 `mkNat <function-newtype-mknat-18836_>`_
-  \: `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Nat <type-newtype-nat-87202_>`_
+  \: `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Nat <type-newtype-nat-87202_>`_
 
 .. _function-newtype-unsafemknat-5876:
 
 `unsafeMkNat <function-newtype-unsafemknat-5876_>`_
-  \: `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Nat <type-newtype-nat-87202_>`_
+  \: `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Nat <type-newtype-nat-87202_>`_
 
 .. _function-newtype-zero0-56775:
 
@@ -55,14 +55,14 @@ Functions
 .. _function-newtype-unnat1-45463:
 
 `unNat1 <function-newtype-unnat1-45463_>`_
-  \: `Nat <type-newtype-nat-87202_>`_ \-\> `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  \: `Nat <type-newtype-nat-87202_>`_ \-\> `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
 .. _function-newtype-unnat2-74120:
 
 `unNat2 <function-newtype-unnat2-74120_>`_
-  \: `Nat <type-newtype-nat-87202_>`_ \-\> `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  \: `Nat <type-newtype-nat-87202_>`_ \-\> `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
 
 .. _function-newtype-unnat3-66997:
 
 `unNat3 <function-newtype-unnat3-66997_>`_
-  \: `Nat <type-newtype-nat-87202_>`_ \-\> `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  \: `Nat <type-newtype-nat-87202_>`_ \-\> `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_

--- a/sdk/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.md
+++ b/sdk/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.md
@@ -6,11 +6,11 @@
 
 > Signatory: issuer, owner
 >
-> | Field                                                                                   | Type                                                                                    | Description |
-> | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
-> | issuer                                                                                  | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
-> | owner                                                                                   | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
-> | amount                                                                                  | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)          |  |
+> | Field                                                                                                               | Type                                                                                                                | Description |
+> | :------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------ | :---------- |
+> | issuer                                                                                                              | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> | owner                                                                                                               | [Party](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> | amount                                                                                                              | [Int](https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261)          |  |
 >
 > * **Choice** Archive
 >

--- a/sdk/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.rst
+++ b/sdk/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.rst
@@ -20,13 +20,13 @@ Templates
        - Type
        - Description
      * - issuer
-       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
        -
      * - owner
-       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - `Party <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
        -
      * - amount
-       - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+       - `Int <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
        -
 
   + **Choice** Archive

--- a/sdk/compiler/damlc/tests/daml-test-files/SingleConEnum.EXPECTED.rst
+++ b/sdk/compiler/damlc/tests/daml-test-files/SingleConEnum.EXPECTED.rst
@@ -15,9 +15,9 @@ Data Types
   `Red <constr-singleconenum-red-9210_>`_
 
 
-  **instance** `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ `Color <type-singleconenum-color-64951_>`_
+  **instance** `Eq <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713>`_ `Color <type-singleconenum-color-64951_>`_
 
-  **instance** `Show <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360>`_ `Color <type-singleconenum-color-64951_>`_
+  **instance** `Show <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#class-ghc-show-show-65360>`_ `Color <type-singleconenum-color-64951_>`_
 
 Functions
 ^^^^^^^^^
@@ -30,4 +30,4 @@ Functions
 .. _function-singleconenum-isred-30935:
 
 `isRed <function-singleconenum-isred-30935_>`_
-  \: `Color <type-singleconenum-color-64951_>`_ \-\> `Bool <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-66265>`_
+  \: `Color <type-singleconenum-color-64951_>`_ \-\> `Bool <https://docs.digitalasset.com/build/3.3/reference/daml/stdlib/Prelude.html#type-ghc-types-bool-66265>`_


### PR DESCRIPTION
Change the base Daml docs to point to the new docs site (backport of #21680).
