### PR TITLE
[backport] Implement hash-based authentication in the IDE ledger 

### DIFF
--- a/sdk/daml-lf/ide-ledger/src/main/scala/com/digitalasset/daml/lf/script/IdeLedgerRunner.scala
+++ b/sdk/daml-lf/ide-ledger/src/main/scala/com/digitalasset/daml/lf/script/IdeLedgerRunner.scala
@@ -4,33 +4,19 @@
 package com.digitalasset.daml.lf
 package script
 
-import com.digitalasset.daml.lf.data.Ref._
-import com.digitalasset.daml.lf.data.{Bytes, ImmArray, Ref, Time}
-import com.digitalasset.daml.lf.engine.{
-  Engine,
-  Result,
-  ResultDone,
-  ResultError,
-  Enricher => LfEnricher,
-}
-import com.digitalasset.daml.lf.engine.preprocessing.ValueTranslator
-import com.digitalasset.daml.lf.language.{Ast, LanguageMajorVersion, LookupError}
-import com.digitalasset.daml.lf.transaction.{
-  CommittedTransaction,
-  FatContractInstance,
-  GlobalKey,
-  NodeId,
-  VersionedTransaction,
-}
-import com.digitalasset.daml.lf.value.Value.ContractId
-import com.digitalasset.daml.lf.speedy._
-import com.digitalasset.daml.lf.speedy.SExpr.{SEApp, SExpr}
-import com.digitalasset.daml.lf.speedy.SResult._
-import com.digitalasset.daml.lf.transaction.IncompleteTransaction
-import com.digitalasset.daml.lf.value.Value
 import com.daml.logging.LoggingContext
 import com.daml.scalautil.Statement.discard
-import com.digitalasset.daml.lf.crypto.Hash
+import com.digitalasset.daml.lf.crypto.{Hash, SValueHash}
+import com.digitalasset.daml.lf.data.Ref._
+import com.digitalasset.daml.lf.data.{ImmArray, Ref, Time}
+import com.digitalasset.daml.lf.engine.{Engine, Result, ResultDone, Enricher => LfEnricher}
+import com.digitalasset.daml.lf.language.{Ast, LanguageMajorVersion, LookupError}
+import com.digitalasset.daml.lf.speedy.SExpr.{SEApp, SExpr}
+import com.digitalasset.daml.lf.speedy.SResult._
+import com.digitalasset.daml.lf.speedy._
+import com.digitalasset.daml.lf.transaction.Transaction.ChildrenRecursion
+import com.digitalasset.daml.lf.transaction._
+import com.digitalasset.daml.lf.value.Value.ContractId
 
 import scala.annotation.tailrec
 import scala.collection.immutable.ArraySeq
@@ -62,7 +48,6 @@ private[lf] object IdeLedgerRunner {
 
   final case class Commit[+R](
       result: R,
-      value: SValue,
       tx: IncompleteTransaction,
   ) extends SubmissionResult[R]
 
@@ -250,16 +235,6 @@ private[lf] object IdeLedgerRunner {
 
   private[this] class EnricherImpl(compiledPackages: CompiledPackages) extends Enricher {
     val config = Engine.DevEngine(LanguageMajorVersion.V2).config
-    val valueTranslator =
-      new ValueTranslator(
-        pkgInterface = compiledPackages.pkgInterface,
-        forbidLocalContractIds = config.forbidLocalContractIds,
-      )
-    def translateValue(typ: Ast.Type, value: Value): Result[SValue] =
-      valueTranslator.translateValue(typ, value) match {
-        case Left(err) => ResultError(err)
-        case Right(sv) => ResultDone(sv)
-      }
     def loadPackage(pkgId: PackageId, context: language.Reference): Result[Unit] = {
       crash(LookupError.MissingPackage.pretty(pkgId, context))
     }
@@ -288,6 +263,55 @@ private[lf] object IdeLedgerRunner {
       consume(strictEnricher.enrichVersionedTransaction(tx))
     override def enrich(tx: IncompleteTransaction): IncompleteTransaction =
       consume(lenientEnricher.enrichIncompleteTransaction(tx))
+  }
+
+  /** A class for suffixing all the local contract IDs of a transaction with the TypedNormalForm hash of their Create
+    * argument. Assumes that the creation package of these contract and its transitive dependencies are all present in
+    * [compiledPackages].
+    */
+  private[this] class CidSuffixer(compiledPackages: CompiledPackages) {
+    private[this] val valueTranslator = new speedy.ValueTranslator(
+      compiledPackages.pkgInterface,
+      forbidLocalContractIds = false,
+      forbidTrailingNones = false,
+    )
+
+    private[this] def hashCreateNode(createNode: Node.Create): crypto.Hash = {
+      val sValue = valueTranslator
+        .translateValue(Ast.TTyCon(createNode.templateId), createNode.arg)
+        .fold(
+          e => crash(s"unexpected error when enriching a Create node produced by the engine: $e"),
+          identity,
+        )
+      SValueHash
+        .hashContractInstance(createNode.packageName, createNode.templateId.qualifiedName, sValue)
+        .fold(
+          e => crash(s"unexpected error when hashing a Create node produced by the engine: $e"),
+          identity,
+        )
+    }
+
+    def suffixCids(tx: VersionedTransaction): VersionedTransaction = {
+      val cidMapping = tx
+        .foldInExecutionOrder(Map.empty[ContractId, ContractId].withDefault(identity))(
+          exerciseBegin = (mapping, _, _) => (mapping, ChildrenRecursion.DoRecurse),
+          rollbackBegin = (mapping, _, _) => (mapping, ChildrenRecursion.DoRecurse),
+          leaf = (mapping, _, leaf) => {
+            leaf match {
+              case create: Node.Create =>
+                val suffix = hashCreateNode(create.mapCid(mapping)).bytes
+                mapping + (create.coid -> data.assertRight(
+                  create.coid.suffixCid(_ => suffix, _ => suffix)
+                ))
+              case _ =>
+                mapping
+            }
+          },
+          exerciseEnd = (mapping, _, _) => mapping,
+          rollbackEnd = (mapping, _, _) => mapping,
+        )
+      tx.mapCid(cidMapping)
+    }
   }
 
   def submit[R](
@@ -328,6 +352,7 @@ private[lf] object IdeLedgerRunner {
     // https://github.com/digital-asset/daml/issues/14108
     val enricher = if (doEnrichment) new EnricherImpl(compiledPackages) else NoEnricher
     import enricher._
+    val suffixer = new CidSuffixer(compiledPackages)
 
     def continue = () => go()
 
@@ -342,7 +367,11 @@ private[lf] object IdeLedgerRunner {
                   callback(
                     fcoinst.nonVerboseWithoutTrailingNones,
                     Hash.HashingMethod.TypedNormalForm,
-                    _ => true, // The IDE ledger doesn't authenticate disclosed contracts
+                    h =>
+                      fcoinst.contractId match {
+                        case ContractId.V1(_, suffix) => h.bytes == suffix
+                        case ContractId.V2(_, suffix) => h.bytes == suffix
+                      },
                   )
                   go()
                 case None =>
@@ -354,7 +383,11 @@ private[lf] object IdeLedgerRunner {
                       callback(
                         fcoinst.nonVerboseWithoutTrailingNones,
                         Hash.HashingMethod.TypedNormalForm,
-                        _ => true, // The IDE ledger doesn't authenticate input contracts
+                        h =>
+                          fcoinst.contractId match {
+                            case ContractId.V1(_, suffix) => h.bytes == suffix
+                            case ContractId.V2(_, suffix) => h.bytes == suffix
+                          },
                       ),
                   ) match {
                     case Left(err) =>
@@ -387,18 +420,15 @@ private[lf] object IdeLedgerRunner {
           }
         case SResultInterruption =>
           Interruption(continue)
-        case SResult.SResultFinal(resultValue) =>
+        case SResult.SResultFinal(_) =>
           ledgerMachine.finish match {
             case Right(Speedy.UpdateMachine.Result(tx, locationInfo, _, _)) =>
-              val suffix = Bytes.fromByteArray(Array(0, 0))
-              val committedTx = CommittedTransaction(
-                enrich(data.assertRight(tx.suffixCid(_ => suffix, _ => suffix)))
-              )
+              val committedTx = CommittedTransaction(enrich(suffixer.suffixCids(tx)))
               ledger.commit(committers, readAs, location, committedTx, locationInfo) match {
                 case Left(err) =>
                   SubmissionError(err, enrich(ledgerMachine.incompleteTransaction))
                 case Right(r) =>
-                  Commit(r, resultValue, enrich(ledgerMachine.incompleteTransaction))
+                  Commit(r, enrich(ledgerMachine.incompleteTransaction))
               }
             case Left(err) =>
               throw err

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -634,7 +634,7 @@ class IdeLedgerClient(
           case IdeLedgerRunner.Interruption(continue) =>
             loop(continue())
           case err: IdeLedgerRunner.SubmissionError => Left(err)
-          case commit @ IdeLedgerRunner.Commit(result, _, _) =>
+          case commit @ IdeLedgerRunner.Commit(result, _) =>
             val referencedParties: Set[Party] =
               result.richTransaction.blindingInfo.disclosure.values
                 .fold(Set.empty[Party])(_ union _)
@@ -745,7 +745,7 @@ class IdeLedgerClient(
         commands,
         optLocation,
       ) match {
-        case Right(IdeLedgerRunner.Commit(result, _, tx)) =>
+        case Right(IdeLedgerRunner.Commit(result, tx)) =>
           val commandResultPackageIds = commands.flatMap(toCommandPackageIds(_))
           _ledger = result.newLedger
           val transaction = result.richTransaction.transaction

--- a/sdk/daml-script/test/daml/upgrades/stable/AuthenticationErrors.daml
+++ b/sdk/daml-script/test/daml/upgrades/stable/AuthenticationErrors.daml
@@ -133,6 +133,25 @@ contents: |
 
       interface instance Iface.AuthenticationErrorsIface for EnumRankChangeTemplate where
         view = Iface.MyUnit
+
+  ---- Templates for testing contracts with contract IDs in their payload ----
+
+  template DummyTemplate
+    with
+      sig: Party
+    where
+      signatory sig
+
+  template ContractIdPayloadTemplate
+    with
+      sig: Party
+      cidField: ContractId DummyTemplate
+    where
+      signatory sig
+
+      choice ContractIdPayloadChoice : ()
+        controller sig
+        do pure ()
 -}
 
 {- PACKAGE
@@ -318,6 +337,12 @@ contents: |
           let cid2 = coerceContractId @V1.TemplateRenamingTemplate1 @V1.TemplateRenamingTemplate2 cid1
           _ <- exercise cid2 V1.TemplateRenamingChoice2
           pure ()
+
+      choice MkContractIdPayloadTemplate: ContractId V1.ContractIdPayloadTemplate
+        controller sig
+        do
+          dummyCid <- create V1.DummyTemplate { sig = sig }
+          create V1.ContractIdPayloadTemplate { sig = sig, cidField = dummyCid }
 -}
 
 main : TestTree
@@ -325,49 +350,49 @@ main = tests
   -- TODO(https://github.com/digital-asset/daml/issues/21667): enable the broken tests once canton uses contract ID v12
   [ subtree "should reject field renaming"
     [ subtree "in fetches"
-      [ brokenOnIDELedger ("from choice body" , fieldRenamingFetchChoiceBody)
+      [ ("from choice body" , fieldRenamingFetchChoiceBody)
       , ("of local contract", fieldRenamingFetchLocal)
       ]
     , subtree "in exercises"
-      [ brokenOnIDELedger ("in command", fieldRenamingExerciseCommand)
-      , brokenOnIDELedger ("from choice body", fieldRenamingExerciseChoiceBody)
+      [ ("in command", fieldRenamingExerciseCommand)
+      , ("from choice body", fieldRenamingExerciseChoiceBody)
       , ("of local contract", fieldRenamingExerciseLocal)
       ]
     , subtree "in interface exercises"
-      [ brokenOnIDELedger ("in command", fieldRenamingExerciseInterfaceCommand)
-      , brokenOnIDELedger ("from choice body", fieldRenamingExerciseInterfaceChoiceBody)
+      [ ("in command", fieldRenamingExerciseInterfaceCommand)
+      , ("from choice body", fieldRenamingExerciseInterfaceChoiceBody)
       , ("of local contract", fieldRenamingExerciseInterfaceLocal)
       ]
     ]
   , subtree "should reject variant rank change"
     [ subtree "in fetches"
-      [ brokenOnIDELedger ("from choice body", variantRankChangeFetchChoiceBody)
+      [ ("from choice body", variantRankChangeFetchChoiceBody)
       , ("of local contract", variantRankChangeFetchLocal)
       ]
     , subtree "in exercises"
-      [ brokenOnIDELedger ("in command", variantRankChangeExerciseCommand)
-      , brokenOnIDELedger ("from choice body", variantRankChangeExerciseChoiceBody)
+      [ ("in command", variantRankChangeExerciseCommand)
+      , ("from choice body", variantRankChangeExerciseChoiceBody)
       , ("of local contract", variantRankChangeExerciseLocal)
       ]
     , subtree "in interface exercises"
-      [ brokenOnIDELedger ("in command", variantRankChangeExerciseInterfaceCommand)
-      , brokenOnIDELedger ("from choice body", variantRankChangeExerciseInterfaceChoiceBody)
+      [ ("in command", variantRankChangeExerciseInterfaceCommand)
+      , ("from choice body", variantRankChangeExerciseInterfaceChoiceBody)
       , ("of local contract", variantRankChangeExerciseInterfaceLocal)
       ]
     ]
   , subtree "should reject enum rank change"
     [ subtree "in fetches"
-      [ brokenOnIDELedger ("from choice body", enumRankChangeFetchChoiceBody)
+      [ ("from choice body", enumRankChangeFetchChoiceBody)
       , ("of local contract", enumRankChangeFetchLocal)
       ]
     , subtree "in exercises"
-      [ brokenOnIDELedger ("in command", enumRankChangeExerciseCommand)
-      , brokenOnIDELedger ("from choice body", enumRankChangeExerciseChoiceBody)
+      [ ("in command", enumRankChangeExerciseCommand)
+      , ("from choice body", enumRankChangeExerciseChoiceBody)
       , ("of local contract", enumRankChangeExerciseLocal)
       ]
     , subtree "in interface exercises"
-      [ brokenOnIDELedger ("in command", enumRankChangeExerciseInterfaceCommand)
-      , brokenOnIDELedger ("from choice body", enumRankChangeExerciseInterfaceChoiceBody)
+      [ ("in command", enumRankChangeExerciseInterfaceCommand)
+      , ("from choice body", enumRankChangeExerciseInterfaceChoiceBody)
       , ("of local contract", enumRankChangeExerciseInterfaceLocal)
       ]
     ]
@@ -381,6 +406,7 @@ main = tests
       , ("of local contract", templateRenamingExerciseLocal)
       ]
     ]
+  , ("should authenticate contracts with a local contract ID in their payload", templateWithContractIdPayload)
   ]
 
 --- Utils ---
@@ -632,3 +658,11 @@ templateRenamingExerciseLocal = test $ do
   (alice, clientCid) <- setUpChoiceBodyTest
   res <- alice `trySubmit` exerciseCmd clientCid (Client.ExerciseTemplateRenamingTemplate2Local)
   assertIsWronglyTypedContractError res
+
+templateWithContractIdPayload = test $ do
+  (alice, clientCid) <- setUpChoiceBodyTest
+  cid <- alice `submit` exerciseCmd clientCid Client.MkContractIdPayloadTemplate
+  res <- alice `trySubmit` exerciseCmd cid V1.ContractIdPayloadChoice
+  case res of
+    Left e -> assertFail $ "Expected success, got " <> show e
+    Right _ -> pure ()

--- a/sdk/daml-script/test/daml/upgrades/stable/VariantChanges.daml
+++ b/sdk/daml-script/test/daml/upgrades/stable/VariantChanges.daml
@@ -46,7 +46,7 @@ main = tests
   , ("Downgrade fails if variant is a new constructor", downgradeFromNewCon)
   , ("Downgrade fails if variant has optional fields added as Some", downgradeFromSomeNewOptField)
   , ("Downgrade fails if variant has optional nested fields added as Some", downgradeFromSomeNewOptNestedField)
-  , brokenOnIDELedger ("Fails if upgrading a variant with a new case in the middle, from a case with changed rank", templateVariantUpgradeNonLastDifferentRank)
+  , ("Fails if upgrading a variant with a new case in the middle, from a case with changed rank", templateVariantUpgradeNonLastDifferentRank)
   , ("Fails if downgrading a variant from a new case in the middle", templateVariantDowngradeNonLastDifferentRank)
   ]
 


### PR DESCRIPTION
Backport of #22184. Pure cherry-pick, no changes.

In the IDE ledger, suffixes the contract IDs of local contracts with the TypedNormalForm hash of their create argument. In the `ResultNeedContract` callback for authenticating contracts given their hash, compares the provided hash to the suffix of the contract ID.

The scenarios enabled by this change were already tested but these tests were marked as broken on the IDE ledger. They now pass.

Also removes the `value: SValue` field from `IdeLedgerRunner.Commit`: it is currently unused but if one were to use it, it would be wrong because the contract IDs this SValue contains are not suffixed.