### PR TITLE
docs: Mark UpdateService.GetUpdateTrees as a broken symbol for now.

### DIFF
--- a/sdk/docs/manually-written/overview/explanations/ledger-model/ledger-privacy.rst
+++ b/sdk/docs/manually-written/overview/explanations/ledger-model/ledger-privacy.rst
@@ -271,7 +271,7 @@ They can therefore infer that their projections have happened in the same atomic
    
 .. note::
    A user of a Participant Node can request the Ledger projection for the user's parties via the
-   :externalref:`updates tree stream <com.daml.ledger.api.v2.UpdateService.GetUpdateTrees>`.
+   :brokenref:`updates tree stream <com.daml.ledger.api.v2.UpdateService.GetUpdateTrees>`.
 
 
 

--- a/sdk/docs/sharable/overview/explanations/ledger-model/ledger-privacy.rst
+++ b/sdk/docs/sharable/overview/explanations/ledger-model/ledger-privacy.rst
@@ -271,7 +271,7 @@ They can therefore infer that their projections have happened in the same atomic
    
 .. note::
    A user of a Participant Node can request the Ledger projection for the user's parties via the
-   :externalref:`updates tree stream <com.daml.ledger.api.v2.UpdateService.GetUpdateTrees>`.
+   :brokenref:`updates tree stream <com.daml.ledger.api.v2.UpdateService.GetUpdateTrees>`.
 
 
 


### PR DESCRIPTION
Links to Java bindings unevenly work throughout the site, and this currently fails the `daml` build. So mark this as `brokenref` for now, just to not block future merges from the `daml` repo to `docs-website`.