### PR TITLE
Daml-script changes to handle unsupported contract IDs

### DIFF
--- a/sdk/compiler/damlc/tests/daml-test-files/Submit.daml
+++ b/sdk/compiler/damlc/tests/daml-test-files/Submit.daml
@@ -56,7 +56,7 @@ template T3 with
   where
   signatory t3_p
 
-#ifdef DAML_NUCK
+#ifdef DAML_FETCH_BY_KEY
   key (t3_p, ms) : (Party, [Party])
   maintainer key._2
 #endif
@@ -67,7 +67,7 @@ template FetchByKeyT3 with
   where
   signatory fetcher
 
-#ifdef DAML_NUCK
+#ifdef DAML_FETCH_BY_KEY
   choice DoFetch : (ContractId T3, T3)
     controller fetcher
     do fetchByKey @T3 fetchKey
@@ -103,7 +103,9 @@ template T5 with
 
 -- ContractNotFound: Cannot test contract not found with IDELedger, no way to get an invalid contract ID
 
-#ifdef DAML_NUCK
+-- UnsupportedContactId: Cannot test unsupported contract ID with IDELedger, no way to get an invalid contract ID
+
+#ifdef DAML_EXERCISE_BY_KEY
 contractKeyNotFound : Script ()
 contractKeyNotFound = script do
   alice <- allocateParty "alice"
@@ -182,7 +184,7 @@ failureStatusError = script do
 
 -- TemplatePreconditionViolated: Same as above
 
-#ifdef DAML_NUCK
+#ifdef DAML_FETCH_BY_KEY
 createEmptyContractKeyMaintainers : Script ()
 createEmptyContractKeyMaintainers = script do
   alice <- allocateParty "alice"
@@ -240,7 +242,7 @@ devError = script do
 -- Can reproduce right now with a timeout, or package vetting test.
 
 -- Using contractKeyNotFound with an enormous key
-#ifdef DAML_NUCK
+#ifdef DAML_EXERCISE_BY_KEY
 truncatedError : Script ()
 truncatedError = script do
   alice <- allocateParty "alice"

--- a/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
+++ b/sdk/daml-script/daml/Daml/Script/Internal/Questions/Submit/Error.daml
@@ -217,6 +217,8 @@ instance Show SubmitError where
     ContractNotFound { unknownContractIds, additionalDebuggingInfo } ->
       "Could not find contract with ID(s) " <> intercalate ", " (toList unknownContractIds) <> "."
       <> foldMap (\info -> " Additional debugging info: " <> show info) additionalDebuggingInfo
+    UnsupportedContractId contractId ->
+      "Unsupported contract ID: " <> contractId
     ContractKeyNotFound contractKey -> "Could not find contract with given key"
     UnresolvedPackageName packageName -> "Could not find any vetted package with name " <> packageName
     AuthorizationError errMessage -> "Authorization failure: " <> errMessage

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/GrpcErrorParser.scala
@@ -131,6 +131,10 @@ object GrpcErrorParser {
               None,
             )
         }
+      case "UNSUPPORTED_CONTRACT_ID" =>
+        caseErr { case Seq((ErrorResource.ContractId, cid)) =>
+          SubmitError.UnsupportedContractId(ContractId.assertFromString(cid))
+        }
       case "UNRESOLVED_PACKAGE_NAME" =>
         caseErr { case Seq((ErrorResource.PackageName, pkgName)) =>
           SubmitError.UnresolvedPackageName(PackageName.assertFromString(pkgName))

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -326,6 +326,8 @@ class IdeLedgerClient(
           NonEmpty(Seq, cid),
           Some(SubmitError.ContractNotFound.AdditionalInfo.NotFound()),
         )
+      case UnsupportedContractId(cid) =>
+        SubmitError.UnsupportedContractId(cid)
       case ContractKeyNotFound(key) => SubmitError.ContractKeyNotFound(key)
       case UnresolvedPackageName(packageName) => SubmitError.UnresolvedPackageName(packageName)
       case e: FailedAuthorization =>

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/SubmitError.scala
@@ -119,6 +119,14 @@ object SubmitError {
       )
   }
 
+  final case class UnsupportedContractId(cid: ContractId) extends SubmitError {
+    override def toDamlSubmitError(env: Env, legacyAnyContractKey: Boolean): ExtendedValue =
+      SubmitErrorConverters(env).damlScriptError(
+        "UnsupportedContractId",
+        ("unknownContractId", ValueText(cid.coid)),
+      )
+  }
+
   final case class UnresolvedPackageName(packageName: PackageName) extends SubmitError {
     override def toDamlSubmitError(env: Env, legacyAnyContractKey: Boolean): ExtendedValue =
       SubmitErrorConverters(env).damlScriptError(

--- a/sdk/security-evidence.md
+++ b/sdk/security-evidence.md
@@ -1,3 +1,5 @@
+Running on Apple Silicon (arm64). Changing stack limit from 8176 to 64000.
+Running on Apple Silicon (arm64). Changing stack limit from 8176 to 64000.
 # Security tests, by category
 
 ## Integrity:


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/canton/issues/33364

- [x] Add `UnsupportedContractId` to daml-script errors
- [ ] Ensure changes compile following merge and code drop of https://github.com/DACH-NY/canton/pull/33565