### PR TITLE
Implement upgrade-check dpm component

### DIFF
--- a/ci/copy-unix-release-artifacts.sh
+++ b/ci/copy-unix-release-artifacts.sh
@@ -59,6 +59,7 @@ copy_oci daml-script bazel-bin/daml-script/runner/daml-script-oci.tar.gz
 copy_oci codegen-js bazel-bin/language-support/ts/codegen/codegen-js-oci.tar.gz
 copy_oci codegen-java bazel-bin/language-support/codegen-main/codegen-java-oci.tar.gz
 copy_oci daml-new bazel-bin/daml-assistant/daml-helper/daml-new-oci.tar.gz
+copy_oci upgrade-check bazel-bin/daml-lf/validation/upgrade-check-oci.tar.gz
 
 # Platform independent artifacts are only built on Linux.
 if [[ "${NAME}" == "linux-intel" ]]; then

--- a/ci/copy-windows-release-artifacts.sh
+++ b/ci/copy-windows-release-artifacts.sh
@@ -53,3 +53,4 @@ copy_oci daml-script bazel-bin/daml-script/runner/daml-script-oci.tar.gz
 copy_oci codegen-js bazel-bin/language-support/ts/codegen/codegen-js-oci.tar.gz
 copy_oci codegen-java bazel-bin/language-support/codegen-main/codegen-java-oci.tar.gz
 copy_oci daml-new bazel-bin/daml-assistant/daml-helper/daml-new-oci.tar.gz
+copy_oci upgrade-check bazel-bin/daml-lf/validation/upgrade-check-oci.tar.gz

--- a/ci/publish-oci.sh
+++ b/ci/publish-oci.sh
@@ -38,7 +38,7 @@ DPM_REGISTRY=$3
 # DPM_REGISTRY="europe-docker.pkg.dev/da-images-dev/oci-playground"
 
 # Should match the tars copied into /release/oci during copy-{OS}-release-artifacts.sh
-declare -a components=(damlc daml-script codegen-js codegen-java daml-new)
+declare -a components=(damlc daml-script codegen-js codegen-java daml-new upgrade-check)
 
 if [[ x"$DEBUG" != x ]]; then
   unarchive="tar -x -v -z -f"

--- a/sdk/daml-lf/validation/BUILD.bazel
+++ b/sdk/daml-lf/validation/BUILD.bazel
@@ -13,6 +13,7 @@ load(
     "lf_scalacopts",
     "lf_scalacopts_stricter",
 )
+load("//bazel_tools/packaging:packaging.bzl", "package_oci_component")
 
 da_scala_library(
     name = "validation",
@@ -43,6 +44,10 @@ da_scala_library(
     name = "upgrade-check-main",
     srcs = glob(["src/main/**/validation/UpgradeCheckMain.scala"]),
     scala_deps = [
+        "@maven//:com_github_scopt_scopt",
+        "@maven//:io_circe_circe_core",
+        "@maven//:io_circe_circe_yaml_common",
+        "@maven//:io_circe_circe_yaml",
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_typelevel_cats_core",
         "@maven//:org_typelevel_cats_kernel",
@@ -69,6 +74,28 @@ da_scala_library(
         "@maven//:com_typesafe_scala_logging_scala_logging_2_13",
         "@maven//:org_slf4j_slf4j_api",
     ],
+)
+
+da_scala_binary(
+    name = "upgrade-check-dpm-main",
+    main_class = "com.digitalasset.daml.lf.validation.UpgradeCheckDpmMain",
+    resources = glob(["src/main/resources/**/*"]),
+    scalacopts = lf_scalacopts_stricter,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":upgrade-check-main",
+    ],
+)
+
+package_oci_component(
+    name = "upgrade-check-oci",
+    component_manifest = ":component.yaml",
+    platform_agnostic = True,
+    resources = [
+        ":upgrade-check-dpm-main_distribute.jar",
+    ],
+    tags = ["no-cache"],
+    visibility = ["//visibility:public"],
 )
 
 da_scala_library(

--- a/sdk/daml-lf/validation/component.yaml
+++ b/sdk/daml-lf/validation/component.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: digitalasset.com/v1
+kind: Component
+spec:
+  jar-commands:
+    - path: upgrade-check-dpm-main_distribute.jar
+      name: upgrade-check
+      desc: Run upgrade checks on DAR(s)

--- a/sdk/dev-env/bin/dpm-sdk-head
+++ b/sdk/dev-env/bin/dpm-sdk-head
@@ -39,6 +39,9 @@ for opt in "$@"; do
     --daml-new)
       TO_BUILD+=(daml-new)
       ;;
+    --upgrade-check)
+      TO_BUILD+=(upgrade-check)
+      ;;
     --dpm)
       TO_BUILD+=(dpm)
       ;;
@@ -78,6 +81,7 @@ for opt in "$@"; do
       echo "  --codegen-js Build and update the codegen-js component"
       echo "  --codegen-java Build and update the codegen-java component"
       echo "  --daml-new Build and update the daml-new component"
+      echo "  --upgrade-check Build and update the upgrade-check component"
       echo "  --dpm Fetch and update the dpm component"
       echo "  --version=<version> Set the component and release version to be built, default 0.0.0"
       echo "  --component-version=<version> Set the component version (internal to dpm) to be built, default 0.0.0"
@@ -190,7 +194,7 @@ if [ ! -f "$assembly_location" ]; then
   echo "$(tput setaf 3)Created assembly for $RELEASE_VERSION from ${latest_version}.$(tput sgr 0)"
 fi
 
-all_components=(damlc daml-script codegen-js codegen-java daml-new)
+all_components=(damlc daml-script codegen-js codegen-java daml-new upgrade-check)
 
 # If no explicit components specified, update all
 if [[ ! ${TO_BUILD[@]} ]]; then


### PR DESCRIPTION
Implements a component containing the participant upgrade checks, and the wrapper CLI for calling the compiler upgrade checks
(which requires finding damlc via the resolution file)
UX should be identical to daml