### PR TITLE
[Backport 3.4] Update docs for Ooracle JDK

### DIFF
--- a/sdk/docs/manually-written/sdk/component-howtos/application-development/dpm-sandbox.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/application-development/dpm-sandbox.rst
@@ -318,16 +318,30 @@ To enable the canton dev protocol:
 
 .. code:: shell
 
-  cat <<EOF
-  canton.participants.sandbox.parameters.alpha-version-support = true
-  canton.sequencers.sequencer1.parameters.alpha-version-support = true
-  canton.parameters {
-      non-standard-config = yes
-      alpha-version-support = yes
-  }
-  EOF > dev-protocol.conf
+  dpm sandbox --dev
 
-  CANTON_PROTOCOL_VERSION=dev dpm sandbox -c dev-protocol.conf
+Run using the Oracle JDK
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using the Oracle JDK, you may likely get an error such as the following when executing transactions:
+
+.. code-block:: none
+
+   java.lang.SecurityException: JCE cannot authenticate the provider BC
+           at java.base/javax.crypto.JceSecurity.getInstance(JceSecurity.java:150)
+           at java.base/javax.crypto.Mac.getInstance(Mac.java:272)
+           at com.digitalasset.canton.crypto.provider.jce.JcePureCrypto.$anonfun$computeHmacWithSecretInternal$1(JcePureCrypto.scala:873)
+           (...)
+
+The reason is that the Canton JAR embeds the BouncyCastle provider, and the Oracle JVM requires to verify the signature of third-party security libraries.
+
+In this case, you need to download the `BouncyCastle JAR file <https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on/1.70>`__ and explicitly provide it on the class path while running the sandbox as follows:
+
+.. code:: shell
+
+   java -cp bcprov-jdk15on-1.70.jar:$HOME/.dpm/cache/components/canton-enterprise/3.4.10/lib/canton-enterprise-3.4.10.jar com.digitalasset.canton.CantonEnterpriseApp sandbox
+
+replacing `3.4.10` with your appropriate Canton version.
 
 
 Troubleshoot

--- a/sdk/docs/sharable/sdk/component-howtos/application-development/dpm-sandbox.rst
+++ b/sdk/docs/sharable/sdk/component-howtos/application-development/dpm-sandbox.rst
@@ -318,16 +318,30 @@ To enable the canton dev protocol:
 
 .. code:: shell
 
-  cat <<EOF
-  canton.participants.sandbox.parameters.alpha-version-support = true
-  canton.sequencers.sequencer1.parameters.alpha-version-support = true
-  canton.parameters {
-      non-standard-config = yes
-      alpha-version-support = yes
-  }
-  EOF > dev-protocol.conf
+  dpm sandbox --dev
 
-  CANTON_PROTOCOL_VERSION=dev dpm sandbox -c dev-protocol.conf
+Run using the Oracle JDK
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using the Oracle JDK, you may likely get an error such as the following when executing transactions:
+
+.. code-block:: none
+
+   java.lang.SecurityException: JCE cannot authenticate the provider BC
+           at java.base/javax.crypto.JceSecurity.getInstance(JceSecurity.java:150)
+           at java.base/javax.crypto.Mac.getInstance(Mac.java:272)
+           at com.digitalasset.canton.crypto.provider.jce.JcePureCrypto.$anonfun$computeHmacWithSecretInternal$1(JcePureCrypto.scala:873)
+           (...)
+
+The reason is that the Canton JAR embeds the BouncyCastle provider, and the Oracle JVM requires to verify the signature of third-party security libraries.
+
+In this case, you need to download the `BouncyCastle JAR file <https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on/1.70>`__ and explicitly provide it on the class path while running the sandbox as follows:
+
+.. code:: shell
+
+   java -cp bcprov-jdk15on-1.70.jar:$HOME/.dpm/cache/components/canton-enterprise/3.4.10/lib/canton-enterprise-3.4.10.jar com.digitalasset.canton.CantonEnterpriseApp sandbox
+
+replacing `3.4.10` with your appropriate Canton version.
 
 
 Troubleshoot


### PR DESCRIPTION
As followup to [DA-3171](https://digitalasset.atlassian.net/browse/DA-3171)

Fixes https://github.com/DACH-NY/canton/issues/30613


[DA-3171]: https://digitalasset.atlassian.net/browse/DA-3171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ