### PR TITLE
Update copyright header for UpdateVersions

### DIFF
--- a/sdk/compatibility/versions/UpdateVersions.hs
+++ b/sdk/compatibility/versions/UpdateVersions.hs
@@ -42,7 +42,7 @@ headVersion = DPMVersion SemVer.initial
 -- We include this here so buildifier does not modify this file.
 copyrightHeader :: [Text]
 copyrightHeader =
-    [ "# Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved."
+    [ "# Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved."
     , "# SPDX-License-Identifier: Apache-2.0"
     ]
 


### PR DESCRIPTION
Following remy's copyright update, this file is now generating a compat versions update PR that only bumps the copyright back to 2025. Fixed by updating the header in the file