### PR TITLE
avoid deprecated submitWithDisclosures in ledger model examples

### DIFF
--- a/sdk/docs/manually-written/overview/explanations/ledger-model/ledger-privacy.rst
+++ b/sdk/docs/manually-written/overview/explanations/ledger-model/ledger-privacy.rst
@@ -325,7 +325,7 @@ Divulgence from the previous section refers to parties learning about contracts 
 Disclosure is about such parties using contracts in their own transactions.
 
 Recall from the :ref:`running example <ledger-structure_running_example>`
-that Bob uses ``submitWithDisclosures`` for the exercising ``Settle`` choice.
+that Bob uses ``submit`` with a disclosure for the exercising ``Settle`` choice.
 This is because Bob (and its Participant Node) in general does not know about the ``SimpleAsset`` contract #2
 that Alice has allocated to the proposal.
 Disclosure means that Alice tells Bob via an off-ledger communication channel about this contract.

--- a/sdk/docs/sharable/overview/explanations/ledger-model/daml/SimpleDvP.daml
+++ b/sdk/docs/sharable/overview/explanations/ledger-model/daml/SimpleDvP.daml
@@ -95,7 +95,7 @@ simpleDvp = script do
   (_, eur, usd, proposeDvP, disclosedEur) <- setup alice bob bank1 bank2
 
   -- SNIPPET-ACCEPT_AND_SETTLE-BEGIN
-  (newUsd, newEur) <- submitWithDisclosures bob [disclosedEur] do
+  (newUsd, newEur) <- submit (actAs bob <> disclose disclosedEur) $ do
       exerciseCmd proposeDvP $ AcceptAndSettle with toBeAllocated = usd
   -- SNIPPET-ACCEPT_AND_SETTLE-END
     
@@ -108,7 +108,7 @@ simpleDvp = script do
   dvp <- submit bob $
     do exerciseCmd proposeDvp $ Accept with toBeAllocated = usd
 
-  (newUsd, newEur) <- submitWithDisclosures bob [disclosedEur] do
+  (newUsd, newEur) <- submit (actAs bob <> disclose disclosedEur) $ do
       exerciseCmd dvp $ Settle with actor = bob
   -- SNIPPET-ACCEPT_THEN_SETTLE-END
 

--- a/sdk/docs/sharable/overview/explanations/ledger-model/ledger-privacy.rst
+++ b/sdk/docs/sharable/overview/explanations/ledger-model/ledger-privacy.rst
@@ -325,7 +325,7 @@ Divulgence from the previous section refers to parties learning about contracts 
 Disclosure is about such parties using contracts in their own transactions.
 
 Recall from the :ref:`running example <ledger-structure_running_example>`
-that Bob uses ``submitWithDisclosures`` for the exercising ``Settle`` choice.
+that Bob uses ``submit`` with a disclosure for the exercising ``Settle`` choice.
 This is because Bob (and its Participant Node) in general does not know about the ``SimpleAsset`` contract #2
 that Alice has allocated to the proposal.
 Disclosure means that Alice tells Bob via an off-ledger communication channel about this contract.

--- a/sdk/docs/source/overview/explanations/ledger-model/daml/SimpleDvP.daml
+++ b/sdk/docs/source/overview/explanations/ledger-model/daml/SimpleDvP.daml
@@ -95,7 +95,7 @@ simpleDvp = script do
   (_, eur, usd, proposeDvP, disclosedEur) <- setup alice bob bank1 bank2
 
   -- SNIPPET-ACCEPT_AND_SETTLE-BEGIN
-  (newUsd, newEur) <- submitWithDisclosures bob [disclosedEur] do
+  (newUsd, newEur) <- submit (actAs bob <> disclose disclosedEur) $ do
       exerciseCmd proposeDvP $ AcceptAndSettle with toBeAllocated = usd
   -- SNIPPET-ACCEPT_AND_SETTLE-END
     
@@ -108,7 +108,7 @@ simpleDvp = script do
   dvp <- submit bob $
     do exerciseCmd proposeDvp $ Accept with toBeAllocated = usd
 
-  (newUsd, newEur) <- submitWithDisclosures bob [disclosedEur] do
+  (newUsd, newEur) <- submit (actAs bob <> disclose disclosedEur) $ do
       exerciseCmd dvp $ Settle with actor = bob
   -- SNIPPET-ACCEPT_THEN_SETTLE-END
 


### PR DESCRIPTION
As pointed out by @roger-bosman-da , we should use `submit` with options.