### PR TITLE
authenticate contracts hashed with TypedNormalForm

### DIFF
--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -33,7 +33,7 @@ import com.digitalasset.daml.lf
 import com.digitalasset.daml.lf.speedy.{DisclosedContract, InitialSeeding, SValue, svalue}
 import com.digitalasset.daml.lf.speedy.SValue._
 import com.digitalasset.daml.lf.command._
-import com.digitalasset.daml.lf.crypto.Hash
+import com.digitalasset.daml.lf.crypto.{Hash, SValueHash}
 import com.digitalasset.daml.lf.engine.Error.Interpretation
 import com.digitalasset.daml.lf.engine.Error.Interpretation.DamlException
 import com.digitalasset.daml.lf.language.{LanguageMajorVersion, LanguageVersion, PackageInterface}
@@ -2621,6 +2621,17 @@ class EngineTest(majorLanguageVersion: LanguageMajorVersion, contractIdVersion: 
       Hash
         .hashContractInstance(simpleId, createArg, basicTestsPkg.pkgName, upgradeFriendly = true)
         .value
+    def expectedTypedNormalFormHash = SValueHash
+      .hashContractInstance(
+        basicTestsPkg.pkgName,
+        simpleId.qualifiedName,
+        SValue.SRecord(
+          simpleId,
+          ImmArray(Ref.Name.assertFromString("p")),
+          ArraySeq(SValue.SParty(alice)),
+        ),
+      )
+      .value
 
     def run(
         cmds: ImmArray[ApiCommand],
@@ -2648,6 +2659,7 @@ class EngineTest(majorLanguageVersion: LanguageMajorVersion, contractIdVersion: 
       ("hashingMethod", "expectedHash"),
       (Hash.HashingMethod.Legacy, expectedLegacyHash),
       (Hash.HashingMethod.UpgradeFriendly, expectedUpgradeFriendlyHash),
+      (Hash.HashingMethod.TypedNormalForm, expectedTypedNormalFormHash),
     )
 
     "be authenticated on fetch" in {

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValidateContractInstanceSpec.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValidateContractInstanceSpec.scala
@@ -162,13 +162,13 @@ class ValidateContractInstanceSpec(majorLanguageVersion: LanguageMajorVersion)
 
   val alice = Party.assertFromString("alice")
   val bob = Party.assertFromString("bob")
-  val packageName = Ref.PackageName.assertFromString("-test-pkg-")
+  val packageName = Ref.PackageName.assertFromString("test-pkg")
   val templateId = Ref.Identifier(pkgId1, Ref.QualifiedName.assertFromString("M:T"))
   val createArg =
     V.ValueRecord(None, ImmArray(None -> V.ValueParty(alice), None -> V.ValueParty(bob)))
   val createNode = Node.Create(
     coid = TransactionBuilder.newCid,
-    packageName = Ref.PackageName.assertFromString("-test-pkg-"),
+    packageName = packageName,
     templateId = Ref.Identifier(pkgId1, Ref.QualifiedName.assertFromString("M:T")),
     arg = createArg,
     signatories = Set(alice),
@@ -208,8 +208,7 @@ class ValidateContractInstanceSpec(majorLanguageVersion: LanguageMajorVersion)
         ("hashingMethod", "expectedHash"),
         (Hash.HashingMethod.Legacy, expectedLegacyHash),
         (Hash.HashingMethod.UpgradeFriendly, expectedUpgradeFriendlyHash),
-        // TODO(https://github.com/digital-asset/daml/issues/21667): enable once TypedNormalForm is supported
-        // (Hash.HashingMethod.TypedNormalForm, expectedTypedNormalFormHash),
+        (Hash.HashingMethod.TypedNormalForm, expectedTypedNormalFormHash),
       )
 
       val targetPackageIds = Table(
@@ -245,8 +244,7 @@ class ValidateContractInstanceSpec(majorLanguageVersion: LanguageMajorVersion)
         "hashingMethod",
         Hash.HashingMethod.Legacy,
         Hash.HashingMethod.UpgradeFriendly,
-        // TODO(https://github.com/digital-asset/daml/issues/21667): enable once TypedNormalForm is supported
-        // Hash.HashingMethod.TypedNormalForm,
+        Hash.HashingMethod.TypedNormalForm,
       )
 
       val targetPackageIds = Table(

--- a/sdk/daml-lf/ide-ledger/src/main/scala/com/digitalasset/daml/lf/script/IdeLedgerRunner.scala
+++ b/sdk/daml-lf/ide-ledger/src/main/scala/com/digitalasset/daml/lf/script/IdeLedgerRunner.scala
@@ -342,7 +342,7 @@ private[lf] object IdeLedgerRunner {
                   callback(
                     fcoinst.nonVerbose,
                     Hash.HashingMethod.TypedNormalForm,
-                    _ => throw new NotImplementedError("authentication not implemented yet"),
+                    _ => true, // The IDE ledger doesn't authenticate disclosed contracts
                   )
                   go()
                 case None =>
@@ -354,7 +354,7 @@ private[lf] object IdeLedgerRunner {
                       callback(
                         fcoinst.nonVerbose,
                         Hash.HashingMethod.TypedNormalForm,
-                        _ => throw new NotImplementedError("authentication not implemented yet"),
+                        _ => true, // The IDE ledger doesn't authenticate input contracts
                       ),
                   ) match {
                     case Left(err) =>

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -2777,28 +2777,30 @@ private[lf] object SBuiltinFun {
       authenticator: Hash => Boolean,
       coid: V.ContractId,
       contractInfo: ContractInfo,
-  )(k: () => Control[Question.Update]) = if (
-    authenticator(
-      SValueHash.assertHashContractInstance(
-        contractInfo.packageName,
-        contractInfo.templateId.qualifiedName,
-        contractInfo.value,
+  )(k: () => Control[Question.Update]) =
+    if (
+      authenticator(
+        SValueHash.assertHashContractInstance(
+          contractInfo.packageName,
+          contractInfo.templateId.qualifiedName,
+          contractInfo.value,
+        )
       )
-    )
-  )
-    k()
-  else
-    Control.Error(
-      IE.Dev(
-        NameOf.qualifiedNameOfCurrentFunc,
-        IE.Dev
-          .AuthenticationError(
-            coid,
-            contractInfo.value.toNormalizedValue,
-            s"failed to authenticate contract",
-          ),
+    ) {
+      k()
+    } else {
+      Control.Error(
+        IE.Dev(
+          NameOf.qualifiedNameOfCurrentFunc,
+          IE.Dev
+            .AuthenticationError(
+              coid,
+              contractInfo.value.toNormalizedValue,
+              s"failed to authenticate contract",
+            ),
+        )
       )
-    )
+    }
 
   /** Checks that the metadata of [original] and [recomputed] are the same, fails with a [Control.Error] if not. */
   private def checkContractUpgradable(

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -1562,13 +1562,13 @@ private[lf] object SBuiltinFun {
             coid,
             srcTmplId,
             srcSArg,
-          ) { srcContracInfo =>
+          ) { srcContractInfo =>
             processSrcContract(
-              srcPackageName = srcContracInfo.packageName,
+              srcPackageName = srcContractInfo.packageName,
               srcTmplId = srcTmplId,
-              srcMetadata = srcContracInfo.metadata,
-              srcArg = srcContracInfo.arg,
-              mbTypedNormalFormAuthenticator = None,
+              srcMetadata = srcContractInfo.metadata,
+              srcArg = srcContractInfo.arg,
+              mbTypedNormalFormAuthenticator = Some(_ == srcContractInfo.valueHash),
             )
           }
         }
@@ -2634,12 +2634,12 @@ private[lf] object SBuiltinFun {
               coid,
               srcTmplId,
               srcSArg,
-            ) { srcContracInfo =>
+            ) { srcContractInfo =>
               processSrcContract(
                 srcTmplId = srcTmplId,
-                srcMetadata = srcContracInfo.metadata,
-                srcArg = srcContracInfo.arg,
-                mbTypedNormalFormAuthenticator = None,
+                srcMetadata = srcContractInfo.metadata,
+                srcArg = srcContractInfo.arg,
+                mbTypedNormalFormAuthenticator = Some(_ == srcContractInfo.valueHash),
               )
             }
           }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -6,7 +6,7 @@ package speedy
 
 import com.daml.nameof.NameOf
 import com.daml.scalautil.Statement.discard
-import com.digitalasset.daml.lf.crypto.Hash
+import com.digitalasset.daml.lf.crypto.{Hash, SValueHash}
 import com.digitalasset.daml.lf.crypto.Hash.{HashingMethod, hashContractInstance}
 import com.digitalasset.daml.lf.data.Numeric.Scale
 import com.digitalasset.daml.lf.data.Ref._
@@ -1508,6 +1508,7 @@ private[lf] object SBuiltinFun {
     *  - typechecks and converts to an SValue the argument of the source contract according to the preferred template
     *  - computes the metadata of the contract according to the preferred template (including the ensure clause),
     *    caches the result, and verifies that it matches the metadata of the source contract
+    *  - authenticates the contract against its contract ID if the contract ID uses the TypedNormalForm hashing method
     *  - returns the converted argument wrapped in an SAny
     */
   private[this] def fetchInterface(
@@ -1521,6 +1522,7 @@ private[lf] object SBuiltinFun {
         srcTmplId: TypeConId,
         srcMetadata: ContractMetadata,
         srcArg: V,
+        mbTypedNormalFormAuthenticator: Option[Hash => Boolean],
     ): Control[Question.Update] = {
       resolvePackageName(machine, srcPackageName) { pkgId =>
         val dstTmplId = srcTmplId.copy(pkg = pkgId)
@@ -1538,6 +1540,7 @@ private[lf] object SBuiltinFun {
                 srcMetadata,
                 dstTmplId,
                 dstSArg,
+                mbTypedNormalFormAuthenticator,
               ) { case (dstTmplId, dstArg, _) =>
                 k(SAny(Ast.TTyCon(dstTmplId), dstArg))
               }
@@ -1561,10 +1564,11 @@ private[lf] object SBuiltinFun {
             srcSArg,
           ) { srcContracInfo =>
             processSrcContract(
-              srcContracInfo.packageName,
-              srcTmplId,
-              srcContracInfo.metadata,
-              srcContracInfo.arg,
+              srcPackageName = srcContracInfo.packageName,
+              srcTmplId = srcTmplId,
+              srcMetadata = srcContracInfo.metadata,
+              srcArg = srcContracInfo.arg,
+              mbTypedNormalFormAuthenticator = None,
             )
           }
         }
@@ -1574,14 +1578,18 @@ private[lf] object SBuiltinFun {
           authenticateIfLegacyContract(coid, coinst, hashingMethod, authenticator) { () =>
             ensureContractActive(machine, coid, coinst.templateId) {
               processSrcContract(
-                coinst.packageName,
-                coinst.templateId,
-                ContractMetadata(
+                srcPackageName = coinst.packageName,
+                srcTmplId = coinst.templateId,
+                srcMetadata = ContractMetadata(
                   coinst.signatories,
                   coinst.nonSignatoryStakeholders,
                   coinst.contractKeyWithMaintainers,
                 ),
-                coinst.createArg,
+                srcArg = coinst.createArg,
+                mbTypedNormalFormAuthenticator = hashingMethod match {
+                  case HashingMethod.TypedNormalForm => Some(authenticator)
+                  case HashingMethod.Legacy | HashingMethod.UpgradeFriendly => None
+                },
               )
             }
           }
@@ -2568,6 +2576,7 @@ private[lf] object SBuiltinFun {
     *  - typechecks and converts to an SValue the argument of the source contract according to the target template
     *  - computes the metadata of the contract according to the target template (including the ensure clause),
     *    caches the result, and verifies that it matches the metadata of the source contract
+    *  - authenticates the contract against its contract ID if the contract ID uses the TypedNormalForm hashing method
     *  - returns the converted argument
     */
   private def fetchTemplate(
@@ -2580,6 +2589,7 @@ private[lf] object SBuiltinFun {
         srcTmplId: TypeConId,
         srcMetadata: ContractMetadata,
         srcArg: V,
+        mbTypedNormalFormAuthenticator: Option[Hash => Boolean],
     ): Control[Question.Update] = {
       if (srcTmplId.qualifiedName != dstTmplId.qualifiedName)
         Control.Error(
@@ -2599,6 +2609,7 @@ private[lf] object SBuiltinFun {
               srcMetadata,
               dstTmplId,
               dstSArg,
+              mbTypedNormalFormAuthenticator,
             )({ case (_, _, dstContract) =>
               k(dstContract.value)
             })
@@ -2624,7 +2635,12 @@ private[lf] object SBuiltinFun {
               srcTmplId,
               srcSArg,
             ) { srcContracInfo =>
-              processSrcContract(srcTmplId, srcContracInfo.metadata, srcContracInfo.arg)
+              processSrcContract(
+                srcTmplId = srcTmplId,
+                srcMetadata = srcContracInfo.metadata,
+                srcArg = srcContracInfo.arg,
+                mbTypedNormalFormAuthenticator = None,
+              )
             }
           }
         }
@@ -2634,13 +2650,17 @@ private[lf] object SBuiltinFun {
           authenticateIfLegacyContract(coid, coinst, hashingMethod, authenticator) { () =>
             ensureContractActive(machine, coid, coinst.templateId) {
               processSrcContract(
-                coinst.templateId,
-                ContractMetadata(
+                srcTmplId = coinst.templateId,
+                srcMetadata = ContractMetadata(
                   coinst.signatories,
                   coinst.nonSignatoryStakeholders,
                   coinst.contractKeyWithMaintainers,
                 ),
-                coinst.createArg,
+                srcArg = coinst.createArg,
+                mbTypedNormalFormAuthenticator = hashingMethod match {
+                  case HashingMethod.TypedNormalForm => Some(authenticator)
+                  case HashingMethod.Legacy | HashingMethod.UpgradeFriendly => None
+                },
               )
             }
           }
@@ -2648,6 +2668,14 @@ private[lf] object SBuiltinFun {
     }
   }
 
+  /** A method called after fetching and upgrading a contract, which:
+    * - computes the metadata of the contract according to the target template (including the ensure clause),
+    *   caches the result, and verifies that it matches the metadata of the source contract
+    * - enforces limits on input contracts, signatories, and observers
+    * - if [mbTypedNormalFormAuthenticator] is defined, authenticates the contract info using SValueHash
+    *
+    * Assumes that the package of [dstTmplId] is already loaded.
+    */
   private def fetchValidateDstContract(
       machine: UpdateMachine,
       coid: V.ContractId,
@@ -2655,6 +2683,7 @@ private[lf] object SBuiltinFun {
       srcContractMetadata: ContractMetadata,
       dstTmplId: TypeConId,
       dstTmplArg: SValue,
+      mbTypedNormalFormAuthenticator: Option[Hash => Boolean],
   )(k: (TypeConId, SValue, ContractInfo) => Control[Question.Update]): Control[Question.Update] =
     getContractInfo(
       machine,
@@ -2672,7 +2701,13 @@ private[lf] object SBuiltinFun {
           srcContractMetadata,
           dstContract.metadata,
         ) { () =>
-          k(dstTmplId, dstTmplArg, dstContract)
+          mbTypedNormalFormAuthenticator match {
+            case Some(authenticator) =>
+              authenticateContractInfo(authenticator, coid, dstContract) { () =>
+                k(dstTmplId, dstTmplArg, dstContract)
+              }
+            case None => k(dstTmplId, dstTmplArg, dstContract)
+          }
         }
       }
     }
@@ -2736,6 +2771,34 @@ private[lf] object SBuiltinFun {
       case None => k()
     }
   }
+
+  /** Authenticates the provided contractInfo using [authenticator] */
+  private def authenticateContractInfo(
+      authenticator: Hash => Boolean,
+      coid: V.ContractId,
+      contractInfo: ContractInfo,
+  )(k: () => Control[Question.Update]) = if (
+    authenticator(
+      SValueHash.assertHashContractInstance(
+        contractInfo.packageName,
+        contractInfo.templateId.qualifiedName,
+        contractInfo.value,
+      )
+    )
+  )
+    k()
+  else
+    Control.Error(
+      IE.Dev(
+        NameOf.qualifiedNameOfCurrentFunc,
+        IE.Dev
+          .AuthenticationError(
+            coid,
+            contractInfo.value.toNormalizedValue,
+            s"failed to authenticate contract",
+          ),
+      )
+    )
 
   /** Checks that the metadata of [original] and [recomputed] are the same, fails with a [Control.Error] if not. */
   private def checkContractUpgradable(

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -7,7 +7,7 @@ package speedy
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.nameof.NameOf
 import com.daml.scalautil.Statement.discard
-import com.digitalasset.daml.lf.crypto.Hash
+import com.digitalasset.daml.lf.crypto.{Hash, SValueHash}
 import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.data.{CostModel => _, _}
 import com.digitalasset.daml.lf.interpretation.{Error => IError}
@@ -181,11 +181,14 @@ private[lf] object Speedy {
         version = version,
       )
 
-    lazy val metadata = ContractMetadata(
+    lazy val metadata: ContractMetadata = ContractMetadata(
       signatories,
       observers,
       keyOpt.map(_.globalKeyWithMaintainers),
     )
+
+    lazy val valueHash: Hash =
+      SValueHash.assertHashContractInstance(packageName, templateId.qualifiedName, value)
   }
 
   private[speedy] def throwLimitError(location: String, error: IError.Dev.Limit.Error): Nothing =

--- a/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
@@ -669,7 +669,7 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
           globalContractObservers = List.empty,
           globalContractKeyWithMaintainers = None,
         )
-      ) { case Left(SError.SErrorDamlException(IE.Dev(_, error: IE.Dev.TranslationError))) =>
+      ) { case Left(SError.SErrorDamlException(IE.Dev(_, error))) =>
         error shouldBe a[IE.Dev.AuthenticationError]
       }
     }

--- a/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
@@ -25,7 +25,6 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 
-import scala.annotation.nowarn
 import scala.collection.immutable.ArraySeq
 
 class UpgradeTestV2 extends UpgradeTest(LanguageMajorVersion.V2)
@@ -179,7 +178,6 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
   }
 
   lazy val pkgId0 = Ref.PackageId.assertFromString("-pkg0-")
-  @nowarn("cat=unused")
   private lazy val pkg0 = {
     implicit def pkgId: Ref.PackageId = pkgId0
     p""" metadata ( '-upgrade-test-' : '1.0.0' )
@@ -321,6 +319,58 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
         \(cId: ContractId M:T) ->
           fetch_template @M:T cId;
       }
+    """
+  }
+
+  lazy val pkgId5 = Ref.PackageId.assertFromString("-pkg5-")
+  private lazy val pkg5 = {
+    // renames "aNumber" in pkg0 to "aNumberRenamed"
+    implicit def pkgId: Ref.PackageId = pkgId5
+    p""" metadata ( '-upgrade-test-' : '5.0.0' )
+    module M {
+
+      record @serializable T = { sig: Party, obs: Party, aNumberRenamed: Int64 };
+      template (this: T) = {
+        precondition True;
+        signatories '-util-':M:mkList (M:T {sig} this) (None @Party);
+        observers '-util-':M:mkList (M:T {obs} this) (None @Party);
+        key @Party (M:T {sig} this) (\ (p: Party) -> Cons @Party [p] Nil @Party);
+      };
+
+      val do_fetch: ContractId M:T -> Update M:T =
+        \(cId: ContractId M:T) ->
+          fetch_template @M:T cId;
+    }
+    """
+  }
+
+  lazy val localUpgradePkgId = Ref.PackageId.assertFromString("-local-upgrade-pkg-")
+  private lazy val pkgLocalUpgrade = {
+    implicit def pkgId: Ref.PackageId = localUpgradePkgId
+    p""" metadata ( '-local-upgrade-' : '1.0.0' )
+    module M {
+
+      record @serializable T = { sig: Party };
+      template (this: T) = {
+        precondition True;
+        signatories '-util-':M:mkList (M:T {sig} this) (None @Party);
+        observers Nil @Party;
+
+        choice @nonConsuming FetchLocal (self) (u: Unit): '-pkg5-':M:T
+          , controllers (Cons @Party [M:T {sig} this] (Nil @Party))
+          , observers (Nil @Party)
+          to ubind cid: ContractId '-pkg0-':M:T <- create
+                 @'-pkg0-':M:T
+                 ('-pkg0-':M:T { sig = M:T {sig} this, obs = M:T {sig} this, aNumber = 42 })
+             in fetch_template
+                 @'-pkg5-':M:T
+                 (COERCE_CONTRACT_ID @'-pkg0-':M:T @'-pkg5-':M:T cid);
+      };
+
+      val do_fetch_local: ContractId M:T -> Update '-pkg5-':M:T =
+        \(cid: ContractId M:T) ->
+          exercise @M:T FetchLocal cid ();
+    }
     """
   }
 
@@ -597,6 +647,30 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
             error shouldBe a[IE.WronglyTypedContract]
           }
         }
+      }
+    }
+
+    "renamed template field in local contract -- should be rejected" in {
+      inside(
+        go(
+          e"'-local-upgrade-pkg-':M:do_fetch_local",
+          // We cannot test the case where the creation package is unavailable because this test case tests the upgrade
+          // of a local contract, which requires the creation package in order to be created.
+          availablePackages = Map(
+            utilPkgId -> utilPkg,
+            pkgId0 -> pkg0,
+            pkgId5 -> pkg5,
+            localUpgradePkgId -> pkgLocalUpgrade,
+          ),
+          globalContractPackageName = pkgLocalUpgrade.pkgName,
+          globalContractTemplateId = i"'-local-upgrade-pkg-':M:T",
+          globalContractArg = makeRecord(ValueParty(alice)),
+          globalContractSignatories = List(alice),
+          globalContractObservers = List.empty,
+          globalContractKeyWithMaintainers = None,
+        )
+      ) { case Left(SError.SErrorDamlException(IE.Dev(_, error: IE.Dev.TranslationError))) =>
+        error shouldBe a[IE.Dev.AuthenticationError]
       }
     }
   }

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -137,7 +137,7 @@
 - Evaluation order of successful lookup_by_key of a local contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3202)
 - Evaluation order of successful lookup_by_key of a non-cached global contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3069)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L37)
-- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2104)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2089)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/stable/Exceptions.daml#L263)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version, where one is new to V2 within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/stable/Exceptions.daml#L267)
 - Smart Contract Upgrade: Can catch same errors thrown by different choice versions within Update: [Exceptions.daml](daml-script/test/daml/upgrades/stable/Exceptions.daml#L259)

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -137,7 +137,7 @@
 - Evaluation order of successful lookup_by_key of a local contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3202)
 - Evaluation order of successful lookup_by_key of a non-cached global contract: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L3069)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L37)
-- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2089)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2104)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/stable/Exceptions.daml#L263)
 - Smart Contract Upgrade: Can catch different errors thrown by different choice version, where one is new to V2 within Update, using AnyException: [Exceptions.daml](daml-script/test/daml/upgrades/stable/Exceptions.daml#L267)
 - Smart Contract Upgrade: Can catch same errors thrown by different choice versions within Update: [Exceptions.daml](daml-script/test/daml/upgrades/stable/Exceptions.daml#L259)


### PR DESCRIPTION
Part of https://github.com/digital-asset/daml/issues/21667.

The IDE ledger does not authenticate contracts (not yet at least) and canton hasn't yet switched to contract ID v12 so there is no way to test this end-to-end yet. Will do once canton has switched to contract ID v12. We may decide to authenticate contracts in the IDE ledger before 3.4 but this is not a must.

I will add daml-script tests that are supposed to fail once canton enables contract IDs v12 in a separate PR (record renaming, label renamings, variant constructor rank modification).