### PR TITLE
Revert "allow publishing release artifacts with source branch release-trigger"

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -196,7 +196,7 @@ steps:
                    eq(variables.skip, 'false'),
                    ne(${{parameters.name_exp}}, 'm1'),
                    eq(${{parameters.is_release}}, 'true'),
-                   in(variables['Build.SourceBranchName'], 'main', 'main-2.x', 'release-trigger'))
+                   in(variables['Build.SourceBranchName'], 'main', 'main-2.x'))
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Unix Release Artifacts'
     inputs:
@@ -206,4 +206,4 @@ steps:
                    eq(variables.skip, 'false'),
                    ne(${{parameters.name_exp}}, 'm1'),
                    eq(${{parameters.is_release}}, 'true'),
-                   in(variables['Build.SourceBranchName'], 'main', 'main-2.x', 'release-trigger'))
+                   in(variables['Build.SourceBranchName'], 'main', 'main-2.x'))

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -107,12 +107,12 @@ steps:
       DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
-                   in(variables['Build.SourceBranchName'], 'main', 'main-2.x', 'release-trigger'))
+                   in(variables['Build.SourceBranchName'], 'main', 'main-2.x'))
 
   - task: PublishPipelineArtifact@0
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
-                   in(variables['Build.SourceBranchName'], 'main', 'main-2.x', 'release-trigger'))
+                   in(variables['Build.SourceBranchName'], 'main', 'main-2.x'))
     inputs:
       targetPath: $(Build.StagingDirectory)/release
       artifactName: windows-release


### PR DESCRIPTION
Reverts digital-asset/daml#22473. This was a no-op: the change had to be made to the release-trigger branch instead.