### PR TITLE
use up-to-date sdk version in docs

### DIFF
--- a/sdk/docs/manually-written/sdk/sdlc-howtos/smart-contracts/build/how-to-build-dar-files.rst
+++ b/sdk/docs/manually-written/sdk/sdlc-howtos/smart-contracts/build/how-to-build-dar-files.rst
@@ -30,7 +30,7 @@ Add the following to your ``daml.yaml``, replacing the ``<place-holders>`` as ap
 
 .. code:: yaml
 
-  sdk-version: <such as 2.10.0>
+  sdk-version: <such as 3.4.8>
   name: <your-package-name>
   version: 1.0.0
   source: daml

--- a/sdk/docs/sharable/sdk/sdlc-howtos/smart-contracts/build/how-to-build-dar-files.rst
+++ b/sdk/docs/sharable/sdk/sdlc-howtos/smart-contracts/build/how-to-build-dar-files.rst
@@ -30,7 +30,7 @@ Add the following to your ``daml.yaml``, replacing the ``<place-holders>`` as ap
 
 .. code:: yaml
 
-  sdk-version: <such as 2.10.0>
+  sdk-version: <such as 3.4.8>
   name: <your-package-name>
   version: 1.0.0
   source: daml


### PR DESCRIPTION
Our "how to build dar files" doc uses 2.10.0 as an example SDK version. Changed to something more recent.