### PR TITLE
Extend snapshot code to capture the number of transaction nodes

### DIFF
--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -531,6 +531,9 @@ class EngineTest(majorLanguageVersion: LanguageMajorVersion, contractIdVersion: 
 
       inside((validatedWithCaching, validatedNoCaching)) {
         case (Right(actualWithCaching), Right(actualNoCaching)) =>
+          actualWithCaching.transactionNodeCount shouldBe expectedWithCaching.transactionNodeCount
+          actualNoCaching.transactionNodeCount shouldBe expectedNoCaching.transactionNodeCount
+          actualWithCaching.transactionNodeCount shouldBe actualNoCaching.transactionNodeCount
           // SEVal and SDefinition caching effects impact Speedy machine step counts
           actualWithCaching.totalStepCount shouldBe expectedWithCaching.totalStepCount
           actualWithCaching.totalStepCount should be <= actualNoCaching.totalStepCount

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -1163,6 +1163,7 @@ private[lf] object SBuiltinFun {
                 machine.storeLocalContract(coid, templateId, templateArg)
                 machine.ptx = newPtx
                 machine.insertContractInfoCache(coid, contract)
+                machine.metrics.incrTransactionNodeCount()
                 Control.Value(SContractId(coid))
               }
               case Left((newPtx, err)) => {
@@ -1258,6 +1259,7 @@ private[lf] object SBuiltinFun {
           ) match {
           case Right(ptx) =>
             machine.ptx = ptx
+            machine.metrics.incrTransactionNodeCount()
             Control.Value(SUnit)
           case Left(err) =>
             Control.Error(convTxError(err))
@@ -1713,6 +1715,7 @@ private[lf] object SBuiltinFun {
           ) match {
             case Right(ptx) =>
               machine.ptx = ptx
+              machine.metrics.incrTransactionNodeCount()
               Control.Value(templateArg)
             case Left(err) =>
               Control.Error(convTxError(err))
@@ -1753,6 +1756,7 @@ private[lf] object SBuiltinFun {
       ) match {
         case Right(ptx) =>
           machine.ptx = ptx
+          machine.metrics.incrTransactionNodeCount()
           Control.Value(SUnit)
         case Left(err) =>
           Control.Error(convTxError(err))

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -51,14 +51,18 @@ private[lf] object Speedy {
     // Speedy evaluates in steps which are grouped into batches of batchSize
     private[this] var stepBatchCount: Long = 0
     private[this] var stepCount: Long = 0
+    private[this] var txNodeCount: Long = 0
 
     private[speedy] def incrStepCount(): Unit = stepCount += 1
     private[speedy] def incrStepBatchCount(): Unit = {
       stepBatchCount += 1
       stepCount = 0
     }
+    private[speedy] def incrTransactionNodeCount(): Unit = txNodeCount += 1
 
     private[lf] def totalStepCount: (Long, Long) = (stepBatchCount, stepCount)
+
+    private[lf] def transactionNodeCount: Long = txNodeCount
   }
 
   /** Instrumentation counters. */

--- a/sdk/daml-lf/snapshot/src/benchmark/scala/com/digitalasset/daml/lf/testing/snapshot/ReplayBenchmark.scala
+++ b/sdk/daml-lf/snapshot/src/benchmark/scala/com/digitalasset/daml/lf/testing/snapshot/ReplayBenchmark.scala
@@ -41,6 +41,7 @@ class ReplayBenchmark {
       val (stepBatchCount, stepCount) = metrics.totalStepCount
       stepBatchCount * metrics.batchSize + stepCount
     }
+    counters.transactionNodeCount += metrics.transactionNodeCount
   }
 
   @Setup(Level.Trial)
@@ -75,8 +76,11 @@ object ReplayBenchmark {
   class EventCounter {
     var stepCount: Long = 0
 
+    var transactionNodeCount: Long = 0
+
     def reset(): Unit = {
       stepCount = 0
+      transactionNodeCount = 0
     }
   }
 }


### PR DESCRIPTION
- [ ] Add in transaction node count metric
- [ ] Update JMH replay benchmarks to capture transaction node count metrics
- [ ] Instrument create, fetch, lookup and exercise Speedy built-ins to increment transaction node count metrics
- [ ] Update `EngineTest` naive metric testing to validate transaction node counts are stable

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
