### PR TITLE
fix run_notices_pr_build

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -155,9 +155,13 @@ jobs:
     variables:
       need_to_build: $[ dependencies.blackduck_scan.outputs['out.need_to_build'] ]
     steps:
+      - template: ../bash-lib.yml
+        parameters:
+          var_name: bash_lib
       - bash: |
           cd sdk
           eval "$(./dev-env/bin/dade-assist)"
+          source "$(bash_lib)"
           if [ "$(need_to_build)" == "true" ]; then
               BRANCH="notices-update-$(Build.BuildId)"
               trigger_azure $AZURE_DEVOPS_EXT_PAT PRs --branch $BRANCH


### PR DESCRIPTION
This step is currently failing with `trigger_azure: command not found`.

I checked all the other calls to `trigger_azure` introduced by [this commit](https://github.com/digital-asset/daml/pull/22183/commits/7bb32e9f52f0e52ee73f2d83f7f936545eb24530) and this is the only one which is not sourcing `bash_lib` so I think we're good.