### PR TITLE
Fix issues with data-dep pattern synonyms with infix operators and types

### DIFF
--- a/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -411,7 +411,12 @@ generateSrcFromLf env = noLoc mod
     mkRdrNameUnqualUnsafe (LFC.QualName q) = do
       -- Emit the usage for imports, but don't use it
       void $ genModule env (LF.qualPackage q) (LF.qualModule q)
-      pure $ noLoc $ mkRdrUnqual $ LF.qualObject q
+      let occName = LF.qualObject q
+          bracketOccName :: OccName -> OccName
+          bracketOccName name = mkOccName (occNameSpace name) ("(" <> occNameString name <> ")")
+          bracketedOccName =
+            if isSymOcc occName then bracketOccName occName else occName
+      pure $ noLoc $ mkRdrUnqual bracketedOccName
 
     -- Only allows unqual if the name comes from the same package and module
     mkRdrNameUnqual :: LFC.QualName -> Gen (Located RdrName)
@@ -697,15 +702,16 @@ generateSrcFromLf env = noLoc mod
       where
         makeCompletePragma :: LFC.LFCompleteMatch LFC.QualName -> Gen (LHsDecl GhcPs)
         makeCompletePragma match = do
-          subjectRdrName <- mkRdrNameQual $ LFC.subject match
           -- Parser only allows the pragma to contain unqualified names, but supports those names coming from any module/package
           -- (as long as one name comes from this module)
           matchersRdrNames <- traverse mkRdrNameUnqualUnsafe $ LFC.matchers match
+          -- Similarly, Parser will not allow qualified symbol data types (such as tuple) for the subject, so we unqualify those too
+          subjectRdrName <- mkRdrNameUnqualUnsafe $ LFC.subject match
           pure $ noLoc . SigD noExt $ CompleteMatchSig
             noExt 
             NoSourceText
             (noLoc matchersRdrNames)
-            (Just $ noLoc subjectRdrName)
+            (Just subjectRdrName)
         getCompleteExprs :: [LFC.LFCompleteMatch LFC.QualName]
         getCompleteExprs = do
           LF.DefValue
@@ -728,8 +734,15 @@ generateSrcFromLf env = noLoc mod
             Just qualInstance ->
                 -- If the instance already exists, we still
                 -- need to import it so that we can refer to it from other
-                -- instances.
-                [Nothing <$ genModule env (LF.qualPackage qualInstance) (LF.qualModule qualInstance)]
+                -- instances. Note use of emitModRef directly to specify an EmptyImpSpec,
+                -- as we only need instances here. Wildcard imports here can create 
+                -- namespace collisions which cause problems for `COMPLETE` pragmas, as they
+                -- can only reference names unqualified
+                pure $ Nothing <$ emitModRef ModRef
+                    { modRefModule = LF.qualModule qualInstance
+                    , modRefOrigin = importOriginFromPackageRef (envConfig env) $ LF.qualPackage qualInstance
+                    , modRefImpSpec = EmptyImpSpec
+                    }
             Nothing -> pure $ do
                 polyTy <- HsIB noExt . noLoc <$> convDFunSig env reexportedClasses dfunSig
                 binds <- genInstanceBinds dfunSig

--- a/sdk/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -1793,6 +1793,22 @@ tests TestArgs{..} =
             ]
         ]
 
+    , dataDependenciesTest "Using complete pragma with infix pattern synonyms"
+        [
+            (,) "Base.daml"
+            [ "module Base where"
+            , "pattern a :+: b = (a, b)"
+            , "{-# COMPLETE (:+:) #-}"
+            ]
+        ]
+        [   (,) "Main.daml"
+            [ "module Main where"
+            , "import Base"
+            , "usePattern : (a, b) -> a"
+            , "usePattern (x :+: _) = x"
+            ]
+        ]
+
     , dataDependenciesTest "Using complete pragma with pattern synonyms and non-local types"
         [
             (,) "Base.daml"
@@ -2959,6 +2975,11 @@ tests TestArgs{..} =
 
     dataDependenciesTest :: String -> [(FilePath, [String])] -> [(FilePath, [String])] -> TestTree
     dataDependenciesTest title = dataDependenciesTestOptions title defTestOptions
+
+    -- withTempDirBah step f = do
+    --   (dir, _) <- newTempDir
+    --   _ <- step dir
+    --   f dir
 
     dataDependenciesTestOptions :: String -> DataDependenciesTestOptions -> [(FilePath, [String])] -> [(FilePath, [String])] -> TestTree
     dataDependenciesTestOptions title (DataDependenciesTestOptions buildOptions extraDeps) libModules mainModules =

--- a/sdk/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -2976,11 +2976,6 @@ tests TestArgs{..} =
     dataDependenciesTest :: String -> [(FilePath, [String])] -> [(FilePath, [String])] -> TestTree
     dataDependenciesTest title = dataDependenciesTestOptions title defTestOptions
 
-    -- withTempDirBah step f = do
-    --   (dir, _) <- newTempDir
-    --   _ <- step dir
-    --   f dir
-
     dataDependenciesTestOptions :: String -> DataDependenciesTestOptions -> [(FilePath, [String])] -> [(FilePath, [String])] -> TestTree
     dataDependenciesTestOptions title (DataDependenciesTestOptions buildOptions extraDeps) libModules mainModules =
         testCaseSteps title $ \step -> withTempDir $ \tmpDir -> do


### PR DESCRIPTION
Following issues found with https://github.com/digital-asset/daml/pull/22460, the following bugs have been fixed:
- Infix patterns/constructors in COMPLETE pragmas were not bracketed, causing a parse error
- Subject types in COMPLETE pragmas were fully qualified, leading to parse errors when using infix types, such as tuple
- When instance rewriting decided to use an existing instances by re-importing the same module from its own prelude, it would import said module fully, rather than just instances. This leads to ambiguity errors with complete pragmas that require references to be unqualified. This has also been fixed
