### PR TITLE
Fix the underlines for the enterprise file.

### DIFF
--- a/sdk/docs/manually-written/overview/overview/enterprise.rst
+++ b/sdk/docs/manually-written/overview/overview/enterprise.rst
@@ -1,5 +1,5 @@
 Enterprise Suite for Canton
-***************************
+###########################
 
 Digital Asset offers an enterprise distribution of Canton as well as complementary
 application modules and services geared towards helping institutions bring robust

--- a/sdk/docs/sharable/overview/overview/enterprise.rst
+++ b/sdk/docs/sharable/overview/overview/enterprise.rst
@@ -1,5 +1,5 @@
 Enterprise Suite for Canton
-***************************
+###########################
 
 Digital Asset offers an enterprise distribution of Canton as well as complementary
 application modules and services geared towards helping institutions bring robust


### PR DESCRIPTION
Docs replication is failing (see https://github.com/DACH-NY/docs-website/pull/807) because the new `enterprise.rst` page has multiple top-level headers at the same level.

Make the first header "higher" than the other ones so that the docs build stops complaining.

This is probably a warning/error we can roll out to all of the builds to make sure that this is fixed prior to merging in, but just doing the small thing for now to make replication work again.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
