### PR TITLE
Remove dpm version env var from VSCode when running studio

### DIFF
--- a/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Studio.hs
+++ b/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Studio.hs
@@ -124,7 +124,7 @@ data ReplaceExtension
 runVsCodeCommand :: [String] -> [(String, String)] -> IO (ExitCode, String, String)
 runVsCodeCommand args extraEnv = do
     originalEnv <- getEnvironment
-    let envVarsToRemove = resolutionFileEnvVar : damlEnvVars
+    let envVarsToRemove = resolutionFileEnvVar : sdkVersionDpmEnvVar : damlEnvVars
         strippedEnv = filter ((`notElem` envVarsToRemove) . fst) originalEnv
             -- ^ Strip Daml environment variables before calling VSCode, to
             -- prevent setting DAML_SDK_VERSION too early. See issue #1666.

--- a/sdk/daml-assistant/daml-project-config/DA/Daml/Project/Consts.hs
+++ b/sdk/daml-assistant/daml-project-config/DA/Daml/Project/Consts.hs
@@ -7,6 +7,7 @@ module DA.Daml.Project.Consts
     , projectPathEnvVar
     , packagePathEnvVar
     , sdkPathEnvVar
+    , sdkVersionDpmEnvVar
     , sdkVersionEnvVar
     , sdkVersionLatestEnvVar
     , damlAssistantEnvVar


### PR DESCRIPTION
When running `dpm studio`, `dpm` would add the `DPM_SDK_VERSION` variable, which `studio` would then pass to VSCode
VSCode then keeps this variable in the console and extension environment, which stopped `dpm` from running with a different version.