### PR TITLE
Update vscode market publishing to use dpm

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -102,9 +102,9 @@ jobs:
             - damlc:$latest_damlc
           EOF
             # Install said damlc to this temp dir
-            DPM_HOME=/tmp/dpm-test dpm install package
+            DPM_HOME=/tmp/dpm-test bazel run @dpm_binary//:dpm -- install package
             # Do not assume knowledge of dpm inner structure, ask `dpm resolve` for the component path
-            damlc_path=$(DPM_HOME=/tmp/dpm-test dpm resolve --output json | jq -r '.Packages["/tmp/dpm-test"].ComponentsV2.damlc.path')
+            damlc_path=$(DPM_HOME=/tmp/dpm-test bazel run @dpm_binary//:dpm -- resolve --output json | jq -r '.Packages["/tmp/dpm-test"].ComponentsV2.damlc.path')
             # Assume knowledge of the component structure, since we publish it here
             extension_path=$damlc_path/damlc-dist-dpm/resources/daml-bundles.vsix
             # Publish the vsix directly. We do not check out the branch of the release, so can safely assume the correct path to `vsce`

--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -94,7 +94,8 @@ jobs:
           if [[ "$latest_damlc" != "$MARKET" ]]; then
             echo "Publishing $latest_damlc to VSCode Marketplace"
             # Get extension vsix by installing this damlc in temp dir
-            tmp_dir=$(mktemp -d)
+            # Need the temp dir to be in sdk, so we can use dev-env commands on it (see zip later)
+            tmp_dir=$(mktemp -d -p $(pwd))
             trap "cd; rm -rf $tmp_dir" EXIT
             # Use single component with sdk-less install to grab only damlc
             cat << EOF > $tmp_dir/daml.yaml
@@ -103,13 +104,24 @@ jobs:
           EOF
             # Install said damlc to this temp dir
             DPM_HOME=$tmp_dir DAML_PROJECT=$tmp_dir bazel run @dpm_binary//:dpm -- install package
+
             # Do not assume knowledge of dpm inner structure, ask `dpm resolve` for the component path
             damlc_path=$(DPM_HOME=$tmp_dir DAML_PROJECT=$tmp_dir bazel run @dpm_binary//:dpm -- resolve --output json \
                         | jq -r --arg path $tmp_dir '.Packages[$path].ComponentsV2.damlc.path')
+
             # Assume knowledge of the component structure, since we publish it here
             extension_path=$damlc_path/damlc-dist-dpm/resources/daml-bundled.vsix
-            # Publish the vsix directly. We do not check out the branch of the release, so can safely assume the correct path to `vsce`
-            bazel run @daml_extension_deps//@vscode/vsce/bin:vsce -- publish --packagePath $extension_path -p $MARKETPLACE_TOKEN
+
+            # The bundled extension is still called "daml-bundled". We need to rename it to "daml" to replace the existing marketplace
+            # The name is only used in two place, `extension/package.json` and `extension.vsixmanifest`. We run a simple grep and replace over the zip
+            unzip $extension_path -d $tmp_dir/daml
+            sed -i 's/daml-bundled/daml/g' $tmp_dir/daml/extension.vsixmanifest $tmp_dir/daml/extension/package.json
+            # Zip doesn't let you set the "directory root", you have to cd to it
+            # if "tmp_dir" wasn't under "daml/sdk", we would not be able to use "zip"
+            (cd $tmp_dir/daml && zip -r -X $tmp_dir/daml.vsix .)
+
+            # Publish the renamed vsix directly. We do not check out the branch of the release, so can safely assume the correct path to `vsce`
+            bazel run @daml_extension_deps//@vscode/vsce/bin:vsce -- publish --packagePath $tmp_dir/daml.vsix -p $MARKETPLACE_TOKEN
             rm -rf $tmp_dir
           else
             echo "Version on marketplace is already the latest ($latest_damlc)."

--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -98,7 +98,7 @@ jobs:
             tmp_dir=$(mktemp -d -p $(pwd))
             trap "cd; rm -rf $tmp_dir" EXIT
             # Use single component with sdk-less install to grab only damlc
-            cat << EOF > $tmp_dir/daml.yaml
+            cat << EOF > "$tmp_dir/daml.yaml"
           components:
             - damlc:$latest_damlc
           EOF
@@ -107,22 +107,22 @@ jobs:
 
             # Do not assume knowledge of dpm inner structure, ask `dpm resolve` for the component path
             damlc_path=$(DPM_HOME=$tmp_dir DAML_PROJECT=$tmp_dir bazel run @dpm_binary//:dpm -- resolve --output json \
-                        | jq -r --arg path $tmp_dir '.Packages[$path].ComponentsV2.damlc.path')
+                        | jq -r --arg path "$tmp_dir" '.Packages[$path].ComponentsV2.damlc.path')
 
             # Assume knowledge of the component structure, since we publish it here
             extension_path=$damlc_path/damlc-dist-dpm/resources/daml-bundled.vsix
 
             # The bundled extension is still called "daml-bundled". We need to rename it to "daml" to replace the existing marketplace
             # The name is only used in two place, `extension/package.json` and `extension.vsixmanifest`. We run a simple grep and replace over the zip
-            unzip $extension_path -d $tmp_dir/daml
-            sed -i 's/daml-bundled/daml/g' $tmp_dir/daml/extension.vsixmanifest $tmp_dir/daml/extension/package.json
+            unzip "$extension_path" -d "$tmp_dir/daml"
+            sed -i 's/daml-bundled/daml/g' "$tmp_dir/daml/extension.vsixmanifest" "$tmp_dir/daml/extension/package.json"
             # Zip doesn't let you set the "directory root", you have to cd to it
             # if "tmp_dir" wasn't under "daml/sdk", we would not be able to use "zip"
-            (cd $tmp_dir/daml && zip -r -X $tmp_dir/daml.vsix .)
+            (cd "$tmp_dir/daml" && zip -r -X "$tmp_dir/daml.vsix" .)
 
             # Publish the renamed vsix directly. We do not check out the branch of the release, so can safely assume the correct path to `vsce`
-            bazel run @daml_extension_deps//@vscode/vsce/bin:vsce -- publish --packagePath $tmp_dir/daml.vsix -p $MARKETPLACE_TOKEN
-            rm -rf $tmp_dir
+            bazel run @daml_extension_deps//@vscode/vsce/bin:vsce -- publish --packagePath "$tmp_dir/daml.vsix" -p $MARKETPLACE_TOKEN
+            rm -rf "$tmp_dir"
           else
             echo "Version on marketplace is already the latest ($latest_damlc)."
           fi

--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -97,18 +97,20 @@ jobs:
             tmp_dir=$(mktemp -d)
             trap "cd; rm -rf $tmp_dir" EXIT
             # Use single component with sdk-less install to grab only damlc
-            cat << EOF > $$TMP_DIR/daml.yaml
+            cat << EOF > $tmp_dir/daml.yaml
           components:
             - damlc:$latest_damlc
           EOF
             # Install said damlc to this temp dir
-            DPM_HOME=/tmp/dpm-test bazel run @dpm_binary//:dpm -- install package
+            DPM_HOME=$tmp_dir DAML_PROJECT=$tmp_dir bazel run @dpm_binary//:dpm -- install package
             # Do not assume knowledge of dpm inner structure, ask `dpm resolve` for the component path
-            damlc_path=$(DPM_HOME=/tmp/dpm-test bazel run @dpm_binary//:dpm -- resolve --output json | jq -r '.Packages["/tmp/dpm-test"].ComponentsV2.damlc.path')
+            damlc_path=$(DPM_HOME=$tmp_dir DAML_PROJECT=$tmp_dir bazel run @dpm_binary//:dpm -- resolve --output json \
+                        | jq -r --arg path $tmp_dir '.Packages[$path].ComponentsV2.damlc.path')
             # Assume knowledge of the component structure, since we publish it here
-            extension_path=$damlc_path/damlc-dist-dpm/resources/daml-bundles.vsix
+            extension_path=$damlc_path/damlc-dist-dpm/resources/daml-bundled.vsix
             # Publish the vsix directly. We do not check out the branch of the release, so can safely assume the correct path to `vsce`
             bazel run @daml_extension_deps//@vscode/vsce/bin:vsce -- publish --packagePath $extension_path -p $MARKETPLACE_TOKEN
+            rm -rf $tmp_dir
           else
             echo "Version on marketplace is already the latest ($latest_damlc)."
           fi

--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -15,6 +15,7 @@ trigger: none
 # does, however, work as expected for Azure-hosted repos. As a workaround, we
 # have created a repo inside Azure that contains an `azure-pipelines.yml` file
 # that just triggers this job.
+# (https://dev.azure.com/digitalasset/daml/_git/cron-workaround?path=/azure-pipelines.yml)
 #
 # When the situation is resolved, delete that repo in Azure and uncomment the
 # following. In the meantime, this should stay commented so we avoid running
@@ -68,11 +69,14 @@ jobs:
     steps:
       - checkout: self
         clean: true
+      - bash: ci/dev-env-install.sh
+        displayName: 'Build/Install the Developer Environment'
       - bash: |
           set -euo pipefail
+          cd sdk
 
           # Enter dade assist for tools needed to find correct git branch
-          eval "$(cd sdk; dev-env/bin/dade-assist)"
+          eval "$(dev-env/bin/dade-assist)"
 
           AUTH=$(echo -n "OAuth:${MARKETPLACE_TOKEN}" | base64 -w0)
           MARKET=$(curl -H "Authorization: Basic $AUTH" \
@@ -80,81 +84,33 @@ jobs:
                         -sSfL \
                         "https://marketplace.visualstudio.com/_apis/gallery/publishers/DigitalAssetHoldingsLLC/extensions/daml?flags=1" \
                         | jq -r '.versions[0].version')
-          # This jq expression should ensure that we always upload the
-          # highest-number version. Here is how this works:
-          #
-          # 1. The GitHub API documentation does not specify the order for the
-          #    "list releases" endpoint, but does specify that the "latest"
-          #    endpoint returns the release that points to the most recent commit.
-          #    Assuming the same sort order is applied for the list endpoint
-          #    (which empirically seems to hold so far), this means that they may
-          #    be out-of-order wrt version numbers, e.g. 1.1.0 may appear after
-          #    1.0.2.
-          # 2. The `.tag_name | .[1:] | split (".") | map(tonumber)` part will
-          #    turn "v1.0.2" into an array [1, 0, 2].
-          # 3. jq documents its sort method to sort numbers in numeric order
-          #    and arrays in lexical order (ascending in both cases).
-          #
-          # This is required because, while the VSCode Marketplace does show
-          # _a_ version number, it doesn't handle versions at all: we can only
-          # have one version on the marketplace at any given time, and any
-          # upload replaces the existing version.
-          GITHUB=$(curl https://api.github.com/repos/digital-asset/daml/releases -sSfL \
-                   | jq -r '. | map(select(.prerelease == false)
-                                    | .tag_name
-                                    | .[1:]
-                                    | split (".")
-                                    | map(tonumber))
-                              | sort
-                              | reverse
-                              | .[0]
-                              | map(tostring)
-                              | join(".")')
-          if [[ "$GITHUB" != "$MARKET" ]] && git merge-base --is-ancestor 798e96c9b9034eac85ace786b9e1955cf380285c v$GITHUB; then
-            echo "Publishing $GITHUB to VSCode Marketplace"
-            git checkout v$GITHUB
-            # Enter correct dade for deployment
-            eval "$(cd sdk; dev-env/bin/dade-assist)"
-            (
-            cd sdk
-            cp LICENSE compiler/daml-extension
-            trap "rm -rf $PWD/compiler/daml-extension/LICENSE" EXIT
-            cd compiler/daml-extension
-            sed -i "s/__VERSION__/$GITHUB/" package.json
-            # This produces out/src/extension.js
-
-            # Some branches have updated vsce, and different daml_extension_deps name, so we detect that.
-            # We build conditions here, rather than using a checked in script, as we're currently stuck trying
-            # to push a release to marketplace which is already frozen in git.
-
-            # Find the external deps repo name
-            if bazel query @daml_extension_deps_2x//... >/dev/null 2>&1; then
-              EXT_DEPS_REPO=daml_extension_deps_2x
-            else
-              EXT_DEPS_REPO=daml_extension_deps
-            fi
-
-            echo "Using external repository @$EXT_DEPS_REPO"
-
-            # Find which vsce path we need
-            if bazel query @$EXT_DEPS_REPO//... | grep -q @vscode; then
-              VSCE_PATH=@$EXT_DEPS_REPO//@vscode/vsce/bin:vsce
-            else
-              VSCE_PATH=@$EXT_DEPS_REPO//vsce/bin:vsce
-            fi
-
-            echo "Using VSCE $VSCE_PATH"
-
-            bazel run --run_under="cd $PWD &&" //:yarn install
-            bazel run --run_under="cd $PWD &&" //:yarn compile
-            bazel run --run_under="cd $PWD &&" $VSCE_PATH -- publish --yarn $GITHUB -p $MARKETPLACE_TOKEN
-            )
+          
+          # Grab latest damlc by reading all public/stable versions, filtering only full version strings (i.e. 3.5.1), taking maximum
+          # Version ordering is achieved by transforming simple semver into list of integers, and taking the max of this list (which jq does correctly)
+          latest_damlc=$(bazel run @dpm_binary//:dpm -- tags oci://europe-docker.pkg.dev/da-images/public/components/damlc \
+                        | jq -Rrs '. | split("\n")
+                                     | map(select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$")))
+                                     | max_by(split(".")|map(tonumber))')
+          if [[ "$latest_damlc" != "$MARKET" ]]; then
+            echo "Publishing $latest_damlc to VSCode Marketplace"
+            # Get extension vsix by installing this damlc in temp dir
+            tmp_dir=$(mktemp -d)
+            trap "cd; rm -rf $tmp_dir" EXIT
+            # Use single component with sdk-less install to grab only damlc
+            cat << EOF > $$TMP_DIR/daml.yaml
+          components:
+            - damlc:$latest_damlc
+          EOF
+            # Install said damlc to this temp dir
+            DPM_HOME=/tmp/dpm-test dpm install package
+            # Do not assume knowledge of dpm inner structure, ask `dpm resolve` for the component path
+            damlc_path=$(DPM_HOME=/tmp/dpm-test dpm resolve --output json | jq -r '.Packages["/tmp/dpm-test"].ComponentsV2.damlc.path')
+            # Assume knowledge of the component structure, since we publish it here
+            extension_path=$damlc_path/damlc-dist-dpm/resources/daml-bundles.vsix
+            # Publish the vsix directly. We do not check out the branch of the release, so can safely assume the correct path to `vsce`
+            bazel run @daml_extension_deps//@vscode/vsce/bin:vsce -- publish --packagePath $extension_path -p $MARKETPLACE_TOKEN
           else
-            if [[ "$GITHUB" == "$MARKET" ]]; then
-              echo "Version on marketplace is already the latest ($GITHUB)."
-            else
-              echo "Latest version is not ready for marketplace publication."
-            fi
+            echo "Version on marketplace is already the latest ($latest_damlc)."
           fi
         displayName: 'Publish to VSCode Marketplace'
         env:


### PR DESCRIPTION
This only needs to be merged to main, as this job runs from main only.
Since moving to dpm, the existing logic broke for two reasons:
- We no longer keep assembly and component version the same, so finding component from assembly needs logic
- We no longer tag daml commits with their release, so finding the commit from a release is hard

We now take a different approach, instead of rebuilding the extension and publishing it, we pull down the latest stable damlc component, and upload the extension contained within it directly.
Notably now the extension will be published under the damlc component version, rather than the bundle version. This is reasonable as the extension is part of damlc, but may be confusing. For now, in 3.5.2, assembly and component version are still the same, so we're okay.

An issue we hit when testing is that the extension bundled with the damlc component has been renamed to `daml-bundled`, rather than just `daml` as per the package.json file.
We need to undo this renaming in order to publish it correctly, but since it's already built, we have to manipulate the vsix to do this. The comments in this section explain how this is done, it's not as bad as it sounds :)