### PR TITLE
Derive daml-script component.yaml using COMPILER_LF_VERSIONS

### DIFF
--- a/sdk/bazel_tools/packaging/packaging.bzl
+++ b/sdk/bazel_tools/packaging/packaging.bzl
@@ -24,13 +24,19 @@ def _package_app_impl(ctx):
 def _package_oci_component_impl(ctx):
     args = ctx.actions.args()
     args.add(ctx.outputs.out.path)
-    args.add(ctx.files.component_manifest[0].path)
+    component_manifest = ctx.actions.declare_file("component.yaml")
+    ctx.actions.expand_template(
+        output = component_manifest,
+        template = ctx.files.component_manifest[0],
+        substitutions = ctx.attr.component_substitutions,
+    )
+    args.add(component_manifest.path)
     args.add(1 if ctx.attr.platform_agnostic else 0)
     args.add_all(ctx.attr.resources + [ctx.attr.license], map_each = _get_resource_path)
     ctx.actions.run(
         executable = ctx.executable.package_oci_component,
         outputs = [ctx.outputs.out],
-        inputs = ctx.files.resources + ctx.files.component_manifest + ctx.files.license,
+        inputs = ctx.files.resources + [component_manifest] + ctx.files.license,
         arguments = [args],
         progress_message = "Packaging OCI " + ctx.attr.name,
     )
@@ -87,6 +93,7 @@ package_oci_component = rule(
         "component_manifest": attr.label(
             allow_single_file = True,
         ),
+        "component_substitutions": attr.string_dict(),
         "platform_agnostic": attr.bool(
             default = False,
         ),

--- a/sdk/daml-script/runner/BUILD.bazel
+++ b/sdk/daml-script/runner/BUILD.bazel
@@ -200,9 +200,13 @@ daml_compile(
 
 exports_files(["src/main/resources/logback.xml"])
 
+# Contains the daml-script dar for all LF versions in COMPILER_LF_VERSIONS
 package_oci_component(
     name = "daml-script-oci",
     component_manifest = ":component.yaml",
+    component_substitutions = {
+        "{SCRIPT_DAR_NAMES}": "\n".join(["        - ./daml-script-{}.dar".format(lf_version) for lf_version in COMPILER_LF_VERSIONS]),
+    },
     platform_agnostic = True,
     resources = [
         ":daml-script-binary_distribute.jar",

--- a/sdk/daml-script/runner/component.yaml
+++ b/sdk/daml-script/runner/component.yaml
@@ -12,10 +12,7 @@ spec:
     dars:
       conflict-strategy: extend
       paths:
-        - ./daml-script-2.1.dar
-        - ./daml-script-2.2.dar
-        - ./daml-script-2.3-staging.dar
-        - ./daml-script-2.dev.dar
+{SCRIPT_DAR_NAMES}
     script-service:
       conflict-strategy: fail
       paths:


### PR DESCRIPTION
Cleaning up LF versions, one automation at a time