### PR TITLE
add label to canton upgrade prs

### DIFF
--- a/ci/bash-lib.yml
+++ b/ci/bash-lib.yml
@@ -33,12 +33,13 @@ steps:
         fi
     }
     open_pr() {
-      local branch title body pr_number base header output
+      local branch title body pr_number base label header output
       branch="$1"
       title="$2"
       body="${3:-}"
       pr_number="${4:-}"
       base="${5:-main}"
+      label="${6:-}"
       header=$(mktemp)
       output=$(mktemp)
 
@@ -66,6 +67,19 @@ steps:
       cat "$header" "$output"
       if [ -n "$pr_number" ]; then
           jq '.number' "$output" > "$pr_number"
+      fi
+      if [ -n "$label" ]; then
+          local pr_num
+          pr_num=$(jq -r '.number' "$output")
+          jq -n --arg label "$label" \
+                '{"labels": [$label]}' \
+            | curl -H "Content-Type: application/json" \
+                   -H "$(get_gh_auth_header)" \
+                   --fail \
+                   --silent \
+                   --location \
+                   -d @- \
+                   "https://api.github.com/repos/digital-asset/daml/issues/$pr_num/labels"
       fi
     }
     request_pr_review() {

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -222,7 +222,7 @@ jobs:
                       ')
                   body=$(printf "Canton changes:\n\n%s\n\ntell-slack: canton" "$changelog")
 
-                  open_pr "$branch" "update canton to $version" "$body" "" "$(Build.SourceBranchName)"
+                  open_pr "$branch" "update canton to $version" "$body" "" "$(Build.SourceBranchName)" "ci-generated-canton-upgrade"
                   az pipelines build queue --branch "$branch" \
                                            --definition-name "PRs" \
                                            --org "https://dev.azure.com/digitalasset" \


### PR DESCRIPTION
adds label `ci-generated-canton-upgrade` to canton prs (such that we can use https://github.com/digital-asset/daml/issues?q=state%3Aopen%20label%3Aci-generated-canton-upgrade to look for these PRs)