### PR TITLE
Fix incorrect DAML_PROJECT and project-check warnings

### DIFF
--- a/sdk/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/sdk/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -11,7 +11,7 @@ import qualified DA.Service.Logger as L
 import qualified DA.Service.Logger.Impl.Pure as L
 import qualified DA.Service.Logger.Impl.GCP as L
 import DA.Daml.Project.Config
-import DA.Daml.Project.Consts (projectPathEnvVar, sdkVersionEnvVar)
+import DA.Daml.Project.Consts (packagePathEnvVar, projectPathEnvVar, sdkVersionEnvVar)
 import DA.Daml.Assistant.Types
 import DA.Daml.Assistant.Env
 import DA.Daml.Assistant.Command
@@ -60,7 +60,9 @@ main = withSdkVersions $ do
         installSignalHandlers
         builtinCommandM <- tryBuiltinCommand
         usingProjectRootVar <- isJust <$> lookupEnv projectPathEnvVar
-        when usingProjectRootVar $
+        usingPackageRootVar <- isJust <$> lookupEnv packagePathEnvVar
+        -- Don't warn if both old and new are provided, as daml assistant must do this for backwards compatibility
+        when (usingProjectRootVar && not usingPackageRootVar) $
           hPutStrLn stderr "The DAML_PROJECT environment variable is deprecated, please use DAML_PACKAGE"
         case builtinCommandM of
             Just builtinCommand -> do

--- a/sdk/release/sdk-config.yaml.tmpl
+++ b/sdk/release/sdk-config.yaml.tmpl
@@ -32,7 +32,7 @@ commands:
   completion: true
 - name: clean
   path: damlc/damlc
-  args: ["clean", "--project-check"]
+  args: ["clean", "--package-check"]
   desc: "Delete build artifacts from project folder"
   completion: true
 - name: damlc


### PR DESCRIPTION
Fixes the following incorrect warnings:
- Warning about DAML_PROJECT when running commands like `daml start`
- Warning about `--project-check` when running `daml clean`