### PR TITLE
increase the timeout of the windows job on release-trigger

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -134,7 +134,7 @@ jobs:
     - name: is_split_release
       value: $[ dependencies.check_for_release.outputs['out.split_release_process'] ]
     - template: job-variables.yml
-  timeoutInMinutes: 240
+  timeoutInMinutes: 480
   pool:
     name: 'windows-pool'
     demands: assignment -equals default


### PR DESCRIPTION
When the cache fails on windows, which happens regularly, the windows job times out. This is problematic when it happens post-merge of a PR that modifies the LATEST file, because only @samuel-williams-da and @paulbrauner-da can restart the failed job. So we double the timeout from 4h to 8h.