### PR TITLE
fix flaky FuncWallClock by adding drift tolerance

### DIFF
--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ScriptF.scala
@@ -663,7 +663,11 @@ object ScriptF {
 
     private def sleepAtLeast(totalNanos: Long) = {
       // Thread.sleep can wake up earlier so we loop it to guarantee a minimum
-      // sleep time
+      // sleep time. We use the monotonic clock (System.nanoTime) rather than
+      // the wall clock to ensure the actual elapsed time matches the requested
+      // duration, regardless of NTP adjustments or leap seconds.
+      // Note: getTime uses the wall clock, so observed timestamps may differ
+      // slightly from the requested sleep duration due to clock drift.
       val t0 = System.nanoTime
       var nanosLeft = totalNanos
       while (nanosLeft > 0) {

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/FuncWallClockIT.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/FuncWallClockIT.scala
@@ -29,8 +29,13 @@ class FuncWallClockIT extends AbstractFuncIT {
         val duration1 = Duration.between(t0, t1)
         val duration2 = Duration.between(t1, t2)
 
-        val required1 = Duration.ofMillis(1000)
-        val required2 = Duration.ofMillis(2000)
+        // Sleep uses the monotonic clock (System.nanoTime) for accurate real-time
+        // duration, but getTime uses the wall clock (Clock.systemUTC). These clocks
+        // can drift slightly due to NTP adjustments, so we allow a small tolerance.
+        val clockDriftTolerance = Duration.ofMillis(5)
+
+        val required1 = Duration.ofMillis(1000).minus(clockDriftTolerance)
+        val required2 = Duration.ofMillis(2000).minus(clockDriftTolerance)
         val required1_upper = Duration.ofMillis(1100)
         val required2_upper = Duration.ofMillis(2100)
 


### PR DESCRIPTION
Fixes https://github.com/digital-asset/daml/issues/20707

Apparently, there are two clocks on the JVM:

- Monotonic clock (`System.nanoTime()`), used by `sleep`, which is mostly used for just the durations between stuff, somewhat like a digital hourglass
- Wall clock (`Clock.systemUTC().instant()`, `System.currentTimeMillis()`), used by `getTime`, which essentially does calculations based on timestamps.

Whenever a correction needs to be made via NTP it is _**slewed**_ instead, running the clock a little faster or slower to sync. This would explain the time difference.

It does not explain why it happens on macos only though. That being said, the differences here are so small and there are many variables, perhaps the macs clock are less precise or something?