### PR TITLE
Improve DPM resolution missing error message

### DIFF
--- a/sdk/compiler/damlc/daml-resolution-config/src/DA/Daml/Resolution/Config.hs
+++ b/sdk/compiler/damlc/daml-resolution-config/src/DA/Daml/Resolution/Config.hs
@@ -189,7 +189,7 @@ findPackageResolutionData path (ResolutionData packages) =
   Map.lookup (toPosixFilePath path) packages & \case
     Just (ErrorPackageResolutionData errs) -> Left $ ResolutionError $ "Couldn't resolve package " <> path <> ":\n" <> unlines (show <$> errs)
     Just (ValidPackageResolutionData res) -> Right res
-    Nothing -> Left $ ResolutionError $ "Failed to find DPM package resolution for " <> path <> ". This should never happen, contact support."
+    Nothing -> Left $ ResolutionError $ "DPM did not provide information for package at " <> path <> ". Is this a valid package? If you have a multi-package.yaml, is this package included?"
 
 resolutionFileEnvVar :: String
 resolutionFileEnvVar = "DPM_RESOLUTION_FILE"


### PR DESCRIPTION
As per @hrischuk-da's request, the DPM resolution missing error has been made more user friendly.
It provides two possible reasons for the error. We should aim to avoid this error ever being thrown by improving DPM's validation logic, such that DPM catches these cases first.