### PR TITLE
Make hide-successes the default for integration tests

### DIFF
--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -95,6 +95,7 @@ import Test.Tasty
 import Test.Tasty.Golden (goldenVsStringDiff)
 import qualified Test.Tasty.HUnit as HUnit
 import Test.Tasty.HUnit ((@?=))
+import Test.Tasty.Ingredients.ConsoleReporter (HideSuccesses(..))
 import Test.Tasty.Options
 import Test.Tasty.Providers
 import Test.Tasty.Runners (Result(..))
@@ -197,7 +198,8 @@ main = withComponentVersions $ do
     integrationTestCases <- collectIntegrationTests
     withScriptServices withScriptService integrationTestCases $ \getScriptService -> do
       integrationTests <- buildIntegrationTestTree integrationTestCases registerTODO getScriptService scriptPackageData
-      let tests = testGroup "All" [parseRenderRangeTest, uniqueUniques, integrationTests]
+      let tests = localOption (HideSuccesses True) $
+            testGroup "All" [parseRenderRangeTest, uniqueUniques, integrationTests]
       defaultMainWithIngredients ingredients tests
         `finally` (do
         todos <- readIORef todoRef


### PR DESCRIPTION
## Summary
- Default integration test output now hides passing tests via Tasty's
  `HideSuccesses` option, applied in the shared integration-lib so it
  covers all LF version targets (v21, v22, v23, v2dev).
- Override with `TASTY_HIDE_SUCCESSES=False` to restore full output.

## Verification

**All tests pass** — output is a single summary line:
```
All 892 tests passed (122.70s)
```

**Deliberate failure** (`assert False` added to `ContractKeys.daml`) —
only the failing test is printed with full diagnostics:
```
        Failed with status: UNHANDLED_EXCEPTION/DA.Exception.AssertionFailed:AssertionFailed: Assertion failed
        Using Canton Error Category InvalidGivenCurrentSystemStateOther

      Ledger time: 1970-01-01T00:00:00Z

      Committed transactions:
        TX 0 1970-01-01T00:00:00Z (ContractKeys:38:22)
        #0:0
        │   consumed by: #1:0
        │   referenced by #1:0
        │   disclosed to (since): 'Alice' (0), 'Bank' (0)
        └─> 'Bank' creates ContractKeys:AccountInvitation
                            with
                              account =
                                (ContractKeys:Account with
                                   bank = 'Bank';
                                   accountHolder = 'Alice';
                                   accountNumber =
                                     (DA.Types:Tuple2 with
                                        _1 = "CH"; _2 = 123))

        TX 1 1970-01-01T00:00:00Z (ContractKeys:40:19)
        #1:0
        │   disclosed to (since): 'Alice' (1), 'Bank' (1)
        └─> 'Alice' exercises Accept on #0:0 (ContractKeys:AccountInvitation)
            children:
            #1:1
            │   disclosed to (since): 'Alice' (1), 'Bank' (1)
            └─> 'Alice' and 'Bank' create ContractKeys:Account
                                                     with
                                                       bank = 'Bank';
                                                       accountHolder = 'Alice';
                                                       accountNumber =
                                                         (DA.Types:Tuple2 with
                                                            _1 = "CH"; _2 = 123)
      Wrong number of diagnostics, expected 0, but got 1

      Use -p '/ContractKeys.daml.Check diagnostics/' to rerun this test only.

1 out of 892 tests failed (103.92s)
```

## Test plan
- [x] Ran `bazel run //compiler/damlc/tests:integration-v2dev` — all 892 tests pass
- [x] Introduced intentional failure in `ContractKeys.daml`, confirmed only the failure is shown with full diagnostics
- [x] Reverted the test file