### PR TITLE
Revive deprecation warnings for java bindings.

### DIFF
--- a/sdk/language-support/java/javaopts.bzl
+++ b/sdk/language-support/java/javaopts.bzl
@@ -1,4 +1,4 @@
 # Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-da_java_bindings_javacopts = ["-Werror", "-Xlint", "-Xlint:-serial", "-Xlint:-deprecation"]
+da_java_bindings_javacopts = ["-Werror", "-deprecation", "-Xlint", "-Xlint:-serial"]


### PR DESCRIPTION
Closes https://github.com/digital-asset/daml/issues/21435. 