### PR TITLE
ci: Move everything to da-images/public, instead of da-images-dev/private.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,21 +150,6 @@ jobs:
       displayName: 'Publish to OCI Registry'
       env:
         GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
-        DPM_REGISTRY: "europe-docker.pkg.dev/da-images-dev/private"
-      condition: and(succeeded(), not(eq(variables['skip-github'], 'TRUE')), not(startsWith(variables['release_tag'], '2.')), not(startsWith(variables['release_tag'], '3.3')))
-    - bash: |
-        set -euo pipefail
-        # Note: this gets dev-env from the release commit, not the trigger commit
-        eval "$(cd sdk; ./dev-env/bin/dade-assist)"
-        # Authorize in GCLOUD
-        gcloud beta auth activate-service-account --key-file=<(echo "${GOOGLE_APPLICATION_CREDENTIALS_CONTENT}")
-        gcloud auth configure-docker --quiet ${DPM_REGISTRY%%/*}
-        ./ci/get-dpm.sh "${DPM_REGISTRY}/components/dpm:latest"
-        ./ci/publish-oci.sh $(Build.StagingDirectory) $(release_tag) ${DPM_REGISTRY}
-      name: publish_to_oci
-      displayName: 'Publish to OCI Registry'
-      env:
-        GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
         DPM_REGISTRY: "europe-docker.pkg.dev/da-images/private"
       condition: and(succeeded(), not(eq(variables['skip-github'], 'TRUE')), not(startsWith(variables['release_tag'], '2.')), not(startsWith(variables['release_tag'], '3.3')))
     - bash: |

--- a/ci/get-dpm.sh
+++ b/ci/get-dpm.sh
@@ -6,7 +6,7 @@ TEMP_DIR="$(mktemp -d)"
 ORAS_VERSION="1.2.2"
 ORAS="oras"
 # DPM latest url
-DPM_URL="${1:-europe-docker.pkg.dev/da-images-dev/private/components/dpm:latest}"
+DPM_URL="${1:-europe-docker.pkg.dev/da-images/public/components/dpm:latest}"
 # Get current machine OS type and ARCH
 OS_TYPE="$(uname -s | tr A-Z a-z)"
 if [[ $(uname -m) == 'x86_64' ]]; then

--- a/ci/split-release-job.yml
+++ b/ci/split-release-job.yml
@@ -140,7 +140,7 @@ jobs:
       displayName: "Publish Split Release Artifacts to OCI Registry"
       env:
         GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
-        DPM_REGISTRY: "europe-docker.pkg.dev/da-images-dev/private"
+        DPM_REGISTRY: "europe-docker.pkg.dev/da-images/public"
       condition: and(not(startsWith(variables['release_tag'], '2.')), not(startsWith(variables['release_tag'], '3.3')))
     - bash: |
         set -euo pipefail

--- a/sdk/dev-env/bin/dpm-sdk-head
+++ b/sdk/dev-env/bin/dpm-sdk-head
@@ -124,11 +124,11 @@ fi
 
 if [ ! -d "$DPM_HOME" ]; then
   echo "$(tput setaf 5)DPM is not installed, installing latest from remote....$(tput sgr 0)"
-  "$REPO_ROOT/../ci/get-dpm.sh" "europe-docker.pkg.dev/da-images-dev/private/components/dpm:latest"
+  "$REPO_ROOT/../ci/get-dpm.sh" "europe-docker.pkg.dev/da-images/public/components/dpm:latest"
   # Setup DPM config using private edition
   cat > "${DPM_HOME}/dpm-config.yaml" << EOF
 edition: private
-registry: europe-docker.pkg.dev/da-images-dev/private
+registry: europe-docker.pkg.dev/da-images/public
 EOF
   CONF_FILE=
   case $SHELL in
@@ -226,7 +226,7 @@ update_component() {
 
     # get-dpm script doesn't delete, it only updates
     # use it to pull down a new dpm
-    "$REPO_ROOT/../ci/get-dpm.sh" "europe-docker.pkg.dev/da-images-dev/private/components/dpm:latest"
+    "$REPO_ROOT/../ci/get-dpm.sh" "europe-docker.pkg.dev/da-images/public/components/dpm:latest"
     version_line=$("$DPM_HOME/bin/dpm" version --assistant | grep -o 'version: .*')
     DPM_VERSION=${version_line#version: }
 


### PR DESCRIPTION
#21988 was meant to dual-publish artifacts from the development version of Release Drive so we could cut over, but that PR apparently had no effect at all.

Rather than try to reason about why it failed, let's just cut these artifacts directly over to where they are supposed to be published. The only thing this affects is the nascent `dpm-assembly` process and in-flight efforts to integrate `dpm`-based artifact sharing into the various artifacts, so it's not clear that being extra careful here is going to have much value, especially if the process of figuring out how to thread that needle drags on too long.

This partially reverts commit 78aa70f9595b76b62c60f24bff4ca9cea0de2be6.