### PR TITLE
fix cheat sheet refs to react

### DIFF
--- a/sdk/docs/manually-written/sdk/reference/cheat-sheet.rst
+++ b/sdk/docs/manually-written/sdk/reference/cheat-sheet.rst
@@ -21,18 +21,18 @@ Cheat Sheet
         class="cheat-sheet-container"
         data-layout-small='[
             ["what-is", "concepts", "command-line-tools", "basics", "types", "data", "functions", "contract-templates", "contract-keys"],
-            ["choices", "updates", "scripts", "javascript-react-api", "daml-resources"]
+            ["choices", "updates", "scripts", "daml-resources"]
         ]'
         data-layout-medium='[
             ["what-is", "concepts", "command-line-tools", "basics", "types", "data"],
             ["functions", "contract-templates", "contract-keys", "choices", "updates"],
-            ["scripts", "javascript-react-api", "daml-resources"]
+            ["scripts", "daml-resources"]
         ]'
         data-layout-large='[
             ["what-is", "concepts", "command-line-tools", "basics", "types"],
             ["data", "functions", "contract-templates", "contract-keys", "choices"],
             ["updates", "scripts"],
-            ["javascript-react-api", "daml-resources"]
+            ["daml-resources"]
          ]'
     >
 

--- a/sdk/docs/sharable/sdk/reference/cheat-sheet.rst
+++ b/sdk/docs/sharable/sdk/reference/cheat-sheet.rst
@@ -21,18 +21,18 @@ Cheat Sheet
         class="cheat-sheet-container"
         data-layout-small='[
             ["what-is", "concepts", "command-line-tools", "basics", "types", "data", "functions", "contract-templates", "contract-keys"],
-            ["choices", "updates", "scripts", "javascript-react-api", "daml-resources"]
+            ["choices", "updates", "scripts", "daml-resources"]
         ]'
         data-layout-medium='[
             ["what-is", "concepts", "command-line-tools", "basics", "types", "data"],
             ["functions", "contract-templates", "contract-keys", "choices", "updates"],
-            ["scripts", "javascript-react-api", "daml-resources"]
+            ["scripts", "daml-resources"]
         ]'
         data-layout-large='[
             ["what-is", "concepts", "command-line-tools", "basics", "types"],
             ["data", "functions", "contract-templates", "contract-keys", "choices"],
             ["updates", "scripts"],
-            ["javascript-react-api", "daml-resources"]
+            ["daml-resources"]
          ]'
     >
 


### PR DESCRIPTION
On 29-08-2025 @atriantafyllos-da merged https://github.com/digital-asset/daml/pull/21800 that removed the daml-react component as part as the removal of daml-react overall. However, as far as the cheat sheet is concerned, only the `include::` was deleted, not the inclusion in the layouts.