### PR TITLE
[Speedy] Check SPAP type value earlier in evaluation

### DIFF
--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -112,10 +112,11 @@ private[lf] object SExpr {
 
   /** Function application: ANF case: 'fun' and 'args' are atomic expressions */
   final case class SEAppAtomicGeneral(fun: SExprAtomic, args: ArraySeq[SExprAtomic]) extends SExpr {
-    override def execute[Q](machine: Machine[Q]): Control[Q] = {
-      val vfun = fun.lookupValue(machine)
-      machine.enterApplication(vfun, args)
-    }
+    override def execute[Q](machine: Machine[Q]): Control[Q] =
+      fun.lookupValue(machine) match {
+        case vfun: SPAP => machine.enterApplication(vfun, args)
+        case other => throw SError.SErrorCrash("SEAppAtomicGeneral", s"except SPAP, but got $other")
+      }
   }
 
   /** Function application: ANF case: 'fun' is builtin; 'args' are atomic expressions.  Size


### PR DESCRIPTION
Moved SPAP type checking earlier in the machine's evaluation process. This minor refactoring enables earlier access to SPAP contents, facilitating costModel's continuation execution costing.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
