### PR TITLE
[Backport #22239] Fix Daml Studio DocumentSymbols error

### DIFF
--- a/sdk/bazel-haskell-deps.bzl
+++ b/sdk/bazel-haskell-deps.bzl
@@ -18,8 +18,8 @@ load("@dadew//:dadew.bzl", "dadew_tool_home")
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 load("//bazel_tools/ghc-lib:repositories.bzl", "ghc_lib_and_dependencies")
 
-GHCIDE_REV = "1ec6a3457f8f3700376be6b6ee4fe6591fc129ee"
-GHCIDE_SHA256 = "6ed371ebf9597aab21675fc4c54dbc59bc4b7648ab7513482620c996b650ea29"
+GHCIDE_REV = "2914f9328dc549bd4918c3cf0fc008690a102d70"
+GHCIDE_SHA256 = "bc2bd2fbfbfb501e303b35fb4b2f503b122e4eb0aff34472f0e882d2289afc57"
 GHCIDE_LOCAL_PATH = None
 JS_JQUERY_VERSION = "3.3.1"
 JS_DGTABLE_VERSION = "0.5.2"


### PR DESCRIPTION
Backport of #22239

Relevant GHCIDE PR here:
https://github.com/digital-asset/daml-ghcide/pull/39

The GHCIDE Pr fixes the language server from giving back bad responses, however this doesn't fix the IDE for 3.3
This PR also includes a patch mechanism in the multi-ide to fix responses as they come from the language servers, to hopefully minimise the times this error is hit.

I tried to do this in the language client VSCode extension, but it doesn't allow us to manipulate the response before it sends it through VSCode's validation, which is what's throwing the error. (VSCode LanguageClient.middleware isn't strong enough)
We could avoid this by writing middleware that replicates the call to the language server, but thats quite messy.