### PR TITLE
Fix Blackduck Npm Scan

### DIFF
--- a/ci/blackduck.yml
+++ b/ci/blackduck.yml
@@ -83,7 +83,7 @@ jobs:
       eval "$(dev-env/bin/dade-assist)"
 
       # npm install for canton npm examples
-      (cd language-support/ts && yarn install)
+      (cd language-support/js && yarn install)
       (cd canton/community/app/src/pack/examples/09-json-api/typescript && npm install && npm ls)
 
       bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/$(blackduck_script_sha)/synopsys-detect) \
@@ -93,9 +93,9 @@ jobs:
       --detect.included.detector.types=YARN,NPM,CLANG \
       --detect.yarn.dependency.types.excluded=NON_PRODUCTION \
       --detect.follow.symbolic.links=false \
-      --detect.excluded.directories=language-support/ts/daml-ledger,language-support/ts/daml-types,language-support/ts/codegen/tests/ts,bazel-out,bazel-bin,.bazel-cache,bazel-testlogs,bazel-daml,bazel-s,node_modules,dev-env \
-      --detect.blackduck.signature.scanner.exclusion.name.patterns=language-support/ts/daml-ledger,language-support/ts/daml-types,bazel-bin,.bazel-cache,bazel-testlogs,bazel-daml,bazel-s,node_modules,dev-env \
-      --detect.detector.search.exclusion.paths=language-support/ts/daml-ledger,language-support/ts/daml-types,bazel-out,bazel-bin,.bazel-cache,bazel-testlogs,bazel-daml,bazel-s,node_modules,dev-env \
+      --detect.excluded.directories=language-support/js/daml-types,language-support/js/codegen/tests/ts,bazel-out,bazel-bin,.bazel-cache,bazel-testlogs,bazel-daml,bazel-s,node_modules,dev-env \
+      --detect.blackduck.signature.scanner.exclusion.name.patterns=language-support/js/daml-types,bazel-bin,.bazel-cache,bazel-testlogs,bazel-daml,bazel-s,node_modules,dev-env \
+      --detect.detector.search.exclusion.paths=language-support/js/daml-types,bazel-out,bazel-bin,.bazel-cache,bazel-testlogs,bazel-daml,bazel-s,node_modules,dev-env \
       --detect.notices.report=true \
       --detect.code.location.name=digital-asset_daml_npm \
       --detect.timeout=1500

--- a/sdk/language-support/js/codegen/README.md
+++ b/sdk/language-support/js/codegen/README.md
@@ -23,7 +23,7 @@ you specify via the `-o` option.
 
 The integration-test suite is started via
 ```
-bazel test //language-support/ts/codegen/tests/...
+bazel test //language-support/js/codegen/tests/...
 ```
 
 Unfortunately, this is a bit slow and not suitable for repeated running during


### PR DESCRIPTION
I broke it in #22419 when I renamed `ts` folder into `js`