### PR TITLE
Archive schema reader bug fixes

### DIFF
--- a/sdk/daml-lf/api-type-signature/src/main/scala/com/digitalasset/daml/lf/typesig/reader/DamlLfArchiveReader.scala
+++ b/sdk/daml-lf/api-type-signature/src/main/scala/com/digitalasset/daml/lf/typesig/reader/DamlLfArchiveReader.scala
@@ -16,7 +16,7 @@ object DamlLfArchiveReader {
     \/.fromEither(either).leftMap(err => s"Cannot parse archive: $err")
 
   def readPackage(lf: DamlLf.Archive): String \/ (Ref.PackageId, Ast.PackageSignature) =
-    fromEither(archive.Reader.readArchive(lf)) flatMap readPackage
+    fromEither(archive.Reader.readArchive(lf, schemaMode = true)) flatMap readPackage
 
   def readPackage(
       packageId: Ref.PackageId,

--- a/sdk/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Decode.scala
+++ b/sdk/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Decode.scala
@@ -73,7 +73,7 @@ object Decode {
       archive: DamlLf.Archive
   ): Either[Error, (PackageId, Ast.Package)] =
     Reader
-      .readArchive(archive, schemaMode = true)
+      .readArchive(archive, schemaMode = false)
       .flatMap(decodeArchivePayload)
 
   @throws[Error]
@@ -86,7 +86,7 @@ object Decode {
       archive: DamlLf.Archive
   ): Either[Error, (PackageId, Ast.PackageSignature)] =
     Reader
-      .readArchive(archive, schemaMode = false)
+      .readArchive(archive, schemaMode = true)
       .flatMap(decodeArchivePayloadSchema)
 
   @throws[Error]

--- a/sdk/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Reader.scala
+++ b/sdk/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Reader.scala
@@ -53,7 +53,7 @@ object Reader {
    */
   def readArchive(
       lf: DamlLf.Archive,
-      schemaMode: Boolean = false,
+      schemaMode: Boolean,
   ): Either[Error, ArchivePayload] = for {
     _ <- validateUnknownFields(lf, schemaMode)
     theirHash <- lf.getHashFunction match {

--- a/sdk/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/sdk/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -95,7 +95,7 @@ class DecodeV1Spec
       typeTable,
       None,
       Some(dummyModuleName),
-      onlySchema = false,
+      schemaMode = false,
     )
   }
 
@@ -907,7 +907,7 @@ class DecodeV1Spec
           IndexedSeq.empty,
           None,
           None,
-          onlySchema = false,
+          schemaMode = false,
         )
         val parseError =
           the[Error.Parsing] thrownBy (decoder

--- a/sdk/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV2Spec.scala
+++ b/sdk/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV2Spec.scala
@@ -110,7 +110,7 @@ class DecodeV2Spec
       exprTable,
       None,
       Some(dummyModuleName),
-      onlySchema = false,
+      schemaMode = false,
       None,
       Left("package made in com.digitalasset.daml.lf.archive.DecodeV2Spec"),
     )


### PR DESCRIPTION
- [x] consistent `schemaMode` parameter name
- [x] remove `Reader.readArchive` default `schemaMode` parameter
- [x] fix incorrect `schemaMode` usage