### PR TITLE
`[backport 3.4] update to not point to 2.x daml.yaml schema file

### DIFF
--- a/sdk/templates/multi-package-example/interfaces/daml.yaml.template
+++ b/sdk/templates/multi-package-example/interfaces/daml.yaml.template
@@ -1,5 +1,5 @@
 # for config file options, refer to
-# https://docs.daml.com/tools/assistant.html#project-config-file-daml-yaml
+# https://docs.digitalasset.com/build/3.4/component-howtos/smart-contracts/assistant/config-files.html
 
 sdk-version: __VERSION__
 name: __PROJECT_NAME__-interfaces

--- a/sdk/templates/multi-package-example/main/daml.yaml.template
+++ b/sdk/templates/multi-package-example/main/daml.yaml.template
@@ -1,5 +1,5 @@
 # for config file options, refer to
-# https://docs.daml.com/tools/assistant.html#project-config-file-daml-yaml
+# https://docs.digitalasset.com/build/3.4/component-howtos/smart-contracts/assistant/config-files.html
 
 sdk-version: __VERSION__
 name: __PROJECT_NAME__-main

--- a/sdk/templates/multi-package-example/test/daml.yaml.template
+++ b/sdk/templates/multi-package-example/test/daml.yaml.template
@@ -1,5 +1,5 @@
 # for config file options, refer to
-# https://docs.daml.com/tools/assistant.html#project-config-file-daml-yaml
+# https://docs.digitalasset.com/build/3.4/component-howtos/smart-contracts/assistant/config-files.html
 
 sdk-version: __VERSION__
 name: __PROJECT_NAME__-test

--- a/sdk/templates/skeleton/daml.yaml.template
+++ b/sdk/templates/skeleton/daml.yaml.template
@@ -1,5 +1,5 @@
 # for config file options, refer to
-# https://docs.daml.com/tools/assistant.html#project-config-file-daml-yaml
+# https://docs.digitalasset.com/build/3.4/component-howtos/smart-contracts/assistant/config-files.html
 
 sdk-version: __VERSION__
 name: __PROJECT_NAME__

--- a/sdk/templates/upgrades-example/interfaces/daml.yaml.template
+++ b/sdk/templates/upgrades-example/interfaces/daml.yaml.template
@@ -1,5 +1,5 @@
 # for config file options, refer to
-# https://docs.daml.com/tools/assistant.html#project-config-file-daml-yaml
+# https://docs.digitalasset.com/build/3.4/component-howtos/smart-contracts/assistant/config-files.html
 
 sdk-version: __VERSION__
 name: __PROJECT_NAME__-interfaces

--- a/sdk/templates/upgrades-example/main-v1/daml.yaml.template
+++ b/sdk/templates/upgrades-example/main-v1/daml.yaml.template
@@ -1,5 +1,5 @@
 # for config file options, refer to
-# https://docs.daml.com/tools/assistant.html#project-config-file-daml-yaml
+# https://docs.digitalasset.com/build/3.4/component-howtos/smart-contracts/assistant/config-files.html
 
 sdk-version: __VERSION__
 name: __PROJECT_NAME__-main

--- a/sdk/templates/upgrades-example/main-v2/daml.yaml.template
+++ b/sdk/templates/upgrades-example/main-v2/daml.yaml.template
@@ -1,5 +1,5 @@
 # for config file options, refer to
-# https://docs.daml.com/tools/assistant.html#project-config-file-daml-yaml
+# https://docs.digitalasset.com/build/3.4/component-howtos/smart-contracts/assistant/config-files.html
 
 sdk-version: __VERSION__
 name: __PROJECT_NAME__-main

--- a/sdk/templates/upgrades-example/test/daml.yaml.template
+++ b/sdk/templates/upgrades-example/test/daml.yaml.template
@@ -1,5 +1,5 @@
 # for config file options, refer to
-# https://docs.daml.com/tools/assistant.html#project-config-file-daml-yaml
+# https://docs.digitalasset.com/build/3.4/component-howtos/smart-contracts/assistant/config-files.html
 
 sdk-version: __VERSION__
 name: __PROJECT_NAME__-test


### PR DESCRIPTION
# Problem Statement
`dpm new ...` templates point to 2.x docs for daml.yaml schema

Instead the docs link in the generated daml.yaml should point to up to date 3.x docs