### PR TITLE
Assign more precise issues to NUCK todos

### DIFF
--- a/sdk/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -66,7 +66,7 @@ main = withSdkVersions $ do
                 [ withResourceCps
                     (withScriptService lfVersion Nothing)
                     (testScriptServiceWithKeys lfVersion)
-                -- TODO (canton#30398) Change the feature min-bound to LF.defaultLfVersion once 2.3 becomes default
+                -- TODO (canton#31925) Change the feature min-bound to LF.defaultLfVersion once 2.3 becomes default
                 | Just lfVersion <- [LF.minBound $ LF.featureVersionReq LF.featureContractKeys]
                 ]
             ]

--- a/sdk/daml-script/test/BUILD.bazel
+++ b/sdk/daml-script/test/BUILD.bazel
@@ -272,7 +272,7 @@ daml_compile(
         "//daml-script/daml:daml-script-2.3-staging.dar",
     ],
     project_name = "upgrade-test-lib",
-    # TODO(https://github.com/DACH-NY/canton/issues/30398): revert to DEFAULT_LF_VERSION once LF 2.3 is stable
+    # TODO(https://github.com/DACH-NY/canton/issues/31925): revert to DEFAULT_LF_VERSION once LF 2.3 is stable
     target = STAGING_LF_VERSION,
     version = "1.0.0",
 )

--- a/sdk/daml-script/test/daml/upgrades/stable/ContractKeys.daml
+++ b/sdk/daml-script/test/daml/upgrades/stable/ContractKeys.daml
@@ -147,7 +147,7 @@ main = tests
   , subtree "LookupN and QueryN behaviour"
     [ ("query can upgrade and downgrade at the same time", queryNUpgradeDowngrade)
     , ("query fail if any contract cannot be downgraded", queryNFailedDowngrade)
-    , -- TODO(canton#30398) Remove once NUCK works in canton
+    , -- TODO(canton#31926) Remove once NUCK works in canton
       brokenOnCanton ("lookup can upgrade and downgrade at the same time", lookupNUpgradeDowngrade)
     , ("lookup fail if any contract cannot be downgraded", lookupNFailedDowngrade)
     ]

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/CompileUpgradeTestCases.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/CompileUpgradeTestCases.scala
@@ -39,7 +39,7 @@ object CompileUpgradeTestCases {
 
   private val targets: Seq[Target] = Seq(
     Target(
-      // TODO(https://github.com/DACH-NY/canton/issues/30398): revert to LanguageVersion.latestStableLfVersion once
+      // TODO(https://github.com/DACH-NY/canton/issues/31925): revert to LanguageVersion.latestStableLfVersion once
       //  LF 2.3 is stable
       LanguageVersion.v2_3,
       rlocation(Paths.get("daml-script/test/upgrade-test-lib.dar")),

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/DamlScriptTestRunnerDev.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/DamlScriptTestRunnerDev.scala
@@ -37,7 +37,7 @@ class DamlScriptTestRunnerDev extends DamlScriptTestRunner {
            |Submit:truncatedError FAILURE (com.digitalasset.daml.lf.engine.free.InterpretationError: Error: User failure: UNHANDLED_EXCEPTION/DA.Exception.GeneralError:GeneralError (error category 9): EXPECTED_TRUNCATED_ERROR)
            |Submit:wronglyTypedContract SUCCESS
            |""".stripMargin,
-        // TODO[canton#30398]: put line below back in
+        // TODO[canton#31926]: put line below back in
         // |Submit:prefetchContractKeys SUCCESS
       )
 

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/DamlScriptTestRunnerPV35.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/DamlScriptTestRunnerPV35.scala
@@ -10,7 +10,7 @@ import org.scalatest.Suite
 
 import java.nio.file.Paths
 
-// TODO (canton#30398) Change this to DamlScriptTestRunnerPVLatest, and update/remove protocolVersion to reflect that
+// TODO (canton#31925) Change this to DamlScriptTestRunnerPVLatest, and update/remove protocolVersion to reflect that
 // once PV35 is the default/out of alpha
 
 class DamlScriptTestRunnerPV35 extends DamlScriptTestRunner {

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/UpgradesIT.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/UpgradesIT.scala
@@ -210,7 +210,7 @@ class UpgradesIT(
 // safe to break down tests into many classes like this.
 class UpgradesITSmallStable
     extends UpgradesIT(
-      // TODO(https://github.com/DACH-NY/canton/issues/30398): revert to ProtocolVersion.latest and
+      // TODO(https://github.com/DACH-NY/canton/issues/31925): revert to ProtocolVersion.latest and
       //  LanguageVersion.latestStableLfVersion once v35 is stable
       cantonProtocolVersion = ProtocolVersion.Explicit("v35"),
       languageVersion = LanguageVersion.v2_3,
@@ -222,7 +222,7 @@ class UpgradesITSmallStable
 
 class UpgradesITLargeStable
     extends UpgradesIT(
-      // TODO(https://github.com/DACH-NY/canton/issues/30398): revert to ProtocolVersion.latest and
+      // TODO(https://github.com/DACH-NY/canton/issues/31925): revert to ProtocolVersion.latest and
       //  LanguageVersion.latestStableLfVersion once v35 is stable
       cantonProtocolVersion = ProtocolVersion.Explicit("v35"),
       languageVersion = LanguageVersion.v2_3,

--- a/sdk/docs/BUILD.bazel
+++ b/sdk/docs/BUILD.bazel
@@ -464,7 +464,7 @@ daml_test(
 )
 
 # Disabled as template uses keys and rollbacks, which is no longer permitted
-# TODO: (canton#30398) Remove/refactor this template and re-enable the test
+# TODO: (canton#31927) Remove/refactor this template and re-enable the test
 # [
 #     daml_test(
 #         name = "daml-intro-exceptions-daml-test-{}".format(version),


### PR DESCRIPTION
The two remaining TODOs pointing to the umbrella issue are addressed in https://github.com/digital-asset/daml/pull/22871, soon to be merged.