### PR TITLE
ci: Publish OCI images to the da-images project as well as da-images-…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -154,6 +154,21 @@ jobs:
       condition: and(succeeded(), not(eq(variables['skip-github'], 'TRUE')), not(startsWith(variables['release_tag'], '2.')), not(startsWith(variables['release_tag'], '3.3')))
     - bash: |
         set -euo pipefail
+        # Note: this gets dev-env from the release commit, not the trigger commit
+        eval "$(cd sdk; ./dev-env/bin/dade-assist)"
+        # Authorize in GCLOUD
+        gcloud beta auth activate-service-account --key-file=<(echo "${GOOGLE_APPLICATION_CREDENTIALS_CONTENT}")
+        gcloud auth configure-docker --quiet ${DPM_REGISTRY%%/*}
+        ./ci/get-dpm.sh "${DPM_REGISTRY}/components/dpm:latest"
+        ./ci/publish-oci.sh $(Build.StagingDirectory) $(release_tag) ${DPM_REGISTRY}
+      name: publish_to_oci
+      displayName: 'Publish to OCI Registry'
+      env:
+        GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
+        DPM_REGISTRY: "europe-docker.pkg.dev/da-images/private"
+      condition: and(succeeded(), not(eq(variables['skip-github'], 'TRUE')), not(startsWith(variables['release_tag'], '2.')), not(startsWith(variables['release_tag'], '3.3')))
+    - bash: |
+        set -euo pipefail
 
         if [ -d sdk ]; then
           cd sdk


### PR DESCRIPTION
Dual publish to `da-images` and `da-images-dev`.

We'll look to drop the publishing to `da-images-dev` once we've verified everything has moved over.