### PR TITLE
Temporary owners to prevent unexpected changes to daml-lf and engine

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,4 +18,4 @@ sdk/release/           @digital-asset/daml-language
 sdk/release.sh         @digital-asset/daml-language
 
 # Temporary owners to prevent unexpected changes to daml-lf and engine
-/daml-lf               @remyhaemmerle-da @carlpulley-da @dylant-da
+/sdk/daml-lf           @remyhaemmerle-da @carlpulley-da @dylant-da


### PR DESCRIPTION
Owning all of `/daml-lf` may cover some directories that we don't strictly need to, would be up to Carl/Remy/Dylan to decide in harder cases.