### PR TITLE
don't run build on non-release PRs

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -33,6 +33,7 @@ jobs:
 
 - job: verify_docs_synchronized
   displayName: 'Verify docs synchronized'
+  condition: false
   pool:
     name: 'ubuntu_20_04'
     demands: assignment -equals default
@@ -77,6 +78,8 @@ jobs:
 - job: Linux
   dependsOn:
     - check_for_release
+  condition: and(succeeded(),
+                 eq(dependencies.check_for_release.outputs['out.is_release'], 'true'))
   variables:
     - name: release_sha
       value: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
@@ -163,6 +166,8 @@ jobs:
 - job: Windows
   dependsOn:
     - check_for_release
+  condition: and(succeeded(),
+                 eq(dependencies.check_for_release.outputs['out.is_release'], 'true'))
   variables:
     - name: release_sha
       value: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
@@ -294,6 +299,8 @@ jobs:
   dependsOn:
     - check_for_release
     - compatibility_ts_libs
+  condition: and(succeeded(),
+                 eq(dependencies.check_for_release.outputs['out.is_release'], 'true'))
   timeoutInMinutes: 240
   pool:
     name: ubuntu_20_04

--- a/ci/macOS.yml
+++ b/ci/macOS.yml
@@ -16,6 +16,7 @@ jobs:
     name: macOS-pool
     demands: assignment -equals ${{parameters.assignment}}
   condition: and(succeeded(),
+                 eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
                  or(eq('${{parameters.name}}', 'macos'),
                     and(or(eq(variables['Build.SourceBranchName'], 'main'),
                            eq(variables['Build.SourceBranchName'], 'main-2.x')),


### PR DESCRIPTION
This is useless and can cost us hours when making changes to the CI config on release-trigger. 

There is a chance that https://github.com/digital-asset/daml/pull/23034 will need to be rolled back because I got something wrong, but rolling it back would take hours if this PR wasn't merged first.