### PR TITLE
Add security note about using profiler in prod

### DIFF
--- a/sdk/docs/manually-written/sdk/component-howtos/smart-contracts/profiler.rst
+++ b/sdk/docs/manually-written/sdk/component-howtos/smart-contracts/profiler.rst
@@ -9,6 +9,13 @@ Daml Profiler
 The Daml Profiler allows you to to profile execution of your Daml code
 which can help spot bottlenecks and opportunities for optimization.
 
+.. warning::
+  **SECURITY**\:
+
+  | The profiler is not intended to be used in production and doing so
+  | can lead to unxpected consequences for security. See 
+  | :ref:`Caveats <caveats>` for more details.
+
 Usage
 =====
 
@@ -87,6 +94,8 @@ your profile. Refer to the
 `documentation <https://github.com/jlfwong/speedscope#views>`_
 for more information on that.
 
+.. _caveats:
+
 Caveats
 =======
 
@@ -102,6 +111,12 @@ Caveats
    code that the compiler generated using ``dpm damlc inspect``. This
    can be useful to see where an identifier is being used but it does
    take some experience to be able to read Daml-LF code with ease.
+
+3. The profiler logs and uses potentially untrusted user input in its
+   operation, e.g., by creating files with file names based on contract
+   choices. It is generally considered unsafe to run the profiler in
+   production, as this could lead to the creation of arbitrary files or
+   worse.
 
 .. code-block:: sh
 

--- a/sdk/docs/sharable/sdk/component-howtos/smart-contracts/profiler.rst
+++ b/sdk/docs/sharable/sdk/component-howtos/smart-contracts/profiler.rst
@@ -13,10 +13,8 @@ which can help spot bottlenecks and opportunities for optimization.
   **SECURITY**\:
 
   | The profiler is not intended to be used in production and doing so
-  | can lead to unxpected consequences for security. See. 
-  | :ref:`Caveats <caveats>` for more details\.
-
-A wrapper for all exception types\.
+  | can lead to unxpected consequences for security. See 
+  | :ref:`Caveats <caveats>` for more details.
 
 Usage
 =====

--- a/sdk/docs/sharable/sdk/component-howtos/smart-contracts/profiler.rst
+++ b/sdk/docs/sharable/sdk/component-howtos/smart-contracts/profiler.rst
@@ -9,6 +9,15 @@ Daml Profiler
 The Daml Profiler allows you to to profile execution of your Daml code
 which can help spot bottlenecks and opportunities for optimization.
 
+.. warning::
+  **SECURITY**\:
+
+  | The profiler is not intended to be used in production and doing so
+  | can lead to unxpected consequences for security. See. 
+  | :ref:`Caveats <caveats>` for more details\.
+
+A wrapper for all exception types\.
+
 Usage
 =====
 
@@ -87,6 +96,8 @@ your profile. Refer to the
 `documentation <https://github.com/jlfwong/speedscope#views>`_
 for more information on that.
 
+.. _caveats:
+
 Caveats
 =======
 
@@ -102,6 +113,12 @@ Caveats
    code that the compiler generated using ``dpm damlc inspect``. This
    can be useful to see where an identifier is being used but it does
    take some experience to be able to read Daml-LF code with ease.
+
+3. The profiler logs and uses potentially untrusted user input in its
+   operation, e.g., by creating files with file names based on contract
+   choices. It is generally considered unsafe to run the profiler in
+   production, as this could lead to the creation of arbitrary files or
+   worse.
 
 .. code-block:: sh
 


### PR DESCRIPTION
The profiler is not intended to be used in production. As such, it may use potentially untrusted inputs in its operation, e.g., creating files with arbitrary file names based on user contract choices.

See also discussion in DACH-NY/canton#32346 and DACH-NY/canton#29990.