### PR TITLE
delete obsolete upgrade error codes

### DIFF
--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
@@ -156,16 +156,6 @@ object RejectionGenerators {
         case LfInterpretationError.Upgrade(error: LfInterpretationError.Upgrade.ValidationFailed) =>
           CommandExecutionErrors.Interpreter.UpgradeError.ValidationFailed
             .Reject(renderedMessage, error)
-        case LfInterpretationError.Upgrade(
-              error: LfInterpretationError.Upgrade.DowngradeDropDefinedField
-            ) =>
-          CommandExecutionErrors.Interpreter.UpgradeError.DowngradeDropDefinedField
-            .Reject(renderedMessage, error)
-        case LfInterpretationError.Upgrade(
-              error: LfInterpretationError.Upgrade.DowngradeFailed
-            ) =>
-          CommandExecutionErrors.Interpreter.UpgradeError.DowngradeFailed
-            .Reject(renderedMessage, error)
         case LfInterpretationError.Crypto(
               error: LfInterpretationError.Crypto.MalformedByteEncoding
             ) =>

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
@@ -855,59 +855,6 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
           }
         }
       }
-
-      @Explanation(
-        "An optional contract field with a value of Some may not be dropped during downgrading"
-      )
-      @Resolution(
-        "There is data that is newer than the implementation using it, and thus is not compatible. Ensure new data (i.e. those with additional fields as `Some`) is only used with new/compatible choices"
-      )
-      object DowngradeDropDefinedField
-          extends ErrorCode(
-            id = "INTERPRETATION_UPGRADE_ERROR_DOWNGRADE_DROP_DEFINED_FIELD",
-            ErrorCategory.InvalidGivenCurrentSystemStateOther,
-          ) {
-        final case class Reject(
-            override val cause: String,
-            err: LfInterpretationError.Upgrade.DowngradeDropDefinedField,
-        )(implicit
-            loggingContext: ErrorLoggingContext
-        ) extends DamlErrorWithDefiniteAnswer(
-              cause = cause
-            ) {
-          override def resources: Seq[(ErrorResource, String)] =
-            Seq(
-              (ErrorResource.ExpectedType, err.expectedType.pretty),
-              (ErrorResource.FieldIndex, err.fieldIndex.toString),
-            )
-        }
-      }
-
-      @Explanation(
-        "An optional contract field with a value of Some may not be dropped during downgrading"
-      )
-      @Resolution(
-        "There is data that is newer than the implementation using it, and thus is not compatible. Ensure new data (i.e. those with additional fields as `Some`) is only used with new/compatible choices"
-      )
-      object DowngradeFailed
-          extends ErrorCode(
-            id = "INTERPRETATION_UPGRADE_ERROR_DOWNGRADE_FAILED",
-            ErrorCategory.InvalidGivenCurrentSystemStateOther,
-          ) {
-        final case class Reject(
-            override val cause: String,
-            err: LfInterpretationError.Upgrade.DowngradeFailed,
-        )(implicit
-            loggingContext: ErrorLoggingContext
-        ) extends DamlErrorWithDefiniteAnswer(
-              cause = cause
-            ) {
-          override def resources: Seq[(ErrorResource, String)] =
-            Seq(
-              (ErrorResource.ExpectedType, err.expectedType.pretty)
-            )
-        }
-      }
     }
 
     @Explanation("Errors that occur when using cyptography primitives")

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -153,12 +153,6 @@ private[lf] object Pretty {
                   text("recomputed maintainers are") & prettyParties(key.maintainers) /
                     text("recomputed key is") & prettyValue(verbose = false)(key.value)
               })
-          case Upgrade.DowngradeDropDefinedField(_, fieldIndex, _) =>
-            text(s"An optional contract field (field offset $fieldIndex)") /
-              text("with a value of Some may not be dropped during downgrading")
-          case Upgrade.DowngradeFailed(expectedType, actualValue) =>
-            text("Attempt to downgrade ") & prettyValue(false)(actualValue) /
-              text(s" to the variant or enum constructor type ${expectedType.pretty}")
         }
       case Crypto(error) =>
         error match {

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
@@ -171,17 +171,6 @@ object Error {
         keyOpt: Option[GlobalKeyWithMaintainers],
         msg: String,
     ) extends Error
-
-    // TODO https://github.com/digital-asset/daml/issues/17647:
-    //  - add coid, srcTmplId (alternatively pkgId of srcTmplId), and dstTempId
-    final case class DowngradeDropDefinedField(
-        expectedType: Ast.Type,
-        fieldIndex: Long,
-        actualValue: Value,
-    ) extends Error
-
-    final case class DowngradeFailed(expectedType: Ast.Type, actualValue: Value) extends Error
-
   }
 
   sealed case class Crypto(error: Crypto.Error) extends Error

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
@@ -27,11 +27,10 @@ data UpgradeErrorType
         signatories : [Party]
         observers : [Party]
         keyOpt : Optional (AnyContractKey, [Party])
-  | DowngradeDropDefinedField with
-        expectedType : Text
-        fieldIndex : Int
-  | DowngradeFailed with
-        expectedType : Text
+  -- We will add new constructors soon. In the meantime we need a dummy constructor so that the compile doesn't confuse
+  -- UpgradeErrorType for a record, which would force us to rename ValidationFailed to UpgradeErrorType.
+  -- TODO(https://github.com/digital-asset/daml/issues/21667): remove
+  | Dummy
 
 -- | MOVE Daml.Script
 -- Daml Crypto (Secp256k1) related submission errors
@@ -238,7 +237,4 @@ instance Show UpgradeErrorType where
   show err = case err of
     ValidationFailed coid _srcTemplateId _dstTemplateId signatories observers _keyOpt ->
       "Validation failed for contract " <> show coid <> " (Signatories: " <> show signatories <> ", Observers: " <> show observers <> ")"
-    DowngradeDropDefinedField expectedType rank ->
-      "Cannot drop Some field at position " <> show rank <> " in record to downgrade to " <> show expectedType
-    DowngradeFailed expectedType ->
-      "Could not downgrade from new variant/enum constructor to " <> show expectedType
+

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
@@ -231,11 +231,11 @@ instance Show SubmitError where
     DevError ty msg -> "DevError of type " <> show ty <> " and message \"" <> msg <> "\""
     UnknownError msg -> "Unknown error: " <> msg
     TruncatedError ty msg -> "TruncatedError of type " <> ty <> " and message \"" <> msg <> "\""
-    Dummy -> error "This should never happen"
 
 -- | MOVE Daml.Script
 instance Show UpgradeErrorType where
   show err = case err of
     ValidationFailed coid _srcTemplateId _dstTemplateId signatories observers _keyOpt ->
       "Validation failed for contract " <> show coid <> " (Signatories: " <> show signatories <> ", Observers: " <> show observers <> ")"
+    Dummy -> error "This should never happen"
 

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
@@ -231,6 +231,7 @@ instance Show SubmitError where
     DevError ty msg -> "DevError of type " <> show ty <> " and message \"" <> msg <> "\""
     UnknownError msg -> "Unknown error: " <> msg
     TruncatedError ty msg -> "TruncatedError of type " <> ty <> " and message \"" <> msg <> "\""
+    Dummy -> error "This should never happen"
 
 -- | MOVE Daml.Script
 instance Show UpgradeErrorType where

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
@@ -308,26 +308,6 @@ object GrpcErrorParser {
               message,
             )
         }
-      case "INTERPRETATION_UPGRADE_ERROR_DOWNGRADE_DROP_DEFINED_FIELD" =>
-        caseErr {
-          case Seq(
-                (ErrorResource.ExpectedType, expectedType),
-                (ErrorResource.FieldIndex, fieldIndex),
-              ) =>
-            SubmitError.UpgradeError.DowngradeDropDefinedField(
-              expectedType,
-              fieldIndex.toLong,
-              message,
-            )
-        }
-
-      case "INTERPRETATION_UPGRADE_ERROR_DOWNGRADE_FAILED" =>
-        caseErr {
-          case Seq(
-                (ErrorResource.ExpectedType, expectedType)
-              ) =>
-            SubmitError.UpgradeError.DowngradeFailed(expectedType, message)
-        }
 
       case "DAML_FAILURE" => {
         // Fields added automatically by canton, and not by the user

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -377,17 +377,6 @@ class IdeLedgerClient(
           innerError.keyOpt,
           Pretty.prettyDamlException(e).renderWideStream.mkString,
         )
-      case e @ Upgrade(innerError: Upgrade.DowngradeDropDefinedField) =>
-        SubmitError.UpgradeError.DowngradeDropDefinedField(
-          innerError.expectedType.pretty,
-          innerError.fieldIndex,
-          Pretty.prettyDamlException(e).renderWideStream.mkString,
-        )
-      case e @ Upgrade(innerError: Upgrade.DowngradeFailed) =>
-        SubmitError.UpgradeError.DowngradeFailed(
-          innerError.expectedType.pretty,
-          Pretty.prettyDamlException(e).renderWideStream.mkString,
-        )
       case e @ Crypto(innerError: Crypto.MalformedByteEncoding) =>
         SubmitError.CryptoError.MalformedByteEncoding(
           innerError.value,

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
@@ -463,43 +463,6 @@ object SubmitError {
         )
       }
     }
-
-    sealed case class DowngradeDropDefinedField(
-        expectedType: String,
-        fieldIndex: Long,
-        message: String,
-    ) extends SubmitError {
-      override def toDamlSubmitError(env: Env): SValue = {
-        val upgradeErrorType = damlScriptUpgradeErrorType(
-          env,
-          "DowngradeDropDefinedField",
-          1,
-          ("expectedType", SText(expectedType)),
-          ("fieldIndex", SInt64(fieldIndex)),
-        )
-        SubmitErrorConverters(env).damlScriptError(
-          "UpgradeError",
-          ("errorType", upgradeErrorType),
-          ("errorMessage", SText(message)),
-        )
-      }
-    }
-
-    sealed case class DowngradeFailed(expectedType: String, message: String) extends SubmitError {
-      override def toDamlSubmitError(env: Env): SValue = {
-        val upgradeErrorType = damlScriptUpgradeErrorType(
-          env,
-          "DowngradeFailed",
-          2,
-          ("expectedType", SText(expectedType)),
-        )
-        SubmitErrorConverters(env).damlScriptError(
-          "UpgradeError",
-          ("errorType", upgradeErrorType),
-          ("errorMessage", SText(message)),
-        )
-      }
-    }
   }
 
   final case class FailureStatusError(

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/UpgradesMatrixIT.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/UpgradesMatrixIT.scala
@@ -301,11 +301,7 @@ abstract class UpgradesMatrixIntegration(n: Int, k: Int)
         result shouldBe a[Right[_, _]]
       case UpgradesMatrixCases.ExpectUpgradeError =>
         inside(result) { case Left(ScriptLedgerClient.SubmitFailure(_, error)) =>
-          error should (
-            be(a[SubmitError.UpgradeError.ValidationFailed]) or
-              be(a[SubmitError.UpgradeError.DowngradeDropDefinedField]) or
-              be(a[SubmitError.UpgradeError.DowngradeFailed])
-          )
+          error shouldBe a[SubmitError.UpgradeError.ValidationFailed]
         }
       case UpgradesMatrixCases.ExpectRuntimeTypeMismatchError =>
         inside(result) { case Left(ScriptLedgerClient.SubmitFailure(_, error)) =>

--- a/sdk/docs/sharable/hoogle/daml-script-hoogle.txt
+++ b/sdk/docs/sharable/hoogle/daml-script-hoogle.txt
@@ -377,17 +377,8 @@ observers :: UpgradeErrorType -> [Party]
 
 keyOpt :: UpgradeErrorType -> Optional (AnyContractKey, [Party])
 
-@url https://docs.daml.com/daml-script/api/Daml-Script.html#constr-daml-script-internal-questions-submit-error-downgradedropdefinedfield-50092
-DowngradeDropDefinedField :: Text -> Int -> UpgradeErrorType
-
-expectedType :: UpgradeErrorType -> Text
-
-fieldIndex :: UpgradeErrorType -> Int
-
-@url https://docs.daml.com/daml-script/api/Daml-Script.html#constr-daml-script-internal-questions-submit-error-downgradefailed-38019
-DowngradeFailed :: Text -> UpgradeErrorType
-
-expectedType :: UpgradeErrorType -> Text
+@url https://docs.daml.com/daml-script/api/Daml-Script.html#constr-daml-script-internal-questions-submit-error-dummy-93243
+Dummy :: UpgradeErrorType
 
 @url https://docs.daml.com/daml-script/api/Daml-Script.html#type-daml-script-internal-questions-transactiontree-created-98301
 data Created

--- a/sdk/docs/sharable/sdk/reference/daml-script/api/Daml-Script.rst
+++ b/sdk/docs/sharable/sdk/reference/daml-script/api/Daml-Script.rst
@@ -838,38 +838,10 @@ Data Types
          - `Optional <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153>`_ (`AnyContractKey <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193>`_, \[`Party <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_\])
          -
 
-  .. _constr-daml-script-internal-questions-submit-error-downgradedropdefinedfield-50092:
+  .. _constr-daml-script-internal-questions-submit-error-dummy-93243:
 
-  `DowngradeDropDefinedField <constr-daml-script-internal-questions-submit-error-downgradedropdefinedfield-50092_>`_
+  `Dummy <constr-daml-script-internal-questions-submit-error-dummy-93243_>`_
 
-    .. list-table::
-       :widths: 15 10 30
-       :header-rows: 1
-
-       * - Field
-         - Type
-         - Description
-       * - expectedType
-         - `Text <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
-         -
-       * - fieldIndex
-         - `Int <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
-         -
-
-  .. _constr-daml-script-internal-questions-submit-error-downgradefailed-38019:
-
-  `DowngradeFailed <constr-daml-script-internal-questions-submit-error-downgradefailed-38019_>`_
-
-    .. list-table::
-       :widths: 15 10 30
-       :header-rows: 1
-
-       * - Field
-         - Type
-         - Description
-       * - expectedType
-         - `Text <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
-         -
 
 .. _type-daml-script-internal-questions-transactiontree-created-98301:
 


### PR DESCRIPTION
Part of https://github.com/digital-asset/daml/issues/21667

These error code are no longer used. They are subsumed by new ones currently under `Error.Dev`. They will be promoted to non-dev error codes in a separate PR.

This is almost entirely code deletion, except for `Error.daml` where I had to add a dummy constructor temporarily in order to convince the compiler my error type was a variant type and not a record.

@atriantafyllos-da FYI: the code deletions in `RejectionGenerators.scala` will need to be replicated in the canton repo in the next daml upgrade.