### PR TITLE
use up-to-date sdk version in docs (#22420)

### DIFF
--- a/sdk/docs/manually-written/sdk/sdlc-howtos/smart-contracts/build/how-to-build-dar-files.rst
+++ b/sdk/docs/manually-written/sdk/sdlc-howtos/smart-contracts/build/how-to-build-dar-files.rst
@@ -30,7 +30,7 @@ Add the following to your ``daml.yaml``, replacing the ``<place-holders>`` as ap
 
 .. code:: yaml
 
-  sdk-version: <such as 3.4.8>
+  sdk-version: <such as 3.4.9>
   name: <your-package-name>
   version: 1.0.0
   source: daml
@@ -70,7 +70,7 @@ Environment variables in configuration files
 
 When your project has more than one package, consider using environment variables to avoid duplication of information like the ``sdk-version``.
 Replace the ``sdk-version`` field with ``sdk-version: $SDK_VERSION`` (or any other valid environment variable name), and ensure this variable is set before building.
-``SDK_VERSION=2.10.0 dpm build --all``
+``SDK_VERSION=3.4.9 dpm build --all``
 
 Variables can also be placed inline, and are supported on all string fields in the daml.yaml, as the following example shows:
 

--- a/sdk/docs/sharable/sdk/sdlc-howtos/smart-contracts/build/how-to-build-dar-files.rst
+++ b/sdk/docs/sharable/sdk/sdlc-howtos/smart-contracts/build/how-to-build-dar-files.rst
@@ -30,7 +30,7 @@ Add the following to your ``daml.yaml``, replacing the ``<place-holders>`` as ap
 
 .. code:: yaml
 
-  sdk-version: <such as 3.4.8>
+  sdk-version: <such as 3.4.9>
   name: <your-package-name>
   version: 1.0.0
   source: daml
@@ -70,7 +70,7 @@ Environment variables in configuration files
 
 When your project has more than one package, consider using environment variables to avoid duplication of information like the ``sdk-version``.
 Replace the ``sdk-version`` field with ``sdk-version: $SDK_VERSION`` (or any other valid environment variable name), and ensure this variable is set before building.
-``SDK_VERSION=2.10.0 dpm build --all``
+``SDK_VERSION=3.4.9 dpm build --all``
 
 Variables can also be placed inline, and are supported on all string fields in the daml.yaml, as the following example shows:
 


### PR DESCRIPTION
Our "how to build dar files" doc uses 2.10.0 as an example SDK version. Changed to something more recent.