### PR TITLE
Try and fix flaky behavior in tests calling 'canton sandbox'

### DIFF
--- a/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTestUtils.hs
+++ b/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTestUtils.hs
@@ -70,10 +70,11 @@ data SandboxPorts = SandboxPorts
   , sequencerPublic :: PortNumber
   , sequencerAdmin :: PortNumber
   , mediatorAdmin :: PortNumber
+  , jsonApi :: PortNumber
   }
 
 sandboxPorts :: IO SandboxPorts
-sandboxPorts = SandboxPorts <$> getFreePort <*> getFreePort <*> getFreePort <*> getFreePort <*> getFreePort
+sandboxPorts = SandboxPorts <$> getFreePort <*> getFreePort <*> getFreePort <*> getFreePort <*> getFreePort <*> getFreePort
 
 throwError :: MonadFail m => T.Text -> T.Text -> m ()
 throwError msg e = fail (T.unpack $ msg <> " " <> e)

--- a/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -627,6 +627,7 @@ cantonTests = testGroup "daml sandbox"
         sequencerPublicApiPort <- getFreePort
         sequencerAdminApiPort <- getFreePort
         mediatorAdminApiPort <- getFreePort
+        jsonApiPort <- getFreePort
         step "Staring Canton sandbox"
         let portFile = dir </> "canton-portfile.json"
         withDamlServiceIn (dir </> "skeleton") "sandbox"
@@ -635,6 +636,7 @@ cantonTests = testGroup "daml sandbox"
             , "--sequencer-public-port", show sequencerPublicApiPort
             , "--sequencer-admin-port", show sequencerAdminApiPort
             , "--mediator-admin-port", show mediatorAdminApiPort
+            , "--json-api-port", show jsonApiPort
             , "--canton-port-file", portFile
             ] $ \ ph -> do
             -- wait for port file to be written

--- a/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/QuickstartTests.hs
+++ b/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/QuickstartTests.hs
@@ -82,6 +82,7 @@ quickSandbox projDir = do
                         , "--sequencer-public-port", show $ sequencerPublic ports
                         , "--sequencer-admin-port", show $ sequencerAdmin ports
                         , "--mediator-admin-port", show $ mediatorAdmin ports
+                        , "--json-api-port", show $ jsonApi ports
                         , "--port-file", portFile
                         , "--dar", darFile
                         , "--static-time"


### PR DESCRIPTION
Canton now starts the JSON API by default, so if we don't pick a free port for it, it might create collisions between tests.