### PR TITLE
remove automatic relase git tag

### DIFF
--- a/ci/split-release-job.yml
+++ b/ci/split-release-job.yml
@@ -144,13 +144,6 @@ jobs:
       condition: and(not(startsWith(variables['release_tag'], '2.')), not(startsWith(variables['release_tag'], '3.3')))
     - bash: |
         set -euo pipefail
-        rtag="$(release_tag)"
-        tag=internal-"$rtag"
-        sha=$(release_sha)
-        git tag -a "$tag" "$sha" -m "Internal SDK release $tag"
-        git push origin "$tag"
-    - bash:
-        set -euo pipefail
         # Note: this gets dev-env from the release commit, not the trigger commit
         eval "$(cd sdk; dev-env/bin/dade-assist)"
         source $(bash-lib)
@@ -162,3 +155,4 @@ jobs:
     - template: tell-slack-failed.yml
       parameters:
         trigger_sha: '$(trigger_sha)'
+

--- a/ci/split-release-job.yml
+++ b/ci/split-release-job.yml
@@ -147,9 +147,7 @@ jobs:
         rtag="$(release_tag)"
         tag=internal-"$rtag"
         sha=$(release_sha)
-        git -c user.name="Azure Pipelines Daml Build" \
-            -c user.email="support@digitalasset.com" \
-            tag -a "$tag" "$sha" -m "Internal SDK release $tag"
+        git tag -a "$tag" "$sha" -m "Internal SDK release $tag"
         git push origin "$tag"
       displayName: "Tag Release in Git"
     - bash: |
@@ -165,4 +163,3 @@ jobs:
     - template: tell-slack-failed.yml
       parameters:
         trigger_sha: '$(trigger_sha)'
-

--- a/ci/split-release-job.yml
+++ b/ci/split-release-job.yml
@@ -149,8 +149,9 @@ jobs:
         sha=$(release_sha)
         git tag -a "$tag" "$sha" -m "Internal SDK release $tag"
         git push origin "$tag"
+      name: tag_release_in_git
       displayName: "Tag Release in Git"
-    - bash: |
+    - bash:
         set -euo pipefail
         # Note: this gets dev-env from the release commit, not the trigger commit
         eval "$(cd sdk; dev-env/bin/dade-assist)"

--- a/ci/split-release-job.yml
+++ b/ci/split-release-job.yml
@@ -149,7 +149,6 @@ jobs:
         sha=$(release_sha)
         git tag -a "$tag" "$sha" -m "Internal SDK release $tag"
         git push origin "$tag"
-      displayName: "Tag Release in Git"
     - bash:
         set -euo pipefail
         # Note: this gets dev-env from the release commit, not the trigger commit

--- a/ci/split-release-job.yml
+++ b/ci/split-release-job.yml
@@ -149,7 +149,6 @@ jobs:
         sha=$(release_sha)
         git tag -a "$tag" "$sha" -m "Internal SDK release $tag"
         git push origin "$tag"
-      name: tag_release_in_git
       displayName: "Tag Release in Git"
     - bash:
         set -euo pipefail


### PR DESCRIPTION
what use to resolve the get the  maven_install_2.13.json file from the canton repo, but this is not needed anymore as the dependency is reverted. 