### PR TITLE
fix: peer-dependencies and target for JS codegen

### DIFF
--- a/sdk/language-support/js/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/JsCodeGen.scala
+++ b/sdk/language-support/js/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/JsCodeGen.scala
@@ -91,7 +91,7 @@ private final class JsCodeGen(
         |  "dependencies": {
         |    ${deps.mkString(",\n    ")}
         |  },
-        |  "peer-dependencies": {
+        |  "peerDependencies": {
         |    "@daml/types": "$damlVersion"
         |  }
         |}
@@ -281,7 +281,7 @@ private final class JsCodeGen(
        |    "skipLibCheck": true,
        |    "sourceMap": true,
        |    "strict": true,
-       |    "target": "es5"
+       |    "target": "ES2015"
        |  },
        |  "include": [
        |    "src/**/*.ts"


### PR DESCRIPTION
Hello DA Daml team!

i have a small PR here that i hope you would take a look that addresses two minor concerns/problems i saw when using the codegen.

this PR fixes two areas in the javascript/typescript code generation.

1.  its called "peerDependencies" and not "peer-dependencies" (https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependencies)
2. "es5" has end-of-life with typescript 6.0, so updating to es2015 makes sense, epseically since it is already included in the "lib" section anyway.