### PR TITLE
Add new test cases for the preprocessing of records

### DIFF
--- a/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslatorSpec.scala
+++ b/sdk/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslatorSpec.scala
@@ -391,6 +391,196 @@ class ValueTranslatorSpec(languageVersion: LanguageVersion)
           ),
         ),
         upgradeCaseSuccess(
+          true,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              None -> ValueInt64(1),
+              "extraField" -> ValueOptional(Some(ValueText("a"))),
+              "anotherExtraField" -> ValueOptional(Some(ValueText("b"))),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          true,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              None -> ValueInt64(1),
+              "extraField" -> ValueOptional(Some(ValueText("a"))),
+              "anotherExtraField" -> ValueOptional(Some(ValueText("b"))),
+              "bonusField" -> ValueOptional(None),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          true,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              None -> ValueInt64(1),
+              "extraField" -> ValueOptional(Some(ValueText("a"))),
+              "anotherExtraField" -> ValueOptional(Some(ValueText("b"))),
+              None -> ValueOptional(None),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          true,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              "field" -> ValueInt64(1),
+              None -> ValueOptional(Some(ValueText("a"))),
+              "anotherExtraField" -> ValueOptional(Some(ValueText("b"))),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          true,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              "field" -> ValueInt64(1),
+              None -> ValueOptional(Some(ValueText("a"))),
+              "anotherExtraField" -> ValueOptional(Some(ValueText("b"))),
+              "bonusField" -> ValueOptional(None),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          true,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              "field" -> ValueInt64(1),
+              None -> ValueOptional(Some(ValueText("a"))),
+              "anotherExtraField" -> ValueOptional(Some(ValueText("b"))),
+              None -> ValueOptional(None),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          true,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              "field" -> ValueInt64(1),
+              "extraField" -> ValueOptional(Some(ValueText("a"))),
+              None -> ValueOptional(Some(ValueText("b"))),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          true,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              "field" -> ValueInt64(1),
+              "extraField" -> ValueOptional(Some(ValueText("a"))),
+              None -> ValueOptional(Some(ValueText("b"))),
+              "bonusField" -> ValueOptional(None),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          true,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              "field" -> ValueInt64(1),
+              "extraField" -> ValueOptional(Some(ValueText("a"))),
+              None -> ValueOptional(Some(ValueText("b"))),
+              None -> ValueOptional(None),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          true,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              None -> ValueInt64(1),
+              "extraField" -> ValueOptional(Some(ValueText("a"))),
+              None -> ValueOptional(Some(ValueText("b"))),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          true,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              None -> ValueInt64(1),
+              "extraField" -> ValueOptional(Some(ValueText("a"))),
+              None -> ValueOptional(Some(ValueText("b"))),
+              "bonusField" -> ValueOptional(None),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          true,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              None -> ValueInt64(1),
+              "extraField" -> ValueOptional(Some(ValueText("a"))),
+              None -> ValueOptional(Some(ValueText("b"))),
+              None -> ValueOptional(None),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          true,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              None -> ValueInt64(1),
+              None -> ValueOptional(Some(ValueText("a"))),
+              None -> ValueOptional(Some(ValueText("b"))),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          true,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              None -> ValueInt64(1),
+              None -> ValueOptional(Some(ValueText("a"))),
+              None -> ValueOptional(Some(ValueText("b"))),
+              "bonusField" -> ValueOptional(None),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          true,
+          true,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              None -> ValueInt64(1),
+              None -> ValueOptional(Some(ValueText("a"))),
+              None -> ValueOptional(Some(ValueText("b"))),
+              None -> ValueOptional(None),
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
           false,
           true,
           ValueRecord(
@@ -432,6 +622,27 @@ class ValueTranslatorSpec(languageVersion: LanguageVersion)
             "Mod:Upgradeable",
             ImmArray(
               "field" -> ValueInt64(1)
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          false,
+          false,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              None -> ValueInt64(1)
+            ),
+          ),
+        ),
+        upgradeCaseSuccess(
+          true,
+          false,
+          ValueRecord(
+            "Mod:Upgradeable",
+            ImmArray(
+              None -> ValueInt64(1),
+              None -> ValueOptional(Some(ValueText("a"))),
             ),
           ),
         ),


### PR DESCRIPTION
Fixes https://github.com/digital-asset/daml/issues/21829.

Turns out https://github.com/digital-asset/daml/issues/21829 didn't need fixing: we're already lenient that way. I just added more test cases to demonstrate that is the case.