### PR TITLE
(backport #23024) Remove multi-ide support setting to always enable (#23024)

### DIFF
--- a/sdk/UNRELEASED.md
+++ b/sdk/UNRELEASED.md
@@ -9,6 +9,9 @@ schedule, i.e. if you add an entry effective at or after the first
 header, prepend the new date header that corresponds to the
 Wednesday after your change.
 
+## Until 2026-05-12 (Exclusive)
+- Always enable multi-ide support in Dpm Studio, remove option to disable.
+
 ## Until 2026-05-05 (Exclusive)
 - adopted LF 2.3
 - Removed daml assistant

--- a/sdk/compiler/daml-extension/package.json
+++ b/sdk/compiler/daml-extension/package.json
@@ -121,7 +121,7 @@
                 "daml.multiPackageIdeSupport": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Enables support for multi-package projects in the IDE."
+                    "description": "Enables support for multi-package projects in the IDE. Can only be disabled when using legacy Daml Assistant."
                 },
                 "daml.multiPackageIdeGradleSupport": {
                     "type": "boolean",

--- a/sdk/compiler/daml-extension/src/extension.ts
+++ b/sdk/compiler/daml-extension/src/extension.ts
@@ -220,7 +220,9 @@ async function startLanguageServers(context: ExtensionContext) {
   const consent = await getTelemetryConsent(config, context);
   const rootPath = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
   if (!rootPath) throw "Couldn't find workspace root";
-  const multiIDESupport = config.get("multiPackageIdeSupport");
+  const multiPackageSupportOpt = config.get("multiPackageIdeSupport");
+  const usingDpm = config.get("useDPMWhenAvailable");
+  const allowMultiIde = multiPackageSupportOpt || usingDpm;
   const gradleSupport = config.get("multiPackageIdeGradleSupport");
 
   const gradlewExists = await fileExists(rootPath + "/gradlew");
@@ -261,7 +263,7 @@ async function startLanguageServers(context: ExtensionContext) {
   }
 
   var isGradleProject = false;
-  if (multiIDESupport && gradleSupport && gradlewExists) {
+  if (allowMultiIde && gradleSupport && gradlewExists) {
     isGradleProject = await tryGenerateIdeManifest(
       rootPath,
       envrcExistsWithoutExt,

--- a/sdk/compiler/daml-extension/src/language_client.ts
+++ b/sdk/compiler/daml-extension/src/language_client.ts
@@ -246,13 +246,15 @@ export class DamlLanguageClient {
     config: vscode.WorkspaceConfiguration,
     sdkVersion: string | undefined,
   ): boolean {
-    const multiIDESupport: boolean =
+    const multiPackageSupportOpt: boolean =
       config.get("multiPackageIdeSupport") || false;
+    const usingDpm: boolean = config.get("useDPMWhenAvailable") || false;
+    const allowMultiIde = multiPackageSupportOpt || usingDpm;
 
     // We'll say multi-ide is introduced in 2.9.0. The command existed
     // in 2.8, but it was unfinished, so we shouldn't allow it to be used.
     if (
-      multiIDESupport &&
+      allowMultiIde &&
       sdkVersion &&
       sdkVersion != "0.0.0" &&
       semver.lt(sdkVersion, "2.9.0")
@@ -262,7 +264,7 @@ export class DamlLanguageClient {
       );
       return false;
     }
-    return multiIDESupport;
+    return allowMultiIde;
   }
 
   private static getLanguageServerArgs(


### PR DESCRIPTION
Backport of https://github.com/digital-asset/daml/pull/23024

The IDE no longer works without multi-ide enabled when using DPM. The utilities team still had the old setting to disable multi-ide support. Multi-ide is stable enough that it can be enabled always now.