### PR TITLE
bump curl's version on windows

### DIFF
--- a/sdk/dev-env/windows/manifests/curl.json
+++ b/sdk/dev-env/windows/manifests/curl.json
@@ -1,13 +1,13 @@
 {
-    "version": "8.3.0_1",
+    "version": "8.19.0_5",
     "description": "Command line tool and library for transferring data with URLs",
     "homepage": "https://curl.haxx.se/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://curl.se/windows/dl-8.3.0_1/curl-8.3.0_1-win64-mingw.zip",
-            "hash": "50837a214b5307e9334f8b79acb8978324222126e7cc90a06465f82945d205c2",
-            "extract_dir": "curl-8.3.0_1-win64-mingw"
+            "url": "https://curl.se/windows/dl-8.19.0_5/curl-8.19.0_5-win64-mingw.zip",
+            "hash": "2b65835d690e3799e6fbbfa5dc457be8ff614721bb3663800814491b3f12c423",
+            "extract_dir": "curl-8.19.0_5-win64-mingw"
         }
     },
     "bin": "bin\\curl.exe"


### PR DESCRIPTION
Had already been done on `main` but has to be done on this branch too.