### PR TITLE
get lf feature json from canton jar

### DIFF
--- a/sdk/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/DecodeV2.hs
+++ b/sdk/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/DecodeV2.hs
@@ -693,7 +693,7 @@ decodeUpdate LF2.Update{..} = mayDecode "updateSum" updateSum $ \case
       <*> mayDecode "update_ExerciseInterfaceArg" update_ExerciseInterfaceArg decodeExpr
       <*> traverse decodeExpr update_ExerciseInterfaceGuard
   LF2.UpdateSumExerciseByKey LF2.Update_ExerciseByKey{..} -> do
-    assertSupportsFeature featureExerciseByKey
+    assertSupportsFeature featureNUCK
     fmap EUpdate $ UExerciseByKey
       <$> mayDecode "update_ExerciseByKeyTemplate" update_ExerciseByKeyTemplate decodeTypeConId
       <*> decodeNameId ChoiceName update_ExerciseByKeyChoiceInternedStr
@@ -721,7 +721,7 @@ decodeUpdate LF2.Update{..} = mayDecode "updateSum" updateSum $ \case
   LF2.UpdateSumQueryNByKey LF2.Update_QueryNByKey{..} ->
     EUpdate . ULookupNByKey <$> mayDecode "update_RetrieveByKeyTemplate" update_QueryNByKeyTemplate decodeTypeConId
   LF2.UpdateSumFetchByKey retrieveByKey -> do
-    assertSupportsFeature featureFetchByKey
+    assertSupportsFeature featureNUCK
     fmap (EUpdate . UFetchByKey) (decodeRetrieveByKey retrieveByKey)
   LF2.UpdateSumTryCatch LF2.Update_TryCatch{..} ->
     fmap EUpdate $ UTryCatch

--- a/sdk/compiler/daml-lf-proto-encode/src/DA/Daml/LF/Proto3/EncodeV2.hs
+++ b/sdk/compiler/daml-lf-proto-encode/src/DA/Daml/LF/Proto3/EncodeV2.hs
@@ -821,7 +821,7 @@ encodeUpdate = fmap (P.Update . Just) . \case
         update_ExerciseInterfaceGuard <- traverse encodeExpr' exeGuard
         pure $ P.UpdateSumExerciseInterface P.Update_ExerciseInterface{..}
     UExerciseByKey{..} -> do
-        assertSupportsFeature featureExerciseByKey
+        assertSupportsFeature featureNUCK
         update_ExerciseByKeyTemplate <- encodeQualTypeConId exeTemplate
         update_ExerciseByKeyChoiceInternedStr <- encodeNameId unChoiceName exeChoice
         update_ExerciseByKeyKey <- encodeExpr exeKey
@@ -844,7 +844,7 @@ encodeUpdate = fmap (P.Update . Just) . \case
         update_EmbedExprBody <- encodeExpr e
         pure $ P.UpdateSumEmbedExpr P.Update_EmbedExpr{..}
     UFetchByKey tmplId -> do
-        assertSupportsFeature featureFetchByKey
+        assertSupportsFeature featureNUCK
         P.UpdateSumFetchByKey <$> encodeRetrieveByKey tmplId
     ULookupByKey tmplId -> do
         assertSupportsFeature featureLegacyLookupByKey

--- a/sdk/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/sdk/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -854,13 +854,13 @@ convertTypeDef env msi o@(ATyCon t) = withRange (convNameLoc t) $ if
     -> pure []
 
     -- Remove HasFetchByKey class declaration when unsupported
-    | not (envLfVersion env `supports` featureFetchByKey)
+    | not (envLfVersion env `supports` featureNUCK)
     , Just cls <- tyConClass_maybe t
     , NameIn DA_Internal_Template_Functions "HasFetchByKey" <- cls
     -> pure []
 
     -- Remove HasExerciseByKey class declaration when unsupported
-    | not (envLfVersion env `supports` featureExerciseByKey)
+    | not (envLfVersion env `supports` featureNUCK)
     , Just cls <- tyConClass_maybe t
     , NameIn DA_Internal_Template_Functions "HasExerciseByKey" <- cls
     -> pure []
@@ -1420,22 +1420,22 @@ convertBind env mc (name, x)
     = pure []
 
     -- Remove _fetchByKey wrapper defintition when unsupported
-    | not (envLfVersion env `supports` featureFetchByKey)
+    | not (envLfVersion env `supports` featureNUCK)
     , NameIn DA_Internal_Template_Functions "_fetchByKey" <- name
     = pure []
 
     -- Remove HasFetchByKey dictionary declaration when NUCK is unsupported
-    | not (envLfVersion env `supports` featureFetchByKey)
+    | not (envLfVersion env `supports` featureNUCK)
     , DesugarDFunId _ _ (NameIn DA_Internal_Template_Functions "HasFetchByKey") _ <- name
     = pure []
 
     -- Remove _exerciseByKey wrapper defintition when unsupported
-    | not (envLfVersion env `supports` featureExerciseByKey)
+    | not (envLfVersion env `supports` featureNUCK)
     , NameIn DA_Internal_Template_Functions "_exerciseByKey" <- name
     = pure []
 
     -- Remove HasExerciseByKey dictionary declaration when NUCK is unsupported
-    | not (envLfVersion env `supports` featureExerciseByKey)
+    | not (envLfVersion env `supports` featureNUCK)
     , DesugarDFunId _ _ (NameIn DA_Internal_Template_Functions "HasExerciseByKey") _ <- name
     = pure []
 
@@ -1755,13 +1755,13 @@ convertExpr env0 e = do
     -- convert usages of _fetchByKey to errorr wen unsupported since the
     -- defintion won't exist
     go env (VarIn DA_Internal_Template_Functions "_fetchByKey") _
-        | not $ envLfVersion env `supports` featureFetchByKey
-        = conversionError $ FeatureNotSupported featureFetchByKey (envLfVersion env)
+        | not $ envLfVersion env `supports` featureNUCK
+        = conversionError $ FeatureNotSupported featureNUCK (envLfVersion env)
     -- convert usages of _exerciseByKey to errorr wen unsupported since the
     -- defintion won't exist
     go env (VarIn DA_Internal_Template_Functions "_exerciseByKey") _
-        | not $ envLfVersion env `supports` featureExerciseByKey
-        = conversionError $ FeatureNotSupported featureExerciseByKey (envLfVersion env)
+        | not $ envLfVersion env `supports` featureNUCK
+        = conversionError $ FeatureNotSupported featureNUCK (envLfVersion env)
     -- convert usages of _lookupNByKey to errorr wen NUCK is unsupported since the
     -- defintion won't exist
     go env (VarIn DA_Internal_Template_Functions "_lookupNByKey") _

--- a/sdk/compiler/damlc/daml-stdlib-src/DA/Internal/Template/Functions.daml
+++ b/sdk/compiler/damlc/daml-stdlib-src/DA/Internal/Template/Functions.daml
@@ -162,7 +162,7 @@ type TemplateKey t k =
 #ifdef DAML_LEGACY_LOOKUP_BY_KEY
   , HasLookupByKey t k
 #endif
-#ifdef DAML_FETCH_BY_KEY
+#ifdef DAML_NUCK
   , HasFetchByKey t k
 #endif
   , HasMaintainer t k

--- a/sdk/compiler/damlc/tests/daml-test-files/ConsumedContractKey.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/ConsumedContractKey.daml
@@ -1,4 +1,4 @@
--- @SUPPORTS-LF-FEATURE DAML_UCK_BUILTINS
+-- @IGNORE
 
 -- @ERROR range=29:1-29:32; no contract with that key was found
 -- @ERROR range=39:1-39:29; consumed in same transaction

--- a/sdk/compiler/damlc/tests/daml-test-files/ContractIdInContractKeySkipCheck.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/ContractIdInContractKeySkipCheck.daml
@@ -5,7 +5,7 @@
 -- defining the type that contains a contract id in a separate module, the
 -- runtime check is still performed.
 
--- @SUPPORTS-LF-FEATURE DAML_UCK_BUILTINS
+-- @IGNORE
 
 -- @ERROR range=41:1-41:17; Contract IDs are not supported in contract key
 -- @ERROR range=50:1-50:13; Contract IDs are not supported in contract key

--- a/sdk/compiler/damlc/tests/daml-test-files/ContractKeyNotEffective.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/ContractKeyNotEffective.daml
@@ -1,4 +1,4 @@
--- @SUPPORTS-LF-FEATURE DAML_FETCH_BY_KEY
+-- @SUPPORTS-LF-FEATURE DAML_NUCK
 
 -- @ERROR range=28:1-28:19; Attempt to fetch or exercise by key but no contract with that key was found
 module ContractKeyNotEffective where

--- a/sdk/compiler/damlc/tests/daml-test-files/ContractKeyNotVisible.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/ContractKeyNotVisible.daml
@@ -1,4 +1,4 @@
--- @SUPPORTS-LF-FEATURE DAML_UCK_BUILTINS
+-- @IGNORE
 
 -- @ERROR range=20:1-20:8; Couldn't see contract with key 'Bob'
 -- @ERROR range=63:1-63:15; Attempt to fetch, lookup or exercise a key associated with a contract

--- a/sdk/compiler/damlc/tests/daml-test-files/EmptyContractKeyMaintainers.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/EmptyContractKeyMaintainers.daml
@@ -1,4 +1,4 @@
--- @SUPPORTS-LF-FEATURE DAML_UCK_BUILTINS
+-- @IGNORE
 
 -- @ERROR range=46:1-46:22; Attempt to create a contract key with an empty set of maintainers
 -- @TODO queryByKey loses errors, ideally below is: Attempt to fetch, lookup or exercise a contract key with an empty set of maintainers

--- a/sdk/compiler/damlc/tests/daml-test-files/ExplicitDisclosureWithKeys.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/ExplicitDisclosureWithKeys.daml
@@ -3,7 +3,7 @@
 
 {-# LANGUAGE ApplicativeDo #-}
 
--- @SUPPORTS-LF-FEATURE DAML_EXERCISE_BY_KEY
+-- @SUPPORTS-LF-FEATURE DAML_NUCK
 
 module ExplicitDisclosureWithKeys where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/FetchByKey.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/FetchByKey.daml
@@ -1,4 +1,4 @@
--- @SUPPORTS-LF-FEATURE DAML_UCK_BUILTINS
+-- @IGNORE
 
 -- @ERROR range=34:1-34:11; Attempt to fetch or exercise by key
 -- @ERROR range=38:1-38:11; Attempt to fetch or exercise by key

--- a/sdk/compiler/damlc/tests/daml-test-files/KeyNotVisibleStakeholders.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/KeyNotVisibleStakeholders.daml
@@ -3,7 +3,7 @@
 
 {-# LANGUAGE ApplicativeDo #-}
 
--- @SUPPORTS-LF-FEATURE DAML_UCK_BUILTINS
+-- @IGNORE
 
 -- @ERROR failed due to a missing authorization from 's'
 -- @ERROR failed due to a missing authorization from 's'

--- a/sdk/compiler/damlc/tests/daml-test-files/LFContractKeys.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/LFContractKeys.daml
@@ -3,7 +3,7 @@
 
 {- DLINT ignore -}
 
--- @SUPPORTS-LF-FEATURE DAML_UCK_BUILTINS
+-- @IGNORE
 
 module LFContractKeys where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/LfDevContractKeys.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/LfDevContractKeys.daml
@@ -3,7 +3,7 @@
 
 {-# LANGUAGE ApplicativeDo #-}
 
--- @SUPPORTS-LF-FEATURE DAML_UCK_BUILTINS
+-- @IGNORE
 
 module LfDevContractKeys where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/SemanticsEvalOrderWithKeys.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/SemanticsEvalOrderWithKeys.daml
@@ -12,7 +12,7 @@
 
 {-# LANGUAGE ApplicativeDo #-}
 
--- @SUPPORTS-LF-FEATURE DAML_UCK_BUILTINS
+-- @IGNORE
 
 module SemanticsEvalOrderWithKeys where
 

--- a/sdk/compiler/damlc/tests/daml-test-files/Submit.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/Submit.daml
@@ -56,7 +56,7 @@ template T3 with
   where
   signatory t3_p
 
-#ifdef DAML_FETCH_BY_KEY
+#ifdef DAML_NUCK
   key (t3_p, ms) : (Party, [Party])
   maintainer key._2
 #endif
@@ -67,7 +67,7 @@ template FetchByKeyT3 with
   where
   signatory fetcher
 
-#ifdef DAML_FETCH_BY_KEY
+#ifdef DAML_NUCK
   choice DoFetch : (ContractId T3, T3)
     controller fetcher
     do fetchByKey @T3 fetchKey
@@ -103,7 +103,7 @@ template T5 with
 
 -- ContractNotFound: Cannot test contract not found with IDELedger, no way to get an invalid contract ID
 
-#ifdef DAML_EXERCISE_BY_KEY
+#ifdef DAML_NUCK
 contractKeyNotFound : Script ()
 contractKeyNotFound = script do
   alice <- allocateParty "alice"
@@ -182,7 +182,7 @@ failureStatusError = script do
 
 -- TemplatePreconditionViolated: Same as above
 
-#ifdef DAML_FETCH_BY_KEY
+#ifdef DAML_NUCK
 createEmptyContractKeyMaintainers : Script ()
 createEmptyContractKeyMaintainers = script do
   alice <- allocateParty "alice"
@@ -240,7 +240,7 @@ devError = script do
 -- Can reproduce right now with a timeout, or package vetting test.
 
 -- Using contractKeyNotFound with an enormous key
-#ifdef DAML_EXERCISE_BY_KEY
+#ifdef DAML_NUCK
 truncatedError : Script ()
 truncatedError = script do
   alice <- allocateParty "alice"

--- a/sdk/daml-lf/BUILD.bazel
+++ b/sdk/daml-lf/BUILD.bazel
@@ -76,7 +76,7 @@ sh_binary(
     srcs = ["update_versions.sh"],
     args = [
         "$(location daml-lf-versions-generated.json)",
-        "daml-lf/daml-lf-versions.json",  # The path relative to workspace root
+        "daml-lf/daml-lf-versions.json",
     ],
     data = ["daml-lf-versions-generated.json"],
 )
@@ -86,7 +86,7 @@ sh_binary(
     srcs = ["update_versions.sh"],
     args = [
         "$(location daml-lf-features-generated.json)",
-        "daml-lf/daml-lf-features.json",  # The path relative to workspace root
+        "daml-lf/daml-lf-features.json",
     ],
     data = ["daml-lf-features-generated.json"],
 )

--- a/sdk/daml-lf/BUILD.bazel
+++ b/sdk/daml-lf/BUILD.bazel
@@ -19,6 +19,20 @@ genrule(
     visibility = ["//visibility:private"],
 )
 
+genrule(
+    name = "daml-lf-features-json-extract",
+    srcs = ["@maven//:com_daml_daml_lf_language_2_13"],
+    outs = ["daml-lf-features-generated.json"],
+    cmd = """
+        # Extract the dto file from the jar
+        $(location @bazel_tools//tools/zip:zipper) x $(SRCS) -d $(RULEDIR) daml-lf-features.json
+        # Rename it to match our declared output
+        mv $(RULEDIR)/daml-lf-features.json $@
+    """,
+    tools = ["@bazel_tools//tools/zip:zipper"],
+    visibility = ["//visibility:private"],
+)
+
 exports_files(
     [
         "daml-lf-versions.json",
@@ -42,6 +56,20 @@ py_test(
     main = "check_versions.py",
 )
 
+py_test(
+    name = "daml-lf-features-check",
+    srcs = ["check_versions.py"],
+    args = [
+        "$(location daml-lf-features.json)",
+        "$(location daml-lf-features-generated.json)",
+    ],
+    data = [
+        "daml-lf-features.json",
+        "daml-lf-features-generated.json",
+    ],
+    main = "check_versions.py",
+)
+
 # The Golden File Updater (runs via `bazel run`)
 sh_binary(
     name = "update-daml-lf-versions",
@@ -51,6 +79,16 @@ sh_binary(
         "daml-lf/daml-lf-versions.json",  # The path relative to workspace root
     ],
     data = ["daml-lf-versions-generated.json"],
+)
+
+sh_binary(
+    name = "update-daml-lf-features",
+    srcs = ["update_versions.sh"],
+    args = [
+        "$(location daml-lf-features-generated.json)",
+        "daml-lf/daml-lf-features.json",  # The path relative to workspace root
+    ],
+    data = ["daml-lf-features-generated.json"],
 )
 
 py_binary(

--- a/sdk/daml-lf/daml-lf-features.json
+++ b/sdk/daml-lf/daml-lf-features.json
@@ -36,13 +36,6 @@
       }
     }
   },
-  "featureUCKBuiltins" : {
-    "name" : "Old style (UCK) key builtins (fetchByKey, exerciseByKey (UCK semantics), lookupByKey (UCK semantics), ...)",
-    "cppFlag" : "DAML_UCK_BUILTINS",
-    "versionRange" : {
-      "type" : "Empty"
-    }
-  },
   "featureContractKeys" : {
     "name" : "Contract Keys",
     "cppFlag" : "DAML_CONTRACT_KEYS",
@@ -66,7 +59,7 @@
         "major" : 2,
         "minor" : {
           "Dev" : {
-
+            
           }
         }
       },
@@ -74,21 +67,7 @@
         "major" : 2,
         "minor" : {
           "Dev" : {
-
-          }
-        }
-      }
-    }
-  },
-  "featurePackageUpgrades" : {
-    "name" : "Package upgrades",
-    "cppFlag" : "DAML_PackageUpgrades",
-    "versionRange" : {
-      "lowerBound" : {
-        "major" : 2,
-        "minor" : {
-          "Stable" : {
-            "version" : 1
+            
           }
         }
       }
@@ -102,7 +81,7 @@
         "major" : 2,
         "minor" : {
           "Dev" : {
-
+            
           }
         }
       },
@@ -110,7 +89,7 @@
         "major" : 2,
         "minor" : {
           "Dev" : {
-
+            
           }
         }
       }
@@ -124,7 +103,7 @@
         "major" : 2,
         "minor" : {
           "Dev" : {
-
+            
           }
         }
       },
@@ -132,7 +111,7 @@
         "major" : 2,
         "minor" : {
           "Dev" : {
-
+            
           }
         }
       }
@@ -160,7 +139,7 @@
         "major" : 2,
         "minor" : {
           "Dev" : {
-
+            
           }
         }
       },
@@ -168,59 +147,7 @@
         "major" : 2,
         "minor" : {
           "Dev" : {
-
-          }
-        }
-      }
-    }
-  },
-  "featureTextMap" : {
-    "name" : "TextMap type",
-    "cppFlag" : "DAML_TEXTMAP",
-    "versionRange" : {
-      "lowerBound" : {
-        "major" : 2,
-        "minor" : {
-          "Dev" : {
-
-          }
-        }
-      },
-      "upperBound" : {
-        "major" : 2,
-        "minor" : {
-          "Dev" : {
-
-          }
-        }
-      }
-    }
-  },
-  "featureExerciseByKey" : {
-    "name" : "Exercise by key",
-    "cppFlag" : "DAML_EXERCISE_BY_KEY",
-    "versionRange" : {
-      "lowerBound" : {
-        "major" : 2,
-        "minor" : {
-          "Staging" : {
-            "version" : 3,
-            "revision" : 1
-          }
-        }
-      }
-    }
-  },
-  "featureFetchByKey" : {
-    "name" : "Fetch by key",
-    "cppFlag" : "DAML_FETCH_BY_KEY",
-    "versionRange" : {
-      "lowerBound" : {
-        "major" : 2,
-        "minor" : {
-          "Staging" : {
-            "version" : 3,
-            "revision" : 1
+            
           }
         }
       }
@@ -255,7 +182,7 @@
         "major" : 2,
         "minor" : {
           "Dev" : {
-
+            
           }
         }
       },
@@ -263,7 +190,7 @@
         "major" : 2,
         "minor" : {
           "Dev" : {
-
+            
           }
         }
       }
@@ -277,7 +204,7 @@
         "major" : 2,
         "minor" : {
           "Dev" : {
-
+            
           }
         }
       },
@@ -285,7 +212,7 @@
         "major" : 2,
         "minor" : {
           "Dev" : {
-
+            
           }
         }
       }
@@ -300,6 +227,28 @@
         "minor" : {
           "Stable" : {
             "version" : 2
+          }
+        }
+      }
+    }
+  },
+  "featureExternalCall" : {
+    "name" : "External Call",
+    "cppFlag" : "DAML_ExternalCall",
+    "versionRange" : {
+      "lowerBound" : {
+        "major" : 2,
+        "minor" : {
+          "Dev" : {
+            
+          }
+        }
+      },
+      "upperBound" : {
+        "major" : 2,
+        "minor" : {
+          "Dev" : {
+            
           }
         }
       }
@@ -327,7 +276,7 @@
         "major" : 2,
         "minor" : {
           "Dev" : {
-
+            
           }
         }
       },
@@ -335,7 +284,7 @@
         "major" : 2,
         "minor" : {
           "Dev" : {
-
+            
           }
         }
       }


### PR DESCRIPTION
fixes https://github.com/digital-asset/daml/issues/22936
fixes https://github.com/digital-asset/daml/issues/22937

replicates the scala feature state (where the pre-nuck features don't exist anymore)

