### PR TITLE
fix some space leaks in interning

### DIFF
--- a/sdk/compiler/daml-lf-proto-encode/src/DA/Daml/LF/Proto3/EncodeV2.hs
+++ b/sdk/compiler/daml-lf-proto-encode/src/DA/Daml/LF/Proto3/EncodeV2.hs
@@ -56,9 +56,9 @@ data EncodeState = EncodeState
     , internedDottedNames :: !(HMS.HashMap [Int32] Int32)
     , nextInternedDottedNameId :: !Int32
       -- ^ We track the size of `internedDottedNames` explicitly since `HMS.size` is `O(n)`.
-    , internedKindsMap :: InternedKindsMap
-    , internedTypesMap :: InternedTypesMap
-    , internedExprsMap :: InternedExprsMap
+    , internedKindsMap :: !InternedKindsMap
+    , internedTypesMap :: !InternedTypesMap
+    , internedExprsMap :: !InternedExprsMap
     }
 
 makeLensesFor [ ("internedKindsMap", "internedKindsMapLens")

--- a/sdk/compiler/daml-lf-proto-encode/src/DA/Daml/LF/Proto3/InternedArr.hs
+++ b/sdk/compiler/daml-lf-proto-encode/src/DA/Daml/LF/Proto3/InternedArr.hs
@@ -41,7 +41,7 @@ toVec (InternedArr xs _) = V.fromList $ reverse xs
 internState :: val -> State (InternedArr val) Int32
 internState x = do
   (InternedArr xs n) <- get
-  put $ InternedArr (x : xs) (n + 1)
+  put $! InternedArr (x : xs) (n + 1)
   return n
 
 instance G.Interned InternedArr where

--- a/sdk/compiler/daml-lf-proto-encode/src/DA/Daml/LF/Proto3/InternedMap.hs
+++ b/sdk/compiler/daml-lf-proto-encode/src/DA/Daml/LF/Proto3/InternedMap.hs
@@ -54,7 +54,7 @@ internState x = do
     Nothing -> if n == maxBound
       then error "Interning table grew too large"
       else do
-        put $ InternedMap (Map.insert x n mp) (n + 1)
+        put $! InternedMap (Map.insert x n mp) (n + 1)
         return n
 
 instance G.Interned InternedMap where


### PR DESCRIPTION
In a branch that makes 2.2 the default version, the `memory-bond-trading` test fails with a heap overflow, even with a huge heap. With this fix applied and with a larger stack (700k) and slightly large heap, it terminates.