### PR TITLE
Fix collect_build_data_failed following non-split-release removal

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -313,7 +313,6 @@ jobs:
     - Linux
     - macOS
     - Windows
-    - release
     - git_sha
     - compatibility_linux
     - check_for_release


### PR DESCRIPTION
Forgot to remove a reference to the `release` job, after removing it with the Daml Assistant removal. Sadly we didn't notice main CI breaking :(