### PR TITLE
Remove `3.5` and `main` tags on adhoc release

### DIFF
--- a/ci/publish-oci.sh
+++ b/ci/publish-oci.sh
@@ -90,7 +90,7 @@ function publish_artifact {
       fi
       platform_args+=( "--platform ${arch}=dist/${arch}/${artifact_name} " )
     done
-    if [[ "${RELEASE_TAG}" != *"-adhoc-"* ]] then
+    if [[ "${RELEASE_TAG}" != *"-adhoc"* ]] then
       extra_tags_args+=( "--extra-tags main" )
       extra_tags_args+=( "--extra-tags $(extract_major_minor ${RELEASE_TAG})" )
     fi


### PR DESCRIPTION
Today's `daml_upgrade_pr` job in Canton failed because it tried to install an adhoc version:
https://app.circleci.com/pipelines/github/DACH-NY/canton/114922/workflows/6b8c31f0-b7c7-4e83-b93b-b1a237c6c002/jobs/3012256

Indeed:
```
$ dpm repo resolve-tags damlc:3.5 --registry europe-docker.pkg.dev/da-images/public-unstable
3.5.0-adhoc.20251210.14512.0.v69f56b39
```

To fix this we stop pushing the `3.5` and `main` tags on adhoc releases.