### PR TITLE
feat(damlc): infer --all for daml build with only multi-package.yaml …

### DIFF
--- a/sdk/UNRELEASED.md
+++ b/sdk/UNRELEASED.md
@@ -9,6 +9,9 @@ schedule, i.e. if you add an entry effective at or after the first
 header, prepend the new date header that corresponds to the
 Wednesday after your change.
 
+## Until 2026-07-04 (Exclusive)
+- `dpm build` now infers `--all` when invoked from a directory that contains a `multi-package.yaml` but no `daml.yaml`, instead of erroring out.
+
 ## Until 2026-05-19 (Exclusive)
 - Fix error in sin/cos implementation in DA.Math (issue #23027)
 

--- a/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/sdk/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -911,11 +911,12 @@ execBuild packageLocationOpts opts mbOutFile incrementalBuild initPkgDb enableMu
           hPutStrLn stderr $ "Running single package build of " <> T.unpack (LF.unPackageName $ pName pkgConfig) <> " as no multi-package.yaml was found."
           buildSingle pkgPath pkgConfig
 
-        -- We have no package context, but we have found a multi package at the current directory
-        (False, Nothing, Just _) -> do
-          hPutStrLn stderr $ "No valid daml.yaml found, but a multi-package.yaml was found instead.\n"
-            <> "If you intended to build everything within this multi-package.yaml, use the --all flag"
-          exitFailure
+        -- We have no package context, but we have found a multi-package.yaml.
+        -- Treat this as `--all`, since the user has no other valid build target.
+        (False, Nothing, Just multiPackagePath) -> do
+          hPutStrLn stderr $ "Interpreting as `dpm build --all`, since a multi-package.yaml was found at "
+            <> unwrapPackagePath multiPackagePath <> " but no daml.yaml was found."
+          buildMulti pkgPath Nothing multiPackagePath
 
         -- We have nothing, we're lost
         (False, Nothing, Nothing) -> do

--- a/sdk/compiler/damlc/tests/src/DA/Test/DamlcMultiPackage.hs
+++ b/sdk/compiler/damlc/tests/src/DA/Test/DamlcMultiPackage.hs
@@ -93,6 +93,8 @@ tests =
             $ Right [PackageIdentifier "package-a" "0.0.1", PackageIdentifier "package-b" "0.0.1"]
         , test "Build all from root" ["--all"] "" simpleTwoPackageProject
             $ Right [PackageIdentifier "package-a" "0.0.1", PackageIdentifier "package-b" "0.0.1"]
+        , test "Build from root without --all infers --all when only multi-package.yaml is present" [] "" simpleTwoPackageProject
+            $ Right [PackageIdentifier "package-a" "0.0.1", PackageIdentifier "package-b" "0.0.1"]
         , test "Build all from A with explicit path" ["--all", "--multi-package-path=.."] "./package-a" simpleTwoPackageProject
             $ Right [PackageIdentifier "package-a" "0.0.1", PackageIdentifier "package-b" "0.0.1"]
         , test "Build B from nested directory with search" [] "./package-b/daml" simpleTwoPackageProject


### PR DESCRIPTION
Backport of https://github.com/digital-asset/daml/commit/0c35e9dafb15bed49fa96129c5cace31d3f94094
Sadly PR itself is missing since the repo it was from was made private4.

### Original description:

When `daml build` is invoked from a directory that contains a `multi-package.yaml`
but no resolvable `daml.yaml`, the build now treats the invocation as `daml build --all` instead of erroring out.

A heads-up is printed to stderr naming the `multi-package.yaml` that was used,
so the inference is visible to the user:

```
Interpreting as `daml build --all`, since a multi-package.yaml was found at <path> but no daml.yaml was found.
```

The genuinely-lost case (no `daml.yaml` and no `multi-package.yaml`) continues
to error as before.

- [x] Added a test in `DamlcMultiPackage.hs` covering "build from root with no
`daml.yaml` infers `--all` when only `multi-package.yaml` is present"
      against `simpleTwoPackageProject`.
- [x] Existing `Build all from root` (with explicit `--all`) test still passes.
- [x] `daml clean` behavior is unchanged — the analogous error path there is
      not in scope of this issue.

Fixes #22519