### PR TITLE
Fix TS codegen to produce interfaces using pkg name rather than pkg id

### DIFF
--- a/sdk/UNRELEASED.md
+++ b/sdk/UNRELEASED.md
@@ -9,5 +9,21 @@ schedule, i.e. if you add an entry effective at or after the first
 header, prepend the new date header that corresponds to the
 Wednesday after your change.
 
-## Until YYYY-MM-DD (Exclusive)
+## Until 2025-09-18 (Exclusive)
+- typescript codegen has been changed to produce the interface definitions that use package id rather than package name.
+  Following definition
+  ```
+  exports.Token = damlTypes.assembleInterface(
+    '41d34898b0a96f443eef3fa59e0ca61465caa5e1c2ca24ecb8e7de5e1ba611f5:Main:Token',
+    function () { return exports.EmptyInterfaceView; },
+    {
+    ...
+  ```
+  becomes
+  ```
+  exports.Token = damlTypes.assembleInterface(
+    '#tokens:Main:Token',
+    function () { return exports.EmptyInterfaceView; },
+    {
+  ```
 

--- a/sdk/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/sdk/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -221,7 +221,7 @@ genModule pkgMap (Scope scope) curPkgId curPkgNameVer mod
     Nothing -- If no serializable types or interfaces, nothing to do.
   | otherwise =
     let (decls, refs) = unzip (map (genDataDef curPkgId curPkgNameVer mod (interfaceChoices pkgMap curPkgId) tpls) serDefs)
-        (ifaceDecls, ifaceRefs) = unzip (map (genIfaceDecl curPkgId mod) $ NM.toList ifaces)
+        (ifaceDecls, ifaceRefs) = unzip (map (genIfaceDecl curPkgNameVer mod) $ NM.toList ifaces)
         imports = (SelfPackageId, modName) `Set.delete` Set.unions (refs ++ ifaceRefs)
         (internalImports, externalImports) = splitImports imports
         rootPath = map (const "..") (unModuleName modName)
@@ -325,14 +325,14 @@ genDataDef curPkgId curPkgNameVer mod ifcChoices tpls def = case unTypeConName (
         (decls, refs) = genDefDataType curPkgId curPkgNameVer c2 mod ifcChoices tpls def
         tyDecls = [d | DeclTypeDef d <- decls]
 
-genIfaceDecl :: PackageId -> Module -> DefInterface -> ([TsDecl], Set.Set ModuleRef)
-genIfaceDecl pkgId mod DefInterface {intName, intChoices, intView} =
+genIfaceDecl :: PackageNameVersion -> Module -> DefInterface -> ([TsDecl], Set.Set ModuleRef)
+genIfaceDecl curPkgNameVer mod DefInterface {intName, intChoices, intView} =
   ( [ DeclInterface
         (InterfaceDef
            { ifName = name
+           , ifPkgNameVer = curPkgNameVer
            , ifChoices = choices
            , ifModule = moduleName mod
-           , ifPkgId = pkgId
            , ifView = view
            })
     ]
@@ -473,15 +473,15 @@ renderTemplateDef TemplateDef {..} =
 
 data InterfaceDef = InterfaceDef
   { ifName :: T.Text
+  , ifPkgNameVer :: PackageNameVersion
   , ifModule :: ModuleName
-  , ifPkgId :: PackageId
   , ifChoices :: [ChoiceDef]
   , ifView :: (TsTypeConRef, JsSerializerConRef)
   }
 
 renderInterfaceDef :: InterfaceDef -> (T.Text, T.Text)
-renderInterfaceDef InterfaceDef{ifName, ifChoices, ifModule,
-                                ifPkgId, ifView} = (jsSource, tsDecl)
+renderInterfaceDef InterfaceDef{ifName, ifPkgNameVer, ifChoices,
+                                ifModule, ifView} = (jsSource, tsDecl)
   where
     jsSource = T.unlines $ concat
       [ [ "exports." <> ifName <> " = damlTypes.assembleInterface("
@@ -515,7 +515,7 @@ renderInterfaceDef InterfaceDef{ifName, ifChoices, ifModule,
       ]
     (TsTypeConRef viewTy, JsSerializerConRef viewCompanion) = ifView
     ifaceId =
-        unPackageId ifPkgId <> ":" <>
+        pkgNameVerToPackageRef ifPkgNameVer <> ":" <>
         T.intercalate "." (unModuleName ifModule) <> ":" <>
         ifName
 


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
