### PR TITLE
[3.4][Backport] Use scalapb options from Canton

### DIFF
--- a/sdk/canton/BUILD.bazel
+++ b/sdk/canton/BUILD.bazel
@@ -1537,6 +1537,7 @@ java_library(
         "@maven//:com_google_api_grpc_proto_google_common_protos",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:com_thesamet_scalapb_compilerplugin_2_13",
         "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_core",
         "@maven//:io_grpc_grpc_netty_shaded",
@@ -1583,6 +1584,7 @@ da_java_library(
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:com_thesamet_scalapb_compilerplugin_2_13",
         "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_core",
         "@maven//:io_grpc_grpc_netty_shaded",
@@ -1682,10 +1684,13 @@ ledger_api_proto_source_root = "canton/community/ledger-api/src/main/protobuf"
 
 proto_jars(
     name = "ledger_api_proto",
-    srcs = glob(["community/ledger-api/src/main/protobuf/com/daml/ledger/api/v*/**/*.proto"]),
+    srcs = glob(["community/ledger-api/src/main/protobuf/com/daml/ledger/api/**/*.proto"]),
     grpc = True,
     java_conversions = True,
-    java_deps = ["@maven//:com_google_api_grpc_proto_google_common_protos"],
+    java_deps = [
+        "@maven//:com_google_api_grpc_proto_google_common_protos",
+        "@maven//:com_thesamet_scalapb_compilerplugin_2_13",
+    ],
     maven_artifact_prefix = "ledger-api",
     maven_artifact_scala_suffix = "scalapb",
     maven_group = "com.daml",
@@ -1703,5 +1708,6 @@ proto_jars(
         "@com_google_protobuf//:wrappers_proto",
         "@go_googleapis//google/rpc:error_details_proto",
         "@go_googleapis//google/rpc:status_proto",
+        "@scalapb//:scalapb_proto",
     ],
 )

--- a/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/sdk/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -478,7 +478,8 @@ damlStartTests getDamlStart =
                                 "identifierFilter" Aeson..= Aeson.object [
                                   "TemplateFilter" Aeson..= Aeson.object [
                                     "value" Aeson..= Aeson.object [
-                                      "templateId" Aeson..= (packageRef ++ ":Main:T")
+                                      "templateId" Aeson..= (packageRef ++ ":Main:T"),
+                                      "includeCreatedEventBlob" Aeson..= True
                                     ]
                                   ]
                                 ]

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
@@ -174,7 +174,7 @@ class GrpcLedgerClient(
         Seq(
           CumulativeFilter(
             IdentifierFilter.InterfaceFilter(
-              InterfaceFilter(Some(toApiIdentifier(interfaceId)), true)
+              InterfaceFilter(Some(toApiIdentifier(interfaceId)), true, false)
             )
           )
         )
@@ -377,6 +377,7 @@ class GrpcLedgerClient(
           templateId = Some(toApiIdentifier(tmplId)),
           contractId = cid.coid,
           createdEventBlob = blob.toByteString,
+          synchronizerId = "",
         )
       }
     for {
@@ -390,16 +391,15 @@ class GrpcLedgerClient(
         prefetchContractKeys.traverse(toPrefetchContractKey)
       )
 
-      apiCommands = Commands(
-        actAs = actAs.toList,
-        readAs = readAs.toList,
-        commands = ledgerCommands,
-        userId = userId.getOrElse(""),
-        commandId = UUID.randomUUID.toString,
-        disclosedContracts = ledgerDisclosures,
-        prefetchContractKeys = ledgerPrefetchContractKeys,
-        packageIdSelectionPreference = optPackagePreference.getOrElse(List.empty),
-      )
+      apiCommands = Commands.defaultInstance
+        .withActAs(actAs.toList)
+        .withReadAs(readAs.toList)
+        .withCommands(ledgerCommands)
+        .withUserId(userId.getOrElse(""))
+        .withCommandId(UUID.randomUUID.toString)
+        .withDisclosedContracts(ledgerDisclosures)
+        .withPrefetchContractKeys(ledgerPrefetchContractKeys)
+        .withPackageIdSelectionPreference(optPackagePreference.getOrElse(List.empty))
       eResp <- grpcClient.commandService
         .submitAndWaitForTransaction(apiCommands, TRANSACTION_SHAPE_LEDGER_EFFECTS)
 

--- a/sdk/hie.yaml
+++ b/sdk/hie.yaml
@@ -7,5 +7,7 @@ cradle:
       config: { cradle: { bios: { shell: "./.hie-bios //compiler/damlc:damlc@ghci@bios" } } }
     - path: "./compiler/damlc/tests"
       config: { cradle: { bios: { shell: "./.hie-bios //compiler/damlc/tests:tests@ghci@bios"}}}
+    - path: "./daml-assistant/integration-tests"
+      config: { cradle: { bios: { shell: "./.hie-bios //daml-assistant/integration-tests:integration-tests@ghci@bios"}}}
     - path: "./release/src"
       config: { cradle: { bios: { shell: "./.hie-bios //release:release@ghci@bios"}}}

--- a/sdk/release/test-protobuf-structure.sh
+++ b/sdk/release/test-protobuf-structure.sh
@@ -57,6 +57,7 @@ com/daml/ledger/api/v2/transaction_filter.proto
 com/daml/ledger/api/v2/value.proto
 com/daml/ledger/api/v2/event_query_service.proto
 com/daml/ledger/api/v2/reassignment_commands.proto
+com/daml/ledger/api/scalapb/package.proto
 com/daml/ledger/api/v2/admin/command_inspection_service.proto
 com/daml/ledger/api/v2/admin/participant_pruning_service.proto
 com/daml/ledger/api/v2/admin/identity_provider_config_service.proto


### PR DESCRIPTION
Backport of:

- https://github.com/digital-asset/daml/pull/22215 

[This PR](https://github.com/DACH-NY/canton/pull/28047) is failing because the scalapb generated on the canton repo does not provide defaults, whereas ours does, and the canton one takes priority on the class path.
This PR stops daml-script using these defaults. We should align our scalapb to canton, but this turned out to be more complex than expected.

- https://github.com/digital-asset/daml/pull/22217

The goal is to use the scalapb options from Canton to ensure we generate the same source files.