### PR TITLE
Ensure empty JSON files can be loaded

### DIFF
--- a/sdk/daml-lf/snapshot/scripts/display-benchmarks.py
+++ b/sdk/daml-lf/snapshot/scripts/display-benchmarks.py
@@ -6,6 +6,7 @@ import json
 import os
 import pandas as pd
 import plotly.express as px
+from json.decoder import JSONDecodeError
 
 def get_jmh_data(base_dir):
     result = []
@@ -14,7 +15,10 @@ def get_jmh_data(base_dir):
             for jmh_data in os.listdir("{}/{}/{}".format(base_dir, dar_file, script)):
                 if jmh_data.endswith(".json"):
                     with open("{}/{}/{}/{}".format(base_dir, dar_file, script, jmh_data)) as fd:
-                        data = json.load(fd)
+                        try:
+                            data = json.load(fd)
+                        except JSONDecodeError:
+                            data = []
                         fd.close()
                         if len(data) > 0:
                             entry = {


### PR DESCRIPTION
Currently, if there is a JSON decode exception (e.g. because the JMH benchmarking JSON file is empty) then the exception isn't handled. Here we recover by simply setting the loaded data to be an empty list.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
