### PR TITLE
Add LF 2.2 dars for daml-script to DPM component

### DIFF
--- a/sdk/daml-script/runner/BUILD.bazel
+++ b/sdk/daml-script/runner/BUILD.bazel
@@ -14,6 +14,7 @@ load("//rules_daml:daml.bzl", "daml_compile")
 load("//bazel_tools:proto.bzl", "proto_gen")
 load("@os_info//:os_info.bzl", "is_windows")
 load("//bazel_tools/packaging:packaging.bzl", "package_oci_component")
+load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS")
 
 # Should match RunnerMainTestBase.DAR_COUNT
 test_dar_count = 5
@@ -191,8 +192,9 @@ package_oci_component(
     resources = [
         ":daml-script-binary_distribute.jar",
         "//compiler/script-service/server:script-service.jar",
-        "//daml-script/daml:daml-script-2.1.dar",
-        "//daml-script/daml:daml-script-2.dev.dar",
+    ] + [
+        "//daml-script/daml:daml-script-{}.dar".format(lf_version)
+        for lf_version in COMPILER_LF_VERSIONS
     ],
     tags = ["no-cache"],
     visibility = ["//visibility:public"],

--- a/sdk/daml-script/runner/component.yaml
+++ b/sdk/daml-script/runner/component.yaml
@@ -13,6 +13,7 @@ spec:
       conflict-strategy: extend
       paths:
         - ./daml-script-2.1.dar
+        - ./daml-script-2.2.dar
         - ./daml-script-2.dev.dar
     script-service:
       conflict-strategy: fail


### PR DESCRIPTION
Noticed that since changing our default LF to 2.2, dpm build fails as the 2.2 daml-script dar isn't included in the component.
Updated it here, it would be nice if we could pass glob patterns to dpm to avoid this @dasormeter 