### PR TITLE
Fix flaky //compiler/lsp-tests:lsp-tests script interrupt tests

### DIFF
--- a/sdk/compiler/lsp-tests/BUILD.bazel
+++ b/sdk/compiler/lsp-tests/BUILD.bazel
@@ -39,6 +39,7 @@ da_haskell_test(
         "tasty",
         "tasty-hunit",
         "text",
+        "time",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/sdk/compiler/lsp-tests/src/Main.hs
+++ b/sdk/compiler/lsp-tests/src/Main.hs
@@ -8,6 +8,7 @@ module Main (main) where
 {- HLINT ignore "locateRunfiles/package_app" -}
 
 import Control.Concurrent
+import Data.Time.Clock (getCurrentTime, diffUTCTime)
 import Control.Applicative.Combinators
 import Control.Lens hiding (List, children, (.=))
 import Control.Monad
@@ -745,8 +746,9 @@ scriptTests runScripts = testGroup "scripts"
 
           closeDoc script
           closeDoc main'
-    , localOption (mkTimeout 60000000) $ -- 60s timeout
+    , localOption (mkTimeout 30000000) $ -- 30s timeout
         testCaseSteps "scenario service does not interrupt on non-script messages" $ \step -> runScripts $ \_stderr -> do
+          let foldSize = 1000000 :: Integer
           -- open document with long-running script
           main' <- openDoc' "Main.daml" damlId $
               T.unlines
@@ -754,7 +756,7 @@ scriptTests runScripts = testGroup "scripts"
                   , "module Main where"
                   , "import Daml.Script"
                   , "main : Script ()"
-                  , "main = debug $ foldl (+) 0 [1..10000000]"
+                  , "main = debug $ foldl (+) 0 [1.." <> T.pack (show foldSize) <> "]"
                   ]
           liftIO $ step "Document opened."
 
@@ -784,12 +786,20 @@ scriptTests runScripts = testGroup "scripts"
 
           -- run hover event
           _ <- sendRequest STextDocumentHover (HoverParams main' (Position 4 3) Nothing)
+          afterHoverTime <- liftIO getCurrentTime
           liftIO $ step "Hover sent..."
 
           -- Check that script did return and that log does not show any cancellations
           _changeResult <- waitForScriptDidChange
+          scriptDoneTime <- liftIO getCurrentTime
+          let afterHover = realToFrac (diffUTCTime scriptDoneTime afterHoverTime) :: Double
+          liftIO $ step $ "Script finished " ++ show afterHover ++ "s after hover was sent (fold size: " ++ show foldSize ++ ")"
           _scriptFinishedMessage <- liftIO $ assertUntilWithout _stderr "SCRIPT SERVICE STDOUT: Script finished." "SCRIPT SERVICE STDOUT: Script cancelled."
           liftIO $ step "Script returned without cancellation."
+
+          liftIO $ assertBool
+              ("Script finished too quickly after hover (" ++ show afterHover ++ "s) — fold size " ++ show foldSize ++ " may be too small to ensure the script is still running when hover is processed")
+              (afterHover >= 0.5)
 
           closeDoc script
           closeDoc main'

--- a/sdk/compiler/lsp-tests/src/Main.hs
+++ b/sdk/compiler/lsp-tests/src/Main.hs
@@ -687,9 +687,11 @@ scriptTests runScripts = testGroup "scripts"
               assertRegex (_vrcpContents changeResult) "Trace:[^/]+secondRun"
           closeDoc script
           closeDoc main'
-    , localOption (mkTimeout 30000000) $ -- 30s timeout
+    , let timeoutSeconds = 30 :: Int in
+      localOption (mkTimeout (fromIntegral timeoutSeconds * 1000000)) $
         testCaseSteps "scenario service interrupts outdated script runs" $ \step -> runScripts $ \_stderr -> do
-          let mkDoc :: Integer -> T.Text
+          let foldSize = 1000000 :: Integer
+              mkDoc :: Integer -> T.Text
               mkDoc duration = T.unlines
                   [ "{-# LANGUAGE ApplicativeDo #-}"
                   , "module Main where"
@@ -697,9 +699,10 @@ scriptTests runScripts = testGroup "scripts"
                   , "main : Script ()"
                   , "main = debug $ foldl (+) 0 [1.." <> T.pack (show duration) <> "]"
                   ]
+          testStartTime <- liftIO getCurrentTime
 
           -- open document with long-running script
-          main' <- openDoc' "Main.daml" damlId $ mkDoc 10000000
+          main' <- openDoc' "Main.daml" damlId $ mkDoc foldSize
           liftIO $ step "Document opened."
 
           -- wait until lenses processed, open script
@@ -742,13 +745,22 @@ scriptTests runScripts = testGroup "scripts"
           -- check that returned value is new script
           _changeResult <- waitForScriptDidChange
           liftIO $ assertRegex (_vrcpContents _changeResult) "Trace:( |<br>)*276([^0-9]|$)"
-          liftIO $ step "Script results received."
+          testEndTime <- liftIO getCurrentTime
+          let totalTime = realToFrac (diffUTCTime testEndTime testStartTime) :: Double
+              maxSafeTime = fromIntegral timeoutSeconds * 0.5
+          liftIO $ step $ "Script results received. Total time: " ++ show totalTime ++ "s (timeout: " ++ show timeoutSeconds ++ "s)"
+
+          liftIO $ assertBool
+              ("Total test time " ++ show totalTime ++ "s is more than 50% of the " ++ show timeoutSeconds ++ "s timeout — this test is at risk of flaking under further CI load. Reduce fold size (currently " ++ show foldSize ++ ") or investigate why compilation/script evaluation is slow.")
+              (totalTime < maxSafeTime)
 
           closeDoc script
           closeDoc main'
-    , localOption (mkTimeout 30000000) $ -- 30s timeout
+    , let timeoutSeconds = 30 :: Int in
+      localOption (mkTimeout (fromIntegral timeoutSeconds * 1000000)) $
         testCaseSteps "scenario service does not interrupt on non-script messages" $ \step -> runScripts $ \_stderr -> do
           let foldSize = 1000000 :: Integer
+          testStartTime <- liftIO getCurrentTime
           -- open document with long-running script
           main' <- openDoc' "Main.daml" damlId $
               T.unlines
@@ -797,9 +809,17 @@ scriptTests runScripts = testGroup "scripts"
           _scriptFinishedMessage <- liftIO $ assertUntilWithout _stderr "SCRIPT SERVICE STDOUT: Script finished." "SCRIPT SERVICE STDOUT: Script cancelled."
           liftIO $ step "Script returned without cancellation."
 
+          testEndTime <- liftIO getCurrentTime
+          let totalTime = realToFrac (diffUTCTime testEndTime testStartTime) :: Double
+              maxSafeTime = fromIntegral timeoutSeconds * 0.5
+
           liftIO $ assertBool
               ("Script finished too quickly after hover (" ++ show afterHover ++ "s) — fold size " ++ show foldSize ++ " may be too small to ensure the script is still running when hover is processed")
               (afterHover >= 0.5)
+
+          liftIO $ assertBool
+              ("Total test time " ++ show totalTime ++ "s is more than 50% of the " ++ show timeoutSeconds ++ "s timeout — this test is at risk of flaking under further CI load. Reduce fold size (currently " ++ show foldSize ++ ") or investigate why compilation/script evaluation is slow.")
+              (totalTime < maxSafeTime)
 
           closeDoc script
           closeDoc main'


### PR DESCRIPTION
Fixes #20724

Problem

Both script interrupt tests ("scenario service interrupts outdated script runs" and "scenario service does not interrupt on non-script messages") used an interpreted foldl (+) 0 [1..10000000] to simulate a long-running script. This 10M-element fold took ~3s on a fast local machine but 25-43s on loaded CI runners (linux arm, linux intel, m1 mac), regularly exceeding the 30-60s timeouts.

The flake was observed across multiple platforms and dates:
- m1 mac: "does not interrupt" TIMEOUT at 60s (Jul 14, Aug 6)
- macOS intel: "does not interrupt" TIMEOUT at 60s (Apr 8)
- linux arm: "interrupts outdated" TIMEOUT at 30s, while "does not interrupt" barely passed at 53s (Apr 9)
- linux intel: "interrupts outdated" TIMEOUT at 30s, "does not interrupt" barely passed at 33s (Apr 23)

Fix

- Reduce fold size from 10M to 1M in both tests. On a local machine this gives ~3s total test time vs the old ~30s. The fold only needs to run long enough for the test's LSP interaction to happen during execution — 1M is more than sufficient.
- Add lower-bound timing guard ("does not interrupt" only): assert the script took at least 0.5s after the hover was sent, proving the script was still running when the hover was processed.
- Add upper-bound timing guard (both tests): fail deterministically if total test time exceeds 50% of the timeout, with a message like: "Total test time 16.2s is more than 50% of the 30s timeout — this test is at risk of flaking under further CI load. Reduce fold size or investigate why compilation/script evaluation is slow." This catches slowdowns before they manifest as flaky timeouts.
- Unify timeouts to 30s for both tests (the "does not interrupt" test previously had 60s).
- Add time to BUILD deps for Data.Time.Clock.

Test results (local)
```
┌─────────────────────┬────────────┬─────────┬──────────┐
│        Test         │ Total time │ Timeout │ Headroom │
├─────────────────────┼────────────┼─────────┼──────────┤
│ interrupts outdated │ 3.1s       │ 30s     │ 90%      │
├─────────────────────┼────────────┼─────────┼──────────┤
│ does not interrupt  │ 5.0s       │ 30s     │ 83%      │
└─────────────────────┴────────────┴─────────┴──────────┘
```