### PR TITLE
Fix CI on main

### DIFF
--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/UpgradesMatrixIT.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/UpgradesMatrixIT.scala
@@ -24,7 +24,6 @@ import com.digitalasset.daml.lf.engine.{
   UpgradesMatrixCasesV2MaxStable,
 }
 import com.digitalasset.daml.lf.language.{LanguageMajorVersion, LanguageVersion}
-import com.digitalasset.daml.lf.value.ContractIdVersion
 import com.digitalasset.daml.lf.value.Value._
 import com.google.protobuf.ByteString
 import io.grpc.{Status, StatusRuntimeException}


### PR DESCRIPTION
The CI is failing on main because of an unused import in a file that is compiled on main only. Fixing this.