### PR TITLE
Refactor speedy Stack to separate grow and push operations

### DIFF
--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Stack.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Stack.scala
@@ -34,7 +34,7 @@ private[speedy] final class Stack[X <: AnyRef](initialCapacity: Int) extends Ite
   def isFull: Boolean =
     size == capacity
 
-  // it is the responsibility of the caller to check the stack is not full
+  // It is the responsibility of the caller to check the stack is not full
   def push(value: X): Unit = {
     array(size_) = value
     size_ += 1
@@ -58,6 +58,7 @@ private[speedy] final class Stack[X <: AnyRef](initialCapacity: Int) extends Ite
   }
 
   // Indexed from 1 by relative offset from the top of the stack (1 is top!)
+  @throws[ArrayIndexOutOfBoundsException]
   def apply(i: Int): X =
     array(size_ - i).asInstanceOf[X]
 


### PR DESCRIPTION
This update decouples the `grow` operation from `push`, making the caller responsible for ensuring sufficient capacity before pushing. This will enable additional validations, such as checking available gas, before actually growing the stack.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
