### PR TITLE
Drop explicit protobuf-java dep in quickstart-java

### DIFF
--- a/sdk/docs/sharable/sdk/tutorials/quickstart/template-root/pom.xml
+++ b/sdk/docs/sharable/sdk/tutorials/quickstart/template-root/pom.xml
@@ -38,11 +38,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>3.25.5</version>
-        </dependency>
-        <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
             <version>1.77.0</version>

--- a/sdk/docs/source/sdk/tutorials/quickstart/template-root/pom.xml
+++ b/sdk/docs/source/sdk/tutorials/quickstart/template-root/pom.xml
@@ -38,11 +38,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>3.25.5</version>
-        </dependency>
-        <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
             <version>1.77.0</version>


### PR DESCRIPTION
Following protobuf version changes to canton/ledger-api, the protobuf java version in quickstart-java is wrong.
We fixed this issue in the dpm-assembly repo by simple removing the dependency: https://github.com/digital-asset/dpm-assembly/pull/27/changes
This PR does the same to the original template.