### PR TITLE
DPM Codegen integration

### DIFF
--- a/ci/copy-unix-release-artifacts.sh
+++ b/ci/copy-unix-release-artifacts.sh
@@ -56,7 +56,7 @@ function copy_oci {
 # Copy all platforms for each, publishing script picks out platform independent
 copy_oci damlc bazel-bin/compiler/damlc/damlc-oci.tar.gz
 copy_oci daml-script bazel-bin/daml-script/runner/daml-script-oci.tar.gz
-copy_oci daml2js bazel-bin/language-support/ts/codegen/daml2js-oci.tar.gz
+copy_oci codegen-js bazel-bin/language-support/ts/codegen/codegen-js-oci.tar.gz
 copy_oci codegen bazel-bin/language-support/java/codegen/codegen-oci.tar.gz
 copy_oci daml-new bazel-bin/daml-assistant/daml-helper/daml-new-oci.tar.gz
 

--- a/ci/copy-unix-release-artifacts.sh
+++ b/ci/copy-unix-release-artifacts.sh
@@ -57,7 +57,7 @@ function copy_oci {
 copy_oci damlc bazel-bin/compiler/damlc/damlc-oci.tar.gz
 copy_oci daml-script bazel-bin/daml-script/runner/daml-script-oci.tar.gz
 copy_oci codegen-js bazel-bin/language-support/ts/codegen/codegen-js-oci.tar.gz
-copy_oci codegen bazel-bin/language-support/java/codegen/codegen-oci.tar.gz
+copy_oci codegen-java bazel-bin/language-support/java/codegen/codegen-java-oci.tar.gz
 copy_oci daml-new bazel-bin/daml-assistant/daml-helper/daml-new-oci.tar.gz
 
 # Platform independent artifacts are only built on Linux.

--- a/ci/copy-windows-release-artifacts.sh
+++ b/ci/copy-windows-release-artifacts.sh
@@ -50,6 +50,6 @@ function copy_oci {
 # Copy all platforms for each, publishing script picks out platform independent
 copy_oci damlc bazel-bin/compiler/damlc/damlc-oci.tar.gz
 copy_oci daml-script bazel-bin/daml-script/runner/daml-script-oci.tar.gz
-copy_oci daml2js bazel-bin/language-support/ts/codegen/daml2js-oci.tar.gz
+copy_oci codegen-js bazel-bin/language-support/ts/codegen/codegen-js-oci.tar.gz
 copy_oci codegen bazel-bin/language-support/java/codegen/codegen-oci.tar.gz
 copy_oci daml-new bazel-bin/daml-assistant/daml-helper/daml-new-oci.tar.gz

--- a/ci/copy-windows-release-artifacts.sh
+++ b/ci/copy-windows-release-artifacts.sh
@@ -51,5 +51,5 @@ function copy_oci {
 copy_oci damlc bazel-bin/compiler/damlc/damlc-oci.tar.gz
 copy_oci daml-script bazel-bin/daml-script/runner/daml-script-oci.tar.gz
 copy_oci codegen-js bazel-bin/language-support/ts/codegen/codegen-js-oci.tar.gz
-copy_oci codegen bazel-bin/language-support/java/codegen/codegen-oci.tar.gz
+copy_oci codegen-java bazel-bin/language-support/java/codegen/codegen-java-oci.tar.gz
 copy_oci daml-new bazel-bin/daml-assistant/daml-helper/daml-new-oci.tar.gz

--- a/ci/publish-oci.sh
+++ b/ci/publish-oci.sh
@@ -38,7 +38,7 @@ DPM_REGISTRY=$3
 # DPM_REGISTRY="europe-docker.pkg.dev/da-images-dev/oci-playground"
 
 # Should match the tars copied into /release/oci during copy-{OS}-release-artifacts.sh
-declare -a components=(damlc daml-script daml2js codegen daml-new)
+declare -a components=(damlc daml-script codegen-js codegen-java daml-new)
 
 if [[ x"$DEBUG" != x ]]; then
   unarchive="tar -x -v -z -f"

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/SdkInstall.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/SdkInstall.hs
@@ -42,6 +42,7 @@ import DA.Daml.Assistant.Types
 import DA.Daml.Assistant.Util (tryConfig)
 import DA.Daml.Assistant.Version
 import DA.Daml.Project.Config
+import DA.Daml.Project.Consts (projectPathEnvVar, packagePathEnvVar)
 import DA.Daml.Resolution.Config
 import qualified Language.LSP.Types as LSP
 import qualified Language.LSP.Types.Lens as LSP
@@ -198,9 +199,9 @@ releaseVersionFromLspId _ = Nothing
 data DpmResolveMode = DpmResolveMultiPackage | DpmResolveSinglePackage PackageHome
   deriving Show
 
-dpmResolveModeEnvVar :: MultiIdeState -> DpmResolveMode -> (String, String)
-dpmResolveModeEnvVar miState DpmResolveMultiPackage = ("DPM_MULTI_PACKAGE", misMultiPackageHome miState)
-dpmResolveModeEnvVar _ (DpmResolveSinglePackage home) = ("DAML_PROJECT", unPackageHome home)
+dpmResolveModeEnvVar :: MultiIdeState -> DpmResolveMode -> [(String, String)]
+dpmResolveModeEnvVar miState DpmResolveMultiPackage = [("DPM_MULTI_PACKAGE", misMultiPackageHome miState)]
+dpmResolveModeEnvVar _ (DpmResolveSinglePackage home) = [(projectPathEnvVar, unPackageHome home), (packagePathEnvVar, unPackageHome home)]
 
 callDpmResolve :: MultiIdeState -> DpmResolveMode -> IO (Either String (Map.Map PackageHome PackageResolutionData))
 callDpmResolve miState dpmResolveMode = do
@@ -210,7 +211,7 @@ callDpmResolve miState dpmResolveMode = do
   (exit, resolutionStr, err) <-
     readCreateProcessWithExitCode ((proc dpmBinary ["resolve"])
       { cwd = Just $ takeDirectory $ unPackageHome $ misDefaultPackagePath miState
-      , env = Just $ dpmResolveModeEnvVar miState dpmResolveMode : currentEnv
+      , env = Just $ dpmResolveModeEnvVar miState dpmResolveMode ++ currentEnv
       }) ""
   case exit of
     ExitSuccess -> do

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/SubIdeManagement.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Command/MultiIde/SubIdeManagement.hs
@@ -25,6 +25,7 @@ import DA.Cli.Damlc.Command.MultiIde.SubIdeCommunication
 import DA.Cli.Damlc.Command.MultiIde.Types
 import DA.Cli.Damlc.Command.MultiIde.Util
 import DA.Cli.Damlc.Command.MultiIde.SdkInstall
+import DA.Daml.Project.Consts (projectPathEnvVar, packagePathEnvVar)
 import DA.Daml.Resolution.Config (ValidPackageResolution (..), PackageResolutionData (..), ResolutionData (..), resolutionFileEnvVar)
 import Data.Foldable (traverse_)
 import qualified Data.Map as Map
@@ -223,7 +224,7 @@ unsafeAddNewSubIdeAndSend miState ides home mMsg = do
 -- Returns process handle and optional filepath temp resolution file for removal
 runSubProc :: MultiIdeState -> PackageHome -> Maybe (ValidPackageResolution, FilePath) -> IO (Process Handle Handle Handle, Maybe FilePath)
 runSubProc miState home mPackageResolution = do
-  assistantEnv <- filter (flip notElem ["DAML_PROJECT", "DAML_SDK_VERSION", "DAML_SDK", resolutionFileEnvVar] . fst) <$> getEnvironment
+  assistantEnv <- filter (flip notElem [projectPathEnvVar, packagePathEnvVar, "DAML_SDK_VERSION", "DAML_SDK", resolutionFileEnvVar] . fst) <$> getEnvironment
 
   (assistantPath, mResolutionPath, assistantEnv') <-
     case mPackageResolution of

--- a/sdk/compiler/damlc/tests/BUILD.bazel
+++ b/sdk/compiler/damlc/tests/BUILD.bazel
@@ -57,6 +57,7 @@ da_haskell_test(
     visibility = ["//visibility:private"],
     deps = [
         "//compiler/damlc:damlc-lib",
+        "//daml-assistant:daml-project-config",
         "//libs-haskell/da-hs-base",
         "//libs-haskell/test-utils",
         "//sdk-version/hs:sdk-version-lib",
@@ -1050,6 +1051,7 @@ da_haskell_test(
     deps = [
         "//compiler/daml-dar-reader",
         "//compiler/daml-lf-ast",
+        "//daml-assistant:daml-project-config",
         "//daml-assistant/daml-helper:daml-helper-lib",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/canton-test-utils",

--- a/sdk/compiler/damlc/tests/src/CliParser.hs
+++ b/sdk/compiler/damlc/tests/src/CliParser.hs
@@ -8,6 +8,7 @@ module Cli
 import Control.Exception (SomeException, try)
 import qualified DA.Cli.Args as ParseArgs
 import DA.Cli.Damlc (Command (..), fullParseArgs)
+import DA.Daml.Project.Consts (packagePathEnvVar)
 import DA.Test.Util
 import Data.Either (isRight)
 import Data.List (isInfixOf)
@@ -69,9 +70,9 @@ assertDamlcParser cliArgs damlYamlArgs mExpectedError = withCurrentTempDir $ do
 withDamlProject :: IO a -> IO a
 withDamlProject f = do
   cwd <- getCurrentDirectory
-  setEnv "DAML_PROJECT" cwd True
+  setEnv packagePathEnvVar cwd True
   res <- f
-  unsetEnv "DAML_PROJECT"
+  unsetEnv packagePathEnvVar
   pure res
 
 -- Run the damlc parser with a set of command line flags/options, and a set of daml.yaml flags/options

--- a/sdk/compiler/damlc/tests/src/DamlcPkgManager.hs
+++ b/sdk/compiler/damlc/tests/src/DamlcPkgManager.hs
@@ -10,6 +10,7 @@ import DA.Bazel.Runfiles
 import DA.Daml.Dar.Reader
 import DA.Daml.Helper.Ledger (downloadAllReachablePackages)
 import qualified DA.Daml.LF.Ast as LF
+import DA.Daml.Project.Consts (packagePathEnvVar)
 import DA.Test.Sandbox
 import qualified Data.HashMap.Strict as HMS
 import Data.List
@@ -74,7 +75,7 @@ testsForRemoteDataDependencies damlc dar =
                             , "template T with p : Party where"
                             , "  signatory p"
                             ]
-                    setEnv "DAML_PROJECT" projDir True
+                    setEnv packagePathEnvVar projDir True
                     (exitCode, _stdout, _stderr) <- readProcessWithExitCode damlc ["build"] ""
                     exitCode @?= ExitSuccess
               , testCase "package name:version data-dependency" $
@@ -103,7 +104,7 @@ testsForRemoteDataDependencies damlc dar =
                             , "template T with p : Party where"
                             , "  signatory p"
                             ]
-                    setEnv "DAML_PROJECT" projDir True
+                    setEnv packagePathEnvVar projDir True
                     (exitCode, _stdout, _stderr) <- readProcessWithExitCode damlc ["build"] ""
                     exitCode @?= ExitSuccess
                   -- check that a lock file is written
@@ -197,7 +198,7 @@ testsForRemoteDataDependencies damlc dar =
                             , "template T with p : Party where"
                             , "  signatory p"
                             ]
-                    setEnv "DAML_PROJECT" projDir True
+                    setEnv packagePathEnvVar projDir True
                     (exitCode, _stdout, _stderr) <- readProcessWithExitCode damlc ["build"] ""
                     exitCode @?= ExitSuccess
               ]

--- a/sdk/daml-assistant/daml-helper/BUILD.bazel
+++ b/sdk/daml-assistant/daml-helper/BUILD.bazel
@@ -157,6 +157,7 @@ da_haskell_test(
         "//compiler/daml-lf-ast",
         "//compiler/daml-lf-proto",
         "//compiler/daml-lf-reader",
+        "//daml-assistant:daml-project-config",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/canton-test-utils",
         "//libs-haskell/test-utils",

--- a/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Codegen.hs
+++ b/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Codegen.hs
@@ -9,7 +9,6 @@ module DA.Daml.Helper.Codegen
 import Control.Exception
 import Control.Exception.Safe (catchIO)
 import DA.Daml.Helper.Util
-import DA.Daml.Project.Config
 import DA.Daml.Project.Consts
 import qualified Data.Text as T
 import System.FilePath
@@ -30,28 +29,8 @@ runCodegen :: Lang -> [String] -> IO ()
 runCodegen lang args =
   case lang of
     JavaScript -> do
-      args' <-
-        if null args
-          then do
-            darPath <- getDarPath
-            projectConfig <- getProjectConfig Nothing
-            outputPath <-
-              requiredE
-                "Failed to read output directory for JavaScript code generation" $
-              queryProjectConfigRequired
-                ["codegen", showLang lang, "output-directory"]
-                projectConfig
-            mbNpmScope :: Maybe FilePath <-
-              requiredE "Failed to read NPM scope for JavaScript code generation" $
-              queryProjectConfig
-                ["codegen", showLang lang, "npm-scope"]
-                projectConfig
-            pure $
-              [darPath, "-o", outputPath] ++
-              ["-s" <> npmScope | Just npmScope <- [mbNpmScope]]
-          else pure args
       daml2js <- fmap (</> "daml2js" </> "daml2js") getSdkPath
-      withProcessWait_' (proc daml2js args') (const $ pure ()) `catchIO`
+      withProcessWait_' (proc daml2js args) (const $ pure ()) `catchIO`
         (\e -> hPutStrLn stderr "Failed to invoke daml2js." *> throwIO e)
     Java ->
       runJar

--- a/sdk/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Deployment.hs
+++ b/sdk/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Deployment.hs
@@ -21,6 +21,7 @@ import qualified Data.Text as T
 
 import DA.Bazel.Runfiles (mainWorkspace,locateRunfiles,exe)
 import DA.Daml.LF.Reader (Dalfs(..),readDalfs)
+import DA.Daml.Project.Consts (packagePathEnvVar)
 import DA.Test.Process (callProcessSilent)
 import DA.Test.Sandbox (mbSharedSecret, withCantonSandbox, defaultSandboxConf, makeSignedAdminJwt)
 import DA.Test.Util
@@ -91,12 +92,12 @@ authenticationTests Tools{..} =
                 , "  access-token-file: " <> tokenFile
                 ]
               writeFileUTF8 tokenFile (makeSignedAdminJwt sharedSecret <> "\n")
-              setEnv "DAML_PROJECT" deployDir True
+              setEnv packagePathEnvVar deployDir True
               callProcessSilent damlHelper
                 [ "ledger", "list-parties"
                 , "--host", "localhost", "--port", show port
                 ]
-              unsetEnv "DAML_PROJECT"
+              unsetEnv packagePathEnvVar
 
     ]
   where

--- a/sdk/daml-assistant/daml-project-config/DA/Daml/Project/Consts.hs
+++ b/sdk/daml-assistant/daml-project-config/DA/Daml/Project/Consts.hs
@@ -5,6 +5,7 @@ module DA.Daml.Project.Consts
     ( damlPathEnvVar
     , damlCacheEnvVar
     , projectPathEnvVar
+    , packagePathEnvVar
     , sdkPathEnvVar
     , sdkVersionEnvVar
     , sdkVersionLatestEnvVar
@@ -58,8 +59,17 @@ damlCacheEnvVar = "DAML_CACHE"
 -- | The DAML_PROJECT environment variable determines the path of
 -- the current daml project. By default, this is done by traversing
 -- up the directory structure until we find a "daml.yaml" file.
+-- (deprecated, replaced by packagePathEnvVar, check for both in 3.4)
 projectPathEnvVar :: String
 projectPathEnvVar = "DAML_PROJECT"
+
+-- | The DAML_PACKAGE environment variable determines the path of
+-- the current daml package. By default, this is done by traversing
+-- up the directory structure until we find a "daml.yaml" file.
+-- This variable replaces the deprecated `DAML_PROJECT` environment variable
+-- in DPM
+packagePathEnvVar :: String
+packagePathEnvVar = "DAML_PACKAGE"
 
 -- | The DAML_SDK environment variable determines the path of the
 -- sdk folder. By default, this is calculated as
@@ -118,6 +128,7 @@ damlEnvVars =
     [ damlPathEnvVar
     , damlCacheEnvVar
     , projectPathEnvVar
+    , packagePathEnvVar
     , sdkPathEnvVar
     , sdkVersionEnvVar
     , sdkVersionLatestEnvVar
@@ -132,12 +143,14 @@ damlEnvVars =
 getDamlPath :: IO FilePath
 getDamlPath = getEnv damlPathEnvVar
 
--- | Returns the path of the current daml project or
---`Nothing` if invoked outside of a project.
+-- | Returns the path of the current daml package or
+--`Nothing` if invoked outside of a package.
 getProjectPath :: IO (Maybe FilePath)
 getProjectPath = do
+    let nullToNothing p = if null p then Nothing else Just p
+    mbPackagePath <- lookupEnv packagePathEnvVar
     mbProjectPath <- lookupEnv projectPathEnvVar
-    pure ((\p -> if null p then Nothing else Just p) =<< mbProjectPath)
+    pure $ (mbPackagePath >>= nullToNothing) <|> (mbProject >>= nullToNothing)
 
 -- | Returns the path of the sdk folder.
 --

--- a/sdk/daml-assistant/integration-tests/BUILD.bazel
+++ b/sdk/daml-assistant/integration-tests/BUILD.bazel
@@ -172,6 +172,7 @@ da_haskell_test(
     visibility = ["//visibility:public"],
     deps = [
         ":integration-test-utils",
+        "//daml-assistant:daml-project-config",
         "//daml-assistant/daml-helper:daml-helper-lib",
         "//language-support/hs/bindings:hs-ledger",
         "//language-support/ts/codegen/tests:daml2js-test-helpers",

--- a/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/QuickstartTests.hs
+++ b/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/QuickstartTests.hs
@@ -24,6 +24,7 @@ import Test.Tasty.HUnit
 import DA.Bazel.Runfiles
 import DA.Daml.Assistant.IntegrationTestUtils
 import DA.Daml.Helper.Util (waitForHttpServer)
+import DA.Daml.Project.Consts (packagePathEnvVar)
 import DA.Test.Process (callCommandSilent, callCommandSilentIn, callCommandSilentWithEnvIn)
 import DA.Test.Util
 import DA.PortFile
@@ -188,7 +189,7 @@ quickstartTests quickstartDir mvnDir getSandbox =
         subtest "daml codegen java with DAML_PROJECT" $ do
             withTempDir $ \dir -> do
                 callCommandSilentIn dir $ unwords ["daml", "new", dir </> "quickstart", "--template=quickstart-java"]
-                let projEnv = [("DAML_PROJECT", dir </> "quickstart")]
+                let projEnv = [(packagePathEnvVar, dir </> "quickstart")]
                 -- TODO(#14706): remove explicit target once the default major version is 2
                 callCommandSilentWithEnvIn dir projEnv "daml build --target=2.1"
                 callCommandSilentWithEnvIn dir projEnv "daml codegen java"

--- a/sdk/daml-assistant/scala-daml-project-config/src/main/scala/com/daml/assistant/config/ProjectConfig.scala
+++ b/sdk/daml-assistant/scala-daml-project-config/src/main/scala/com/daml/assistant/config/ProjectConfig.scala
@@ -122,7 +122,11 @@ object ProjectConfig {
     sys.env
       .get(envVarPackagePath)
       .orElse(sys.env.get(envVarProjectPath))
-      .toRight(ConfigMissing(s"Neither $envVarPackagePath or $envVarProjectPath set, could not find package."))
+      .toRight(
+        ConfigMissing(
+          s"Neither $envVarPackagePath or $envVarProjectPath set, could not find package."
+        )
+      )
 
   /** Returns the path of the current daml project config file, if any.
     * The path is given by environment variables set by the SDK Assistant.

--- a/sdk/daml-assistant/scala-daml-project-config/src/main/scala/com/daml/assistant/config/ProjectConfig.scala
+++ b/sdk/daml-assistant/scala-daml-project-config/src/main/scala/com/daml/assistant/config/ProjectConfig.scala
@@ -104,11 +104,13 @@ case class ProjectConfig(
 
 object ProjectConfig {
 
-  /** The DAML_PROJECT environment variable determines the path of
-    * the current daml project. By default, this is done by traversing
+  /** The DAML_PACKAGE environment variable determines the path of
+    * the current daml package. By default, this is done by traversing
     * up the directory structure until we find a "daml.yaml" file.
+    * DAML_PROJECT is the legacy name for this variable
     */
   val envVarProjectPath = "DAML_PROJECT"
+  val envVarPackagePath = "DAML_PACKAGE"
 
   /** File name of config file in DAML_PROJECT (the project path). */
   val projectConfigName = "daml.yaml"
@@ -118,8 +120,9 @@ object ProjectConfig {
     */
   def projectPath(): Either[ConfigLoadingError, String] =
     sys.env
-      .get(envVarProjectPath)
-      .toRight(ConfigMissing(s"Environment variable $envVarProjectPath not found"))
+      .get(envVarPackagePath)
+      .orElse(sys.env.get(envVarProjectPath))
+      .toRight(ConfigMissing(s"Neither $envVarPackagePath or $envVarProjectPath set, could not find package."))
 
   /** Returns the path of the current daml project config file, if any.
     * The path is given by environment variables set by the SDK Assistant.

--- a/sdk/daml-assistant/test/DA/Daml/Assistant/Tests.hs
+++ b/sdk/daml-assistant/test/DA/Daml/Assistant/Tests.hs
@@ -110,7 +110,7 @@ testGetProjectPath = Tasty.testGroup "DA.Daml.Assistant.Env.getProjectPath"
             let expected = dir </> "project"
             setCurrentDirectory dir
             createDirectory expected
-            Just got <- withEnv [(projectPathEnvVar, Just expected)] getProjectPath'
+            Just got <- withEnv [(packagePathEnvVar, Just expected)] getProjectPath'
             Tasty.assertEqual "project path" (ProjectPath expected) got
             return ()
 
@@ -119,7 +119,7 @@ testGetProjectPath = Tasty.testGroup "DA.Daml.Assistant.Env.getProjectPath"
             let expected = dir </> "project"
             setCurrentDirectory dir
             createDirectory expected
-            Just got <- withEnv [(projectPathEnvVar, Just "project")] getProjectPath'
+            Just got <- withEnv [(packagePathEnvVar, Just "project")] getProjectPath'
             Tasty.assertEqual "project path" (ProjectPath expected) got
             return ()
 
@@ -130,14 +130,14 @@ testGetProjectPath = Tasty.testGroup "DA.Daml.Assistant.Env.getProjectPath"
         -- or something super fancy like that.
         withSystemTempDirectory "test-getProjectPath" $ \dir -> do
             setCurrentDirectory dir
-            Nothing <- withEnv [(projectPathEnvVar, Nothing)] getProjectPath'
+            Nothing <- withEnv [(packagePathEnvVar, Nothing)] getProjectPath'
             return ()
 
     , Tasty.testCase "getProjectPath returns current directory" $ do
         withSystemTempDirectory "test-getProjectPath" $ \dir -> do
             writeFileUTF8 (dir </> projectConfigName) ""
             setCurrentDirectory dir
-            Just path <- withEnv [(projectPathEnvVar, Nothing)] getProjectPath'
+            Just path <- withEnv [(packagePathEnvVar, Nothing)] getProjectPath'
             Tasty.assertEqual "project path" (ProjectPath dir) path
 
     , Tasty.testCase "getProjectPath returns parent directory" $ do
@@ -145,7 +145,7 @@ testGetProjectPath = Tasty.testGroup "DA.Daml.Assistant.Env.getProjectPath"
             createDirectory (dir </> "foo")
             writeFileUTF8 (dir </> projectConfigName) ""
             setCurrentDirectory (dir </> "foo")
-            Just path <- withEnv [(projectPathEnvVar, Nothing)] getProjectPath'
+            Just path <- withEnv [(packagePathEnvVar, Nothing)] getProjectPath'
             Tasty.assertEqual "project path" (ProjectPath dir) path
 
     , Tasty.testCase "getProjectPath returns grandparent directory" $ do
@@ -153,7 +153,7 @@ testGetProjectPath = Tasty.testGroup "DA.Daml.Assistant.Env.getProjectPath"
             createDirectoryIfMissing True (dir </> "foo" </> "bar")
             writeFileUTF8 (dir </> projectConfigName) ""
             setCurrentDirectory (dir </> "foo" </> "bar")
-            Just path <- withEnv [(projectPathEnvVar, Nothing)] getProjectPath'
+            Just path <- withEnv [(packagePathEnvVar, Nothing)] getProjectPath'
             Tasty.assertEqual "project path" (ProjectPath dir) path
 
     , Tasty.testCase "getProjectPath prefers parent over grandparent" $ do
@@ -162,7 +162,7 @@ testGetProjectPath = Tasty.testGroup "DA.Daml.Assistant.Env.getProjectPath"
             writeFileUTF8 (dir </> projectConfigName) ""
             writeFileUTF8 (dir </> "foo" </> projectConfigName) ""
             setCurrentDirectory (dir </> "foo" </> "bar")
-            Just path <- withEnv [(projectPathEnvVar, Nothing)] getProjectPath'
+            Just path <- withEnv [(packagePathEnvVar, Nothing)] getProjectPath'
             Tasty.assertEqual "project path" (ProjectPath (dir </> "foo")) path
 
     ]

--- a/sdk/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/Conf.scala
+++ b/sdk/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/Conf.scala
@@ -42,11 +42,11 @@ object Conf {
   private[conf] final val PackageAndClassRegex =
     """(?:(\p{javaJavaIdentifierStart}\p{javaJavaIdentifierPart}+(?:\.\p{javaJavaIdentifierStart}\p{javaJavaIdentifierPart}+)*)\.)(\p{javaJavaIdentifierStart}\p{javaJavaIdentifierPart}+)""".r
 
-  def parse(args: Array[String]): Option[Conf] =
-    parser.parse(args, Conf(Map.empty, Paths.get(".")))
+  def parse(args: Array[String], parserName: String = "codegen"): Option[Conf] =
+    parser(parserName).parse(args, Conf(darFiles = Map.empty, outputDirectory = Paths.get(".")))
 
-  def parser: OptionParser[Conf] = new scopt.OptionParser[Conf]("codegen") {
-    head("codegen", BuildInfo.Version)
+  def parser(parserName: String): OptionParser[Conf] = new scopt.OptionParser[Conf](parserName) {
+    head(parserName, BuildInfo.Version)
     note("Code generator for the Daml ledger bindings.\n")
 
     arg[(Path, Option[String])]("<DAR-file[=package-prefix]>...")(

--- a/sdk/language-support/codegen-main/BUILD.bazel
+++ b/sdk/language-support/codegen-main/BUILD.bazel
@@ -11,6 +11,7 @@ load(
 load("//bazel_tools:pom_file.bzl", "pom_file")
 load("@os_info//:os_info.bzl", "is_windows")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("//bazel_tools/packaging:packaging.bzl", "package_oci_component")
 
 da_scala_library(
     name = "codegen-main-lib",
@@ -47,6 +48,17 @@ da_scala_binary(
         "//language-support/codegen-common",
         "//language-support/java/codegen:lib",
     ],
+)
+
+package_oci_component(
+    name = "codegen-java-oci",
+    component_manifest = ":component.yaml",
+    platform_agnostic = True,
+    resources = [
+        ":binary.jar",
+    ],
+    tags = ["no-cache"],
+    visibility = ["//visibility:public"],
 )
 
 copy_file(

--- a/sdk/language-support/codegen-main/component.yaml
+++ b/sdk/language-support/codegen-main/component.yaml
@@ -6,5 +6,6 @@ kind: Component
 spec:
   jar-commands:
     - path: binary.jar
-      name: codegen
+      name: codegen-java
       desc: Daml to Java compiler
+      jar-args: ["java"]

--- a/sdk/language-support/codegen-main/src/main/scala/com/daml/codegen/CodegenMain.scala
+++ b/sdk/language-support/codegen-main/src/main/scala/com/daml/codegen/CodegenMain.scala
@@ -37,7 +37,11 @@ object CodegenMain {
     runCodegen(JavaCodegen.run, codegenConfig(args, Java, parserName), parserName)
   }
 
-  private def runCodegen(generate: Conf => Unit, configO: Option[Conf], parserName: String): ExitCode =
+  private def runCodegen(
+      generate: Conf => Unit,
+      configO: Option[Conf],
+      parserName: String,
+  ): ExitCode =
     configO match {
       case None =>
         println("\n")
@@ -53,7 +57,11 @@ object CodegenMain {
         }
     }
 
-  private def codegenConfig(args: Array[String], mode: CodegenDest, parserName: String): Option[Conf] =
+  private def codegenConfig(
+      args: Array[String],
+      mode: CodegenDest,
+      parserName: String,
+  ): Option[Conf] =
     if (args.nonEmpty) {
       println(s"Reading configuration from command line input: ${args.mkString(",")}")
       Conf.parse(args, parserName)

--- a/sdk/language-support/java/codegen/BUILD.bazel
+++ b/sdk/language-support/java/codegen/BUILD.bazel
@@ -21,7 +21,6 @@ load(
     "mangle_for_java",
     "test_exclusions",
 )
-load("//bazel_tools/packaging:packaging.bzl", "package_oci_component")
 load(
     "//daml-lf/language:daml-lf.bzl",
     "COMPILER_LF_VERSIONS",
@@ -207,17 +206,6 @@ scaladoc_jar(
 scala_source_jar(
     name = "binary_src",
     srcs = [],
-)
-
-package_oci_component(
-    name = "codegen-oci",
-    component_manifest = ":component.yaml",
-    platform_agnostic = True,
-    resources = [
-        ":binary.jar",
-    ],
-    tags = ["no-cache"],
-    visibility = ["//visibility:public"],
 )
 
 [

--- a/sdk/language-support/ts/codegen/BUILD.bazel
+++ b/sdk/language-support/ts/codegen/BUILD.bazel
@@ -45,7 +45,7 @@ package_app(
 )
 
 package_oci_component(
-    name = "daml2js-oci",
+    name = "codegen-js-oci",
     component_manifest = ":component.yaml",
     resources = [
         ":daml2js-dist",

--- a/sdk/language-support/ts/codegen/component.yaml
+++ b/sdk/language-support/ts/codegen/component.yaml
@@ -6,5 +6,5 @@ kind: Component
 spec:
   commands:
     - path: daml2js-dist/daml2js${EXE}
-      name: daml2js
+      name: codegen-js
       desc: Daml to JavaScript compiler


### PR DESCRIPTION
Renames the codegen ocis, and moves their `daml-helper` / `daml-sdk` wrapper logic into the components, to keep original behaviour when using dpm.

Also adds support for the `DAML_PACKAGE` env var, which replaces `DAML_PROJECT`. As a future cleanup task, we should universally rename projects to packages in the codebase.