### PR TITLE
Use buildifier binary directly in pre-commit hook

### DIFF
--- a/sdk/.pre-commit-config.yaml
+++ b/sdk/.pre-commit-config.yaml
@@ -30,8 +30,7 @@ repos:
       name: buildifier
       language: system
       require_serial: true
-      pass_filenames: false
-      entry: "bash -c 'cd sdk/; bazel run //:buildifier-fix'"
+      entry: "bash -c 'cd sdk/ && files=(\"$@\") && bazel run @com_github_bazelbuild_buildtools//buildifier -- -mode=fix -v ${files[@]##sdk/}' bash"
       types: [bazel]
     - id: pprettier
       name: pprettier

--- a/sdk/.pre-commit-config.yaml
+++ b/sdk/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       name: buildifier
       language: system
       require_serial: true
-      entry: "bash -c 'cd sdk/ && bazel build @com_github_bazelbuild_buildtools//buildifier 2>/dev/null && files=(\"$@\") && bazel-bin/external/com_github_bazelbuild_buildtools/buildifier/buildifier_/buildifier -mode=fix -v ${files[@]##sdk/}' bash"
+      entry: "bash -c 'root=$PWD && cd sdk/ && bazel run @com_github_bazelbuild_buildtools//buildifier -- -mode=fix -v \"${@/#/$root/}\"' bash"
       types: [bazel]
     - id: pprettier
       name: pprettier

--- a/sdk/.pre-commit-config.yaml
+++ b/sdk/.pre-commit-config.yaml
@@ -30,7 +30,8 @@ repos:
       name: buildifier
       language: system
       require_serial: true
-      entry: "bash -c 'cd sdk/; bazel run //:buildifier-pre-commit -- -mode=fix -v=true'"
+      pass_filenames: false
+      entry: "bash -c 'cd sdk/; bazel run //:buildifier-fix'"
       types: [bazel]
     - id: pprettier
       name: pprettier

--- a/sdk/.pre-commit-config.yaml
+++ b/sdk/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       name: buildifier
       language: system
       require_serial: true
-      entry: "bash -c 'cd sdk/ && files=(\"$@\") && bazel run @com_github_bazelbuild_buildtools//buildifier -- -mode=fix -v ${files[@]##sdk/}' bash"
+      entry: "bash -c 'cd sdk/ && bazel build @com_github_bazelbuild_buildtools//buildifier 2>/dev/null && files=(\"$@\") && bazel-bin/external/com_github_bazelbuild_buildtools/buildifier/buildifier_/buildifier -mode=fix -v ${files[@]##sdk/}' bash"
       types: [bazel]
     - id: pprettier
       name: pprettier

--- a/sdk/BUILD
+++ b/sdk/BUILD
@@ -190,7 +190,6 @@ buildifier(
     verbose = True,
 )
 
-
 # Default target for da-ghci, da-ghcid.
 da_haskell_repl(
     name = "repl",

--- a/sdk/BUILD
+++ b/sdk/BUILD
@@ -190,18 +190,6 @@ buildifier(
     verbose = True,
 )
 
-# Run by the git pre-commit hook
-genrule(
-    name = "buildifier-pre-commit",
-    outs = ["buildifier-hook"],
-    cmd = """cat <<'EOF' > "$@"
-# !/usr/bin/env bash
-exec "$(execpath @com_github_bazelbuild_buildtools//buildifier)" "$$@"
-EOF
-""",
-    executable = True,
-    tools = ["@com_github_bazelbuild_buildtools//buildifier"],
-)
 
 # Default target for da-ghci, da-ghcid.
 da_haskell_repl(


### PR DESCRIPTION
## Summary
- Replace the `buildifier-pre-commit` genrule with a direct invocation of the
  `@com_github_bazelbuild_buildtools//buildifier` binary in the pre-commit hook
- Scope the hook to only process changed files (previously it either ran on all
  files or silently processed nothing via empty stdin)
- Remove the now-unused `buildifier-pre-commit` genrule from `sdk/BUILD`

## Motivation
The old hook used a genrule wrapper that swallowed the filenames pre-commit
passed (they landed in unused positional params of `bash -c`), making it
effectively a no-op. The new hook passes changed files with absolute paths
directly to the buildifier binary, so it actually formats the files and
runs in ~0.5s even on the full repo.