### PR TITLE
Fix codegen-java-oci copying path

### DIFF
--- a/ci/copy-unix-release-artifacts.sh
+++ b/ci/copy-unix-release-artifacts.sh
@@ -57,7 +57,7 @@ function copy_oci {
 copy_oci damlc bazel-bin/compiler/damlc/damlc-oci.tar.gz
 copy_oci daml-script bazel-bin/daml-script/runner/daml-script-oci.tar.gz
 copy_oci codegen-js bazel-bin/language-support/ts/codegen/codegen-js-oci.tar.gz
-copy_oci codegen-java bazel-bin/language-support/java/codegen/codegen-java-oci.tar.gz
+copy_oci codegen-java bazel-bin/language-support/codegen-main/codegen-java-oci.tar.gz
 copy_oci daml-new bazel-bin/daml-assistant/daml-helper/daml-new-oci.tar.gz
 
 # Platform independent artifacts are only built on Linux.

--- a/ci/copy-windows-release-artifacts.sh
+++ b/ci/copy-windows-release-artifacts.sh
@@ -51,5 +51,5 @@ function copy_oci {
 copy_oci damlc bazel-bin/compiler/damlc/damlc-oci.tar.gz
 copy_oci daml-script bazel-bin/daml-script/runner/daml-script-oci.tar.gz
 copy_oci codegen-js bazel-bin/language-support/ts/codegen/codegen-js-oci.tar.gz
-copy_oci codegen-java bazel-bin/language-support/java/codegen/codegen-java-oci.tar.gz
+copy_oci codegen-java bazel-bin/language-support/codegen-main/codegen-java-oci.tar.gz
 copy_oci daml-new bazel-bin/daml-assistant/daml-helper/daml-new-oci.tar.gz


### PR DESCRIPTION
Forgot to update the bazel path after moving the codegen-java-oci rule.