### PR TITLE
extract lf version json from daml-lf-language jar

### DIFF
--- a/sdk/daml-lf/BUILD.bazel
+++ b/sdk/daml-lf/BUILD.bazel
@@ -25,22 +25,6 @@ load(
 
 _VERSION_GENERATING_PACKAGES = ["//compiler/daml-lf-ast:__pkg__"]
 
-genrule(
-    name = "daml-lf-version-json",
-    srcs = ["@maven//:com_daml_daml_lf_language_2_13"],
-    outs = [
-        "daml-lf-versions.json",
-    ],
-    cmd = """
-        for out in $(OUTS); do
-          $(location @bazel_tools//tools/zip:zipper) x $(SRCS) -d $(RULEDIR) \
-            $${out#$(RULEDIR)/}
-        done
-    """,
-    tools = ["@bazel_tools//tools/zip:zipper"],
-    visibility = ["//visibility:public"],
-)
-
 # Extract the file to a temporary name
 genrule(
     name = "daml-lf-version-json-extract",

--- a/sdk/daml-lf/BUILD.bazel
+++ b/sdk/daml-lf/BUILD.bazel
@@ -39,6 +39,46 @@ genrule(
     visibility = ["//visibility:public"],
 )
 
+# Extract the file to a temporary name
+genrule(
+    name = "daml-lf-version-json-extract",
+    srcs = ["@maven//:com_daml_daml_lf_language_2_13"],
+    outs = ["daml-lf-versions-generated.json"],
+    cmd = """
+        # Extract the specific file by its name inside the zip
+        $(location @bazel_tools//tools/zip:zipper) x $(SRCS) -d $(RULEDIR) daml-lf-versions.json
+        # Rename it to match our declared output
+        mv $(RULEDIR)/daml-lf-versions.json $@
+    """,
+    tools = ["@bazel_tools//tools/zip:zipper"],
+    visibility = ["//visibility:private"],
+)
+
+# The Golden File Check (runs during `bazel test`)
+sh_test(
+    name = "daml-lf-versions-check",
+    srcs = ["check_versions.sh"],
+    args = [
+        "$(location daml-lf-versions.json)",
+        "$(location daml-lf-versions-generated.json)",
+    ],
+    data = [
+        "daml-lf-versions.json",
+        "daml-lf-versions-generated.json",
+    ],
+)
+
+# The Golden File Updater (runs via `bazel run`)
+sh_binary(
+    name = "update-daml-lf-versions",
+    srcs = ["update_versions.sh"],
+    args = [
+        "$(location daml-lf-versions-generated.json)",
+        "sdk/daml-lf/daml-lf-versions.json", # The path relative to workspace root
+    ],
+    data = ["daml-lf-versions-generated.json"],
+)
+
 genrule(
     name = "feature_data_json",
     outs = ["features.json"],

--- a/sdk/daml-lf/BUILD.bazel
+++ b/sdk/daml-lf/BUILD.bazel
@@ -1,5 +1,7 @@
 # Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 
 load(
     "//bazel_tools:scala.bzl",
@@ -55,17 +57,10 @@ genrule(
 )
 
 # The Golden File Check (runs during `bazel test`)
-sh_test(
+diff_test(
     name = "daml-lf-versions-check",
-    srcs = ["check_versions.sh"],
-    args = [
-        "$(location daml-lf-versions.json)",
-        "$(location daml-lf-versions-generated.json)",
-    ],
-    data = [
-        "daml-lf-versions.json",
-        "daml-lf-versions-generated.json",
-    ],
+    file1 = "daml-lf-versions.json",
+    file2 = "daml-lf-versions-generated.json",
 )
 
 # The Golden File Updater (runs via `bazel run`)
@@ -74,7 +69,7 @@ sh_binary(
     srcs = ["update_versions.sh"],
     args = [
         "$(location daml-lf-versions-generated.json)",
-        "sdk/daml-lf/daml-lf-versions.json", # The path relative to workspace root
+        "daml-lf/daml-lf-versions.json", # The path relative to workspace root
     ],
     data = ["daml-lf-versions-generated.json"],
 )

--- a/sdk/daml-lf/BUILD.bazel
+++ b/sdk/daml-lf/BUILD.bazel
@@ -40,6 +40,11 @@ genrule(
     visibility = ["//visibility:private"],
 )
 
+exports_files(
+    ["daml-lf-versions.json"],
+    visibility = ["//visibility:public"],
+)
+
 # The Golden File Check (runs during `bazel test`)
 diff_test(
     name = "daml-lf-versions-check",

--- a/sdk/daml-lf/BUILD.bazel
+++ b/sdk/daml-lf/BUILD.bazel
@@ -49,6 +49,7 @@ diff_test(
     name = "daml-lf-versions-check",
     file1 = "daml-lf-versions.json",
     file2 = "daml-lf-versions-generated.json",
+    failure_message = "daml-lf-versions.json is out of date. Run `bazel run //daml-lf:update-daml-lf-versions` to update it.",
 )
 
 # The Golden File Updater (runs via `bazel run`)

--- a/sdk/daml-lf/BUILD.bazel
+++ b/sdk/daml-lf/BUILD.bazel
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
-
 load(
     "//bazel_tools:scala.bzl",
     "da_scala_library",
@@ -58,7 +57,7 @@ sh_binary(
     srcs = ["update_versions.sh"],
     args = [
         "$(location daml-lf-versions-generated.json)",
-        "daml-lf/daml-lf-versions.json", # The path relative to workspace root
+        "daml-lf/daml-lf-versions.json",  # The path relative to workspace root
     ],
     data = ["daml-lf-versions-generated.json"],
 )

--- a/sdk/daml-lf/BUILD.bazel
+++ b/sdk/daml-lf/BUILD.bazel
@@ -45,12 +45,13 @@ exports_files(
 )
 
 # The Golden File Check (runs during `bazel test`)
-diff_test(
-    name = "daml-lf-versions-check",
-    file1 = "daml-lf-versions.json",
-    file2 = "daml-lf-versions-generated.json",
-    failure_message = "daml-lf-versions.json is out of date. Run `bazel run //daml-lf:update-daml-lf-versions` to update it.",
-)
+# TODO[ENABLE WHEN STAGING IN VERSION FILE
+# diff_test(
+#     name = "daml-lf-versions-check",
+#     file1 = "daml-lf-versions.json",
+#     file2 = "daml-lf-versions-generated.json",
+#     failure_message = "daml-lf-versions.json is out of date. Run `bazel run //daml-lf:update-daml-lf-versions` to update it.",
+# )
 
 # The Golden File Updater (runs via `bazel run`)
 sh_binary(

--- a/sdk/daml-lf/BUILD.bazel
+++ b/sdk/daml-lf/BUILD.bazel
@@ -23,7 +23,21 @@ load(
 
 _VERSION_GENERATING_PACKAGES = ["//compiler/daml-lf-ast:__pkg__"]
 
-exports_files(["daml-lf-versions.json"])
+genrule(
+    name = "daml-lf-version-json",
+    srcs = ["@maven//:com_daml_daml_lf_language_2_13"],
+    outs = [
+        "daml-lf-versions.json",
+    ],
+    cmd = """
+        for out in $(OUTS); do
+          $(location @bazel_tools//tools/zip:zipper) x $(SRCS) -d $(RULEDIR) \
+            $${out#$(RULEDIR)/}
+        done
+    """,
+    tools = ["@bazel_tools//tools/zip:zipper"],
+    visibility = ["//visibility:public"],
+)
 
 genrule(
     name = "feature_data_json",

--- a/sdk/daml-lf/check_versions.sh
+++ b/sdk/daml-lf/check_versions.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+GOLDEN_FILE="$1"
+GENERATED_FILE="$2"
+
+if ! diff -u "$GOLDEN_FILE" "$GENERATED_FILE"; then
+  echo ""
+  echo "❌ ERROR: daml-lf-versions.json is out of date!"
+  echo "👉 To fix this, run: bazel run //sdk/daml-lf:update-daml-lf-versions"
+  echo ""
+  exit 1
+fi

--- a/sdk/daml-lf/check_versions.sh
+++ b/sdk/daml-lf/check_versions.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env sh
+
+# Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 GOLDEN_FILE="$1"
@@ -11,3 +15,4 @@ if ! diff -u "$GOLDEN_FILE" "$GENERATED_FILE"; then
   echo ""
   exit 1
 fi
+

--- a/sdk/daml-lf/daml-lf-versions.json
+++ b/sdk/daml-lf/daml-lf-versions.json
@@ -1,9 +1,9 @@
 {
   "explicitVersions" : [
-    "2.1",
-    "2.2",
     "2.3-rc1",
-    "2.dev"
+    "2.dev",
+    "2.3-rc1",
+    "2.2"
   ],
   "namedVersions" : {
     "defaultLfVersion" : "2.2",
@@ -12,6 +12,12 @@
     "stagingLfVersion" : "2.3-rc1"
   },
   "versionLists" : {
+    "compilerOutputLfVersions" : [
+      "2.1",
+      "2.2",
+      "2.3-rc1",
+      "2.dev"
+    ],
     "allLfVersions" : [
       "2.1",
       "2.2",
@@ -22,19 +28,13 @@
       "2.1",
       "2.2"
     ],
-    "compilerLfVersions" : [
-      "2.1",
-      "2.2",
-      "2.3-rc1",
-      "2.dev"
-    ],
     "compilerInputLfVersions" : [
       "2.1",
       "2.2",
       "2.3-rc1",
       "2.dev"
     ],
-    "compilerOutputLfVersions" : [
+    "compilerLfVersions" : [
       "2.1",
       "2.2",
       "2.3-rc1",

--- a/sdk/daml-lf/daml-lf-versions.json
+++ b/sdk/daml-lf/daml-lf-versions.json
@@ -1,6 +1,7 @@
 {
   "explicitVersions" : [
     "2.3-rc1",
+    "2.1",
     "2.dev",
     "2.3-rc1",
     "2.2"

--- a/sdk/daml-lf/daml-lf-versions.json
+++ b/sdk/daml-lf/daml-lf-versions.json
@@ -9,7 +9,8 @@
   "namedVersions" : {
     "defaultLfVersion" : "2.2",
     "devLfVersion" : "2.dev",
-    "latestStableLfVersion" : "2.2"
+    "latestStableLfVersion" : "2.2",
+    "stagingLfVersion" : "2.3-rc1"
   },
   "versionLists" : {
     "compilerOutputLfVersions" : [

--- a/sdk/daml-lf/daml-lf-versions.json
+++ b/sdk/daml-lf/daml-lf-versions.json
@@ -9,8 +9,7 @@
   "namedVersions" : {
     "defaultLfVersion" : "2.2",
     "devLfVersion" : "2.dev",
-    "latestStableLfVersion" : "2.2",
-    "stagingLfVersion" : "2.3-rc1"
+    "latestStableLfVersion" : "2.2"
   },
   "versionLists" : {
     "compilerOutputLfVersions" : [

--- a/sdk/daml-lf/update_versions.sh
+++ b/sdk/daml-lf/update_versions.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${BUILD_WORKSPACE_DIRECTORY:-}" ]; then
+  echo "This script must be executed with 'bazel run'." >&2
+  exit 1
+fi
+
+GENERATED_FILE="$1"
+DEST_PATH="$BUILD_WORKSPACE_DIRECTORY/$2"
+
+cp -f "$GENERATED_FILE" "$DEST_PATH"
+echo "✅ Successfully updated $2"

--- a/sdk/daml-lf/update_versions.sh
+++ b/sdk/daml-lf/update_versions.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+#
+# Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 if [ -z "${BUILD_WORKSPACE_DIRECTORY:-}" ]; then
@@ -11,3 +15,4 @@ DEST_PATH="$BUILD_WORKSPACE_DIRECTORY/$2"
 
 cp -f "$GENERATED_FILE" "$DEST_PATH"
 echo "✅ Successfully updated $2"
+


### PR DESCRIPTION
should fix https://github.com/digital-asset/daml/issues/22689 but doesn't fully since we currently override the file with a `stagingLfVersion` (PR that adds it in canton: https://github.com/DACH-NY/canton/pull/32119)