### PR TITLE
Authenticate legacy contracts in the engine

### DIFF
--- a/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/Conversions.scala
+++ b/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/Conversions.scala
@@ -268,6 +268,9 @@ final class Conversions(
                   // TODO(https://github.com/digital-asset/daml/issues/21667): handle translation errors properly
                   case Dev.TranslationError(translationError) =>
                     builder.setCrash(s"translation error: ${translationError}")
+                  // TODO(https://github.com/digital-asset/daml/issues/21667): handle authentication errors properly
+                  case Dev.AuthenticationError(coid, value, msg) =>
+                    builder.setCrash(s"authentication error: $coid, $value, $msg")
                 }
               case _: Upgrade =>
                 builder.setUpgradeError(

--- a/sdk/daml-lf/engine/src/test/daml/BasicTests.daml
+++ b/sdk/daml-lf/engine/src/test/daml/BasicTests.daml
@@ -24,6 +24,16 @@ template Simple
       controller p
       do pure "hello"
 
+template SimpleFetcher
+  with
+    p : Party
+  where
+    signatory p
+    choice DoFetchSimple : Simple
+      with cid : ContractId Simple
+      controller p
+      do fetch cid
+
 template SimpleNumeric
   with
     p: Party

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -2918,7 +2918,7 @@ class EngineTest(majorLanguageVersion: LanguageMajorVersion, contractIdVersion: 
             } else true
           },
         )
-        // idValidatorCalledWithExpectedHash shouldBe true
+        idValidatorCalledWithExpectedHash shouldBe true
         result shouldBe a[Right[_, _]]
       }
     }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -255,6 +255,9 @@ private[lf] object Pretty {
               case TranslationError.InvalidValue(value, message) =>
                 text("invalid value") & prettyValue(verbose = true)(value) / text(message)
             }
+          case Dev.AuthenticationError(coid, value, message) =>
+            text("Authentication error for contract") & prettyContractId(coid) /
+              text("with argument") & prettyValue(verbose = false)(value) / text(message)
         }
     }
   }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -2463,6 +2463,7 @@ private[lf] object SBuiltinFun {
         }
       case None =>
         machine.lookupContract(coid)((coinst, hashingMethod, authenticator) =>
+          // If hashingMethod is one of the legacy methods, we need to authenticate the contract before normalizing it.
           authenticateIfLegacyContract(coid, coinst, hashingMethod, authenticator) { () =>
             machine.ensurePackageIsLoaded(
               NameOf.qualifiedNameOfCurrentFunc,
@@ -2476,6 +2477,10 @@ private[lf] object SBuiltinFun {
     }
   }
 
+  /** Authenticates the provided FatContractInstance using [hashingMethod] if [hashingMethod] is
+    * one of [[HashingMethod.Legacy]] or [[HashingMethod.UpgradeFriendly]]. Does nothing if the
+    * hashing method is [[HashingMethod.TypedNormalForm]].
+    */
   private def authenticateIfLegacyContract(
       coid: V.ContractId,
       coinst: FatContractInstance,

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
@@ -243,6 +243,9 @@ object Error {
       final case class InvalidValue(value: Value, message: String) extends Error
     }
 
+    final case class AuthenticationError(coid: ContractId, value: Value, message: String)
+        extends Error
+
     final case class Limit(error: Limit.Error) extends Error
 
     object Limit {

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -138,7 +138,7 @@
 - Evaluation order of successful lookup_by_key of a local contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3237)
 - Evaluation order of successful lookup_by_key of a non-cached global contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3104)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L38)
-- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2371)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2372)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/stable/Exceptions.daml#L263)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version, where one is new to V2 within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/stable/Exceptions.daml#L267)
 - Smart Contract Upgrade: Can catch same errors thrown by different choice versions within Update: [Exceptions.daml](daml-script/test/daml/upgrades/stable/Exceptions.daml#L259)


### PR DESCRIPTION
Part of https://github.com/digital-asset/daml/issues/21667.

Adds the authentication of legacy (contract ID v10 or v11) contracts in the engine. When such a contract is imported, the engine now computes its hash and  authenticates it using the provided ID validator provided to the continuation or `ResultNeedContract`. If the requested hashing method is TypedNormalForm then do nothing for now. Doing nothing is safe to make without compromising the security of Canton HEAD as TypedNormalForm is never provided for now.

The authentication has to happen early, before the contract is type-checked/translated because v10 contracts may contain trailing Nones that the translation would remove. The authentication of v12 contracts will happen after translation.

After this change is merged, it should be safe to provided disclosures via `ResultNeedContract` rather than via command preprocessing without compromising the security.