### PR TITLE
set support-alpha-version=yes in daml sandbox

### DIFF
--- a/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/sdk/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -352,6 +352,9 @@ cantonConfig CantonOptions{..} =
                 , [ "clock" Aeson..= Aeson.object
                         [ "type" Aeson..= ("sim-clock" :: T.Text) ]
                   | StaticTime True <- [cantonStaticTime] ]
+                , [ "alpha-version-support" Aeson..= True
+                  , "non-standard-config" Aeson..= True
+                  ]
                 ] )
             , "participants" Aeson..= Aeson.object
                 [ "sandbox" Aeson..= Aeson.object
@@ -363,7 +366,8 @@ cantonConfig CantonOptions{..} =
                          , "user-management-service" Aeson..= Aeson.object [ "enabled" Aeson..= True ]
                          -- Can be dropped once user mgmt is enabled by default
                          ]
-
+                     , "parameters"  Aeson..= Aeson.object
+                         [ "alpha-version-support" Aeson..= True ]
                      ] <>
                      [ "testing-time" Aeson..= Aeson.object [ "type" Aeson..= ("monotonic-time" :: T.Text) ]
                      | StaticTime True <- [cantonStaticTime]


### PR DESCRIPTION
https://github.com/digital-asset/daml/pull/22862 defaults `daml sandbox` to pv35, but without `support-alpha-version=yes`, it won't accept LF 2.3 dars. This fixes it.