### PR TITLE
Fix complete matches references by making all imports qualified

### DIFF
--- a/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -12,7 +12,7 @@ module DA.Daml.Compiler.DataDependencies
 
 import DA.Pretty hiding (first)
 import Control.Applicative
-import Control.Lens hiding (unsnoc, (<.>))
+import Control.Lens hiding ((<.>))
 import Control.Monad
 import Control.Monad.State.Strict
 import Data.Bifunctor (first)

--- a/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/sdk/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -12,7 +12,7 @@ module DA.Daml.Compiler.DataDependencies
 
 import DA.Pretty hiding (first)
 import Control.Applicative
-import Control.Lens hiding ((<.>))
+import Control.Lens hiding (unsnoc, (<.>))
 import Control.Monad
 import Control.Monad.State.Strict
 import Data.Bifunctor (first)
@@ -218,6 +218,10 @@ data ModRefImpSpec
         -- ^ For open imports, e.g.
         --
         -- > import SomeModule
+    | QualifiedImpSpec
+        -- ^ For qualified open imports, e.g.
+        --
+        -- > import qualified SomeModule
     | EmptyImpSpec
         -- ^ For instances-only imports, e.g.
         --
@@ -232,7 +236,7 @@ modRefImport Config{..} ModRef{..} = noLoc ImportDecl
     , ideclSource = False
     , ideclSafe = False
     , ideclImplicit = False
-    , ideclQualified = False
+    , ideclQualified = modRefImpSpec == QualifiedImpSpec
     , ideclAs = Nothing
     , ideclHiding = impSpec
     , ideclExt = noExt
@@ -246,6 +250,7 @@ modRefImport Config{..} ModRef{..} = noLoc ImportDecl
              | otherwise -> prefixDependencyModule importPkgId modRefModule
       impSpec = case modRefImpSpec of
           NoImpSpec -> Nothing
+          QualifiedImpSpec -> Nothing
           EmptyImpSpec -> Just (False, noLoc []) -- False = not 'hiding'
 
 data GenState = GenState
@@ -407,10 +412,15 @@ generateSrcFromLf env = noLoc mod
         pure $ mkOrig ghcMod (LF.qualObject q)
 
     -- Allows unqual regardless of name location, can be dangerous.
-    mkRdrNameUnqualUnsafe :: LFC.QualName -> Gen (Located RdrName)
-    mkRdrNameUnqualUnsafe (LFC.QualName q) = do
+    mkRdrNameUnqualUnsafe :: LFC.QualName -> ModRefImpSpec -> Gen (Located RdrName)
+    mkRdrNameUnqualUnsafe (LFC.QualName q) impSpec = do
       -- Emit the usage for imports, but don't use it
-      void $ genModule env (LF.qualPackage q) (LF.qualModule q)
+      emitModRef ModRef
+        { modRefModule = LF.qualModule q
+        , modRefOrigin = importOriginFromPackageRef (envConfig env) (LF.qualPackage q)
+        , modRefImpSpec = impSpec
+        }
+
       let occName = LF.qualObject q
           bracketOccName :: OccName -> OccName
           bracketOccName name = mkOccName (occNameSpace name) ("(" <> occNameString name <> ")")
@@ -418,12 +428,29 @@ generateSrcFromLf env = noLoc mod
             if isSymOcc occName then bracketOccName occName else occName
       pure $ noLoc $ mkRdrUnqual bracketedOccName
 
+    -- Tuples become "(,)" in LFC.QualName, which `isSymOcc` returns false for, as the brackets have
+    -- already been applied.
+    -- This function checks isSymOcc and for tuples
+    isSymOccOrTuple :: OccName -> Bool
+    isSymOccOrTuple name =
+        isSymOcc name || isTuple (occNameString name)
+      where
+        isTuple :: String -> Bool
+        isTuple s = s == "(" <> replicate (length s - 2) ',' <> ")"
+
+    -- If the qualName is a symbol, we keep it unqualified (as {-# COMPLETE #-} dont support qualified symbols)
+    mkRdrNameUnqualUnsafeIfSymbol :: LFC.QualName -> Gen (Located RdrName)
+    mkRdrNameUnqualUnsafeIfSymbol name@(LFC.QualName q) =
+        if isSymOccOrTuple (LF.qualObject q)
+          then mkRdrNameUnqualUnsafe name NoImpSpec
+          else noLoc <$> mkRdrNameQual name
+
     -- Only allows unqual if the name comes from the same package and module
     mkRdrNameUnqual :: LFC.QualName -> Gen (Located RdrName)
     mkRdrNameUnqual name@(LFC.QualName q) =
         if LF.qualPackage q /= LF.SelfPackageId || LF.qualModule q /= lfModName
           then pure $ error "Tried to call mkRdrNameUnqual on non-local package/module"
-          else mkRdrNameUnqualUnsafe name
+          else mkRdrNameUnqualUnsafe name QualifiedImpSpec
 
     mkFieldLblRdrNameQual :: FieldLbl LFC.QualName -> Gen (Located (FieldLbl RdrName))
     mkFieldLblRdrNameQual = fmap noLoc . traverse mkRdrNameQual
@@ -704,9 +731,9 @@ generateSrcFromLf env = noLoc mod
         makeCompletePragma match = do
           -- Parser only allows the pragma to contain unqualified names, but supports those names coming from any module/package
           -- (as long as one name comes from this module)
-          matchersRdrNames <- traverse mkRdrNameUnqualUnsafe $ LFC.matchers match
+          matchersRdrNames <- traverse (`mkRdrNameUnqualUnsafe` NoImpSpec) $ LFC.matchers match
           -- Similarly, Parser will not allow qualified symbol data types (such as tuple) for the subject, so we unqualify those too
-          subjectRdrName <- mkRdrNameUnqualUnsafe $ LFC.subject match
+          subjectRdrName <- mkRdrNameUnqualUnsafeIfSymbol $ LFC.subject match
           pure $ noLoc . SigD noExt $ CompleteMatchSig
             noExt 
             NoSourceText
@@ -1135,7 +1162,7 @@ prefixDependencyModule (LF.PackageId pkgId) = prefixModuleName ["Pkg_" <> pkgId]
 
 genModuleAux :: Config -> ImportOrigin -> LF.ModuleName -> Gen Module
 genModuleAux conf origin moduleName = do
-    let modRef = ModRef moduleName origin NoImpSpec
+    let modRef = ModRef moduleName origin QualifiedImpSpec
     let ghcModuleName = (unLoc . ideclName . unLoc . modRefImport conf) modRef
     let unitId = case origin of
             FromCurrentSdk unitId -> unitId


### PR DESCRIPTION
I hit more issues around the Complete pragmas in data-deps, where having constructors and pattern synonyms of the same name lead to ambiguity errors. I've solved this by making all imports in generated data-deps code qualified, since we always reference them qualified, then adding a mechanism to bring some imports unqualified, which solves the ambiguity issue in pretty much all cases. The only cases that could cause issue shouldn't be valid Daml in the first place.
In aid of https://github.com/digital-asset/daml/pull/23312