### PR TITLE
Allow remote/cloud machines to serve plotly graphs via SSH tunnels

### DIFF
--- a/sdk/daml-lf/snapshot/scripts/display-benchmarks.py
+++ b/sdk/daml-lf/snapshot/scripts/display-benchmarks.py
@@ -68,7 +68,7 @@ def main():
         html.Div(children="JMH Benchmarking Data for Snapshot Files"),
         html.Div(children=[dcc.Graph(figure=display_graph(graph_data))], style={"width":"100%", "height":"100vh"})
     ]
-    app.run(host="0.0.0.0", port=8080)
+    app.run(host="127.0.0.1", port=8080)
 
 if __name__ == "__main__":
     main()

--- a/sdk/daml-lf/snapshot/scripts/display-benchmarks.py
+++ b/sdk/daml-lf/snapshot/scripts/display-benchmarks.py
@@ -6,6 +6,7 @@ import json
 import os
 import pandas as pd
 import plotly.express as px
+from dash import Dash, html, dash_table, dcc
 from json.decoder import JSONDecodeError
 
 def get_jmh_data(base_dir):
@@ -51,7 +52,7 @@ def get_graph_data(base_data, update_data):
     return pd.DataFrame(result)
 
 def display_graph(graph_data):
-    return px.bar(graph_data, x="choice", y="score", color="type", barmode="group", facet_row="dar#script", facet_col="choice")
+    return px.bar(graph_data, x="choice", y="score", color="type", barmode="group", facet_row="dar#script")
 
 def main():
     parser = argparse.ArgumentParser(description="Display JMH Benchmarking Data for Snapshot Files")
@@ -61,9 +62,13 @@ def main():
     base_data = get_jmh_data(args.base_dir)
     update_data = get_jmh_data(args.update_dir)
     graph_data = get_graph_data(base_data, update_data)
-    fig = display_graph(graph_data)
-    fig.show()
+
+    app = Dash()
+    app.layout = [
+        html.Div(children="JMH Benchmarking Data for Snapshot Files"),
+        html.Div(children=[dcc.Graph(figure=display_graph(graph_data))], style={"width":"100%", "height":"100vh"})
+    ]
+    app.run(host="0.0.0.0", port=8080)
 
 if __name__ == "__main__":
     main()
-

--- a/sdk/daml-lf/snapshot/scripts/requirements.txt
+++ b/sdk/daml-lf/snapshot/scripts/requirements.txt
@@ -1,2 +1,3 @@
+dash==3.2.0
 pandas==2.2.1
 plotly==5.21.0


### PR DESCRIPTION
Currently, plotly graphs can not be displayed over SSH tunnels. This PR fixes this issue by using `dash` to serve graphs via the socket `127.0.0.1:8080`, and so port 8080 may now be forwarded using an SSH tunnel.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
