### PR TITLE
build all tests in PRs, even main-only ones

### DIFF
--- a/sdk/build.sh
+++ b/sdk/build.sh
@@ -153,7 +153,7 @@ case $test_mode in
       echo "ignoring 'pr' test mode because the commit message features 'run-all-tests: true'"
     else
       echo "running fewer tests because test mode is 'pr'"
-      tag_filter="$tag_filter,-main-only"
+      tag_filter="${tag_filter}${tag_filter:+,}-main-only"
     fi
     ;;
   *)


### PR DESCRIPTION
Currently, tests marked as `main-only` are not even built by the CI against PR. This PR fixes this.