### PR TITLE
Allow () in user ids

### DIFF
--- a/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
+++ b/sdk/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
@@ -335,7 +335,7 @@ private[data] final class IdStringImpl extends IdString {
     new MatchingStringModule("Daml-LF Contract ID", """#[\w._:\-#/ ]{0,254}""")
 
   /** Identifiers for participant node users are non-empty strings with a length <= 128 that consist of
-    * ASCII alphanumeric characters and the symbols "@^$.!`-#+'~_|:".
+    * ASCII alphanumeric characters and the symbols "@^$.!`-#+'~_|:()".
     * This character set is chosen such that it maximizes the ease of integration with IAM systems.
     * Since the Ledger API needs to be compatible with JWT and uses the "sub" registered claim to
     * represent participant node users, the definition and use of these identifiers must keep in
@@ -343,6 +343,6 @@ private[data] final class IdStringImpl extends IdString {
     */
   override type UserId = String
   override val UserId: StringModule[UserId] =
-    new MatchingStringModule("User ID", """[a-zA-Z0-9@^$.!`\-#+'~_|:]{1,128}""")
+    new MatchingStringModule("User ID", """[a-zA-Z0-9@^$.!`\-#+'~_|:\(\)]{1,128}""")
 
 }

--- a/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RefTest.scala
+++ b/sdk/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RefTest.scala
@@ -414,7 +414,7 @@ class RefTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks w
   }
 
   "UserId" - {
-    val validCharacters = ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9') ++ "._-#!|@^$`+'~:"
+    val validCharacters = ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9') ++ "._-#!|@^$`+'~:()"
     val validUserIds =
       validCharacters.flatMap(c => Vector(c.toString, s"$c$c")) ++
         Vector(
@@ -430,6 +430,8 @@ class RefTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks w
           "windowslive|4cf0a30169d55031",
           "office365|10030000838d23ad@microsoftonline.com",
           "adfs|john@fabrikam.com",
+          "mailto:john@fabrikam.com",
+          "(usr!67324682736476)",
         )
 
     "accept valid user ids" in {
@@ -437,7 +439,7 @@ class RefTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks w
     }
 
     "reject user ids containing invalid characters" in {
-      val invalidCharacters = "àá \\%&*()=[]{};<>,?\""
+      val invalidCharacters = "àá \\%&*=[]{};<>,?\""
       val invalidUserIds = invalidCharacters.map(_.toString) :+ "john/doe"
       invalidUserIds.foreach(userId => UserId.fromString(userId) shouldBe a[Left[_, _]])
     }

--- a/sdk/docs/manually-written/sdk/sdlc-howtos/applications/secure/authorization.rst
+++ b/sdk/docs/manually-written/sdk/sdlc-howtos/applications/secure/authorization.rst
@@ -218,7 +218,7 @@ To interpret the above notation:
 Requirements for User IDs
 =========================
 
-User IDs must be non-empty strings of at most 128 characters that are either alphanumeric ASCII characters or one of the symbols "@^$.!`-#+'~_|:".
+User IDs must be non-empty strings of at most 128 characters that are either alphanumeric ASCII characters or one of the symbols "@^$.!`-#+'~_|:()".
 
 Identity providers
 ==================

--- a/sdk/docs/sharable/sdk/sdlc-howtos/applications/secure/authorization.rst
+++ b/sdk/docs/sharable/sdk/sdlc-howtos/applications/secure/authorization.rst
@@ -218,7 +218,7 @@ To interpret the above notation:
 Requirements for User IDs
 =========================
 
-User IDs must be non-empty strings of at most 128 characters that are either alphanumeric ASCII characters or one of the symbols "@^$.!`-#+'~_|:".
+User IDs must be non-empty strings of at most 128 characters that are either alphanumeric ASCII characters or one of the symbols "@^$.!`-#+'~_|:()".
 
 Identity providers
 ==================


### PR DESCRIPTION
We need to allow user ids containing (), to facilitate user name of the form demanded by ForgeRock IAM integrations: `(usr!74367645684765487567)`