### PR TITLE
Document allowing `()` in user ids (#22617)

### DIFF
--- a/sdk/docs/manually-written/sdk/sdlc-howtos/applications/secure/authorization.rst
+++ b/sdk/docs/manually-written/sdk/sdlc-howtos/applications/secure/authorization.rst
@@ -218,7 +218,7 @@ To interpret the above notation:
 Requirements for User IDs
 =========================
 
-User IDs must be non-empty strings of at most 128 characters that are either alphanumeric ASCII characters or one of the symbols "@^$.!`-#+'~_|:".
+User IDs must be non-empty strings of at most 128 characters that are either alphanumeric ASCII characters or one of the symbols "@^$.!`-#+'~_|:()".
 
 Identity providers
 ==================

--- a/sdk/docs/sharable/sdk/sdlc-howtos/applications/secure/authorization.rst
+++ b/sdk/docs/sharable/sdk/sdlc-howtos/applications/secure/authorization.rst
@@ -218,7 +218,7 @@ To interpret the above notation:
 Requirements for User IDs
 =========================
 
-User IDs must be non-empty strings of at most 128 characters that are either alphanumeric ASCII characters or one of the symbols "@^$.!`-#+'~_|:".
+User IDs must be non-empty strings of at most 128 characters that are either alphanumeric ASCII characters or one of the symbols "@^$.!`-#+'~_|:()".
 
 Identity providers
 ==================


### PR DESCRIPTION
We need to allow user ids containing (), to facilitate user name of the form demanded by ForgeRock IAM integrations:
`(usr!74367645684765487567)`