### PR TITLE
fix(timer-utils): cap exponential backoff factor and format attempt count string cleanly

### DIFF
--- a/sdk/timer-utils/BUILD.bazel
+++ b/sdk/timer-utils/BUILD.bazel
@@ -4,7 +4,7 @@
 load(
     "//bazel_tools:scala.bzl",
     "da_scala_library",
-    "da_scala_test",
+    "da_scala_test_suite",
 )
 
 da_scala_library(
@@ -17,11 +17,18 @@ da_scala_library(
     deps = [],
 )
 
-da_scala_test(
+da_scala_test_suite(
     name = "timer-utils-tests",
+    size = "small",
     srcs = glob(["src/test/scala/**/*.scala"]),
+    scala_deps = [
+        "@maven//:org_scalatest_scalatest_core",
+        "@maven//:org_scalatest_scalatest_matchers_core",
+        "@maven//:org_scalatest_scalatest_shouldmatchers",
+        "@maven//:org_scalatest_scalatest_wordspec",
+    ],
     deps = [
         ":timer-utils",
-        "//3rdparty/jvm/org/scalatest",
+        "@maven//:org_scalatest_scalatest_compatible",
     ],
 )

--- a/sdk/timer-utils/BUILD.bazel
+++ b/sdk/timer-utils/BUILD.bazel
@@ -4,6 +4,7 @@
 load(
     "//bazel_tools:scala.bzl",
     "da_scala_library",
+    "da_scala_test",
 )
 
 da_scala_library(
@@ -14,4 +15,13 @@ da_scala_library(
         "//visibility:public",
     ],
     deps = [],
+)
+
+da_scala_test(
+    name = "timer-utils-tests",
+    srcs = glob(["src/test/scala/**/*.scala"]),
+    deps = [
+        ":timer-utils",
+        "//3rdparty/jvm/org/scalatest",
+    ],
 )

--- a/sdk/timer-utils/src/main/scala/com/daml/timer/RetryStrategy.scala
+++ b/sdk/timer-utils/src/main/scala/com/daml/timer/RetryStrategy.scala
@@ -15,14 +15,21 @@ object RetryStrategy {
 
   /** Retry a fixed amount of times with exponential backoff, regardless of the exception thrown
     */
-  def exponentialBackoff(attempts: Int, firstWaitTime: Duration): RetryStrategy =
+  def exponentialBackoff(attempts: Int, firstWaitTime: Duration): RetryStrategy = {
+    val cap = firstWaitTime match {
+      case fd: FiniteDuration =>
+        val maxFactor = math.pow(2.0, attempts.toDouble.min(62.0))
+        fd * maxFactor
+      case other => other
+    }
     new RetryStrategy(
       Some(attempts),
       firstWaitTime,
-      firstWaitTime * math.pow(2.0, attempts.toDouble),
+      cap,
       _ * 2,
       { case _ => true },
     )
+  }
 
   /** Retry a fixed amount of times with constant wait time, regardless of the exception thrown
     */
@@ -92,8 +99,9 @@ final class RetryStrategy private (
         run(attempt, wait).recoverWith { case throwable =>
           if (attempts.exists(attempt >= _)) {
             val timeTaken = Duration.fromNanos(System.nanoTime() - startTime)
+            val attemptsStr = attempts.fold(attempt.toString)(_.toString)
             val message =
-              s"Gave up trying after $attempts attempts and ${timeTaken.toUnit(SECONDS)} seconds."
+              s"Gave up trying after $attemptsStr attempts and ${timeTaken.toUnit(SECONDS)} seconds."
             Future.failed(TooManyAttemptsException(attempt, timeTaken, message, throwable))
           } else if (predicate.lift(throwable).getOrElse(false)) {
             Delayed.Future.by(wait)(go(attempt + 1, clip(progression(wait))))

--- a/sdk/timer-utils/src/test/scala/com/daml/timer/RetryStrategyTest.scala
+++ b/sdk/timer-utils/src/test/scala/com/daml/timer/RetryStrategyTest.scala
@@ -11,11 +11,10 @@ class RetryStrategyTest extends AsyncWordSpec with Matchers {
 
   "RetryStrategy.exponentialBackoff" should {
     "not throw overflow exception when attempts count is large" in {
-      // Large attempt count (e.g. 1024) causes math.pow(2.0, 1024.0) to equal Double.PositiveInfinity.
-      // Without capping, multiplying FiniteDuration * Infinity throws an overflow exception.
       noException should be thrownBy {
         RetryStrategy.exponentialBackoff(attempts = 1024, firstWaitTime = 10.millis)
       }
+      succeed
     }
 
     "format attempts count string cleanly without printing Option wrapper" in {

--- a/sdk/timer-utils/src/test/scala/com/daml/timer/RetryStrategyTest.scala
+++ b/sdk/timer-utils/src/test/scala/com/daml/timer/RetryStrategyTest.scala
@@ -3,8 +3,8 @@
 
 package com.daml.timer
 
-import org.scalatest.wordspec.AsyncWordSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
 import scala.concurrent.duration._
 
 class RetryStrategyTest extends AsyncWordSpec with Matchers {
@@ -14,7 +14,6 @@ class RetryStrategyTest extends AsyncWordSpec with Matchers {
       noException should be thrownBy {
         RetryStrategy.exponentialBackoff(attempts = 1024, firstWaitTime = 10.millis)
       }
-      succeed
     }
 
     "format attempts count string cleanly without printing Option wrapper" in {
@@ -23,8 +22,7 @@ class RetryStrategyTest extends AsyncWordSpec with Matchers {
         scala.concurrent.Future.failed(new RuntimeException("test error"))
       }.failed.map {
         case ex: RetryStrategy.TooManyAttemptsException =>
-          ex.getMessage should include("after 1 attempts")
-          ex.getMessage should not include "Some(1)"
+          ex.getMessage should (include("after 1 attempts") and not include "Some(1)")
         case other =>
           fail(s"Unexpected exception type: $other")
       }

--- a/sdk/timer-utils/src/test/scala/com/daml/timer/RetryStrategyTest.scala
+++ b/sdk/timer-utils/src/test/scala/com/daml/timer/RetryStrategyTest.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timer
+
+import org.scalatest.wordspec.AsyncWordSpec
+import org.scalatest.matchers.should.Matchers
+import scala.concurrent.duration._
+
+class RetryStrategyTest extends AsyncWordSpec with Matchers {
+
+  "RetryStrategy.exponentialBackoff" should {
+    "not throw overflow exception when attempts count is large" in {
+      // Large attempt count (e.g. 1024) causes math.pow(2.0, 1024.0) to equal Double.PositiveInfinity.
+      // Without capping, multiplying FiniteDuration * Infinity throws an overflow exception.
+      noException should be thrownBy {
+        RetryStrategy.exponentialBackoff(attempts = 1024, firstWaitTime = 10.millis)
+      }
+    }
+
+    "format attempts count string cleanly without printing Option wrapper" in {
+      val strategy = RetryStrategy.exponentialBackoff(attempts = 1, firstWaitTime = 1.milli)
+      strategy { (_, _) =>
+        scala.concurrent.Future.failed(new RuntimeException("test error"))
+      }.failed.map {
+        case ex: RetryStrategy.TooManyAttemptsException =>
+          ex.getMessage should include("after 1 attempts")
+          ex.getMessage should not include "Some(1)"
+        case other =>
+          fail(s"Unexpected exception type: $other")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Capped exponential backoff power factor using attempts.toDouble.min(62.0) in RetryStrategy.scala to prevent arithmetic overflow to Double.PositiveInfinity when multiplying FiniteDuration. Also formatted attempts count string using .fold(...) to avoid printing "Some(5)" in TooManyAttemptsException messages.