### PR TITLE
`[release/3.5.x]` uptick to dpm 1.0.12

### DIFF
--- a/ci/get-dpm.sh
+++ b/ci/get-dpm.sh
@@ -7,7 +7,7 @@ ORAS_VERSION="1.2.2"
 ORAS="oras"
 # DPM url pinned to known working version
 # Update periodically
-DPM_URL="${1:-europe-docker.pkg.dev/da-images/public/components/dpm:1.0.8}"
+DPM_URL="${1:-europe-docker.pkg.dev/da-images/public/components/dpm:1.0.12}"
 # Get current machine OS type and ARCH
 OS_TYPE="$(uname -s | tr A-Z a-z)"
 if [[ $(uname -m) == 'x86_64' ]]; then

--- a/ci/publish-oci.sh
+++ b/ci/publish-oci.sh
@@ -95,12 +95,15 @@ function publish_artifact {
       extra_tags_args+=( "--extra-tags $(extract_major_minor ${RELEASE_TAG})" )
     fi
     info "Uploading ${artifact_name} to oci registry...\n"
+
     "${HOME}"/.dpm/bin/dpm \
-      repo publish-component \
-        "${artifact_name}" "${RELEASE_TAG}" \
-        ${extra_tags_args[@]} \
-        ${platform_args[@]} \
-        --registry "${DPM_REGISTRY}" 2>&1 | tee "${logs}/${artifact_name}-${RELEASE_TAG}.log"
+      artifacts publish component \
+      --name "${artifact_name}" \
+      --version "${RELEASE_TAG}" \
+      --registry "${DPM_REGISTRY}/components" \
+      ${extra_tags_args[@]} \
+      ${platform_args[@]} \
+      2>&1 | tee "${logs}/${artifact_name}-${RELEASE_TAG}.log"
   )
 }
 

--- a/sdk/UNRELEASED.md
+++ b/sdk/UNRELEASED.md
@@ -11,6 +11,7 @@ Wednesday after your change.
 
 ## Until 2026-04-14 (Exclusive)
 - Added --list-scripts-json flag to `dpm script`, for listing all script names in a DAR
+- Update to DPM 1.0.12
 
 ## Until 2026-03-31 (Exclusive)
 - Codegen-java: Added support for `UnknownTrailingFieldPolicy` in the generated `fromCreatedEvent()` method.

--- a/sdk/UNRELEASED.md
+++ b/sdk/UNRELEASED.md
@@ -11,7 +11,6 @@ Wednesday after your change.
 
 ## Until 2026-04-14 (Exclusive)
 - Added --list-scripts-json flag to `dpm script`, for listing all script names in a DAR
-- Update to DPM 1.0.12
 
 ## Until 2026-03-31 (Exclusive)
 - Codegen-java: Added support for `UnknownTrailingFieldPolicy` in the generated `fromCreatedEvent()` method.

--- a/sdk/WORKSPACE
+++ b/sdk/WORKSPACE
@@ -111,13 +111,13 @@ dpm_binary(
     # Hashes taken from the files themselves, not the OCI artifacts
     # See `layers[0].digest` in the manifest for each platform
     sha256 = {
-        "linux_arm64": "0a108513d99d3f996282ed85c51dc6c10b5790737a299182671c450f87cdf851",
-        "darwin_amd64": "edfeeec2ea7ac5eb03b56cc2a912ebc59d4ff9db9831cfa0b6033def218aa637",
-        "darwin_arm64": "ed9c7c6724efc36ca39cf5193a87a73e146685ae2dd042580ee20ca685aa0e1e",
-        "linux_amd64": "49dcc18c5dbea13bda52f6668b5831b53b46d209e1e539a1ef2a5553c3df6c09",
-        "windows_amd64": "594ac706c4eff9f0779d0cf04c18cda5ea8f6e4cf82fbead3f03f6aa7de423f9",
+        "linux_arm64": "c1b6e89cfe81ae1f49caf994cbeda871c5617c87c71ec44b5cca544000eb4b74",
+        "darwin_amd64": "9cf1d7eab2593e6c25cb9c42dfba64cbda5823736ba3dd5aae9845e4ee50209d",
+        "darwin_arm64": "b2f34b00c84bb399acdd3e31bbb701902457273548d1a37a0661404bb7a2a369",
+        "linux_amd64": "847a1a0b1cff26d562102a4a2ec3950a7692f846eb0bc1c8dd9274cc10295dc4",
+        "windows_amd64": "cb1e482c4303690f71bdbf5668c8d72b800631077f1fc1e4faa1a314cfd881ae",
     },
-    version = "1.0.8",
+    version = "1.0.12",
 )
 
 # Use Nix provisioned cc toolchain


### PR DESCRIPTION
- Uptick to latest dpm binary 1.0.12
- Change to use the new publicly documented artifact publish commands -- instead of prior internal-only `dpm repo` commands, to be ready for supporting publishing and reading from multiple OCI repos