### PR TITLE
reject the retired dev id of EXTERNAL_CALL in the LF2 decoder

### DIFF
--- a/sdk/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/DecodeV2.hs
+++ b/sdk/compiler/daml-lf-proto-decode/src/DA/Daml/LF/Proto3/DecodeV2.hs
@@ -450,6 +450,10 @@ decodeBuiltinFunction = \case
   LF2.BuiltinFunctionEXTERNAL_CALL -> do
     assertSupportsFeature featureExternalCall
     pure BEExternalCall
+  LF2.BuiltinFunctionEXTERNAL_CALL_LEGACY_DEV ->
+    -- The pre-promotion dev id of EXTERNAL_CALL. Canton temporarily still decodes it so that
+    -- DARs from older compilers keep working; damlc never emits it, so reject it here.
+    throwError (UnknownEnum "BuiltinFunction" 5001)
   LF2.BuiltinFunctionSECP256K1_BOOL -> pure BESecp256k1Bool
   LF2.BuiltinFunctionSECP256K1_WITH_ECDSA_BOOL -> pure BESecp256k1WithEcdsaBool
   LF2.BuiltinFunctionSECP256K1_VALIDATE_KEY -> pure BESecp256k1ValidateKey

--- a/sdk/compiler/daml-lf-proto-decode/test/DA/Daml/LF/Proto3/DecodeTest.hs
+++ b/sdk/compiler/daml-lf-proto-decode/test/DA/Daml/LF/Proto3/DecodeTest.hs
@@ -73,9 +73,12 @@ decExternalCallTests = testGroup "external call feature gate"
       Right (EBuiltinFun BEExternalCall) @=? decodeExprWithVersion testVersion externalCallExpr
   , testCase "EXTERNAL_CALL rejects outside feature version range" $
       assertExternalCallUnsupported $ decodeExprWithVersion version2_3 externalCallExpr
+  , testCase "EXTERNAL_CALL_LEGACY_DEV (old dev id 5001) is rejected" $
+      Left (UnknownEnum "BuiltinFunction" 5001) @=? decodeExprWithVersion testVersion legacyExternalCallExpr
   ]
   where
     externalCallExpr = peBuiltin P.BuiltinFunctionEXTERNAL_CALL
+    legacyExternalCallExpr = peBuiltin P.BuiltinFunctionEXTERNAL_CALL_LEGACY_DEV
 
     assertExternalCallUnsupported :: Either Error Expr -> Assertion
     assertExternalCallUnsupported result =


### PR DESCRIPTION
Pre-written for the canton→daml ingest of the external-call LF promotion (digital-asset/canton#648), so the ingest PR needs no hand-written code.

**What it is**: the canton side renumbers the `EXTERNAL_CALL` builtin from its dev staging position 5001 to 74 and keeps 5001 in the proto as `EXTERNAL_CALL_LEGACY_DEV` (a temporary decode alias that only canton maps, so DARs from older compilers keep working there during the transition). On the daml side the regenerated bindings gain that constructor, and `decodeBuiltinFunction` matches exhaustively under `-Werror` — so a case is mandatory, and it must be a **rejection**: once the constructor exists, 5001 no longer falls through to the `UnknownEnum` path, making this case the only barrier against old dev DARs. A DecodeTest pins the rejection.

**Why draft / red**: this compiles only against the post-ingest proto — the constructor does not exist until the canton pin bump regenerates the bindings. Intended use: cherry-pick this commit into the ingest PR (or rebase this PR onto it) — reviewing it now means the ingest itself contains zero unreviewed hand-written code.

cc @roger-bosman-da