### PR TITLE
Update to dpm 1.0.2

### DIFF
--- a/ci/get-dpm.sh
+++ b/ci/get-dpm.sh
@@ -7,7 +7,7 @@ ORAS_VERSION="1.2.2"
 ORAS="oras"
 # DPM url pinned to known working version
 # Update periodically
-DPM_URL="${1:-europe-docker.pkg.dev/da-images/public/components/dpm:1.0.0}"
+DPM_URL="${1:-europe-docker.pkg.dev/da-images/public/components/dpm:1.0.2}"
 # Get current machine OS type and ARCH
 OS_TYPE="$(uname -s | tr A-Z a-z)"
 if [[ $(uname -m) == 'x86_64' ]]; then


### PR DESCRIPTION
Update to dpm 1.0.2, which includes some useful enhancements

## What's Changed
* improve args passing to root cmd in tests by @sammy-da in https://github.com/DACH-NY/dpm/pull/497
* modify auth to not require HOME env var by @sammy-da in https://github.com/DACH-NY/dpm/pull/495
* add 'dpm uninstall' command by @sammy-da in https://github.com/DACH-NY/dpm/pull/496
* trim trailing slash in --registry arg by @sammy-da in https://github.com/DACH-NY/dpm/pull/494


**Full Changelog**: https://github.com/DACH-NY/dpm/compare/1.0.0...1.0.2