### PR TITLE
fix minor language version parsing

### DIFF
--- a/sdk/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version/VersionUtil.hs
+++ b/sdk/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version/VersionUtil.hs
@@ -11,7 +11,7 @@ import           Data.Char (isDigit)
 import qualified DA.Daml.LF.Ast.Range as R
 import qualified Data.Text as T
 import           Safe (headMay)
-import           Text.ParserCombinators.ReadP (ReadP, pfail, readP_to_S, (+++), munch1)
+import           Text.ParserCombinators.ReadP (ReadP, pfail, readP_to_S, (+++), munch1, eof)
 import qualified Text.ParserCombinators.ReadP as ReadP
 import qualified Data.Map.Strict as MS
 
@@ -114,7 +114,7 @@ readMinorVersion = readStable +++ readDev
 -- >>> parseMinorVersion "garbage"
 -- Nothing
 parseMinorVersion :: String -> Maybe MinorVersion
-parseMinorVersion = headMay . map fst . readP_to_S readMinorVersion
+parseMinorVersion = headMay . map fst . readP_to_S (readMinorVersion <* eof)
 
 readVersion :: ReadP Version
 readVersion = do


### PR DESCRIPTION
Turns out parsing was "broken" all this time in the sense that we didn't check eof, so we would be able to parse 2.3garbage as 2.3