### PR TITLE
Remove deprecated methods generated for java

### DIFF
--- a/sdk/UNRELEASED.md
+++ b/sdk/UNRELEASED.md
@@ -9,6 +9,20 @@ schedule, i.e. if you add an entry effective at or after the first
 header, prepend the new date header that corresponds to the
 Wednesday after your change.
 
+## Until 2025-12-11 (Exclusive)
+- Changed java codegen to drop methods deprecated since 2.3.0. 
+  Given template `Pizza` and choice `Bake`, Following methods will no longer be generated:
+  ```
+  createAndExerciseArchive(Archive arg)
+  createAndExerciseArchive()
+  createAndExerciseBake(Pizza_Bake arg)
+  createAndExerciseBake(String pizzaiolo)
+  exerciseByKeyArchive(PizzaKey key, Archive arg)
+  exerciseByKeyArchive(PizzaKey key)
+  exerciseByKeyBake(PizzaKey key, Pizza_Bake arg)
+  exerciseByKeyBake(PizzaKey key, String pizzaiolo)
+  ```
+
 ## Until 2025-12-04 (Exclusive)
 - Added `templateIdWithPackageId` in generated typescript instances of `Template` and `InterfaceCompanion`.
 

--- a/sdk/language-support/java/codegen/src/it/java/com/daml/TemplateMethodTest.java
+++ b/sdk/language-support/java/codegen/src/it/java/com/daml/TemplateMethodTest.java
@@ -63,29 +63,6 @@ public class TemplateMethodTest {
   }
 
   @Test
-  void templateHasCreateAndExerciseMethods() {
-    SimpleTemplate simple = new SimpleTemplate("Bob");
-    var fromSplatted = simple.createAndExerciseTestTemplate_Int(42L);
-    var fromRecord = simple.createAndExerciseTestTemplate_Int(new TestTemplate_Int(42L));
-
-    assertNotNull(fromSplatted, "Update<R> from splatted choice was null");
-    assertNotNull(fromRecord, "Update<R> from record choice was null");
-    assertEquals(
-        fromRecord.commands(),
-        fromSplatted.commands(),
-        "Update<R> commands from both methods are not the same");
-
-    assertEquals(
-        1,
-        fromSplatted.commands().size(),
-        "There are not exactly one command from Update<R> from splatted choice");
-    assertEquals(
-        1,
-        fromRecord.commands().size(),
-        "There are not exactly one command from Update<R> from record choice");
-  }
-
-  @Test
   void templateHasArchive() {
     SimpleTemplate.ContractId cid = new SimpleTemplate.ContractId("id");
     Exercises.Archivable<?> wideCid = cid;

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
@@ -176,7 +176,7 @@ private[inner] object ClassGenUtils {
       choiceName: ChoiceName,
       choice: TemplateChoice[Type],
       fields: Fields,
-  )(alter: MethodSpec.Builder => MethodSpec.Builder)(implicit
+  )(implicit
       packagePrefixes: PackagePrefixes
   ): MethodSpec = {
     val methodName = s"$name${choiceName.capitalize}"
@@ -188,13 +188,15 @@ private[inner] object ClassGenUtils {
     for (FieldInfo(_, _, javaName, javaType) <- fields) {
       choiceBuilder.addParameter(javaType, javaName)
     }
-    choiceBuilder.addStatement(
-      "return $L(new $T($L))",
-      methodName,
-      javaType,
-      generateArgumentList(fields.map(_.javaName)),
-    )
-    alter(choiceBuilder).build()
+    choiceBuilder
+      .addStatement(
+        "return $L(new $T($L))",
+        methodName,
+        javaType,
+        generateArgumentList(fields.map(_.javaName)),
+      )
+      .addModifiers(Modifier.DEFAULT)
+      .build()
   }
 
   def generateGetCompanion(companionType: TypeName, companionName: String): MethodSpec = {

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
@@ -185,7 +185,7 @@ object ContractIdClass {
         choiceName,
         choice,
         fields,
-      )(_.addModifiers(Modifier.DEFAULT))
+      )
 
     private[ContractIdClass] def generateExerciseMethod(
         choiceName: ChoiceName,

--- a/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/sdk/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -8,13 +8,7 @@ import ClassGenUtils.{companionFieldName, generateGetCompanion, templateIdFieldN
 import com.digitalasset.daml.lf.codegen.TypeWithContext
 import com.digitalasset.daml.lf.data.Ref
 import Ref.ChoiceName
-import com.daml.ledger.javaapi.data.codegen.{
-  Choice,
-  Created,
-  Exercised,
-  Update,
-  ContractTypeCompanion,
-}
+import com.daml.ledger.javaapi.data.codegen.{Choice, Created, Update, ContractTypeCompanion}
 import com.digitalasset.daml.lf.codegen.backend.java.inner.ToValueGenerator.generateToValueConverter
 import com.digitalasset.daml.lf.typesig
 import typesig._
@@ -107,7 +101,6 @@ private[inner] object TemplateClass extends StrictLogging {
   private val updateClassName = ClassName get classOf[Update[_]]
   private val createUpdateClassName = ClassName get classOf[Update.CreateUpdate[_, _]]
   private val createdClassName = ClassName get classOf[Created[_]]
-  private val exercisedClassName = ClassName get classOf[Exercised[_]]
   private def parameterizedTypeName(raw: ClassName, arg: TypeName*) =
     ParameterizedTypeName.get(raw, arg: _*)
 


### PR DESCRIPTION
Since Daml 2.3.0 https://github.com/digital-asset/daml/issues/13920, the `createAndExercise*` and `exerciseByKey*` methods in Java codegen output are deprecated, with Javadoc explaining how to trivially port to the supported form. 

As the deprecation cycle has completed, we delete the code that generates those methods in `TemplateClass`.