### PR TITLE
Add logging of canton to debug flaky assistant integration tests

### DIFF
--- a/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -313,7 +313,6 @@ withCantonSandbox options remainingArgs k = do
             , "val synchronizerOwners = Seq(sequencer1, mediator1)"
             , "bootstrap.synchronizer(\"mysynchronizer\", Seq(sequencer1), Seq(mediator1), synchronizerOwners, PositiveInt.one, staticSynchronizerParameters)"
             , "sandbox.synchronizers.connect_local(sequencer1, \"mysynchronizer\")"
-            , "sys.exit(1337)"
             ]
 
 -- | Obtain a path to use as canton portfile, and give updated options.


### PR DESCRIPTION
This PR enables verbose debug information if it fails whilst running //daml-assistant/integration-tests:integration-tests. In general we prefer to not dump so much to stderr but canton exits with error code 117 sometimes causing a flake and it is not reproducible locally. Therefore we log everything and wait until it flakes such that we get the information this way. 

We log only in case of errors, so for normal runs the log should be unaffected.