### PR TITLE
remove unused dep from generated dar in UpgradesMatrixIT

### DIFF
--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/UpgradesMatrixIT.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/UpgradesMatrixIT.scala
@@ -111,7 +111,6 @@ abstract class UpgradesMatrixIntegration(upgradesMatrixCases: UpgradesMatrixCase
     cases.clientGlobalDalfName,
     cases.clientGlobalDalf,
     List(
-      (cases.templateDefsV1DalfName, cases.templateDefsV1Dalf),
       (cases.templateDefsV2DalfName, cases.templateDefsV2Dalf),
       (cases.commonDefsDalfName, cases.commonDefsDalf),
       (primDATypesDalfName, primDATypesDalf),


### PR DESCRIPTION
`clientGlobalDar` was including an unused dep, which is now rejected by Canton, causing the test to fail.