### PR TITLE
bump da-ghc to a PR that contains ghc/pull/197

### DIFF
--- a/sdk/bazel_tools/ghc-lib/version.bzl
+++ b/sdk/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "ebe7cf9b51e27066a2d960f407d953f529789b39"
+GHC_REV = "5498b70afa00c93a959ced0f1d974aab73f5a53b"
 GHC_PATCHES = [
 ]
 

--- a/sdk/bazel_tools/ghc-lib/version.bzl
+++ b/sdk/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "b21728e57a4d837ace41131b65373e70bc16d89c"
+GHC_REV = "ebe7cf9b51e27066a2d960f407d953f529789b39"
 GHC_PATCHES = [
 ]
 


### PR DESCRIPTION

Point daml to a revision of da-ghc that gets its submodules from github mirrors, in order to avoid timeouts from haskell gitlab.