### PR TITLE
Remove dead DAML_LEGACY_LOOKUP_BY_KEY CPP block

### DIFF
--- a/sdk/compiler/damlc/daml-stdlib-src/DA/Internal/Template/Functions.daml
+++ b/sdk/compiler/damlc/daml-stdlib-src/DA/Internal/Template/Functions.daml
@@ -159,9 +159,6 @@ class HasFromAnyChoice t c r | t c -> r where
 type TemplateKey t k =
   ( Template t
   , HasKey t k
-#ifdef DAML_LEGACY_LOOKUP_BY_KEY
-  , HasLookupByKey t k
-#endif
 #ifdef DAML_CONTRACT_KEYS
   , HasFetchByKey t k
 #endif


### PR DESCRIPTION
The DAML_LEGACY_LOOKUP_BY_KEY flag was no longer defined in daml-lf-features.json or any build configuration, making the #ifdef block permanently inactive dead code.

This was a remnant from the transition to non-unique contract keys (NUCK) that was never cleaned up.