### PR TITLE
Use da-hls as the default language server in PATH

### DIFF
--- a/sdk/dev-env/bin/da-hls
+++ b/sdk/dev-env/bin/da-hls
@@ -1,11 +1,1 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash ../../shell.nix
-
-set -euo pipefail
-
-DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
-cd $DADE_CURRENT_SCRIPT_DIR
-cd ../..
-
-bazel build @hls-exe//haskell-language-server
-exec ./bazel-bin/external/hls/haskell-language-server-1.7.0.0/_install/bin/haskell-language-server "$@"
+./haskell-language-server

--- a/sdk/dev-env/bin/haskell-language-server
+++ b/sdk/dev-env/bin/haskell-language-server
@@ -1,0 +1,11 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash ../../shell.nix
+
+set -euo pipefail
+
+DADE_CURRENT_SCRIPT_DIR="$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )"
+cd $DADE_CURRENT_SCRIPT_DIR
+cd ../..
+
+bazel build @hls-exe//haskell-language-server
+exec ./bazel-bin/external/hls/haskell-language-server-1.7.0.0/_install/bin/haskell-language-server "$@"


### PR DESCRIPTION
`da-hls` is a version of HLS that is built locally by Bazel. As such it should work out-of-the-box for all contributors of daml, on all operating systems.

In this PR, I renamed the `da-hls` bin to `haskell-language-server` so that it can be found automatically (from PATH) by VSCode. It makes it possible to import our Haskell code in VSCode without any manual configuration. One needs to load direnv before opening VSCode, for this to work.


```
$ cd digital-asset/daml/sdk
$ direnv allow .
$ code .
```

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
