### PR TITLE
Add --list-scripts-json flag to daml-script

### DIFF
--- a/sdk/UNRELEASED.md
+++ b/sdk/UNRELEASED.md
@@ -9,6 +9,9 @@ schedule, i.e. if you add an entry effective at or after the first
 header, prepend the new date header that corresponds to the
 Wednesday after your change.
 
+## Until 2026-04-14 (Exclusive)
+- Added --list-scripts-json flag to `dpm script`, for listing all script names in a DAR
+
 ## Until 2026-03-31 (Exclusive)
 - Codegen-java: Added support for `UnknownTrailingFieldPolicy` in the generated `fromCreatedEvent()` method.
 - Support NUCK in IDE ledger

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -48,7 +48,7 @@ object ScriptTimeMode {
 }
 
 object RunnerMain {
-  def main(config: RunnerMainConfig): Unit = {
+  def main(action: RunnerAction): Unit = {
     implicit val system: ActorSystem = ActorSystem("RunnerMain")
     implicit val sequencer: ExecutionSequencerFactory =
       new PekkoExecutionSequencerPool("ScriptCliRunnerPool")(system)
@@ -56,7 +56,7 @@ object RunnerMain {
     implicit val materializer: Materializer = Materializer(system)
     implicit val traceContext: TraceContext = TraceContext.empty
 
-    val flow = run(config)
+    val flow = run(action)
 
     flow.onComplete(_ => system.terminate())
 
@@ -78,7 +78,26 @@ object RunnerMain {
       acc.flatMap(bs => f(nxt).map(b => bs :+ b))
     }
 
-  def run(config: RunnerMainConfig)(implicit
+  def getScriptTests(
+      dar: Dar[(PackageId, Package)],
+      compiledPackages: PureCompiledPackages,
+      excludes: Seq[String] = Seq(),
+  ): Seq[Identifier] =
+    dar.main._2.modules.flatMap { case (moduleName, module) =>
+      module.definitions.collect(Function.unlift { case (name, _) =>
+        val id = Identifier(dar.main._1, QualifiedName(moduleName, name))
+        ScriptAction.fromIdentifier(compiledPackages, id) match {
+          // We exclude generated identifiers starting with `$`.
+          case Right(_: ScriptAction.NoParam)
+              if !name.dottedName.startsWith("$") &&
+                !excludes.contains(id.qualifiedName.toString) =>
+            Some(id)
+          case _ => None
+        }
+      })
+    }.toSeq
+
+  def run(action: RunnerAction)(implicit
       sequencer: ExecutionSequencerFactory,
       ec: ExecutionContext,
       materializer: Materializer,
@@ -86,15 +105,41 @@ object RunnerMain {
   ): Future[Boolean] =
     for {
       _ <- Future.successful(())
-      machineLogger = ScriptMachineLogger()
 
-      dar: Dar[(PackageId, Package)] = DarDecoder.assertReadArchiveFromFile(config.darPath)
-
-      majorVersion = dar.main._2.languageVersion.major
+      dar: Dar[(PackageId, Package)] = DarDecoder.assertReadArchiveFromFile(action.darPath)
       compiledPackages = PureCompiledPackages.assertBuild(
         dar.all.toMap,
         defaultCompilerConfig,
       )
+
+      success <- action match {
+        case RunnerAction.RunScripts(config) => runScripts(config, dar, compiledPackages)
+        case RunnerAction.ListScripts(_, jsonOutputPath) =>
+          Future {
+            val scriptNames = getScriptTests(dar, compiledPackages)
+            val scriptNamesJsVal =
+              JsArray(scriptNames.map(_.qualifiedName.toString).map(JsString(_)).toVector)
+            Files.write(jsonOutputPath.toPath, Seq(scriptNamesJsVal.prettyPrint).asJava)
+            true
+          }
+      }
+    } yield success
+
+  def runScripts(
+      config: RunnerMainConfig,
+      dar: Dar[(PackageId, Package)],
+      compiledPackages: PureCompiledPackages,
+  )(implicit
+      sequencer: ExecutionSequencerFactory,
+      ec: ExecutionContext,
+      materializer: Materializer,
+      traceContext: TraceContext,
+  ): Future[Boolean] =
+    for {
+      _ <- Future.successful(())
+
+      machineLogger = ScriptMachineLogger()
+      majorVersion = dar.main._2.languageVersion.major
       ifaceDar =
         dar.map { case (pkgId, _) =>
           SignatureReader
@@ -190,22 +235,7 @@ object RunnerMain {
 
       success <- config.runMode match {
         case RunnerMainConfig.RunMode.RunExcluding(excludes) => {
-          val testScripts: Seq[Identifier] = dar.main._2.modules.flatMap {
-            case (moduleName, module) =>
-              module.definitions.collect(Function.unlift { case (name, _) =>
-                val id = Identifier(dar.main._1, QualifiedName(moduleName, name))
-                ScriptAction.fromIdentifier(compiledPackages, id) match {
-                  // We exclude generated identifiers starting with `$`.
-                  case Right(_: ScriptAction.NoParam)
-                      if !name.dottedName.startsWith("$") &&
-                        !excludes.contains(id.qualifiedName.toString) =>
-                    Some(id)
-                  case _ => None
-                }
-              })
-          }.toSeq
-
-          runManyTests(testScripts)
+          runManyTests(getScriptTests(dar, compiledPackages, excludes))
         }
         case RunnerMainConfig.RunMode.RunIncluding(ids) =>
           runManyTests(

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMainConfig.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMainConfig.scala
@@ -10,6 +10,17 @@ import com.digitalasset.daml.lf.data.Ref
 import com.daml.tls.{TlsConfiguration, TlsConfigurationCli}
 import com.digitalasset.daml.lf.engine.script.Runner.IdeLedgerProtocolVersion
 
+sealed trait RunnerAction {
+  val darPath: File
+}
+
+object RunnerAction {
+  case class RunScripts(config: RunnerMainConfig) extends RunnerAction {
+    override val darPath = config.darPath
+  }
+  case class ListScripts(darPath: File, jsonOutputPath: File) extends RunnerAction
+}
+
 case class RunnerMainConfig(
     darPath: File,
     runMode: RunnerMainConfig.RunMode,
@@ -48,17 +59,22 @@ object RunnerMainConfig {
     ) extends RunMode
   }
 
-  def parse(args: Array[String]): Option[RunnerMainConfig] =
+  def parse(args: Array[String]): Option[RunnerAction] =
     for {
       intermediate <- RunnerMainConfigIntermediate.parse(args)
       config <-
-        intermediate.toRunnerMainConfig.fold(
-          err => {
-            System.err.println(err)
-            None
-          },
-          Some(_),
-        )
+        intermediate.listScriptsJsonFile match {
+          case Some(jsonOutputPath) =>
+            Some(RunnerAction.ListScripts(intermediate.darPath, jsonOutputPath))
+          case None =>
+            intermediate.toRunnerMainConfig.fold(
+              err => {
+                System.err.println(err)
+                None
+              },
+              conf => Some(RunnerAction.RunScripts(conf)),
+            )
+        }
     } yield config
 
   sealed trait ResultMode
@@ -92,6 +108,7 @@ private[script] case class RunnerMainConfigIntermediate(
     includeScriptNames: List[String],
     excludeScriptNames: List[String],
     ideLedgerProtocolVersion: Option[IdeLedgerProtocolVersion],
+    listScriptsJsonFile: Option[File],
 ) {
 
   def getRunMode: Either[String, RunnerMainConfig.RunMode] =
@@ -183,6 +200,12 @@ private[script] object RunnerMainConfigIntermediate {
       .required()
       .action((f, c) => c.copy(darPath = f))
       .text("Path to the dar file containing the script")
+
+    opt[File]("list-scripts-json")
+      .text(
+        "List all scripts in a dar to a given json file. This flag can only be used with the --dar flag."
+      )
+      .action((f, c) => c.copy(listScriptsJsonFile = Some(f)))
 
     opt[String]("script-name")
       .optional()
@@ -309,7 +332,13 @@ private[script] object RunnerMainConfigIntermediate {
     help("help").text("Print this usage text")
 
     checkConfig(c => {
-      if (c.ledgerHost.isDefined != c.ledgerPort.isDefined) {
+      if (c.listScriptsJsonFile.isDefined) {
+        if (!c.copy(darPath = null, listScriptsJsonFile = None).equals(defaultConf)) {
+          failure("Only --dar can be provided when using --list-scripts")
+        } else {
+          success
+        }
+      } else if (c.ledgerHost.isDefined != c.ledgerPort.isDefined) {
         failure("Must specify both --ledger-host and --ledger-port")
       } else if (
         List(c.ledgerHost.isDefined, c.participantConfig.isDefined, c.isIdeLedger)
@@ -337,29 +366,33 @@ private[script] object RunnerMainConfigIntermediate {
     config.copy(timeMode = Some(timeMode))
   }
 
+  private[script] val defaultConf =
+    RunnerMainConfigIntermediate(
+      darPath = null,
+      ledgerHost = None,
+      ledgerPort = None,
+      adminPort = None,
+      participantConfig = None,
+      isIdeLedger = false,
+      timeMode = None,
+      inputFile = None,
+      outputFile = None,
+      accessTokenFile = None,
+      tlsConfig = TlsConfiguration(false, None, None, None),
+      maxInboundMessageSize = RunnerMainConfig.DefaultMaxInboundMessageSize,
+      userId = None,
+      uploadDar = false,
+      resultMode = RunnerMainConfig.ResultMode.Text,
+      runAll = false,
+      includeScriptNames = List(),
+      excludeScriptNames = List(),
+      ideLedgerProtocolVersion = None,
+      listScriptsJsonFile = None,
+    )
+
   private[script] def parse(args: Array[String]): Option[RunnerMainConfigIntermediate] =
     parser.parse(
       args,
-      RunnerMainConfigIntermediate(
-        darPath = null,
-        ledgerHost = None,
-        ledgerPort = None,
-        adminPort = None,
-        participantConfig = None,
-        isIdeLedger = false,
-        timeMode = None,
-        inputFile = None,
-        outputFile = None,
-        accessTokenFile = None,
-        tlsConfig = TlsConfiguration(false, None, None, None),
-        maxInboundMessageSize = RunnerMainConfig.DefaultMaxInboundMessageSize,
-        userId = None,
-        uploadDar = false,
-        resultMode = RunnerMainConfig.ResultMode.Text,
-        runAll = false,
-        includeScriptNames = List(),
-        excludeScriptNames = List(),
-        ideLedgerProtocolVersion = None,
-      ),
+      defaultConf,
     )
 }

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptMain.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptMain.scala
@@ -7,7 +7,7 @@ object ScriptMain {
   def main(args: Array[String]): Unit = {
     RunnerMainConfig.parse(args) match {
       case None => sys.exit(1)
-      case Some(config) => RunnerMain.main(config)
+      case Some(action) => RunnerMain.main(action)
     }
   }
 }


### PR DESCRIPTION
Adds a `--list-scripts-json=<json-path>` which writes a json list of the script identifiers in a dar
Initially planned to use stdout, but this is often polluted by pekko, so preferred file.
Output is of form `["Module:testName", "Module2:testName2"]`