### PR TITLE
Drop deleted canton npm example from Blackduck scan

### DIFF
--- a/ci/blackduck.yml
+++ b/ci/blackduck.yml
@@ -82,9 +82,8 @@ jobs:
       cd sdk
       eval "$(dev-env/bin/dade-assist)"
 
-      # npm install for canton npm examples
+      # install dependencies for the daml JS libraries
       (cd language-support/js && yarn install)
-      (cd canton/community/app/src/pack/examples/09-json-api/typescript && npm install && npm ls)
 
       bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/$(blackduck_script_sha)/synopsys-detect) \
       ci-build digital-asset_daml $(Build.SourceBranchName) \


### PR DESCRIPTION
`canton/community/app/src/pack/examples/09-json-api/typescript` was removed along with the rest of the vendored canton sources in #22692, so the 'Blackduck Npm Scan' step failed when cd-ing into it. Remove the obsolete npm install and scan only the remaining language-support/js libraries.