### PR TITLE
Fix DPM resolution file parsing for sdk-version: null

### DIFF
--- a/sdk/compiler/damlc/daml-resolution-config/src/DA/Daml/Resolution/Config.hs
+++ b/sdk/compiler/damlc/daml-resolution-config/src/DA/Daml/Resolution/Config.hs
@@ -302,6 +302,8 @@ instance Aeson.FromJSON ValidPackageResolution where
       parseSdkVersion obj = case KM.lookup (Key.fromText "sdk-version") obj of
         Nothing -> pure Nothing
         Just (Aeson.String "") -> pure Nothing
+        -- Sometimes DPM gives `sdk-version: null` instead of omitting the field.
+        Just Aeson.Null -> pure Nothing
         Just ver -> Just <$> parseJSON ver
       -- Worst outcome is `dpm new` would do something wrong.
       componentsToV2 :: Map.Map String FilePath -> Map.Map String ComponentData


### PR DESCRIPTION
Resolution file parsing assumes sdk-version will either be omitted, empty string, or valid version. DPM sometimes provides it as "null", which we didn't handle correctly before.