### PR TITLE
update directory hints in daml tutorial

### DIFF
--- a/sdk/docs/manually-written/sdk/tutorials/smart-contracts/choices.rst
+++ b/sdk/docs/manually-written/sdk/tutorials/smart-contracts/choices.rst
@@ -12,7 +12,7 @@ In this section you will learn about how to define simple data transformations u
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro4`` by running ``dpm new intro-choices  --template daml-intro-choices``
+  Remember that you can load all the code for this section into a folder called ``intro-choices`` by running ``dpm new intro-choices  --template daml-intro-choices``
 
 Choices as methods
 ------------------

--- a/sdk/docs/manually-written/sdk/tutorials/smart-contracts/compose.rst
+++ b/sdk/docs/manually-written/sdk/tutorials/smart-contracts/compose.rst
@@ -18,7 +18,7 @@ The model in this section is not a single Daml file, but a Daml project consisti
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro7`` by running ``dpm new intro-compose  --template daml-intro-compose``
+  Remember that you can load all the code for this section into a folder called ``intro-compose`` by running ``dpm new intro-compose  --template daml-intro-compose``
 
 Daml projects
 -------------

--- a/sdk/docs/manually-written/sdk/tutorials/smart-contracts/constraints.rst
+++ b/sdk/docs/manually-written/sdk/tutorials/smart-contracts/constraints.rst
@@ -15,7 +15,7 @@ Lastly, you will learn about time on the ledger and in Daml Script.
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro5`` by running ``dpm new intro-constraints  --template daml-intro-constraints``
+  Remember that you can load all the code for this section into a folder called ``intro-constraints`` by running ``dpm new intro-constraints  --template daml-intro-constraints``
 
 Template preconditions
 ----------------------

--- a/sdk/docs/manually-written/sdk/tutorials/smart-contracts/contracts.rst
+++ b/sdk/docs/manually-written/sdk/tutorials/smart-contracts/contracts.rst
@@ -16,7 +16,7 @@ To begin with, you're going to write a very small Daml template, which represent
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder ``intro1`` by running ``dpm new intro-contracts  --template daml-intro-contracts``
+  Remember that you can load all the code for this section into a folder ``intro-contracts`` by running ``dpm new intro-contracts  --template daml-intro-contracts``
 
 Daml ledger basics
 ------------------

--- a/sdk/docs/manually-written/sdk/tutorials/smart-contracts/daml-scripts.rst
+++ b/sdk/docs/manually-written/sdk/tutorials/smart-contracts/daml-scripts.rst
@@ -17,7 +17,7 @@ In this section we test the ``Token`` model from :doc:`contracts` using the :ref
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro2`` by running ``dpm new intro-daml-scripts  --template daml-intro-daml-scripts``
+  Remember that you can load all the code for this section into a folder called ``intro-daml-scripts`` by running ``dpm new intro-daml-scripts  --template daml-intro-daml-scripts``
 
 .. script_basics:
 

--- a/sdk/docs/manually-written/sdk/tutorials/smart-contracts/data.rst
+++ b/sdk/docs/manually-written/sdk/tutorials/smart-contracts/data.rst
@@ -27,7 +27,7 @@ After this section, you should be able to use a Daml ledger as a simple database
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro3`` by running ``dpm new intro-data  --template daml-intro-data``
+  Remember that you can load all the code for this section into a folder called ``intro-data`` by running ``dpm new intro-data  --template daml-intro-data``
 
 .. _native-types:
 

--- a/sdk/docs/manually-written/sdk/tutorials/smart-contracts/exceptions.rst
+++ b/sdk/docs/manually-written/sdk/tutorials/smart-contracts/exceptions.rst
@@ -36,7 +36,7 @@ outside of Daml.
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro8`` by running ``dpm new intro-exceptions  --template daml-intro-exceptions``
+  Remember that you can load all the code for this section into a folder called ``intro-exceptions`` by running ``dpm new intro-exceptions  --template daml-intro-exceptions``
 
 Our example for the use of exceptions will be a simple shop
 template. Users can order items by calling a choice and transfer money

--- a/sdk/docs/manually-written/sdk/tutorials/smart-contracts/parties.rst
+++ b/sdk/docs/manually-written/sdk/tutorials/smart-contracts/parties.rst
@@ -14,7 +14,7 @@ In this section you will learn about Daml's authorization rules and how to devel
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro6`` by running ``dpm new intro-parties  --template daml-intro-parties``
+  Remember that you can load all the code for this section into a folder called ``intro-parties`` by running ``dpm new intro-parties  --template daml-intro-parties``
 
 Prevent IOU revocation
 ----------------------

--- a/sdk/docs/manually-written/sdk/tutorials/smart-contracts/tests.rst
+++ b/sdk/docs/manually-written/sdk/tutorials/smart-contracts/tests.rst
@@ -17,7 +17,7 @@ Note that this section only covers testing your Daml contracts.
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro12`` by running ``dpm new intro-test  --template daml-intro-test``
+  Remember that you can load all the code for this section into a folder called ``intro-test`` by running ``dpm new intro-test  --template daml-intro-test``
 
 Multi-package project structure
 -------------------------------

--- a/sdk/docs/sharable/sdk/tutorials/smart-contracts/choices.rst
+++ b/sdk/docs/sharable/sdk/tutorials/smart-contracts/choices.rst
@@ -12,7 +12,7 @@ In this section you will learn about how to define simple data transformations u
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro4`` by running ``dpm new intro-choices  --template daml-intro-choices``
+  Remember that you can load all the code for this section into a folder called ``intro-choices`` by running ``dpm new intro-choices  --template daml-intro-choices``
 
 Choices as methods
 ------------------

--- a/sdk/docs/sharable/sdk/tutorials/smart-contracts/compose.rst
+++ b/sdk/docs/sharable/sdk/tutorials/smart-contracts/compose.rst
@@ -18,7 +18,7 @@ The model in this section is not a single Daml file, but a Daml project consisti
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro7`` by running ``dpm new intro-compose  --template daml-intro-compose``
+  Remember that you can load all the code for this section into a folder called ``intro-compose`` by running ``dpm new intro-compose  --template daml-intro-compose``
 
 Daml projects
 -------------

--- a/sdk/docs/sharable/sdk/tutorials/smart-contracts/constraints.rst
+++ b/sdk/docs/sharable/sdk/tutorials/smart-contracts/constraints.rst
@@ -15,7 +15,7 @@ Lastly, you will learn about time on the ledger and in Daml Script.
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro5`` by running ``dpm new intro-constraints  --template daml-intro-constraints``
+  Remember that you can load all the code for this section into a folder called ``intro-constraints`` by running ``dpm new intro-constraints  --template daml-intro-constraints``
 
 Template preconditions
 ----------------------

--- a/sdk/docs/sharable/sdk/tutorials/smart-contracts/contracts.rst
+++ b/sdk/docs/sharable/sdk/tutorials/smart-contracts/contracts.rst
@@ -16,7 +16,7 @@ To begin with, you're going to write a very small Daml template, which represent
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder ``intro1`` by running ``dpm new intro-contracts  --template daml-intro-contracts``
+  Remember that you can load all the code for this section into a folder ``intro-contracts`` by running ``dpm new intro-contracts  --template daml-intro-contracts``
 
 Daml ledger basics
 ------------------

--- a/sdk/docs/sharable/sdk/tutorials/smart-contracts/daml-scripts.rst
+++ b/sdk/docs/sharable/sdk/tutorials/smart-contracts/daml-scripts.rst
@@ -17,7 +17,7 @@ In this section we test the ``Token`` model from :doc:`contracts` using the :ref
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro2`` by running ``dpm new intro-daml-scripts  --template daml-intro-daml-scripts``
+  Remember that you can load all the code for this section into a folder called ``intro-daml-scripts`` by running ``dpm new intro-daml-scripts  --template daml-intro-daml-scripts``
 
 .. script_basics:
 

--- a/sdk/docs/sharable/sdk/tutorials/smart-contracts/data.rst
+++ b/sdk/docs/sharable/sdk/tutorials/smart-contracts/data.rst
@@ -27,7 +27,7 @@ After this section, you should be able to use a Daml ledger as a simple database
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro3`` by running ``dpm new intro-data  --template daml-intro-data``
+  Remember that you can load all the code for this section into a folder called ``intro-data`` by running ``dpm new intro-data  --template daml-intro-data``
 
 .. _native-types:
 

--- a/sdk/docs/sharable/sdk/tutorials/smart-contracts/exceptions.rst
+++ b/sdk/docs/sharable/sdk/tutorials/smart-contracts/exceptions.rst
@@ -36,7 +36,7 @@ outside of Daml.
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro8`` by running ``dpm new intro-exceptions  --template daml-intro-exceptions``
+  Remember that you can load all the code for this section into a folder called ``intro-exceptions`` by running ``dpm new intro-exceptions  --template daml-intro-exceptions``
 
 Our example for the use of exceptions will be a simple shop
 template. Users can order items by calling a choice and transfer money

--- a/sdk/docs/sharable/sdk/tutorials/smart-contracts/parties.rst
+++ b/sdk/docs/sharable/sdk/tutorials/smart-contracts/parties.rst
@@ -14,7 +14,7 @@ In this section you will learn about Daml's authorization rules and how to devel
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro6`` by running ``dpm new intro-parties  --template daml-intro-parties``
+  Remember that you can load all the code for this section into a folder called ``intro-parties`` by running ``dpm new intro-parties  --template daml-intro-parties``
 
 Prevent IOU revocation
 ----------------------

--- a/sdk/docs/sharable/sdk/tutorials/smart-contracts/tests.rst
+++ b/sdk/docs/sharable/sdk/tutorials/smart-contracts/tests.rst
@@ -17,7 +17,7 @@ Note that this section only covers testing your Daml contracts.
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro12`` by running ``dpm new intro-test  --template daml-intro-test``
+  Remember that you can load all the code for this section into a folder called ``intro-test`` by running ``dpm new intro-test  --template daml-intro-test``
 
 Multi-package project structure
 -------------------------------


### PR DESCRIPTION
I chose to go with the named (e.g. `intro-choices`) rather than numeric ones (e.g. `intro4`).