### PR TITLE
Restore preprocessing.ValueTranslator and its test

### DIFF
--- a/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
+++ b/sdk/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
@@ -5,11 +5,15 @@ package com.digitalasset.daml.lf
 package engine
 package preprocessing
 
-import com.digitalasset.daml.lf.interpretation
+import com.digitalasset.daml.lf.data._
 import com.digitalasset.daml.lf.language.Ast._
+import com.digitalasset.daml.lf.language.TypeDestructor
 import com.digitalasset.daml.lf.speedy.SValue
 import com.digitalasset.daml.lf.value.Value
-import com.digitalasset.daml.lf.value.Value.ContractId
+import com.digitalasset.daml.lf.value.Value._
+
+import scala.annotation.tailrec
+import scala.collection.immutable.ArraySeq
 
 private[lf] final class ValueTranslator(
     pkgInterface: language.PackageInterface,
@@ -17,54 +21,265 @@ private[lf] final class ValueTranslator(
     shouldCheckDataSerializable: Boolean = true,
 ) {
 
-  private[this] val speedyValueTranslator =
-    new speedy.ValueTranslator(pkgInterface, requireContractIdSuffix, shouldCheckDataSerializable)
+  import Preprocessor._
 
-  private[this] def translateError(
-      error: interpretation.Error.Dev.TranslationError.Error
-  ): Error.Preprocessing.Error = {
-    import interpretation.Error.Dev.TranslationError._
-    error match {
-      case LookupError(lookupError) => Error.Preprocessing.Lookup(lookupError)
-      case TypeMismatch(expectedType, actualValue, message) =>
-        Error.Preprocessing.TypeMismatch(expectedType, actualValue, message)
-      case ValueNesting(value) =>
-        Error.Preprocessing.ValueNesting(value)
-      case NonSuffixedV1ContractId(cid) =>
-        Error.Preprocessing.IllegalContractId.NonSuffixV1ContractId(cid)
-      case NonSuffixedV2ContractId(cid) =>
-        Error.Preprocessing.IllegalContractId.NonSuffixV2ContractId(cid)
+  @throws[Error.Preprocessing.Error]
+  private def labeledRecordToMap(
+      fields: ImmArray[(Option[Ref.Name], Value)]
+  ): Either[String, Option[Map[Ref.Name, Value]]] = {
+    @tailrec
+    def go(
+        fields: FrontStack[(Option[Ref.Name], Value)],
+        map: Map[Ref.Name, Value],
+    ): Either[String, Option[Map[Ref.Name, Value]]] = {
+      fields.pop match {
+        case None => Right(Some(map))
+        case Some(((None, _), _)) => Right(None)
+        // Retain error on duplicate label behaviour from pre-upgrades
+        case Some(((Some(label), _), _)) if map.contains(label) =>
+          Left(s"Duplicate label $label in record")
+        case Some(((Some(label), value), tail)) =>
+          go(tail, map + (label -> value))
+      }
     }
+
+    go(fields.toFrontStack, Map.empty)
   }
 
-  /** Executes an action and rethrows any [[interpretation.Error.Dev.TranslationError.Error]]
-    * it may throw as an [[Error.Preprocessing.Error]]
-    */
-  @throws[Error.Preprocessing.Error]
-  private[this] def translateException[A](f: => A): A = {
-    try {
-      f
-    } catch {
-      case e: interpretation.Error.Dev.TranslationError.Error =>
-        throw translateError(e)
+  val validateCid: ContractId => Unit =
+    if (requireContractIdSuffix) {
+      case cid: ContractId.V1 =>
+        if (cid.suffix.isEmpty)
+          throw Error.Preprocessing.IllegalContractId.NonSuffixV1ContractId(cid)
+      case cid: ContractId.V2 =>
+        // We forbid only local contract IDs in Engine commands, but not relative contract IDs
+        // because relative contract IDs may appear in reinterpretation of projections
+        if (cid.suffix.isEmpty)
+          throw Error.Preprocessing.IllegalContractId.NonSuffixV2ContractId(cid)
     }
+    else { _ => () }
+
+  @throws[Error.Preprocessing.Error]
+  private[preprocessing] def unsafeTranslateCid(cid: ContractId): SValue.SContractId = {
+    validateCid(cid)
+    SValue.SContractId(cid)
   }
 
+  // For efficient reason we do not produce here the monad Result[SValue] but rather throw
+  // exception in case of error or package missing.
   @throws[Error.Preprocessing.Error]
-  def validateCid(cid: Value.ContractId): Unit =
-    translateException(speedyValueTranslator.validateCid(cid))
+  private[preprocessing] def unsafeTranslateValue(
+      ty: Type,
+      value: Value,
+  ): SValue = {
+    import TypeDestructor.SerializableTypeF._
+    val Destructor = TypeDestructor(pkgInterface)
 
-  @throws[Error.Preprocessing.Error]
-  private[preprocessing] def unsafeTranslateCid(cid: ContractId): SValue.SContractId =
-    translateException(speedyValueTranslator.unsafeTranslateCid(cid))
+    // TODO: https://github.com/digital-asset/daml/issues/17082
+    //   Should we consider factorizing this code with Seedy.Machine#importValues
+    def go(ty0: Type, value0: Value, nesting: Int): SValue =
+      if (nesting > Value.MAXIMUM_NESTING) {
+        throw Error.Preprocessing.ValueNesting(value)
+      } else {
+        val newNesting = nesting + 1
+        def typeError(msg: String = s"mismatching type: ${ty0.pretty} and value: $value0") =
+          throw Error.Preprocessing.TypeMismatch(ty0, value0, msg)
+        def destruct(typ: Type) =
+          Destructor.destruct(typ, shouldCheckDataSerializable) match {
+            case Right(value) => value
+            case Left(TypeDestructor.Error.TypeError(err)) =>
+              typeError(err)
+            case Left(TypeDestructor.Error.LookupError(err)) =>
+              throw Error.Preprocessing.Lookup(err)
+          }
 
-  @throws[Error.Preprocessing.Error]
-  private[preprocessing] def unsafeTranslateValue(ty: Type, value: Value): SValue =
-    translateException(speedyValueTranslator.unsafeTranslateValue(ty, value))
+        def checkUserTypeId(targetType: Ref.TypeConId, mbSourceType: Option[Ref.TypeConId]) =
+          mbSourceType.foreach(sourceType =>
+            // In case of upgrade we simply ignore the package ID.
+            if (targetType.qualifiedName != sourceType.qualifiedName)
+              typeError(
+                s"Mismatching variant id, the type tells us ${targetType.qualifiedName}, but the value tells us ${sourceType.qualifiedName}"
+              )
+          )
+
+        (destruct(ty0), value0) match {
+          case (UnitF, ValueUnit) =>
+            SValue.SUnit
+          case (BoolF, ValueBool(b)) =>
+            if (b) SValue.SValue.True else SValue.SValue.False
+          case (Int64F, ValueInt64(i)) =>
+            SValue.SInt64(i)
+          case (TimestampF, ValueTimestamp(t)) =>
+            SValue.STimestamp(t)
+          case (DateF, ValueDate(t)) =>
+            SValue.SDate(t)
+          case (TextF, ValueText(t)) =>
+            SValue.SText(t)
+          case (PartyF, ValueParty(p)) =>
+            SValue.SParty(p)
+          case (NumericF(s), ValueNumeric(d)) =>
+            Numeric.fromBigDecimal(s, d) match {
+              case Right(value) => SValue.SNumeric(value)
+              case Left(message) => typeError(message)
+            }
+          case (ContractIdF(_), ValueContractId(c)) =>
+            unsafeTranslateCid(c)
+          case (OptionalF(a), ValueOptional(mbValue)) =>
+            mbValue match {
+              case Some(v) =>
+                SValue.SOptional(Some(go(a, v, newNesting)))
+              case None =>
+                SValue.SValue.None
+            }
+          case (ListF(a), ValueList(ls)) =>
+            if (ls.isEmpty) {
+              SValue.SValue.EmptyList
+            } else {
+              SValue.SList(ls.toImmArray.toSeq.map(go(a, _, newNesting)).toImmArray.toFrontStack)
+            }
+          case (MapF(a, b), ValueGenMap(entries)) =>
+            if (entries.isEmpty) {
+              SValue.SValue.EmptyGenMap
+            } else {
+              SValue.SMap(
+                isTextMap = false,
+                entries = entries.toSeq.view.map { case (k, v) =>
+                  go(a, k, newNesting) -> go(b, v, newNesting)
+                },
+              )
+            }
+          case (TextMapF(a), ValueTextMap(entries)) =>
+            if (entries.isEmpty) {
+              SValue.SValue.EmptyTextMap
+            } else {
+              SValue.SMap(
+                isTextMap = true,
+                entries = entries.toImmArray.toSeq.view.map { case (k, v) =>
+                  SValue.SText(k) -> go(a, v, newNesting)
+                }.toList,
+              )
+            }
+          case (
+                vF @ VariantF(tyCon, _, _, consTyp),
+                ValueVariant(mbId, constructorName, val0),
+              ) =>
+            checkUserTypeId(tyCon, mbId)
+            val i = handleLookup(vF.consRank(constructorName))
+            SValue.SVariant(
+              tyCon,
+              constructorName,
+              i,
+              go(consTyp(i), val0, newNesting),
+            )
+          // records
+          case (
+                RecordF(tyCon, _, fieldNames, filedTypes),
+                ValueRecord(mbId, sourceElements),
+              ) =>
+            checkUserTypeId(tyCon, mbId)
+
+            def addMissingField(lbl: Ref.Name, ty: Type): (Option[Ref.Name], Value) =
+              destruct(ty) match {
+                // If missing field is optional, fill it with None
+                case OptionalF(_) => (Some(lbl), Value.ValueOptional(None))
+                // Else, throw error
+                case _ =>
+                  typeError(
+                    s"Missing non-optional field \"$lbl\", cannot upgrade non-optional fields."
+                  )
+              }
+
+            val oLabeledFlds = labeledRecordToMap(sourceElements).fold(typeError, identity _)
+
+            // correctFields: (correct only by label/position) gives the value and type, length == targetFieldsAndTypes
+            //   filled with Nones when type is Optional
+            // extraFields: Unknown additional fields with name and value
+            val (correctFields, extraFields): (
+                List[(Ref.Name, Value, Type)],
+                List[(Option[Ref.Name], Value)],
+            ) =
+              oLabeledFlds match {
+                // Not fully labelled (or reordering disabled), so order dependent
+                // Additional fields should downgrade, missing fields should upgrade
+                case None => {
+                  val correctFields = (fieldNames.view zip filedTypes).zipWithIndex.map {
+                    case ((lbl, ty), i) =>
+                      val (mbLbl, v) =
+                        sourceElements.get(i).getOrElse(addMissingField(lbl, ty))
+                      mbLbl.foreach(lbl_ =>
+                        if (lbl_ != lbl)
+                          typeError(
+                            s"Mismatching record field label '$lbl_' (expecting '$lbl') for record $tyCon"
+                          )
+                      )
+                      (lbl, v, ty)
+                  }.toList
+                  val numS = sourceElements.length
+                  val numT = filedTypes.length
+                  // We have extra fields
+                  val extraFields =
+                    if (numS > numT)
+                      sourceElements.strictSlice(numT, numS).toList
+                    else
+                      List.empty
+
+                  (correctFields, extraFields)
+                }
+                // Fully labelled and allowed to re-order
+                case Some(labeledFlds) =>
+                  // new logic
+                  // iterate the expected fields, replace any missing with none
+                  val correctFields = (fieldNames.view zip filedTypes).map { case (lbl, ty) =>
+                    (lbl, labeledFlds.getOrElse(lbl, addMissingField(lbl, ty)._2), ty)
+                  }.toList
+                  val extraFields = (labeledFlds -- fieldNames).view.map { case (lbl, v) =>
+                    (Some(lbl), v)
+                  }.toList
+                  (correctFields, extraFields)
+              }
+
+            // Recursive substitution
+            val translatedCorrectFields = correctFields.map { case (lbl, v, typ) =>
+              lbl -> go(typ, v, newNesting)
+            }
+
+            extraFields.foreach {
+              // If additional field is None, do nothing
+              case (_, ValueOptional(None)) =>
+              // Else, error depending on type
+              case (oLbl, ValueOptional(Some(_))) =>
+                typeError(
+                  s"An optional contract field${oLbl.fold("")(lbl => s" (\"$lbl\")")} with a value of Some may not be dropped during downgrading."
+                )
+              case (oLbl, _) =>
+                typeError(
+                  s"Found non-optional extra field${oLbl.fold("")(lbl => s" \"$lbl\"")}, cannot remove for downgrading."
+                )
+            }
+
+            SValue.SRecord(
+              tyCon,
+              ImmArray.from(translatedCorrectFields.map(_._1)),
+              translatedCorrectFields.map(_._2).to(ArraySeq),
+            )
+          case (eF @ EnumF(tyCon, _, _), ValueEnum(mbId, constructor)) =>
+            checkUserTypeId(tyCon, mbId)
+            val rank = handleLookup(eF.consRank(constructor))
+            SValue.SEnum(tyCon, constructor, rank)
+          case _ =>
+            typeError()
+        }
+      }
+
+    go(ty, value, 0)
+  }
 
   def translateValue(
       ty: Type,
       value: Value,
   ): Either[Error.Preprocessing.Error, SValue] =
-    speedyValueTranslator.translateValue(ty, value).left.map(translateError)
+    safelyRun(
+      unsafeTranslateValue(ty, value)
+    )
+
 }

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslatorSpec.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslatorSpec.scala
@@ -1,0 +1,652 @@
+// Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf
+package engine
+package preprocessing
+
+import com.digitalasset.daml.lf.data._
+import com.digitalasset.daml.lf.language.{
+  Ast,
+  LanguageMajorVersion,
+  LanguageVersion,
+  LookupError,
+  Reference,
+}
+import com.digitalasset.daml.lf.language.Util._
+import com.digitalasset.daml.lf.speedy.SValue._
+import com.digitalasset.daml.lf.testing.parser.ParserParameters
+import com.digitalasset.daml.lf.value.Value
+import com.digitalasset.daml.lf.value.Value._
+import org.scalatest.Inside
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.wordspec.AnyWordSpec
+import com.digitalasset.daml.lf.speedy.Compiler
+
+import scala.collection.immutable.ArraySeq
+import scala.util.{Failure, Success, Try}
+
+class ValueTranslatorSpecV2 extends ValueTranslatorSpec(LanguageMajorVersion.V2)
+
+class ValueTranslatorSpec(majorLanguageVersion: LanguageMajorVersion)
+    extends AnyWordSpec
+    with Inside
+    with Matchers
+    with TableDrivenPropertyChecks {
+
+  import com.digitalasset.daml.lf.testing.parser.Implicits.SyntaxHelper
+  import com.digitalasset.daml.lf.transaction.test.TransactionBuilder.Implicits.{
+    defaultPackageId => _,
+    _,
+  }
+
+  val aInt = ValueInt64(42)
+  val aText = ValueText("42")
+  val aParty = ValueParty("42")
+  val someText = ValueOptional(Some(aText))
+  val someParty = ValueOptional(Some(aParty))
+  val none = Value.ValueNone
+
+  private[this] implicit val parserParameters: ParserParameters[ValueTranslatorSpec.this.type] =
+    ParserParameters.defaultFor(majorLanguageVersion)
+
+  private[this] implicit val defaultPackageId: Ref.PackageId =
+    parserParameters.defaultPackageId
+
+  private[this] val aCid =
+    ContractId.V1.assertBuild(
+      crypto.Hash.hashPrivateKey("a Contract ID"),
+      Bytes.assertFromString("00"),
+    )
+
+  private[this] val pkg =
+    p"""metadata ( 'pkg' : '1.0.0' )
+
+        module Mod {
+
+          record @serializable Tuple (a: *) (b: *) = { x: a, y: b };
+          record @serializable Record = { field : Int64 };
+          variant @serializable Either (a: *) (b: *) = Left : a | Right : b;
+          enum @serializable Color = red | green | blue;
+
+          record @serializable MyCons = { head : Int64, tail: Mod:MyList };
+          variant @serializable  MyList = MyNil : Unit | MyCons: Mod:MyCons ;
+
+          record @serializable Template = { field : Int64 };
+          record @serializable TemplateRef = { owner: Party, cid: (ContractId Mod:Template) };
+
+          record @serializable Upgradeable = { field: Int64, extraField: (Option Text), anotherExtraField: (Option Text) };
+        }
+    """
+
+  val upgradablePkgId = Ref.PackageId.assertFromString("-upgradable-v1-")
+  val upgradablePkg = {
+    implicit val parserParameters: ParserParameters[ValueTranslatorSpec.this.type] =
+      ParserParameters(upgradablePkgId, LanguageVersion.v2_1)
+    p"""metadata ( 'upgradable' : '1.0.0' )
+      module Mod {
+        record @serializable Record (a: *) (b: *) (c: *) (d: *) = { fieldA: a, fieldB: Option b, fieldC: Option c };
+        variant @serializable Variant (a: *) (b: *) (c: *) = ConsA: a | ConsB: b ;
+        enum @serializable Enum = Cons1 | Cons2 ;
+        record MyCons = { head : Int64, tail: Mod:MyList };
+        variant MyList = MyNil : Unit | MyCons: Mod:MyCons ;
+      }
+    """
+  }
+
+  private[this] val compiledPackage = ConcurrentCompiledPackages(
+    Compiler.Config.Default(majorLanguageVersion)
+  )
+  assert(compiledPackage.addPackage(defaultPackageId, pkg) == ResultDone.Unit)
+  assert(compiledPackage.addPackage(upgradablePkgId, upgradablePkg) == ResultDone.Unit)
+
+  "translateValue" should {
+
+    val valueTranslator = new ValueTranslator(
+      compiledPackage.pkgInterface,
+      requireContractIdSuffix = false,
+    )
+    import valueTranslator.unsafeTranslateValue
+
+    val testCases = Table[Ast.Type, Value, speedy.SValue](
+      ("type", "value", "svalue"),
+      (TUnit, ValueUnit, SValue.Unit),
+      (TBool, ValueTrue, SValue.True),
+      (TInt64, ValueInt64(42), SInt64(42)),
+      (
+        TTimestamp,
+        ValueTimestamp(Time.Timestamp.assertFromString("1969-07-20T20:17:00Z")),
+        STimestamp(Time.Timestamp.assertFromString("1969-07-20T20:17:00Z")),
+      ),
+      (
+        TDate,
+        ValueDate(Time.Date.assertFromString("1879-03-14")),
+        SDate(Time.Date.assertFromString("1879-03-14")),
+      ),
+      (TText, ValueText("daml"), SText("daml")),
+      (
+        TNumeric(Ast.TNat(Numeric.Scale.assertFromInt(10))),
+        ValueNumeric(Numeric.assertFromString("10.")),
+        SNumeric(Numeric.assertFromString("10.0000000000")),
+      ),
+      (TParty, ValueParty("Alice"), SParty("Alice")),
+      (
+        TContractId(t"Mod:Template"),
+        ValueContractId(aCid),
+        SContractId(aCid),
+      ),
+      (
+        TList(TText),
+        ValueList(FrontStack(ValueText("a"), ValueText("b"))),
+        SList(FrontStack(SText("a"), SText("b"))),
+      ),
+      (
+        TTextMap(TBool),
+        ValueTextMap(SortedLookupList(Map("0" -> ValueTrue, "1" -> ValueFalse))),
+        SMap(true, SText("0") -> SValue.True, SText("1") -> SValue.False),
+      ),
+      (
+        TGenMap(TInt64, TText),
+        ValueGenMap(ImmArray(ValueInt64(1) -> ValueText("1"), ValueInt64(42) -> ValueText("42"))),
+        SMap(false, SInt64(1) -> SText("1"), SInt64(42) -> SText("42")),
+      ),
+      (TOptional(TText), ValueOptional(Some(ValueText("text"))), SOptional(Some(SText("text")))),
+      (
+        t"Mod:Tuple Int64 Text",
+        ValueRecord("", ImmArray("x" -> ValueInt64(33), "y" -> ValueText("a"))),
+        SRecord("Mod:Tuple", ImmArray("x", "y"), ArraySeq(SInt64(33), SText("a"))),
+      ),
+      (
+        t"Mod:Either Int64 Text",
+        ValueVariant("", "Right", ValueText("some test")),
+        SVariant("Mod:Either", "Right", 1, SText("some test")),
+      ),
+      (Ast.TTyCon("Mod:Color"), ValueEnum("", "blue"), SEnum("Mod:Color", "blue", 2)),
+    )
+
+    val emptyTestCase = Table[Ast.Type, Value, speedy.SValue](
+      ("type", "value", "svalue"),
+      (TList(TText), ValueList(FrontStack.empty), SList(FrontStack.empty)),
+      (
+        TOptional(TText),
+        ValueOptional(None),
+        SOptional(None),
+      ),
+      (
+        TTextMap(TText),
+        ValueTextMap(SortedLookupList.Empty),
+        SMap(true),
+      ),
+      (
+        TGenMap(TInt64, TText),
+        ValueGenMap(ImmArray.empty),
+        SMap(false),
+      ),
+    )
+
+    "succeeds on well type values" in {
+      forAll(testCases ++ emptyTestCase) { (typ, value, svalue) =>
+        Try(unsafeTranslateValue(typ, value)) shouldBe Success(svalue)
+      }
+    }
+
+    "handle different representation of the same record" in {
+      val typ = t"Mod:Tuple Int64 Text"
+      val testCases = Table(
+        "record",
+        ValueRecord("Mod:Tuple", ImmArray("x" -> ValueInt64(33), "y" -> ValueText("a"))),
+        ValueRecord("Mod:Tuple", ImmArray("y" -> ValueText("a"), "x" -> ValueInt64(33))),
+        ValueRecord("", ImmArray("x" -> ValueInt64(33), "y" -> ValueText("a"))),
+        ValueRecord("", ImmArray("" -> ValueInt64(33), "" -> ValueText("a"))),
+      )
+      val svalue = SRecord("Mod:Tuple", ImmArray("x", "y"), ArraySeq(SInt64(33), SText("a")))
+
+      forEvery(testCases)(testCase =>
+        Try(unsafeTranslateValue(typ, testCase)) shouldBe Success(svalue)
+      )
+    }
+
+    "handle different representation of the same static record with upgrades enabled" in {
+      val typ = t"Mod:Tuple Int64 Text"
+      val testCases = Table(
+        "record",
+        ValueRecord("Mod:Tuple", ImmArray("x" -> ValueInt64(33), "y" -> ValueText("a"))),
+        ValueRecord("Mod:Tuple", ImmArray("y" -> ValueText("a"), "x" -> ValueInt64(33))),
+        ValueRecord("", ImmArray("x" -> ValueInt64(33), "y" -> ValueText("a"))),
+        ValueRecord("", ImmArray("" -> ValueInt64(33), "" -> ValueText("a"))),
+      )
+      val svalue = SRecord("Mod:Tuple", ImmArray("x", "y"), ArraySeq(SInt64(33), SText("a")))
+
+      forEvery(testCases)(testCase =>
+        Try(unsafeTranslateValue(typ, testCase)) shouldBe Success(svalue)
+      )
+    }
+
+    val TRecordUpgradable =
+      t"Mod:Record Int64 Text Party Unit"
+
+    val TVariantUpgradable =
+      t"Mod:Variant Int64 Text"
+
+    val TEnumUpgradable =
+      t"Mod:Enum"
+
+    "return proper mismatch error for upgrades" in {
+      val testCases = Table[Ast.Type, Value, PartialFunction[Error.Preprocessing.Error, _]](
+        ("type", "value", "error"),
+        (
+          TRecordUpgradable,
+          ValueRecord(
+            "",
+            ImmArray(
+              "fieldA" -> aInt,
+              "fieldB" -> someParty, // Here the field has type Party instead of Text
+              "fieldC" -> none,
+            ),
+          ),
+          { case Error.Preprocessing.TypeMismatch(typ, value, _) =>
+            typ shouldBe t"Text"
+            value shouldBe aParty
+          },
+        ),
+        (
+          TRecordUpgradable,
+          ValueRecord(
+            "",
+            ImmArray( // fields non-order and non fully labelled.
+              "fieldA" -> aInt,
+              "" -> none,
+              "fieldB" -> someText,
+            ),
+          ),
+          { case Error.Preprocessing.TypeMismatch(typ, _, _) =>
+            typ shouldBe TRecordUpgradable
+          },
+        ),
+        (
+          TRecordUpgradable,
+          ValueRecord(
+            "",
+            ImmArray(), // missing a non-optional field
+          ),
+          { case Error.Preprocessing.TypeMismatch(typ, _, _) =>
+            typ shouldBe TRecordUpgradable
+          },
+        ),
+        (
+          TRecordUpgradable,
+          ValueRecord(
+            "",
+            ImmArray(
+              "fieldA" -> aInt,
+              "fieldB" -> someText,
+              "fieldC" -> someParty,
+              "fieldD" -> aInt, // extra non-optional field
+            ),
+          ),
+          { case Error.Preprocessing.TypeMismatch(typ, _, _) =>
+            typ shouldBe TRecordUpgradable
+          },
+        ),
+        (
+          TVariantUpgradable,
+          ValueVariant("", "ConsB", aInt), // Here the variant has type Text instead of Int64
+          { case Error.Preprocessing.TypeMismatch(typ, value, _) =>
+            typ shouldBe t"Text"
+            value shouldBe aInt
+          },
+        ),
+        (
+          TVariantUpgradable,
+          ValueVariant("", "ConsC", aInt), // ConsC is not a constructor of Mod:Variant
+          {
+            case Error.Preprocessing.Lookup(
+                  LookupError.NotFound(
+                    Reference.DataVariantConstructor(_, consName),
+                    Reference.DataVariantConstructor(_, _),
+                  )
+                ) =>
+              consName shouldBe "ConsC"
+          },
+        ),
+        (
+          TEnumUpgradable,
+          ValueEnum("", "Cons3"), // Cons3 is not a constructor of Mod:Enum
+          {
+            case Error.Preprocessing.Lookup(
+                  LookupError.NotFound(
+                    Reference.DataEnumConstructor(_, consName),
+                    Reference.DataEnumConstructor(_, _),
+                  )
+                ) =>
+              consName shouldBe "Cons3"
+          },
+        ),
+        (
+          TVariantUpgradable,
+          ValueVariant("", "ConsC", aInt), // ConsC is not a constructor of Mod:Variant
+          {
+            case Error.Preprocessing.Lookup(
+                  LookupError.NotFound(
+                    Reference.DataVariantConstructor(_, consName),
+                    Reference.DataVariantConstructor(_, _),
+                  )
+                ) =>
+              consName shouldBe "ConsC"
+          },
+        ),
+        (
+          TEnumUpgradable,
+          ValueEnum("", "Cons3"), // Cons3 is not a constructor of Mod:Enum
+          {
+            case Error.Preprocessing.Lookup(
+                  LookupError.NotFound(
+                    Reference.DataEnumConstructor(_, consName),
+                    Reference.DataEnumConstructor(_, _),
+                  )
+                ) =>
+              consName shouldBe "Cons3"
+          },
+        ),
+      )
+      forEvery(testCases)((typ, value, _) =>
+        inside(Try(unsafeTranslateValue(typ, value))) {
+          case Failure(_: Error.Preprocessing.Error) =>
+            ()
+          // checkError(error)
+        }
+      )
+    }
+
+    "handle different representation of the same upgraded/downgraded record" in {
+      val typ = t"Mod:Upgradeable"
+      def sValue(extraFieldDefined: Boolean, anotherExtraFieldDefined: Boolean) =
+        SRecord(
+          "Mod:Upgradeable",
+          ImmArray("field", "extraField", "anotherExtraField"),
+          ArraySeq(
+            SInt64(1),
+            SOptional(Some(SText("a")).filter(Function.const(extraFieldDefined))),
+            SOptional(Some(SText("b")).filter(Function.const(anotherExtraFieldDefined))),
+          ),
+        )
+      def upgradeCaseSuccess(
+          extraFieldDefined: Boolean,
+          anotherExtraFieldDefined: Boolean,
+          value: Value,
+      ) =
+        (Success(sValue(extraFieldDefined, anotherExtraFieldDefined)), value)
+      def upgradeCaseFailure(s: String, value: Value) =
+        (Failure(Error.Preprocessing.TypeMismatch(typ, value, s)), value)
+      val testCases = Table(
+        ("svalue", "record"),
+        upgradeCaseSuccess(
+          true,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              "field" -> ValueInt64(1),
+              "extraField" -> ValueOptional(Some(ValueText("a"))),
+              "anotherExtraField" -> ValueOptional(Some(ValueText("b"))),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          false,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              "field" -> ValueInt64(1),
+              "extraField" -> ValueOptional(None),
+              "anotherExtraField" -> ValueOptional(Some(ValueText("b"))),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          false,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              "field" -> ValueInt64(1),
+              "anotherExtraField" -> ValueOptional(Some(ValueText("b"))),
+              "extraField" -> ValueOptional(None),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          false,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              "field" -> ValueInt64(1),
+              "anotherExtraField" -> ValueOptional(Some(ValueText("b"))),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          false,
+          false,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              "field" -> ValueInt64(1)
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          false,
+          false,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              "field" -> ValueInt64(1),
+              "bonusField" -> ValueOptional(None),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          false,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              "field" -> ValueInt64(1),
+              "bonusField" -> ValueOptional(None),
+              "anotherExtraField" -> ValueOptional(Some(ValueText("b"))),
+            ),
+          ),
+        ),
+        upgradeCaseFailure(
+          "An optional contract field (\"bonusField\") with a value of Some may not be dropped during downgrading.",
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              "field" -> ValueInt64(1),
+              "bonusField" -> ValueOptional(Some(ValueText("bad"))),
+            ),
+          ),
+        ),
+        upgradeCaseFailure(
+          "Found non-optional extra field \"bonusField\", cannot remove for downgrading.",
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              "field" -> ValueInt64(1),
+              "bonusField" -> ValueText("bad"),
+            ),
+          ),
+        ),
+        upgradeCaseFailure(
+          "Missing non-optional field \"field\", cannot upgrade non-optional fields.",
+          ValueRecord("Mod:Upgradeable", ImmArray()),
+        ),
+      )
+
+      forEvery(testCases)((result, value) => Try(unsafeTranslateValue(typ, value)) shouldBe result)
+    }
+
+    "handle different representation of the same variant" in {
+      val typ = t"Mod:Either Text Int64"
+      val testCases = Table(
+        "variant",
+        ValueVariant("Mod:Either", "Left", ValueText("some test")),
+        ValueVariant("", "Left", ValueText("some test")),
+      )
+      val svalue = SVariant("Mod:Either", "Left", 0, SText("some test"))
+
+      forEvery(testCases)(value => Try(unsafeTranslateValue(typ, value)) shouldBe Success(svalue))
+    }
+
+    "handle different representation of the same enum" in {
+      val typ = t"Mod:Color"
+      val testCases = Table("enum", ValueEnum("Mod:Color", "green"), ValueEnum("", "green"))
+      val svalue = SEnum("Mod:Color", "green", 1)
+      forEvery(testCases)(value => Try(unsafeTranslateValue(typ, value)) shouldBe Success(svalue))
+    }
+
+    "return proper mismatch error" in {
+      val res = Try(
+        unsafeTranslateValue(
+          t"Mod:Tuple Int64 Text",
+          ValueRecord(
+            "",
+            ImmArray(
+              "x" -> ValueInt64(33),
+              "y" -> ValueParty("Alice"), // Here the field has type Party instead of Text
+            ),
+          ),
+        )
+      )
+      inside(res) { case Failure(Error.Preprocessing.TypeMismatch(typ, value, _)) =>
+        typ shouldBe t"Text"
+        value shouldBe ValueParty("Alice")
+      }
+    }
+
+    "fails on non-well type values" in {
+      forAll(testCases) { (typ1, value1, _) =>
+        forAll(testCases) { (_, value2, _) =>
+          if (value1 != value2) {
+            a[Error.Preprocessing.Error] shouldBe thrownBy(
+              unsafeTranslateValue(typ1, value2)
+            )
+          }
+        }
+      }
+    }
+
+    "fails on too deep values" in {
+
+      def mkMyList(n: Int) =
+        Iterator.range(0, n).foldLeft[Value](ValueVariant("", "MyNil", ValueUnit)) { case (v, n) =>
+          ValueVariant(
+            "",
+            "MyCons",
+            ValueRecord("", ImmArray("" -> ValueInt64(n.toLong), "" -> v)),
+          )
+        }
+      val notTooBig = mkMyList(49)
+      val tooBig = mkMyList(50)
+      val failure = Failure(Error.Preprocessing.ValueNesting(tooBig))
+
+      Try(unsafeTranslateValue(t"Mod:MyList", notTooBig)) shouldBe a[Success[_]]
+      Try(unsafeTranslateValue(t"Mod:MyList", tooBig)) shouldBe failure
+    }
+
+    def testCasesForCid(culprit: ContractId) = {
+      val cid = ValueContractId(culprit)
+      Table[Ast.Type, Value](
+        ("type" -> "value"),
+        t"ContractId Mod:Template" -> cid,
+        TList(t"ContractId Mod:Template") -> ValueList(FrontStack(cid)),
+        TTextMap(t"ContractId Mod:Template") -> ValueTextMap(SortedLookupList(Map("0" -> cid))),
+        TGenMap(TInt64, t"ContractId Mod:Template") -> ValueGenMap(ImmArray(ValueInt64(1) -> cid)),
+        TGenMap(t"ContractId Mod:Template", TInt64) -> ValueGenMap(ImmArray(cid -> ValueInt64(0))),
+        TOptional(t"ContractId Mod:Template") -> ValueOptional(Some(cid)),
+        t"Mod:TemplateRef" -> ValueRecord(
+          "",
+          ImmArray("" -> ValueParty("Alice"), "" -> cid),
+        ),
+        TTyConApp("Mod:Either", ImmArray(t"ContractId Mod:Template", TInt64)) -> ValueVariant(
+          "",
+          "Left",
+          cid,
+        ),
+      )
+    }
+
+    "accept all contract IDs when require flags are false" in {
+
+      val valueTranslator = new ValueTranslator(
+        compiledPackage.pkgInterface,
+        requireContractIdSuffix = false,
+      )
+      val unsuffixedCidV1 = ContractId.V1
+        .assertBuild(crypto.Hash.hashPrivateKey("a non-suffixed V1 Contract ID"), Bytes.Empty)
+      val suffixedCidV1 = ContractId.V1.assertBuild(
+        crypto.Hash.hashPrivateKey("a suffixed V1 Contract ID"),
+        Bytes.assertFromString("00"),
+      )
+      val unsuffixedCidV2 = ContractId.V2.unsuffixed(
+        Time.Timestamp.Epoch,
+        crypto.Hash.hashPrivateKey("an unsuffixed V2 Contract ID"),
+      )
+      val suffixedCidV2 =
+        ContractId.V2.assertBuild(unsuffixedCidV2.local, Bytes.assertFromString("00"))
+      val cids = List(suffixedCidV1, unsuffixedCidV1, suffixedCidV2, unsuffixedCidV2)
+
+      cids.foreach(cid =>
+        forEvery(testCasesForCid(cid))((typ, value) =>
+          Try(valueTranslator.unsafeTranslateValue(typ, value)) shouldBe a[Success[_]]
+        )
+      )
+    }
+
+    "reject non suffixed V1/V2 Contract IDs when requireContractIdSuffix is true" in {
+
+      val valueTranslator = new ValueTranslator(
+        compiledPackage.pkgInterface,
+        requireContractIdSuffix = true,
+      )
+      val legalCidV1 =
+        ContractId.V1.assertBuild(
+          crypto.Hash.hashPrivateKey("a legal Contract ID"),
+          Bytes.assertFromString("00"),
+        )
+      val legalCidV2 = ContractId.V2.assertBuild(
+        Bytes.fromByteArray(Array.fill[Byte](ContractId.V2.localSize)(0x12.toByte)),
+        Bytes.assertFromString("00"),
+      )
+      val illegalCidV1 =
+        ContractId.V1.assertBuild(crypto.Hash.hashPrivateKey("an illegal Contract ID"), Bytes.Empty)
+      val illegalCidV2 = ContractId.V2.unsuffixed(
+        Time.Timestamp.Epoch,
+        crypto.Hash.hashPrivateKey("an illegal Contract ID"),
+      )
+      val failureV1 =
+        Failure(Error.Preprocessing.IllegalContractId.NonSuffixV1ContractId(illegalCidV1))
+      val failureV2 =
+        Failure(Error.Preprocessing.IllegalContractId.NonSuffixV2ContractId(illegalCidV2))
+
+      forEvery(testCasesForCid(legalCidV1))((typ, value) =>
+        Try(valueTranslator.unsafeTranslateValue(typ, value)) shouldBe a[Success[_]]
+      )
+      forEvery(testCasesForCid(legalCidV2))((typ, value) =>
+        Try(valueTranslator.unsafeTranslateValue(typ, value)) shouldBe a[Success[_]]
+      )
+      forEvery(testCasesForCid(illegalCidV1))((typ, value) =>
+        Try(valueTranslator.unsafeTranslateValue(typ, value)) shouldBe failureV1
+      )
+      forEvery(testCasesForCid(illegalCidV2))((typ, value) =>
+        Try(valueTranslator.unsafeTranslateValue(typ, value)) shouldBe failureV2
+      )
+    }
+
+  }
+
+}


### PR DESCRIPTION
Since `importValue` and preprocessing are going to differ significantly as we've discussed making `importValue` stricter and making preprocessing more lenient yesterday, it makes no longer sense to have one delegate to the other. This PR simply restores the original `ValueTranslator.scala` and `ValueTranslatorSpec.scala`. It doesn't make any modification to them, except from removing an unused legacy method from ValueTranslator.

