### PR TITLE
enforce strictly ordered genmaps in importValue

### DIFF
--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -231,12 +231,12 @@ object SValue {
       * SValue keys are assumed to be in ascending order - hence the SMap's TreeMap will be built in time O(n) using a
       * sorted map specialisation.
       */
-    def fromOrderedEntries(
+    def fromStrictlyOrderedEntries(
         isTextMap: Boolean,
         entries: Iterable[(SValue, SValue)],
     ): SMap = {
       entries.foreach { case (k, _) => comparable(k) }
-      SMap(isTextMap, data.TreeMap.fromOrderedEntries(entries))
+      SMap(isTextMap, data.TreeMap.fromStrictlyOrderedEntries(entries))
     }
 
     /** Build an SMap from an iterator over SValue key/value pairs.

--- a/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SValueTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SValueTest.scala
@@ -50,7 +50,7 @@ class SValueTest extends AnyWordSpec with Inside with Matchers with TableDrivenP
 
   "SMap" should {
 
-    "fail on creation with unordered indexed sequences" in {
+    "fail on creation with non-strictly ordered indexed sequences" in {
       val testCases = Table[Boolean, IndexedSeqView[(SValue, SValue)]](
         ("isTextMap", "entries"),
         (
@@ -58,8 +58,16 @@ class SValueTest extends AnyWordSpec with Inside with Matchers with TableDrivenP
           ImmArray(SText("1") -> SValue.SValue.True, SText("0") -> SValue.SValue.False).toSeq.view,
         ),
         (
+          true,
+          ImmArray(SText("1") -> SValue.SValue.True, SText("1") -> SValue.SValue.True).toSeq.view,
+        ),
+        (
           false,
           ImmArray(SText("1") -> SValue.SValue.True, SText("0") -> SValue.SValue.False).toSeq.view,
+        ),
+        (
+          false,
+          ImmArray(SText("1") -> SValue.SValue.True, SText("1") -> SValue.SValue.True).toSeq.view,
         ),
         (
           true,
@@ -72,10 +80,10 @@ class SValueTest extends AnyWordSpec with Inside with Matchers with TableDrivenP
       )
 
       forAll(testCases) { (isTextMap, entries) =>
-        val result = Try(SMap.fromOrderedEntries(isTextMap, entries))
+        val result = Try(SMap.fromStrictlyOrderedEntries(isTextMap, entries))
 
         inside(result) { case Failure(error: IllegalArgumentException) =>
-          error.getMessage shouldBe "the entries are not ordered"
+          error.getMessage shouldBe "the entries are not strictly ordered"
         }
       }
     }
@@ -106,7 +114,7 @@ class SValueTest extends AnyWordSpec with Inside with Matchers with TableDrivenP
       )
 
       forAll(testCases) { (isTextMap, entries, result) =>
-        SMap.fromOrderedEntries(isTextMap, entries) shouldBe result
+        SMap.fromStrictlyOrderedEntries(isTextMap, entries) shouldBe result
       }
     }
 
@@ -134,7 +142,7 @@ class SValueTest extends AnyWordSpec with Inside with Matchers with TableDrivenP
       )
 
       forEvery(testCases) { entries =>
-        Try(SMap.fromOrderedEntries(true, entries)) shouldBe nonComparableFailure
+        Try(SMap.fromStrictlyOrderedEntries(true, entries)) shouldBe nonComparableFailure
         Try(SMap(false, entries)) shouldBe nonComparableFailure
         Try(SMap(true, entries: _*)) shouldBe nonComparableFailure
       }


### PR DESCRIPTION
Part of https://github.com/digital-asset/daml/issues/21667.

In `importValue`, enforce that GenMaps are strictly ordered. If not, throw a TranslationError. We cannot implement that check for text maps, not at this level at least, because `ValueTextMap`s are ordered by construction.