### PR TITLE
[Fwd] Remove `scalapb-compilerplugin` dep and exclude `package.proto` from jar

### DIFF
--- a/sdk/bazel_tools/proto.bzl
+++ b/sdk/bazel_tools/proto.bzl
@@ -204,6 +204,7 @@ def _proto_scala_deps(grpc, proto_deps, java_conversions):
 def proto_jars(
         name,
         srcs,
+        scalapb_options_files = [],
         visibility = None,
         strip_import_prefix = "",
         grpc = False,
@@ -260,7 +261,7 @@ def proto_jars(
     # Compiled protobufs.
     proto_library(
         name = name,
-        srcs = srcs,
+        srcs = srcs + scalapb_options_files,
         strip_import_prefix = strip_import_prefix,
         visibility = visibility,
         deps = deps + proto_deps,

--- a/sdk/canton/BUILD.bazel
+++ b/sdk/canton/BUILD.bazel
@@ -1695,7 +1695,7 @@ ledger_api_proto_source_root = "canton/community/ledger-api/src/main/protobuf"
 
 proto_jars(
     name = "ledger_api_proto",
-    srcs = glob(["community/ledger-api/src/main/protobuf/com/daml/ledger/api/**/*.proto"]),
+    srcs = glob(["community/ledger-api/src/main/protobuf/com/daml/ledger/api/v*/**/*.proto"]),
     grpc = True,
     java_conversions = True,
     java_deps = [
@@ -1706,6 +1706,9 @@ proto_jars(
     maven_artifact_scala_suffix = "scalapb",
     maven_group = "com.daml",
     proto_deps = ["//daml-lf/ledger-api-value:ledger_api_value_proto"],
+    scalapb_options_files = [
+        "community/ledger-api/src/main/protobuf/com/daml/ledger/api/scalapb/package.proto",
+    ],
     strip_import_prefix = "community/ledger-api/src/main/protobuf",
     visibility = ["//visibility:public"],
     deps = [

--- a/sdk/release/test-protobuf-structure.sh
+++ b/sdk/release/test-protobuf-structure.sh
@@ -57,7 +57,6 @@ com/daml/ledger/api/v2/transaction_filter.proto
 com/daml/ledger/api/v2/value.proto
 com/daml/ledger/api/v2/event_query_service.proto
 com/daml/ledger/api/v2/reassignment_commands.proto
-com/daml/ledger/api/scalapb/package.proto
 com/daml/ledger/api/v2/admin/command_inspection_service.proto
 com/daml/ledger/api/v2/admin/participant_pruning_service.proto
 com/daml/ledger/api/v2/admin/identity_provider_config_service.proto


### PR DESCRIPTION
This is forward port of:
#### https://github.com/digital-asset/daml/pull/22369 Remove Scalapb compilerplugin dep from runtime classpath
`com_thesamet_scalapb_compilerplugin_2_13` should not appear in the runtime classpath. We should use `com_thesamet_scalapb_scalapb_runtime_2_13` instead.
#### https://github.com/digital-asset/daml/pull/22371 Exclude Scalapb options files from published proto artifact
Publishing the `package.proto` file, which contains the Scalapb options, is inconvenient because:
- It forces our users to add `scalapb-runtime` dep in their classpath, even if they just want to generate the Java classes 
- It forces our users to use the same Scalapb options as us, which is likely not what they need.

The `package.proto` file was not included in the proto JAR before 3.4. It has caused issues in transcode, scribe and cn-quickstart since then.