### PR TITLE
Fix contract id in key error message on grpc ledger

### DIFF
--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/grpcLedgerClient/GrpcLedgerClient.scala
@@ -1,7 +1,8 @@
 // Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.daml.lf.engine.script
+package com.digitalasset.daml.lf.engine
+package script
 package v2.ledgerinteraction
 package grpcLedgerClient
 
@@ -49,7 +50,9 @@ import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.data.{Bytes, Ref, Time}
 import com.digitalasset.daml.lf.engine.script.v2.Converter
 import com.digitalasset.daml.lf.engine.{Enricher, ResultDone, preprocessing}
+import com.digitalasset.daml.lf.interpretation.Error.ContractIdInContractKey
 import com.digitalasset.daml.lf.language.{Ast, LanguageVersion, Reference}
+import com.digitalasset.daml.lf.speedy.Pretty
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.ContractId
 import com.digitalasset.canton.ledger.api.util.LfEngineToApi.{
@@ -379,8 +382,15 @@ class GrpcLedgerClient(
     Future(
       preprocessor
         .unsafePreprocessApiContractKey(Map.empty, ApiContractKey(templateId.toRef, key))
-        .hash
     )
+      .recoverWith { case Error.Preprocessing.ContractIdInContractKey(key) =>
+        Future.failed(
+          new RuntimeException(
+            Pretty.prettyDamlException(ContractIdInContractKey(key)).renderWideStream.mkString
+          )
+        )
+      }
+      .map(_.hash)
 
   override def queryNByKey(
       parties: OneAnd[Set, Ref.Party],


### PR DESCRIPTION
The error reported when running `queryContractKey` on a key with a contract id differed between ide-ledger and grpc
Previously ide-ledger gave 
```
Contract IDs are not supported in contract keys: 00a4a51ecf4cfa5ef5b2d6708698092d722917b940990cba8cfe866666ab8c245538b09c66e55ae30e009868c092c9e931073cfb7d353f2c0c7da75a549e3949cf
```
and grpc gave 
```
ContractIdInContractKey(Record(Some(5aee9b21b8e9a4c4975b5f4c4198e6e6e8469df49e2010820e792f393db870f4:DA.Types:Tuple2),ImmArray((Some(_1),Party(Alice-ContractIdInContractKeySkipCheck:queryCrashes-d4d95138::122022a8b27657d7a4978394d37ace47577dd263d8bd75ba26c9aae15a3b5e79d45e)),(Some(_2),Record(Some(71c5e1f58fb8e76b6ede77d3a56e1e2d940895cfafea5fa21be454f85af97308:ContractIdInContractKeySkipCheckType2:ContractId2),ImmArray((Some(unpack),ContractId(ContractId(00bb5db2425abb9e73e1bab1f921963ef7bd25c246d060fa9755427ee7ad4f91f7ca121220f278a315622ccb10ee7b5daaba7ab31ab6425b467c75a401270a151e93024884)))))))))
```
Now both give the former

Created to fix #17554, which turned out to not be a huge issue, as the error was correct, but consistency is good