### PR TITLE
Publish Scala artifacts to Google Artifact Repository

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -154,8 +154,11 @@ steps:
       set -euo pipefail
       cd sdk
       eval "$(./dev-env/bin/dade-assist)"
+      # Authorize in GCLOUD and get a token
+      gcloud beta auth activate-service-account --key-file=<(echo "${GOOGLE_APPLICATION_CREDENTIALS_CONTENT}")
+      export GOOGLE_ARTIFACT_REGISTRY_KEY=$(gcloud auth print-access-token)
       bazel build //release:release
-      ./bazel-bin/release/release --release-dir "$(mktemp -d)" --upload
+      ./bazel-bin/release/release --release-dir "$(mktemp -d)" --upload --google-artifact-registry
     env:
       DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
       DAML_SCALA_VERSION: ${{parameters.scala_version}}
@@ -163,6 +166,8 @@ steps:
       MAVEN_USERNAME: $(MAVEN_USERNAME)
       MAVEN_PASSWORD: $(MAVEN_PASSWORD)
       MAVEN_URL: "https://central.sonatype.com"
+      GOOGLE_ARTIFACT_REGISTRY_URL: "https://europe-maven.pkg.dev/da-artifacts-dev/playground-maven"
+      GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
       NPM_TOKEN: $(NPM_TOKEN)
     name: publish_npm_mvn
     displayName: 'Publish NPM and Maven artifacts'

--- a/sdk/release/BUILD.bazel
+++ b/sdk/release/BUILD.bazel
@@ -50,6 +50,7 @@ da_haskell_binary(
         "text",
         "temporary",
         "transformers",
+        "unliftio",
         "unliftio-core",
         "unordered-containers",
         "yaml",

--- a/sdk/release/src/Main.hs
+++ b/sdk/release/src/Main.hs
@@ -155,7 +155,7 @@ main = do
                   when optsUploadToGoogleArtifactRegistry $ do
                     $logInfo "Uploading to Google Artifact Registry"
                     garConfig <- liftIO googleArtifactRegistryConfigFromEnv
-                    uploadToGoogleArtifactRegistry garConfig releaseDir mvnUploadArtifacts
+                    tryUploadToGoogleArtifactRegistry garConfig releaseDir mvnUploadArtifacts
                   $logInfo "Uploading to Maven Central"
                   mavenUploadConfig <- liftIO mavenConfigFromEnv
                   uploadToMavenCentral mavenUploadConfig releaseDir mvnUploadArtifacts

--- a/sdk/release/src/Options.hs
+++ b/sdk/release/src/Options.hs
@@ -17,6 +17,7 @@ parseOptions =
 
 data Options = Options
   { optsPerformUpload :: PerformUpload
+  , optsUploadToGoogleArtifactRegistry :: Bool
   , optsReleaseDir :: FilePath
   , optsLocallyInstallJars :: Bool
   , optIncludeTypescript :: IncludeTypescript
@@ -27,6 +28,7 @@ data Options = Options
 optsParser :: Parser Options
 optsParser = Options
   <$> (PerformUpload <$> switch (long "upload" <> help "upload java/scala artifacts to Maven Central and typescript artifacts to the npm registry."))
+  <*> switch (long "google-artifact-registry" <> help "in addition to Maven Central, also upload artifacts to Google Artifact Registry. Requires the --upload flag.")
   <*> option str (long "release-dir" <> help "specify full path to release directory")
   <*> switch (long "install-head-jars" <> help "install jars to ~/.m2")
   <*> fmap (IncludeTypescript . not) (switch (long "no-ts" <> help "Do not build and upload typescript packages"))

--- a/sdk/release/src/Types.hs
+++ b/sdk/release/src/Types.hs
@@ -8,6 +8,7 @@ module Types (
     CIException(..),
     Classifier,
     GitRev,
+    GoogleArtifactRegistryConfig(..),
     GroupId,
     MavenAllowUnsecureTls(..),
     MavenCoords(..),
@@ -136,6 +137,11 @@ instance FromJSON MavenUploadConfig where
         <*> o .: "password"
         <*> (fromMaybe (MavenAllowUnsecureTls False) <$> o .:? "allowUnsecureTls")
         <*> o .: "signingKey"
+
+data GoogleArtifactRegistryConfig = GoogleArtifactRegistryConfig
+  { garUrl :: !Text
+  , garKey :: !Text
+  }
 
 -- | Whether typescript packages should also be built and uploaded.
 newtype IncludeTypescript = IncludeTypescript { getIncludeTypescript :: Bool}

--- a/sdk/release/src/Upload.hs
+++ b/sdk/release/src/Upload.hs
@@ -7,7 +7,7 @@
 
 module Upload (
     uploadToMavenCentral,
-    mavenConfigFromEnv,
+    uploadToGoogleArtifactRegistry,
 ) where
 
 import qualified "zip-archive" Codec.Archive.Zip as ZipArchive
@@ -30,10 +30,16 @@ import           Network.Connection (TLSSettings(..))
 import           Network.HTTP.Client
 import           Network.HTTP.Client.TLS (mkManagerSettings, tlsManagerSettings)
 import           Network.HTTP.Client.MultipartFormData
-import           Network.HTTP.Simple (setRequestBasicAuth, setRequestHeader, setRequestMethod, setRequestPath, setRequestQueryString)
+import           Network.HTTP.Simple ( setRequestBasicAuth
+                                     , setRequestBodyFile
+                                     , setRequestHeader
+                                     , setRequestMethod
+                                     , setRequestPath
+                                     , setRequestQueryString
+                                     , setRequestBearerAuth
+                                     )
 import           Network.HTTP.Types.Status
 import           Path
-import           System.Environment
 import           System.IO.Temp
 import Text.Printf
 
@@ -65,7 +71,7 @@ uploadToMavenCentral MavenUploadConfig{..} releaseDir artifacts = do
 
     parsedUrlRequest <- parseUrlThrow $ T.unpack mucUrl -- Note: Will throw exception on non-2XX responses
     let baseRequest = setRequestBasicAuth (T.encodeUtf8 mucUser) (T.encodeUtf8 mucPassword)
-            $ setRequestMethod "POST"
+            $ setRequestMethod "PUT"
             $ setRequestHeader "User-Agent" ["http-conduit"] parsedUrlRequest
 
     decodedSigningKey <- decodeSigningKey mucSigningKey
@@ -102,6 +108,30 @@ uploadToMavenCentral MavenUploadConfig{..} releaseDir artifacts = do
     _ <- recovering checkStatusRetryPolicy [ httpResponseHandler, checkRepoStatusHandler ] (\_ -> handleStatusRequest statusRequest manager)
 
     return ()
+
+uploadToGoogleArtifactRegistry :: (MonadCI m) => GoogleArtifactRegistryConfig -> Path Abs Dir -> [(MavenCoords, Path Rel File)] -> m ()
+uploadToGoogleArtifactRegistry GoogleArtifactRegistryConfig{..} releaseDir artifacts = do
+    -- Create HTTP Connection manager with 30 s response timeout
+    manager <- liftIO $ newManager tlsManagerSettings { managerResponseTimeout = responseTimeoutMicro (30 * 1000 * 1000) }
+
+    parsedUrlRequest <- parseUrlThrow $ T.unpack garUrl -- Note: Will throw exception on non-2XX responses
+    let repositoryPath = decodeUtf8 $ path parsedUrlRequest
+    let baseRequest = setRequestBearerAuth (T.encodeUtf8 garKey)
+            $ setRequestMethod "PUT"
+            $ setRequestHeader "User-Agent" ["http-conduit"] parsedUrlRequest
+
+    for_ artifacts $ \(_, file) -> do
+        let absFile = releaseDir </> file -- (T.intercalate "/" (groupId <> [artifactId]))
+        let artUploadPath = repositoryPath <> "/" <> T.pack (toFilePath file)
+
+        $logDebug ("(Uploading " <> artUploadPath <> " from " <> tshow absFile <> ")")
+
+        let request = setRequestPath (encodeUtf8 artUploadPath)
+                $ setRequestBodyFile (fromAbsFile absFile) baseRequest
+
+        _ <- recovering uploadRetryPolicy [ httpResponseHandler ] (\_ -> liftIO $ httpNoBody request manager)
+
+        return ()
 
 decodeSigningKey :: (MonadCI m) => String -> m BS.ByteString
 decodeSigningKey signingKey =  case Base64.decode $ C8.pack signingKey of
@@ -140,21 +170,6 @@ noVerifyTlsManagerSettings = mkManagerSettings
     , settingUseServerName = False
     }
     Nothing
-
-mavenConfigFromEnv :: (MonadIO m, E.MonadThrow m) => m MavenUploadConfig
-mavenConfigFromEnv = do
-    url <- liftIO $ getEnv "MAVEN_URL"
-    user <- liftIO $ getEnv "MAVEN_USERNAME"
-    password <- liftIO $ getEnv "MAVEN_PASSWORD"
-    mbAllowUnsecureTls <- liftIO $ lookupEnv "MAVEN_UNSECURE_TLS"
-    signingKey <- liftIO $ getEnv "GPG_KEY"
-    pure MavenUploadConfig
-        { mucUrl = T.pack url
-        , mucUser = T.pack user
-        , mucPassword = T.pack password
-        , mucAllowUnsecureTls = MavenAllowUnsecureTls $ mbAllowUnsecureTls == Just "True"
-        , mucSigningKey = signingKey
-        }
 
 --
 -- HTTP Response Handlers


### PR DESCRIPTION
By default it still publishes to Maven Central.

I added a `--google-artifact-registry` flag to also publish to our GAR Maven repository. This is activated in the CI and thus it will publish to both repositories, Maven Central and GAR Maven.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
