### PR TITLE
default to v35 in 'daml sandbox'

### DIFF
--- a/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -309,7 +309,7 @@ withCantonSandbox options remainingArgs k = do
             , "import com.digitalasset.canton.config.RequireTypes.PositiveInt"
             , "import com.digitalasset.canton.version.ProtocolVersion"
             , ""
-            , "val staticSynchronizerParameters = StaticSynchronizerParameters.defaults(sequencer1.config.crypto, ProtocolVersion.latest, topologyChangeDelay = NonNegativeFiniteDuration.Zero)"
+            , "val staticSynchronizerParameters = StaticSynchronizerParameters.defaults(sequencer1.config.crypto, ProtocolVersion.v35, topologyChangeDelay = NonNegativeFiniteDuration.Zero)"
             , "val synchronizerOwners = Seq(sequencer1, mediator1)"
             , "bootstrap.synchronizer(\"mysynchronizer\", Seq(sequencer1), Seq(mediator1), synchronizerOwners, PositiveInt.one, staticSynchronizerParameters)"
             , "sandbox.synchronizers.connect_local(sequencer1, \"mysynchronizer\")"


### PR DESCRIPTION
This is needed for testing MUT. Ideally we'd offer a way to pick the PV, but that's lower priority than getting these MUT tests to pass.