### PR TITLE
IdeLedgerClient: adapt to IdeLedgerRunner.submit taking List[ApiCommand]

### DIFF
--- a/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
+++ b/sdk/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/v2/ledgerinteraction/IdeLedgerClient.scala
@@ -664,26 +664,8 @@ class IdeLedgerClient(
         }
 
       // We use try + unsafePreprocess here to avoid the addition template lookup logic in `preprocessApiCommands`
-      val eitherSpeedyCommands =
-        try {
-          Right(
-            preprocessor.unsafePreprocessApiCommands(
-              packageMap,
-              commands
-                .map(toCommand(_, reversePackageIdMap.view.filterKeys(packageSupportsUpgrades(_))))
-                .to(ImmArray),
-            )
-          )
-        } catch {
-          case Error.Preprocessing.Lookup(err) => Left(makeLookupError(err))
-          // Expose type mismatches as unknown errors to match canton behaviour. Later this should be fully expressed as a SubmitError
-          case Error.Preprocessing.TypeMismatch(_, _, msg) =>
-            Left(
-              makeEmptySubmissionError(
-                script.Error.Internal("COMMAND_PREPROCESSING_FAILED(0, 00000000): " + msg)
-              )
-            )
-        }
+      val apiCommands: List[ApiCommand] =
+        commands.map(toCommand(_, reversePackageIdMap.view.filterKeys(packageSupportsUpgrades(_))))
 
       val eitherSpeedyDisclosures
           : Either[script.IdeLedgerRunner.SubmissionError, List[FatContractInstance]] = {
@@ -698,23 +680,34 @@ class IdeLedgerClient(
       val ledgerApi = IdeLedgerRunner.ScriptLedgerApi(ledger)
 
       for {
-        speedyCommands <- eitherSpeedyCommands
         speedyDisclosures <- eitherSpeedyDisclosures
-        translated = compiledPackages.compiler.unsafeCompile(speedyCommands)
-        result =
-          IdeLedgerRunner.submit(
-            compiledPackages = compiledPackages,
-            disclosures = speedyDisclosures,
-            ledger = ledgerApi,
-            committers = actAs.toSortedSet,
-            readAs = readAs,
-            commands = translated,
-            location = optLocation,
-            seed = nextSeed(),
-            machineLogger = machineLogger,
-            packageResolution = packageMap,
-            snapshotDir = snapshotDir,
-          )
+        result <-
+          try {
+            Right(
+              IdeLedgerRunner.submit(
+                compiledPackages = compiledPackages,
+                disclosures = speedyDisclosures,
+                ledger = ledgerApi,
+                committers = actAs.toSortedSet,
+                readAs = readAs,
+                commands = apiCommands,
+                location = optLocation,
+                seed = nextSeed(),
+                machineLogger = machineLogger,
+                packageResolution = packageMap,
+                snapshotDir = snapshotDir,
+              )
+            )
+          } catch {
+            case Error.Preprocessing.Lookup(err) => Left(makeLookupError(err))
+            // Expose type mismatches as unknown errors to match canton behaviour. Later this should be fully expressed as a SubmitError
+            case Error.Preprocessing.TypeMismatch(_, _, msg) =>
+              Left(
+                makeEmptySubmissionError(
+                  script.Error.Internal("COMMAND_PREPROCESSING_FAILED(0, 00000000): " + msg)
+                )
+              )
+          }
         res <- loop(result)
       } yield res
     }


### PR DESCRIPTION
Preprocessing/compilation now happens inside IdeLedgerRunner.submit, so we just build the ApiCommand list and wrap the submit call itself in the existing preprocessing-error try/catch.

companion PR: https://github.com/DACH-NY/canton/pull/35577