### PR TITLE
promote dev upgrade errors to non-dev ones

### DIFF
--- a/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
+++ b/sdk/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
@@ -103,6 +103,9 @@ object RejectionGenerators {
         case e: LfInterpretationError.ContractNotActive =>
           CommandExecutionErrors.Interpreter.ContractNotActive
             .Reject(renderedMessage, e)
+        case e :LfInterpretationError.ContractHashingError =>
+          CommandExecutionErrors.Interpreter.ContractHashingError
+            .Reject(renderedMessage, e)
         case e: LfInterpretationError.DisclosedContractKeyHashingError =>
           CommandExecutionErrors.Interpreter.DisclosedContractKeyHashingError
             .Reject(renderedMessage, e)
@@ -155,6 +158,12 @@ object RejectionGenerators {
             .Reject(renderedMessage, e, transactionTrace)
         case LfInterpretationError.Upgrade(error: LfInterpretationError.Upgrade.ValidationFailed) =>
           CommandExecutionErrors.Interpreter.UpgradeError.ValidationFailed
+            .Reject(renderedMessage, error)
+        case LfInterpretationError.Upgrade(error: LfInterpretationError.Upgrade.TranslationFailed) =>
+          CommandExecutionErrors.Interpreter.UpgradeError.TranslationFailed
+            .Reject(renderedMessage, error)
+        case LfInterpretationError.Upgrade(error: LfInterpretationError.Upgrade.AuthenticationFailed) =>
+          CommandExecutionErrors.Interpreter.UpgradeError.AuthenticationFailed
             .Reject(renderedMessage, error)
         case LfInterpretationError.Crypto(
               error: LfInterpretationError.Crypto.MalformedByteEncoding

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
@@ -410,6 +410,38 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
     }
 
     @Explanation(
+      """This error occurs when trying to hash an ill-formed contract."""
+    )
+    @Resolution(
+      "Ensure that the contract being hashed is a valid contract."
+    )
+    object ContractHashingError
+      extends ErrorCode(
+        id = "CONTRACT_HASHING_ERROR",
+        ErrorCategory.InvalidGivenCurrentSystemStateOther,
+      ) {
+
+      final case class Reject(
+        override val cause: String,
+        err: LfInterpretationError.ContractHashingError,
+      )(implicit
+        loggingContext: ErrorLoggingContext
+      ) extends DamlErrorWithDefiniteAnswer(
+        cause = cause
+      ) {
+
+        override def resources: Seq[(ErrorResource, String)] =
+          withEncodedValue(err.createArg) { encodedCreateArg =>
+            Seq(
+              (ErrorResource.ContractId, err.coid.coid),
+              (ErrorResource.TemplateId, err.dstTemplateId.toString),
+              (ErrorResource.ContractArg, encodedCreateArg),
+            )
+          }
+      }
+    }
+
+    @Explanation(
       """This error occurs if a user attempts to provide a key hash for a disclosed contract which we have already cached to be different."""
     )
     @Resolution(
@@ -851,6 +883,66 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
             ++ encodeParties(err.recomputedObservers)
             ++ optKeyResources(err.recomputedKeyOpt)
           }
+        }
+      }
+
+      @Explanation("Contract is malformed or doesn't match the expected type")
+      @Resolution(
+        "Verify that the template used for loading the contract is upgrade-compatible with the template that created it."
+      )
+      object TranslationFailed
+        extends ErrorCode(
+          id = "INTERPRETATION_UPGRADE_ERROR_TRANSLATION_FAILED",
+          ErrorCategory.InvalidGivenCurrentSystemStateOther,
+        ) {
+        final case class Reject(
+          override val cause: String,
+          err: LfInterpretationError.Upgrade.TranslationFailed,
+        )(implicit
+          loggingContext: ErrorLoggingContext
+        ) extends DamlErrorWithDefiniteAnswer(
+          cause = cause
+        ) {
+
+          override def resources: Seq[(ErrorResource, String)] =
+            withEncodedValue(err.createArg) { encodedArg =>
+              Seq(
+                (ErrorResource.ContractId.nullable, err.coid.fold("NULL")(_.coid)),
+                (ErrorResource.TemplateId, err.srcTemplateId.toString),
+                (ErrorResource.TemplateId, err.dstTemplateId.toString),
+                (ErrorResource.ContractArg, encodedArg),
+              )
+            }
+        }
+      }
+
+      @Explanation("Cannot authenticate contract")
+      @Resolution(
+        "Verify that the template used for loading the contract is upgrade-compatible with the template that created it."
+      )
+      object AuthenticationFailed
+        extends ErrorCode(
+          id = "INTERPRETATION_UPGRADE_ERROR_AUTHENTICATION_FAILED",
+          ErrorCategory.InvalidGivenCurrentSystemStateOther,
+        ) {
+        final case class Reject(
+          override val cause: String,
+          err: LfInterpretationError.Upgrade.AuthenticationFailed,
+        )(implicit
+          loggingContext: ErrorLoggingContext
+        ) extends DamlErrorWithDefiniteAnswer(
+          cause = cause
+        ) {
+
+          override def resources: Seq[(ErrorResource, String)] =
+            withEncodedValue(err.createArg) { encodedArg =>
+              Seq(
+                (ErrorResource.ContractId, err.coid.coid),
+                (ErrorResource.TemplateId, err.srcTemplateId.toString),
+                (ErrorResource.TemplateId, err.dstTemplateId.toString),
+                (ErrorResource.ContractArg, encodedArg),
+              )
+            }
         }
       }
     }

--- a/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
+++ b/sdk/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
@@ -418,7 +418,7 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
     object ContractHashingError
       extends ErrorCode(
         id = "CONTRACT_HASHING_ERROR",
-        ErrorCategory.InvalidGivenCurrentSystemStateOther,
+        ErrorCategory.InvalidIndependentOfSystemState,
       ) {
 
       final case class Reject(
@@ -852,7 +852,7 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
       object ValidationFailed
           extends ErrorCode(
             id = "INTERPRETATION_UPGRADE_ERROR_VALIDATION_FAILED",
-            ErrorCategory.InvalidGivenCurrentSystemStateOther,
+            ErrorCategory.InvalidIndependentOfSystemState,
           ) {
         final case class Reject(
             override val cause: String,
@@ -893,7 +893,7 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
       object TranslationFailed
         extends ErrorCode(
           id = "INTERPRETATION_UPGRADE_ERROR_TRANSLATION_FAILED",
-          ErrorCategory.InvalidGivenCurrentSystemStateOther,
+          ErrorCategory.InvalidIndependentOfSystemState,
         ) {
         final case class Reject(
           override val cause: String,
@@ -923,7 +923,7 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
       object AuthenticationFailed
         extends ErrorCode(
           id = "INTERPRETATION_UPGRADE_ERROR_AUTHENTICATION_FAILED",
-          ErrorCategory.InvalidGivenCurrentSystemStateOther,
+          ErrorCategory.InvalidIndependentOfSystemState,
         ) {
         final case class Reject(
           override val cause: String,

--- a/sdk/compiler/script-service/client/src/DA/Daml/LF/PrettyScript.hs
+++ b/sdk/compiler/script-service/client/src/DA/Daml/LF/PrettyScript.hs
@@ -312,6 +312,14 @@ prettyScriptErrorError lvl (Just err) =  do
                   (prettyContractRef lvl world)
                   scriptError_ContractNotActiveContractRef
         ]
+    ScriptErrorErrorContractHashingError (ScriptError_ContractHashingError contractRef dstTemplateId createArg message) ->
+      pure $ vcat
+        [ "Error when hashing a contract."
+        , label_ "Contract:" $ prettyMay "<missing contract>" (prettyContractRef lvl world) contractRef
+        , label_ "target template:" $ prettyMay "<missing template id>" (prettyDefName lvl world) dstTemplateId
+        , label_ "contract argument:" $ prettyMay "<missing contract argument>" (prettyValue' lvl False 0 world) createArg
+        , label_ "reason:" $ ltext message
+        ]
     ScriptErrorErrorDisclosedContractKeyHashingError(ScriptError_DisclosedContractKeyHashingError contractId key computedHash declaredHash) ->
       pure $ vcat
         [ "Mismatched disclosed contract key hash for contract"

--- a/sdk/compiler/script-service/protos/script_service.proto
+++ b/sdk/compiler/script-service/protos/script_service.proto
@@ -208,6 +208,13 @@ message ScriptError {
     NodeId consumed_by = 2; // optional. A contract whose create was rolled back will not have this set.
   }
 
+  message ContractHashingError {
+      ContractRef contract_ref = 1;
+      Identifier dst_template_id = 3;
+      Value create_arg = 4;
+      string message = 5;
+  }
+
   message DisclosedContractKeyHashingError {
       ContractRef contract_ref = 1;
       Value key = 2;
@@ -372,6 +379,7 @@ message ScriptError {
     ChoiceGuardFailed choice_guard_failed = 34;
     ContractDoesNotImplementInterface contract_does_not_implement_interface = 35;
     ContractDoesNotImplementRequiringInterface contract_does_not_implement_requiring_interface = 36;
+    ContractHashingError contract_hashing_error = 48;
     DisclosedContractKeyHashingError disclosed_contract_key_hashing_error = 39;
     int64 evaluationTimeout = 40;
     Empty cancelledByRequest = 41;
@@ -379,7 +387,7 @@ message ScriptError {
     UpgradeError upgrade_error = 44;
     FailureStatusError failure_status_error = 45;
     CryptoError crypto_error = 47;
-    // next is 48;
+    // next is 49;
   }
 }
 

--- a/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/Conversions.scala
+++ b/sdk/compiler/script-service/server/src/main/scala/com/digitalasset/daml/lf/script/Conversions.scala
@@ -141,6 +141,16 @@ final class Conversions(
                     .setConsumedBy(proto.NodeId.newBuilder.setId(consumedBy.toString).build)
                     .build
                 )
+              case ContractHashingError(contractId, dstTemplateId, createArg, message) =>
+                builder.setContractHashingError(
+                  proto.ScriptError.ContractHashingError.newBuilder
+                    .setContractRef(mkContractRef(contractId, dstTemplateId))
+                    .setDstTemplateId(convertIdentifier(dstTemplateId))
+                    .setCreateArg(convertValue(createArg))
+                    .setMessage(message)
+                    .build
+                )
+
               case DisclosedContractKeyHashingError(contractId, globalKey, hash) =>
                 builder.setDisclosedContractKeyHashingError(
                   proto.ScriptError.DisclosedContractKeyHashingError.newBuilder
@@ -265,15 +275,6 @@ final class Conversions(
                       cgfBuilder.setByInterface(convertIdentifier(ifaceId))
                     )
                     builder.setChoiceGuardFailed(cgfBuilder.build)
-                  // TODO(https://github.com/digital-asset/daml/issues/21667): handle translation errors properly
-                  case Dev.TranslationError(translationError) =>
-                    builder.setCrash(s"translation error: ${translationError}")
-                  // TODO(https://github.com/digital-asset/daml/issues/21667): handle authentication errors properly
-                  case Dev.AuthenticationError(coid, value, msg) =>
-                    builder.setCrash(s"authentication error: $coid, $value, $msg")
-                  // TODO(https://github.com/digital-asset/daml/issues/21667): handle hashing errors properly
-                  case Dev.HashingError(msg) =>
-                    builder.setCrash(s"hashing error: $msg")
                   case Dev.Cost(Dev.Cost.BudgetExceeded(cause)) =>
                     builder.setCrash(cause)
                 }

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -2448,12 +2448,24 @@ class EngineTest(majorLanguageVersion: LanguageMajorVersion, contractIdVersion: 
         case Left(
               Interpretation(
                 DamlException(
-                  interpretation.Error.Dev(_, interpretation.Error.Dev.TranslationError(error))
+                  interpretation.Error.Upgrade(
+                    interpretation.Error.Upgrade.TranslationFailed(
+                      Some(coid),
+                      srcTemplateId,
+                      dstTemplateId,
+                      createArg,
+                      error,
+                    )
+                  )
                 ),
                 _,
               )
             ) =>
-          error shouldBe a[interpretation.Error.Dev.TranslationError.TypeMismatch]
+          coid shouldBe cid
+          srcTemplateId shouldBe simpleId
+          dstTemplateId shouldBe simpleId
+          createArg shouldBe contracts(cid).createArg
+          error shouldBe a[interpretation.Error.Upgrade.TranslationFailed.TypeMismatch]
       }
     }
 
@@ -2472,12 +2484,24 @@ class EngineTest(majorLanguageVersion: LanguageMajorVersion, contractIdVersion: 
         case Left(
               Interpretation(
                 DamlException(
-                  interpretation.Error.Dev(_, interpretation.Error.Dev.TranslationError(error))
+                  interpretation.Error.Upgrade(
+                    interpretation.Error.Upgrade.TranslationFailed(
+                      Some(coid),
+                      srcTemplateId,
+                      dstTemplateId,
+                      createArg,
+                      error,
+                    )
+                  )
                 ),
                 _,
               )
             ) =>
-          error shouldBe a[interpretation.Error.Dev.TranslationError.TypeMismatch]
+          coid shouldBe cid
+          srcTemplateId shouldBe simpleId
+          dstTemplateId shouldBe simpleId
+          createArg shouldBe contracts(cid).createArg
+          error shouldBe a[interpretation.Error.Upgrade.TranslationFailed.TypeMismatch]
       }
     }
   }
@@ -2544,12 +2568,24 @@ class EngineTest(majorLanguageVersion: LanguageMajorVersion, contractIdVersion: 
         case Left(
               Interpretation(
                 DamlException(
-                  interpretation.Error.Dev(_, interpretation.Error.Dev.TranslationError(error))
+                  interpretation.Error.Upgrade(
+                    interpretation.Error.Upgrade.TranslationFailed(
+                      Some(coid),
+                      srcTemplateId,
+                      dstTemplateId,
+                      createArg,
+                      error,
+                    )
+                  )
                 ),
                 _,
               )
             ) =>
-          error shouldBe a[interpretation.Error.Dev.TranslationError.InvalidValue]
+          coid shouldBe cid
+          srcTemplateId shouldBe simpleId
+          dstTemplateId shouldBe simpleId
+          createArg shouldBe contracts(cid).createArg
+          error shouldBe a[interpretation.Error.Upgrade.TranslationFailed.InvalidValue]
       }
     }
 
@@ -2568,12 +2604,24 @@ class EngineTest(majorLanguageVersion: LanguageMajorVersion, contractIdVersion: 
         case Left(
               Interpretation(
                 DamlException(
-                  interpretation.Error.Dev(_, interpretation.Error.Dev.TranslationError(error))
+                  interpretation.Error.Upgrade(
+                    interpretation.Error.Upgrade.TranslationFailed(
+                      Some(coid),
+                      srcTemplateId,
+                      dstTemplateId,
+                      createArg,
+                      error,
+                    )
+                  )
                 ),
                 _,
               )
             ) =>
-          error shouldBe a[interpretation.Error.Dev.TranslationError.InvalidValue]
+          coid shouldBe cid
+          srcTemplateId shouldBe simpleId
+          dstTemplateId shouldBe simpleId
+          createArg shouldBe contracts(cid).createArg
+          error shouldBe a[interpretation.Error.Upgrade.TranslationFailed.InvalidValue]
       }
     }
   }

--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/UpgradesMatrixUnit.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/UpgradesMatrixUnit.scala
@@ -173,13 +173,13 @@ abstract class UpgradesMatrixUnit(n: Int, k: Int)
         }
       case UpgradesMatrixCases.ExpectAuthenticationError =>
         inside(result) {
-          case Left(EE.Interpretation(EE.Interpretation.DamlException(IE.Dev(_, error)), _)) =>
-            error shouldBe a[IE.Dev.AuthenticationError]
+          case Left(EE.Interpretation(EE.Interpretation.DamlException(IE.Upgrade(error)), _)) =>
+            error shouldBe a[IE.Upgrade.AuthenticationFailed]
         }
       case UpgradesMatrixCases.ExpectRuntimeTypeMismatchError =>
         inside(result) {
-          case Left(EE.Interpretation(EE.Interpretation.DamlException(IE.Dev(_, error)), _)) =>
-            error shouldBe a[IE.Dev.TranslationError]
+          case Left(EE.Interpretation(EE.Interpretation.DamlException(IE.Upgrade(error)), _)) =>
+            error shouldBe a[IE.Upgrade.TranslationFailed]
         }
       case UpgradesMatrixCases.ExpectPreprocessingError =>
         inside(result) { case Left(error) =>

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -10,7 +10,7 @@ import com.digitalasset.daml.lf.value.Value
 import Value._
 import com.digitalasset.daml.lf.ledger._
 import com.digitalasset.daml.lf.data.Ref._
-import com.digitalasset.daml.lf.interpretation.Error.Dev.TranslationError
+import com.digitalasset.daml.lf.interpretation.Error.Upgrade.TranslationFailed
 import com.digitalasset.daml.lf.script.IdeLedger.{Disclosure, TransactionId}
 import com.digitalasset.daml.lf.script._
 import com.digitalasset.daml.lf.transaction.{
@@ -60,6 +60,11 @@ private[lf] object Pretty {
         text("Update failed due to fetch of an inactive contract") & prettyContractId(coid) &
           char('(') + (prettyTypeConId(tid)) + text(").") /
           text(s"The contract had been consumed in sub-transaction #$consumedBy:")
+      case ContractHashingError(coid, dstTemplateId, createArg, msg) =>
+        text("Hash computation failed for contract") & prettyContractId(coid) /
+          text("Reason:") & text(msg) /
+          text("The hash computation assumes target type") & prettyTypeConId(dstTemplateId) /
+          text("The contract argument is") & prettyValue(true)(createArg)
       case DisclosedContractKeyHashingError(coid, gkey, declaredHash) =>
         text("Mismatched disclosed contract key hash for contract") & prettyContractId(coid) &
           char('(') + prettyTypeConId(gkey.templateId) + text(").") / text("declared hash:") &
@@ -164,6 +169,41 @@ private[lf] object Pretty {
                   text("recomputed maintainers are") & prettyParties(key.maintainers) /
                     text("recomputed key is") & prettyValue(verbose = false)(key.value)
               })
+          case Upgrade.TranslationFailed(
+                coidOpt,
+                srcTemplateId,
+                dstTemplateId,
+                createArg,
+                translationError,
+              ) =>
+            text("Translation of") &
+              (coidOpt match {
+                case Some(coid) => text("contract") & prettyContractId(coid)
+                case None => text("a contract")
+              }) & text("to a value of type") & prettyTypeConId(dstTemplateId) & text("fails.") /
+              text("The contract is purportedly an instance of") & prettyTypeConId(srcTemplateId) /
+              text("Its contract argument is: ") & prettyValue(verbose = false)(createArg) /
+              text("Reason:") & (translationError match {
+                case TranslationFailed.LookupError(lookupError) => text(lookupError.pretty)
+                case TranslationFailed.TypeMismatch(expectedType, value, message) =>
+                  text("Type-checking fails ") & text(message) /
+                    text("  Expected type:") & text(expectedType.pretty) /
+                    text("  Actual value:") & prettyValue(verbose = false)(value)
+                case TranslationFailed.ValueNesting(_) =>
+                  text(s"Value exceeds maximum nesting level of ${Value.MAXIMUM_NESTING}")
+                case TranslationFailed.NonSuffixedV1ContractId(badCoid) =>
+                  text("Encountered non-suffixed Contract ID") & prettyContractId(badCoid)
+                case TranslationFailed.NonSuffixedV2ContractId(badCoid) =>
+                  text("Encountered non-suffixed Contract ID") & prettyContractId(badCoid)
+                case TranslationFailed.InvalidValue(value, message) =>
+                  text("Invalid value") & prettyValue(verbose = false)(value) & text(message)
+              })
+          case Upgrade.AuthenticationFailed(coid, srcTemplateId, dstTemplateId, value, message) =>
+            text("Error when authenticating contract") & prettyContractId(coid) &
+              text("against template") & prettyTypeConId(dstTemplateId) & text(":") &
+              text(message) /
+              text("The contract is purportedly an instance of") & prettyTypeConId(srcTemplateId) /
+              text("The contract argument is") & prettyValue(verbose = false)(value)
         }
       case Crypto(error) =>
         error match {
@@ -247,27 +287,9 @@ private[lf] object Pretty {
                 case None => text("by template")
                 case Some(interfaceId) => text("by interface") & prettyTypeConId(interfaceId)
               })
-          case Dev.TranslationError(translationError) =>
-            translationError match {
-              case TranslationError.LookupError(lookupError) => text(lookupError.pretty)
-              case TranslationError.TypeMismatch(_, _, message) => text(message)
-              case TranslationError.ValueNesting(_) =>
-                text(s"Provided value exceeds maximum nesting level of ${Value.MAXIMUM_NESTING}")
-              case TranslationError.NonSuffixedV1ContractId(_) =>
-                text("non-suffixed V1 Contract IDs are forbidden")
-              case TranslationError.NonSuffixedV2ContractId(_) =>
-                text("non-suffixed V2 Contract IDs are forbidden")
-              case TranslationError.InvalidValue(value, message) =>
-                text("invalid value") & prettyValue(verbose = true)(value) / text(message)
-            }
-          case Dev.AuthenticationError(coid, value, message) =>
-            text("Authentication error for contract") & prettyContractId(coid) /
-              text("with argument") & prettyValue(verbose = false)(value) / text(message)
           case Dev.Cost(Dev.Cost.BudgetExceeded(cause)) =>
             text("Cost budget has been exceeded:") /
               text(cause)
-          case Dev.HashingError(message) =>
-            text("Hashing error:") / text(message)
         }
     }
   }

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -2760,7 +2760,7 @@ private[lf] object SBuiltinFun {
                       srcTemplateId = coinst.templateId,
                       dstTemplateId = coinst.templateId,
                       createArg = coinst.createArg,
-                      msg = s"failed to authenticate contract",
+                      msg = "failed to authenticate contract",
                     )
                 )
               )

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -1532,7 +1532,7 @@ private[lf] object SBuiltinFun {
           language.Reference.Template(dstTmplId.toRef),
         ) { () =>
           ensureTemplateImplementsInterface(machine, interfaceId, coid, dstTmplId) {
-            importValue(machine, Ast.TTyCon(dstTmplId), srcArg) { dstSArg =>
+            importCreateArg(machine, Some(coid), srcTmplId, dstTmplId, srcArg) { dstSArg =>
               fetchValidateDstContract(
                 machine,
                 coid,
@@ -1772,8 +1772,9 @@ private[lf] object SBuiltinFun {
         // This isn't ideal as it's a large uncached computation in a non Update primitive.
         // Ideally this would run in Update, and not iterate the value twice
         // i.e. using an upgrade transformation function directly on SValues
-        importValue(machine, Ast.TTyCon(dstTplId), srcArg.toNormalizedValue) { templateArg =>
-          Control.Value(SOptional(Some(templateArg)))
+        importCreateArg(machine, None, srcTplId, dstTplId, srcArg.toNormalizedValue) {
+          templateArg =>
+            Control.Value(SOptional(Some(templateArg)))
         }
       } else {
         Control.Value(SValue.SValue.None)
@@ -2601,7 +2602,7 @@ private[lf] object SBuiltinFun {
           dstTmplId.packageId,
           language.Reference.Template(dstTmplId.toRef),
         )(() => {
-          importValue(machine, Ast.TTyCon(dstTmplId), srcArg) { dstSArg =>
+          importCreateArg(machine, Some(coid), srcTmplId, dstTmplId, srcArg) { dstSArg =>
             fetchValidateDstContract(
               machine,
               coid,
@@ -2703,7 +2704,7 @@ private[lf] object SBuiltinFun {
         ) { () =>
           mbTypedNormalFormAuthenticator match {
             case Some(authenticator) =>
-              authenticateContractInfo(authenticator, coid, dstContract) { () =>
+              authenticateContractInfo(authenticator, coid, srcTmplId, dstContract) { () =>
                 k(dstTmplId, dstTmplArg, dstContract)
               }
             case None => k(dstTmplId, dstTmplArg, dstContract)
@@ -2752,18 +2753,28 @@ private[lf] object SBuiltinFun {
               k()
             } else {
               Control.Error(
-                IE.Dev(
-                  NameOf.qualifiedNameOfCurrentFunc,
-                  IE.Dev
-                    .AuthenticationError(coid, coinst.createArg, s"failed to authenticate contract"),
+                IE.Upgrade(
+                  IE.Upgrade
+                    .AuthenticationFailed(
+                      coid = coid,
+                      srcTemplateId = coinst.templateId,
+                      dstTemplateId = coinst.templateId,
+                      createArg = coinst.createArg,
+                      msg = s"failed to authenticate contract",
+                    )
                 )
               )
             }
           case Left(msg) =>
             Control.Error(
-              IE.Dev(
-                NameOf.qualifiedNameOfCurrentFunc,
-                IE.Dev.AuthenticationError(coid, coinst.createArg, msg),
+              IE.Upgrade(
+                IE.Upgrade.AuthenticationFailed(
+                  coid = coid,
+                  srcTemplateId = coinst.templateId,
+                  dstTemplateId = coinst.templateId,
+                  createArg = coinst.createArg,
+                  msg = msg,
+                )
               )
             )
         }
@@ -2776,6 +2787,7 @@ private[lf] object SBuiltinFun {
   private def authenticateContractInfo(
       authenticator: Hash => Boolean,
       coid: V.ContractId,
+      srcTemplateId: TypeConId,
       contractInfo: ContractInfo,
   )(k: () => Control[Question.Update]) =
     if (
@@ -2790,14 +2802,14 @@ private[lf] object SBuiltinFun {
       k()
     } else {
       Control.Error(
-        IE.Dev(
-          NameOf.qualifiedNameOfCurrentFunc,
-          IE.Dev
-            .AuthenticationError(
-              coid,
-              contractInfo.value.toNormalizedValue,
-              s"failed to authenticate contract",
-            ),
+        IE.Upgrade(
+          IE.Upgrade.AuthenticationFailed(
+            coid = coid,
+            srcTemplateId = srcTemplateId,
+            dstTemplateId = contractInfo.templateId,
+            createArg = contractInfo.value.toNormalizedValue,
+            msg = s"failed to authenticate contract",
+          )
         )
       )
     }
@@ -2846,13 +2858,30 @@ private[lf] object SBuiltinFun {
     }
   }
 
-  private def importValue[Q](machine: Machine[Q], typ: Ast.Type, value: V)(
-      f: SValue => Control[Q]
+  /** Type-checks [createArg] against [dstTmplId] and converts it to an SValue. The [coid] and [srcTmplId] parameters
+    *  are used for error reporting only.
+    */
+  private def importCreateArg[Q](
+      machine: Machine[Q],
+      coidOpt: Option[V.ContractId],
+      srcTmplId: TypeConId,
+      dstTmplId: TypeConId,
+      createArg: V,
+  )(
+      k: SValue => Control[Q]
   ): Control[Q] = {
-    machine.importValue(typ, value) match {
-      case Right(value) => f(value)
-      case Left(error) => Control.Error(error)
-    }
+    new ValueTranslator(machine.compiledPackages.pkgInterface, forbidLocalContractIds = true)
+      .translateValue(Ast.TTyCon(dstTmplId), createArg)
+      .fold(
+        translationError =>
+          Control.Error(
+            IE.Upgrade(
+              IE.Upgrade
+                .TranslationFailed(coidOpt, srcTmplId, dstTmplId, createArg, translationError)
+            )
+          ),
+        k,
+      )
   }
 
   // Get the contract info for a contract, computing if not in our cache

--- a/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/sdk/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -1229,16 +1229,6 @@ private[lf] object Speedy {
       }
     }
 
-    // This translates and type-checks an LF value (typically coming from the ledger)
-    // to speedy value and set the control of with the result.
-    private[speedy] final def importValue(typ: Type, value: V): Either[IError.Dev, SValue] =
-      new ValueTranslator(compiledPackages.pkgInterface, forbidLocalContractIds = true)
-        .translateValue(typ, value)
-        .left
-        .map(error =>
-          IError.Dev(NameOf.qualifiedNameOfCurrentFunc, IError.Dev.TranslationError(error))
-        )
-
     final def updateGasBudget(cost: CostModel => CostModel.Cost): Unit =
       if (hasGasBudget) {
         val consumed = cost(costModel)

--- a/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
+++ b/sdk/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/UpgradeTest.scala
@@ -569,13 +569,24 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
       ) {
         case Left(
               SError.SErrorDamlException(
-                IE.Dev(
-                  _,
-                  IE.Dev.TranslationError(IE.Dev.TranslationError.TypeMismatch(_, _, reason)),
+                IE.Upgrade(
+                  IE.Upgrade.TranslationFailed(
+                    Some(coid),
+                    srcTemplateId,
+                    dstTemplateId,
+                    createArg,
+                    IE.Upgrade.TranslationFailed.TypeMismatch(expectedType, actualValue, message),
+                  )
                 )
               )
             ) =>
-          reason should include(
+          coid shouldBe theCid
+          srcTemplateId shouldBe i"'-pkg1-':M:T"
+          dstTemplateId shouldBe i"'-pkg1-':M:T"
+          createArg shouldBe v_missingField
+          expectedType shouldBe TTyCon(i"'-pkg1-':M:T")
+          actualValue shouldBe v_missingField
+          message should include(
             "Unexpected non-optional extra template field type encountered during upgrading."
           )
       }
@@ -669,8 +680,17 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
           globalContractObservers = List.empty,
           globalContractKeyWithMaintainers = None,
         )
-      ) { case Left(SError.SErrorDamlException(IE.Dev(_, error))) =>
-        error shouldBe a[IE.Dev.AuthenticationError]
+      ) {
+        case Left(
+              SError.SErrorDamlException(
+                IE.Upgrade(
+                  IE.Upgrade.AuthenticationFailed(_, srcTemplateId, dstTemplateId, createArg, _)
+                )
+              )
+            ) =>
+          srcTemplateId shouldBe i"'-pkg0-':M:T"
+          dstTemplateId shouldBe i"'-pkg5-':M:T"
+          createArg shouldBe makeRecord(ValueParty(alice), ValueParty(alice), ValueInt64(42))
       }
     }
   }
@@ -753,13 +773,24 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
       inside(res) {
         case Left(
               SError.SErrorDamlException(
-                IE.Dev(
-                  _,
-                  IE.Dev.TranslationError(IE.Dev.TranslationError.TypeMismatch(_, _, reason)),
+                IE.Upgrade(
+                  IE.Upgrade.TranslationFailed(
+                    Some(coid),
+                    srcTemplateId,
+                    dstTemplateId,
+                    createArg,
+                    IE.Upgrade.TranslationFailed.TypeMismatch(expectedType, actualValue, message),
+                  )
                 )
               )
             ) =>
-          reason should include(
+          coid shouldBe theCid
+          srcTemplateId shouldBe i"'-pkg1-':M:T"
+          dstTemplateId shouldBe i"'-pkg1-':M:T"
+          createArg shouldBe v1_extraText
+          expectedType shouldBe TTyCon(i"'-pkg1-':M:T")
+          actualValue shouldBe v1_extraText
+          message should include(
             "Found non-optional extra field at index 3, cannot remove for downgrading."
           )
       }
@@ -813,13 +844,24 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
         inside(res) {
           case Left(
                 SError.SErrorDamlException(
-                  IE.Dev(
-                    _,
-                    IE.Dev.TranslationError(IE.Dev.TranslationError.TypeMismatch(_, _, reason)),
+                  IE.Upgrade(
+                    IE.Upgrade.TranslationFailed(
+                      Some(coid),
+                      srcTemplateId,
+                      dstTemplateId,
+                      createArg,
+                      IE.Upgrade.TranslationFailed.TypeMismatch(expectedType, actualValue, message),
+                    )
                   )
                 )
               ) =>
-            reason should include(
+            coid shouldBe theCid
+            srcTemplateId shouldBe i"'-pkg3-':M:T"
+            dstTemplateId shouldBe i"'-pkg2-':M:T"
+            createArg shouldBe v1_extraSome
+            expectedType shouldBe TTyCon(i"'-pkg2-':M:T")
+            actualValue shouldBe v1_extraSome
+            message should include(
               "Found an optional contract field with a value of Some at index 3, may not be dropped during downgrading."
             )
         }
@@ -916,13 +958,22 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
         ) {
           case Left(
                 SError.SErrorDamlException(
-                  IE.Dev(
-                    _,
-                    IE.Dev.TranslationError(error),
+                  IE.Upgrade(
+                    IE.Upgrade.TranslationFailed(
+                      Some(coid),
+                      srcTemplateId,
+                      dstTemplateId,
+                      createArg,
+                      error,
+                    )
                   )
                 )
               ) =>
-            error shouldBe a[IE.Dev.TranslationError.LookupError]
+            coid shouldBe theCid
+            srcTemplateId shouldBe i"'-variant-v1-':M:T"
+            dstTemplateId shouldBe i"'-variant-v2-':M:T"
+            createArg shouldBe v1Arg
+            error shouldBe a[IE.Upgrade.TranslationFailed.LookupError]
         }
       }
     }
@@ -965,13 +1016,22 @@ class UpgradeTest(majorLanguageVersion: LanguageMajorVersion)
         ) {
           case Left(
                 SError.SErrorDamlException(
-                  IE.Dev(
-                    _,
-                    IE.Dev.TranslationError(error),
+                  IE.Upgrade(
+                    IE.Upgrade.TranslationFailed(
+                      Some(coid),
+                      srcTemplateId,
+                      dstTemplateId,
+                      createArg,
+                      error,
+                    )
                   )
                 )
               ) =>
-            error shouldBe a[IE.Dev.TranslationError.LookupError]
+            coid shouldBe theCid
+            srcTemplateId shouldBe i"'-enum-v1-':M:T"
+            dstTemplateId shouldBe i"'-enum-v2-':M:T"
+            createArg shouldBe v1Arg
+            error shouldBe a[IE.Upgrade.TranslationFailed.LookupError]
         }
       }
     }

--- a/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
+++ b/sdk/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
@@ -48,6 +48,14 @@ object Error {
       consumedBy: NodeId,
   ) extends Error
 
+  /** Hashing a contract generated an error. */
+  final case class ContractHashingError(
+      coid: ContractId,
+      dstTemplateId: TypeConId,
+      createArg: Value,
+      msg: String,
+  ) extends Error
+
   /** When caching a disclosed contract key, hashing the contract key generated an error. */
   final case class DisclosedContractKeyHashingError(
       coid: ContractId,
@@ -174,6 +182,44 @@ object Error {
         recomputedKeyOpt: Option[GlobalKeyWithMaintainers],
         msg: String,
     ) extends Error
+
+    final case class TranslationFailed(
+        coid: Option[ContractId],
+        srcTemplateId: TypeConId,
+        dstTemplateId: TypeConId,
+        createArg: Value,
+        error: TranslationFailed.Error,
+    ) extends Error
+
+    final case class AuthenticationFailed(
+        coid: ContractId,
+        srcTemplateId: TypeConId,
+        dstTemplateId: TypeConId,
+        createArg: Value,
+        msg: String,
+    ) extends Error
+
+    object TranslationFailed {
+      sealed abstract class Error
+          extends RuntimeException
+          with scala.util.control.NoStackTrace
+          with Serializable
+          with Product
+
+      final case class LookupError(lookupError: com.digitalasset.daml.lf.language.LookupError)
+          extends Error
+
+      final case class TypeMismatch(expectedType: Ast.Type, actualValue: Value, message: String)
+          extends Error
+
+      final case class ValueNesting(value: Value) extends Error
+
+      final case class NonSuffixedV1ContractId(cid: Value.ContractId.V1) extends Error
+
+      final case class NonSuffixedV2ContractId(cid: Value.ContractId.V2) extends Error
+
+      final case class InvalidValue(value: Value, message: String) extends Error
+    }
   }
 
   sealed case class Crypto(error: Crypto.Error) extends Error
@@ -210,35 +256,6 @@ object Error {
         choiceName: ChoiceName,
         byInterface: Option[TypeConId],
     ) extends Error
-
-    final case class TranslationError(error: TranslationError.Error) extends Error
-
-    object TranslationError {
-      sealed abstract class Error
-          extends RuntimeException
-          with scala.util.control.NoStackTrace
-          with Serializable
-          with Product
-
-      final case class LookupError(lookupError: com.digitalasset.daml.lf.language.LookupError)
-          extends Error
-
-      final case class TypeMismatch(expectedType: Ast.Type, actualValue: Value, message: String)
-          extends Error
-
-      final case class ValueNesting(value: Value) extends Error
-
-      final case class NonSuffixedV1ContractId(cid: Value.ContractId.V1) extends Error
-
-      final case class NonSuffixedV2ContractId(cid: Value.ContractId.V2) extends Error
-
-      final case class InvalidValue(value: Value, message: String) extends Error
-    }
-
-    final case class AuthenticationError(coid: ContractId, value: Value, message: String)
-        extends Error
-
-    final case class HashingError(msg: String) extends Error
 
     final case class Limit(error: Limit.Error) extends Error
 

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
@@ -30,10 +30,16 @@ data UpgradeErrorType
         recomputedSignatories : [Party]
         recomputedObservers : [Party]
         recomputedKeyOpt : Optional (AnyContractKey, [Party])
-  -- We will add new constructors soon. In the meantime we need a dummy constructor so that the compile doesn't confuse
-  -- UpgradeErrorType for a record, which would force us to rename ValidationFailed to UpgradeErrorType.
-  -- TODO(https://github.com/digital-asset/daml/issues/21667): remove
-  | DummyUpgradeError
+  | TranslationFailed with
+        mCoid : Optional AnyContractId
+        srcTemplateId : TemplateTypeRep
+        dstTemplateId : TemplateTypeRep
+        createArg : AnyTemplate
+  | AuthenticationFailed with
+        coid : AnyContractId
+        srcTemplateId : TemplateTypeRep
+        dstTemplateId : TemplateTypeRep
+        createArg : AnyTemplate
 
 -- | MOVE Daml.Script
 -- Daml Crypto (Secp256k1) related submission errors
@@ -52,8 +58,6 @@ data CryptoErrorType
 -- Errors that will be promoted to SubmitError once stable - code needs to be kept in sync with SubmitError.scala
 data DevErrorType
   = ChoiceGuardFailed
-  | TranslationError
-  | AuthenticationError
   | UnknownNewFeature -- ^ This should never happen - Update Scripts when you see this!
   deriving Show
 
@@ -100,6 +104,12 @@ data SubmitError
   | -- | Generic authorization failure, included missing party authority, invalid signatories, etc.
     AuthorizationError with
       authorizationErrorMessage : Text -- We can't pass over the data at the moment, so we just give the full string error here, for anyone that wants to check it
+  | -- | Failed to hash a contract
+    ContractHashingError with
+      contractId : AnyContractId
+      dstTemplateId : TemplateTypeRep
+      createArg : AnyTemplate
+      errorMessage: Text
   | -- | Given disclosed contract key does not match the contract key of the contract on ledger.
     DisclosedContractKeyHashingError with
       contractId : AnyContractId
@@ -206,6 +216,8 @@ instance Show SubmitError where
     ContractKeyNotFound contractKey -> "Could not find contract with given key"
     UnresolvedPackageName packageName -> "Could not find any vetted package with name " <> packageName
     AuthorizationError errMessage -> "Authorization failure: " <> errMessage
+    ContractHashingError contractId _dstTemplateId _createArg msg ->
+      "Failed to hash contract with ID " <> show contractId <> "\n with message \"" <> msg <> "\""
     DisclosedContractKeyHashingError contractId contractKey contractKeyHash ->
       "Disclosed contract with ID " <> show contractId <> " used incorrect payload - contract key hash: " <> contractKeyHash
     DuplicateContractKey contractKey -> "Attempted to create a contract with a contract key that is already in use"
@@ -245,5 +257,7 @@ instance Show UpgradeErrorType where
           <> ", original observers: " <> show originalObservers
           <> ", recomputed signatories: " <> show recomputedSignatories
           <> ", recomputed observers: " <> show recomputedObservers <> ")"
-    DummyUpgradeError -> error "This should never happen"
-
+    TranslationFailed mCoid _srcTemplateId _dstTemplateId _createArg ->
+      "Failed to load " <> (optional "a contract" (\coid -> "contract" <> show coid)) mCoid
+    AuthenticationFailed coid _srcTemplateId _dstTemplateId _createArg ->
+      "Authentication of contract " <> show coid <> " failed"

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
@@ -153,6 +153,20 @@ object GrpcErrorParser {
             None,
           )
         }
+      case "CONTRACT_HASHING_ERROR" =>
+        caseErr {
+          case Seq(
+                (ErrorResource.ContractId, cid),
+                (ErrorResource.TemplateId, tid),
+                (ErrorResource.ContractArg, decodeValue.unlift(arg)),
+              ) =>
+            SubmitError.ContractHashingError(
+              ContractId.assertFromString(cid),
+              Identifier.assertFromString(tid),
+              arg,
+              message,
+            )
+        }
       case "DISCLOSED_CONTRACT_KEY_HASHING_ERROR" =>
         caseErr {
           case Seq(
@@ -338,6 +352,39 @@ object GrpcErrorParser {
                 recomputedPn,
                 recomputedMaintainers,
               ),
+              message,
+            )
+        }
+      case "INTERPRETATION_UPGRADE_ERROR_TRANSLATION_FAILED" =>
+        val NullableContractId = ErrorResource.ContractId.nullable
+        caseErr {
+          case Seq(
+                (NullableContractId, decodeNullableString.unlift(coidOpt)),
+                (ErrorResource.TemplateId, srcTemplateId),
+                (ErrorResource.TemplateId, dstTemplateId),
+                (ErrorResource.ContractArg, decodeValue.unlift(createArg)),
+              ) =>
+            SubmitError.UpgradeError.TranslationFailed(
+              coidOpt.map(ContractId.assertFromString),
+              Identifier.assertFromString(srcTemplateId),
+              Identifier.assertFromString(dstTemplateId),
+              createArg,
+              message,
+            )
+        }
+      case "INTERPRETATION_UPGRADE_ERROR_AUTHENTICATION_FAILED" =>
+        caseErr {
+          case Seq(
+                (ErrorResource.ContractId, coid),
+                (ErrorResource.TemplateId, srcTemplateId),
+                (ErrorResource.TemplateId, dstTemplateId),
+                (ErrorResource.ContractArg, decodeValue.unlift(createArg)),
+              ) =>
+            SubmitError.UpgradeError.AuthenticationFailed(
+              ContractId.assertFromString(coid),
+              Identifier.assertFromString(srcTemplateId),
+              Identifier.assertFromString(dstTemplateId),
+              createArg,
               message,
             )
         }

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -342,6 +342,13 @@ class IdeLedgerClient(
           NonEmpty(Seq, cid),
           Some(SubmitError.ContractNotFound.AdditionalInfo.NotActive(cid, tid)),
         )
+      case e @ ContractHashingError(coid, dstTemplateId, createArg, _) =>
+        SubmitError.ContractHashingError(
+          coid,
+          dstTemplateId,
+          createArg,
+          Pretty.prettyDamlException(e).renderWideStream.mkString,
+        )
       case DisclosedContractKeyHashingError(cid, key, hash) =>
         SubmitError.DisclosedContractKeyHashingError(cid, key, hash.toString)
       case DuplicateContractKey(key) => SubmitError.DuplicateContractKey(Some(key))
@@ -378,6 +385,22 @@ class IdeLedgerClient(
           innerError.recomputedSignatories,
           innerError.recomputedObservers,
           innerError.recomputedKeyOpt,
+          Pretty.prettyDamlException(e).renderWideStream.mkString,
+        )
+      case e @ Upgrade(innerError: Upgrade.TranslationFailed) =>
+        SubmitError.UpgradeError.TranslationFailed(
+          innerError.coid,
+          innerError.srcTemplateId,
+          innerError.dstTemplateId,
+          innerError.createArg,
+          Pretty.prettyDamlException(e).renderWideStream.mkString,
+        )
+      case e @ Upgrade(innerError: Upgrade.AuthenticationFailed) =>
+        SubmitError.UpgradeError.AuthenticationFailed(
+          innerError.coid,
+          innerError.srcTemplateId,
+          innerError.dstTemplateId,
+          innerError.createArg,
           Pretty.prettyDamlException(e).renderWideStream.mkString,
         )
       case e @ Crypto(innerError: Crypto.MalformedByteEncoding) =>

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
@@ -227,6 +227,23 @@ object SubmitError {
       )
   }
 
+  final case class ContractHashingError(
+      coid: ContractId,
+      dstTemplateId: TypeConId,
+      createArg: Value,
+      message: String,
+  ) extends SubmitError {
+    override def toDamlSubmitError(env: Env): SValue = {
+      SubmitErrorConverters(env).damlScriptError(
+        "ContractHashingError",
+        ("coid", fromAnyContractId(env.scriptIds, toApiIdentifier(dstTemplateId), coid)),
+        ("dstTemplateId", fromTemplateTypeRep(dstTemplateId)),
+        ("createArg", fromAnyTemplate(env.valueTranslator, dstTemplateId, createArg).toOption.get),
+        ("contractHashingErrorMessage", SText(message)),
+      )
+    }
+  }
+
   final case class DisclosedContractKeyHashingError(
       contractId: ContractId,
       key: GlobalKey,
@@ -482,6 +499,69 @@ object SubmitError {
         )
       }
     }
+
+    sealed case class TranslationFailed(
+        coid: Option[ContractId],
+        srcTemplateId: Identifier,
+        dstTemplateId: Identifier,
+        createArg: Value,
+        message: String,
+    ) extends SubmitError {
+      override def toDamlSubmitError(env: Env): SValue = {
+        val upgradeErrorType =
+          damlScriptUpgradeErrorType(
+            env,
+            "TranslationFailed",
+            1,
+            (
+              "coid",
+              SOptional.apply(
+                coid.map(id => fromAnyContractId(env.scriptIds, toApiIdentifier(srcTemplateId), id))
+              ),
+            ),
+            ("srcTemplateId", fromTemplateTypeRep(srcTemplateId)),
+            ("dstTemplateId", fromTemplateTypeRep(dstTemplateId)),
+            (
+              "createArg",
+              fromAnyTemplate(env.valueTranslator, srcTemplateId, createArg).toOption.get,
+            ),
+          )
+        SubmitErrorConverters(env).damlScriptError(
+          "UpgradeError",
+          ("errorType", upgradeErrorType),
+          ("errorMessage", SText(message)),
+        )
+      }
+    }
+
+    sealed case class AuthenticationFailed(
+        coid: ContractId,
+        srcTemplateId: Identifier,
+        dstTemplateId: Identifier,
+        createArg: Value,
+        message: String,
+    ) extends SubmitError {
+      override def toDamlSubmitError(env: Env): SValue = {
+        val upgradeErrorType =
+          damlScriptUpgradeErrorType(
+            env,
+            "AuthenticationFailed",
+            2,
+            ("coid", fromAnyContractId(env.scriptIds, toApiIdentifier(srcTemplateId), coid)),
+            ("srcTemplateId", fromTemplateTypeRep(srcTemplateId)),
+            ("dstTemplateId", fromTemplateTypeRep(dstTemplateId)),
+            (
+              "createArg",
+              fromAnyTemplate(env.valueTranslator, srcTemplateId, createArg).toOption.get,
+            ),
+          )
+        SubmitErrorConverters(env).damlScriptError(
+          "UpgradeError",
+          ("errorType", upgradeErrorType),
+          ("errorMessage", SText(message)),
+        )
+      }
+    }
   }
 
   final case class FailureStatusError(
@@ -592,11 +672,7 @@ object SubmitError {
       val devErrorType = errorType match {
         case "ChoiceGuardFailed" =>
           SEnum(devErrorTypeIdentifier, Name.assertFromString("ChoiceGuardFailed"), 0)
-        case "TranslationError" =>
-          SEnum(devErrorTypeIdentifier, Name.assertFromString("TranslationError"), 1)
-        case "AuthenticationError" =>
-          SEnum(devErrorTypeIdentifier, Name.assertFromString("AuthenticationError"), 2)
-        case _ => SEnum(devErrorTypeIdentifier, Name.assertFromString("UnknownNewFeature"), 3)
+        case _ => SEnum(devErrorTypeIdentifier, Name.assertFromString("UnknownNewFeature"), 1)
       }
       SubmitErrorConverters(env).damlScriptError(
         "DevError",

--- a/sdk/daml-script/test/daml/upgrades/dev/DataChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/dev/DataChanges.daml
@@ -130,7 +130,7 @@ templateOptionalFieldsSetWhenDowngradingTest trailer f = ("Fails if an optional 
     b <- allocatePartyOn "bob" participant0
     res <- f a b
     case res of
-      Left (DevError TranslationError _) -> pure ()
+      Left (UpgradeError (TranslationFailed _ _ _ _) _) -> pure ()
       _ -> assertFail $ "Expected specific failure but got " <> show res
 
 tofswdViaKeyExerciseInCommandGlobal : (Text, Test)

--- a/sdk/daml-script/test/daml/upgrades/stable/AuthenticationErrors.daml
+++ b/sdk/daml-script/test/daml/upgrades/stable/AuthenticationErrors.daml
@@ -398,7 +398,7 @@ setUpChoiceBodyTest = do
   pure (alice, clientCid)
 
 assertIsAuthenticationError : Show a => Either SubmitError a -> Script ()
-assertIsAuthenticationError (Left (DevError AuthenticationError _)) = pure ()
+assertIsAuthenticationError (Left (UpgradeError (AuthenticationFailed _ _ _ _) _)) = pure ()
 assertIsAuthenticationError res = assertFail $ "Expected TranslationError, got " <> show res
 
 assertIsWronglyTypedContractError : Show a => Either SubmitError a -> Script ()

--- a/sdk/daml-script/test/daml/upgrades/stable/AuthenticationErrors.daml
+++ b/sdk/daml-script/test/daml/upgrades/stable/AuthenticationErrors.daml
@@ -373,11 +373,11 @@ main = tests
     ]
   , subtree "should reject template renaming"
     [ subtree "in fetches"
-      [ broken ("from choice body", templateRenamingFetchChoiceBody)
+      [ ("from choice body", templateRenamingFetchChoiceBody)
       , ("of local contract", templateRenamingFetchLocal)
       ]
     , subtree "in exercises"
-      [ broken ("from choice body", templateRenamingExerciseChoiceBody)
+      [ ("from choice body", templateRenamingExerciseChoiceBody)
       , ("of local contract", templateRenamingExerciseLocal)
       ]
     ]
@@ -611,9 +611,7 @@ templateRenamingFetchChoiceBody = test $ do
   cid1 <- alice `submit` createExactCmd V1.TemplateRenamingTemplate1 { sig = alice }
   let cid2 = coerceContractId @V1.TemplateRenamingTemplate1 @V1.TemplateRenamingTemplate2 cid1
   res <- alice `trySubmit` exerciseCmd clientCid (Client.FetchTemplateRenamingTemplate2 with cid = cid2)
-  -- once we migrate to contract ID v12 this will become a WronglyTypedContract error, as authentication happens after
-  -- template name comparison for v12 contract IDs
-  assertIsAuthenticationError res
+  assertIsWronglyTypedContractError res
 
 templateRenamingFetchLocal : Test
 templateRenamingFetchLocal = test $ do
@@ -627,9 +625,7 @@ templateRenamingExerciseChoiceBody = test $ do
   cid1 <- alice `submit` createExactCmd V1.TemplateRenamingTemplate1 { sig = alice }
   let cid2 = coerceContractId @V1.TemplateRenamingTemplate1 @V1.TemplateRenamingTemplate2 cid1
   res <- alice `trySubmit` exerciseCmd clientCid (Client.ExerciseTemplateRenamingTemplate2 with cid = cid2)
-  -- once we migrate to contract ID v12 this will become a WronglyTypedContract error, as authentication happens after
-  -- template name comparison for v12 contract IDs
-  assertIsAuthenticationError res
+  assertIsWronglyTypedContractError res
 
 templateRenamingExerciseLocal : Test
 templateRenamingExerciseLocal = test $ do

--- a/sdk/daml-script/test/daml/upgrades/stable/DataChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/stable/DataChanges.daml
@@ -71,7 +71,7 @@ templateInvalidChange shouldSucceed makeV1Contract v2Choice = test $ do
   case (res, shouldSucceed) of
     (Right "V2", True) -> pure ()
     (Left (WronglyTypedContract {}), False) -> pure ()
-    (Left (DevError TranslationError _), False) -> pure ()
+    (Left (UpgradeError (TranslationFailed _ _ _ _) _), False) -> pure ()
     (Left (UnknownError msg), False) | "SErrorCrash" `isInfixOf` msg -> pure ()
     (Left (UnknownError msg), False) | "An error occurred." `isInfixOf` msg -> pure ()
     _ -> assertFail $ "Expected " <> (if shouldSucceed then "success" else "specific failure") <> " but got " <> show res
@@ -292,7 +292,7 @@ templateEnumDowngradeFromNew = test $ do
   res <- a `trySubmit` exerciseExactCmd cidV1 V1.EnumAdditionalCall
 
   case res of
-    Left (DevError TranslationError _) -> pure ()
+    Left (UpgradeError (TranslationFailed _ _ _ _) _) -> pure ()
     Left (UnknownError msg) | "An error occurred." `isInfixOf` msg -> pure ()
     _ -> assertFail $ "Expected specific failure but got " <> show res
 
@@ -483,7 +483,7 @@ templateOptionalFieldsSetWhenDowngradingTest trailer f = ("Fails if an optional 
     b <- allocatePartyOn "bob" participant0
     res <- f a b
     case res of
-      Left (DevError TranslationError _) -> pure ()
+      Left (UpgradeError (TranslationFailed _ _ _ _) _) -> pure ()
       _ -> assertFail $ "Expected specific failure but got " <> show res
 
 tofswdViaCIDExerciseInCommandGlobal : (Text, Test)

--- a/sdk/daml-script/test/daml/upgrades/stable/Exceptions.daml
+++ b/sdk/daml-script/test/daml/upgrades/stable/Exceptions.daml
@@ -209,7 +209,7 @@ contents: |
 
 assertIsUpgradeError : Either SubmitError a -> Script ()
 assertIsUpgradeError (Left (UpgradeError _ _)) = pure ()
-assertIsUpgradeError (Left (DevError TranslationError _)) = pure ()
+assertIsUpgradeError (Left (UpgradeError (TranslationFailed _ _ _ _) _)) = pure ()
 assertIsUpgradeError (Left e) = fail $ "Expected upgrade error but got " <> show e
 assertIsUpgradeError _ = fail "Expected upgrade error but got success"
 

--- a/sdk/daml-script/test/daml/upgrades/stable/Fetch.daml
+++ b/sdk/daml-script/test/daml/upgrades/stable/Fetch.daml
@@ -184,7 +184,7 @@ mkFetchDowngradedSome trailer f = ("Fail to downgrade a contract with Somes when
     b <- allocatePartyOn "bob" participant0
     res <- f a b
     case res of
-      Left (DevError TranslationError _) -> pure ()
+      Left (UpgradeError (TranslationFailed _ _ _ _) _) -> pure ()
       res -> assertFail $ "Expected UpgradeError, got " <> show res
 
 fetchDowngradedSomeGlobal : (Text, Test)

--- a/sdk/daml-script/test/daml/upgrades/stable/FromInterface.daml
+++ b/sdk/daml-script/test/daml/upgrades/stable/FromInterface.daml
@@ -147,5 +147,5 @@ fromInterfaceInvalidDowngrade = test $ do
   res <- a `trySubmit` createAndExerciseCmd (TestHelper a) InvalidDowngrade
   case res of
     Right _ -> fail "Expected failure but got success"
-    Left (DevError TranslationError _) -> pure ()
+    Left (UpgradeError (TranslationFailed _ _ _ _) _) -> pure ()
     Left e -> fail $ "Expected Upgrade error but got " <> show e

--- a/sdk/daml-script/test/daml/upgrades/stable/VariantChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/stable/VariantChanges.daml
@@ -38,6 +38,7 @@ main = tests
   , ("Upgrade fails if variant has fields removed", upgradeToRemovedField)
   , ("Upgrade fails if variant has non-optional fields added", upgradeToNewNonOptField)
   , ("Upgrade fails if variant has non-optional nested fields added", upgradeToNewNonOptNestedField)
+  , ("Succeeds if upgrading a variant with a new case in the middle, from a case with unchanged rank", templateVariantUpgradeNonLastSameRank)
 
   , ("Downgrade succeeds if variant is an existing constructor", downgradeFromExistingCon)
   , ("Downgrade succeeds if variant has optional fields added as None", downgradeFromNoneNewOptField)
@@ -45,8 +46,7 @@ main = tests
   , ("Downgrade fails if variant is a new constructor", downgradeFromNewCon)
   , ("Downgrade fails if variant has optional fields added as Some", downgradeFromSomeNewOptField)
   , ("Downgrade fails if variant has optional nested fields added as Some", downgradeFromSomeNewOptNestedField)
-  , broken ("Fails if upgrading a variant with a new case in the middle, from a case with unchanged rank", templateVariantUpgradeNonLastSameRank)
-  , broken ("Fails if upgrading a variant with a new case in the middle, from a case with changed rank", templateVariantUpgradeNonLastDifferentRank)
+  , brokenOnIDELedger ("Fails if upgrading a variant with a new case in the middle, from a case with changed rank", templateVariantUpgradeNonLastDifferentRank)
   , ("Fails if downgrading a variant from a new case in the middle", templateVariantDowngradeNonLastDifferentRank)
   ]
 
@@ -61,7 +61,6 @@ templateInvalidChange shouldSucceed makeV1Contract v2Choice = test $ do
     (Right "V1", True) -> pure ()
     (Right "V2", True) -> pure ()
     (Left (UpgradeError _ _), False) -> pure ()
-    (Left (UpgradeError (TranslationFailed _ _ _ _) _), False) -> pure ()
     (Left (WronglyTypedContract {}), False) -> pure ()
     (Left (UnknownError msg), False) | "An error occurred." `isInfixOf` msg -> pure ()
     -- IDE Ledger doesn't apply obfuscation, instead the lookup error is wrapped in SCrash
@@ -422,7 +421,7 @@ templateVariantUpgradeNonLastSameRank : Test
 templateVariantUpgradeNonLastSameRank =
   templateInvalidChange
     @V2.VariantNonLastAdditional
-    False
+    True
     (`V1.VariantNonLastAdditional` V1.VariantNonLastAdditionalData1 1)
     V2.VariantNonLastAdditionalCall
 

--- a/sdk/daml-script/test/daml/upgrades/stable/VariantChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/stable/VariantChanges.daml
@@ -61,7 +61,7 @@ templateInvalidChange shouldSucceed makeV1Contract v2Choice = test $ do
     (Right "V1", True) -> pure ()
     (Right "V2", True) -> pure ()
     (Left (UpgradeError _ _), False) -> pure ()
-    (Left (DevError TranslationError _), False) -> pure ()
+    (Left (UpgradeError (TranslationFailed _ _ _ _) _), False) -> pure ()
     (Left (WronglyTypedContract {}), False) -> pure ()
     (Left (UnknownError msg), False) | "An error occurred." `isInfixOf` msg -> pure ()
     -- IDE Ledger doesn't apply obfuscation, instead the lookup error is wrapped in SCrash

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/UpgradesMatrixIT.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/UpgradesMatrixIT.scala
@@ -305,11 +305,11 @@ abstract class UpgradesMatrixIntegration(n: Int, k: Int)
         }
       case UpgradesMatrixCases.ExpectAuthenticationError =>
         inside(result) { case Left(ScriptLedgerClient.SubmitFailure(_, error)) =>
-          error shouldBe a[SubmitError.DevError]
+          error shouldBe a[SubmitError.UpgradeError.AuthenticationFailed]
         }
       case UpgradesMatrixCases.ExpectRuntimeTypeMismatchError =>
         inside(result) { case Left(ScriptLedgerClient.SubmitFailure(_, error)) =>
-          error shouldBe a[SubmitError.DevError]
+          error shouldBe a[SubmitError.UpgradeError.TranslationFailed]
         }
       case UpgradesMatrixCases.ExpectPreprocessingError =>
         inside(result) { case Left(ScriptLedgerClient.SubmitFailure(statusError, submitError)) =>

--- a/sdk/docs/sharable/hoogle/daml-script-hoogle.txt
+++ b/sdk/docs/sharable/hoogle/daml-script-hoogle.txt
@@ -186,6 +186,18 @@ AuthorizationError :: Text -> SubmitError
 
 authorizationErrorMessage :: SubmitError -> Text
 
+-- | Failed to hash a contract
+@url https://docs.daml.com/daml-script/api/Daml-Script.html#constr-daml-script-internal-questions-submit-error-contracthashingerror-75608
+ContractHashingError :: AnyContractId -> TemplateTypeRep -> AnyTemplate -> Text -> SubmitError
+
+contractId :: SubmitError -> AnyContractId
+
+dstTemplateId :: SubmitError -> TemplateTypeRep
+
+createArg :: SubmitError -> AnyTemplate
+
+errorMessage :: SubmitError -> Text
+
 -- | Given disclosed contract key does not match the contract key of the contract on ledger.
 @url https://docs.daml.com/daml-script/api/Daml-Script.html#constr-daml-script-internal-questions-submit-error-disclosedcontractkeyhashingerror-69749
 DisclosedContractKeyHashingError :: AnyContractId -> AnyContractKey -> Text -> SubmitError
@@ -383,8 +395,27 @@ recomputedObservers :: UpgradeErrorType -> [Party]
 
 recomputedKeyOpt :: UpgradeErrorType -> Optional (AnyContractKey, [Party])
 
-@url https://docs.daml.com/daml-script/api/Daml-Script.html#constr-daml-script-internal-questions-submit-error-dummyupgradeerror-28037
-DummyUpgradeError :: UpgradeErrorType
+@url https://docs.daml.com/daml-script/api/Daml-Script.html#constr-daml-script-internal-questions-submit-error-translationfailed-4701
+TranslationFailed :: Optional AnyContractId -> TemplateTypeRep -> TemplateTypeRep -> AnyTemplate -> UpgradeErrorType
+
+mCoid :: UpgradeErrorType -> Optional AnyContractId
+
+srcTemplateId :: UpgradeErrorType -> TemplateTypeRep
+
+dstTemplateId :: UpgradeErrorType -> TemplateTypeRep
+
+createArg :: UpgradeErrorType -> AnyTemplate
+
+@url https://docs.daml.com/daml-script/api/Daml-Script.html#constr-daml-script-internal-questions-submit-error-authenticationfailed-3671
+AuthenticationFailed :: AnyContractId -> TemplateTypeRep -> TemplateTypeRep -> AnyTemplate -> UpgradeErrorType
+
+coid :: UpgradeErrorType -> AnyContractId
+
+srcTemplateId :: UpgradeErrorType -> TemplateTypeRep
+
+dstTemplateId :: UpgradeErrorType -> TemplateTypeRep
+
+createArg :: UpgradeErrorType -> AnyTemplate
 
 @url https://docs.daml.com/daml-script/api/Daml-Script.html#type-daml-script-internal-questions-transactiontree-created-98301
 data Created

--- a/sdk/docs/sharable/sdk/reference/daml-script/api/Daml-Script.rst
+++ b/sdk/docs/sharable/sdk/reference/daml-script/api/Daml-Script.rst
@@ -397,6 +397,32 @@ Data Types
          - `Text <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
          -
 
+  .. _constr-daml-script-internal-questions-submit-error-contracthashingerror-75608:
+
+  `ContractHashingError <constr-daml-script-internal-questions-submit-error-contracthashingerror-75608_>`_
+
+    Failed to hash a contract
+
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+
+       * - Field
+         - Type
+         - Description
+       * - contractId
+         - `AnyContractId <type-daml-script-internal-questions-util-anycontractid-11399_>`_
+         -
+       * - dstTemplateId
+         - `TemplateTypeRep <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
+         -
+       * - createArg
+         - `AnyTemplate <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anytemplate-63703>`_
+         -
+       * - errorMessage
+         - `Text <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-ghc-types-text-51952>`_
+         -
+
   .. _constr-daml-script-internal-questions-submit-error-disclosedcontractkeyhashingerror-69749:
 
   `DisclosedContractKeyHashingError <constr-daml-script-internal-questions-submit-error-disclosedcontractkeyhashingerror-69749_>`_
@@ -847,10 +873,53 @@ Data Types
          - `Optional <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153>`_ (`AnyContractKey <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anycontractkey-68193>`_, \[`Party <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_\])
          -
 
-  .. _constr-daml-script-internal-questions-submit-error-dummyupgradeerror-28037:
+  .. _constr-daml-script-internal-questions-submit-error-translationfailed-4701:
 
-  `DummyUpgradeError <constr-daml-script-internal-questions-submit-error-dummyupgradeerror-28037_>`_
+  `TranslationFailed <constr-daml-script-internal-questions-submit-error-translationfailed-4701_>`_
 
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+
+       * - Field
+         - Type
+         - Description
+       * - mCoid
+         - `Optional <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153>`_ `AnyContractId <type-daml-script-internal-questions-util-anycontractid-11399_>`_
+         -
+       * - srcTemplateId
+         - `TemplateTypeRep <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
+         -
+       * - dstTemplateId
+         - `TemplateTypeRep <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
+         -
+       * - createArg
+         - `AnyTemplate <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anytemplate-63703>`_
+         -
+
+  .. _constr-daml-script-internal-questions-submit-error-authenticationfailed-3671:
+
+  `AuthenticationFailed <constr-daml-script-internal-questions-submit-error-authenticationfailed-3671_>`_
+
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+
+       * - Field
+         - Type
+         - Description
+       * - coid
+         - `AnyContractId <type-daml-script-internal-questions-util-anycontractid-11399_>`_
+         -
+       * - srcTemplateId
+         - `TemplateTypeRep <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
+         -
+       * - dstTemplateId
+         - `TemplateTypeRep <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-templatetyperep-33792>`_
+         -
+       * - createArg
+         - `AnyTemplate <https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/Prelude.html#type-da-internal-any-anytemplate-63703>`_
+         -
 
 .. _type-daml-script-internal-questions-transactiontree-created-98301:
 


### PR DESCRIPTION
Part of https://github.com/digital-asset/daml/issues/21667

This PR promotes upgrade error messages from dev errors to full-fledged errors understood and reported by Canton.

Upgrade errors are classified into 3 categories:
- ValidationFailed: already exists in 3.3, returned when the metadata of a contract changed
- TranslationFailed: raised for any error that can happen during the type-checking/translation of a contract: failed to look up some identifier, type mismatch, value too deeply nested, non-suffixed contract id encountered, unexpected label in record value, unordered GenMap. 
- AuthenticationFailed: the computed hash doesn't match the contract ID

I also introduce a new toplevel error: ContractHashingError. I put it at toplevel for consistency with DisclosedContractKeyHashingError and also because I suspect it might occur outside of upgrades in the future. For this error to be raised, something needs to go really wrong: like a user providing a disclosure whose key contains a contract ID. I could probably have been a crash but I have a hard time convincing myself that it won't happen in some scenarios so I made it an error.