### PR TITLE
Blackduck CI job: Fix the NOTICES file PR creation

### DIFF
--- a/ci/blackduck.yml
+++ b/ci/blackduck.yml
@@ -151,8 +151,6 @@ jobs:
       eval "$(./dev-env/bin/dade-assist)"
       source $(bash_lib)
       
-      git config --global url.https://${GITHUB_TOKEN}@github.com/.insteadOf https://github.com/
-      
       branch="notices-update-$(Build.BuildId)"
 
       tr -d '\015' < digital_asset_daml_$(Build.SourceBranchName)_Black_Duck_Notices_Report.txt | grep -v digital-asset_daml > NOTICES
@@ -160,14 +158,12 @@ jobs:
           echo "NOTICES file already up-to-date."
           setvar need_to_build false
       else
-          
           git add NOTICES
           open_pr "$branch" "update NOTICES file"  "" "" "$(Build.SourceBranchName)"
           setvar need_to_build true
       fi
     env:
       AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
-      GITHUB_TOKEN: $(GH_DAML_READWRITE)
     displayName: 'Open PR to update NOTICES file'
     name: out
     condition: and(succeeded(),


### PR DESCRIPTION
I have tried out this change by forcing the job to run on this PR (the commits doing that has since been reverted). One thing I had to do for it to work was to set the base branch to `main` explicitly because when running on PRs, `$(Build.SourceBranchName)` is not `main`. I believe that when this job run with the daily compat then it will be `main`.