### PR TITLE
Fix spelling errors in documentation

### DIFF
--- a/sdk/docs/sharable/hoogle/daml-base-hoogle.txt
+++ b/sdk/docs/sharable/hoogle/daml-base-hoogle.txt
@@ -3571,7 +3571,7 @@ find :: (a -> Bool) -> NonEmpty a -> Optional a
 @url https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-NonEmpty.html#function-da-nonempty-deleteby-6333
 deleteBy :: (a -> a -> Bool) -> a -> NonEmpty a -> [a]
 
--- | Remove the first occurence of x from the non-empty list, potentially
+-- | Remove the first occurrence of x from the non-empty list, potentially
 --   removing all elements.
 @url https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-NonEmpty.html#function-da-nonempty-delete-59160
 delete :: (Eq a) => a -> NonEmpty a -> [a]

--- a/sdk/docs/sharable/hoogle/daml-script-hoogle.txt
+++ b/sdk/docs/sharable/hoogle/daml-script-hoogle.txt
@@ -775,7 +775,7 @@ submitWithOptions :: (HasCallStack, ScriptSubmit script, IsSubmitOptions options
 @url https://docs.daml.com/daml-script/api/Daml-Script.html#function-daml-script-internal-questions-submit-submittree-5925
 submitTree :: (HasCallStack, ScriptSubmit script, IsSubmitOptions options) => options -> Commands a -> script TransactionTree
 
--- | Submit a transaction and recieve back either the result, or a `SubmitError`.
+-- | Submit a transaction and receive back either the result, or a `SubmitError`.
 --   In the majority of failures, this will not crash at runtime.
 @url https://docs.daml.com/daml-script/api/Daml-Script.html#function-daml-script-internal-questions-submit-trysubmit-23693
 trySubmit :: (HasCallStack, ScriptSubmit script, IsSubmitOptions options) => options -> Commands a -> script (Either SubmitError a)

--- a/sdk/docs/sharable/sdk/reference/daml-script/api/Daml-Script.rst
+++ b/sdk/docs/sharable/sdk/reference/daml-script/api/Daml-Script.rst
@@ -1527,7 +1527,7 @@ Functions
 `trySubmit <function-daml-script-internal-questions-submit-trysubmit-23693_>`_
   \: (`HasCallStack <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Stack.html#type-ghc-stack-types-hascallstack-63713>`_, `ScriptSubmit <class-daml-script-internal-questions-submit-scriptsubmit-55101_>`_ script, `IsSubmitOptions <class-daml-script-internal-questions-submit-issubmitoptions-64211_>`_ options) \=\> options \-\> `Commands <type-daml-script-internal-questions-commands-commands-79301_>`_ a \-\> script (`Either <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-types-either-56020>`_ `SubmitError <type-daml-script-internal-questions-submit-error-submiterror-38284_>`_ a)
 
-  Submit a transaction and recieve back either the result, or a ``SubmitError``\.
+  Submit a transaction and receive back either the result, or a ``SubmitError``\.
   In the majority of failures, this will not crash at runtime\.
 
 .. _function-daml-script-internal-questions-submit-trysubmittree-68085:

--- a/sdk/docs/sharable/sdk/reference/daml/stdlib/DA-NonEmpty.rst
+++ b/sdk/docs/sharable/sdk/reference/daml/stdlib/DA-NonEmpty.rst
@@ -89,7 +89,7 @@ Functions
 `delete <function-da-nonempty-delete-59160_>`_
   \: :ref:`Eq <class-ghc-classes-eq-22713>` a \=\> a \-\> :ref:`NonEmpty <type-da-nonempty-types-nonempty-16010>` a \-\> \[a\]
 
-  Remove the first occurence of x from the non\-empty list, potentially
+  Remove the first occurrence of x from the non\-empty list, potentially
   removing all elements\.
 
 .. _function-da-nonempty-foldl1-17561:


### PR DESCRIPTION
- Fix 'recieve' to 'receive' in Daml-Script.rst and daml-script-hoogle.txt
- Fix 'occurence' to 'occurrence' in DA-NonEmpty.rst and daml-base-hoogle.txt

These corrections improve the quality and professionalism of the documentation.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
