### PR TITLE
Reformat string since da-ghci does not like the `\`'s

### DIFF
--- a/sdk/libs-haskell/da-hs-base/src/DA/Pretty.hs
+++ b/sdk/libs-haskell/da-hs-base/src/DA/Pretty.hs
@@ -328,7 +328,7 @@ highlightClass = "da-code"
 
 -- | Highlighting stylesheet for Visual Studio Code.
 highlightStylesheet :: T.Text
-highlightStylesheet = T.concat
+highlightStylesheet = T.unlines
   [ "." <> highlightClass <> " { "
   , "  font-family: monospace; line-height: 1.1em; white-space: pre; padding: 10px; "
   , "  position: absolute; width: 100%; height: 100%; "


### PR DESCRIPTION
`da-ghci` does not like the backslashes in DA.Pretty (we get some weird lexing error), so I replaced them with a unlines instead (concat would have been the direct replacement but @samuel-williams-da preferred the css to have newlines)
```
[23 of 42] Compiling DA.Pretty        ( libs-haskell/da-hs-base/src/DA/Pretty.hs, libs-haskell/da-hs-base/src/DA/Pretty.o ) [flags changed]

libs-haskell/da-hs-base/src/DA/Pretty.hs:331:25: error:
    lexical error in string/character literal at character '.'
    |
331 | highlightStylesheet = "\
    |                         ^
Failed, 22 modules loaded.
```