### PR TITLE
move damlc flags docs up one level

### DIFF
--- a/sdk/docs/manually-written/sdk/component-howtos/smart-contracts/flags.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/smart-contracts/flags.rst
@@ -1,10 +1,6 @@
 .. Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-.. warning::
-   Daml Assistant is deprecated from 3.4.x onwards. Use :externalref:`dpm <dpm>` instead.
-   Refer to the ``dpm`` :externalref:`migration guide <dpm-daml-assistant-to-dpm-migration>` for more details.
-
 .. _daml-assistant-flags:
 
 Daml Compiler flags

--- a/sdk/docs/sharable/sdk/component-howtos/smart-contracts/flags.rst
+++ b/sdk/docs/sharable/sdk/component-howtos/smart-contracts/flags.rst
@@ -1,10 +1,6 @@
 .. Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-.. warning::
-   Daml Assistant is deprecated from 3.4.x onwards. Use :externalref:`dpm <dpm>` instead.
-   Refer to the ``dpm`` :externalref:`migration guide <dpm-daml-assistant-to-dpm-migration>` for more details.
-
 .. _daml-assistant-flags:
 
 Daml Compiler flags


### PR DESCRIPTION
The compiler flags docs pages apply to damlc components regardless of whether they are accessed through `dpm` or `daml`.

Therefore, move this page out from under daml assistant, and remove the deprecation warning clause at the top

In a separate dpm PR will also link DPM to this one changes make it to the docs site.