### PR TITLE
enterprise overview docs: Fix broken docker install ref

### DIFF
--- a/sdk/docs/manually-written/overview/overview/enterprise.rst
+++ b/sdk/docs/manually-written/overview/overview/enterprise.rst
@@ -72,13 +72,13 @@ Obtaining The Enterprise Edition
 
 Enterprise releases are available on request (sales@digitalasset.com) and can be downloaded from the
 respective `repository <https://digitalasset.jfrog.io/artifactory/canton-enterprise/>`__, or you can use
-our Canton Enterprise Docker images as described in our `Docker instructions <https://docs.digitalasset.com/operate/3.3/howtos/install/docker.html>`.
+our Canton Enterprise Docker images as described in our :externalref:`Docker instructions <install-with-docker>`.
 
 
 Downloading the Open Source Edition
 ***********************************
 
 The Open Source release is available from `Github <https://github.com/digital-asset/daml/releases/latest>`__.
-You can also use our Canton Docker images by following our `Docker instructions <https://docs.digitalasset.com/operate/3.3/howtos/install/docker.html>`.
+You can also use our Canton Docker images by following our :externalref:`Docker instructions <install-with-docker>`.
 
 

--- a/sdk/docs/sharable/overview/overview/enterprise.rst
+++ b/sdk/docs/sharable/overview/overview/enterprise.rst
@@ -72,13 +72,13 @@ Obtaining The Enterprise Edition
 
 Enterprise releases are available on request (sales@digitalasset.com) and can be downloaded from the
 respective `repository <https://digitalasset.jfrog.io/artifactory/canton-enterprise/>`__, or you can use
-our Canton Enterprise Docker images as described in our `Docker instructions <https://docs.digitalasset.com/operate/3.3/howtos/install/docker.html>`.
+our Canton Enterprise Docker images as described in our :externalref:`Docker instructions <install-with-docker>`.
 
 
 Downloading the Open Source Edition
 ***********************************
 
 The Open Source release is available from `Github <https://github.com/digital-asset/daml/releases/latest>`__.
-You can also use our Canton Docker images by following our `Docker instructions <https://docs.digitalasset.com/operate/3.3/howtos/install/docker.html>`.
+You can also use our Canton Docker images by following our :externalref:`Docker instructions <install-with-docker>`.
 
 


### PR DESCRIPTION
fix brokenref in docs - make link to docker installation instructions an externalref to correct

<img width="995" height="835" alt="image" src="https://github.com/user-attachments/assets/845a6a75-d82c-4066-af48-2b9c96a8bb36" />
