### PR TITLE
some 3.4 sandbox and canton docs

### DIFF
--- a/sdk/docs/manually-written/sdk/component-howtos/application-development/dpm-sandbox.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/application-development/dpm-sandbox.rst
@@ -12,7 +12,7 @@ Use the sandbox when you need access to a Canton ledger running your Daml code a
 Install
 -------
 
-Install the Sandbox by :ref:`installing dpm <dpm-install>`.
+Install the Sandbox by :externalref:`installing dpm <dpm-install>`.
 
 Configure
 ---------

--- a/sdk/docs/sharable/sdk/component-howtos/application-development/dpm-sandbox.rst
+++ b/sdk/docs/sharable/sdk/component-howtos/application-development/dpm-sandbox.rst
@@ -12,7 +12,7 @@ Use the sandbox when you need access to a Canton ledger running your Daml code a
 Install
 -------
 
-Install the Sandbox by :ref:`installing dpm <dpm-install>`.
+Install the Sandbox by :externalref:`installing dpm <dpm-install>`.
 
 Configure
 ---------


### PR DESCRIPTION
- some declarative api docs
- canton dev protocol config docs
- replacing `daml` with `dpm`

I still have to replace `daml start` with the appropriate 3.4 equivalent