### PR TITLE
retarget the external-call script tests to LF 2.4-staging and PV36

### DIFF
--- a/sdk/UNRELEASED.md
+++ b/sdk/UNRELEASED.md
@@ -9,6 +9,10 @@ schedule, i.e. if you add an entry effective at or after the first
 header, prepend the new date header that corresponds to the
 Wednesday after your change.
 
+## Until 2026-09-08 (Exclusive)
+
+- Daml Script: `--ide-ledger-protocol-version` now accepts `v36`
+
 ## Until 2026-08-08 (Exclusive)
 
 Cut a not-yet-to-be-released version of lf 2.4 such that we can start targetting

--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -367,16 +367,21 @@ object Runner {
       val csmMode = ContractStateMachine.Mode.Key
       override val toString = "V35"
     }
+    final case object V36 extends IdeLedgerProtocolVersion {
+      val csmMode = ContractStateMachine.Mode.Key
+      override val toString = "V36"
+    }
     final case object VDev extends IdeLedgerProtocolVersion {
       val csmMode = ContractStateMachine.Mode.Key
       override val toString = "VDev"
     }
-    val all = List(V34, V35, VDev)
+    val all = List(V34, V35, V36, VDev)
     val latest = V35
     def parseIdeLedgerProtocolVersion(str: String): Either[String, IdeLedgerProtocolVersion] =
       str.toLowerCase match {
         case "v34" | "34" => Right(V34)
         case "v35" | "35" => Right(V35)
+        case "v36" | "36" => Right(V36)
         case "vdev" | "dev" => Right(VDev)
         case "latest" => Right(latest)
         case _ =>

--- a/sdk/daml-script/test/BUILD.bazel
+++ b/sdk/daml-script/test/BUILD.bazel
@@ -172,17 +172,17 @@ EOF
 ]
 
 genrule(
-    name = "external-call-test-v2.dev",
+    name = "external-call-test-v2.4-staging",
     srcs = glob(["**/*.daml"]) + [
-        "//daml-script/daml:daml-script-2.dev.dar",
+        "//daml-script/daml:daml-script-2.4-staging.dar",
     ],
-    outs = ["external-call-test-v2.dev.dar"],
+    outs = ["external-call-test-v2.4-staging.dar"],
     cmd = """
       set -eou pipefail
       TMP_DIR=$$(mktemp -d)
       mkdir -p $$TMP_DIR/daml
       cp -L $(location :daml/ExternalCallTests.daml) $$TMP_DIR/daml
-      cp -L $(location //daml-script/daml:daml-script-2.dev.dar) $$TMP_DIR/
+      cp -L $(location //daml-script/daml:daml-script-2.4-staging.dar) $$TMP_DIR/
       cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: {sdk}
 name: external-call-test
@@ -191,11 +191,11 @@ version: 0.0.1
 dependencies:
   - daml-stdlib
   - daml-prim
-  - daml-script-2.dev.dar
+  - daml-script-2.4-staging.dar
 build-options:
-  - --target=2.dev
+  - --target=2.4-staging
 EOF
-      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location external-call-test-v2.dev.dar)
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location external-call-test-v2.4-staging.dar)
       rm -rf $$TMP_DIR
     """.format(
         sdk = sdk_version,
@@ -508,7 +508,7 @@ da_scala_test_suite(
     data = [dep for deps in [[
         ":script-test-{}.dar".format(lf),
     ] for lf in [DEV_LF_VERSION]] for dep in deps] + [
-        ":external-call-test-v2.dev.dar",
+        ":external-call-test-v2.4-staging.dar",
         ":script-test-no-ledger.dar",
         "//compiler/damlc/tests:query-test.dar",
         "//compiler/damlc/tests:submit-test.dar",

--- a/sdk/daml-script/test/BUILD.bazel
+++ b/sdk/daml-script/test/BUILD.bazel
@@ -355,6 +355,7 @@ da_scala_test_suite(
     data = [
         ":script-test-no-ledger.dar",
         ":attestation-test-v2.dev.dar",
+        ":external-call-test-v2.4-staging.dar",
         # TODO((https://github.com/digital-asset/daml/issues/18457): remove these dev dependencies
         #  once integration tests don't depend on keys anymore
         # TODO[23010]: replace hardcoded "2.2" with something like `PV34_LATEST_SUPPORTED_LF_VERSION`
@@ -508,7 +509,6 @@ da_scala_test_suite(
     data = [dep for deps in [[
         ":script-test-{}.dar".format(lf),
     ] for lf in [DEV_LF_VERSION]] for dep in deps] + [
-        ":external-call-test-v2.4-staging.dar",
         ":script-test-no-ledger.dar",
         "//compiler/damlc/tests:query-test.dar",
         "//compiler/damlc/tests:submit-test.dar",

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/ExternalCallDevIT.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/ExternalCallDevIT.scala
@@ -25,8 +25,11 @@ final class ExternalCallDevIT extends AsyncWordSpec with AbstractScriptTest with
 
   override protected lazy val timeMode: ScriptTimeMode = ScriptTimeMode.WallClock
 
+  // External call is staged at LF 2.4 and its wire data exists from protocol version 36 on.
+  override protected lazy val protocolVersion = CantonConfig.ProtocolVersion.Explicit("v36")
+
   override lazy val darPath: Path = rlocation(
-    Paths.get("daml-script/test/external-call-test-v2.dev.dar")
+    Paths.get("daml-script/test/external-call-test-v2.4-staging.dar")
   )
   override lazy val dar: CompiledDar = CompiledDar.read(darPath, defaultCompilerConfig)
 

--- a/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/ExternalCallIT.scala
+++ b/sdk/daml-script/test/src/main/scala/com/digitalasset/daml/lf/engine/script/test/ExternalCallIT.scala
@@ -21,7 +21,7 @@ import scala.concurrent.Future
 // Runs the external-call scripts against a Canton participant configured with
 // an in-process test extension service, covering the success path and each
 // external-call submit error.
-final class ExternalCallDevIT extends AsyncWordSpec with AbstractScriptTest with Matchers {
+final class ExternalCallIT extends AsyncWordSpec with AbstractScriptTest with Matchers {
 
   override protected lazy val timeMode: ScriptTimeMode = ScriptTimeMode.WallClock
 

--- a/sdk/test-common/canton/it-lib/src/main/scala/com/daml/integrationtest/CantonRunner.scala
+++ b/sdk/test-common/canton/it-lib/src/main/scala/com/daml/integrationtest/CantonRunner.scala
@@ -91,10 +91,17 @@ object CantonRunner {
       if (config.enableLfBetaVersionSupport) "beta-version-support = yes" else ""
     val globalBetaVersionSupport =
       if (config.enableLfBetaVersionSupport) "beta-version-support = yes" else ""
+    // The dev knob covers all pre-release protocol versions in this harness: alpha protocol
+    // versions (currently v36) sit outside dev-version-support, and without the alpha flag the
+    // synchronizer nodes refuse to handshake at an alpha version (see the TODO below).
     val participantDevVersionSupport =
-      if (config.enableLfDevVersionSupport) "dev-version-support = yes" else ""
+      if (config.enableLfDevVersionSupport)
+        "dev-version-support = yes\n        alpha-version-support = yes"
+      else ""
     val globalDevVersionSupport =
-      if (config.enableLfDevVersionSupport) "dev-version-support = yes" else ""
+      if (config.enableLfDevVersionSupport)
+        "dev-version-support = yes\n    alpha-version-support = yes"
+      else ""
 
     val extensionsConfig =
       config.extensionServices


### PR DESCRIPTION
Follow-up to the external-call promotion (canton PV36 / LF 2.4-staging), per the plan in the promotion thread: the external-call daml-script tests no longer need dev anything.

- `external-call-test` dar: built from `daml-script-2.4-staging.dar` with `--target=2.4-staging` (genrule and references renamed to match).
- `ExternalCallDevIT`: runs against a PV36 synchronizer instead of dev. The class keeps its `Dev` name so it stays in the `*Dev*` test-suite glob; happy to rename if you prefer a different suite placement.
- Dev version support stays enabled (inherited from `AbstractScriptTest`) — same TODO as there: swap to beta support once 2.4-rc1 is in canton's early-access range.

Out of scope: `submit-test.dar` stays at 2.dev — it is a general submit-error corpus with one external-call case among many, and external call remains available at dev.


Two additional fixes, found by running `ExternalCallDevIT` locally against the pinned canton:

- `CantonRunner` (it-lib): `dev-version-support` only admits the dev protocol version, and v36 is alpha — the mediator refused the sequencer handshake with "protocol version required by the server (36) is not among the supported protocol versions by the client: Seq(34, 35, dev)". The harness's dev knob now also emits `alpha-version-support = yes`.
- `Runner.IdeLedgerProtocolVersion`: added `V36` (same contract-state-machine mode as V35/VDev, per canton's `InterpretationConfig`) and its parse case. Without it the test client throws `Unsupported protocol version: v36`. Note this one touches the script runner itself, not just tests.

Validated locally with bazel: `ExternalCallDevIT` passes at v36 (all 4 scripts), and `DamlScriptDevIT`, `DamlScriptTestRunnerDev`, `FuncStaticTimeIT` pass unchanged, so the harness change does not regress the dev-protocol or standard suites.
