### PR TITLE
Fix quadratic diagnostic output in damlc test

### DIFF
--- a/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Output.hs
+++ b/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Output.hs
@@ -6,6 +6,7 @@ module DA.Daml.Compiler.Output
   , writeOutputBSL
   , diagnosticsLogger
   , hDiagnosticsLogger
+  , noopLogger
   , printDiagnostics
   ) where
 
@@ -64,3 +65,6 @@ hDiagnosticsLogger handle = NotificationHandler $ \m params -> case (m, params) 
     (LSP.STextDocumentPublishDiagnostics, LSP.PublishDiagnosticsParams (uriToFilePath' -> Just fp) _ (List diags)) ->
         printDiagnostics handle $ map (toNormalizedFilePath' fp,ShowDiag,) diags
     _ -> pure ()
+
+noopLogger :: NotificationHandler
+noopLogger = NotificationHandler $ \_ _ -> pure ()

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -97,10 +97,11 @@ execTest inFiles runAllOption coverage color mbJUnitOutput mPkgConfig opts table
     let optsWithPkg = case mPkgConfig of
             Just PackageConfigFields{..} -> opts { optMbPackageName = Just pName, optMbPackageVersion = pVersion }
             Nothing -> opts
-    withDamlIdeState optsWithPkg loggerH diagnosticsLogger $ \h -> do
-        runAndReport h inFiles (optDetailLevel opts) (optDamlLfVersion opts) runAllOption coverage color mbJUnitOutput tableOutputPath transactionsOutputPath resultsIO coverageFilters
-        diags <- getDiagnostics h
-        when (any (\(_, _, diag) -> Just DsError == _severity diag) diags) exitFailure
+    withDamlIdeState optsWithPkg loggerH noopLogger $ \h -> do
+        flip finally (getDiagnostics h >>= printDiagnostics stderr) $ do
+            runAndReport h inFiles (optDetailLevel opts) (optDamlLfVersion opts) runAllOption coverage color mbJUnitOutput tableOutputPath transactionsOutputPath resultsIO coverageFilters
+            diags <- getDiagnostics h
+            when (any (\(_, _, diag) -> Just DsError == _severity diag) diags) exitFailure
 
 loadAggregatePrintResults :: CoveragePaths -> [CoverageFilter] -> ShowCoverage -> Maybe TR.TestResults -> IO ()
 loadAggregatePrintResults resultsIO coverageFilters coverage mbNewTestResults = do


### PR DESCRIPTION
## Context

Per LSP protocol, each PublishDiagnosticsParams contains the complete set of diagnostics for a file (replacing previous). The diagnosticsLogger was printing each notification incrementally, causing N failing tests to produce 1+2+...+N error messages instead of N.

Fix by using a no-op logger during test execution and printing the final deduplicated diagnostics from getDiagnostics once at the end. Use `finally` to ensure diagnostics are printed even when exceptions occur (e.g., for non-existent files or parse errors).

## Summary

1. Bug fix: Use a no-op logger during test execution and print the final deduplicated diagnostics from getDiagnostics once at the end. The previous diagnosticsLogger printed each LSP notification incrementally, but per LSP protocol each notification replaces the previous for that file - causing N failing tests to produce 1+2+...+N error messages.
2. Test fix: Wrapped the diagnostic printing in finally to ensure diagnostics are printed even when exceptions occur (e.g., non-existent files, parse errors).

## Future

We have to see if we fixed the problem totally by providing a noooplogger just in this case, or that we need to alter `withDamlIdeState` to not take a logger since it will always have this quadratic problem

EDIT: according to claude:

The quadratic issue is specific to damlc test's sequential script execution pattern. Other callers either:
1. Do single-shot operations (packaging, build)
2. Process files in one batch (daml-doc)