### PR TITLE
Add docs template snippets into tests

### DIFF
--- a/sdk/docs/sharable/sdk/tutorials/smart-contracts/daml/daml-intro-choices/daml.yaml
+++ b/sdk/docs/sharable/sdk/tutorials/smart-contracts/daml/daml-intro-choices/daml.yaml
@@ -1,0 +1,8 @@
+sdk-version: 3.5.1
+name: intro-choices
+source: daml
+version: 1.0.0
+dependencies:
+  - daml-prim
+  - daml-stdlib
+  - daml-script

--- a/sdk/docs/sharable/sdk/tutorials/smart-contracts/daml/daml-intro-choices/daml.yaml
+++ b/sdk/docs/sharable/sdk/tutorials/smart-contracts/daml/daml-intro-choices/daml.yaml
@@ -1,8 +1,0 @@
-sdk-version: 3.5.1
-name: intro-choices
-source: daml
-version: 1.0.0
-dependencies:
-  - daml-prim
-  - daml-stdlib
-  - daml-script

--- a/sdk/docs/sharable/sdk/tutorials/smart-contracts/daml/daml-intro-choices/daml/PartyRoles.daml
+++ b/sdk/docs/sharable/sdk/tutorials/smart-contracts/daml/daml-intro-choices/daml/PartyRoles.daml
@@ -1,0 +1,50 @@
+-- Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+
+module PartyRoles where
+
+import Daml.Script
+
+-- ASSET_BEGIN
+template Asset
+  with
+    issuer : Party   -- Will be signatory
+    owner : Party    -- Will be observer and controller
+    auditor : Party  -- Will be observer
+  where
+    signatory issuer        -- Must authorize creation; always sees contract
+    observer owner, auditor -- Can see contract
+
+    choice ChangeOwner : ContractId Asset
+      with newOwner : Party
+      controller owner      -- Only owner can exercise this choice
+      do create this with owner = newOwner
+-- ASSET_END
+
+test_party_roles = script do
+  issuer <- allocateParty "Issuer"
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
+  auditor <- allocateParty "Auditor"
+
+  assetCid <- submit issuer do
+    createCmd Asset with
+      issuer = issuer
+      owner = alice
+      auditor = auditor
+
+  Some _ <- queryContractId alice assetCid
+  Some _ <- queryContractId auditor assetCid
+
+  newCid <- submit alice do
+    exerciseCmd assetCid ChangeOwner with newOwner = bob
+
+  Some asset <- queryContractId issuer newCid
+  assert (asset.owner == bob)
+
+  submitMustFail issuer do
+    exerciseCmd newCid ChangeOwner with newOwner = alice
+
+  submitMustFail auditor do
+    exerciseCmd newCid ChangeOwner with newOwner = alice

--- a/sdk/docs/sharable/sdk/tutorials/smart-contracts/daml/daml-intro-choices/daml/TemplateChoices.daml
+++ b/sdk/docs/sharable/sdk/tutorials/smart-contracts/daml/daml-intro-choices/daml/TemplateChoices.daml
@@ -1,0 +1,53 @@
+-- Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+
+module TemplateChoices where
+
+import Daml.Script
+
+-- TEMPLATE_STRUCTURE_BEGIN
+template Token
+  with
+    -- Data fields
+    owner : Party
+    issuer : Party
+    amount : Decimal
+  where
+    -- Authorization
+    signatory issuer
+    observer owner
+
+    -- Actions
+    choice ChangeOwner : ContractId Token
+      with
+        newOwner : Party
+      controller owner
+      do
+        create this with owner = newOwner
+-- TEMPLATE_STRUCTURE_END
+
+    nonconsuming choice GetBalance : Decimal
+      controller owner
+      do return amount
+
+test_token_choices = script do
+  issuer <- allocateParty "Issuer"
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
+
+  tokenCid <- submit issuer do
+    createCmd Token with
+      issuer = issuer
+      owner = alice
+      amount = 100.0
+
+  balance <- submit alice do
+    exerciseCmd tokenCid GetBalance
+  assert (balance == 100.0)
+
+  newCid <- submit alice do
+    exerciseCmd tokenCid ChangeOwner with newOwner = bob
+
+  Some token <- queryContractId issuer newCid
+  assert (token.owner == bob)

--- a/sdk/docs/source/sdk/tutorials/smart-contracts/daml/daml-intro-choices/daml/PartyRoles.daml
+++ b/sdk/docs/source/sdk/tutorials/smart-contracts/daml/daml-intro-choices/daml/PartyRoles.daml
@@ -1,4 +1,4 @@
--- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
 

--- a/sdk/docs/source/sdk/tutorials/smart-contracts/daml/daml-intro-choices/daml/PartyRoles.daml
+++ b/sdk/docs/source/sdk/tutorials/smart-contracts/daml/daml-intro-choices/daml/PartyRoles.daml
@@ -1,0 +1,50 @@
+-- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+
+module PartyRoles where
+
+import Daml.Script
+
+-- ASSET_BEGIN
+template Asset
+  with
+    issuer : Party   -- Will be signatory
+    owner : Party    -- Will be observer and controller
+    auditor : Party  -- Will be observer
+  where
+    signatory issuer        -- Must authorize creation; always sees contract
+    observer owner, auditor -- Can see contract
+
+    choice ChangeOwner : ContractId Asset
+      with newOwner : Party
+      controller owner      -- Only owner can exercise this choice
+      do create this with owner = newOwner
+-- ASSET_END
+
+test_party_roles = script do
+  issuer <- allocateParty "Issuer"
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
+  auditor <- allocateParty "Auditor"
+
+  assetCid <- submit issuer do
+    createCmd Asset with
+      issuer = issuer
+      owner = alice
+      auditor = auditor
+
+  Some _ <- queryContractId alice assetCid
+  Some _ <- queryContractId auditor assetCid
+
+  newCid <- submit alice do
+    exerciseCmd assetCid ChangeOwner with newOwner = bob
+
+  Some asset <- queryContractId issuer newCid
+  assert (asset.owner == bob)
+
+  submitMustFail issuer do
+    exerciseCmd newCid ChangeOwner with newOwner = alice
+
+  submitMustFail auditor do
+    exerciseCmd newCid ChangeOwner with newOwner = alice

--- a/sdk/docs/source/sdk/tutorials/smart-contracts/daml/daml-intro-choices/daml/TemplateChoices.daml
+++ b/sdk/docs/source/sdk/tutorials/smart-contracts/daml/daml-intro-choices/daml/TemplateChoices.daml
@@ -1,4 +1,4 @@
--- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
 

--- a/sdk/docs/source/sdk/tutorials/smart-contracts/daml/daml-intro-choices/daml/TemplateChoices.daml
+++ b/sdk/docs/source/sdk/tutorials/smart-contracts/daml/daml-intro-choices/daml/TemplateChoices.daml
@@ -1,0 +1,53 @@
+-- Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+
+module TemplateChoices where
+
+import Daml.Script
+
+-- TEMPLATE_STRUCTURE_BEGIN
+template Token
+  with
+    -- Data fields
+    owner : Party
+    issuer : Party
+    amount : Decimal
+  where
+    -- Authorization
+    signatory issuer
+    observer owner
+
+    -- Actions
+    choice ChangeOwner : ContractId Token
+      with
+        newOwner : Party
+      controller owner
+      do
+        create this with owner = newOwner
+-- TEMPLATE_STRUCTURE_END
+
+    nonconsuming choice GetBalance : Decimal
+      controller owner
+      do return amount
+
+test_token_choices = script do
+  issuer <- allocateParty "Issuer"
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
+
+  tokenCid <- submit issuer do
+    createCmd Token with
+      issuer = issuer
+      owner = alice
+      amount = 100.0
+
+  balance <- submit alice do
+    exerciseCmd tokenCid GetBalance
+  assert (balance == 100.0)
+
+  newCid <- submit alice do
+    exerciseCmd tokenCid ChangeOwner with newOwner = bob
+
+  Some token <- queryContractId issuer newCid
+  assert (token.owner == bob)


### PR DESCRIPTION
This adds two tests for templates which are extracted into the new docs page, into the core concepts section ([https://docs.canton.network/overview/understand/core-concepts](https://docs.canton.network/overview/understand/core-concepts)).

Template content between markers is extracted into the docs repo.