### PR TITLE
Update release testing instructions

### DIFF
--- a/sdk/release/RELEASE.md
+++ b/sdk/release/RELEASE.md
@@ -1,17 +1,17 @@
 # Making a Release
 
-Daml Enterprise releases are made in the [assembly] repo by combining the
-releases of individual components (as of 2024-05-28, those are SDK (this repo),
-canton, drivers, scribe, and finance). SDK releases are triggered in this repo
-by modifying the [`LATEST`] file.
+Daml SDK releases are created by the [dpm-assembly] repo, as bundles of components created by other repos. The daml repo is repsonsible for publishing the following components (as of 2026-05-05):
+- damlc - The daml compiler and IDE
+- daml-script - The daml script runner and daml library
+- upgrade-check - A tool for checking upgrade compatibility between DARs
+- daml-new - A project templating tool, for new daml projects
 
-If you're looking for broader context on Daml Enterprise releases, please see
-the [assembly] repo.
+Releases of the above components are unified and triggered by changes to the [`LATEST`] file.
 
 ## Release Branches
 
 In this repo, the release branch for minor version `A.B` must be named
-`release/A.B.x`, e.g. `release/2.7.x`.
+`release/A.B.x`, e.g. `release/3.5.x`.
 
 > Note: This also means you should not create branches with those (or similar)
 > names if they are not meant to be release branches.
@@ -22,7 +22,7 @@ In this repo, the release branch for minor version `A.B` must be named
 
 > **When you create the release branch in the [daml] repo, make a PR to `main`
 > bumping [`NIGHTLY_PREFIX`] accordingly.** You may also want to bump it in the
-> release branch (e.g. from 2.8.0 to 2.8.1).
+> release branch (e.g. from 3.5.0 to 3.5.1).
 
 ## Creating an SDK Release
 
@@ -34,11 +34,11 @@ The steps to create a release are:
    build, and the words `SPLIT_RELEASE` (for historical reason dating to
    pre-2.0 days). For a snapshot release, one can generate a snapshot version
    string using the `release.sh` script. For example, to create a PR for a
-   2.0.0 snapshot release:
+   3.5.0 snapshot release:
 
    ```
    $ git fetch
-   $ ./release.sh snapshot origin/release/3.4.x 3.4.0
+   $ ./release.sh snapshot origin/release/3.5.x 3.5.0
    ```
 
    You should put that line in the file in order to preserve semver ordering,
@@ -47,7 +47,7 @@ The steps to create a release are:
    For non-adhoc snapshot please add the link to the commits of the release branch
    and the commit sha in the description of you PR. For instance here are examples 
     - "Create a snapshot for [main](https://github.com/digital-asset/daml/commits/main/) at commit ae6a13742aa79da2fcac79e0a27c6f7fe81fcf10"
-    - "Create a snapshot for [release/3.3.x](https://github.com/digital-asset/daml/commits/release/3.3.x/) at commit 7f71343bd265865977a09c4936d48278322e34ad"
+    - "Create a snapshot for [release/3.5.x](https://github.com/digital-asset/daml/commits/release/3.5.x/) at commit 7f71343bd265865977a09c4936d48278322e34ad"
 
    For a stable release, follow the same steps but remove the `-snapshot.*`
    part of the generated string.
@@ -74,18 +74,14 @@ using the steps in the previous section.
 
 ## Testing
 
-This testing procedure starts once the release is listed on the [releases
-page]. That is, _after_ the [assembly] step has finished.
+This testing procedure starts once a dpm assembly release has been created. Stable releases are listed [here](https://console.cloud.google.com/artifacts/docker/da-images/europe/public/sdk-manifests%2Fopen-source?project=da-images), unstable releases (snapshots + ad-hoc) are listed [here](https://console.cloud.google.com/artifacts/docker/da-images/europe/public-unstable/sdk-manifests%2Fopen-source?project=da-images)
 
 ### Windows
 
-You will now also need to test the release using DPM, please follow the instructions below (they look similar, but have small tweaks, don't reuse commands from the Daml Assistant section above).
-**ONLY RUN THESE STEPS FOR 3.4+ VERSIONS RELEASED AFTER 2025/09/22**
-
-1. If you're testing a snapshot, the PR that created the daml snapshot (on the dpm-assembly repo) should have a comment with a link to the windows install you need. If it does not, contact @samuelwilliams-da. Download this installer (by copying the link into your browser on windows, and running the downloaded file)
+1. If you're testing a snapshot, the PR that created the dpm snapshot (on the dpm-assembly repo) should have a comment with a link to the windows installer you need. If it does not, contact @samuelwilliams-da. Download this installer (by copying the link into your browser on windows, and running the downloaded file)
    If you're testing a full release, install it as per [dpm documentation](https://docs.digitalasset.com/build/3.4/dpm/dpm.html)
 
-1. Run `dpm versions` and verify the (green) version is what you expect. If you did not know what version to expect, ensure it is less than a week old for weekly testing.
+1. Run `dpm versions` and verify the (green) version is what you expect (for snapshots, this should be the version in the most recent generated comment on the snapshot PR). If you did not know what version to expect, ensure it is less than a week old for weekly testing.
    (If it is too old, leave a message about this in #project-dpm and pause testing until you get a response. #project-dpm is US based so consider this for timezones.)
 
 1. Run `dpm new myproject --template multi-package-example` to create a new project and switch to it
@@ -112,17 +108,14 @@ You will now also need to test the release using DPM, please follow the instruct
 
 1. Close VSCode
 
-1. On the [assembly] PR, add the comment:
+1. On the [dpm-assembly] PR, add the comment:
 
-   > Manual tests passed on Windows using DPM.
+   > Manual tests passed on Windows.
 
 1. Destroy your Windows VM.
 
 
 ### Linux/macOS
-
-You will now also need to test the release using DPM, please follow the instructions below (they look similar, but have small tweaks, don't reuse commands from the Daml Assistant section above).
-**ONLY RUN THESE STEPS FOR 3.4+ VERSIONS RELEASED AFTER 2025/09/22**
 
 1. If you're testing a snapshot, the PR that created the daml snapshot (on the dpm-assembly repo) should have a comment with the curl command you need. If it does not, contact @samuelwilliams-da.
    If you're testing a full release, install it as per [dpm documentation](https://docs.digitalasset.com/build/3.4/dpm/dpm.html)
@@ -132,7 +125,7 @@ You will now also need to test the release using DPM, please follow the instruct
    - [Visual Studio Code, Java-SDK](https://docs.daml.com/getting-started/installation.html)
    - [Maven](https://maven.apache.org)
 
-1. Run `dpm versions` and verify the (green) version is what you expect. If you did not know what version to expect, ensure it is less than a week old for weekly testing.
+1. Run `dpm versions` and verify the (green) version is what you expect (for snapshots, this should be the version in the most recent generated comment on the snapshot PR). If you did not know what version to expect, ensure it is less than a week old for weekly testing.
    (If it is too old, leave a message about this in #project-dpm and pause testing until you get a response. #project-dpm is US based so consider this for timezones.)
    (If the version you need is listed but not green, run `rm -rf ~/.dpm` then run the installation again)
 
@@ -245,40 +238,23 @@ You will now also need to test the release using DPM, please follow the instruct
 
 1. Close VSCode.
 
-1. On the [assembly] PR, add the comment:
+1. On the [dpm-assembly] PR, add the comment:
 
-   > Manual tests passed on [Linux/macOS] using DPM.
+   > Manual tests passed on [Linux/macOS].
 
    specifying which platform you tested on.
 
 ### Wrap up
 
-1. If the release is bad, ask #team-daml to delete the release from the [releases
-   page]. Mention why it is bad as a comment on your PR, and **stop the process
-   here**.
-
+1. If the release is bad, close the PR on the [dpm-assembly] repo. Mention why the release is bad in the closing comment. After this, please report the failure on #project-dpm (or #team-daml-language, if you know better).
    Note that **the Standard-Change label must remain on the PR**, even if the
    release has failed.
 
-1. if testing fails, do not report this on #product-releases, instead please report this in #team-daml-language.
+1. If the release is good, merge the PR! This will label the release as tested in DPM.
 
-1. for 2.10 and 3.x releases, please annouce that tests were successful on #product-releases.
+1. For stable releases, please announce that tests were successful on #product-releases.
 
-1. for 3.x releases, that pass testing, please ensure that artifacts are successfully published on [artifactory](https://digitalasset.jfrog.io/ui/repos/tree/General/external-files/daml-enterprise) and [github](https://github.com/digital-asset/daml/releases).
-
-1. for 2.10 rleases, that pass testing, please ensure that _key_ stakeholders are pinged in the slack message that announces successful testing (that way they may inform selected end users of the snapshots availability).
-
-1. Announce the release on `#product-releases` on Slack. For a stable release,
-   direct people to the release blog post. If there were any errors during testing,
-   but we decided to keep the release anyway, report those on the PR and include a
-   link to the PR in the announcement.
-
-For a stable release, you need to additionally:
-
-1. Go to the [releases page] and remove the prerelease marker on
-   the release. Also change the text to
-   `See [the release notes blog]() for details.`
-   adding in the direct link to this version's [release notes].
+1. For 2.10 releases that pass testing, please ensure that _key_ stakeholders are pinged in the slack message that announces successful testing (that way they may inform selected end users of the snapshots availability).
 
 Thanks for making a release!
 
@@ -287,7 +263,7 @@ Thanks for making a release!
 [`NIGHTLY_PREFIX`]: https://github.com/digital-asset/daml/blob/main/NIGHTLY_PREFIX
 [`release.sh`]: https://github.com/digital-asset/daml/blob/main/release.sh
 [ad-hoc]: https://github.com/DACH-NY/daml-language-ad-hoc
-[assembly]: https://github.com/DACH-NY/assembly
+[dpm-assembly]: https://github.com/DACH-NY/dpm-assembly
 [daml]: https://github.com/digital-asset/daml
 [release notes]: https://daml.com/release-notes/
 [releases page]: https://github.com/digital-asset/daml/releases


### PR DESCRIPTION
Following Daml assistant removal, and Remy's PR to remove the instructions around that, I've cleaned up the rest of the release instructions doc to be up to date.