### PR TITLE
backport #22511

### DIFF
--- a/sdk/docs/manually-written/sdk/reference/daml/exceptions.rst
+++ b/sdk/docs/manually-written/sdk/reference/daml/exceptions.rst
@@ -9,8 +9,7 @@ Reference: Exceptions (Deprecated)
 .. warning:: User-defined Daml Exceptions, catching, and throwing have been
    deprecated and are being phased out in favour of the :externalref:`Canton
    error framework <error_codes>`, which represents Daml errors as
-   :externalref:`InvalidGivenCurrentSystemStateOther
-   <error-categories-inventory_InvalidGivenCurrentSystemStateOther>`.
+   ``InvalidGivenCurrentSystemStateOther``.
 
 Exceptions are a deprecated Daml feature which provides a way to handle
 certain errors that arise during interpretation instead of aborting

--- a/sdk/docs/manually-written/sdk/tutorials/smart-contracts/exceptions.rst
+++ b/sdk/docs/manually-written/sdk/tutorials/smart-contracts/exceptions.rst
@@ -7,8 +7,7 @@ Handle exceptions (Deprecated)
 .. warning:: User-defined Daml Exceptions, catching, and throwing have been
    deprecated and are being phased out in favour of the :externalref:`Canton
    error framework <error_codes>`, which represents Daml errors as
-   :externalref:`InvalidGivenCurrentSystemStateOther
-   <error-categories-inventory_InvalidGivenCurrentSystemStateOther>`.
+   ``InvalidGivenCurrentSystemStateOther``.
 
 .. warning::
 
@@ -47,7 +46,7 @@ outside of Daml.
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro-exceptions`` by running ``dpm new intro-exceptions  --template daml-intro-exceptions``
+  Remember that you can load all the code for this section into a folder called ``intro8`` by running ``dpm new intro-exceptions  --template daml-intro-exceptions``
 
 Our example for the use of exceptions will be a simple shop
 template. Users can order items by calling a choice and transfer money

--- a/sdk/docs/sharable/sdk/reference/daml/exceptions.rst
+++ b/sdk/docs/sharable/sdk/reference/daml/exceptions.rst
@@ -9,8 +9,7 @@ Reference: Exceptions (Deprecated)
 .. warning:: User-defined Daml Exceptions, catching, and throwing have been
    deprecated and are being phased out in favour of the :externalref:`Canton
    error framework <error_codes>`, which represents Daml errors as
-   :externalref:`InvalidGivenCurrentSystemStateOther
-   <error-categories-inventory_InvalidGivenCurrentSystemStateOther>`.
+   ``InvalidGivenCurrentSystemStateOther``.
 
 Exceptions are a deprecated Daml feature which provides a way to handle
 certain errors that arise during interpretation instead of aborting

--- a/sdk/docs/sharable/sdk/tutorials/smart-contracts/exceptions.rst
+++ b/sdk/docs/sharable/sdk/tutorials/smart-contracts/exceptions.rst
@@ -7,8 +7,7 @@ Handle exceptions (Deprecated)
 .. warning:: User-defined Daml Exceptions, catching, and throwing have been
    deprecated and are being phased out in favour of the :externalref:`Canton
    error framework <error_codes>`, which represents Daml errors as
-   :externalref:`InvalidGivenCurrentSystemStateOther
-   <error-categories-inventory_InvalidGivenCurrentSystemStateOther>`.
+   ``InvalidGivenCurrentSystemStateOther``.
 
 .. warning::
 
@@ -47,7 +46,7 @@ outside of Daml.
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``intro-exceptions`` by running ``dpm new intro-exceptions  --template daml-intro-exceptions``
+  Remember that you can load all the code for this section into a folder called ``intro8`` by running ``dpm new intro-exceptions  --template daml-intro-exceptions``
 
 Our example for the use of exceptions will be a simple shop
 template. Users can order items by calling a choice and transfer money


### PR DESCRIPTION
Backport of deprecation warning on exception docs, commit 4a580f0, issue https://github.com/digital-asset/daml/pull/22511. 

Fixed the `externalref` since this handle only exists on 3.5 docs canton-side