### PR TITLE
Fix publish codegen component

### DIFF
--- a/ci/copy-unix-release-artifacts.sh
+++ b/ci/copy-unix-release-artifacts.sh
@@ -56,8 +56,7 @@ function copy_oci {
 # Copy all platforms for each, publishing script picks out platform independent
 copy_oci damlc bazel-bin/compiler/damlc/damlc-oci.tar.gz
 copy_oci daml-script bazel-bin/daml-script/runner/daml-script-oci.tar.gz
-copy_oci codegen-js bazel-bin/language-support/ts/codegen/codegen-js-oci.tar.gz
-copy_oci codegen-java bazel-bin/language-support/codegen-main/codegen-java-oci.tar.gz
+copy_oci codegen bazel-bin/language-support/codegen-main/codegen-oci.tar.gz
 copy_oci daml-new bazel-bin/daml-assistant/daml-helper/daml-new-oci.tar.gz
 copy_oci upgrade-check bazel-bin/daml-lf/validation/upgrade-check-oci.tar.gz
 

--- a/ci/copy-windows-release-artifacts.sh
+++ b/ci/copy-windows-release-artifacts.sh
@@ -50,7 +50,6 @@ function copy_oci {
 # Copy all platforms for each, publishing script picks out platform independent
 copy_oci damlc bazel-bin/compiler/damlc/damlc-oci.tar.gz
 copy_oci daml-script bazel-bin/daml-script/runner/daml-script-oci.tar.gz
-copy_oci codegen-js bazel-bin/language-support/ts/codegen/codegen-js-oci.tar.gz
-copy_oci codegen-java bazel-bin/language-support/codegen-main/codegen-java-oci.tar.gz
+copy_oci codegen bazel-bin/language-support/codegen-main/codegen-oci.tar.gz
 copy_oci daml-new bazel-bin/daml-assistant/daml-helper/daml-new-oci.tar.gz
 copy_oci upgrade-check bazel-bin/daml-lf/validation/upgrade-check-oci.tar.gz

--- a/ci/publish-oci.sh
+++ b/ci/publish-oci.sh
@@ -38,7 +38,7 @@ DPM_REGISTRY=$3
 # DPM_REGISTRY="europe-docker.pkg.dev/da-images-dev/oci-playground"
 
 # Should match the tars copied into /release/oci during copy-{OS}-release-artifacts.sh
-declare -a components=(damlc daml-script codegen-js codegen-java daml-new upgrade-check)
+declare -a components=(damlc daml-script codegen daml-new upgrade-check)
 
 if [[ x"$DEBUG" != x ]]; then
   unarchive="tar -x -v -z -f"


### PR DESCRIPTION
After #22419, `codegen-js` and `codegen-java` are merged into a single `codegen` component.