### PR TITLE
Backport of #22292 (Archive schema reader bug fixes)

### DIFF
--- a/sdk/daml-lf/api-type-signature/src/main/scala/com/digitalasset/daml/lf/typesig/reader/DamlLfArchiveReader.scala
+++ b/sdk/daml-lf/api-type-signature/src/main/scala/com/digitalasset/daml/lf/typesig/reader/DamlLfArchiveReader.scala
@@ -16,7 +16,7 @@ object DamlLfArchiveReader {
     \/.fromEither(either).leftMap(err => s"Cannot parse archive: $err")
 
   def readPackage(lf: DamlLf.Archive): String \/ (Ref.PackageId, Ast.PackageSignature) =
-    fromEither(archive.Reader.readArchive(lf)) flatMap readPackage
+    fromEither(archive.Reader.readArchive(lf, schemaMode = true)) flatMap readPackage
 
   def readPackage(
       packageId: Ref.PackageId,

--- a/sdk/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Decode.scala
+++ b/sdk/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Decode.scala
@@ -74,7 +74,7 @@ object Decode {
       archive: DamlLf.Archive
   ): Either[Error, (PackageId, Ast.Package)] =
     Reader
-      .readArchive(archive, schemaMode = true)
+      .readArchive(archive, schemaMode = false)
       .flatMap(decodeArchivePayload)
 
   @throws[Error]
@@ -87,7 +87,7 @@ object Decode {
       archive: DamlLf.Archive
   ): Either[Error, (PackageId, Ast.PackageSignature)] =
     Reader
-      .readArchive(archive, schemaMode = false)
+      .readArchive(archive, schemaMode = true)
       .flatMap(decodeArchivePayloadSchema)
 
   @throws[Error]

--- a/sdk/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV2.scala
+++ b/sdk/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV2.scala
@@ -30,7 +30,7 @@ private[archive] class DecodeV2(minor: LV.Minor) {
   def decodePackage( // entry point
       packageId: PackageId,
       lfPackage: PLF.Package,
-      onlySchema: Boolean,
+      schemaMode: Boolean,
   ): Either[Error, Package] = attempt(NameOf.qualifiedNameOfCurrentFunc) {
 
     val internedStrings = lfPackage.getInternedStringsList.asScala.to(ImmArraySeq)
@@ -56,7 +56,7 @@ private[archive] class DecodeV2(minor: LV.Minor) {
       IndexedSeq.empty,
       Some(dependencyTracker),
       None,
-      onlySchema,
+      schemaMode,
     )
 
     val internedTypes = Work.run(decodeInternedTypes(env0, lfPackage))
@@ -121,7 +121,7 @@ private[archive] class DecodeV2(minor: LV.Minor) {
       IndexedSeq.empty,
       None,
       None,
-      onlySchema = false,
+      schemaMode = false,
     )
     val internedTypes = Work.run(decodeInternedTypes(env0, lfSingleModule))
     val env = env0.copy(internedTypes = internedTypes)
@@ -189,7 +189,7 @@ private[archive] class DecodeV2(minor: LV.Minor) {
       internedTypes: collection.IndexedSeq[Type],
       optDependencyTracker: Option[PackageDependencyTracker],
       optModuleName: Option[ModuleName],
-      onlySchema: Boolean,
+      schemaMode: Boolean,
   ) {
 
     // decode*ForTest -- test entry points
@@ -237,7 +237,7 @@ private[archive] class DecodeV2(minor: LV.Minor) {
       val exceptions = mutable.ArrayBuffer[(DottedName, DefException)]()
       val interfaces = mutable.ArrayBuffer[(DottedName, DefInterface)]()
 
-      if (!onlySchema) {
+      if (!schemaMode) {
         // collect type synonyms
         lfModule.getSynonymsList.asScala
           .foreach { defn =>
@@ -251,7 +251,7 @@ private[archive] class DecodeV2(minor: LV.Minor) {
 
       // collect data types
       lfModule.getDataTypesList.asScala
-        .filter(!onlySchema || _.getSerializable)
+        .filter(!schemaMode || _.getSerializable)
         .foreach { defn =>
           val defName = getInternedDottedName(defn.getNameInternedDname)
           currentDefinitionRef = Some(DefinitionRef(packageId, QualifiedName(moduleName, defName)))
@@ -259,7 +259,7 @@ private[archive] class DecodeV2(minor: LV.Minor) {
           defs += (defName -> d)
         }
 
-      if (!onlySchema) {
+      if (!schemaMode) {
         // collect values
         lfModule.getValuesList.asScala.foreach { defn =>
           val nameWithType = defn.getNameWithType
@@ -280,7 +280,7 @@ private[archive] class DecodeV2(minor: LV.Minor) {
 
       if (versionIsOlderThan(LV.Features.exceptions)) {
         assertEmpty(lfModule.getExceptionsList, "Module.exceptions")
-      } else if (!onlySchema) {
+      } else if (!schemaMode) {
         lfModule.getExceptionsList.asScala
           .foreach { defn =>
             val defName = getInternedDottedName(defn.getNameInternedDname)
@@ -792,14 +792,14 @@ private[archive] class DecodeV2(minor: LV.Minor) {
     }
 
     private def decodeExpr[T](lfExpr: PLF.Expr, definition: String)(k: Expr => Work[T]): Work[T] =
-      if (onlySchema)
+      if (schemaMode)
         k(EUnit) // we can call k directly because we know there is no recursion on decodeExpr
       else
         Work.Bind(Work.Delay(() => decodeExpr1(lfExpr, definition)), k)
 
     private def decodeExpr1(lfExpr: PLF.Expr, definition: String): Work[Expr] = {
-      if (onlySchema)
-        throw new IllegalStateException("decodeExpr1 called in onlySchema mode")
+      if (schemaMode)
+        throw new IllegalStateException("decodeExpr1 called in schema mode")
       Work.bind(lfExpr.getSumCase match {
         case PLF.Expr.SumCase.VAR_INTERNED_STR =>
           Ret(EVar(getInternedName(lfExpr.getVarInternedStr)))

--- a/sdk/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Reader.scala
+++ b/sdk/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Reader.scala
@@ -48,7 +48,7 @@ object Reader {
    */
   def readArchive(
       lf: DamlLf.Archive,
-      schemaMode: Boolean = false,
+      schemaMode: Boolean,
   ): Either[Error, ArchivePayload] = for {
     theirHash <- lf.getHashFunction match {
       case DamlLf.HashFunction.SHA256 =>

--- a/sdk/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/sdk/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -95,7 +95,7 @@ class DecodeV1Spec
       typeTable,
       None,
       Some(dummyModuleName),
-      onlySchema = false,
+      schemaMode = false,
     )
   }
 
@@ -907,7 +907,7 @@ class DecodeV1Spec
           IndexedSeq.empty,
           None,
           None,
-          onlySchema = false,
+          schemaMode = false,
         )
         val parseError =
           the[Error.Parsing] thrownBy (decoder

--- a/sdk/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV2Spec.scala
+++ b/sdk/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV2Spec.scala
@@ -92,7 +92,7 @@ class DecodeV2Spec
       typeTable,
       None,
       Some(dummyModuleName),
-      onlySchema = false,
+      schemaMode = false,
     )
   }
 


### PR DESCRIPTION
Backport of https://github.com/digital-asset/daml/pull/22292

- consistent schemaMode parameter name
- remove Reader.readArchive default schemaMode parameter
- fix incorrect schemaMode usage