### PR TITLE
build after merge, publish to npm/maven last

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -150,32 +150,6 @@ steps:
       pathtoPublish: 'sdk/bazel-testlogs/'
       artifactName: 'Test logs ${{parameters.name_str}}'
 
-  - bash: |
-      set -euo pipefail
-      cd sdk
-      eval "$(./dev-env/bin/dade-assist)"
-      # Authorize in GCLOUD and get a token
-      gcloud beta auth activate-service-account --key-file=<(echo "${GOOGLE_APPLICATION_CREDENTIALS_CONTENT}")
-      export GOOGLE_ARTIFACT_REGISTRY_KEY=$(gcloud auth print-access-token)
-      bazel build //release:release
-      ./bazel-bin/release/release --release-dir "$(mktemp -d)" --upload
-    env:
-      DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
-      DAML_SCALA_VERSION: ${{parameters.scala_version}}
-      GPG_KEY: $(gpg-code-signing)
-      MAVEN_USERNAME: $(MAVEN_USERNAME)
-      MAVEN_PASSWORD: $(MAVEN_PASSWORD)
-      MAVEN_URL: "https://central.sonatype.com"
-      GOOGLE_ARTIFACT_REGISTRY_URL: "https://europe-maven.pkg.dev/da-images-dev/playground-maven"
-      GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
-      NPM_TOKEN: $(NPM_TOKEN)
-    name: publish_npm_mvn
-    displayName: 'Publish NPM and Maven artifacts'
-    condition: and(succeeded(),
-                   eq(variables.skip, 'false'),
-                   eq(${{parameters.is_release}}, 'true'),
-                   eq(${{parameters.name_exp}}, 'linux-intel'),
-                   in(variables['Build.SourceBranchName'], 'main', 'main-2.x', 'release-trigger'))
   - template: bash-lib.yml
     parameters:
       var_name: bash-lib

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -35,7 +35,8 @@ jobs:
   dependsOn:
     - check_for_release
   condition: and(succeeded(),
-                 eq(dependencies.check_for_release.outputs['out.is_release'], 'true'))
+                 eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
+                 ne('${{parameters.test_mode}}', 'pr'))
   variables:
     - name: release_sha
       value: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
@@ -121,7 +122,8 @@ jobs:
   dependsOn:
     - check_for_release
   condition: and(succeeded(),
-                 eq(dependencies.check_for_release.outputs['out.is_release'], 'true'))
+                 eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
+                 ne('${{parameters.test_mode}}', 'pr'))
   variables:
     - name: release_sha
       value: $[ dependencies.check_for_release.outputs['out.release_sha'] ]

--- a/ci/macOS.yml
+++ b/ci/macOS.yml
@@ -17,6 +17,7 @@ jobs:
     demands: assignment -equals ${{parameters.assignment}}
   condition: and(succeeded(),
                  eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
+                 ne('${{parameters.test_mode}}', 'pr'),
                  or(eq('${{parameters.name}}', 'macos'),
                     and(or(eq(variables['Build.SourceBranchName'], 'main'),
                            eq(variables['Build.SourceBranchName'], 'main-2.x')),

--- a/ci/split-release-job.yml
+++ b/ci/split-release-job.yml
@@ -42,6 +42,20 @@ jobs:
           setvar skip_arm false
         fi
       displayName: "Set skip_arm variable"
+    - bash: ci/dev-env-install.sh
+      displayName: 'Build/Install the Developer Environment'
+    - bash: |
+        set -euo pipefail
+        ci/create-dotnetrc.sh
+      displayName: 'Create .netrc file'
+      env:
+        GITHUB_TOKEN: $(GH_DAML_READONLY)
+    - bash: |
+        ci/configure-bazel.sh
+      displayName: 'Configure Bazel'
+      env:
+        IS_FORK: $(System.PullRequest.IsFork)
+        GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: linux-intel-release
@@ -151,20 +165,6 @@ jobs:
             tag -a "$tag" "$sha" -m "Internal SDK release $tag"
         git push origin "$tag"
       displayName: "Tag Release in Git"
-    - bash: ci/dev-env-install.sh
-      displayName: 'Build/Install the Developer Environment'
-    - bash: |
-        set -euo pipefail
-        ci/create-dotnetrc.sh
-      displayName: 'Create .netrc file'
-      env:
-        GITHUB_TOKEN: $(GH_DAML_READONLY)
-    - bash: |
-        ci/configure-bazel.sh
-      displayName: 'Configure Bazel'
-      env:
-        IS_FORK: $(System.PullRequest.IsFork)
-        GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
     - bash: |
         set -euo pipefail
         cd sdk

--- a/ci/split-release-job.yml
+++ b/ci/split-release-job.yml
@@ -151,6 +151,40 @@ jobs:
             tag -a "$tag" "$sha" -m "Internal SDK release $tag"
         git push origin "$tag"
       displayName: "Tag Release in Git"
+    - bash: ci/dev-env-install.sh
+      displayName: 'Build/Install the Developer Environment'
+    - bash: |
+        set -euo pipefail
+        ci/create-dotnetrc.sh
+      displayName: 'Create .netrc file'
+      env:
+        GITHUB_TOKEN: $(GH_DAML_READONLY)
+    - bash: |
+        ci/configure-bazel.sh
+      displayName: 'Configure Bazel'
+      env:
+        IS_FORK: $(System.PullRequest.IsFork)
+        GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
+    - bash: |
+        set -euo pipefail
+        cd sdk
+        eval "$(./dev-env/bin/dade-assist)"
+        # Authorize in GCLOUD and get a token
+        gcloud beta auth activate-service-account --key-file=<(echo "${GOOGLE_APPLICATION_CREDENTIALS_CONTENT}")
+        export GOOGLE_ARTIFACT_REGISTRY_KEY=$(gcloud auth print-access-token)
+        bazel build //release:release
+        ./bazel-bin/release/release --release-dir "$(mktemp -d)" --upload
+      env:
+        DAML_SDK_RELEASE_VERSION: $(release_tag)
+        GPG_KEY: $(gpg-code-signing)
+        MAVEN_USERNAME: $(MAVEN_USERNAME)
+        MAVEN_PASSWORD: $(MAVEN_PASSWORD)
+        MAVEN_URL: "https://central.sonatype.com"
+        GOOGLE_ARTIFACT_REGISTRY_URL: "https://europe-maven.pkg.dev/da-images-dev/playground-maven"
+        GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
+        NPM_TOKEN: $(NPM_TOKEN)
+      name: publish_npm_mvn
+      displayName: 'Publish NPM and Maven artifacts'
     - bash: |
         set -euo pipefail
         # Note: this gets dev-env from the release commit, not the trigger commit


### PR DESCRIPTION
Do not run build-release on PRs that modify LATEST. Instead, we only run it on the merge commit. But in order to account for the possibility that the build will fail, we move irreversible steps (publish to NPM and maven) last.