### PR TITLE
Fix to ensure that benchmark script carries on ru nning if no snapshot data was generated for a dar and script

### DIFF
--- a/sdk/daml-lf/snapshot/scripts/generate-benchmarks.sh
+++ b/sdk/daml-lf/snapshot/scripts/generate-benchmarks.sh
@@ -27,19 +27,23 @@ for ((i=0;i<$SIZE;++i)); do
   for ((j=0;j<$SCRIPTS_SIZE;++j)); do
     SCRIPT_NAME=$(cat "$SNAPSHOT_CONFIG" | jq -r ".[$i].scripts[$j]")
     SCRIPT_FUNC=$(echo "$SCRIPT_NAME" | cut -d ":" -f 2)
-    ENTRIES_FILE=$(ls "$SNAPSHOT_DIR/$DAR_NAME/$SCRIPT_FUNC"/snapshot-participant0*.bin)
-    CHOICES_FILE=$(ls "$SNAPSHOT_DIR/$DAR_NAME/$SCRIPT_FUNC"/snapshot-participant0*.bin.choices)
-    for CHOICE in $(cat "$CHOICES_FILE"); do
-      MODULE_NAME=$(echo "${CHOICE}" | cut -d ":" -f 2)
-      TEMPLATE_NAME=$(echo "${CHOICE}" | cut -d ":" -f 3)
-      CHOICE_NAME=$(echo "${CHOICE}" | cut -d ":" -f 4)
-      bazel run --sandbox_debug //daml-lf/snapshot:replay-benchmark -- \
-        -p entriesFile="$ENTRIES_FILE" \
-        -p choiceName="$MODULE_NAME:$TEMPLATE_NAME:$CHOICE_NAME" \
-        -p darFile="$REPO/$DAR_DIR/$DAR_NAME" \
-        -rff "$SNAPSHOT_DIR/$DAR_NAME/$SCRIPT_FUNC/jmh-result-$CHOICE_NAME.json" \
-        -rf json || true
-    done
+    if [ -f "$SNAPSHOT_DIR/$DAR_NAME/$SCRIPT_FUNC"/snapshot-participant0*.bin ]; then
+      ENTRIES_FILE=$(ls "$SNAPSHOT_DIR/$DAR_NAME/$SCRIPT_FUNC"/snapshot-participant0*.bin)
+      CHOICES_FILE=$(ls "$SNAPSHOT_DIR/$DAR_NAME/$SCRIPT_FUNC"/snapshot-participant0*.bin.choices)
+      for CHOICE in $(cat "$CHOICES_FILE"); do
+        MODULE_NAME=$(echo "${CHOICE}" | cut -d ":" -f 2)
+        TEMPLATE_NAME=$(echo "${CHOICE}" | cut -d ":" -f 3)
+        CHOICE_NAME=$(echo "${CHOICE}" | cut -d ":" -f 4)
+        bazel run --sandbox_debug //daml-lf/snapshot:replay-benchmark -- \
+          -p entriesFile="$ENTRIES_FILE" \
+          -p choiceName="$MODULE_NAME:$TEMPLATE_NAME:$CHOICE_NAME" \
+          -p darFile="$REPO/$DAR_DIR/$DAR_NAME" \
+          -rff "$SNAPSHOT_DIR/$DAR_NAME/$SCRIPT_FUNC/jmh-result-$CHOICE_NAME.json" \
+          -rf json || true
+      done
+    else
+      echo "Skipping benchmarking for $DAR_NAME/$SCRIPT_FUNC as no snapshot data has been saved"
+    fi
   done
 done
 


### PR DESCRIPTION
`generate-benchmarks.sh` assumes that `generate-snapshots.sh` has previously generated a snapshot file for each dar and script in the snapshot config JSON file. This patch provides a fix for that assumption.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
